### PR TITLE
Match Torch speed for sum reduction on M1 (redo)

### DIFF
--- a/test/external/external_test_opt.py
+++ b/test/external/external_test_opt.py
@@ -63,7 +63,7 @@ class TestInferenceMinKernels(unittest.TestCase):
     for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=p.dtype.np))
     img = Tensor.randn(1, 3, 224, 224)
     # TODO: this seems very high
-    with CLCache(115):
+    with CLCache(116):
       model.forward(img).realize()
 
   def test_resnet(self):

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -213,10 +213,9 @@ class LazyBuffer:
     if self.shape == tuple(new_shape): return self
     srcs = _push_movement_ops((self,)) if SHUFFLE_MOVEMENT_OPS else (self,)
 
-    shape_differences = [a != b for a,b in zip(self.shape, new_shape)]
-    if sum(shape_differences) > 1:
-      last_difference = len(shape_differences) - 1 - shape_differences[::-1].index(True)
-      intermediate_shape = tuple(new if i == last_difference else old for i, (new, old) in enumerate(zip(new_shape, self.shape)))
+    # Split multi-axis reduction into two kernels on Metal for perf
+    if sum(shape_differences := [new != old for new, old in zip(new_shape, self.shape)]) > 1 and self.device == "METAL":
+      intermediate_shape = tuple(old if i == shape_differences.index(True) else new for i, (new, old) in enumerate(zip(new_shape, self.shape)))
       return create_lazybuffer(self.device, ShapeTracker(intermediate_shape), ReduceOps, LazyOp(op, srcs, intermediate_shape), self.dtype).reduce_op(op, new_shape)
 
     return create_lazybuffer(self.device, ShapeTracker(new_shape), ReduceOps, LazyOp(op, srcs, new_shape), self.dtype)

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -212,6 +212,12 @@ class LazyBuffer:
   def reduce_op(self:LazyBuffer, op:ReduceOps, new_shape:Tuple[int, ...]) -> LazyBuffer:
     if self.shape == tuple(new_shape): return self
     srcs = _push_movement_ops((self,)) if SHUFFLE_MOVEMENT_OPS else (self,)
+    
+    differences = [a != b for a,b in zip(self.shape, new_shape)]
+    if sum(differences) > 1:
+      intermediate_shape = tuple(new if i == differences.index(True) else old for i, (new, old) in enumerate(zip(new_shape, self.shape)))
+      return create_lazybuffer(self.device, ShapeTracker(intermediate_shape), ReduceOps, LazyOp(op, srcs, intermediate_shape), self.dtype).reduce_op(op, new_shape)
+
     return create_lazybuffer(self.device, ShapeTracker(new_shape), ReduceOps, LazyOp(op, srcs, new_shape), self.dtype)
 
   def reshape(self:LazyBuffer, arg:Tuple[int, ...]) -> LazyBuffer:

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import math
 import operator
 from typing import Callable, Optional, Tuple, Union, List, Dict, Any, cast
 import sys, importlib, inspect, functools, pathlib
@@ -209,16 +210,22 @@ class LazyBuffer:
         return root.reshape(ret.st.shape)
     return ret
 
-  def reduce_op(self:LazyBuffer, op:ReduceOps, new_shape:Tuple[int, ...]) -> LazyBuffer:
+  def _reduce_op(self:LazyBuffer, op:ReduceOps, new_shape:Tuple[int, ...]) -> LazyBuffer:
     if self.shape == tuple(new_shape): return self
     srcs = _push_movement_ops((self,)) if SHUFFLE_MOVEMENT_OPS else (self,)
-
-    # Split multi-axis reduction into two kernels on Metal for perf
-    if sum(shape_differences := [new != old for new, old in zip(new_shape, self.shape)]) > 1 and self.device == "METAL":
-      intermediate_shape = tuple(old if i == shape_differences.index(True) else new for i, (new, old) in enumerate(zip(new_shape, self.shape)))
-      return create_lazybuffer(self.device, ShapeTracker(intermediate_shape), ReduceOps, LazyOp(op, srcs, intermediate_shape), self.dtype).reduce_op(op, new_shape)
-
     return create_lazybuffer(self.device, ShapeTracker(new_shape), ReduceOps, LazyOp(op, srcs, new_shape), self.dtype)
