### PR TITLE
Match Torch speed for sum reduction on M1

### DIFF
--- a/test/external/external_test_opt.py
+++ b/test/external/external_test_opt.py
@@ -63,7 +63,7 @@ class TestInferenceMinKernels(unittest.TestCase):
     for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=p.dtype.np))
     img = Tensor.randn(1, 3, 224, 224)
     # TODO: this seems very high
-    with CLCache(115):
+    with CLCache(116):
       model.forward(img).realize()
 
   def test_resnet(self):

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -210,10 +210,10 @@ class LazyBuffer:
   def reduce_op(self:LazyBuffer, op:ReduceOps, new_shape:Tuple[int, ...]) -> LazyBuffer:
     if self.shape == tuple(new_shape): return self
     srcs = _push_movement_ops((self,)) if SHUFFLE_MOVEMENT_OPS else (self,)
-        
-    differences = [a != b for a,b in zip(self.shape, new_shape)]
-    if sum(differences) > 1:
-      last_difference = len(differences) - 1 - differences[::-1].index(True)
+
+    shape_differences = [a != b for a,b in zip(self.shape, new_shape)]
+    if sum(shape_differences) > 1:
+      last_difference = len(shape_differences) - 1 - shape_differences[::-1].index(True)
       intermediate_shape = tuple(new if i == last_difference else old for i, (new, old) in enumerate(zip(new_shape, self.shape)))
       return create_lazybuffer(self.device, ShapeTracker(intermediate_shape), ReduceOps, LazyOp(op, srcs, intermediate_shape), self.dtype).reduce_op(op, new_shape)
 

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -210,10 +210,11 @@ class LazyBuffer:
   def reduce_op(self:LazyBuffer, op:ReduceOps, new_shape:Tuple[int, ...]) -> LazyBuffer:
     if self.shape == tuple(new_shape): return self
     srcs = _push_movement_ops((self,)) if SHUFFLE_MOVEMENT_OPS else (self,)
-    
+        
     differences = [a != b for a,b in zip(self.shape, new_shape)]
     if sum(differences) > 1:
-      intermediate_shape = tuple(new if i == differences.index(True) else old for i, (new, old) in enumerate(zip(new_shape, self.shape)))
+      last_difference = len(differences) - 1 - differences[::-1].index(True)
+      intermediate_shape = tuple(new if i == last_difference else old for i, (new, old) in enumerate(zip(new_shape, self.shape)))
       return create_lazybuffer(self.device, ShapeTracker(intermediate_shape), ReduceOps, LazyOp(op, srcs, intermediate_shape), self.dtype).reduce_op(op, new_shape)
 
     return create_lazybuffer(self.device, ShapeTracker(new_shape), ReduceOps, LazyOp(op, srcs, new_shape), self.dtype)


