### PR TITLE
[perf] use optimize=True in np.einsum

### DIFF
--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -35,7 +35,7 @@ numpy_fxn_for_op: Dict[Op, Callable] = {**base_fxn_for_op, **{
   BinaryOps.MAX: np.maximum, BinaryOps.CMPEQ: lambda x,y: (x==y).astype(np.promote_types(x.dtype,y.dtype)), BinaryOps.MUL: lambda x, y: np.multiply(*match_types(x, y)), UnaryOps.SQRT: np.sqrt,
   MovementOps.PERMUTE: lambda x, order: x.transpose(order), MovementOps.PAD: np.pad, MovementOps.EXPAND: np.broadcast_to,
   MovementOps.STRIDE: lambda x, arg: x[tuple(slice(None, None, i) for i in arg)],
-  FusedOps.MULACC: einsum_mulacc(lambda s,a,b: np.einsum(s, a.copy(), b.copy()), lambda x: x.strides, np.broadcast_to),
+  FusedOps.MULACC: einsum_mulacc(lambda s,a,b: np.einsum(s, a.copy(), b.copy(), optimize=True), lambda x: x.strides, np.broadcast_to),
 }}
 
 class RawNumpyBuffer(RawBuffer):


### PR DESCRIPTION
local testing (test/test_net_speed.py) yields:
```
# optimize=False (default)
forward pass:  185.863 ms, 7.83x off baseline 23.746 ms
backward pass: 820.215 ms, 20.74x off baseline 39.543 ms

# optimize=True (pr change)
forward pass:  157.368 ms, 6.85x off baseline 22.983 ms
backward pass: 209.347 ms, 5.66x off baseline 36.967 ms
```

central tendency for `optimize=True` is around 8x and 20x. `optimize=False` is around 7.5x and 5.5x. I could compile an n=1000 analysis if that would be helpful in analyzing the change.

Reading:
 -  https://numpy.org/doc/stable/reference/generated/numpy.einsum.html
 -  https://stackoverflow.com/questions/49265044/numpy-einsum-path-differences-and-the-optimize-argument