### PR TITLE
adding `param_group` to `Optimizer`

### DIFF
--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -10,7 +10,7 @@ class Optimizer:
     self.param_groups = []
     param_groups = list(params)
     if not param_groups: param_groups = [{'params': []}]
-    if not isinstance(param_groups[0], dict): param_groups = [{'params': param_groups}]
+    elif not isinstance(param_groups[0], dict): param_groups = [{'params': param_groups}]
     for param_group in param_groups: self.add_param_group(param_group)
 
   def zero_grad(self):

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -6,11 +6,10 @@ from tinygrad.tensor import Tensor
 class Optimizer:
   def __init__(self, params: List[Union[Dict, Tensor]],  lr: float):
     self.param_groups = []
-    
     param_groups = list(params)
-    if not isinstance(param_groups[0], dict): param_groups = [{'params': param_groups}]
+    param_groups = [{'params': param_groups}] if not isinstance(param_groups[0], dict) else param_groups
     for param_group in param_groups: self.add_param_group(param_group)
-    
+
     self.lr = Tensor([lr], requires_grad=False)
 
   def zero_grad(self):

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -1,70 +1,89 @@
 # sorted in order of increasing complexity
-from typing import List
+from typing import List, Union, Dict
 from tinygrad.helpers import dedup
 from tinygrad.tensor import Tensor
 
 class Optimizer:
-  def __init__(self, params: List[Tensor], lr: float):
-    # if it's None, but being put into an optimizer, set it to True
-    for x in params:
-      if x.requires_grad is None: x.requires_grad = True
+  def __init__(self, params: List[Union[Dict, Tensor]],  lr: float):
+    self.param_groups = []
 
-    self.params: List[Tensor] = dedup([x for x in params if x.requires_grad])
-    self.buffers: List[Tensor] = dedup([x for x in params if not x.requires_grad])   # buffers are still realized
+    param_groups = list(params)
+
+    if not isinstance(param_groups[0], dict):
+      param_groups = [{'params': param_groups}] #default lr
+    
+    for param_group in param_groups:
+      self.add_param_group(param_group)
+    
     self.lr = Tensor([lr], requires_grad=False)
 
   def zero_grad(self):
-    for param in self.params: param.grad = None
+    for param_group in self.param_groups:
+      for param in param_group['params']: param.grad = None
 
-  def realize(self, extra=None):
-    # TODO: corealize
-    # NOTE: in extra is too late for most of the params due to issues with assign
-    for p in extra + self.params + self.buffers if extra is not None else self.params + self.buffers:
+  def add_param_group(self, param_group):
+    for x in param_group['params']:
+      if x.requires_grad is None: x.requires_grad = True
+
+    param_group['params']: List[Tensor] = dedup([x for x in param_group['params'] if x.requires_grad])
+    param_group['buffers']: List[Tensor] = dedup([x for x in param_group['params'] if not x.requires_grad])
+
+    self.param_groups.append(param_group)
+
+  def realize(self, param_group=None, extra=None):
+    self.realize_group(param_group, extra) if param_group else (self.realize_group(param_group, extra) for param_group in self.param_groups)
+
+  def realize_group(self, param_group, extra=None):
+    for p in extra + param_group['params'] + param_group['buffers'] if extra is not None else param_group['params'] + param_group['buffers']:
       p.realize()
 
 class SGD(Optimizer):
-  def __init__(self, params: List[Tensor], lr=0.001, momentum=0, weight_decay=0.0, nesterov=False):
+  def __init__(self, params: List[Union[Dict, Tensor]], lr=0.001, momentum=0, weight_decay=0.0, nesterov=False):
     super().__init__(params, lr)
-    self.momentum, self.wd, self.nesterov = momentum, weight_decay, nesterov
-    self.b = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in self.params] if self.momentum else []
+    self.lr, self.momentum, self.wd, self.nesterov = lr, momentum, weight_decay, nesterov
+    for param_group in self.param_groups:
+      param_group['b'] = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in param_group['params']] if self.momentum else []
 
   # https://pytorch.org/docs/stable/generated/torch.optim.SGD.html
   def step(self) -> None:
