### PR TITLE
[NOMERGE] ci: multiple speedups, reordering, 3.11, no prints, seeds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,10 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Install Dependencies
       run: pip install -e '.[testing]' --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Test Docs
@@ -54,7 +54,7 @@ jobs:
     - name: Test Quickstart
       run: awk '/```python/{flag=1;next}/```/{flag=0}flag' docs/quickstart.md > quickstart.py && PYTHONPATH=. python3 quickstart.py
     - name: Run Pytest
-      run: python -m pytest -s -v -n=auto test/
+      run: CI=1 python -m pytest -n=auto test/
   
   testwebgpu:
     name: WebGPU Tests
@@ -72,7 +72,7 @@ jobs:
     # - name: Set Env
     #   run: printf "WEBGPU=1\nWGPU_BACKEND_TYPE=D3D12\n" >> $GITHUB_ENV
     - name: Run Pytest
-      run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -s -v -n=auto test/test_ops.py test/test_speed_v_torch.py test/test_nn.py test/test_jit.py test/test_randomness.py test/test_tensor.py test/test_assign.py test/test_conv.py test/test_nn.py test/test_custom_function.py test/test_conv_shapetracker.py
+      run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal CI=1 python -m pytest -n=auto test/test_ops.py test/test_speed_v_torch.py test/test_nn.py test/test_jit.py test/test_randomness.py test/test_tensor.py test/test_assign.py test/test_conv.py test/test_nn.py test/test_custom_function.py test/test_conv_shapetracker.py
     - name: Build WEBGPU Efficientnet
       run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m examples.webgpu.compile_webgpu
     # - name: Install Puppeteer
@@ -115,7 +115,7 @@ jobs:
     - name: Install Dependencies
       run: pip install -e '.[llvm,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Run Pytest
-      run: ENABLE_METHOD_CACHE=1 LLVM=1 python -m pytest -s -v -n=auto test/
+      run: ENABLE_METHOD_CACHE=1 LLVM=1 CI=1 python -m pytest -n=auto test/
 
   testclang:
     strategy:
@@ -136,7 +136,7 @@ jobs:
     - name: Set env
       run: printf "CI=1\nCLANG=1\nENABLE_METHOD_CACHE=1" >> $GITHUB_ENV
     - name: Run Pytest
-      run: python -m pytest -s -v -n=auto test/
+      run: CI=1 python -m pytest -n=auto test/
 
   testtorch:
     name: Torch Tests
@@ -153,9 +153,9 @@ jobs:
     - name: Install Dependencies
       run: pip install -e '.[testing]' --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Run Pytest
-      run: TORCH=1 python -m pytest -s -v -n=auto test/
+      run: TORCH=1 CI=1 python -m pytest -n=auto test/
     - name: Run ONNX
-      run: TORCH=1 python -m pytest test/external/external_test_onnx_backend.py --tb=no --disable-warnings || true
+      run: TORCH=1 CI=1 python -m pytest test/external/external_test_onnx_backend.py --tb=no --disable-warnings || true
 
   testgpu:
     name: GPU Tests
@@ -184,7 +184,7 @@ jobs:
         PYTHONPATH="." OPT=2 GPU=1 python test/external/external_test_opt.py
         PYTHONPATH="." OPT=3 GPU=1 python test/external/external_test_opt.py
     - name: Run Pytest (default)
-      run: GPU=1 python -m pytest -s -v -n=auto test/
+      run: GPU=1 CI=1 python -m pytest -n=auto test/
 
   testopencl:
     name: openpilot (OpenCL) Test
@@ -238,12 +238,12 @@ jobs:
     - name: Test LLaMA compile speed
       run: PYTHONPATH="." METAL=1 python3 test/external/external_test_speed_llama.py
     #- name: Run dtype test
-    #  run: DEBUG=4 METAL=1 python -m pytest test/test_dtype.py
+    #  run: DEBUG=4 METAL=1 CI=1 python -m pytest test/test_dtype.py
     # dtype test has issues on test_half_to_int8
     - name: Run ops test
-      run: DEBUG=2 METAL=1 python -m pytest test/test_ops.py
+      run: DEBUG=2 METAL=1 CI=1 python -m pytest test/test_ops.py
     - name: Run JIT test
-      run: DEBUG=2 METAL=1 python -m pytest test/test_jit.py
+      run: DEBUG=2 METAL=1 CI=1 python -m pytest test/test_jit.py
     # TODO: why not testing the whole test/?
 
 