+
+  def reduce_op(self:LazyBuffer, op:ReduceOps, new_shape:Tuple[int, ...]) -> LazyBuffer:
+    if prod(self.shape) // prod(new_shape) > 8192:
+      reduced_dimensions = [(i, math.gcd(256, old), stride) for i, (old, new, stride) in enumerate(zip(self.shape, new_shape, self.st.real_strides())) if old != new]
+      dimension_to_split, divisor, _ = max(reduced_dimensions, key=lambda v: v[1]//(v[2] or math.inf) ) # heuristic -> choose largest divisor to split on, penalize large strides
+
+      intermediate_input_shape = self.shape[:dimension_to_split] + (self.shape[dimension_to_split]//divisor, divisor) + self.shape[dimension_to_split+1:]
+      intermediate_output_shape = self.shape[:dimension_to_split] + (self.shape[dimension_to_split]//divisor, 1) + self.shape[dimension_to_split+1:]
+      final_input_shape = self.shape[:dimension_to_split] + (self.shape[dimension_to_split]//divisor,) + self.shape[dimension_to_split+1:]
+
+      return self.reshape(intermediate_input_shape)._reduce_op(op, intermediate_output_shape).reshape(final_input_shape)._reduce_op(op, new_shape)
+    return self._reduce_op(op, new_shape)
 
   def reshape(self:LazyBuffer, arg:Tuple[int, ...]) -> LazyBuffer:
     if self.shape == arg: return self

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -212,10 +212,11 @@ class LazyBuffer:
   def reduce_op(self:LazyBuffer, op:ReduceOps, new_shape:Tuple[int, ...]) -> LazyBuffer:
     if self.shape == tuple(new_shape): return self
     srcs = _push_movement_ops((self,)) if SHUFFLE_MOVEMENT_OPS else (self,)
-    
+        
     differences = [a != b for a,b in zip(self.shape, new_shape)]
     if sum(differences) > 1:
-      intermediate_shape = tuple(new if i == differences.index(True) else old for i, (new, old) in enumerate(zip(new_shape, self.shape)))
+      last_difference = len(differences) - 1 - differences[::-1].index(True)
+      intermediate_shape = tuple(new if i == last_difference else old for i, (new, old) in enumerate(zip(new_shape, self.shape)))
       return create_lazybuffer(self.device, ShapeTracker(intermediate_shape), ReduceOps, LazyOp(op, srcs, intermediate_shape), self.dtype).reduce_op(op, new_shape)
 
     return create_lazybuffer(self.device, ShapeTracker(new_shape), ReduceOps, LazyOp(op, srcs, new_shape), self.dtype)

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -212,10 +212,10 @@ class LazyBuffer:
   def reduce_op(self:LazyBuffer, op:ReduceOps, new_shape:Tuple[int, ...]) -> LazyBuffer:
     if self.shape == tuple(new_shape): return self
     srcs = _push_movement_ops((self,)) if SHUFFLE_MOVEMENT_OPS else (self,)
-        
-    differences = [a != b for a,b in zip(self.shape, new_shape)]
-    if sum(differences) > 1:
-      last_difference = len(differences) - 1 - differences[::-1].index(True)
+
+    shape_differences = [a != b for a,b in zip(self.shape, new_shape)]
+    if sum(shape_differences) > 1:
+      last_difference = len(shape_differences) - 1 - shape_differences[::-1].index(True)
       intermediate_shape = tuple(new if i == last_difference else old for i, (new, old) in enumerate(zip(new_shape, self.shape)))
       return create_lazybuffer(self.device, ShapeTracker(intermediate_shape), ReduceOps, LazyOp(op, srcs, intermediate_shape), self.dtype).reduce_op(op, new_shape)
 


### PR DESCRIPTION
Follow up of https://github.com/tinygrad/tinygrad/pull/1187 to fix CIFAR regression https://github.com/tinygrad/tinygrad/pull/1286 and https://github.com/tinygrad/tinygrad/pull/1287

Identified problem was that the heuristic was ranking best places to split, but did not abort when even the best option was bad. This version now skips splitting if (1) the reduction is a small reduction or (2) we'd be forced to reduce with a bad global dim to stride ratio.

I've only tested this on my M1, **so before merging again it would be good to re-test on other envs**!

---

CIFAR specifically was being held up on a single problematic kernel, `r_4096_3_3_2_2_2_4_2_4_8_2_4_4` which on it's own was causing the large boost in memory consumption and a large slowdown.

New CIFAR numbers on M1 Max:
```
  0 1904.08 ms run, 1883.58 ms python,   20.50 ms CL,    2.94 loss, 0.009521 LR, 0.09 GB used,    613.58 GFLOPS
  1 1352.30 ms run, 1351.52 ms python,    0.78 ms CL,    3.02 loss, 0.008464 LR, 7.87 GB used,    863.93 GFLOPS
  2 1241.88 ms run, 1240.57 ms python,    1.31 ms CL,    5.76 loss, 0.007408 LR, 7.87 GB used,    940.75 GFLOPS
  3 1241.01 ms run, 1239.70 ms python,    1.31 ms CL,    7.17 loss, 0.006351 LR, 7.87 GB used,    941.41 GFLOPS
  4 1241.18 ms run, 1239.94 ms python,    1.24 ms CL,    6.99 loss, 0.005294 LR, 7.87 GB used,    941.28 GFLOPS
  5 1242.83 ms run, 1214.35 ms python,   28.48 ms CL,    4.66 loss, 0.004237 LR, 7.87 GB used,    940.03 GFLOPS
  6 1260.45 ms run, 1231.65 ms python,   28.80 ms CL,    3.61 loss, 0.003180 LR, 7.87 GB used,    926.89 GFLOPS
  7 1289.97 ms run, 1287.83 ms python,    2.14 ms CL,    3.33 loss, 0.002124 LR, 7.87 GB used,    905.68 GFLOPS
  8 1253.34 ms run, 1252.23 ms python,    1.10 ms CL,    3.67 loss, 0.001067 LR, 7.87 GB used,    932.15 GFLOPS
  9 1286.83 ms run, 1248.92 ms python,   37.91 ms CL,    2.99 loss, 0.000010 LR, 7.87 GB used,    907.89 GFLOPS
```
