### PR TITLE
docs/abstractions.py typo fix

### DIFF
--- a/docs/abstractions.py
+++ b/docs/abstractions.py
@@ -135,7 +135,7 @@ assert len(lazyop.src) == 2
 # again, a LazyOp AST is like a GPU kernel. you have to copy the data on the device first
 print(lazyop.src[0].op)
 assert lazyop.src[0].op.op == LoadOps.FROM
-assert lazyop.src[0].op.src[0].realized.toCPU()[0] == 2, "the arg of the FROM LazyOP is a LazyBuffer holding [2.]"
+assert lazyop.src[0].op.src[0].realized.toCPU()[0] == 2, "the src of the FROM LazyOP is a LazyBuffer holding [2.]"
 assert result.lazydata.realized is None, "the LazyBuffer is not realized yet"
 
 # now we realize the LazyBuffer


### PR DESCRIPTION
The src property contains the LB not the arg

> LazyOp(op=LoadOps.FROM, src=(<LB (1,) dtypes.float op=buffer<1, dtypes.float> st=ShapeTracker(shape=(1,), views=[View((1,), (0,), 0, None)])>,), arg=None)