### PR TITLE
Fix: AssertionError Transpose/Permute when WHERE Op in LB

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -569,6 +569,9 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3,4,5,6)], lambda x: x.movedim((3,2,1,0),(0,1,2,3)), lambda x: x.permute(order=(3,2,1,0)))
     helper_test_op([()], lambda x: x.permute(()), lambda x: x.permute(()))
 
+  def test_transpose_where(self):
+    Tensor.rand(5,5).ceil().permute((1, 0))
+
   def test_reshape(self):
     helper_test_op([(4,3,6,6)], lambda x: torch.reshape(x, (-1,3,6,6)), lambda x: x.reshape(shape=(-1,3,6,6)))
     helper_test_op([(4,3,6,6)], lambda x: torch.reshape(x, (-1,1,6,6)), lambda x: x.reshape(shape=(-1,1,6,6)))

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -570,7 +570,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([()], lambda x: x.permute(()), lambda x: x.permute(()))
 
   def test_transpose_where(self):
-    Tensor.rand(5,5).ceil().permute((1, 0))
+    helper_test_op([(5, 5)], lambda x: x.ceil().permute((0, 1)), lambda x: x.ceil().permute((0, 1)), forward_only=True)
 
   def test_reshape(self):
     helper_test_op([(4,3,6,6)], lambda x: torch.reshape(x, (-1,3,6,6)), lambda x: x.reshape(shape=(-1,3,6,6)))

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -114,6 +114,12 @@ class TestOps(unittest.TestCase):
         lambda x, a, b: torch.where(x > 0.5, a, b),
         lambda x, a, b: (x > 0.5).where(a, b), forward_only=True)
 
+  def test_where_permute(self):
+    helper_test_op(
+      [(5, 5)],
+      lambda x: torch.where(x > 0.5, 4, 2).permute((1, 0)),
+      lambda x: (x > 0.5).where(4, 2).permute((1, 0)), forward_only=True)
+
   def _test_cmp(self, fxn, reverse=True):
     for shps in [[(3, 4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]:
       helper_test_op(shps, fxn, fxn, forward_only=True)
@@ -569,8 +575,6 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3,4,5,6)], lambda x: x.movedim((3,2,1,0),(0,1,2,3)), lambda x: x.permute(order=(3,2,1,0)))
     helper_test_op([()], lambda x: x.permute(()), lambda x: x.permute(()))
 
-  def test_transpose_where(self):
-    helper_test_op([(5, 5)], lambda x: x.ceil().permute((1, 0)), lambda x: x.ceil().permute((1, 0)), forward_only=True)
 
   def test_reshape(self):
     helper_test_op([(4,3,6,6)], lambda x: torch.reshape(x, (-1,3,6,6)), lambda x: x.reshape(shape=(-1,3,6,6)))

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -570,7 +570,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([()], lambda x: x.permute(()), lambda x: x.permute(()))
 
   def test_transpose_where(self):
-    helper_test_op([(5, 5)], lambda x: x.ceil().permute((0, 1)), lambda x: x.ceil().permute((0, 1)), forward_only=True)
+    helper_test_op([(5, 5)], lambda x: x.ceil().permute((1, 0)), lambda x: x.ceil().permute((1, 0)), forward_only=True)
 
   def test_reshape(self):
     helper_test_op([(4,3,6,6)], lambda x: torch.reshape(x, (-1,3,6,6)), lambda x: x.reshape(shape=(-1,3,6,6)))

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -54,7 +54,7 @@ class LazyOp:
 
   def replace_with_movement_ops(self:LazyOp, ops:List[Tuple[MovementOps, Tuple[Any, ...]]]) -> 'LazyBuffer':
     from tinygrad.lazy import elementwise_op
-    assert self.op in BinaryOps or self.op in UnaryOps
+    assert self.op in BinaryOps or self.op in UnaryOps or self.op in TernaryOps
     return elementwise_op(self.op, *[z.replace_with_movement_ops(ops) for z in self.src], arg=self.arg)   # type: ignore
 
   @property


### PR DESCRIPTION
Related #1263,

I have changed the assertion condition but not sure if it against the logic or just overlooked.

Transposing a tensor throws assertion if there is WHERE Ops in the LB.
