### PR TITLE
Bert pretraining

### DIFF
--- a/datasets/wikibooks.py
+++ b/datasets/wikibooks.py
@@ -1,0 +1,70 @@
+# based on nanoGPT's prepare of openwebtext
+# https://github.com/karpathy/nanoGPT/blob/master/data/openwebtext/prepare.py
+
+import os
+import re
+from tqdm import tqdm
+import numpy as np
+from transformers import BertTokenizer
+from datasets import load_dataset, concatenate_datasets  # huggingface datasets
+
+# number of workers in .map() call
+# good number to use is ~order number of cpu cores // 2
+num_proc = 13
+
+# prepare bookcorpus
+bookcorpus = load_dataset("bookcorpus", split='train', num_proc=num_proc)
+
+# prepare wiki
+wiki = load_dataset("wikipedia", "20220301.en", split='train',  num_proc=num_proc)
+wiki = wiki.remove_columns([col for col in wiki.column_names if col != "text"])
+
+def normalize_whitespaces(example):
+    text = example['text']
+    text = re.sub('\s+', ' ', text)
+    return {'text': text}
+
+wiki = wiki.map(normalize_whitespaces, num_proc=num_proc)
+
+# merge bookcorpus and wiki
+dataset = concatenate_datasets([bookcorpus, wiki])
+
+# owt by default only contains the 'train' split, so create a test split
+split_dataset = dataset.train_test_split(test_size=0.0005, seed=2357, shuffle=True)
+split_dataset['val'] = split_dataset.pop('test')  # rename the test split to val
+
+# we now want to tokenize the dataset.
+tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
+def process(example):
+    ids = tokenizer(example['text'])['input_ids']
+    out = {'ids': ids, 'len': len(ids)}
+    return out
+
+# tokenize the dataset
+tokenized = split_dataset.map(
+    process,
+    remove_columns=['text'],
+    desc="tokenizing the splits",
+    num_proc=num_proc,
+)
+
+# concatenate all the ids in each dataset into one large file we can use for training
+for split, dset in tokenized.items():
+    arr_len = np.sum(dset['len'])
+    filename = os.path.join(os.path.dirname(__file__), f'{split}.bin')
+    dtype = np.uint16  # (can do since enc.max_token_value == 50256 is < 2**16)
+    arr = np.memmap(filename, dtype=dtype, mode='w+', shape=(arr_len,))
+
+    print(f"writing {filename}...")
+    idx = 0
+    for example in tqdm(dset):
+        arr[idx:idx + example['len']] = example['ids']
+        idx += example['len']
+    arr.flush()
+
+# train.bin is ~10.3GB, val.bin ~5.5MB
+# train has ~11B tokens (11,037,086,592) 
+# val has ~6M tokens (5,723,362)
+
+# to read the bin files later, e.g. with numpy:
+# m = np.memmap('train.bin', dtype=np.uint16, mode='r')

--- a/examples/train_bert.py
+++ b/examples/train_bert.py
@@ -10,102 +10,102 @@ from tinygrad.nn.optim import Adam, get_parameters
 
 
 class BertDataset:
-    loss_mask = -100
-    mask_ratio = 0.3
-    def __init__(self, data, block_size, tokenizer):
-        self.data = data
-        self.block_size = block_size
-        self.cls_id = tokenizer.cls_token_id
-        self.mask_id = tokenizer.mask_token_id
-        self.vocab_size = tokenizer.vocab_size
+  loss_mask = -100
+  mask_ratio = 0.3
+  def __init__(self, data, block_size, tokenizer):
+    self.data = data
+    self.block_size = block_size
+    self.cls_id = tokenizer.cls_token_id
+    self.mask_id = tokenizer.mask_token_id
+    self.vocab_size = tokenizer.vocab_size
 
-    def __getitem__(self, idx):
-        x = self.data[idx: idx+self.block_size].astype(np.int32)
-        y = self.data[idx: idx+self.block_size].astype(np.int32)
-        x, y = self.mask_sample(x, y)
-        return x, y
+  def __getitem__(self, idx):
+    x = self.data[idx: idx+self.block_size].astype(np.int32)
+    y = self.data[idx: idx+self.block_size].astype(np.int32)
+    x, y = self.mask_sample(x, y)
+    return x, y
 