@@ -314,4 +314,4 @@ jobs:
     - name: Install tinygrad dependencies
       run: pip install -e '.[testing, cuda]' --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Run pytest
-      run: FORWARD_ONLY=1 JIT=1 OPT=2 CUDA=1 CUDACPU=1 python -m pytest -s -v -n=auto test --ignore=test/external --ignore=test/models --ignore=test/test_speed_v_torch.py --ignore=test/test_specific_conv.py --ignore=test/test_net_speed.py --ignore=test/test_nn.py -k "not half"
+      run: FORWARD_ONLY=1 JIT=1 OPT=2 CUDA=1 CUDACPU=1 CI=1 python -m pytest -n=auto test --ignore=test/external --ignore=test/models --ignore=test/test_speed_v_torch.py --ignore=test/test_specific_conv.py --ignore=test/test_net_speed.py --ignore=test/test_nn.py -k "not half"

--- a/extra/introspection.py
+++ b/extra/introspection.py
@@ -1,6 +1,6 @@
 # TODO: move the GRAPH and DEBUG stuff to here
 import gc
-from tinygrad.helpers import prod
+from tinygrad.helpers import prod, CI
 from tinygrad.tensor import Tensor
 from tinygrad.lazy import LazyBuffer
 from tinygrad.runtime.ops_gpu import CLBuffer
@@ -15,9 +15,10 @@ def print_objects():
   realized_buffers = [x.realized for x in lazybuffers if x.realized]
   gpubuffers_orphaned = [x for x in gpubuffers if x not in realized_buffers]
 
-  print(f"{len(tensors)} tensors allocated in {tensor_ram_used/1e9:.2f} GB, GPU using {GlobalCounters.mem_used/1e9:.2f} GB")
-  print(f"{len(lazybuffers)} lazybuffers {len(realized_buffers)} realized, {len(gpubuffers)} GPU buffers")
-  print(f"{len(gpubuffers_orphaned)} GPU buffers are orphaned")
+  if not CI:
+    print(f"{len(tensors)} tensors allocated in {tensor_ram_used/1e9:.2f} GB, GPU using {GlobalCounters.mem_used/1e9:.2f} GB")
+    print(f"{len(lazybuffers)} lazybuffers {len(realized_buffers)} realized, {len(gpubuffers)} GPU buffers")
+    print(f"{len(gpubuffers_orphaned)} GPU buffers are orphaned")
 
   cnt = 0
   for tb in gpubuffers_orphaned:

--- a/test/extra/test_lr_scheduler.py
+++ b/test/extra/test_lr_scheduler.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 import unittest
+from tinygrad.helpers import print_unless_ci
 from tinygrad.tensor import Tensor
 from tinygrad.state import get_parameters
 from tinygrad.nn.optim import Adam

--- a/test/extra/test_utils.py
+++ b/test/extra/test_utils.py
@@ -5,12 +5,12 @@ from unittest.mock import patch, MagicMock
 
 import torch
 import numpy as np
-from tinygrad.helpers import getenv 
+from tinygrad.helpers import CI 
 from extra.utils import fetch, temp, download_file
 from tinygrad.state import torch_load
 from PIL import Image
 
-@unittest.skipIf(getenv("CI", "") != "", "no internet tests in CI")
+@unittest.skipIf(CI, "no internet tests in CI")
 class TestFetch(unittest.TestCase):
   def test_fetch_bad_http(self):
     self.assertRaises(AssertionError, fetch, 'http://httpstat.us/500')

--- a/test/models/test_end2end.py
+++ b/test/models/test_end2end.py
@@ -5,6 +5,7 @@ import numpy as np
 from tinygrad.state import get_parameters, get_state_dict
 from tinygrad.nn import optim, Linear, Conv2d, BatchNorm2d
 from tinygrad.tensor import Tensor
+from tinygrad.helpers import print_unless_ci
 from extra.datasets import fetch_mnist
 
 def compare_tiny_torch(model, model_torch, X, Y):
@@ -12,7 +13,7 @@ def compare_tiny_torch(model, model_torch, X, Y):
   model_torch.train()
   model_state_dict = get_state_dict(model)
   for k,v in model_torch.named_parameters():
-    print(f"initting {k} from torch")
+    print_unless_ci(f"initting {k} from torch")
     model_state_dict[k].assign(Tensor(v.detach().numpy())).realize()
 
   optimizer = optim.SGD(get_parameters(model), lr=0.01)
@@ -23,11 +24,11 @@ def compare_tiny_torch(model, model_torch, X, Y):
 
   out = model(X)
   loss = (out * Y).mean()
