### PR TITLE
Fix NaN handling in CMPEQ on METAL and LLVM backends and add Tensor.isnan

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1064,6 +1064,15 @@ class TestOps(unittest.TestCase):
     n = (x < 0).where(x, 1).numpy()
     assert np.all(n == 1.)
 
+  def test_is_nan(self):
+    x = Tensor.full((3, 3), float("nan"))
+    n = (x != x).numpy()
+    assert np.all(n == 1.)
+
+    y = Tensor([1, float("nan")])
+    m = (y != y).numpy()
+    assert np.all(m == [0, 1.])
+
 if __name__ == '__main__':
   np.random.seed(1337)
   unittest.main(verbosity=2)

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -45,6 +45,7 @@ class MetalProgram:
       self.library = unwrap(METAL.device.newLibraryWithData_error_(data, None))
     else:
       options = Metal.MTLCompileOptions.alloc().init()
+      options.setFastMathEnabled_(0)
       self.library = unwrap(METAL.device.newLibraryWithSource_options_error_(prg, options, None))
     self.fxn = self.library.newFunctionWithName_(name)
     # hacks to disassemble shader

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -517,6 +517,7 @@ class Tensor:
   def abs(self): return self.relu() + (-self).relu()
   def sign(self): return self / (self.abs() + 1e-10)
   def reciprocal(self): return 1.0/self
+  def isnan(self) -> Tensor: return self != self
 
   # ***** activation functions (unary) *****
   def elu(self, alpha=1.0): return self.relu() - alpha*(1-self.exp()).relu()


### PR DESCRIPTION
Closes #1069 but it comes at the cost of losing all of the fast math optimizations on METAL and the non-NaN optimization in LLVM.