### PR TITLE
Fix llama.py to load and concatenate 13B, 30B, and 65B models

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -198,12 +198,8 @@ def concat_weights(models):
       axis = 0
     lazy_tensors = [data.to(device=Device.DEFAULT) for data in disk_tensors]
     first, rest = lazy_tensors[0], lazy_tensors[1:]
-    return first.cat(*rest, dim=axis).realize()
-  ret = {}
-  for name in (t := tqdm({name: None for model in models for name in model})):
-    t.set_description(f"ram used: {GlobalCounters.mem_used/1e9:5.2f} GB @ {name}")
-    ret[name] = convert(name)
-  return ret
+    return first.cat(*rest, dim=axis)
+  return {name: convert(name) for name in {name: None for model in models for name in model}}
 
 # **** main code ****
 

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -172,7 +172,7 @@ WEIGHTS_13B_FILENAMES = [WEIGHTS_DIR / "13B/consolidated.00.pth", WEIGHTS_DIR / 
 args_30B = {"dim": 6656, "multiple_of": 256, "n_heads": 52, "n_layers": 60, "norm_eps": 1e-06, "vocab_size": VOCAB_SIZE}
 WEIGHTS_30B_FILENAMES = [WEIGHTS_DIR / "30B/consolidated.00.pth", WEIGHTS_DIR / "30B/consolidated.01.pth", WEIGHTS_DIR / "30B/consolidated.02.pth", WEIGHTS_DIR / "30B/consolidated.03.pth"]
 
-args_65B = {"dim": 8192, "multiple_of": 256, "n_heads": 64, "n_layers": 80, "norm_eps": 1e-06, "vocab_size": VOCAB_SIZE}
+args_65B = {"dim": 8192, "multiple_of": 256, "n_heads": 64, "n_layers": 80, "norm_eps": 1e-05, "vocab_size": VOCAB_SIZE}
 WEIGHTS_65B_FILENAMES = [WEIGHTS_DIR / "65B/consolidated.00.pth", WEIGHTS_DIR / "65B/consolidated.01.pth", WEIGHTS_DIR / "65B/consolidated.02.pth", WEIGHTS_DIR / "65B/consolidated.03.pth", WEIGHTS_DIR / "65B/consolidated.04.pth", WEIGHTS_DIR / "65B/consolidated.05.pth", WEIGHTS_DIR / "65B/consolidated.06.pth", WEIGHTS_DIR / "65B/consolidated.07.pth"]
 
 # **** helper functions ****


### PR DESCRIPTION
Add back support for LLaMA 13B and add 30B and 65B.  Closes #1254.

Wasn't able to test 65B due to memory constraints but here are the results with 13B and 30B on a MBP16 M2 Max 96GB:

```
using METAL backend
using 13B model
ram used: 26.03 GB, freqs_cis                                         : 100%|█████████████████████████████████████████████████████████████████████████████████████████| 364/364 [00:06<00:00, 58.91it/s]
loaded weights in 6185.82 ms, 26.03 GB loaded at 4.21 GB/s
Hello.
ran model in 596.72 ms
sync in 31.25 ms
 I
ran model in 154.41 ms
sync in 2.73 ms
 am
ran model in 148.00 ms
sync in 2.73 ms
 a
ran model in 140.58 ms
sync in 3.20 ms
 
ran model in 142.85 ms
sync in 2.65 ms
2
ran model in 149.57 ms
sync in 2.81 ms
0
ran model in 143.11 ms
sync in 2.68 ms
 year
ran model in 142.81 ms
sync in 2.67 ms
 old
ran model in 150.24 ms
sync in 2.81 ms
 female
ran model in 143.87 ms
sync in 2.73 ms
.%                               
```

```
using METAL backend
using 30B model
ram used: 65.06 GB, freqs_cis                                         : 100%|█████████████████████████████████████████████████████████████████████████████████████████| 544/544 [00:22<00:00, 23.88it/s]
loaded weights in 22786.53 ms, 65.06 GB loaded at 2.86 GB/s
Hello.
ran model in 11879.79 ms
sync in 186.19 ms
 I
ran model in 1411.35 ms
sync in 171.10 ms
 am
ran model in 1616.58 ms
sync in 122.17 ms
 a
ran model in 1668.45 ms
sync in 163.60 ms
 
ran model in 1678.47 ms
sync in 136.57 ms
2
ran model in 1796.34 ms
sync in 106.86 ms
0
ran model in 1551.07 ms
sync in 132.73 ms
 year
ran model in 1669.32 ms
sync in 132.06 ms
 old
ran model in 1658.96 ms
sync in 76.19 ms
 female
ran model in 1550.73 ms
sync in 99.92 ms
.%                      
```


