### PR TITLE
Fix Tensor([3]) constant fold take 2

### DIFF
--- a/docs/abstractions.py
+++ b/docs/abstractions.py
@@ -120,7 +120,7 @@ from tinygrad.tensor import Tensor
 from tinygrad.ops import LazyOp, BinaryOps, LoadOps
 
 # the 2+3 from before
-result = Tensor([2]) + Tensor([3])
+result = Tensor([2], force_buffer=True) + Tensor([3], force_buffer=True)
 print(type(result.lazydata), result.lazydata)  # let's look at the lazydata of result
 
 # you'll see it has a LazyOp

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -59,7 +59,7 @@ class TestRealWorld(unittest.TestCase):
     derandomize_model(model)
     @TinyJit
     def test(t): return model(t, 0).realize()
-    helper_test("test_llama", lambda: (Tensor([[1,]]),), test, 0.22 if CI else 13.5, 126 if CI else 486)
+    helper_test("test_llama", lambda: (Tensor([[1,]], force_buffer=True),), test, 0.22 if CI else 13.5, 126 if CI else 486)
 
     Tensor.default_type = old_type
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -101,7 +101,17 @@ class TestJit(unittest.TestCase):
     def f(a, b): return (a+b).realize()
     a = Tensor([1, 2, 3])
     for i in range(5):
-      np.testing.assert_equal(f(a, Tensor([i])).cpu().numpy(), (a+i).cpu().numpy())
+      np.testing.assert_equal(f(a, Tensor([i], force_buffer=True)).cpu().numpy(), (a+i).cpu().numpy())
+    assert len(f.jit_cache) == 1
+
+  def test_jit_size1_input_fail(self):
+    @TinyJit
+    def f(a, b): return (a+b).realize()
+    a = Tensor([1, 2, 3])
+    # this fails because the input folds into constant and becomes non-updatable in jit
+    with self.assertRaises(AssertionError):
+      for i in range(5):
+        np.testing.assert_equal(f(a, Tensor([i])).cpu().numpy(), (a+i).cpu().numpy())
     assert len(f.jit_cache) == 1
 
   def test_jit_output_non_tensor_fail(self):

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -214,5 +214,16 @@ class TestTinygrad(unittest.TestCase):
     self.assertEqual(Tensor([[3]]).shape, (1, 1))
     self.assertEqual(Tensor([[[3]]]).shape, (1, 1, 1))
 
+  def test_size1_input_has_same_dtype(self):
+    for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
+      a = Tensor([1], dtype=datatype)
+      assert a.dtype == datatype, f"a.dtype should be {datatype}"
+      a = Tensor(1, dtype=datatype)
+      assert a.dtype == datatype, f"a.dtype should be {datatype}"
+      a = Tensor([1], dtype=datatype, force_buffer=True)
+      assert a.dtype == datatype, f"a.dtype should be {datatype}"
+      a = Tensor(1, dtype=datatype, force_buffer=True)
+      assert a.dtype == datatype, f"a.dtype should be {datatype}"
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1,10 +1,9 @@
-import dataclasses
 import numpy as np
 import torch
 import unittest
-import itertools
-from tinygrad.tensor import Tensor, Device
+from tinygrad.tensor import Tensor
 from tinygrad.helpers import dtypes
+from tinygrad.ops import LoadOps, OpType
 from extra.gradcheck import numerical_jacobian, jacobian, gradcheck
 
 x_init = np.random.randn(1,3).astype(np.float32)
@@ -191,6 +190,29 @@ class TestTinygrad(unittest.TestCase):
   def test_element_size(self):
     for _, dtype in dtypes.fields().items():
       assert dtype.itemsize == Tensor.randn(3, dtype=dtype).element_size(), f"Tensor.element_size() not matching Tensor.dtype.itemsize for {dtype}"
+
+  def test_constant_fold(self):
+    def helper_assert_all_const(op: OpType):
+      if isinstance(op.op, LoadOps): assert op.op == LoadOps.CONST
+      else:
+        for buf in op.buffers: helper_assert_all_const(buf.op)
+    helper_assert_all_const(Tensor(2).lazydata.op)
+    helper_assert_all_const(Tensor(2).reshape([1, 1, 1]).lazydata.op)
+    helper_assert_all_const(Tensor([2]).lazydata.op)
+    helper_assert_all_const(Tensor([2]).reshape([1, 1, 1]).lazydata.op)
+    helper_assert_all_const((Tensor(2)+Tensor(3)).lazydata.op)
+    helper_assert_all_const((Tensor(2)+Tensor([3])).lazydata.op)
+    helper_assert_all_const((Tensor([[2]])+Tensor([3])).lazydata.op)
+    with self.assertRaises(AssertionError):
+      helper_assert_all_const(Tensor([2], force_buffer=True).lazydata.op)
+    with self.assertRaises(AssertionError):
+      helper_assert_all_const(Tensor(2, force_buffer=True).lazydata.op)
+
+  def test_constant_fold_shape(self):
+    self.assertEqual(Tensor(3).shape, ())
+    self.assertEqual(Tensor([3]).shape, (1,))
+    self.assertEqual(Tensor([[3]]).shape, (1, 1))
+    self.assertEqual(Tensor([[[3]]]).shape, (1, 1, 1))
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -11,7 +11,7 @@ class Optimizer:
 
     self.params: List[Tensor] = dedup([x for x in params if x.requires_grad])
     self.buffers: List[Tensor] = dedup([x for x in params if not x.requires_grad])   # buffers are still realized
-    self.lr = Tensor([lr], requires_grad=False).contiguous()
+    self.lr = Tensor([lr], requires_grad=False, force_buffer=True)
 
   def zero_grad(self):
     for param in self.params: param.grad = None

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -62,7 +62,7 @@ class Tensor:
       if not force_buffer:
         self.lazydata = LazyBuffer.loadop(LoadOps.CONST, tuple(), dtype or Tensor.default_type, device, data)
         return
-      data = np.array(data, dtype=type(data))
+      data = np.array(data, dtype=(dtype or Tensor.default_type).np)
 
     if data.__class__ is list:
       assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"


### PR DESCRIPTION
#1178 
constant fold size 1 tensor by default. Also add a `force_buffer` arg to `Tensor` if we want to force it to be a buffer (only matter now in training with JIT).

now `Tensor(3)` and `Tensor([3])` always use the same `LoadOps`.