-    for i, t in enumerate(self.params):
-      assert t.grad is not None
-      g = t.grad.realize() + self.wd * t.detach()
-      if self.momentum:
-        self.b[i].assign(self.momentum * self.b[i] + g).realize()  # NOTE: self.b[i] is zero on the first run, no if required
-        g = (g + self.momentum * self.b[i]) if self.nesterov else self.b[i]
-      t.assign(t.detach() - g * self.lr)
-    self.realize(self.b)
-
-# LAMB is essentially just the trust ratio part of LARS applied to Adam/W so if we just set the trust ratio to 1.0 its just Adam/W.
-def AdamW(params: List[Tensor], lr=0.001, b1=0.9, b2=0.999, eps=1e-8, wd=0.01): return LAMB(params, lr, b1, b2, eps, wd, adam=True)
-def Adam(params: List[Tensor], lr=0.001, b1=0.9, b2=0.999, eps=1e-8): return LAMB(params, lr, b1, b2, eps, 0.0, adam=True)
+    for param_group in self.param_groups:
+      for i, t in enumerate(param_group['params']):
+        assert t.grad is not None
+        g = t.grad.realize() + self.wd * t.detach()
+        if self.momentum:
+          param_group['b'][i].assign(self.momentum * param_group['b'][i] + g).realize()  # NOTE: param_group['b'][i] is zero on the first run, no if required
+          g = (g + self.momentum * param_group['b'][i]) if self.nesterov else param_group['b'][i]
+        t.assign(t.detach() - g * param_group.get('lr', self.lr))
+      self.realize(param_group, param_group['b'])
 
 class LAMB(Optimizer):
-  def __init__(self, params: List[Tensor], lr=0.001, b1=0.9, b2=0.999, eps=1e-6, wd=0.0, adam=False):
+  def __init__(self, params: List[Union[Dict, Tensor]], lr=0.001, b1=0.9, b2=0.999, eps=1e-6, wd=0.0, adam=False):
     super().__init__(params, lr)
-    self.b1, self.b2, self.eps, self.wd, self.adam, self.t = b1, b2, eps, wd, adam, Tensor([0], requires_grad=False).realize()
-    self.m = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in self.params]
-    self.v = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in self.params]
+    self.lr, self.b1, self.b2, self.eps, self.wd, self.adam, self.t = lr, b1, b2, eps, wd, adam, Tensor([0], requires_grad=False).realize()
+    for param_group in self.param_groups:
+      param_group['m'] = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in param_group['params']]
+      param_group['v'] = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in param_group['params']]
 
   def step(self) -> None:
     self.t.assign(self.t + 1).realize()
-    for i, t in enumerate(self.params):
-      assert t.grad is not None
-      g = t.grad.realize()
-      self.m[i].assign(self.b1 * self.m[i] + (1.0 - self.b1) * g).realize()
-      self.v[i].assign(self.b2 * self.v[i] + (1.0 - self.b2) * (g * g)).realize()
-      m_hat = self.m[i] / (1.0 - self.b1**self.t)
-      v_hat = self.v[i] / (1.0 - self.b2**self.t)
-      up = (m_hat / (v_hat.sqrt() + self.eps)) + self.wd * t.detach()
-      if not self.adam:
-        r1 = t.detach().square().sum().sqrt()
-        r2 = up.square().sum().sqrt()
-        r = Tensor.where(r1 > 0, Tensor.where(r2 > 0, r1 / r2, 1.0), 1.0)
-      else:
-        r = 1.0
-      t.assign(t.detach() - self.lr * r * up)
-    self.realize([self.t] + self.m + self.v)
+    for param_group in self.param_groups:
+      for i, t in enumerate(param_group['params']):
+        assert t.grad is not None
+        g = t.grad.realize()
+        param_group['m'][i].assign(self.b1 * param_group['m'][i] + (1.0 - self.b1) * g).realize()
+        param_group['v'][i].assign(self.b2 * param_group['v'][i] + (1.0 - self.b2) * (g * g)).realize()
+        m_hat = param_group['m'][i] / (1.0 - self.b1**self.t)
+        v_hat = param_group['v'][i] / (1.0 - self.b2**self.t)
+        up = (m_hat / (v_hat.sqrt() + self.eps)) + self.wd * t.detach()
+        if not self.adam:
+          r1 = t.detach().square().sum().sqrt()
+          r2 = up.square().sum().sqrt()
+          r = Tensor.where(r1 > 0, Tensor.where(r2 > 0, r1 / r2, 1.0), 1.0)
+        else:
+          r = 1.0
+        t.assign(t.detach() - param_group.get('lr', self.lr) * r * up)
+      self.realize(param_group, [self.t] + param_group['m'] + param_group['v'])
+
+# LAMB is essentially just the trust ratio part of LARS applied to Adam/W so if we just set the trust ratio to 1.0 its just Adam/W.
+def AdamW(params: List[Union[Dict, Tensor]], lr=0.001, b1=0.9, b2=0.999, eps=1e-8, wd=0.01): return LAMB(params, lr, b1, b2, eps, wd, adam=True)
+def Adam(params: List[Union[Dict, Tensor]], lr=0.001, b1=0.9, b2=0.999, eps=1e-8): return LAMB(params, lr, b1, b2, eps, 0.0, adam=True)

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -6,14 +6,10 @@ from tinygrad.tensor import Tensor
 class Optimizer:
   def __init__(self, params: List[Union[Dict, Tensor]],  lr: float):
     self.param_groups = []
