### PR TITLE
Fix WSGL to render NaN and prevent shader compile error

### DIFF
--- a/tinygrad/codegen/wgsl.py
+++ b/tinygrad/codegen/wgsl.py
@@ -25,14 +25,16 @@ class WGSLLanguage(CStyleLanguage):
     return f"var<workgroup> {name}: array<f32,{size}>;"
 
   def render_const(self, x:Union[float,int], var_dtype) -> str:
-    if math.isinf(x): val = ("-" if x < 0 else "") + "0x1.fffffep+127f"
+    if math.isnan(x): val = "nan()"
+    elif math.isinf(x): val = ("-" if x < 0 else "") + "0x1.fffffep+127f"
     else: val = f"{x}" + ("" if dtypes.is_int(var_dtype) else "f")
     return self.render_cast([val]*var_dtype.sz, var_dtype) if var_dtype.sz > 1 else val
 
   def render_kernel(self, kernel:List[str], bufs:List[Tuple[str,DType]], global_size:List[int], local_size:List[int], prekernel:List[str]) -> Tuple[str, List[int], List[int]]:
     local_size = local_size[::-1] if len(local_size) else [1]
     bind_it = iter(range(len(bufs)))
-    prg = "\n".join(prekernel+[f"@group(0) @binding({next(bind_it)}) var<storage,read_write> {name}: array<{type_map[dtype]}>;" for name,dtype in bufs])
+    prg = "fn nan() -> f32 { let bits = 0xffffffffu; return bitcast<f32>(bits); }\n"
+    prg += "\n".join(prekernel+[f"@group(0) @binding({next(bind_it)}) var<storage,read_write> {name}: array<{type_map[dtype]}>;" for name,dtype in bufs])
     prg += f"\n@compute @workgroup_size({','.join([str(x) for x in local_size])}) fn KERNEL_NAME_PLACEHOLDER(@builtin(workgroup_id) gindex: vec3<u32>, @builtin(local_invocation_id) lindex: vec3<u32>) {{\n" + "\n".join(kernel) + "\n}"
     return prg, global_size[::-1] if len(global_size) else [1], local_size
 


### PR DESCRIPTION
Currently WGSL will fail to compile due to a shader error in the presence of NaN const (renders as "nanf").

For reference on this approach see: https://github.com/gpuweb/gpuweb/issues/3749