### PR TITLE
change fetch to allow for local file selection

### DIFF
--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -85,10 +85,7 @@ if __name__ == "__main__":
     cap.release()
     cv2.destroyAllWindows()
   else:
-    if url.startswith('http'):
-      img = Image.open(io.BytesIO(fetch(url)))
-    else:
-      img = Image.open(url)
+    img = Image.open(io.BytesIO(fetch(url)))
     st = time.time()
     out, _ = infer(model, img)
     print(np.argmax(out), np.max(out), lbls[np.argmax(out)])

--- a/extra/utils.py
+++ b/extra/utils.py
@@ -14,7 +14,7 @@ WINDOWS = platform.system() == "Windows"
 def temp(x:str) -> str: return os.path.join(tempfile.gettempdir(), x)
 
 def fetch(url):
-  if url.startswith("/"):
+  if url.startswith("/") or url.startswith("./"):
     with open(url, "rb") as f:
       return f.read()
   import hashlib
@@ -24,7 +24,7 @@ def fetch(url):
     return f.read()
 
 def fetch_as_file(url):
-  if url.startswith("/"):
+  if url.startswith("/") or url.startswith("./"):
     with open(url, "rb") as f:
       return f.read()
   import hashlib

--- a/extra/utils.py
+++ b/extra/utils.py
@@ -14,7 +14,7 @@ WINDOWS = platform.system() == "Windows"
 def temp(x:str) -> str: return os.path.join(tempfile.gettempdir(), x)
 
 def fetch(url):
-  if url.startswith("/") or url.startswith("./"):
+  if url.startswith("/") or url.startswith("."):
     with open(url, "rb") as f:
       return f.read()
   import hashlib
@@ -24,7 +24,7 @@ def fetch(url):
     return f.read()
 
 def fetch_as_file(url):
-  if url.startswith("/") or url.startswith("./"):
+  if url.startswith("/") or url.startswith("."):
     with open(url, "rb") as f:
       return f.read()
   import hashlib

--- a/test/extra/test_utils.py
+++ b/test/extra/test_utils.py
@@ -25,6 +25,27 @@ class TestFetch(unittest.TestCase):
     pimg = Image.open(io.BytesIO(img))
     assert pimg.size == (705, 1024)
 
+class TestFetchRelative(unittest.TestCase):
+  def setUp(self):
+    # for testing ./
+    with open('test_file.txt', 'x') as f:
+      f.write("12345")
+    # for testing ../
+    os.mkdir('test_file_path')
+
+  def tearDown(self):
+    os.remove('test_file.txt')
+    os.rmdir('test_file_path')
+  
+  #test ./
+  def test_fetch_relative_dotslash(self):
+    self.assertEqual(b'12345', fetch("./test_file.txt"))
+  
+  #test ../
+  def test_fetch_relative_dotdotslash(self):
+    os.chdir('test_file_path')
+    self.assertEqual(b'12345', fetch("../test_file.txt"))
+    os.chdir('../')
 
 class TestDownloadFile(unittest.TestCase):
   def setUp(self):

--- a/test/extra/test_utils.py
+++ b/test/extra/test_utils.py
@@ -26,7 +26,7 @@ class TestFetch(unittest.TestCase):
     pimg = Image.open(io.BytesIO(img))
     assert pimg.size == (705, 1024)
 
-class TestFetchRelative(unittest.TestCase):
+class TestFetchLocalFile(unittest.TestCase):
   def setUp(self):
     self.working_dir = os.getcwd()
     self.tempdir = tempfile.TemporaryDirectory()
@@ -47,6 +47,11 @@ class TestFetchRelative(unittest.TestCase):
       os.mkdir('test_file_path')
       os.chdir('test_file_path')
       self.assertEqual(b'12345', fetch("../test_file.txt"))
+  
+  #test /
+  def test_fetch_slash(self):
+      print(self.tempdir.name + "/test_file.txt")
+      self.assertEqual(b'12345', fetch(self.tempdir.name + "/test_file.txt"))
 
 class TestDownloadFile(unittest.TestCase):
   def setUp(self):

--- a/test/extra/test_utils.py
+++ b/test/extra/test_utils.py
@@ -26,7 +26,7 @@ class TestFetch(unittest.TestCase):
     pimg = Image.open(io.BytesIO(img))
     assert pimg.size == (705, 1024)
 
-class TestFetchLocalFile(unittest.TestCase):
+class TestFetchRelative(unittest.TestCase):
   def setUp(self):
     self.working_dir = os.getcwd()
     self.tempdir = tempfile.TemporaryDirectory()
@@ -47,11 +47,6 @@ class TestFetchLocalFile(unittest.TestCase):
       os.mkdir('test_file_path')
       os.chdir('test_file_path')
       self.assertEqual(b'12345', fetch("../test_file.txt"))
-  
-  #test /
-  def test_fetch_slash(self):
-      print(self.tempdir.name + "/test_file.txt")
-      self.assertEqual(b'12345', fetch(self.tempdir.name + "/test_file.txt"))
 
 class TestDownloadFile(unittest.TestCase):
   def setUp(self):

--- a/test/extra/test_utils.py
+++ b/test/extra/test_utils.py
@@ -11,7 +11,6 @@ from extra.utils import fetch, temp, download_file
 from tinygrad.state import torch_load
 from PIL import Image
 
-
 @unittest.skipIf(getenv("CI", "") != "", "no internet tests in CI")
 class TestFetch(unittest.TestCase):
   def test_fetch_bad_http(self):


### PR DESCRIPTION
you cannot currently use relative file paths with fetch

This shows up in the yolov8 example:

```
desktop>python3 tinygrad/examples/yolov8.py ./TestImages/Abyssinian_1.jpg
No variant given, so choosing 'n' as the default. Yolov8 has different variants, you can choose from ['n', 's', 'm', 'l', 'x']
running inference for YOLO version n
Traceback (most recent call last):
  File "tinygrad/examples/yolov8.py", line 405, in <module>
    image_location = [np.frombuffer(io.BytesIO(fetch(img_path)).read(), np.uint8)]
  File "/home/bigfoot/dev/tinyfork/tinygrad/extra/utils.py", line 22, in fetch
    download_file(url, fp, skip_if_exists=not getenv("NOCACHE"))
  File "/home/bigfoot/dev/tinyfork/tinygrad/extra/utils.py", line 39, in download_file
    r = requests.get(url, stream=True)
  File "/home/bigfoot/.local/lib/python3.8/site-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
  File "/home/bigfoot/.local/lib/python3.8/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/bigfoot/.local/lib/python3.8/site-packages/requests/sessions.py", line 573, in request
    prep = self.prepare_request(req)
  File "/home/bigfoot/.local/lib/python3.8/site-packages/requests/sessions.py", line 484, in prepare_request
    p.prepare(
  File "/home/bigfoot/.local/lib/python3.8/site-packages/requests/models.py", line 368, in prepare
    self.prepare_url(url, params)
  File "/home/bigfoot/.local/lib/python3.8/site-packages/requests/models.py", line 439, in prepare_url
    raise MissingSchema(
requests.exceptions.MissingSchema: Invalid URL './TestImages/Abyssinian_1.jpg': No scheme supplied. Perhaps you meant https://./TestImages/Abyssinian_1.jpg?
```

also removed if statement in efficientnet to use fetch for local url