### PR TITLE
Fix bug where Tensor.randn returns inf

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -145,7 +145,8 @@ class TestTinygrad(unittest.TestCase):
         b = random_fn(10,10).realize()
         np.testing.assert_allclose(a.numpy(), b.numpy())
 
-  def test_randn_isnt_inf(self):
+  def test_randn_isnt_inf_on_zero(self):
+    # simulate failure case of rand handing a zero to randn
     original_rand, Tensor.rand = Tensor.rand, Tensor.zeros
     try: self.assertNotIn(np.inf, Tensor.randn(16).numpy())
     except: raise

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -145,6 +145,13 @@ class TestTinygrad(unittest.TestCase):
         b = random_fn(10,10).realize()
         np.testing.assert_allclose(a.numpy(), b.numpy())
 
+  def test_randn_isnt_inf(self):
+    tensor_rand = Tensor.rand
+    Tensor.rand = Tensor.zeros
+    try: self.assertNotIn(np.inf, Tensor.randn(16).numpy())
+    except: raise
+    finally: Tensor.rand = tensor_rand
+
   def test_zeros_like_has_same_dtype(self):
     for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
       a = Tensor([1, 2, 3], dtype=datatype)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -146,11 +146,10 @@ class TestTinygrad(unittest.TestCase):
         np.testing.assert_allclose(a.numpy(), b.numpy())
 
   def test_randn_isnt_inf(self):
-    tensor_rand = Tensor.rand
-    Tensor.rand = Tensor.zeros
+    original_rand, Tensor.rand = Tensor.rand, Tensor.zeros
     try: self.assertNotIn(np.inf, Tensor.randn(16).numpy())
     except: raise
-    finally: Tensor.rand = tensor_rand
+    finally: Tensor.rand = original_rand
 
   def test_zeros_like_has_same_dtype(self):
     for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -177,7 +177,7 @@ class Tensor:
   def randn(*shape, dtype:Optional[DType]=None, **kwargs) -> Tensor:
     # https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
     src = Tensor.rand(2, *shape, **kwargs)
-    return src[0].mul(2*pi).cos().mul(src[1].log().mul(-2).sqrt()).cast(Tensor.default_type if dtype is None else dtype)
+    return src[0].mul(2*pi).cos().mul(((1 - src[1])).log().mul(-2).sqrt()).cast(Tensor.default_type if dtype is None else dtype)
 
   @staticmethod
   def uniform(*shape, low=-1.0, high=1.0, **kwargs) -> Tensor: return ((high-low) * Tensor.rand(*shape, **kwargs)) + low


### PR DESCRIPTION
Tensor.randn can return ±inf in the rare case of our RNG returning a 0. The cause is the log function in the Box-Muller transform we use for randn.

PyTorch also uses Box-Muller, but avoid this issue by mapping the RNG value from `[0, 1) -> (0, 1]`. This PR implements that fix. [[src]](https://github.com/pytorch/pytorch/blob/91dcc3b2726aa33ca9a30dfb8d165d8ec7b7bba3/aten/src/ATen/native/cpu/DistributionTemplates.h#L142)

---

Since zeros values are extremely rare, it's a bit of a pain to test. I mined a seed that would reproduce the bug on the current implementation, but I didn't add it because it seems too specific. Let me know if you want me to add it, or if you have a better test in mind.

```python
def test_randn_isnt_inf(self):
  Tensor.manual_seed(195866)
  a = Tensor.randn(128)
  assert not np.any(np.isinf(a.numpy()))
```
