### PR TITLE
Improve Metal runtime command buffer handling

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -1,7 +1,6 @@
 # pip3 install pyobjc-framework-Metal pyobjc-framework-Cocoa pyobjc-framework-libdispatch
 import os, subprocess, pathlib
 import Metal, Cocoa, libdispatch # type: ignore
-from typing import List, Any
 from tinygrad.codegen.cstyle import CStyleCodegen, CStyleLanguage
 from tinygrad.helpers import prod, getenv, DEBUG, DType
 from tinygrad.ops import Compiled

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -11,7 +11,6 @@ METAL_XCODE = getenv("METAL_XCODE")
 
 class _METAL:
   def __init__(self):
-    self.mtl_buffers_in_flight: List[Any] = []
     self.device = Metal.MTLCreateSystemDefaultDevice()
     self.dispatch_group = libdispatch.dispatch_group_create() 
     self.mtl_queue = self.device.newCommandQueue()
@@ -20,11 +19,9 @@ class _METAL:
     libdispatch.dispatch_group_enter(METAL.dispatch_group)
     def leave(_): libdispatch.dispatch_group_leave(self.dispatch_group)
     command_buffer.addCompletedHandler_(leave)
-    self.mtl_buffers_in_flight.append(command_buffer)
     return command_buffer
   def synchronize(self):
     libdispatch.dispatch_group_wait(self.dispatch_group, libdispatch.DISPATCH_TIME_FOREVER)
-    self.mtl_buffers_in_flight.clear()
 METAL = _METAL()
 
 class RawMetalBuffer(RawBufferMapped):

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -15,7 +15,7 @@ class _METAL:
     self.mtl_queue = self.device.newCommandQueue()
   def command_buffer(self):
     command_buffer = self.mtl_queue.commandBuffer()
-    libdispatch.dispatch_group_enter(METAL.dispatch_group)
+    libdispatch.dispatch_group_enter(self.dispatch_group)
     def leave(_): libdispatch.dispatch_group_leave(self.dispatch_group)
     command_buffer.addCompletedHandler_(leave)
     return command_buffer


### PR DESCRIPTION
This PR changes how we handle command buffers in the Metal runtime.

Previously, we waited for each command buffer to finish before queuing more work, which according to Apple's [Tuning Hints](https://developer.apple.com/documentation/metalperformanceshaders/tuning_hints) could introduce delays of up to 2.5ms. 

Now, we've implemented a dispatch group approach. We enter the group when we create a new command buffer and leave when it's done. 

This modification allows the `synchronize` method to wait on the group instead of individual buffers, which should enhance both the speed and stability of the Metal runtime.