-  print(loss.realize().numpy())
+  print_unless_ci(loss.realize().numpy())
 
   out_torch = model_torch(torch.Tensor(X.numpy()))
   loss_torch = (out_torch * torch.Tensor(Y.numpy())).mean()
-  print(loss_torch.detach().numpy())
+  print_unless_ci(loss_torch.detach().numpy())
 
   # assert losses match
   np.testing.assert_allclose(loss.realize().numpy(), loss_torch.detach().numpy(), atol=1e-4)
@@ -41,7 +42,7 @@ def compare_tiny_torch(model, model_torch, X, Y):
   for k,v in list(model_torch.named_parameters())[::-1]:
     g = model_state_dict[k].grad.numpy()
     gt = v.grad.detach().numpy()
-    print("testing grads", k)
+    print_unless_ci("testing grads", k)
     np.testing.assert_allclose(g, gt, atol=1e-3, err_msg=f'grad mismatch {k}')
 
   # take the steps
@@ -50,7 +51,7 @@ def compare_tiny_torch(model, model_torch, X, Y):
 
   # assert weights match (they don't!)
   for k,v in model_torch.named_parameters():
-    print("testing weight", k)
+    print_unless_ci("testing weight", k)
     np.testing.assert_allclose(model_state_dict[k].numpy(), v.detach().numpy(), atol=1e-3, err_msg=f'weight mismatch {k}')
 
 def get_mnist_data():

--- a/test/models/test_mnist.py
+++ b/test/models/test_mnist.py
@@ -49,65 +49,59 @@ class TinyConvNet:
     return x.dot(self.l1).log_softmax()
 
 class TestMNIST(unittest.TestCase):
+
+  def test_conv_with_bn(self):
+    model = TinyConvNet(has_batchnorm=True)
+    optimizer = optim.AdamW(model.parameters(), lr=0.003)
+    train(model, X_train, Y_train, optimizer, steps=200)
+    assert evaluate(model, X_test, Y_test) > 0.94
+
+  def test_conv_onestep(self):
+    model = TinyConvNet()
+    optimizer = optim.SGD(model.parameters(), lr=0.001)
+    train(model, X_train, Y_train, optimizer, BS=69, steps=1, noloss=True)
+    for p in model.parameters(): p.realize()
+
   def test_sgd_onestep(self):
-    np.random.seed(1337)
     model = TinyBobNet()
     optimizer = optim.SGD(model.parameters(), lr=0.001)
     train(model, X_train, Y_train, optimizer, BS=69, steps=1)
     for p in model.parameters(): p.realize()
 
   def test_sgd_threestep(self):
-    np.random.seed(1337)
     model = TinyBobNet()
     optimizer = optim.SGD(model.parameters(), lr=0.001)
     train(model, X_train, Y_train, optimizer, BS=69, steps=3)
 
   def test_sgd_sixstep(self):
-    np.random.seed(1337)
     model = TinyBobNet()
     optimizer = optim.SGD(model.parameters(), lr=0.001)
     train(model, X_train, Y_train, optimizer, BS=69, steps=6, noloss=True)
 
   def test_adam_onestep(self):
-    np.random.seed(1337)
     model = TinyBobNet()
     optimizer = optim.Adam(model.parameters(), lr=0.001)
     train(model, X_train, Y_train, optimizer, BS=69, steps=1)
     for p in model.parameters(): p.realize()
 
   def test_adam_threestep(self):
-    np.random.seed(1337)
     model = TinyBobNet()
     optimizer = optim.Adam(model.parameters(), lr=0.001)
     train(model, X_train, Y_train, optimizer, BS=69, steps=3)
 
-  def test_conv_onestep(self):
-    np.random.seed(1337)
-    model = TinyConvNet()
-    optimizer = optim.SGD(model.parameters(), lr=0.001)
-    train(model, X_train, Y_train, optimizer, BS=69, steps=1, noloss=True)
-    for p in model.parameters(): p.realize()
-
   def test_conv(self):
-    np.random.seed(1337)
     model = TinyConvNet()
     optimizer = optim.Adam(model.parameters(), lr=0.001)
     train(model, X_train, Y_train, optimizer, steps=100)
     assert evaluate(model, X_test, Y_test) > 0.94   # torch gets 0.9415 sometimes
 
-  def test_conv_with_bn(self):
-    np.random.seed(1337)
-    model = TinyConvNet(has_batchnorm=True)
-    optimizer = optim.AdamW(model.parameters(), lr=0.003)
-    train(model, X_train, Y_train, optimizer, steps=200)
-    assert evaluate(model, X_test, Y_test) > 0.94
 
   def test_sgd(self):
