### PR TITLE
[WIP] Fix Metal CI tests (bounty)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,11 +207,10 @@ jobs:
         python-version: 3.11
     - name: Install Dependencies
       run: pip install -e '.[metal,testing]'
-    #- name: Run dtype test
-    #  run: DEBUG=4 METAL=1 python -m pytest test/test_dtype.py
+    - name: Run dtype test
+      run: DEBUG=4 METAL=1 python -m pytest test/test_dtype.py
     - name: Run ops test
       run: DEBUG=2 METAL=1 python -m pytest test/test_ops.py
-    # dtype test has issues on test_half_to_int8
 
   # disabled, this test is flaky
   testdocker:

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -671,7 +671,6 @@ class TestOps(unittest.TestCase):
         lambda x,w: torch.nn.functional.conv_transpose2d(x,w, stride=stride).relu(),
         lambda x,w: Tensor.conv_transpose2d(x,w,stride=stride).relu(), atol=1e-4, grad_rtol=1e-5)
 
-  @unittest.skipIf(Device.DEFAULT == "METAL", "weird, broken in METAL CI")
   def test_output_padded_conv_transpose2d(self):
     for output_padding, stride in [((1,1), (2,3)), ((2,1), (3,2))]:
       helper_test_op([(2,4,6,5), (4,4,3,3),(4,)],


### PR DESCRIPTION
Fixes #1019

This fixes `test_half_to_int8` and fixes and reenables `test_output_padded_conv_transpose2d`

This was a synchronization issue when loading the `half4` variable into the `float4` in the shader.

Marked as WIP as I'm not sure I'm quite adding the barrier in the right place to make sure it only applies in the correct cases (first commit, so not  familiar with the codebase). Gonna investigate this, but it's getting pretty late here, so that'll have to wait until tomorrow.

Can you lock the "Get all passing Metal tests in CI" bounty? This should be all tests done. Hope I'm not missing another skipped test.

P.S. Looks like there is a failure in the "openpilot (OpenCL) Test", will fix tomorrow.