### PR TITLE
[tinygrad] basic `nixos` dev shell on `cudakit` 11.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ datasets/open-images-v6-mlperf
 datasets/kits/
 datasets/audio*
 venv
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1687701825,
+        "narHash": "sha256-aMC9hqsf+4tJL7aJWSdEUurW2TsjxtDcJBwM9Y4FIYM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "07059ee2fa34f1598758839b9af87eae7f7ae6ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,127 @@
+{
+  description =
+    "tinygrad: For something between PyTorch and karpathy/micrograd. Maintained by tiny corp.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils }@I:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        P = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
+        B = builtins;
+        L = P.lib;
+
+        pythonVersion = "310";
+        pythonPackageStr = "python${pythonVersion}";
+        pythonNixpkgs = P."${pythonPackageStr}Packages";
+
+        tinygrad = pythonNixpkgs.buildPythonPackage {
+          pname = "tinygrad";
+          version = "v0.6.0";
+          src = ./.;
+
+          propagatedBuildInputs = with pythonNixpkgs; [
+            networkx
+            numpy
+            pillow
+            pyopencl
+            pyyaml
+            requests
+            tqdm
+          ];
+
+          # TODO(b7r6): enable when all tests pass...
+          doCheck = false;
+          pythonImportsCheck = [ "tinygrad" ];
+        };
+
+        commonBuildInputs = with P; [ git nixfmt ];
+        commonPythonPackages = pypkgs:
+          with pypkgs; [
+            # test and development
+            flake8
+            mypy
+            onnx
+            onnxruntime
+            opencv4
+            pylint
+            pytest
+            pytest-xdist
+            pytorch-bin
+            safetensors
+
+            # for LLaMA
+            sentencepiece
+
+            # package
+            tinygrad
+          ];
+
+        shellHook = ''
+          export __NIX_PS1__="tinygrad";
+          source "${P.bash-completion}/etc/profile.d/bash_completion.sh";
+          source "${P.git}/share/bash-completion/completions/git";
+          SCRIPT_DIR="${B.toString ./.}"
+          export PYTHONPATH="$SCRIPT_DIR:$PYTHONPATH"
+        '';
+
+      in {
+        packages = rec {
+          inherit tinygrad;
+          default = tinygrad;
+        };
+
+        devShells = rec {
+          cpu = P.mkShell rec {
+            name = tinygrad.pname;
+            python = P."${pythonPackageStr}".withPackages
+              (pypkgs: (commonPythonPackages pypkgs));
+            buildInputs = commonBuildInputs ++ [ python ];
+            inherit shellHook;
+          };
+
+          cuda = P.mkShell rec {
+            name = tinygrad.pname;
+            cudaVersion = "11_6";
+            cudaPackagesStr = "cudaPackages_${cudaVersion}";
+            python = P."${pythonPackageStr}".withPackages (pypkgs:
+              ((commonPythonPackages pypkgs) ++ (with pypkgs; [ pycuda ])));
+            buildInputs = commonBuildInputs ++ [
+              python
+              P."${cudaPackagesStr}".cudatoolkit
+              P."${cudaPackagesStr}".cuda_nvcc
+            ];
+            inherit shellHook;
+          };
+
+          llvm = P.mkShell rec {
+            name = tinygrad.pname;
+            python = P."${pythonPackageStr}".withPackages (pypkgs:
+              ((commonPythonPackages pypkgs) ++ (with pypkgs; [ llvmlite ])));
+            buildInputs = commonBuildInputs
+              ++ [ python P.llvmPackages_13.clang ];
+            inherit shellHook;
+          };
+
+          triton = P.mkShell rec {
+            name = tinygrad.pname;
+            python = P."${pythonPackageStr}".withPackages
+              (pypkgs: (commonPythonPackages pypkgs));
+            buildInputs = commonBuildInputs ++ [ python P.triton ];
+            inherit shellHook;
+          };
+
+          default = cpu;
+        };
+      });
+}


### PR DESCRIPTION
**Summary**

I'm unsure if this is a useful thing to merge: my NVIDIA box is running NixOS and it seems at least possible that others might want to use `tinygrad` on that platform. This currently only supports `x86_64-linux` and is only tested with `cudakit` 11.6, though that would be easy to change. As a possible ancillary benefit, if this finds any adoption it would ease the path into `nixpkgs`.

**Test Plan**

I've run all the unit tests under `CPU`, `GPU`, and `CUDA` and there don't seem to be any regressions against a vanilla `virtualenv` installation.

Usage is: `nix develop` and start hacking.