### PR TITLE
Experiments with RSQRT and RECIP

### DIFF
--- a/tinygrad/codegen/cstyle.py
+++ b/tinygrad/codegen/cstyle.py
@@ -30,6 +30,8 @@ class CStyleLanguage(NamedTuple):
     UnaryOps.LOG2: lambda x: f"log2({x})",
     UnaryOps.SIN: lambda x: f"sin({x})",
     UnaryOps.SQRT: lambda x: f"sqrt({x})",
+    UnaryOps.RSQRT: lambda x: f"rsqrt({x})",
+    UnaryOps.RECIP: lambda x: f"1.0/{x}",
     BinaryOps.ADD: lambda a,b: f"({a}+{b})", BinaryOps.SUB: lambda a,b: f"({a}-{b})",
     BinaryOps.MUL: lambda a,b: f"({a}*{b})", BinaryOps.DIV: lambda a,b: f"({a}/{b})",
     BinaryOps.MAX: lambda a,b: f"max({a},{b})",

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -64,6 +64,16 @@ class Sqrt(Function):
   def backward(self, grad_output:LazyBuffer) -> LazyBuffer:
     return grad_output.binary_op(BinaryOps.DIV, self.ret.binary_op(BinaryOps.MUL, self.ret.const_like(2)))
 
+class Reciprocal(Function):
+  __slots__ = "ret"
+  def forward(self, x:LazyBuffer) -> LazyBuffer:
+    self.ret = x.unary_op(UnaryOps.RECIP)
+    return self.ret
+
+  def backward(self, grad_output:LazyBuffer) -> LazyBuffer:
+      # g * -1 / x^2
+      return grad_output.binary_op(BinaryOps.MUL, self.ret.const_like(-1).binary_op(BinaryOps.DIV, self.ret.binary_op(BinaryOps.MUL, self.ret)))
+
 # NOTE: the implicit derivative of sigmoid is not stable
 # https://towardsdatascience.com/derivative-of-the-sigmoid-function-536880cf918e
 # TODO: have the backend automatically find this

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 # the Enum class doesn't work with mypy, this is static. sorry it's ugly
 # NOTE: MOD, CMPLT don't have to be implemented on vectors, just scalars
 # NOTE: rdna3 only has RECIP and not DIV. DIV and POW are on the chopping block
-class UnaryOps(Enum): NOOP = auto(); EXP2 = auto(); LOG2 = auto(); CAST = auto(); SIN = auto(); SQRT = auto(); RECIP = auto() # noqa: E702
+class UnaryOps(Enum): NOOP = auto(); EXP2 = auto(); LOG2 = auto(); CAST = auto(); SIN = auto(); SQRT = auto(); RSQRT = auto(); RECIP = auto() # noqa: E702
 class BinaryOps(Enum): ADD = auto(); SUB = auto(); MUL = auto(); DIV = auto(); CMPEQ = auto(); MAX = auto(); MOD = auto(); CMPLT = auto() # noqa: E702
 class ReduceOps(Enum): SUM = auto(); MAX = auto() # noqa: E702
 class TernaryOps(Enum): MULACC = auto(); WHERE = auto() # noqa: E702

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -494,7 +494,7 @@ class Tensor:
   def sigmoid(self): return mlops.Sigmoid.apply(self)
   def sin(self): return mlops.Sin.apply(self)
   def sqrt(self): return mlops.Sqrt.apply(self)
-  def rsqrt(self): return (1/self).sqrt()
+  def rsqrt(self): return self.reciprocal().sqrt()
   def cos(self): return ((pi/2)-self).sin()
   def tan(self): return self.sin() / self.cos()
 
@@ -516,7 +516,7 @@ class Tensor:
   def clip(self, min_, max_): return self.maximum(min_).minimum(max_)
   def abs(self): return self.relu() + (-self).relu()
   def sign(self): return self / (self.abs() + 1e-10)
-  def reciprocal(self): return 1.0/self
+  def reciprocal(self): return mlops.Reciprocal.apply(self)
 
   # ***** activation functions (unary) *****
   def elu(self, alpha=1.0): return self.relu() - alpha*(1-self.exp()).relu()


### PR DESCRIPTION
These are just some ideas I had while reading the code and experimenting with the output (CUDA=1 DEBUG=5)

It seems as though the recently added sqrt/rsqrt functionality is written in terms of SQRT op. Is sqrt more widely implemented in hardware?. For vector normals you want `V * 1/sqrt(V*V)` as in John Carmack's Fast Inverse Square Root. Perhaps norm isn't used that much in ML, I can only think of LayerNorm...

Anyway, my idea was to merge reciprocals e.g:
`1 / ( 1 / x)` → `x`
`x / ( 1 / y)` → `x*y`
`1 / sqrt(x)`→`rsqrt(x)` 

Just a draft, I can add codegen examples in comments if anyone is interested.