### PR TITLE
cse deduped args, cache loads across deduped args, fold fully masked out variables

### DIFF
--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -483,23 +483,22 @@ class Linearizer:
         grouped = list(get_grouped_maybe_float4(*values, grouping_allowed=self.supports_float4_alu and x.op not in {BinaryOps.CMPEQ, TernaryOps.WHERE}))
         for idx, val in grouped:
           out = ssa('alu', dtypes._float4) if any(x.dtype == dtypes._float4 and x.offset is None for x in val) else ssa('alu')
-          op = x.op
 
           fold_result = None
           if any(v.const_zero for v in val):
-            if op in [UnaryOps.NOOP, UnaryOps.SIN, UnaryOps.SQRT]: fold_result = val[0]
-            if op == BinaryOps.ADD:
+            if x.op in [UnaryOps.NOOP, UnaryOps.SIN, UnaryOps.SQRT]: fold_result = val[0]
+            if x.op == BinaryOps.ADD:
               fold_result = val[1] if val[0].const_zero else val[0]
-            elif op == BinaryOps.SUB:
+            elif x.op == BinaryOps.SUB:
               if val[1].const_zero: fold_result = val[0]
-            elif op == BinaryOps.MUL:
+            elif x.op == BinaryOps.MUL:
               fold_result = val[0] if val[0].const_zero else val[1]
             # todo: 0/x? but 0/0 is undefined
 
           if fold_result is not None:
             ret.append((idx, fold_result))
           else:
-            ret.append( (idx, self.uop(UOps.ALU, out, list(val), op)) )
+            ret.append( (idx, self.uop(UOps.ALU, out, list(val), x.op)) )
       ordered_ret: List[Optional[Token]] = [None]*len(values[0])
       # scatter
       for i,j in ret:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -42,6 +42,7 @@ class LocalBuffer(NamedTuple):
   dtype: DType = dtypes.float32
   realized: None = None
   def __str__(self): return f"localbuffer<{self.name}[{self.size}]>"
+  def map_buffers(self, real_srcs: Dict[Any, Any]): return real_srcs.get(self, self)
 
 class Token(NamedTuple):
   name: str
@@ -213,9 +214,8 @@ class Linearizer:
     should_upcast = self.supports_float4 and (self.bufs[i].dtype in [dtypes.float32, dtypes.float16] or isinstance(self.bufs[i].dtype, ImageDType))
     return [x for x in self.sts[i].unit_stride_axes() if should_upcast and x >= self.shape_len-self.upcasted and self.sts[i].shape[x] > 1]
 
-  def global_load(self, i:int, idxs:Sequence[VariableOrNum], const=None) -> List[Token]:
+  def global_load(self, i:int, idxs:Sequence[VariableOrNum], const=None, load_cache=None) -> Tuple[Token]:
     if isinstance(self.bufs[i].realized, RawConst): const = self.bufs[i].realized._buf
-
     expanded_nodes = [expand_node(idx) for idx in idxs]
     _idxs = [x[::-1] for x in itertools.product(*expanded_nodes[::-1])]
     upcast_dim = self.get_upcast_dim(i)
@@ -224,7 +224,7 @@ class Linearizer:
     if len(upcast_dim) == 1 and len(expanded_nodes[upcast_dim[0]]) in [4,2]:
       dim, amt = upcast_dim[0], len(expanded_nodes[upcast_dim[0]])
 
-    cache: Dict[str, Token] = {}
+    cache = load_cache[self.get_buffer_name(i)] if load_cache is not None and const is None else {}
     ret = []
     for _idx in _idxs:
       if amt > 1:
@@ -242,7 +242,7 @@ class Linearizer:
         cache[key] = self.uop(UOps.LOAD, Token(f"val{mnum(i)}_{len(cache)}", localtype), [], MemOp(self.get_buffer_name(i), idx, valid, self.bufs[i].dtype, self.bufs[i].__class__ is LocalBuffer)) if const is None else \
                      self.uop(UOps.CONST, Token(f"acc{mnum(i)}_{len(cache)}", localtype), [], ConstOp(const, self.bufs[i].dtype, valid))
       ret.append(Token(cache[key].name, cache[key].dtype, expanded_nodes[dim].index(_idx[dim])) if localtype != dtypes.float else cache[key])
-    return ret
+    return tuple(ret)
 
   def global_store(self, i, idxs:List[VariableOrNum], store:List[Token], ssa) -> None:
     expanded_nodes = [expand_node(idx) for idx in idxs]
@@ -336,6 +336,8 @@ class Linearizer:
       # reduce loop
       self.uop(UOps.LOOP, None, [], (reduce_idxs, "reduce"))
 
+      inner_load_cache = defaultdict(dict)
+
       # barrier for fast GEMM
       if self.use_tensor_cores: self.uop(UOps.BARRIER, None, [], ())
 
@@ -368,7 +370,7 @@ class Linearizer:
             if DEBUG >= 4: print(f"failed upcasting stride {v} extra locals {extra_locals}")
             this_upcast_idxs.append(v)
         idxs = global_idxs+local_idxs+reduce_idxs+this_upcast_idxs
-        ll = self.global_load(i, idxs)
+        ll = self.global_load(i, idxs, load_cache=inner_load_cache)
         locals_to_store.append((self.bufs.index(self.local_alias[i]), idxs, ll))
 
       # copy in any global buffers
