### PR TITLE
Fix: auto create parent dir when downloading file

### DIFF
--- a/extra/utils.py
+++ b/extra/utils.py
@@ -33,13 +33,13 @@ def fetch_as_file(url):
   return fp
 
 def download_file(url, fp, skip_if_exists=True):
-  import requests, os, pathlib
+  import requests, pathlib
   if skip_if_exists and os.path.isfile(fp) and os.stat(fp).st_size > 0:
     return
   r = requests.get(url, stream=True)
   assert r.status_code == 200
   progress_bar = tqdm(total=int(r.headers.get('content-length', 0)), unit='B', unit_scale=True, desc=url)
-  with tempfile.NamedTemporaryFile(dir=pathlib.Path(fp).parent, delete=False) as f:
+  with tempfile.NamedTemporaryFile(dir=pathlib.Path(fp).parent.mkdir(parents=True, exist_ok=True), delete=False) as f:
     for chunk in r.iter_content(chunk_size=16384):
       progress_bar.update(f.write(chunk))
     f.close()


### PR DESCRIPTION
Did this because some examples that use `download_file` expect a weights dir, this way the user doesn't have to manually create it. 
- also removed duplicate import `os`