### PR TITLE
Small optimization in _Device.__getitem__

### DIFF
--- a/test/unit/test_example.py
+++ b/test/unit/test_example.py
@@ -7,7 +7,7 @@ from tinygrad.helpers import getenv
 def multidevice_test(fxn):
   exclude_devices = getenv("EXCLUDE_DEVICES", "").split(",")
   def ret(self):
-    for device in Device._buffers:
+    for device in Device._names:
       if device in ["DISK", "FAKE"]: continue
       print(device)
       if device in exclude_devices:

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -327,8 +327,7 @@ class _Device:
     x = x.split(":")[0].upper()
     runtime = self._runtimes.get(x)
     if runtime is None:
-      runtime = [cls for cname, cls in inspect.getmembers(importlib.import_module(f'tinygrad.runtime.ops_{x.lower()}')) if (cname.lower() == x.lower() + "buffer") and x in self._names][0]
-      self._runtimes[x] = runtime
+      self._runtimes[x] = runtime = [cls for cname, cls in inspect.getmembers(importlib.import_module(f'tinygrad.runtime.ops_{x.lower()}')) if (cname.lower() == x.lower() + "buffer") and x in self._names][0]
     return runtime
   def _default_device(self) -> str:
     for device in ["METAL", "CUDA", "GPU"]:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -645,7 +645,7 @@ class Tensor:
   def is_floating_point(self) -> bool: return dtypes.is_float(self.dtype)
 
 # register functions to move between devices
-for device in Device._buffers:
+for device in Device._names:
   setattr(Tensor, f"{device.lower()}", partialmethod(Tensor.to, device))
   setattr(Tensor, f"{device.lower()}_", partialmethod(Tensor.to_, device))
 


### PR DESCRIPTION
No need to call `inspect.getmembers(importlib.import_module())` every time `_Device.__getitem__` is called, cache the runtime object instead.
Also renamed `_Device._buffers` to `_Device._names`.