### PR TITLE
[fix] llama.py crashes w/ --profile --count < 3

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -393,7 +393,7 @@ After you are done speaking, output [EOS]. You are not Chad.
 
     last_break = len(outputted)
     for i in range(args.count):
-      if args.profile and i == 2: profiler.enable()
+      if args.profile and i == 0: profiler.enable()
 
       if args.timing: print("")
       st = GlobalCounters.time_sum_s

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -418,7 +418,7 @@ After you are done speaking, output [EOS]. You are not Chad.
       if chatbot and outputted.endswith(end_delim): break
     if not chatbot: break
 
-  if args.profile:
+  if args.profile and args.count > 0:
     profiler.disable()
     stats = pstats.Stats(profiler)
     stats.dump_stats('out.prof')


### PR DESCRIPTION
llama.py has an option to run the profiler on one of the tokens that gets generated, but it seems the profiler wants to run only on the third token. If the users specified `--count x < 3`, the collection of the profile panics and trace is printed (as can be seen below). This MR changes the behavior to profile the first token (if it exists). 


```
carson@Carsons-MBP tinygrad % python3 -O examples/llama.py --prompt "Hello." --profile --
...
 ITraceback (most recent call last):
  File "/Users/carson/code/tinygrad/examples/llama.py", line 423, in <module>
    stats = pstats.Stats(profiler)
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/pstats.py", line 115, in __init__
    self.init(arg)
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/pstats.py", line 129, in init
    self.load_stats(arg)
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/pstats.py", line 155, in load_stats
    raise TypeError("Cannot create or construct a %r object from %r"
TypeError: Cannot create or construct a <class 'pstats.Stats'> object from <cProfile.Profile object at 0x1265c8fa0>
carson@Carsons-MBP tinygrad % 
```