### PR TITLE
HIP CI support and some unit test fixes for HIP GPU/CPU backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,3 +187,26 @@ jobs:
       run: docker build -t tinygrad -f test/Dockerfile .
     - name: Test Docker
       run: docker run --rm tinygrad /usr/bin/env python3 -c "from tinygrad.tensor import Tensor; print(Tensor.eye(3).numpy())"
+
+  testhip:
+    name: HIP CPU Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+    - name: Install clang and libstdc++
+      run: sudo apt install build-essential clang libstdc++-12-dev
+    - name: Install HIP-CPU
+      run: |
+        git clone https://github.com/ROCm-Developer-Tools/HIP-CPU.git
+        mkdir HIP-CPU/build && pushd HIP-CPU/build
+        cmake ../ && cmake --build ./ && sudo cmake --build ./ --target install && popd
+    - name: Install Dependencies
+      run: pip install -e '.[testing]' --extra-index-url https://download.pytorch.org/whl/cpu
+    - name: Run Pytest
+      run: HIP=1 HIP_CPU=1 python -m pytest -s -v -n=auto test/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,8 +199,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.8
-    - name: Install clang and libstdc++
-      run: sudo apt install build-essential clang libstdc++-12-dev
+    - name: Install Dependencies
+      run: sudo apt install build-essential clang libstdc++-12-dev libtbb-dev
     - name: Install HIP-CPU
       run: |
         git clone https://github.com/ROCm-Developer-Tools/HIP-CPU.git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,12 +201,12 @@ jobs:
         python-version: 3.8
     - name: Install Dependencies
       run: sudo apt install build-essential clang libstdc++-12-dev libtbb-dev
-    - name: Install HIP-CPU
+    - name: Clone and Install HIP-CPU
       run: |
         git clone https://github.com/ROCm-Developer-Tools/HIP-CPU.git
         mkdir HIP-CPU/build && pushd HIP-CPU/build
         cmake ../ && cmake --build ./ && sudo cmake --build ./ --target install && popd
-    - name: Install Dependencies
+    - name: Install Python Dependencies
       run: pip install -e '.[testing]' --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Run Pytest
       run: HIP=1 HIP_CPU=1 python -m pytest -s -v -n=auto test/