-    np.random.seed(1337)
     model = TinyBobNet()
     optimizer = optim.SGD(model.parameters(), lr=0.001)
     train(model, X_train, Y_train, optimizer, steps=600)
     assert evaluate(model, X_test, Y_test) > 0.94   # CPU gets 0.9494 sometimes
 
 if __name__ == '__main__':
+  np.random.seed(1337)
   unittest.main()

--- a/test/models/test_onnx.py
+++ b/test/models/test_onnx.py
@@ -8,6 +8,7 @@ import onnx
 from extra.utils import fetch, temp
 from extra.onnx import get_run_onnx
 from tinygrad.tensor import Tensor
+from tinygrad.helpers import print_unless_ci, CI
 
 def run_onnx_torch(onnx_model, inputs):
   import torch
@@ -48,28 +49,32 @@ class TestOnnxModel(unittest.TestCase):
       mt2 = time.monotonic()
       tinygrad_out = tinygrad_out.numpy()
       et = time.monotonic()
-      print(f"ran openpilot model in {(et-st)*1000.0:.2f} ms, waited {(mt2-mt)*1000.0:.2f} ms for realize, {(et-mt2)*1000.0:.2f} ms for GPU queue")
+      print_unless_ci(f"ran openpilot model in {(et-st)*1000.0:.2f} ms, waited {(mt2-mt)*1000.0:.2f} ms for realize, {(et-mt2)*1000.0:.2f} ms for GPU queue")
 
-    import cProfile
-    import pstats
-    inputs = get_inputs()
-    pr = cProfile.Profile(timer=time.perf_counter_ns, timeunit=1e-6)
-    pr.enable()
+    if not CI:
+      import cProfile
+      import pstats
+      inputs = get_inputs()
+      pr = cProfile.Profile(timer=time.perf_counter_ns, timeunit=1e-6)
+      pr.enable()
+
     tinygrad_out = run_onnx(inputs)['outputs']
     tinygrad_out.realize()
     tinygrad_out = tinygrad_out.numpy()
-    pr.disable()
-    stats = pstats.Stats(pr)
-    stats.dump_stats(temp("net.prof"))
-    os.system(f"flameprof {temp('net.prof')} > {temp('prof.svg')}")
-    ps = stats.sort_stats(pstats.SortKey.TIME)
-    ps.print_stats(30)
+
+    if not CI: 
+      pr.disable()
+      stats = pstats.Stats(pr)
+      stats.dump_stats(temp("net.prof"))
+      os.system(f"flameprof {temp('net.prof')} > {temp('prof.svg')}")
+      ps = stats.sort_stats(pstats.SortKey.TIME)
+      ps.print_stats(30)
 
   def test_openpilot_model(self):
     dat = fetch(OPENPILOT_MODEL)
     onnx_model = onnx.load(io.BytesIO(dat))
     run_onnx = get_run_onnx(onnx_model)