-    def mask_sample(self, x, y):
-        # replace first token with a [CLS] token, it's ok bc we sample from a contiguous blob of text anyway
-        x[0] = self.cls_id
-        for i in range(1, len(x)):
-            if np.random.random() < self.mask_ratio:
-                if (p := np.random.random()) < 0.8:
-                    mask_token = self.mask_id
-                elif p < 0.9:
-                    random_token = np.random.randint(self.vocab_size)
-                    mask_token = random_token
-                else:
-                    mask_token = x[i]
-                x[i] = mask_token
-            else:
-                # ignore unmasked for loss calculation
-                y[i] = self.loss_mask
-        return x, y
+  def mask_sample(self, x, y):
+    # replace first token with a [CLS] token, it's ok bc we sample from a contiguous blob of text anyway
+    x[0] = self.cls_id
+    for i in range(1, len(x)):
+      if np.random.random() < self.mask_ratio:
+        if (p := np.random.random()) < 0.8:
+          mask_token = self.mask_id
+        elif p < 0.9:
+          random_token = np.random.randint(self.vocab_size)
+          mask_token = random_token
+        else:
+          mask_token = x[i]
+        x[i] = mask_token
+      else:
+        # ignore unmasked for loss calculation
+        y[i] = self.loss_mask
+    return x, y
 
-    def get_batch(self, batch_size):
-        ix = np.random.randint(len(self.data) - block_size, size=(batch_size,))
-        batch = []
-        for i in ix:
-            batch.append(self[i])
-        input_ids = np.array([c[0] for c in batch])
-        targets = np.array([c[1] for c in batch])
-        return input_ids, targets
-    
+  def get_batch(self, batch_size):
+    ix = np.random.randint(len(self.data) - block_size, size=(batch_size,))
+    batch = []
+    for i in ix:
+      batch.append(self[i])
+    input_ids = np.array([c[0] for c in batch])
+    targets = np.array([c[1] for c in batch])
+    return input_ids, targets
+  
 if __name__ == "__main__":
-    tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
-    tokenizer.vocab_size
-    vocab_size = tokenizer.vocab_size
-    block_size = 128
-    layers = 12
-    num_heads = 12
-    embed_dim = 768
-    ff_dim = 4 * embed_dim
-    bert = Bert(vocab_size,
-                block_size,
-                layers,
-                embed_dim,
-                num_heads,
-                ff_dim)
+  tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
+  tokenizer.vocab_size
+  vocab_size = tokenizer.vocab_size
+  block_size = 128
+  layers = 12
+  num_heads = 12
+  embed_dim = 768
+  ff_dim = 4 * embed_dim
+  bert = Bert(vocab_size,
+        block_size,
+        layers,
+        embed_dim,
+        num_heads,
+        ff_dim)
 
-    dataset_path = 'train.bin'
-    train_data = np.memmap(dataset_path, dtype=np.uint16, mode='r')
-    bert_dataset = BertDataset(train_data, block_size, tokenizer)
+  dataset_path = 'train.bin'
+  train_data = np.memmap(dataset_path, dtype=np.uint16, mode='r')
+  bert_dataset = BertDataset(train_data, block_size, tokenizer)
 
-    Tensor.training = True
-    noloss = False
-    BS = 32
-    model = bert
-    steps = 1_000_000 * 8
-    optim = Adam(get_parameters(bert), lr=1e-4)
+  Tensor.training = True
+  noloss = False
+  BS = 32
+  model = bert
+  steps = 1_000_000 * 8
+  optim = Adam(get_parameters(bert), lr=1e-4)
 
-    def sparse_categorical_crossentropy(out, Y, ignore_index):
-        num_classes = out.shape[-1]
-        YY = Y.flatten().astype(np.int32)
-        y = np.zeros((YY.shape[0], num_classes), np.float32)
-        loss_mask = YY != ignore_index
-        # correct loss for NLL, torch NLL loss returns one per row
-        y[loss_mask, YY[loss_mask]] = -1.0
-        y = y.reshape(list(Y.shape)+[num_classes])
-        y = Tensor(y)
-        return out.mul(y).sum() / sum(loss_mask)
-        
-    losses, accuracies = [], []
-    for i in (t := trange(steps, disable=getenv('CI', False))):
-        x, y = bert_dataset.get_batch(BS)
-        x = Tensor(x, requires_grad=False)
+  def sparse_categorical_crossentropy(out, Y, ignore_index):
+    num_classes = out.shape[-1]
+    YY = Y.flatten().astype(np.int32)
+    y = np.zeros((YY.shape[0], num_classes), np.float32)
+    loss_mask = YY != ignore_index
+    # correct loss for NLL, torch NLL loss returns one per row
+    y[loss_mask, YY[loss_mask]] = -1.0
+    y = y.reshape(list(Y.shape)+[num_classes])
+    y = Tensor(y)
+    return out.mul(y).sum() / sum(loss_mask)
+    
+  losses, accuracies = [], []
+  for i in (t := trange(steps, disable=getenv('CI', False))):
+    x, y = bert_dataset.get_batch(BS)
+    x = Tensor(x, requires_grad=False)
 
