### PR TITLE
ci: cache downloads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
@@ -41,8 +41,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
@@ -62,8 +62,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
@@ -83,8 +83,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
@@ -102,8 +102,8 @@ jobs:
     name: CLANG Tests ${{ matrix.os }} (w method cache)
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
@@ -121,8 +121,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
@@ -140,8 +140,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
     - name: Update packages
       run: |
         wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
@@ -169,8 +169,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
     - name: Update packages
       run: |
         wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
@@ -204,8 +204,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
     - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
@@ -226,8 +226,8 @@ jobs:
     if: ${{ false }}
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
     - name: Build Docker
       run: docker build -t tinygrad -f test/Dockerfile .
     - name: Test Docker
@@ -240,8 +240,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
     - name: Update packages
       run: |
         export DEBIAN_FRONTEND=noninteractive

--- a/extra/utils.py
+++ b/extra/utils.py
@@ -17,7 +17,7 @@ def fetch(url):
   if url.startswith("/"):
     with open(url, "rb") as f:
       return f.read()
-  import hashlib
+    import hashlib
   fp = temp(hashlib.md5(url.encode('utf-8')).hexdigest())
   download_file(url, fp, skip_if_exists=not getenv("NOCACHE"))
   with open(fp, "rb") as f:
@@ -27,7 +27,7 @@ def fetch_as_file(url):
   if url.startswith("/"):
     with open(url, "rb") as f:
       return f.read()
-  import hashlib
+    import hashlib
   fp = temp(hashlib.md5(url.encode('utf-8')).hexdigest())
   download_file(url, fp, skip_if_exists=not getenv("NOCACHE"))
   return fp
@@ -78,12 +78,12 @@ def my_unpickle(fb0):
       if module == "torch._utils":
         if name == "_rebuild_tensor_v2": return _rebuild_tensor_v2
         if name == "_rebuild_parameter": return _rebuild_parameter
-      else:
-        if module.startswith('pytorch_lightning'): return Dummy
-        try:
-          return super().find_class(module, name)
-        except Exception:
-          return Dummy
+        else:
+          if module.startswith('pytorch_lightning'): return Dummy
+          try:
+            return super().find_class(module, name)
+          except Exception:
+            return Dummy
 
     def persistent_load(self, pid):
       return pid


### PR DESCRIPTION
This should fix #1180 by using cache in `actions/setup-python@v4` to store the downloaded files and `actions/cache@v3` to skip installation by caching the python location if `setup.py` is not changed. `actions/cache@v3` stores `efficientnet` model as well by caching the `test/models/efficientnet`.