### PR TITLE
Revert "Cancel previous workflow runs on new commits"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   linter:
     name: Linters


### PR DESCRIPTION
Reverts tinygrad/tinygrad#1184

Going to revert this, it's annoying to see the Xs when there's no bugs, like on #1193.

It makes debugging harder, and hopefully with the timeout it's fine.