### PR TITLE
Add option in llama.py to quantize weights to int8 at runtime

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -3,9 +3,8 @@
 #import typeguard.importhook
 #typeguard.importhook.install_import_hook('tinygrad')
 
-import functools
 from pathlib import Path
-import sys, argparse, math, platform
+import functools, sys, argparse, math, platform
 import numpy as np
 from tqdm import tqdm
 np.set_printoptions(linewidth=200)
@@ -51,8 +50,8 @@ class RMSNorm:
     return (x * (x.pow(2).mean(-1, keepdim=True) + self.eps).rsqrt()) * self.weight
 
 class Attention:
-  def __init__(self, dim, n_heads):
-    self.wq, self.wk, self.wv, self.wo = [Linear(dim, dim, bias=False) for _ in range(4)]
+  def __init__(self, dim, n_heads, linear=Linear):
+    self.wq, self.wk, self.wv, self.wo = [linear(dim, dim, bias=False) for _ in range(4)]
     self.n_heads = n_heads
     self.head_dim = dim // n_heads
 
@@ -92,24 +91,24 @@ class Attention:
     return self.wo(output)
 
 class FeedForward:
-  def __init__(self, dim, hidden_dim, multiple_of, ffn_dim_multiplier=None):
+  def __init__(self, dim, hidden_dim, multiple_of, linear=Linear, ffn_dim_multiplier=None):
     # TODO: what is this?
     hidden_dim = int(2 * hidden_dim / 3)
     # custom dim factor multiplier
     if ffn_dim_multiplier is not None:
       hidden_dim = int(ffn_dim_multiplier * hidden_dim)
     hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
-    self.w1 = Linear(dim, hidden_dim, bias=False)
-    self.w2 = Linear(hidden_dim, dim, bias=False)
-    self.w3 = Linear(dim, hidden_dim, bias=False)
+    self.w1 = linear(dim, hidden_dim, bias=False)
+    self.w2 = linear(hidden_dim, dim, bias=False)
+    self.w3 = linear(dim, hidden_dim, bias=False)
 
   def __call__(self, x:Tensor) -> Tensor:
     return self.w2(self.w1(x).silu() * self.w3(x))
 
 class TransformerBlock:
-  def __init__(self, dim, multiple_of, n_heads, norm_eps, ffn_dim_multiplier=None):
-    self.attention = Attention(dim, n_heads)
-    self.feed_forward = FeedForward(dim, 4*dim, multiple_of, ffn_dim_multiplier)
+  def __init__(self, dim, multiple_of, n_heads, norm_eps, linear=Linear, ffn_dim_multiplier=None):
+    self.attention = Attention(dim, n_heads, linear)
+    self.feed_forward = FeedForward(dim, 4*dim, multiple_of, linear, ffn_dim_multiplier)
     self.attention_norm = RMSNorm(dim, norm_eps)
     self.ffn_norm = RMSNorm(dim, norm_eps)
     if getenv("JIT"):
@@ -133,11 +132,11 @@ class TransformerBlock:
     return self._post(x, output)
 
 class Transformer:
-  def __init__(self, dim, multiple_of, n_heads, n_layers, norm_eps, vocab_size, max_batch_size=32, max_seq_len=1024, ffn_dim_multiplier=None):
-    self.layers = [TransformerBlock(dim, multiple_of, n_heads, norm_eps, ffn_dim_multiplier) for _ in range(n_layers)]
+  def __init__(self, dim, multiple_of, n_heads, n_layers, norm_eps, vocab_size, linear=Linear, max_batch_size=32, max_seq_len=1024, ffn_dim_multiplier=None):
+    self.layers = [TransformerBlock(dim, multiple_of, n_heads, norm_eps, linear, ffn_dim_multiplier) for _ in range(n_layers)]
     self.norm = RMSNorm(dim, norm_eps)
     self.tok_embeddings = Embedding(vocab_size, dim)