-
-    param_groups = list(params)
-
-    if not isinstance(param_groups[0], dict): 
-      param_groups = [{'params': param_groups}]
     
-    for param_group in param_groups: 
-      self.add_param_group(param_group)
+    param_groups = list(params)
+    if not isinstance(param_groups[0], dict): param_groups = [{'params': param_groups}]
+    for param_group in param_groups: self.add_param_group(param_group)
     
     self.lr = Tensor([lr], requires_grad=False)
 

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -7,7 +7,7 @@ class Optimizer:
   def __init__(self, params: List[Union[Dict, Tensor]],  lr: float):
     self.lr = Tensor([lr], requires_grad=False)
 
-    self.param_groups = []
+    self.param_groups: List[Dict] = []
     param_groups = list(params)
     if not param_groups: param_groups = [{'params': []}]
     elif not isinstance(param_groups[0], dict): param_groups = [{'params': param_groups}]

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -7,7 +7,7 @@ class Optimizer:
   def __init__(self, params: List[Union[Dict, Tensor]],  lr: float):
     self.param_groups = []
     param_groups = list(params)
-    param_groups = [{'params': param_groups}] if not isinstance(param_groups[0], dict) else param_groups
+    if not isinstance(param_groups[0], dict): param_groups = [{'params': param_groups}]
     for param_group in param_groups: self.add_param_group(param_group)
 
     self.lr = Tensor([lr], requires_grad=False)


### PR DESCRIPTION
Using the recommendations from https://github.com/tinygrad/tinygrad/pull/1147. I'm proposing adding `param_groups` to the `Optimizer` so that the user can augment the parameters individually. The syntax would be similar to `torch`. This change functionally accomplishes what I had been using with `lr_mult` before

`torch`
```
class Net(nn.Module):
    def __init__(self):
        super(Net, self).__init__()
        self.layer1 = nn.Linear(1, 1)
        self.layer1.weight.data.fill_(1)
        self.layer1.bias.data.fill_(1)
        self.layer2 = nn.Linear(1, 1)
        self.layer2.weight.data.fill_(1)
        self.layer2.bias.data.fill_(1)
    def forward(self, x):
        x = self.layer1(x)
        return self.layer2(x)
net = Net()
optimizer = optim.Adam([
            {'params': net.layer1.weight},
            {'params': net.layer1.bias, 'lr': 0.01, 'weight_decay': 0.001},
            {'params': net.layer2.weight, 'lr': 0.001}
        ], lr=0.1, weight_decay=0.0001)
```
`tinygrad`
```
net = ResNet50()
parameters = get_parameters(net)
optimizer1 = Adam(
    [
        {'params': parameters[:20], 'lr': 0.001, 'wd': 0.001},
        {'params': parameters[20:-3], 'lr': 0.01, 'eps': 1e-2},
        {'params': parameters[-3:]}
    ], lr=0.1)
optimizer2 = Adam(parameters, lr=0.1)
```
