### PR TITLE
implement common subexpression elimination

### DIFF
--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -372,8 +372,7 @@ class Linearizer:
       # Reorder sources to put constants first so get_grouped_maybe_float4 can fold the op
       srcs = sorted(x.src, key=lambda x: (x.realized.__class__ != RawConst) if x.__class__ == LazyBuffer else 0)
       x.src = tuple(srcs)
-    if x in self.saved_exprs:
-      return self.saved_exprs[x]
+    if x in self.saved_exprs: return self.saved_exprs[x]
     values = [self.ast_parse(v, acc, loaded_buffers, ssa) for v in x.src]
     if x.op.__class__ in {ReduceOps, FusedOps}:
       ret = [(idx, self.uop(UOps.ALU, val[-1], list(val), {ReduceOps.SUM:BinaryOps.ADD, ReduceOps.MAX:BinaryOps.MAX, FusedOps.MULACC:FusedOps.MULACC}[x.op])) for idx, val in get_grouped_maybe_float4(*values, acc, grouping_allowed=self.supports_float4_alu)]

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -240,6 +240,7 @@ class Linearizer:
   def linearize(self):
     # uops
     self.uops: List[UOp] = []
+    self.alu_exprs = dict()
 
     # add a local buffer for multistage reduce
     if len(self.group_for_reduce):
@@ -354,6 +355,9 @@ class Linearizer:
 
   _OT = TypeVar("_OT")
   def uop(self, uop:UOps, out:_OT, vin:List[Token], arg:Any=None) -> _OT:
+    if uop == UOps.ALU:
+      if (arg, *vin) in self.alu_exprs: return self.alu_exprs[(arg, *vin)]
+      self.alu_exprs[(arg, *vin)] = out
     self.uops.append(UOp(uop, cast(Optional[Token], out), vin, arg))
     if DEBUG >= 4: print(self.uops[-1])
     return out

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -240,7 +240,6 @@ class Linearizer:
   def linearize(self):
     # uops
     self.uops: List[UOp] = []
-    self.alu_exprs = dict()
 
     # add a local buffer for multistage reduce
     if len(self.group_for_reduce):
@@ -355,9 +354,6 @@ class Linearizer:
 
   _OT = TypeVar("_OT")
   def uop(self, uop:UOps, out:_OT, vin:List[Token], arg:Any=None) -> _OT:
-    if uop == UOps.ALU:
-      if (arg, *vin) in self.alu_exprs: return self.alu_exprs[(arg, *vin)]
-      self.alu_exprs[(arg, *vin)] = out
     self.uops.append(UOp(uop, cast(Optional[Token], out), vin, arg))
     if DEBUG >= 4: print(self.uops[-1])
     return out

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -372,20 +372,20 @@ class Linearizer:
       # Reorder sources to put constants first so get_grouped_maybe_float4 can fold the op
       srcs = sorted(x.src, key=lambda x: (x.realized.__class__ != RawConst) if x.__class__ == LazyBuffer else 0)
       x.src = tuple(srcs)
-    if x in self.saved_exprs: return self.saved_exprs[x]
-    values = [self.ast_parse(v, acc, loaded_buffers, ssa) for v in x.src]
-    if x.op.__class__ in {ReduceOps, FusedOps}:
-      ret = [(idx, self.uop(UOps.ALU, val[-1], list(val), {ReduceOps.SUM:BinaryOps.ADD, ReduceOps.MAX:BinaryOps.MAX, FusedOps.MULACC:FusedOps.MULACC}[x.op])) for idx, val in get_grouped_maybe_float4(*values, acc, grouping_allowed=self.supports_float4_alu)]
-    else:
-      ret = [(idx, self.uop(UOps.ALU, ssa('alu', dtypes._float4) if any(x.dtype == dtypes._float4 and x.offset is None for x in val) else ssa('alu'), list(val), x.op)) for idx, val in get_grouped_maybe_float4(*values, grouping_allowed=self.supports_float4_alu and x.op!=BinaryOps.CMPEQ)]
-    ordered_ret: List[Optional[Token]] = [None]*len(values[0])
-    # scatter
-    for i,j in ret:
-      for o,k in enumerate(i):
-        ordered_ret[k] = Token(j.name, j.dtype, o) if j.dtype == dtypes._float4 else j
-    assert all(isinstance(x, Token) for x in ordered_ret), "some tokens didn't get scattered?"
-    self.saved_exprs[x] = cast(List[Token], ordered_ret)
-    return cast(List[Token], ordered_ret)
+    if x not in self.saved_exprs:
+      values = [self.ast_parse(v, acc, loaded_buffers, ssa) for v in x.src]
+      if x.op.__class__ in {ReduceOps, FusedOps}:
+        ret = [(idx, self.uop(UOps.ALU, val[-1], list(val), {ReduceOps.SUM:BinaryOps.ADD, ReduceOps.MAX:BinaryOps.MAX, FusedOps.MULACC:FusedOps.MULACC}[x.op])) for idx, val in get_grouped_maybe_float4(*values, acc, grouping_allowed=self.supports_float4_alu)]
+      else:
+        ret = [(idx, self.uop(UOps.ALU, ssa('alu', dtypes._float4) if any(x.dtype == dtypes._float4 and x.offset is None for x in val) else ssa('alu'), list(val), x.op)) for idx, val in get_grouped_maybe_float4(*values, grouping_allowed=self.supports_float4_alu and x.op!=BinaryOps.CMPEQ)]
+      ordered_ret: List[Optional[Token]] = [None]*len(values[0])
+      # scatter
+      for i,j in ret:
+        for o,k in enumerate(i):
+          ordered_ret[k] = Token(j.name, j.dtype, o) if j.dtype == dtypes._float4 else j
+      assert all(isinstance(x, Token) for x in ordered_ret), "some tokens didn't get scattered?"
+      self.saved_exprs[x] = cast(List[Token], ordered_ret)
+    return self.saved_exprs[x]
 
   @property
   def first_reduce(self) -> int: return [x!=y for x,y in zip(self.sts[0].shape[:self.shape_len-self.upcasted]+(0,), self.full_shape[:self.shape_len-self.upcasted]+(1,))].index(True)


### PR DESCRIPTION
fixes: #1198 

remaining:
 - [x] proper type annotations
 - [x] avoid skipping identifier suffixes

example:
```python
from tinygrad.tensor import Tensor

a, b = Tensor(2), Tensor(5)
((a+b) * (a+b)).realize()
```

codegen before change:
```c
void E_(float* restrict data0) {
  float val1_0 = 2.0f;
  float val2_0 = 5.0f;
  float alu0 = (val1_0+val2_0);
  float alu1 = (val1_0+val2_0);
  float alu2 = (alu0*alu1);
  data0[0] = alu2;
  /* global+local */
}
```

after change:
```c
void E_(float* restrict data0) {
  float val1_0 = 2.0f;
  float val2_0 = 5.0f;
  float alu0 = (val1_0+val2_0);
  float alu1 = (alu0*alu0);
  data0[0] = alu1;
  /* global+local */
}
```
