### PR TITLE
Fix view merging for masked views (issue #1152)

### DIFF
--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -92,7 +92,7 @@ def merge_views(vm2:View, vm1:View) -> Optional[View]:
   if None in strides: return None
   return View(vm1.shape, cast(Tuple[int, ...], strides), mst.real_offset(), merge_masks(vm1.mask, vm2.mask))
 
-# def merge_masks(mask1, mask2): return [m1 or m2 for m1, m2 in zip(mask1, mask2)] if mask1 and mask2 else mask1 or mask2
+@functools.lru_cache(maxsize=None)
 def merge_masks(mask1, mask2):
     if not mask1 or not mask2:
         return mask1 or mask2

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -86,11 +86,18 @@ def view_from_shape(shape:Tuple[int, ...]) -> View:
 
 @functools.lru_cache(maxsize=None)
 def merge_views(vm2:View, vm1:View) -> Optional[View]:
-  if vm2.mask: return None  # this isn't supported yet
+  if vm1 is None or vm2 is None: return None
   mst = ShapeTracker(vm1.shape, [vm2, vm1])
   strides = mst.real_strides()
   if None in strides: return None
-  return View(vm1.shape, cast(Tuple[int, ...], strides), mst.real_offset(), vm1.mask)
+  return View(vm1.shape, cast(Tuple[int, ...], strides), mst.real_offset(), merge_masks(vm1.mask, vm2.mask))
+
+# def merge_masks(mask1, mask2): return [m1 or m2 for m1, m2 in zip(mask1, mask2)] if mask1 and mask2 else mask1 or mask2
+def merge_masks(mask1, mask2):
+    if not mask1 or not mask2:
+        return mask1 or mask2
+    else:
+        return tuple(tuple(m1 or m2 for m1, m2 in zip(t1, t2)) for t1, t2 in zip(mask1, mask2))
 
 @functools.lru_cache(maxsize=None)
 def _reshape(view: View, new_shape: Tuple[int, ...]) -> Tuple[View, bool]:


### PR DESCRIPTION
**Description:**
This PR addresses the issue of view merging when dealing with masked views #1152 . The changes involve the addition of new unit tests, the creation of the merge_masks function, and modifications to the merge_views function.

I have:

Introduced a **merge_masks** function in **shapetracker.py** to combine masks logically. The **merge_views** function is now updated to utilize this and handle masked views. Added relevant unit tests for these functions.

**Affected Files:**

```
test/unit/test_shapetracker.py
tinygrad/shape/shapetracker.py
```
**Commit Messages:**

Fix view merging for masked views - 1152
Removed commented out code
I am looking forward to your feedback.

**Checklist:**

- [x] My code follows the repository's contribution guidelines.
- [x]  I have performed a self-review of my own code.
- [x]  I have added tests that prove my fix is effective or that my feature works.
- [x]  All new and existing tests passed.