### PR TITLE
Fix discriminator balancing in mnist_gan example

### DIFF
--- a/examples/mnist_gan.py
+++ b/examples/mnist_gan.py
@@ -31,7 +31,8 @@ class LinearDisc:
     self.l4 = Tensor.scaled_uniform(256, 2)
 
   def forward(self, x):
-    x = x.dot(self.l1).leakyrelu(0.2).dropout(0.3)
+    # balance the discriminator inputs with const bias (.add(1))
+    x = x.dot(self.l1).add(1).leakyrelu(0.2).dropout(0.3)
     x = x.dot(self.l2).leakyrelu(0.2).dropout(0.3)
     x = x.dot(self.l3).leakyrelu(0.2).dropout(0.3)
     x = x.dot(self.l4).log_softmax()
@@ -39,13 +40,12 @@ class LinearDisc:
 
 def make_batch(images):
   sample = np.random.randint(0, len(images), size=(batch_size))
-  image_b = images[sample].reshape(-1, 28*28).astype(np.float32) / 255.0
-  image_b = (image_b - 0.5) / 0.5
+  image_b = images[sample].reshape(-1, 28*28).astype(np.float32) / 127.5 - 1.0
   return Tensor(image_b)
 
-def make_labels(bs, val):
+def make_labels(bs, col, val=-2.0):
   y = np.zeros((bs, 2), np.float32)
-  y[range(bs), [val] * bs] = -2.0  # Can we do label smoothin? i.e -2.0 changed to -1.98789.
+  y[range(bs), [col] * bs] = val  # Can we do label smoothing? i.e -2.0 changed to -1.98789.
   return Tensor(y)
 
 def train_discriminator(optimizer, data_real, data_fake):


### PR DESCRIPTION
I was looking at the mnist_gan example and noticed the output images lacked saturation, resulting in a subdued and low-contrast appearance. After a bit of investigation I think the primary cause of this is the lack of bias terms within the networks. I tried adding these for example:

```python
self.b1 = Tensor.zeros(256)
.
.
.
x = x.dot(self.L1).add(self.b1).leakyrelu(0.2)
```

This worked very well and produced the following final result:

![image_300](https://github.com/tinygrad/tinygrad/assets/444143/90e3c7a1-369d-489d-95e4-90748f78e88d)

I realise that bias terms are often left out of GAN architecture for simplicity, and on further investigation they all converged to 0, except for in the first layer of the discriminator. Therefore it was possible to simply add a hard coded const bias to the first discriminator layer.

The rationale for this change is that the generator is zero cantered, creating output image tensors between -1, and 1. Whereas the discriminator is a classification task which requires values between 0 and 1. The const bias term is all that is needed to balance the discriminator. 

The other changes are refactoring in clarification of the parameter names in `make_labels`