-    print("got run_onnx")
+    print_unless_ci("got run_onnx")
     inputs = {
       "input_imgs": np.random.randn(*(1, 12, 128, 256)),
       "big_input_imgs": np.random.randn(*(1, 12, 128, 256)),
@@ -81,20 +86,20 @@ class TestOnnxModel(unittest.TestCase):
     inputs = {k:v.astype(np.float32) for k,v in inputs.items()}
 
     st = time.monotonic()
-    print("****** run onnx ******")
+    print_unless_ci("****** run onnx ******")
     tinygrad_out = run_onnx(inputs)['outputs']
     mt = time.monotonic()
-    print("****** realize ******")
+    print_unless_ci("****** realize ******")
     tinygrad_out.realize()
     mt2 = time.monotonic()
     tinygrad_out = tinygrad_out.numpy()
     et = time.monotonic()
-    print(f"ran openpilot model in {(et-st)*1000.0:.2f} ms, waited {(mt2-mt)*1000.0:.2f} ms for realize, {(et-mt2)*1000.0:.2f} ms for GPU queue")
+    print_unless_ci(f"ran openpilot model in {(et-st)*1000.0:.2f} ms, waited {(mt2-mt)*1000.0:.2f} ms for realize, {(et-mt2)*1000.0:.2f} ms for GPU queue")
 
     Tensor.no_grad = True
     torch_out = run_onnx_torch(onnx_model, inputs).numpy()
     Tensor.no_grad = False
-    print(tinygrad_out, torch_out)
+    print_unless_ci(tinygrad_out, torch_out)
     np.testing.assert_allclose(torch_out, tinygrad_out, atol=1e-4, rtol=1e-2)
 
   def test_efficientnet(self):
@@ -104,7 +109,7 @@ class TestOnnxModel(unittest.TestCase):
 
   def test_shufflenet(self):
     dat = fetch("https://github.com/onnx/models/raw/main/vision/classification/shufflenet/model/shufflenet-9.onnx")
-    print(f"shufflenet downloaded : {len(dat)/1e6:.2f} MB")
+    print_unless_ci(f"shufflenet downloaded : {len(dat)/1e6:.2f} MB")
     input_name, input_new = "gpu_0/data_0", False
     self._test_model(dat, input_name, input_new)
 
@@ -112,13 +117,13 @@ class TestOnnxModel(unittest.TestCase):
   def test_resnet(self):
     # NOTE: many onnx models can't be run right now due to max pool with strides != kernel_size
     dat = fetch("https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet18-v2-7.onnx")
-    print(f"resnet downloaded : {len(dat)/1e6:.2f} MB")
+    print_unless_ci(f"resnet downloaded : {len(dat)/1e6:.2f} MB")
     input_name, input_new = "data", False
     self._test_model(dat, input_name, input_new)
 
   def _test_model(self, dat, input_name, input_new, debug=False):
     onnx_model = onnx.load(io.BytesIO(dat))
-    print("onnx loaded")
+    print_unless_ci("onnx loaded")
     from test.models.test_efficientnet import chicken_img, car_img, preprocess, _LABELS
     run_onnx = get_run_onnx(onnx_model)
 
@@ -128,10 +133,10 @@ class TestOnnxModel(unittest.TestCase):
       return tinygrad_out.argmax()
 
     cls = run(chicken_img)
-    print(cls, _LABELS[cls])
+    print_unless_ci(cls, _LABELS[cls])
     assert _LABELS[cls] == "hen" or _LABELS[cls] == "cock"
     cls = run(car_img)
-    print(cls, _LABELS[cls])
+    print_unless_ci(cls, _LABELS[cls])
     assert "car" in _LABELS[cls] or _LABELS[cls] == "convertible"
 
 if __name__ == "__main__":

--- a/test/models/test_train.py
+++ b/test/models/test_train.py
@@ -4,7 +4,7 @@ import numpy as np
 from tinygrad.state import get_parameters
 from tinygrad.nn import optim
 from tinygrad.tensor import Device
-from tinygrad.helpers import getenv
+from tinygrad.helpers import getenv, DEBUG, print_unless_ci
 from extra.training import train
 from models.convnext import ConvNeXt
 from models.efficientnet import EfficientNet
@@ -20,11 +20,11 @@ def train_one_step(model,X,Y):
   for p in params:
     pcount += np.prod(p.shape)
   optimizer = optim.SGD(params, lr=0.001)
-  print("stepping %r with %.1fM params bs %d" % (type(model), pcount/1e6, BS))
+  print_unless_ci("stepping %r with %.1fM params bs %d" % (type(model), pcount/1e6, BS))
   st = time.time()
   train(model, X, Y, optimizer, steps=1, BS=BS)
   et = time.time()-st
-  print("done in %.2f ms" % (et*1000.))
+  print_unless_ci("done in %.2f ms" % (et*1000.))
 
 def check_gc():
   if Device.DEFAULT == "GPU":

--- a/test/test_conv.py
+++ b/test/test_conv.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 from tinygrad.tensor import Tensor
+from tinygrad.helpers import print_unless_ci
 
 class TestConv(unittest.TestCase):
   def test_simple(self):
@@ -17,7 +18,7 @@ class TestConv(unittest.TestCase):
     #w = Tensor(np.arange(8*8*1*1).reshape(8,8,1,1).astype(np.float32))
     w = Tensor.eye(8).reshape((8,8,1,1))
     ret = x.conv2d(w, stride=(1,2), padding=(0,0)).numpy()
-    print(ret)
+    print_unless_ci(ret)
 
   def test_lazycache(self):
     Tensor.no_grad = True
@@ -33,8 +34,7 @@ class TestConv(unittest.TestCase):
     w = Tensor.eye(C).reshape((C,C,1,1))
     b = Tensor(np.arange(C).astype(np.float32))
     ret = Tensor.conv2d(x,w,b).relu().conv2d(w,b)
-
-    print(ret.numpy())
+    print_unless_ci(ret.numpy())
 
   def test_two_binops_no_rerun(self):
     Tensor.no_grad = True
@@ -70,7 +70,7 @@ class TestConv(unittest.TestCase):
     x = x.conv2d(w).elu()
 
     x = x.numpy()
-    print(x.shape)
+    print_unless_ci(x.shape)
     Tensor.no_grad = False
 
   def test_elu(self):
@@ -114,7 +114,7 @@ class TestConv(unittest.TestCase):
     x = Tensor.ones(1,12,128,256)
     w = Tensor.ones(12,12,3,3)
     x = x.conv2d(w, padding=(1,1))
-    print(x.shape)
+    print_unless_ci(x.shape)
     x = x.reshape((1, 12, 256, 128))
     x += 1
     x += 1

--- a/test/test_custom_function.py
+++ b/test/test_custom_function.py
@@ -4,7 +4,7 @@
 import unittest
 import numpy as np
 from typing import Optional, Tuple
-from tinygrad.helpers import prod, dtypes
+from tinygrad.helpers import prod, dtypes, print_unless_ci
 
 # *** first, we implement the atan2 op at the lowest level ***
 # `atan2_gpu` for GPUBuffers and `atan2_cpu` for CPUBuffers
@@ -59,7 +59,7 @@ class TestCustomFunction(unittest.TestCase):
 
     # run the forward pass. note: up until the .numpy(), it's all lazy
     c = ATan2.apply(a, b)
-    print(c.numpy())
+    print_unless_ci(c.numpy())
 
     # check the forward pass (in numpy)
     np.testing.assert_allclose(c.numpy(), np.arctan2(a.numpy(), b.numpy()), atol=1e-5)
@@ -74,8 +74,8 @@ class TestCustomFunction(unittest.TestCase):
     # run the backward pass
     c.mean().backward()
     assert a.grad is not None and b.grad is not None, "tinygrad didn't compute gradients"
-    print(a.grad.numpy())
-    print(b.grad.numpy())
+    print_unless_ci(a.grad.numpy())
+    print_unless_ci(b.grad.numpy())
 
     # check the backward pass (in torch)
     import torch

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -1,14 +1,14 @@
 import unittest
 import numpy as np
-from tinygrad.helpers import getenv, DType, DEBUG
+from tinygrad.helpers import getenv, DType, DEBUG, CI, print_unless_ci
 from tinygrad.lazy import Device
 from tinygrad.tensor import Tensor, dtypes
 from extra.utils import OSX
 
 def _test_to_np(a:Tensor, np_dtype, target):
-  print(a)
+  print_unless_ci(a)
   na = a.numpy()
-  print(na, na.dtype, a.lazydata.realized)
+  print_unless_ci(na, na.dtype, a.lazydata.realized)
   assert na.dtype == np_dtype
   np.testing.assert_allclose(na, target)
 
@@ -28,7 +28,7 @@ def _test_matmul_upcast(a:Tensor, b:Tensor, target_dtype:DType, target): _test_o
 
 # for GPU, cl_khr_fp16 isn't supported (except now we don't need it!)
 # for LLVM, it segfaults because it can't link to the casting function
-@unittest.skipIf((getenv("CI", "") != "" and Device.DEFAULT in ["LLVM"]) or Device.DEFAULT == "WEBGPU", "float16 broken in some CI backends")
+@unittest.skipIf((CI and Device.DEFAULT in ["LLVM"]) or Device.DEFAULT == "WEBGPU", "float16 broken in some CI backends")
 class TestHalfDtype(unittest.TestCase):
   def test_half_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.float16), np.float16, [1,2,3,4])
 

