### PR TITLE
Enable JIT tests for supported devices, skip METAL and WEBGPU

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,9 +239,13 @@ jobs:
       run: PYTHONPATH="." METAL=1 python3 test/external/external_test_speed_llama.py
     #- name: Run dtype test
     #  run: DEBUG=4 METAL=1 python -m pytest test/test_dtype.py
+    # dtype test has issues on test_half_to_int8
     - name: Run ops test
       run: DEBUG=2 METAL=1 python -m pytest test/test_ops.py
-    # dtype test has issues on test_half_to_int8
+    - name: Run JIT test
+      run: DEBUG=2 METAL=1 python -m pytest test/test_jit.py
+    # TODO: why not testing the whole test/?
+
 
   testdocker:
     name: Docker Test

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2,9 +2,9 @@
 import unittest
 import numpy as np
 from tinygrad.tensor import Tensor, Device
-from tinygrad.jit import TinyJit
+from tinygrad.jit import TinyJit, JIT_SUPPORTED_DEVICE
 
-@unittest.skipUnless(Device.DEFAULT == "GPU", "JIT is only for GPU")
+@unittest.skipUnless(Device.DEFAULT in JIT_SUPPORTED_DEVICE, f"no JIT on {Device.DEFAULT}")
 class TestJit(unittest.TestCase):
   def test_simple_jit(self):
     @TinyJit

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4,7 +4,8 @@ import numpy as np
 from tinygrad.tensor import Tensor, Device
 from tinygrad.jit import TinyJit, JIT_SUPPORTED_DEVICE
 
-@unittest.skipUnless(Device.DEFAULT in JIT_SUPPORTED_DEVICE, f"no JIT on {Device.DEFAULT}")
+# NOTE: METAL fails, might be platform and optimization options dependent.
+@unittest.skipUnless(Device.DEFAULT in JIT_SUPPORTED_DEVICE and Device.DEFAULT not in ["METAL", "WEBGPU"], f"no JIT on {Device.DEFAULT}")
 class TestJit(unittest.TestCase):
   def test_simple_jit(self):
     @TinyJit


### PR DESCRIPTION
Enable test to not skip any supported device by default.

While doing so, I realized METAL test fails, presumably due to fast-math optimization. But disabling fast-math did not fix it on CI, it fixed on my local M1 though.

I think we want to test these devices, so I recommend adding the test for all and explicitly skipping METAL and WEBGPU for now. [Link to show that these two failed in CI](https://github.com/leastcompressible/tinygrad/actions/runs/5589540711).