--- a/extra/hip_cpu_wrapper.py
+++ b/extra/hip_cpu_wrapper.py
@@ -1,0 +1,203 @@
+import ctypes
+import subprocess
+import tempfile
+import hashlib
+import os
+
+prg = r"""
+#include <hip/hip_runtime.h>
+
+extern "C" {
+
+hipError_t my_hipMalloc(void** ptr, std::size_t size) {
+  auto r = hipMalloc(ptr, size);
+  return r;
+}
+
+hipError_t my_hipMemcpy(
+  void* dst,
+  const void* src,
+  std::size_t size,
+  hipMemcpyKind kind = hipMemcpyDefault) {
+  auto r = hipMemcpy(dst, src, size, kind);
+  return r;
+}
+
+hipError_t my_hipMemcpyAsync(
+  void* dst,
+  const void* src,
+  std::size_t size,
+  hipMemcpyKind kind,
+  hipStream_t stream) {
+  return hipMemcpyAsync(dst, src, size, kind, stream);
+}
+
+hipError_t my_hipDeviceSynchronize() {
+  return hipDeviceSynchronize();
+}
+
+hipError_t my_hipEventCreate(hipEvent_t* event)
+{
+    return hipEventCreate(event);
+}
+
+hipError_t my_hipEventDestroy(hipEvent_t event)
+{
+    return hipEventDestroy(event);
+}
+
+hipError_t my_hipEventElapsedTime(float* ms, hipEvent_t start, hipEvent_t stop)
+{
+    return hipEventElapsedTime(ms, start, stop);
+}
+
+hipError_t my_hipEventRecord(hipEvent_t event, hipStream_t stream = nullptr)
+{
+    return hipEventRecord(event, stream);
+}
+
+hipError_t my_hipEventSynchronize(hipEvent_t event)
+{
+   return hipEventSynchronize(event);
+}
+
+hipError_t my_hipStreamSynchronize(hipStream_t 	stream) {
+  return hipStreamSynchronize(stream);
+}
+
+}
+"""
+
+fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.so"
+if not os.path.exists(fn):
+  subprocess.check_output(args=('clang -g -std=c++20 -shared -O2 -Wall -Werror -x c++ -ltbb -ltbbmalloc -fPIC --rtlib=compiler-rt - -o '+fn+'.tmp').split(), input=prg.encode('utf-8'))
+  os.rename(fn+'.tmp', fn)
+_libhip = ctypes.CDLL(fn)
+
+def hipCheckStatus(status):
+  if status != 0:
+    raise RuntimeError('HIP error %s' % status)
+
+def hipDeviceSynchronize():
+  status = _libhip['my_hipDeviceSynchronize']()
+  hipCheckStatus(status)
+
+_libhip['my_hipMalloc'].restype = int
+_libhip['my_hipMalloc'].argtypes = [ctypes.POINTER(ctypes.c_void_p),
+                              ctypes.c_size_t]
+
+
+def hipMalloc(count):
+  ptr = ctypes.c_void_p()
+  c_count = ctypes.c_size_t(count)
+
+  status = _libhip['my_hipMalloc'](ctypes.byref(ptr), c_count)
+  hipCheckStatus(status)
+  return ptr
+
+hipMemcpyHostToHost = 0
+hipMemcpyHostToDevice = 1
+hipMemcpyDeviceToHost = 2
+hipMemcpyDeviceToDevice = 3
+hipMemcpyDefault = 4
+
+
+_libhip['my_hipMemcpy'].restype = int
+_libhip['my_hipMemcpy'].argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                   ctypes.c_size_t, ctypes.c_int]
+
+def hipMemcpy(dst, src, count, direction):
+  #print('dst', type(dst), 'src', type(src), src)
+  status = _libhip['my_hipMemcpy'](dst, src, ctypes.c_size_t(count), direction)
+  hipCheckStatus(status)
+
+
+_libhip['my_hipMemcpyAsync'].restype = int
+_libhip['my_hipMemcpyAsync'].argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                   ctypes.c_size_t, ctypes.c_int, ctypes.c_void_p]
+
+def hipMemcpyAsync_htod(dst, src, count, stream):
+  status = _libhip['my_hipMemcpyAsync'](dst, src, ctypes.c_size_t(count), hipMemcpyHostToDevice, stream)
+  hipCheckStatus(status)
+
+
+def hipMemcpyAsync_dtoh(dst, src, count, stream):
+  status = _libhip['my_hipMemcpyAsync'](dst, src, ctypes.c_size_t(count), hipMemcpyDeviceToHost, stream)
+  hipCheckStatus(status)
+
+
+def hipMemcpyAsync(dst, src, count, direction, stream):
+  status = _libhip['my_hipMemcpyAsync'](dst, src, ctypes.c_size_t(count), direction, stream)
+  hipCheckStatus(status)
+
+def hipEventCreate():
+  ptr = ctypes.c_void_p()
+  status = _libhip['my_hipEventCreate'](ctypes.byref(ptr))
+  hipCheckStatus(status)
+  return ptr
+
+
+_libhip['my_hipEventRecord'].restype = int
+_libhip['my_hipEventRecord'].argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+
+def hipEventRecord(event, stream=None):
+  status = _libhip['my_hipEventRecord'](event, stream)
+  hipCheckStatus(status)
+
+
+_libhip['my_hipEventDestroy'].restype = int
+_libhip['my_hipEventDestroy'].argtypes = [ctypes.c_void_p]
+
+
+def hipEventDestroy(event):
+  status = _libhip['my_hipEventDestroy'](event)
+  hipCheckStatus(status)
+
+_libhip['my_hipEventSynchronize'].restype = int
+_libhip['my_hipEventSynchronize'].argtypes = [ctypes.c_void_p]
+
+
+def hipEventSynchronize(event):
+  status = _libhip['my_hipEventSynchronize'](event)
+  hipCheckStatus(status)
+
+
+_libhip['my_hipEventElapsedTime'].restype = int
+_libhip['my_hipEventElapsedTime'].argtypes = [ctypes.POINTER(
+    ctypes.c_float), ctypes.c_void_p, ctypes.c_void_p]
+
+
+def hipEventElapsedTime(start, stop):
+  t = ctypes.c_float()
+  status = _libhip['my_hipEventElapsedTime'](ctypes.byref(t), start, stop)
+  hipCheckStatus(status)
+  return t.value
+
+_libhip['my_hipStreamSynchronize'].restype = int
+_libhip['my_hipStreamSynchronize'].argtypes = [ctypes.c_void_p]
+
+def hipStreamSynchronize(stream):
+  status = _libhip['my_hipStreamSynchronize'](stream)
+  hipCheckStatus(status)
+
+def hiprtcCreateProgram(source, name, header_names, header_sources):
+  return ""
+
+def hipGetDeviceProperties(deviceId: int):
+  return ""
+
+def hiprtcCompileProgram(prog, options):
+  pass
+
+def hiprtcGetCode(prog):
+  return ""
+
+def hipModuleLoadData(data):
+  return ""
+
+def hipModuleGetFunction(module, func_name):
+  return ""
+
+def hipModuleLaunchKernel(kernel, bx, by, bz, tx, ty, tz, shared, stream, struct):
+  pass