-        # network
-        logprobs = model.forward(x) if hasattr(model, 'forward') else model(x)
-        loss = sparse_categorical_crossentropy(logprobs, y, ignore_index=bert_dataset.loss_mask)
-        optim.zero_grad()
-        loss.backward()
-        if noloss: del loss
-        optim.step()
+    # network
+    logprobs = model.forward(x) if hasattr(model, 'forward') else model(x)
+    loss = sparse_categorical_crossentropy(logprobs, y, ignore_index=bert_dataset.loss_mask)
+    optim.zero_grad()
+    loss.backward()
+    if noloss: del loss
+    optim.step()
 
-        # printing
-        if not noloss and i%20==0:
-            cat = np.argmax(logprobs.cpu().numpy(), axis=-1)
-            loss = loss.detach().cpu().numpy()
-            losses.append(loss)
-            t.set_description("loss %.2f" % (loss))
+    # printing
+    if not noloss and i%20==0:
+      cat = np.argmax(logprobs.cpu().numpy(), axis=-1)
+      loss = loss.detach().cpu().numpy()
+      losses.append(loss)
+      t.set_description("loss %.2f" % (loss))

--- a/examples/train_bert.py
+++ b/examples/train_bert.py
@@ -1,0 +1,111 @@
+import numpy as np
+from tqdm import trange
+from transformers import BertTokenizer
+
+from models.transformer_bert import Bert
+from tinygrad.tensor import Tensor
+from tinygrad.tensor import Tensor
+from tinygrad.helpers import getenv
+from tinygrad.nn.optim import Adam, get_parameters
+
+
+class BertDataset:
+    loss_mask = -100
+    mask_ratio = 0.3
+    def __init__(self, data, block_size, tokenizer):
+        self.data = data
+        self.block_size = block_size
+        self.cls_id = tokenizer.cls_token_id
+        self.mask_id = tokenizer.mask_token_id
+        self.vocab_size = tokenizer.vocab_size
+
+    def __getitem__(self, idx):
+        x = self.data[idx: idx+self.block_size].astype(np.int32)
+        y = self.data[idx: idx+self.block_size].astype(np.int32)
+        x, y = self.mask_sample(x, y)
+        return x, y
+
+    def mask_sample(self, x, y):
+        # replace first token with a [CLS] token, it's ok bc we sample from a contiguous blob of text anyway
+        x[0] = self.cls_id
+        for i in range(1, len(x)):
+            if np.random.random() < self.mask_ratio:
+                if (p := np.random.random()) < 0.8:
+                    mask_token = self.mask_id
+                elif p < 0.9:
+                    random_token = np.random.randint(self.vocab_size)
+                    mask_token = random_token
+                else:
+                    mask_token = x[i]
+                x[i] = mask_token
+            else:
+                # ignore unmasked for loss calculation
+                y[i] = self.loss_mask
+        return x, y
+
+    def get_batch(self, batch_size):
+        ix = np.random.randint(len(self.data) - block_size, size=(batch_size,))
+        batch = []
+        for i in ix:
+            batch.append(self[i])
+        input_ids = np.array([c[0] for c in batch])
+        targets = np.array([c[1] for c in batch])
+        return input_ids, targets
+    
+if __name__ == "__main__":
+    tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
+    tokenizer.vocab_size
+    vocab_size = tokenizer.vocab_size
+    block_size = 128
+    layers = 12
+    num_heads = 12
+    embed_dim = 768
+    ff_dim = 4 * embed_dim
+    bert = Bert(vocab_size,
+                block_size,
+                layers,
+                embed_dim,
+                num_heads,
+                ff_dim)
+
+    dataset_path = 'train.bin'
+    train_data = np.memmap(dataset_path, dtype=np.uint16, mode='r')
+    bert_dataset = BertDataset(train_data, block_size, tokenizer)
+
+    Tensor.training = True
+    noloss = False
+    BS = 32
+    model = bert
+    steps = 1_000_000 * 8
+    optim = Adam(get_parameters(bert), lr=1e-4)
+
+    def sparse_categorical_crossentropy(out, Y, ignore_index):
+        num_classes = out.shape[-1]
+        YY = Y.flatten().astype(np.int32)
+        y = np.zeros((YY.shape[0], num_classes), np.float32)
+        loss_mask = YY != ignore_index
+        # correct loss for NLL, torch NLL loss returns one per row
+        y[loss_mask, YY[loss_mask]] = -1.0
+        y = y.reshape(list(Y.shape)+[num_classes])
+        y = Tensor(y)
+        return out.mul(y).sum() / sum(loss_mask)
+        
+    losses, accuracies = [], []
+    for i in (t := trange(steps, disable=getenv('CI', False))):
+        x, y = bert_dataset.get_batch(BS)
+        x = Tensor(x, requires_grad=False)
+
+        # network
+        logprobs = model.forward(x) if hasattr(model, 'forward') else model(x)
+        loss = sparse_categorical_crossentropy(logprobs, y, ignore_index=bert_dataset.loss_mask)
+        optim.zero_grad()
+        loss.backward()
+        if noloss: del loss
+        optim.step()
+
+        # printing
+        if not noloss and i%20==0:
+            cat = np.argmax(logprobs.cpu().numpy(), axis=-1)
+            loss = loss.detach().cpu().numpy()
+            losses.append(loss)
+            t.set_description("loss %.2f" % (loss))