@@ -385,10 +387,10 @@ class Linearizer:
           self.uop(UOps.BARRIER, None, [], ())
 
         # load earlybufs
-        loaded_buffers.update({b:self.global_load(self.bufs.index(self.local_alias[i]) if i in self.local_alias else i, global_idxs+local_idxs+reduce_idxs+full_upcast_idxs) for i,b in enumerate(self.bufs) if b in self.earlybufs and i != 0})
+        loaded_buffers.update({b:self.global_load(self.bufs.index(self.local_alias[i]) if i in self.local_alias else i, global_idxs+local_idxs+reduce_idxs+full_upcast_idxs, load_cache=inner_load_cache) for i,b in enumerate(self.bufs) if b in self.earlybufs and i != 0})
 
         # run early AST (with reduce)
-        self.ast_parse(self.reduceop, [acc[off] for off in self.acc_offsets(self.full_buf_index)], loaded_buffers, ssa, do_reduce=True)
+        self.ast_parse(self.reduceop.map_buffers(loaded_buffers), [acc[off] for off in self.acc_offsets(self.full_buf_index)], ssa, do_reduce=True)
 
       # end the reduce loop
       self.uop(UOps.ENDLOOP, None, [], (reduce_idxs, "reduce"))
@@ -422,19 +424,20 @@ class Linearizer:
         self.uop(UOps.LOOP, None, [], (end_local_idxs, "late_reduce"))
 
         # load localbufs
-        loaded_buffers["LOCAL_BUFFER"] = self.global_load(-1, end_local_idxs+fake_reduce_idxs+upcast_idxs)
+        loaded_buffers[self.bufs[-1]] = self.global_load(-1, end_local_idxs+fake_reduce_idxs+upcast_idxs)
 
         # there's no AST here (and there's no shape for the reduce LazyOp)
-        self.ast_parse(LazyOp(self.reduceop.op, ("LOCAL_BUFFER",)), [acc[off] for off in self.acc_offsets(-1)], loaded_buffers, ssa, do_reduce=True) # type: ignore
+        self.ast_parse(LazyOp(self.reduceop.op, (self.bufs[-1],)).map_buffers(loaded_buffers), [acc[off] for off in self.acc_offsets(-1)], ssa, do_reduce=True) # type: ignore
 
         # end the late reduce loop
         self.uop(UOps.ENDLOOP, None, [], (end_local_idxs, "late_reduce"))
 
     # load latebufs
-    loaded_buffers.update({b:self.global_load(i, global_idxs+local_idxs+fake_reduce_idxs+upcast_idxs) for i,b in enumerate(self.bufs) if b not in self.earlybufs and i != 0 and b.__class__ is not LocalBuffer})
+    outer_load_cache = defaultdict(dict)
+    loaded_buffers.update({b:self.global_load(i, global_idxs+local_idxs+fake_reduce_idxs+upcast_idxs, load_cache=outer_load_cache) for i,b in enumerate(self.bufs) if b not in self.earlybufs and i != 0 and b.__class__ is not LocalBuffer})
 
     # run late AST
-    val = self.ast_parse(self.ast, acc, loaded_buffers, ssa)
+    val = self.ast_parse(self.ast.map_buffers(loaded_buffers), acc, ssa)
 
     # store
     self.global_store(0, global_idxs+local_idxs+fake_reduce_idxs+upcast_idxs, val, ssa)
@@ -452,9 +455,9 @@ class Linearizer:
     if DEBUG >= 4: print(self.uops[-1])
     return out
 
-  def ast_parse(self, x, acc, loaded_buffers, ssa, do_reduce=False) -> List[Token]:
-    if x.__class__ is not LazyOp: return loaded_buffers[x]
-    if x.op in [UnaryOps.NOOP, UnaryOps.CAST]: return self.ast_parse(x.src[0], acc, loaded_buffers, ssa)  # cast isn't an ALU op
+  def ast_parse(self, x, acc, ssa, do_reduce=False) -> List[Token]:
+    if x.__class__ is not LazyOp: return x
+    if x.op in [UnaryOps.NOOP, UnaryOps.CAST]: return self.ast_parse(x.src[0], acc, ssa)  # cast isn't an ALU op
     if x.op in ReduceOps and not do_reduce: return acc
     # MULACC fusion. TODO: this is copied from Interpreted
     if x.op == ReduceOps.SUM and x.src[0].__class__ is LazyOp and x.src[0].op == BinaryOps.MUL:
@@ -466,7 +469,7 @@ class Linearizer:
       srcs = sorted(x.src, key=lambda x: (x.realized.__class__ != RawConst) if x.__class__ == LazyBuffer else 0)
       x.src = tuple(srcs)
     if x not in self.saved_exprs:
-      values = [self.ast_parse(v, acc, loaded_buffers, ssa) for v in x.src]
+      values = [self.ast_parse(v, acc, ssa) for v in x.src]
       ops = {ReduceOps.SUM:BinaryOps.ADD, ReduceOps.MAX:BinaryOps.MAX, TernaryOps.MULACC:TernaryOps.MULACC}
       if x.op in ops:
         ret = [(idx, self.uop(UOps.ALU, val[-1], list(val), ops[x.op])) for idx, val in get_grouped_maybe_float4(*values, acc, grouping_allowed=self.supports_float4_alu)]


### PR DESCRIPTION
This is part 2/k of winograd (#1037). The primary use case for these new optimization is Tensor.stack, with the stack dimension upcasted.