### PR TITLE
[WIP] fuse several reduces into one kernel

### DIFF
--- a/tinygrad/codegen/cstyle.py
+++ b/tinygrad/codegen/cstyle.py
@@ -170,34 +170,34 @@ def uops_to_cstyle(uops:List[UOp], bufs:List[Union[LocalBuffer,LazyBuffer]], lan
         kk(f"*(({lang.smem_prefix if isinstance(bufs[args.i], LocalBuffer) else lang.buffer_prefix}{bufs[args.i].dtype.name}4*)({bufnames[args.i]}+{args.idx.render(render_cl)})) = ({bufs[args.i].dtype.name}4){vin[0].render()};")
     elif uop == UOps.ATOMIC_ADD:
       atomic_on_bufs.add(args[0].i)
-      # TODO: Fix this.
-      # kk(lang.atomic_add.format(f"{bufnames[args[0].i]}", vin[0].render()) + ";")
-      kk("if (lidx1 == 0) {")
-      kk(lang.atomic_add.format(f"{bufnames[args[0].i]}", "val") + ";")
-      kk("}}")
+      kk(lang.atomic_add.format(f"&{bufnames[args[0].i]}[{args[0].idx.render(render_cl)}]", vin[0].render()) + ";")
+      # kk("if (lidx1 == 0) {")
+      # kk(lang.atomic_add.format(f"&{bufnames[args[0].i]}[{args[0].idx.render(render_cl)}] ", "val") + ";")
+      # kk("}}")
     elif uop == UOps.DEFINE_LOCAL:
       kk(lang.smem_prefix + f"float {args[0]}[{args[1]}];")
     elif uop == UOps.CUDA_REDUCE:
-      kk("""
-static __shared__ int tmpshared[32];
+      kk(f"""
+{lang.smem_prefix} int tmpshared[64];
+int lidx1 = lidx2;
 const int max_lidx1 = 64;
-int lane = lidx1 % 32;
-int wid = lidx1 / 32;
+int lane = lidx1 % warp_size;
+int wid = lidx1 / warp_size;
 
 float val = acc_0_0;
-for (int offset = 32/2; offset > 0; offset /= 2) 
-  val += __shfl_down_sync(0xFFFFFFFF, val, offset);
+val = simd_sum(val);
+//for (int offset = warp_size/2; offset > 0; offset /= 2) val += __shfl_down_sync(0xFFFFFFFF, val, offset);
 
 if (lane == 0)
   tmpshared[wid]=val;
 
-__syncthreads();
+{lang.barrier}
 
-val = (lidx1 < max_lidx1 / 32) ? tmpshared[lane] : 0;
+val = (lidx1 < max_lidx1 / warp_size) ? tmpshared[lane] : 0;
 
 if (wid == 0)
-  for (int offset = 32/2; offset > 0; offset /= 2) 
-    val += __shfl_down_sync(0xFFFFFFFF, val, offset);""")
+  val = simd_sum(val);
+  //for (int offset = warp_size/2; offset > 0; offset /= 2) val += __shfl_down_sync(0xFFFFFFFF, val, offset);""")
     else:
       raise RuntimeError(f"failed to render {uop}")
 
@@ -217,6 +217,7 @@ class CStyleCodegen(Linearizer):
   supports_constant_folding: bool = True
   supports_float4: bool = True
   supports_float4_alu: bool = True
+  supports_atomics: bool = True
 
   # for renaming
   kernel_cnt: Final[DefaultDict[str, int]] = collections.defaultdict(int)

--- a/tinygrad/codegen/cstyle.py
+++ b/tinygrad/codegen/cstyle.py
@@ -170,7 +170,7 @@ def uops_to_cstyle(uops:List[UOp], bufs:List[Union[LocalBuffer,LazyBuffer]], lan
         kk(f"*(({lang.smem_prefix if isinstance(bufs[args.i], LocalBuffer) else lang.buffer_prefix}{bufs[args.i].dtype.name}4*)({bufnames[args.i]}+{args.idx.render(render_cl)})) = ({bufs[args.i].dtype.name}4){vin[0].render()};")
     elif uop == UOps.ATOMIC_ADD:
       atomic_on_bufs.add(args[0].i)
-      kk(lang.atomic_add.format(f"{bufnames[args[0].i]}", vin[0].render()) + ";")
+      kk(lang.atomic_add.format(f"&{bufnames[args[0].i]}[{args[0].idx.render(render_cl)}]", vin[0].render()) + ";")
     elif uop == UOps.DEFINE_LOCAL:
       kk(lang.smem_prefix + f"float {args[0]}[{args[1]}];")
     else:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -265,14 +265,14 @@ class Linearizer:
         fake_reduce_idxs = [x*0 for x in reduce_idxs]
 
         # define accumulator
-        acc = self.global_load(0, global_idxs+local_idxs+fake_reduce_idxs+upcast_idxs, {ReduceOps.SUM: 0.0, ReduceOps.MAX: -math.inf}[cast(ReduceOps, reduceop.op)], reduceid=reduce_idx)
+        acc = self.global_load(reduce_idx, global_idxs+local_idxs+fake_reduce_idxs+upcast_idxs, {ReduceOps.SUM: 0.0, ReduceOps.MAX: -math.inf}[cast(ReduceOps, reduceop.op)])
         accs.append(acc)
 
         # reduce loop
         self.uop(UOps.LOOP, None, [], (reduce_idxs, "reduce"))
 
         # load earlybufs
-        loaded_buffers.update({b:self.global_load(i, global_idxs+local_idxs+reduce_idxs+full_upcast_idxs, reduceid=reduce_idx) for i,b in enumerate(self.bufs) if b in self.earlybufs_per_reduce[reduce_idx] and i != 0})
+        loaded_buffers.update({b:self.global_load(i, global_idxs+local_idxs+reduce_idxs+full_upcast_idxs) for i,b in enumerate(self.bufs) if b in self.earlybufs_per_reduce[reduce_idx] and i != 0})
 
         # run early AST (with reduce)
         self.ast_parse(reduceop, [accs[-1][off] for off in self.acc_offsets(self.full_buf_index)], loaded_buffers, ssa, do_reduce=True)

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -23,7 +23,7 @@ def ansilen(s): return len(re.sub('\x1b\\[(K|.*?m)', '', s))
 def partition(lst, fxn): return [x for x in lst if fxn(x)], [x for x in lst if not fxn(x)]
 def make_pair(x:Union[int, Tuple[int, ...]], cnt=2) -> Tuple[int, ...]: return (x,)*cnt if isinstance(x, int) else x
 def flatten(l:Iterator): return [item for sublist in l for item in sublist]
-def mnum(i) -> str: return str(i) if i >= 0 else f"m{-i}"
+def mnum(i) -> str: return "" if i is None else str(i) if i >= 0 else f"m{-i}"
 def fromimport(mod, frm): return getattr(__import__(mod, fromlist=[frm]), frm)
 
 @functools.lru_cache(maxsize=None)

--- a/tinygrad/jit.py
+++ b/tinygrad/jit.py
@@ -20,7 +20,7 @@ class TinyJit:
   def __call__(self, *args, **kwargs) -> Any:
     # TODO: Back METAL for JIT: atomic operation which are implemented for metal requires
     # zeroes/-inf buffers (for sum/max). This is broken for JIT.
-    if Device.DEFAULT not in ["GPU", "CLANG", "HIP"]: return self.fxn(*args, **kwargs)  # only jit on the GPU codegen
+    if Device.DEFAULT not in ["GPU", "CLANG", "METAL", "HIP"]: return self.fxn(*args, **kwargs)  # only jit on the GPU codegen
     # NOTE: this cast is needed since although we know realize will create a ".realized" DeviceBuffer, the type checker doesn't
     input_rawbuffers: Dict[Union[int, str], RawBuffer] = {cast(Union[int, str], k):cast(RawBuffer, v.realize().lazydata.realized) for k,v in itertools.chain(enumerate(args), kwargs.items()) if isinstance(v, Tensor)}
     assert len(input_rawbuffers) != 0, "no inputs to JIT"

--- a/tinygrad/jit.py
+++ b/tinygrad/jit.py
@@ -20,7 +20,7 @@ class TinyJit:
   def __call__(self, *args, **kwargs) -> Any:
     # TODO: Back METAL for JIT: atomic operation which are implemented for metal requires
     # zeroes/-inf buffers (for sum/max). This is broken for JIT.
-    if Device.DEFAULT not in ["GPU", "CLANG", "CUDA", "HIP"]: return self.fxn(*args, **kwargs)  # only jit on the GPU codegen
+    if Device.DEFAULT not in ["GPU", "CLANG", "HIP"]: return self.fxn(*args, **kwargs)  # only jit on the GPU codegen
     # NOTE: this cast is needed since although we know realize will create a ".realized" DeviceBuffer, the type checker doesn't
     input_rawbuffers: Dict[Union[int, str], RawBuffer] = {cast(Union[int, str], k):cast(RawBuffer, v.realize().lazydata.realized) for k,v in itertools.chain(enumerate(args), kwargs.items()) if isinstance(v, Tensor)}
     assert len(input_rawbuffers) != 0, "no inputs to JIT"

--- a/tinygrad/jit.py
+++ b/tinygrad/jit.py
@@ -18,7 +18,9 @@ class TinyJit:
   def __get__(self, obj, objtype): return functools.partial(self.__call__, obj)
 
   def __call__(self, *args, **kwargs) -> Any:
-    if Device.DEFAULT not in ["GPU", "CLANG", "METAL", "CUDA", "HIP"]: return self.fxn(*args, **kwargs)  # only jit on the GPU codegen
+    # TODO: Back METAL for JIT: atomic operation which are implemented for metal requires
+    # zeroes/-inf buffers (for sum/max). This is broken for JIT.
+    if Device.DEFAULT not in ["GPU", "CLANG", "CUDA", "HIP"]: return self.fxn(*args, **kwargs)  # only jit on the GPU codegen
     # NOTE: this cast is needed since although we know realize will create a ".realized" DeviceBuffer, the type checker doesn't
     input_rawbuffers: Dict[Union[int, str], RawBuffer] = {cast(Union[int, str], k):cast(RawBuffer, v.realize().lazydata.realized) for k,v in itertools.chain(enumerate(args), kwargs.items()) if isinstance(v, Tensor)}
     assert len(input_rawbuffers) != 0, "no inputs to JIT"

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -80,7 +80,7 @@ def _ast_binaryops(self:LazyBuffer) -> LazyOp:
         intermediate_shape = psrc[1].shape
         assert psrc[0].shape == self.shape, f"shape mismatch {psrc[0].shape} != {self.shape}"
 
-      if getenv("ONEREDUCE"):
+      if getenv("ONEREDUCE", 1):
         break
 
   # reshape all the late ops into the output shape

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -72,6 +72,9 @@ class CUDAProgram:
     if wait:
       start, end = cuda.Event(), cuda.Event()
       start.record()
+    
+    if (local_size[0] == 256):
+      cuda.memset_d32(args[0]._buf, 0, args[0].size)
     self.prg(*[x._buf for x in args], block=tuple(local_size), grid=tuple(global_size))
     if wait:
       end.record()

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -83,6 +83,7 @@ class CUDACodegen(CStyleCodegen):
     kernel_prefix = "typedef unsigned char uchar;\ntypedef unsigned int uint;\ntypedef unsigned long ulong;\n__global__", smem_prefix = "__shared__ ", barrier = "__syncthreads();", float4 = "make_float4",
     gid = [f'blockIdx.{chr(120+i)}' for i in range(3)],
     lid = [f'threadIdx.{chr(120+i)}' for i in range(3)],
+    atomic_add = "atomicAdd({0}, {1})",
     half_prekernel = """
       #include <cuda_fp16.h>
       struct __align__(8) half4 {

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -78,6 +78,8 @@ class MetalCodegen(CStyleCodegen):
     kernel_prefix = "#include <metal_stdlib>\nusing namespace metal;\nkernel", buffer_prefix = "device ", smem_prefix = "threadgroup ",
     barrier = "threadgroup_barrier(mem_flags::mem_threadgroup);", float4 = "float4",
     gid = [f"gid.{chr(120+i)}" for i in range(3)], lid = [f"lid.{chr(120+i)}" for i in range(3)],
+    atomic_prefix = "device atomic_",
+    atomic_add = "atomic_fetch_add_explicit({0}, {1}, memory_order_relaxed)",
     extra_args = ['uint3 gid [[threadgroup_position_in_grid]]', 'uint3 lid [[thread_position_in_threadgroup]]'])
 
 MetalBuffer = Compiled(RawMetalBuffer, MetalCodegen, MetalProgram, METAL.synchronize)


### PR DESCRIPTION
The following code `_ = ((x@y)+(a@b)).numpy()` can benefit from fusing it into one kernel. It was measured to get about 10gflops (~195 -> ~205).

There are several cases where reduceops can be fused for training (found for efficientnet and resnet).