### PR TITLE
fix: prevent infinite "loading..." state at webgpu demo page

### DIFF
--- a/examples/webgpu/index.html
+++ b/examples/webgpu/index.html
@@ -93,12 +93,16 @@ canvas {  display: none; }
 	}
 
 	const loadLet = async () => {
-		resultText.innerHTML = "loading..."
-		labels = await getLabels();
-		const safetensor = await getSavetensorBuffer();
-		const device = await getDevice();
-		net = await timer(() => setupNet(device, safetensor), "(compilation)");
-		resultText.innerHTML = "ready"
+		try {
+			resultText.innerHTML = "loading..."
+			labels = await getLabels();
+			const safetensor = await getSavetensorBuffer();
+			const device = await getDevice();
+			net = await timer(() => setupNet(device, safetensor), "(compilation)");
+			resultText.innerHTML = "ready"
+		} catch (e) {
+			error(e)
+		}
 	}
 
 	const runNet = async (data) => {


### PR DESCRIPTION
* demo somewhy doesn't work on my device and throws error "Error: GPUPipelineError: [Invalid ShaderModule] is invalid" inside setupNet func
* because of that, JS halts the execution of the rest of the code below and on the screen, we see "loading..." forever
* added try catch here to communicate about the error in a proper way

<details>
  <summary>web page screenshot</summary>
  
  
<img width="1728" alt="Screenshot 2023-07-22 at 00 11 59" src="https://github.com/tinygrad/tinygrad/assets/28751226/b70f30ee-0137-4a9a-8157-a924ced19d84">

  
</details>
