### PR TITLE
Cancel previous workflow runs on new commits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   linter:
     name: Linters


### PR DESCRIPTION
Something is very wrong with CI right now, the queue is pretty much completely backed up.

This should help a bit by canceling older runs when there are new commits.