-    self.output = Linear(dim, vocab_size, bias=False)
+    self.output = linear(dim, vocab_size, bias=False)
     self.freqs_cis = Tensor(precompute_freqs_cis(dim // n_heads, max_seq_len * 2))
 
   def __call__(self, tokens:Tensor, start_pos:int):
@@ -148,8 +147,7 @@ class Transformer:
     freqs_cis = self.freqs_cis[:, start_pos:start_pos+seqlen].contiguous().realize()
     mask = Tensor.full((1, 1, seqlen, start_pos + seqlen), float("-inf"), dtype=dtypes.float32).triu(start_pos+1).realize() if seqlen > 1 else None
     h = h.sequential([functools.partial(layer, start_pos=start_pos, freqs_cis=freqs_cis, mask=mask) for layer in self.layers])
-
-    return self.output(self.norm(h)[:, -1, :])
+    return self.output(self.norm(h))
 
 # **** files and arguments ****
 
@@ -203,18 +201,70 @@ def sample(logits, temperature):
 def concat_weights(models):
   def convert(name) -> Tensor:
     disk_tensors = [model[name] for model in models]
-    if len(disk_tensors) == 1:
-      return disk_tensors[0]
-    if len(disk_tensors[0].shape) == 1:
-      return disk_tensors[0]
-    if name.startswith('tok_embeddings.') or name.endswith('.attention.wo.weight') or name.endswith('.feed_forward.w2.weight'):
-      axis = 1
-    else:
-      axis = 0
+    if len(disk_tensors) == 1 or len(disk_tensors[0].shape) == 1:
+      return disk_tensors[0].to(device=Device.DEFAULT)
+    axis = 1 if name.startswith('tok_embeddings.') or name.endswith('.attention.wo.weight') or name.endswith('.feed_forward.w2.weight') else 0
     lazy_tensors = [data.to(device=Device.DEFAULT) for data in disk_tensors]
-    first, rest = lazy_tensors[0], lazy_tensors[1:]
-    return first.cat(*rest, dim=axis)
+    return lazy_tensors[0].cat(*lazy_tensors[1:], dim=axis)
   return {name: convert(name) for name in {name: None for model in models for name in model}}
+
+class AbsmaxQuantizedLinear:
+  def __init__(self, in_features, out_features, bias=False):
+    assert bias == False
+    self.weight = Tensor.ones(out_features, in_features, dtype=dtypes.int8)
+    self.scale = Tensor.ones(out_features, dtype=dtypes.half)
+
+  def __call__(self, x):
+    return x.dot(self.weight.cast(dtype=dtypes.half).T/self.scale)
+
+  @staticmethod
+  def quantize(tensors):
+    new_tensors = {}
+    for name,v in tensors.items():
+      if 'feed_forward' in name or ('attention.w') in name or name == 'output.weight':
+        scale = 127.0 / v.abs().max(axis=1)
+        int8_weight = (v.T*scale).T.cast(dtype=dtypes.int8)
+        new_tensors[name] = int8_weight
+        new_tensors[name.replace('weight', 'scale')] = scale
+      else:
+        new_tensors[name] = v
+    return new_tensors
+
+class LLaMa:
+  @staticmethod
+  def build(model_path, tokenizer_path, model_gen=1, model_size="7B", quantize=False):
+    from sentencepiece import SentencePieceProcessor
+    sp_model = SentencePieceProcessor(model_file=str(tokenizer_path))
+    assert sp_model.vocab_size() == VOCAB_SIZE
+
+    from tinygrad.state import torch_load, load_state_dict
+    params = MODEL_PARAMS[model_gen][model_size]
+    model = Transformer(**params["args"], linear=AbsmaxQuantizedLinear) if quantize else Transformer(**params["args"])
+    weights = concat_weights([torch_load(filename) for filename in [f"{model_path}/{model_size}/consolidated.{i:02d}.pth" for i in range(params["files"])]])
+    if quantize:
+      weights = AbsmaxQuantizedLinear.quantize(weights)
+    load_state_dict(model, weights, strict=False)
+
+    return LLaMa(model, sp_model)
+
+  def __init__(self, model, tokenizer):
+    self.model = model
+    self.tokenizer = tokenizer
+
+  def greedy_until(self, prompt:str, until, max_length, temperature):
+    toks = [self.tokenizer.bos_id()] + self.tokenizer.encode(prompt)
+    start_pos = 0
+    for i in range(max_length):
+      logits = self.model(Tensor([toks[start_pos:]]), start_pos).realize()[:, -1, :]
+      tok = sample(logits, temperature)
+      start_pos = len(toks)
+      toks.append(tok)
+
+      if tok == self.tokenizer.eos_id(): break
+      output = self.tokenizer.decode(toks)
+      for s in until:
+        if output.endswith(s): return output[0:-len(s)]
+    return output
 
 # **** main code ****
 
@@ -234,27 +284,10 @@ if __name__ == "__main__":
   parser.add_argument('--profile', action='store_true', help="Output profile data to out.prof")
   parser.add_argument('--size', type=str, default="7B", help="Size of model to use [7B, 13B, 30B, 65B] for Gen 1, [7B, 13B] for Gen 2")
   parser.add_argument('--gen', type=int, default="1", help="Generation of the model to use [1, 2]")
+  parser.add_argument('--quantize', action='store_true', help="Quantize the weights to int8 in memory")
 
   args = parser.parse_args()
   chatbot = args.prompt == None
-
-  LLAMA_SUFFIX = {1: "", 2: "-2"}[args.gen]
-  WEIGHTS_DIR = Path(__file__).parent.parent / f"weights/LLaMA{LLAMA_SUFFIX}/"
-  TOKENIZER_FILENAME = WEIGHTS_DIR / "tokenizer.model"
-
-  from sentencepiece import SentencePieceProcessor
-  sp_model = SentencePieceProcessor(model_file=str(TOKENIZER_FILENAME))
-  assert sp_model.vocab_size() == VOCAB_SIZE
-
-  from tinygrad.state import torch_load, load_state_dict
-  print(f"using LLaMA{LLAMA_SUFFIX}-{args.size} model")
-  params = MODEL_PARAMS[args.gen][args.size]
-  model = Transformer(**params["args"])
-  weights = [torch_load(WEIGHTS_DIR / f"{args.size}/consolidated.{i:02d}.pth") for i in range(params["files"])]
-  if len(weights) == 1:
-    load_state_dict(model, weights[0], strict=False)
-  else:
-    load_state_dict(model, concat_weights(weights), strict=False)
 
   # *** prompt engineers work here ****
 
@@ -345,21 +378,28 @@ After you are done speaking, output [EOS]. You are not Chad.
 
   # *** prompt engineers stop here ****
 
+
+  LLAMA_SUFFIX = {1: "", 2: "-2"}[args.gen]
+  WEIGHTS_DIR = Path(__file__).parent.parent / f"weights/LLaMA{LLAMA_SUFFIX}/"
+  TOKENIZER_FILENAME = WEIGHTS_DIR / "tokenizer.model"
+  print(f"using LLaMA{LLAMA_SUFFIX}-{args.size} model")
+  llama = LLaMa.build(WEIGHTS_DIR, TOKENIZER_FILENAME, model_gen=args.gen, model_size=args.size, quantize=args.quantize)
+
   if chatbot:
     # encode pre prompt
-    toks = [sp_model.bos_id()] + sp_model.encode(pre_prompt)
+    toks = [llama.tokenizer.bos_id()] + llama.tokenizer.encode(pre_prompt)
 
     print(f"Preparing KV cache for chatbot with personality {args.personality}...")
     with Timing():
-      model(Tensor([toks]), 0).realize()  # NOTE: output logits are not used
+      llama.model(Tensor([toks]), 0).realize()  # NOTE: output logits are not used
     start_pos = len(toks)
   else:
     # non chat bot mode
-    toks = [sp_model.bos_id()] + sp_model.encode(args.prompt)
+    toks = [llama.tokenizer.bos_id()] + llama.tokenizer.encode(args.prompt)
     start_pos = 0
 
   # print prompt
-  outputted = sp_model.decode(toks)
+  outputted = llama.tokenizer.decode(toks)
   sys.stdout.write(outputted)
   sys.stdout.flush()
 
@@ -374,10 +414,10 @@ After you are done speaking, output [EOS]. You are not Chad.
       user_prompt = user_delim + input(user_delim) + "\n"
       outputted += user_prompt
 
-    new_toks = [sp_model.bos_id()] + sp_model.encode(outputted)
+    new_toks = [llama.tokenizer.bos_id()] + llama.tokenizer.encode(outputted)
     assert toks == new_toks[:len(toks)]
     toks = new_toks
-    assert outputted == sp_model.decode(toks)
+    assert outputted == llama.tokenizer.decode(toks)
 
     last_break = len(outputted)
     for i in range(args.count):
@@ -386,7 +426,7 @@ After you are done speaking, output [EOS]. You are not Chad.
       if args.timing: print("")
       st = GlobalCounters.time_sum_s
       with Timing("ran model in ", on_exit=(lambda et: f", {(GlobalCounters.time_sum_s-st)*1e3:.2f} ms on GPU") if DEBUG else None, enabled=args.timing):
-        logits = model(Tensor([toks[start_pos:]]), start_pos).realize()
+        logits = llama.model(Tensor([toks[start_pos:]]), start_pos).realize()[:, -1, :]
       with Timing("sync in ", enabled=args.timing):
         tok = sample(logits, args.temperature)
 
@@ -397,7 +437,7 @@ After you are done speaking, output [EOS]. You are not Chad.
       toks.append(tok)
 
       # TODO: this is a hack to deal with spaces. i think the decode is fast though, so who cares?
-      cur = sp_model.decode(toks)
+      cur = llama.tokenizer.decode(toks)
       sys.stdout.write(cur[len(outputted):])
       sys.stdout.flush()
       outputted = cur

--- a/test/external/external_llama_eval.py
+++ b/test/external/external_llama_eval.py
@@ -10,6 +10,7 @@ class LLaMaAdaptor(BaseLM):
   def __init__(
     self,
     model_size="7B",
+    model_gen=1,
     device="",
     quantize=False,
     batch_size=1,
@@ -27,12 +28,13 @@ class LLaMaAdaptor(BaseLM):
     self.temperature = temperature
     self._device = device
 
+    assert isinstance(model_gen, int)
     assert isinstance(model_size, str)
     assert isinstance(batch_size, int)
     assert isinstance(checkpoint_path, str)
     assert isinstance(tokenizer_path, str)
 
-    self.llama = LLaMa.build(checkpoint_path, tokenizer_path, model_size, quantize)
+    self.llama = LLaMa.build(checkpoint_path, tokenizer_path, model_gen, model_size, quantize)
 
   @classmethod
   def create_from_arg_string(cls, arg_string, additional_config=None):
@@ -85,7 +87,8 @@ if __name__ == '__main__':
   print(f"using {Device.DEFAULT} backend")
 
   parser = argparse.ArgumentParser(description='Run LLaMA evals in tinygrad', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-  parser.add_argument('--size', type=str, default="7B", help="Size of model to use [7B, 13B, 30B, 65B]")
+  parser.add_argument('--size', type=str, default="7B", help="Size of model to use [7B, 13B, 30B, 65B] for Gen 1, [7B, 13B] for Gen 2")
+  parser.add_argument('--gen', type=int, default="1", help="Generation of the model to use [1, 2]")
   parser.add_argument('--quantize', action='store_true', help="Quantize the weights to int8 in memory")
   parser.add_argument('--eval', type=str, default="arc_easy", help="Run in evaluation mode")
   parser.add_argument('--limit', type=int, default=None, help="Limit tests in eval")
@@ -94,6 +97,6 @@ if __name__ == '__main__':
   args = parser.parse_args()
 
   # run eval and exit
-  adaptor = LLaMaAdaptor(model_size=args.size, quantize=args.quantize, checkpoint_path=args.weights, tokenizer_path=args.tokenizer, device="cpu")
+  adaptor = LLaMaAdaptor(model_gen=args.gen, model_size=args.size, quantize=args.quantize, checkpoint_path=args.weights, tokenizer_path=args.tokenizer, device="cpu")
   results = evaluator.evaluate(adaptor, tasks.get_task_dict(args.eval.split(",")), False, 0, args.limit)
   print(json.dumps(results, indent=2))

--- a/test/external/external_llama_eval.py
+++ b/test/external/external_llama_eval.py
@@ -1,0 +1,99 @@
+from lm_eval.base import BaseLM
+from lm_eval import evaluator, tasks
+import torch, json, argparse
+
+from examples.llama import LLaMa
+from tinygrad.tensor import Tensor
+from tinygrad.lazy import Device
+
+class LLaMaAdaptor(BaseLM):
+  def __init__(
+    self,
+    model_size="7B",
+    device="",
+    quantize=False,
+    batch_size=1,
+    max_batch_size=1,
+    do_sample=False,
+    temperature=1.0,
+    checkpoint_path="",
+    tokenizer_path="",
+  ):
+    super().__init__()
+
+    if batch_size is None:
+      batch_size = 1
+    self.do_sample = do_sample
+    self.temperature = temperature
+    self._device = device
+
+    assert isinstance(model_size, str)
+    assert isinstance(batch_size, int)
+    assert isinstance(checkpoint_path, str)
+    assert isinstance(tokenizer_path, str)
+
+    self.llama = LLaMa.build(checkpoint_path, tokenizer_path, model_size, quantize)
+
+  @classmethod
+  def create_from_arg_string(cls, arg_string, additional_config=None):
+    kwargs = {el.split("=")[0]: el.split("=")[1] for el in arg_string.split(",")}
+    return cls(**kwargs, **additional_config)
+
+  @property
+  def eot_token_id(self):
+    # we use EOT because end of *text* is more accurate for what we're doing than end of *sentence*
+    return self.llama.tokenizer.eos_id()
+
+  @property
+  def max_length(self):
+    return 1024
+
+  @property
+  def max_gen_toks(self):
+    return 256
+
+  @property
+  def batch_size(self):
+    return 1
+
+  @property
+  def device(self):
+    return self._device
+
+  def tok_encode(self, string: str):
+    return [self.llama.tokenizer.bos_id()] + self.llama.tokenizer.encode(string)
+
+  def tok_decode(self, tokens):
+    return self.llama.tokenizer.decode(tokens)
+
+  def _model_call(self, inps):
+    Tensor.no_grad = True
+    return torch.Tensor(self.llama.model(Tensor(inps.numpy()), 0).numpy())
+
+  def greedy_until(self, requests):
+    continuations = []
+    for request in requests:
+      prompt, until = request[0], request[1]['until']
+      output = self.llama.greedy_until(prompt, until, max_length=128, temperature=0.0)
+      continuations.append(output[len(prompt):])
+    return continuations
+
+  def _model_generate(self, context, max_length, eos_token_id):
+    raise NotImplementedError()
+
+if __name__ == '__main__':
+  print(f"using {Device.DEFAULT} backend")
+
+  parser = argparse.ArgumentParser(description='Run LLaMA evals in tinygrad', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  parser.add_argument('--size', type=str, default="7B", help="Size of model to use [7B, 13B, 30B, 65B]")
+  parser.add_argument('--quantize', action='store_true', help="Quantize the weights to int8 in memory")
+  parser.add_argument('--eval', type=str, default="arc_easy", help="Run in evaluation mode")
+  parser.add_argument('--limit', type=int, default=None, help="Limit tests in eval")
+  parser.add_argument('--weights', type=str, default="./weights/LLaMa/", help="Location of the weights")
+  parser.add_argument('--tokenizer', type=str, default="./weights/LLaMa/tokenizer.model", help="Location of the tokenizer")
+  args = parser.parse_args()
+
+  # run eval and exit
+  adaptor = LLaMaAdaptor(model_size=args.size, quantize=args.quantize, checkpoint_path=args.weights, tokenizer_path=args.tokenizer, device="cpu")
+  results = evaluator.evaluate(adaptor, tasks.get_task_dict(args.eval.split(",")), False, 0, args.limit)
+  print(json.dumps(results, indent=2))

--- a/tinygrad/state.py
+++ b/tinygrad/state.py
@@ -72,7 +72,7 @@ def torch_load(fn:str):
     # upstream LLaMA also does this conversion:
     # https://github.com/facebookresearch/llama/blob/6c7fe276574e78057f917549435a2554000a876d/llama/generation.py#L95
     if storage[1] == dtypes.bfloat16:
-      ret = ret.to("LLVM").half().to(Device.DEFAULT).realize()
+      ret = ret.to("LLVM").half().to(Device.DEFAULT)
 
     # 7 lines to deal with permuted tensors. NOTE: this currently requires reading off the disk
     shape_strides = [(s, st) for s,st in zip(size, stride) if s != 1]


### PR DESCRIPTION
Here's a summary of the memory and performance on METAL on my M2 Max with and without the `--quantize` option:

| Model Size | Loading Time | RAM | Fastest Ran Model Time |
| --- | --- | --- | --- | 
| 7B (fp16) | 1786.25 ms | 13.48GB | 105.30ms |
| 7B (int8) | 2608.36 ms | 6.87GB | 128.51 ms |
| 13B (fp16) | 6218.58 ms | 26.03 GB | 129.24 ms |
| 13B (int8) | 5576.42 ms | 13.19 GB | 169.25 ms |
| 30B (fp16) | 22970.66 ms | 65.06 GB | 1534.54 ms |
| 30B (int8) | 17363.83 ms | 32.75 GB | 258.79 ms | 
| 65B (fp16) | N/A | N/A | N/A |
| 65B (int8) | 40315.09 ms | 65.56 GB | 1551.57 ms | 

The performance of 30B (int8) is quite a bit better than 30B (fp16), perhaps due to memory bandwidth limitations.