### PR TITLE
Fix ShapeTracker mismatch in LazyBuffer.fromCPU

### DIFF
--- a/test/test_lazybuffer.py
+++ b/test/test_lazybuffer.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import numpy as np
+import unittest
+from tinygrad.lazy import LazyBuffer
+
+class TestLazyBuffer(unittest.TestCase):
+  def test_fromcpu_buffer_sharing(self):
+    a = np.arange(8)
+    assert LazyBuffer.fromCPU(a).realized._buf is a
+
+  def test_fromcpu_shape_tracker(self):
+    def helper(a: np.ndarray):
+      print(a.shape, a.strides, a.flags.c_contiguous)
+      b = LazyBuffer.fromCPU(a).realize()
+      assert b.st.contiguous == a.flags.c_contiguous
+      assert b.st.shape == a.shape
+
+    for ndims in range(1, 4):
+      a = np.random.randn(*(4,)*ndims).astype(np.float32)
+      for stride in [-2, 1, 2]:
+        for start in [0, 1]:
+          helper(a[(slice(start, None, stride),)*ndims])
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -178,7 +178,6 @@ class LazyBuffer:
   def fromCPU(x: np.ndarray) -> LazyBuffer:
     return LazyBuffer("CPU", ShapeTracker(x.shape, [View(x.shape, tuple(st//x.itemsize for st in x.strides))]), LoadOps, LazyOp(LoadOps.EMPTY, (), None), dtypes.from_np(x.dtype), RawNumpyBuffer.fromCPU(x))
 
-
   # create a constant with the shape and dtype of self
   def const_like(self, val) -> LazyBuffer:
     # NOTE: dtypes.from_np(self.dtype.np) to deal with image types

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -8,7 +8,7 @@ import numpy as np
 from tinygrad.helpers import GRAPH, DEBUG, prod, getenv, DType, dtypes, flatten, ImageDType, LightWeakSet, LightWeakValueDictionary
 from tinygrad.runtime.ops_cpu import RawNumpyBuffer
 from tinygrad.runtime.ops_disk import RawDiskBuffer
-from tinygrad.shape.shapetracker import MovementOps, ShapeTracker, get_contraction
+from tinygrad.shape.shapetracker import MovementOps, ShapeTracker, View, get_contraction
 from tinygrad.ops import Compiled, Interpreted, UnaryOps, BinaryOps, ReduceOps, LoadOps, OpType, LazyOp
 from tinygrad.runtime.lib import RawBufferMapped, RawConst, RawBuffer
 
@@ -176,7 +176,8 @@ class LazyBuffer:
 
   @staticmethod
   def fromCPU(x: np.ndarray) -> LazyBuffer:
-    return LazyBuffer("CPU", ShapeTracker(x.shape), LoadOps, LazyOp(LoadOps.EMPTY, (), None), dtypes.from_np(x.dtype), RawNumpyBuffer.fromCPU(x))
+    return LazyBuffer("CPU", ShapeTracker(x.shape, [View(x.shape, tuple(st//x.itemsize for st in x.strides))]), LoadOps, LazyOp(LoadOps.EMPTY, (), None), dtypes.from_np(x.dtype), RawNumpyBuffer.fromCPU(x))
+
 
   # create a constant with the shape and dtype of self
   def const_like(self, val) -> LazyBuffer:


### PR DESCRIPTION
The shape tracker in LazyBuffer.fromCPU is initialized with only the input array's shape, meaning it will always claim to be contiguous, including when the input array is not. This was the actual cause of the bug in #1150, as `x` already should already have been made contiguous [1].

This PR proposes a "fix" by simply making a copy of the array, which allocates a new contiguous buffer and thereby corrects the shape tracker mismatch. The downside is that it changes the previous behaviour of sharing/reusing the buffer.

If we wish to keep supporting buffer sharing, it should also be possible to construct a correct shape tracker by passing the array's shape, strides, and base.


[1]: Specifically the problem is that `_realize_contiguous` avoids emitting `UnaryOps.NOOP` (soon to be `LoadOps.CONTIGUOUS`) if the input is already contiguous (according to the shape tracker). 