### PR TITLE
Added test for `nn.Conv1d`

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5,7 +5,7 @@ from extra.utils import WINDOWS
 from tinygrad.helpers import getenv
 from tinygrad.jit import TinyJit
 from tinygrad.tensor import Tensor, Device
-from tinygrad.nn import BatchNorm2d, Conv2d, ConvTranspose2d, Linear, GroupNorm, LayerNorm, LayerNorm2d, Embedding, InstanceNorm
+from tinygrad.nn import BatchNorm2d, Conv1d, Conv2d, ConvTranspose2d, Linear, GroupNorm, LayerNorm, LayerNorm2d, Embedding, InstanceNorm
 import torch
 
 class TestNN(unittest.TestCase):
@@ -74,6 +74,26 @@ class TestNN(unittest.TestCase):
     BS, T, in_dim, out_dim = 4, 2, 8, 16
     _test_linear(Tensor.randn(BS, in_dim))
     _test_linear(Tensor.randn(BS, T, in_dim)) # test with more dims
+
+  def test_conv1d(self):
+    BS, C1, W = 4, 16, 224
+    C2, K, S, P = 64, 7, 2, 1
+
+    # create in tinygrad
+    layer = Conv1d(C1, C2, kernel_size=K, stride=S, padding=P)
+
+    # create in torch
+    with torch.no_grad():
+      torch_layer = torch.nn.Conv1d(C1, C2, kernel_size=K, stride=S, padding=P).eval()
+      torch_layer.weight[:] = torch.tensor(layer.weight.numpy(), dtype=torch.float32)
+      torch_layer.bias[:] = torch.tensor(layer.bias.numpy(), dtype=torch.float32)
+
+    # test
+    x = Tensor.uniform(BS, C1, W)
+    z = layer(x)
+    torch_x = torch.tensor(x.cpu().numpy())
+    torch_z = torch_layer(torch_x)
+    np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-4, rtol=1e-5)
 
   def test_conv2d(self):
     BS, C1, H, W = 4, 16, 224, 224


### PR DESCRIPTION
Not really sure if this is necessary since it's the same implementation as Conv2d, but still good to compare to torch I think.