### PR TITLE
Limit the number of kernel buffers

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1024,10 +1024,11 @@ class TestOps(unittest.TestCase):
 
   def test_many_buffers(self):
     x = [Tensor.randn(1024) for i in range(1024)]
-    expected = np.sum([y.numpy() for y in x], 0)
+    expected = np.array([y.numpy() for y in x])
     while len(x) > 1:
       x = [x[2*i] + x[2*i+1] for i in range(len(x) // 2)]
-    np.testing.assert_allclose(x[0].numpy(), expected, atol=1e-6, rtol=1e-3)
+      expected = expected[0::2] + expected[1::2]
+    np.testing.assert_allclose(x[0].numpy(), expected[0], atol=1e-6, rtol=1e-3)
 
 if __name__ == '__main__':
   np.random.seed(1337)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1022,6 +1022,13 @@ class TestOps(unittest.TestCase):
     n = (x < 0).where(x, 1).numpy()
     assert np.all(n == 1.)
 
+  def test_many_buffers(self):
+    x = [Tensor.randn(1024) for i in range(1024)]
+    expected = np.sum([y.numpy() for y in x], 0)
+    while len(x) > 1:
+      x = [x[2*i] + x[2*i+1] for i in range(len(x) // 2)]
+    np.testing.assert_allclose(x[0].numpy(), expected, atol=1e-6, rtol=1e-3)
+
 if __name__ == '__main__':
   np.random.seed(1337)
   unittest.main(verbosity=2)


### PR DESCRIPTION
If I'm not mistaken, the only place where the AST optimization adds buffers to a kernel is when two BinaryOps get merged. So adding a check here and not doing the merge in case it would exceed the buffer threshold should prevent kernels with too many buffers to be created.

I'm not sure how the limit should be defined. For now I've just made it an environment variable which defaults to 30 on Metal and to 256 on any other backend.

This fixes #1121 on my machine and also https://github.com/tinygrad/tinygrad/issues/953#issuecomment-1584562667 executes quickly.