--- a/extra/hip_cpu_wrapper.py
+++ b/extra/hip_cpu_wrapper.py
@@ -75,7 +75,7 @@ hipError_t my_hipStreamSynchronize(hipStream_t 	stream) {
 
 fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.so"
 if not os.path.exists(fn):
-  subprocess.check_output(args=('clang -g -std=c++20 -shared -O2 -Wall -Werror -x c++ -ltbb -ltbbmalloc -fPIC --rtlib=compiler-rt - -o '+fn+'.tmp').split(), input=prg.encode('utf-8'))
+  subprocess.check_output(args=('clang -g -std=c++20 --stdlib=libstdc++ -shared -O2 -Wall -Werror -x c++ -ltbb -ltbbmalloc -fPIC --rtlib=compiler-rt - -o '+fn+'.tmp').split(), input=prg.encode('utf-8'))
   os.rename(fn+'.tmp', fn)
 _libhip = ctypes.CDLL(fn)
 

--- a/extra/hip_cpu_wrapper.py
+++ b/extra/hip_cpu_wrapper.py
@@ -195,6 +195,7 @@ def hipStreamSynchronize(stream):
   status = _libhip['my_hipStreamSynchronize'](stream)
   hipCheckStatus(status)
 
+# Define some unused dummy functions to satisfy mypy
 def hiprtcCreateProgram(source, name, header_names, header_sources):
   return ""
 

--- a/extra/hip_cpu_wrapper.py
+++ b/extra/hip_cpu_wrapper.py
@@ -14,6 +14,11 @@ hipError_t my_hipMalloc(void** ptr, std::size_t size) {
   return r;
 }
 
+hipError_t my_hipFree(void* ptr)
+{
+    return hip::detail::deallocate(ptr);
+}
+
 hipError_t my_hipMemcpy(
   void* dst,
   const void* src,
@@ -92,6 +97,15 @@ def hipMalloc(count):
   c_count = ctypes.c_size_t(count)
 
   status = _libhip['my_hipMalloc'](ctypes.byref(ptr), c_count)
+  hipCheckStatus(status)
+  return ptr
+
+_libhip['my_hipFree'].restype = int
+_libhip['my_hipFree'].argtypes = [ctypes.c_void_p]
+
+
+def hipFree(ptr):
+  status = _libhip['my_hipFree'](ptr)
   hipCheckStatus(status)
   return ptr
 

--- a/extra/hip_wrapper.py
+++ b/extra/hip_wrapper.py
@@ -108,6 +108,10 @@ _libhip.hipMemcpy.restype = int
 _libhip.hipMemcpy.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]
 
 
+def hipMemcpy(dst, src, count, t):
+  status = _libhip.hipMemcpy(dst, src, ctypes.c_size_t(count), t)
+  hipCheckStatus(status)
+
 def hipMemcpy_htod(dst, src, count):
   status = _libhip.hipMemcpy(dst, src, ctypes.c_size_t(count), hipMemcpyHostToDevice)
   hipCheckStatus(status)

--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -176,8 +176,7 @@ class TestSpeed(unittest.TestCase):
 
   def test_gemm(self):
     def f(a, b): return a @ b
-    for _ in range(1000):
-      helper_test_generic_square('gemm', 1024, f, f)
+    helper_test_generic_square('gemm', 1024, f, f)
 
   def test_gemm_small(self):
     def f(a, b): return a @ b

--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -176,7 +176,8 @@ class TestSpeed(unittest.TestCase):
 
   def test_gemm(self):
     def f(a, b): return a @ b
-    helper_test_generic_square('gemm', 1024, f, f)
+    for _ in range(1000):
+      helper_test_generic_square('gemm', 1024, f, f)
 
   def test_gemm_small(self):
     def f(a, b): return a @ b

--- a/tinygrad/codegen/cstyle.py
+++ b/tinygrad/codegen/cstyle.py
@@ -24,6 +24,8 @@ class CStyleLanguage(NamedTuple):
   float4: Optional[str] = None
   half_prekernel: Optional[str] = None
   double_prekernel: Optional[str] = None
+  need_kernel_launcher: bool = False
+  build_kernel_launcher: Optional[Callable] = None
   uses_vload: bool = False
 
 def to_image_idx(base_shape:Tuple[int, ...], idxy:Node, valid:Node, validhacks=False) -> Tuple[Node, Node]:
@@ -174,6 +176,8 @@ def uops_to_cstyle(uops:List[UOp], bufs:List[Union[LocalBuffer,LazyBuffer]], lan
 
   if lang.half_prekernel and any(x.dtype == dtypes.float16 for x in bufs): prg = ''.join([f"{lang.half_prekernel}", "\n", prg])
   if lang.double_prekernel and any(x.dtype == dtypes.float64 for x in bufs): prg = ''.join([f"{lang.double_prekernel}", "\n", prg])
+  if lang.need_kernel_launcher and lang.build_kernel_launcher:
+    prg = ''.join([prg, '\n'] + lang.build_kernel_launcher(bufnames, buftypes))
   return prg, global_size, local_size
 
 class CStyleCodegen(Linearizer):

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -121,6 +121,16 @@ class HIPCodegen(CStyleCodegen):
   lang = CStyleLanguage(
     kernel_prefix = r"""
 #define INFINITY (__builtin_inff())
+__device__ float4 pow(float x, float4 y) {
+  return float4(pow(x, y.x), pow(x, y.y), pow(x, y.z), pow(x, y.w));
+}
+
+__device__ float4 pow(float4 x, float4 y) {
+  return float4(pow(x.x, y.x), pow(x.y, y.y), pow(x.z, y.z), pow(x.w, y.w));
+}
+__device__ float4 log2(float4 x) {
+  return float4(log2(x.x), log2(x.y), log2(x.z), log2(x.w));
+}
 extern "C" __global__""",
     smem_prefix = "__shared__ ", barrier = "__syncthreads();", float4 = "make_float4",
     half_prekernel = r"""

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -131,15 +131,19 @@ class HIPCodegenCPU(CStyleCodegen):
 typedef unsigned char uchar;
 using half_float::half;
 MAKE_VECTOR_TYPE(half, half)
+
 inline float max(float x, float y) {
   return fmax(x, y);
 }
+
 inline float4 max(float4 x, float4 y) {
   return float4(fmax(x.x, y.x), fmax(x.y, y.y), fmax(x.z, y.z), fmax(x.w, y.w));
 }
-inline float4 pow(float4 x, float y) {
-  return float4(pow(x.x, y), pow(x.y, y), pow(x.z, y), pow(x.w, y));
+
+inline float4 pow(float x, float4 y) {
+  return float4(pow(x, y.x), pow(x, y.y), pow(x, y.z), pow(x, y.w));
 }
+
 inline float4 log2(float4 x) {
   return float4(log2(x.x), log2(x.y), log2(x.z), log2(x.w));
 }

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -144,6 +144,10 @@ inline float4 pow(float x, float4 y) {
   return float4(pow(x, y.x), pow(x, y.y), pow(x, y.z), pow(x, y.w));
 }
 
+inline float4 pow(float4 x, float4 y) {
+  return float4(pow(x.x, y.x), pow(x.y, y.y), pow(x.z, y.z), pow(x.w, y.w));
+}
+
 inline float4 log2(float4 x) {
   return float4(log2(x.x), log2(x.y), log2(x.z), log2(x.w));
 }

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -74,7 +74,7 @@ class HIPProgramCPU:
     # TODO: is there a way to not write this to disk?
     fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.so"
     if not os.path.exists(fn):
-      subprocess.check_output(args=('clang -g -std=c++20 -shared -O2 -Wall -Werror -x c++ -ltbb -ltbbmalloc -fPIC --rtlib=compiler-rt - -o '+fn+'.tmp').split(), input=prg.encode('utf-8'))
+      subprocess.check_output(args=('clang -g -std=c++20 --stdlib=libstdc++ -shared -O2 -Wall -Werror -x c++ -ltbb -ltbbmalloc -fPIC --rtlib=compiler-rt - -o '+fn+'.tmp').split(), input=prg.encode('utf-8'))
       os.rename(fn+'.tmp', fn)
     self.lib = ctypes.CDLL(fn)
     self.prg = self.lib[f"launch_and_wait_{name}"]

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -1,7 +1,6 @@
 import numpy as np
-import ctypes
-import extra.hip_wrapper as hip
-from tinygrad.helpers import DEBUG
+import ctypes, subprocess, tempfile, hashlib, os
+from tinygrad.helpers import DEBUG, getenv
 from tinygrad.ops import Compiled
 from tinygrad.runtime.lib import RawBufferCopyInOut
 from tinygrad.codegen.cstyle import CStyleCodegen, CStyleLanguage
@@ -11,14 +10,27 @@ if DEBUG >= 5:
   from extra.helpers import enable_early_exec
   early_exec = enable_early_exec()
 
+HIP_CPU = getenv('HIP_CPU', 0)
+if HIP_CPU:
+  import extra.hip_cpu_wrapper as hip
+else:
+  import extra.hip_wrapper as hip # type: ignore
+
 # The default HIP stream is used for everything.
 
 class RawHIPBuffer(RawBufferCopyInOut):
   def __init__(self, size, dtype):
     self.buf_sz = size * dtype.itemsize
     super().__init__(size, dtype, hip.hipMalloc(self.buf_sz))
-  def _copyin(self, x:np.ndarray): hip.hipMemcpyAsync_htod(self._buf, x.ctypes.data, self.buf_sz, 0)
-  def _copyout(self, x:np.ndarray): hip.hipMemcpyAsync_dtoh(x.ctypes.data, self._buf, self.buf_sz, 0)
+  def _copyin(self, x:np.ndarray): hip.hipMemcpyAsync_htod(self._buf, x.ctypes.data_as(ctypes.c_void_p), self.buf_sz, ctypes.c_void_p(0))
+  def _copyout(self, x:np.ndarray): hip.hipMemcpyAsync_dtoh(x.ctypes.data_as(ctypes.c_void_p), self._buf, self.buf_sz, ctypes.c_void_p(0))
+
+class RawHIPBufferCPU(RawBufferCopyInOut):
+  def __init__(self, size, dtype):
+    self.buf_sz = size * dtype.itemsize
+    super().__init__(size, dtype, hip.hipMalloc(self.buf_sz))
+  def _copyin(self, x:np.ndarray): hip.hipMemcpy(self._buf, x.ctypes.data_as(ctypes.c_void_p), self.buf_sz, hip.hipMemcpyHostToDevice)
+  def _copyout(self, x:np.ndarray): hip.hipMemcpy(x.ctypes.data_as(ctypes.c_void_p), self._buf, self.buf_sz, hip.hipMemcpyDeviceToHost)
 
 class HIPProgram:
   def __init__(self, name:str, prg:str, binary=False):
@@ -55,11 +67,69 @@ class HIPProgram:
       hip.hipEventSynchronize(end)
       return hip.hipEventElapsedTime(start, end)*1e-3
 
+class HIPProgramCPU:
+  def __init__(self, name:str, prg:str, binary=False):
+    prg = '#include <hip/hip_runtime.h>\n' + prg
+    # TODO: is there a way to not write this to disk?
+    fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.so"
+    if not os.path.exists(fn):
+      subprocess.check_output(args=('clang -g -std=c++20 -shared -O2 -Wall -Werror -x c++ -ltbb -ltbbmalloc -fPIC --rtlib=compiler-rt - -o '+fn+'.tmp').split(), input=prg.encode('utf-8'))
+      os.rename(fn+'.tmp', fn)
+    self.lib = ctypes.CDLL(fn)
+    self.prg = self.lib[f"launch_and_wait_{name}"]
+
+  def __call__(self, global_size, local_size, *args, wait=False):
+    local_size = (local_size + [1] * (3 - len(local_size))) if local_size is not None else (1,1,1)
+    global_size = global_size + [1] * (3 - len(global_size))
+    assert all(x%y == 0 for x,y in zip(global_size, local_size)), f"local:{local_size} must divide global:{global_size}"
+    global_size = [x//y for x,y in zip(global_size, local_size)]
+    self.prg.argtypes = [ctypes.c_uint,                   # block x
+                         ctypes.c_uint,                   # block y
+                         ctypes.c_uint,                   # block z
+                         ctypes.c_uint,                   # thread x
+                         ctypes.c_uint,                   # thread y
+                         ctypes.c_uint,                   # thread z
+                         ctypes.c_uint,                   # shared mem
+                         ctypes.c_void_p,                 # stream
+                        *[ctypes.c_void_p for _ in args]]
+    # Launch the kernel and wait the stream.
+    self.prg(global_size[0], global_size[1], global_size[2], local_size[0], local_size[1], local_size[2], 0, ctypes.c_void_p(0), *[data._buf for data in args])
+    # This doesn't work unless put it into the c++ code.
+    # hip.hipStreamSynchronize(ctypes.c_void_p(0))
+
+# Some hacks for HIP CPU.
+#   1) hipLaunchKernelGGL doesn't work unless compiled with the kernel together, so we add a function after the kernel for launching the kernel.
+#   2) hipLaunchKernelGGL is async so we have to wait on the stream by calling hipStreamSynchronize.
+#   3) hipStreamSynchronize doesn't work either unless compiled with the kernel together, so we append a call to hipStreamSynchronize after hipLaunchKernelGG>
+def build_kernel_launcher(bufnames, buftypes):
+  return ['extern "C" void launch_and_wait_KERNEL_NAME_PLACEHOLDER('] + [r"""
+  std::uint32_t grid_dim_x,
+  std::uint32_t grid_dim_y,
+  std::uint32_t grid_dim_z,
+  std::uint32_t block_dim_x,
+  std::uint32_t block_dim_y,
+  std::uint32_t block_dim_z,
+  std::uint32_t shared_mem_bytes,
+  hipStream_t stream,
+"""] + [', '.join([f'{t} {bufnames[i]}' for i,t in buftypes])] + [r"""
+) {
+  hipLaunchKernelGGL(KERNEL_NAME_PLACEHOLDER, dim3(grid_dim_x, grid_dim_y, grid_dim_z), dim3(block_dim_x, block_dim_y, block_dim_z), shared_mem_bytes, stream,
+"""] + [', '.join([f'{bufnames[i]}' for i,t in buftypes])] + [');\nhipStreamSynchronize(stream);\n}']
+
 class HIPCodegen(CStyleCodegen):
   lang = CStyleLanguage(
-    kernel_prefix = "#define INFINITY (__builtin_inff())\nextern \"C\" __global__", smem_prefix = "__shared__ ", barrier = "__syncthreads();", float4 = "make_float4",
+    kernel_prefix = "#include <math.h>\ntypedef unsigned char uchar;\ntypedef half_float::half half;\n#define max fmax\ninline float4 pow(float4 x, float4 y) {\n  return float4(pow(x.x, y.x), pow(x.y, y.y), pow(x.z, y.z), pow(x.w, y.w));}\nextern \"C\" __global__", smem_prefix = "__shared__ ", barrier = "__syncthreads();", float4 = "make_float4",
     half_prekernel = "",
     gid = [f'blockDim.{chr(120+i)}*blockIdx.{chr(120+i)}+threadIdx.{chr(120+i)}' for i in range(3)],
     lid = [f'threadIdx.{chr(120+i)}' for i in range(3)])
 
-HIPBuffer = Compiled(RawHIPBuffer, HIPCodegen, HIPProgram, hip.hipDeviceSynchronize)
+class HIPCodegenCPU(CStyleCodegen):
+  lang = CStyleLanguage(
+    kernel_prefix = "#include <math.h>\ntypedef unsigned char uchar;\ntypedef half_float::half half;\n#define max fmax\ninline float4 pow(float4 x, float4 y) {\n  return float4(pow(x.x, y.x), pow(x.y, y.y), pow(x.z, y.z), pow(x.w, y.w));}\nextern \"C\" __global__", smem_prefix = "__shared__ ", barrier = "__syncthreads();", float4 = "make_float4",
+    half_prekernel = "",
+    need_kernel_launcher = True,
+    build_kernel_launcher = build_kernel_launcher,
+    gid = [f'blockDim.{chr(120+i)}*blockIdx.{chr(120+i)}+threadIdx.{chr(120+i)}' for i in range(3)],
+    lid = [f'threadIdx.{chr(120+i)}' for i in range(3)])
+
+HIPBuffer = Compiled(RawHIPBufferCPU if HIP_CPU else RawHIPBuffer, HIPCodegenCPU if HIP_CPU else HIPCodegen, HIPProgramCPU if HIP_CPU else HIPProgram, hip.hipDeviceSynchronize)

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -120,7 +120,14 @@ def build_kernel_launcher(bufnames, buftypes):
 class HIPCodegen(CStyleCodegen):
   lang = CStyleLanguage(
     kernel_prefix = r"""
+#include <hip/hip_common.h>
+#include <hip/hip_math_constants.h>
 #define INFINITY (__builtin_inff())
+#define NAN HIP_NAN_F
+__device__ float4 max(float4 x, float4 y) {
+  return float4(fmax(x.x, y.x), fmax(x.y, y.y), fmax(x.z, y.z), fmax(x.w, y.w));
+}
+
 __device__ float4 pow(float x, float4 y) {
   return float4(pow(x, y.x), pow(x, y.y), pow(x, y.z), pow(x, y.w));
 }


### PR DESCRIPTION
1. HIP CI support by adding HIP CPU backend, see test.yml modifications.
How to run HIP CPU backend locally:
- Install HIP-CPU by following these instructions: [https://github.com/ROCm-Developer-Tools/HIP-CPU/blob/master/docs/gcc_linux.md](https://github.com/ROCm-Developer-Tools/HIP-CPU/blob/master/docs/gcc_linux.md)
- Run tinygrad code using HIP-CPU:
```
HIP=1 HIP_CPU=1 python3 test/test_dtype.py
```
2. Since HIP-CPU is a header only library, [hip_cpu_wrapper.py](https://github.com/geohot/tinygrad/compare/master...nanamiwang:tinygrad:hip_ci?expand=1#diff-39d50bf559ac666b3e21dbf5fb7123756bfbdc3187713bb1f05befb03a482d8a) was added for wrapping HIP-CPU APIs into a shared library.
3. For HIP CPU backend, kernel and kernel launcher code have to be compiled together into one shared library, so add 2 properties (need_kernel_launcher&build_kernel_launcher) to CStyleLanguage.
HIP CPU kernels will look like this:
```
extern "C" __global__
 void E_2925(float* data0, const float* data1, const float* data2) {
{ int gidx0 = blockDim.x*blockIdx.x+threadIdx.x;  /* 2925 */
  float val1_0 = data1[gidx0];
  float val2_0 = data2[gidx0];
  float alu0 = (val1_0+val2_0);
  data0[gidx0] = alu0;
} /* global */
}
extern "C" void launch_and_wait_E_2925(
  std::uint32_t grid_dim_x,
  std::uint32_t grid_dim_y,
  std::uint32_t grid_dim_z,
  std::uint32_t block_dim_x,
  std::uint32_t block_dim_y,
  std::uint32_t block_dim_z,
  std::uint32_t shared_mem_bytes,
  hipStream_t stream,
float* data0, const float* data1, const float* data2
) {
  hipLaunchKernelGGL(E_2925, dim3(grid_dim_x, grid_dim_y, grid_dim_z), dim3(block_dim_x, block_dim_y, block_dim_z), shared_mem_bytes, stream,
data0, data1, data2);
  hipStreamSynchronize(stream);
}
```
4. Add half4, float4 pow/log/max supports to HIP GPU/CPU backend, fix some test_ops.py/test_dtype.py test failures.

#### Remained issues
HIP CPU backend is slow, so HIP CI test will take more than 5 hours and get cancelled on github actions.  Even run the tests locally, it is still very slow and memory consumption is very high. [CI log](https://github.com/nanamiwang/tinygrad/actions/runs/5373605398/jobs/9748138423)