--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -3,6 +3,7 @@ import gc
 import unittest
 import numpy as np
 from tinygrad.tensor import Tensor
+from tinygrad.helpers import print_unless_ci
 
 def tensors_allocated():
   return sum([isinstance(x, Tensor) for x in gc.get_objects()])
@@ -26,9 +27,9 @@ class TestGC(unittest.TestCase):
     del b
     assert(tensors_allocated() == 2)
     b = Tensor(np.zeros((4, 4), dtype=np.float32), requires_grad=True)
-    print(tensors_allocated())
+    print_unless_ci(tensors_allocated())
     (a*b).mean().backward()
-    print(tensors_allocated())
+    print_unless_ci(tensors_allocated())
     assert(tensors_allocated() == 4)
     del b
     assert(tensors_allocated() == 2)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2,7 +2,7 @@
 import unittest
 import numpy as np
 from extra.utils import WINDOWS
-from tinygrad.helpers import getenv
+from tinygrad.helpers import CI
 from tinygrad.jit import TinyJit
 from tinygrad.tensor import Tensor, Device
 from tinygrad.nn import BatchNorm2d, Conv1d, ConvTranspose1d, Conv2d, ConvTranspose2d, Linear, GroupNorm, LayerNorm, LayerNorm2d, Embedding, InstanceNorm
