### PR TITLE
Fix argfix

### DIFF
--- a/models/mask_rcnn.py
+++ b/models/mask_rcnn.py
@@ -5,7 +5,7 @@ import numpy as np
 from pathlib import Path
 from tinygrad import nn
 from tinygrad.tensor import Tensor
-from tinygrad.helpers import dtypes
+from tinygrad.helpers import argsort, dtypes
 from extra.utils import get_child, download_file
 from tinygrad.state import torch_load
 from models.resnet import ResNet
@@ -1004,7 +1004,7 @@ class Pooler:
           all_idxs.extend(idx_in_level)
           results.append(pooler_output)
 
-      return tensor_gather(Tensor.cat(*results), [x[0] for x in sorted({i:idx for i, idx in enumerate(all_idxs)}.items(), key=lambda x: x[1])])
+      return tensor_gather(Tensor.cat(*results), argsort(all_idxs))
 
 
 class FPNPredictor:

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -192,5 +192,14 @@ class TestTinygrad(unittest.TestCase):
     for _, dtype in dtypes.fields().items():
       assert dtype.itemsize == Tensor.randn(3, dtype=dtype).element_size(), f"Tensor.element_size() not matching Tensor.dtype.itemsize for {dtype}"
 
+  def test_argfix(self):
+    self.assertEqual(Tensor.zeros().shape, ())
+    self.assertEqual(Tensor.zeros(tuple()).shape, ())
+    self.assertEqual(Tensor.zeros(1).shape, (1,))
+    self.assertEqual(Tensor.zeros((1,)).shape, (1,))
+    self.assertEqual(Tensor.zeros(1, 2, 3).shape, (1, 2, 3))
+    self.assertEqual(Tensor.zeros((1, 2, 3)).shape, (1, 2, 3))
+    self.assertEqual(Tensor.zeros([1, 2, 3]).shape, (1, 2, 3))
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/graph.py
+++ b/tinygrad/graph.py
@@ -53,7 +53,7 @@ def log_op(ret: LazyBuffer, ast: LazyOp, show_graph: Optional[bool] = None, phan
   op: List[Op] = [x.op for x in ast.get_lazyops()]
   inp: List[LazyBuffer] = [x for x in ast.buffers if not isinstance(x.realized, RawConst) or GRAPH > 1]
   oporder = [LoadOps, FusedOps, ReduceOps, BinaryOps, UnaryOps, MovementOps]
-  optype = type(sorted(op, key=lambda x: oporder.index(type(x)))[0])
+  optype = min((type(x) for x in op), key=oporder.index)
   cnts[optype] += 1
   if DEBUG >= 6: print(f"{op} : {', '.join([f'{x.shape}-<{nm(x)}>' for x in inp])} -> {ret.shape}-<{nm(ret)}>")
   if show_graph:

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -11,11 +11,7 @@ ShapeType = Tuple[int, ...]
 OSX = platform.system() == "Darwin"
 
 def dedup(x): return list(dict.fromkeys(x))   # retains list order
-def argfix(*x):
-  if x[0].__class__ in {tuple, list}:
-    try: return tuple(x[0])
-    except IndexError: return tuple()
-  return tuple(x)
+def argfix(*x): return tuple(x[0]) if x and x[0].__class__ in (tuple, list) else x
 def argsort(x): return type(x)(sorted(range(len(x)), key=x.__getitem__)) # https://stackoverflow.com/questions/3382352/equivalent-of-numpy-argsort-in-basic-python
 def all_same(items): return all(x == items[0] for x in items)
 def colored(st, color, background=False): return f"\u001b[{10*background+60*(color.upper() == color)+30+['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'].index(color.lower())}m{st}\u001b[0m" if color is not None else st  # replace the termcolor library with one line

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -46,7 +46,7 @@ class LazyOp:
     return self.op == __value.op and self.src == __value.src and self.arg == __value.arg
   def __hash__(self) -> int: return hash((self.op, self.src, self.arg))
   @property
-  def key(self): return (self.op, tuple(getattr(x, "key", x) for x in self.src), getattr(self.arg, "key", self.arg))
+  def key(self): return (self.op, tuple([getattr(x, "key", x) for x in self.src]), getattr(self.arg, "key", self.arg))
 
   # Any == Union[LazyBuffer, DeviceBuffer]
   def map_buffers(self, real_srcs: Dict[Any, Any]) -> LazyOp: return LazyOp(self.op, tuple([y.map_buffers(real_srcs) for y in self.src]), self.arg)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -46,7 +46,7 @@ class LazyOp:
     return self.op == __value.op and self.src == __value.src and self.arg == __value.arg
   def __hash__(self) -> int: return hash((self.op, self.src, self.arg))
   @property
-  def key(self): return (self.op, tuple(map(lambda x: getattr(x, "key", x), self.src)), getattr(self.arg, "key", self.arg))
+  def key(self): return (self.op, tuple(getattr(x, "key", x) for x in self.src), getattr(self.arg, "key", self.arg))
 
   # Any == Union[LazyBuffer, DeviceBuffer]
   def map_buffers(self, real_srcs: Dict[Any, Any]) -> LazyOp: return LazyOp(self.op, tuple([y.map_buffers(real_srcs) for y in self.src]), self.arg)


### PR DESCRIPTION
argfix for 0 arguments got broken in #987, this fixes it and adds a couple of tests to make sure it keeps working

the author of the change says it was "statistical optimization" (https://github.com/tinygrad/tinygrad/pull/987#discussion_r1231584626) but in my benchmarks my version is comparable (possibly even a little bit faster) across all use cases:

```python
import timeit

def argfix_old(*x):
  if x[0].__class__ in {tuple, list}:
    try: return tuple(x[0])
    except IndexError: return tuple()
  return tuple(x)

def argfix_new(*x): return tuple(x[0]) if x and x[0].__class__ in (tuple, list) else x

N = 1_000_000
for argfix in (argfix_old, argfix_new):
    print(argfix.__name__)
    print(timeit.timeit("argfix(1, 2, 3)", number=N, globals={"argfix": argfix}))
    print(timeit.timeit("argfix(1)", number=N, globals={"argfix": argfix}))
    print(timeit.timeit("argfix((1,2,3))", number=N, globals={"argfix": argfix}))
    print(timeit.timeit("argfix([1,2,3])", number=N, globals={"argfix": argfix}))
```
```
argfix_old
0.13264382199849933
0.12719697097782046
0.1347857450018637
0.16105678299209103

argfix_new
0.10527223203098401
0.1038119489676319
0.11646945198299363
0.1526102180359885
```

I also included a couple of simplifications/optimizations that I ran into while reading the code