### PR DESCRIPTION
This PR is for matching PyTorch speed on the sum reduction on Metal (https://github.com/tinygrad/tinygrad/issues/1167)

When tested on an M1 Max, we get the following results:


| test | Original | This PR |
| --- | --- | --- |
| sum 1024 x 1024 | 2.05x slower | 0.90x faster |
| sum 2048 x 2048 | 2.65x slower | 0.87x faster |
| sum 4096 x 4096 | 10.90x slower | 0.96x faster |
| sum 8192 x 8192 | 21.78x slower | 0.88x faster |
| sum 16384 x 16384 | 36.65x slower | 0.95x faster |
| cube_sum 256 x 256 x 256 | 11.62x slower | 0.91x faster |
| line_sum 4194304 | 2.85x slower | 0.98x faster |
| line_sum 16777216 | 10.29x slower | 0.96x faster |
| max 4096 x 4096 | 16.21x slower | 0.95x faster |


<details>
  <summary>Raw Results</summary>
NEW RESULTS

```
 sum                             1024x 1024    0.37 ms (    2.85 GFLOPS    11.45 GB/s) in torch,    0.33 ms (    3.17 GFLOPS    12.74 GB/s) in tinygrad,    0.90x faster       1.05 MOPS     4.23 MB
 sum                             2048x 2048    0.43 ms (    9.86 GFLOPS    39.59 GB/s) in torch,    0.37 ms (   11.31 GFLOPS    45.43 GB/s) in tinygrad,    0.87x faster       4.21 MOPS    16.91 MB
 sum                             4096x 4096    0.68 ms (   24.59 GFLOPS    98.75 GB/s) in torch,    0.66 ms (   25.59 GFLOPS   102.75 GB/s) in tinygrad,    0.96x faster      16.84 MOPS    67.63 MB
 sum                             8192x 8192    1.40 ms (   47.97 GFLOPS   192.64 GB/s) in torch,    1.23 ms (   54.73 GFLOPS   219.77 GB/s) in tinygrad,    0.88x faster      67.37 MOPS   270.53 MB
 sum                            16384x16384    3.68 ms (   73.26 GFLOPS   294.17 GB/s) in torch,    3.51 ms (   76.71 GFLOPS   308.05 GB/s) in tinygrad,    0.95x faster     269.48 MOPS  1082.13 MB
 cube_sum                   256x  256x  256    0.70 ms (   24.08 GFLOPS    96.71 GB/s) in torch,    0.63 ms (   26.54 GFLOPS   106.59 GB/s) in tinygrad,    0.91x faster      16.84 MOPS    67.63 MB
 line_sum                       4194304        0.42 ms (   10.12 GFLOPS    40.63 GB/s) in torch,    0.41 ms (   10.37 GFLOPS    41.64 GB/s) in tinygrad,    0.98x faster       4.21 MOPS    16.91 MB
 line_sum                       16777216       0.68 ms (   24.71 GFLOPS    99.22 GB/s) in torch,    0.66 ms (   25.66 GFLOPS   103.03 GB/s) in tinygrad,    0.96x faster      16.84 MOPS    67.63 MB
 max                             4096x 4096    0.69 ms (   24.55 GFLOPS    98.57 GB/s) in torch,    0.65 ms (   25.75 GFLOPS   103.40 GB/s) in tinygrad,    0.95x faster      16.84 MOPS    67.63 MB
```

OLD RESULTS
```
 sum                             1024x 1024    0.39 ms (    2.65 GFLOPS    10.62 GB/s) in torch,    0.81 ms (    1.29 GFLOPS     5.17 GB/s) in tinygrad,    2.05x slower       1.05 MOPS     4.19 MB
 sum                             2048x 2048    0.48 ms (    8.71 GFLOPS    34.85 GB/s) in torch,    1.28 ms (    3.29 GFLOPS    13.14 GB/s) in tinygrad,    2.65x slower       4.19 MOPS    16.78 MB
 sum                             4096x 4096    0.72 ms (   23.41 GFLOPS    93.63 GB/s) in torch,    7.81 ms (    2.15 GFLOPS     8.59 GB/s) in tinygrad,   10.90x slower      16.78 MOPS    67.11 MB
 sum                             8192x 8192    1.34 ms (   50.20 GFLOPS   200.79 GB/s) in torch,   29.12 ms (    2.30 GFLOPS     9.22 GB/s) in tinygrad,   21.78x slower      67.11 MOPS   268.44 MB
 sum                            16384x16384    3.57 ms (   75.09 GFLOPS   300.38 GB/s) in torch,  131.02 ms (    2.05 GFLOPS     8.20 GB/s) in tinygrad,   36.65x slower     268.44 MOPS  1073.74 MB
 cube_sum                   256x  256x  256    0.64 ms (   26.40 GFLOPS   105.59 GB/s) in torch,    7.39 ms (    2.27 GFLOPS     9.09 GB/s) in tinygrad,   11.62x slower      16.78 MOPS    67.11 MB
 line_sum                       4194304        0.43 ms (    9.85 GFLOPS    39.40 GB/s) in torch,    1.21 ms (    3.46 GFLOPS    13.85 GB/s) in tinygrad,    2.85x slower       4.19 MOPS    16.78 MB
 line_sum                       16777216       0.71 ms (   23.59 GFLOPS    94.35 GB/s) in torch,    7.32 ms (    2.29 GFLOPS     9.17 GB/s) in tinygrad,   10.29x slower      16.78 MOPS    67.11 MB
 max                             4096x 4096    0.69 ms (   24.22 GFLOPS    96.86 GB/s) in torch,   11.23 ms (    1.49 GFLOPS     5.98 GB/s) in tinygrad,   16.21x slower      16.78 MOPS    67.11 MB
```
</details>

---

Todo:
- [x] Detect when a reduction *can* be split, and split the reduction
- [x] Disassemble the MPS method is doing anything that we've completely missed to avoid needing 2 kernels
- [x] Guard against performing this reduction on non-Metal devices
- [x] Test whether we should strictly split the reduction into 2 kernels, or whether we continue splitting `n` times (current behavior) -> Limited to 2 kernels max
- [x] Test case to ensure splitting to multiple kernels maintains correctness
- [x] Fix tests
- [ ] Find way to run both code paths for tests even when on small reductions


---

OUTDATED: Discussion in comments has more detail!

This PR is taking the 'two kernels' approach.

I've quite thouroughly tested various single kernel approaches. As [Matthew points out](https://betterprogramming.pub/optimizing-parallel-reduction-in-metal-for-apple-m1-8e8677b49b01), Metal has no global synchronization primitives, and so 

> Consequently, this usually implies that when the number of values to reduce is too large to do in a single threadgroup, a multilevel strategy is employed where threadgroups are dispatched and reduce their respective values into a partial reduction array.
> A second kernel dispatch occurs to reduce the partial reduction values, and so on, until the operation is complete. 

Global atomics for 32-bit signed and unsigned integers are available and are more preformant than the two kernel approach, but not for floating-point types.

He makes a strong case that the multiple kernel approach is really the only option for large reductions. Regardless, I'll disassemble the MPS method to confirm the logic here.

Matthew also points out a handwritten kernel with some clever SIMD tricks could futher improve the single-kernel approach, but the complexity of code-genning this makes me believe it's not yet worth it.