@@ -115,7 +115,7 @@ class TestNN(unittest.TestCase):
     torch_z = torch_layer(torch_x)
     np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-4, rtol=1e-5)
 
-  @unittest.skipIf(getenv("CI", "") != "" and (WINDOWS or Device.DEFAULT == "WEBGPU"), "runs out of memory in CI")
+  @unittest.skipIf(CI and (WINDOWS or Device.DEFAULT == "WEBGPU"), "runs out of memory in CI")
   def test_conv_transpose1d(self):
     BS, C1, W = 4, 16, 224
     C2, K, S, P = 64, 7, 2, 1
@@ -136,7 +136,7 @@ class TestNN(unittest.TestCase):
     torch_z = torch_layer(torch_x)
     np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-4, rtol=1e-5)
 
-  @unittest.skipIf(getenv("CI", "") != "" and (WINDOWS or Device.DEFAULT == "WEBGPU"), "runs out of memory in CI")
+  @unittest.skipIf(CI and (WINDOWS or Device.DEFAULT == "WEBGPU"), "runs out of memory in CI")
   def test_conv_transpose2d(self):
     BS, C1, H, W = 4, 16, 224, 224
     C2, K, S, P = 64, 7, 2, 1

--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -14,7 +14,7 @@ from tinygrad.lazy import Device
 from tinygrad.ops import GlobalCounters
 from tinygrad.tensor import Tensor
 from tinygrad.nn import Conv2d
-from tinygrad.helpers import colored, getenv, DEBUG
+from tinygrad.helpers import colored, getenv, DEBUG, print_unless_ci
 from tinygrad.jit import TinyJit
 
 IN_CHANS = [int(x) for x in getenv("IN_CHANS", "4,16,64").split(",")]
@@ -93,7 +93,7 @@ def helper_test_generic(name, f1, f1_args, f2, f2_args):
   desc = "faster" if et_torch > et_tinygrad else "slower"
   flops = save_ops*1e-6
   mem = save_mem*1e-6
-  print(f"{prefix}{name:42s} {et_torch:7.2f} ms ({flops/et_torch:8.2f} GFLOPS {mem/et_torch:8.2f} GB/s) in torch, {et_tinygrad:7.2f} ms ({flops/et_tinygrad:8.2f} GFLOPS {mem/et_tinygrad:8.2f} GB/s) in tinygrad, {colorize_float(et_tinygrad/et_torch)} {desc} {flops:10.2f} MOPS {mem:8.2f} MB")
+  print_unless_ci(f"{prefix}{name:42s} {et_torch:7.2f} ms ({flops/et_torch:8.2f} GFLOPS {mem/et_torch:8.2f} GB/s) in torch, {et_tinygrad:7.2f} ms ({flops/et_tinygrad:8.2f} GFLOPS {mem/et_tinygrad:8.2f} GB/s) in tinygrad, {colorize_float(et_tinygrad/et_torch)} {desc} {flops:10.2f} MOPS {mem:8.2f} MB")
   prefix = " "
   np.testing.assert_allclose(val_tinygrad, val_torch, atol=1e-4, rtol=1e-3)
 

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -5,7 +5,7 @@ from tinygrad.tensor import Tensor, Device
 from tinygrad.state import safe_load, safe_save, get_state_dict, torch_load
 from tinygrad.helpers import dtypes
 from tinygrad.runtime.ops_disk import RawDiskBuffer
-from tinygrad.helpers import Timing
+from tinygrad.helpers import Timing, print_unless_ci
 from extra.utils import fetch_as_file, temp
 
 def compare_weights_both(url):
@@ -16,7 +16,7 @@ def compare_weights_both(url):
   assert list(tg_weights.keys()) == list(torch_weights.keys())
   for k in tg_weights:
     np.testing.assert_equal(tg_weights[k].numpy(), torch_weights[k].numpy(), err_msg=f"mismatch at {k}, {tg_weights[k].shape}")
-  print(f"compared {len(tg_weights)} weights")
+  print_unless_ci(f"compared {len(tg_weights)} weights")
 
 class TestTorchLoad(unittest.TestCase):
   # pytorch pkl format
@@ -96,7 +96,7 @@ class TestDiskTensor(unittest.TestCase):
 
     out = Tensor.ones(10, 10, device="CPU")
     outdisk = out.to(f"disk:{temp('dt2')}")
