### PR TITLE
fixing cifar data

### DIFF
--- a/extra/datasets/__init__.py
+++ b/extra/datasets/__init__.py
@@ -25,5 +25,6 @@ def fetch_cifar(train=True):
     db = [pickle.load(tt.extractfile('cifar-10-batches-py/test_batch'), encoding="bytes")]
   X = np.concatenate([x[b'data'].reshape((-1, 3, 32, 32)) for x in db], axis=0)
   Y = np.concatenate([np.array(x[b'labels']) for x in db], axis=0)
+  X = X / 255.
   X = (X - cifar10_mean) / cifar10_std
   return X, Y


### PR DESCRIPTION
current code produces a vector of `X.min(), X.max() == (-1.989213, 1045.3115)`  (below)

```
X[0]
array([[[637.6034  , 641.6514  , 665.93976 , ..., 552.59424 ,
         508.06564 , 467.58508 ],
        [613.31506 , 609.267   , 641.6514  , ..., 548.5462  ,
         504.01758 , 479.72925 ],
        [609.267   , 609.267   , 637.6034  , ..., 560.69037 ,
         524.2579  , 483.7773  ],
        ...,
```
should produce a vector of `X.min(), X.max() == (-1.9892129679394217, 2.126788393620005)`
```
X[0]
array([[[ 0.51899327,  0.53486799,  0.63011633, ...,  0.18562409,
          0.01100213, -0.1477451 ],
        [ 0.42374493,  0.40787021,  0.53486799, ...,  0.16974936,
         -0.00487259, -0.10012093],
        [ 0.40787021,  0.40787021,  0.51899327, ...,  0.21737353,
          0.07450103, -0.0842462 ],
        ...
```