--- a/models/transformer_bert.py
+++ b/models/transformer_bert.py
@@ -1,0 +1,36 @@
+import math
+import numpy as np
+from tinygrad.tensor import Tensor
+from models.transformer import TransformerBlock
+
+
+# src: https://github.com/karpathy/nanoGPT/blob/7fe4a099ad2a4654f96a51c0736ecf347149c34c/model.py#L19
+def new_gelu(x):
+    """
+    Implementation of the GELU activation function currently in Google BERT repo (identical to OpenAI GPT).
+    Reference: Gaussian Error Linear Units (GELU) paper: https://arxiv.org/abs/1606.08415
+    """
+    return 0.5 * x * (1.0 + Tensor.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * Tensor.pow(x, 3.0))))
+
+class Bert:
+  def __init__(self, syms, maxlen, layers, embed_dim, num_heads, ff_dim):
+    self.maxlen, self.syms = maxlen, syms
+    self.embed = Tensor.scaled_uniform(maxlen+syms, embed_dim)
+    self.tbs = []
+    for i in range(layers):
+      self.tbs.append(TransformerBlock(embed_dim, num_heads, ff_dim, prenorm=True, act=new_gelu))
+    self.final = Tensor.scaled_uniform(embed_dim, syms)
+
+  def forward(self, x):
+    bs = x.shape[0]
+    xnp = x.cpu().numpy().astype(np.int32)
+    onehot = np.zeros((bs, x.shape[1], self.maxlen+self.syms), dtype=np.float32)
+    for i in range(x.shape[1]):
+      onehot[range(bs), i, i] = 1
+      onehot[range(bs), i, self.maxlen + xnp[:, i]] = 1
+    onehot = onehot.reshape(bs*x.shape[1], self.maxlen+self.syms)
+
+    x = Tensor(onehot, device=x.device).dot(self.embed).reshape(shape=(bs, x.shape[1], -1))
+    x = x.sequential(self.tbs)
+    x = x.reshape(shape=(-1, x.shape[-1])).dot(self.final).log_softmax()
+    return x.reshape(shape=(bs, -1, x.shape[-1]))


### PR DESCRIPTION
I've seen that the bounty is already locked, but still wanted to post my take on the Bert's pretraining code. 

If it's not worth including in the repo, feel free to close the PR.

Details:

For the Bert model, I've modified [models/transformer.py](https://github.com/geohot/tinygrad/blob/ae83e9844c7ed07f04087af7c865df97540be745/models/transformer.py#LL52C10-L52C10) to use prenorm, new_gelu activation and turned on gradient for the embedding layer, the rest is the same.

Dataset prep is a modified version of [nanoGPTs dataset preps](https://github.com/karpathy/nanoGPT/blob/master/data/openwebtext/prepare.py).

During training batches are sampled from the pretokenized train.bin blob and masked. I've ommited the NSP (Next Sentence Prediction) loss as it was shown in later papers to not improve models' quality. 

I've run the code on A10 gpu, achieving ~6s/step with bert_base architecture (12 layers, 12 heads, 786 embed_dim, ffn = 4*embed_dim), context 128 and BS=32. Original Bert was trained for 1,000,000 steps with BS=256.