-    print(outdisk)
+    print_unless_ci(outdisk)
     outdisk.realize()
     del out, outdisk
 
@@ -114,7 +114,7 @@ class TestDiskTensor(unittest.TestCase):
     Tensor.arange(10, device="CPU").to(f"disk:{temp('dt3')}").realize()
 
     slice_me = Tensor.empty(10, device=f"disk:{temp('dt3')}")
-    print(slice_me)
+    print_unless_ci(slice_me)
     is_3 = slice_me[3:4].cpu()
     assert is_3.numpy()[0] == 3
 
@@ -123,7 +123,7 @@ class TestDiskTensor(unittest.TestCase):
     Tensor.arange(100, device="CPU").to(f"disk:{temp('dt5')}").realize()
     slice_me = Tensor.empty(10, 10, device=f"disk:{temp('dt5')}")
     tst = slice_me[1].numpy()
-    print(tst)
+    print_unless_ci(tst)
     np.testing.assert_allclose(tst, np.arange(10, 20))
 
   def test_assign_slice(self):
@@ -131,9 +131,9 @@ class TestDiskTensor(unittest.TestCase):
     cc = Tensor.arange(10, device="CPU").to(f"disk:{temp('dt4')}").realize()
 
     #cc.assign(np.ones(10)).realize()
-    print(cc[3:5].numpy())
+    print_unless_ci(cc[3:5].numpy())
     cc[3:5].assign([13, 12]).realize()
-    print(cc.numpy())
+    print_unless_ci(cc.numpy())
 
 if __name__ == "__main__":
   unittest.main()

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -3,7 +3,7 @@ import itertools, math
 from collections import defaultdict
 from enum import Enum, auto
 
-from tinygrad.helpers import dedup, colored, ImageDType, DEBUG, prod, dtypes, mnum, DType, all_same, partition, getenv
+from tinygrad.helpers import dedup, colored, ImageDType, DEBUG, CI, prod, dtypes, mnum, DType, all_same, partition, getenv
 from tinygrad.ops import LazyOp, FlopCounter, get_lazyop_info, UnaryOps
 from tinygrad.lazy import LazyBuffer
 from tinygrad.ops import MovementOps, ReduceOps, BinaryOps, TernaryOps
@@ -635,7 +635,7 @@ class Linearizer:
 
     # should use tensor cores?
     # first, confirm it's a straightforward mulacc on a device with real locals
-    tensor_cores_allowed = getenv("TC", 1) != 0 and (getenv("TC", 1) == 2 or (self.bufs[0].device == "METAL" and getenv("CI", "") != "true"))
+    tensor_cores_allowed = getenv("TC", 1) != 0 and (getenv("TC", 1) == 2 or (self.bufs[0].device == "METAL" and CI))
     if tensor_cores_allowed and self.reduceop and self.reduceop.op == ReduceOps.SUM and \
        isinstance(self.reduceop.src[0], LazyOp) and self.reduceop.src[0].op == BinaryOps.MUL and \
        isinstance(self.reduceop.src[0].src[0], LazyBuffer) and isinstance(self.reduceop.src[0].src[1], LazyBuffer) and hasattr(self, 'lang') and len(self.lang.lid):

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -49,6 +49,7 @@ class ContextVar:
 
 DEBUG, IMAGE = ContextVar("DEBUG", 0), ContextVar("IMAGE", 0)
 GRAPH, PRUNEGRAPH, GRAPHPATH = getenv("GRAPH", 0), getenv("PRUNEGRAPH", 0), getenv("GRAPHPATH", "/tmp/net")
+CI = getenv("CI", "")
 
 class Timing(object):
   def __init__(self, prefix="", on_exit=None, enabled=True): self.prefix, self.on_exit, self.enabled = prefix, on_exit, enabled
@@ -152,3 +153,6 @@ class LightWeakValueDictionary:
   def __delitem__(self, key): del self.data[key]
   def __setitem__(self, key, value): self.data[key] = KeyedRef(value, self._remove, key)
   def __contains__(self, key): return key in self.data
+
+def print_unless_ci(*args, **kwargs):
+  if not CI: print(*args, **kwargs)


### PR DESCRIPTION
Draft only for @cheeetoo to illustrate some ideas:

* Use Python 3.11 (if possible, check with @geohot, you might have to keep a Python3.8 compatibility check somewhere)
* Reorder tests to start with the slowest (mnist, conv stuff)
* disable prints and timing where possible
* set random seeds once per file instead of for each test