### PR TITLE
Slice migrated in Eye op

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -96,6 +96,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([], lambda: torch.ones_like(b), lambda: Tensor.ones_like(a), forward_only=True)
   def test_eye(self):
     helper_test_op([], lambda: torch.eye(10), lambda: Tensor.eye(10), forward_only=True)
+    helper_test_op([], lambda: torch.eye(1), lambda: Tensor.eye(1), forward_only=True)
 
   def test_arange(self):
     helper_test_op([], lambda: torch.arange(10), lambda: Tensor.arange(10), forward_only=True)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -168,7 +168,9 @@ class Tensor:
   def ones_like(tensor, **kwargs): return Tensor.full_like(tensor, 1, **kwargs)
 
   @staticmethod
-  def eye(dim:int, **kwargs): return Tensor([1], **kwargs).pad(((0,dim),)).repeat((dim,)).shrink(((0,dim*dim),)).reshape(dim, dim)
+  def eye(dim:int, **kwargs):
+    return Tensor([1], **kwargs).pad(((0,dim),)).reshape(1, dim+1).expand(dim, dim+1).reshape(dim*(dim+1)).shrink(((0,dim*dim),)).reshape(dim, dim)
+
 
   # ***** rng hlops *****
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -168,7 +168,7 @@ class Tensor:
   def ones_like(tensor, **kwargs): return Tensor.full_like(tensor, 1, **kwargs)
 
   @staticmethod
-  def eye(dim, **kwargs): return Tensor([1], **kwargs).slice(((0,dim+1),)).reshape(1, dim+1).expand(dim, dim+1).reshape(dim*(dim+1)).slice(((0,dim*dim),)).reshape(dim, dim)
+  def eye(dim:int, **kwargs): return Tensor([1], **kwargs).pad(((0,dim),)).repeat((dim,)).shrink(((0,dim*dim),)).reshape(dim, dim)
 
   # ***** rng hlops *****
 


### PR DESCRIPTION
Based on 

`# NOTE: using slice is discouraged and things should migrate to pad and shrink`

Just updated the "Tensor.eye()" function replacing slice with pad/shrink.

I do not know if I should continue cleanup code.

Maybe bit faster but not sure