### PR TITLE
[READY] ci: don't install recommended packages for GPU

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,7 +247,7 @@ jobs:
         export DEBIAN_FRONTEND=noninteractive
         sudo apt-get update -y
     - name: Install packages
-      run: sudo apt-get install -y git g++ cmake ninja-build llvm-15-dev libz-dev libglew-dev flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-toolkit-gcc
+      run: sudo apt-get install -y --no-install-recommends git g++ cmake ninja-build llvm-15-dev libz-dev libglew-dev flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-toolkit-gcc
     - name: Cache gpuocelot
       id: cache-build
       uses: actions/cache@v3


### PR DESCRIPTION
CI: don't install the recommended packages for the GPU test, saves a GB of installs and a bit more than a minute.

Before
Install dependencies: 2m 37s
```
Need to get 2054 MB of archives.
After this operation, 5981 MB of additional disk space will be used.
```

After
Install dependencies: 1m 12s
```
Need to get 1491 MB of archives.
After this operation, 4633 MB of additional disk space will be used.
```