### PR TITLE
Reshape into symbolic shape

### DIFF
--- a/test/test_custom_function.py
+++ b/test/test_custom_function.py
@@ -43,7 +43,7 @@ class ATan2(Function):
     assert prod(a.shape) == prod(b.shape) and a.device == b.device, "shape or device mismatch"
     self.a, self.b = a, b
     ast = LazyOp(LoadOps.CUSTOM, (a.contiguous(), b.contiguous()), {"GPU": atan2_gpu, "CPU": atan2_cpu}[a.device])
-    return create_lazybuffer(a.device, ShapeTracker(a.shape), LoadOps, ast, max(a.dtype, b.dtype))
+    return create_lazybuffer(a.device, ShapeTracker(a.shape), LoadOps, ast, max(a.dtype, b.dtype), {})
   def backward(self, grad_output:LazyBuffer) -> Tuple[Optional[LazyBuffer], Optional[LazyBuffer]]:
     denom = (self.a.binary_op(BinaryOps.MUL, self.a)).binary_op(BinaryOps.ADD, self.b.binary_op(BinaryOps.MUL, self.b))
     return grad_output.binary_op(BinaryOps.MUL, self.b.binary_op(BinaryOps.DIV, denom)) if self.needs_input_grad[0] else None, \

--- a/test/test_custom_function.py
+++ b/test/test_custom_function.py
@@ -43,7 +43,7 @@ class ATan2(Function):
     assert prod(a.shape) == prod(b.shape) and a.device == b.device, "shape or device mismatch"
     self.a, self.b = a, b
     ast = LazyOp(LoadOps.CUSTOM, (a.contiguous(), b.contiguous()), {"GPU": atan2_gpu, "CPU": atan2_cpu}[a.device])
-    return create_lazybuffer(a.device, ShapeTracker(a.shape), LoadOps, ast, max(a.dtype, b.dtype), {})
+    return create_lazybuffer(a.device, ShapeTracker(a.shape), LoadOps, ast, max(a.dtype, b.dtype))
   def backward(self, grad_output:LazyBuffer) -> Tuple[Optional[LazyBuffer], Optional[LazyBuffer]]:
     denom = (self.a.binary_op(BinaryOps.MUL, self.a)).binary_op(BinaryOps.ADD, self.b.binary_op(BinaryOps.MUL, self.b))
     return grad_output.binary_op(BinaryOps.MUL, self.b.binary_op(BinaryOps.DIV, denom)) if self.needs_input_grad[0] else None, \

--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -36,21 +36,21 @@ class TestSymbolic(unittest.TestCase):
     assert st.real_strides() == (i+j+k, 1)
 
 class TestSymbolicReshape(unittest.TestCase):
-  def test_reshape_into_symbols(self):
+  def test_reshape_into_symbols_simple(self):
     for i in range(1, 10):
       vi = Variable("i", 1, 10)
       t = Tensor.rand(i, 4).reshape(vi, 4)
       assert t.shape == (vi, 4)
       assert t.inferred_shape == (i, 4)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
       t = Tensor.rand(i, 4).reshape(vi, 4)
       assert t.shape == (vi, 4)
       assert t.inferred_shape == (i, 4)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
       t = Tensor.rand(i, 6).reshape(vi, 2, 3)
       assert t.shape == (vi, 2, 3)
       assert t.inferred_shape == (i, 2, 3)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
 
   def test_reshape_symbols_reshape_ints(self):
     for i in range(1, 10):
@@ -58,15 +58,15 @@ class TestSymbolicReshape(unittest.TestCase):
       t = Tensor.rand(i, 4).reshape(vi, 4).reshape(i, 4)
       assert t.shape == (i, 4)
       assert t.inferred_shape == (i, 4)
-      assert t.lazydata.symbols == {}
+      assert t.lazydata.st.symbols == {}
       t = Tensor.rand(i, 4).reshape(vi, 4).reshape(i*4,)
       assert t.shape == (i*4,)
       assert t.inferred_shape == (i*4,)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
       t = Tensor.rand(i, 6).reshape(vi, 6).reshape(i*2, 3)
       assert t.shape == (i*2, 3)
       assert t.inferred_shape == (i*2, 3)
-      assert t.lazydata.symbols == {}
+      assert t.lazydata.st.symbols == {}
 
   def test_reshape_into_symbols_bad_shape(self):
     vi = Variable("i", 1, 10)
@@ -88,7 +88,7 @@ class TestSymbolicReshape(unittest.TestCase):
       t = Tensor.full_like(Tensor.rand(i, 4).reshape(vi, 4), 5)
       assert t.shape == (vi, 4)
       assert t.inferred_shape == (i, 4)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
 
   def test_reshape_move_ops(self):
     for i in range(1, 10):
@@ -96,11 +96,11 @@ class TestSymbolicReshape(unittest.TestCase):
       t = Tensor.rand(i, 4).reshape(vi, 4).permute((1, 0))
       assert t.shape == (4, vi)
       assert t.inferred_shape == (4, i)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
       t = Tensor.rand(i, 4).reshape(vi, 4).reshape(vi*4,)
       assert t.shape == (vi*4,)
       assert t.inferred_shape == (i*4,)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
 
   def test_reshape_unary_ops(self):
     for i in range(1, 10):
@@ -108,15 +108,15 @@ class TestSymbolicReshape(unittest.TestCase):
       t = Tensor.rand(i, 4).reshape(vi, 4).contiguous()
       assert t.shape == (vi, 4)
       assert t.inferred_shape == (i, 4)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
       t = Tensor.rand(i, 4).reshape(vi, 4).log()
       assert t.shape == (vi, 4)
       assert t.inferred_shape == (i, 4)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
       t = Tensor.rand(i, 4).reshape(vi, 4).relu()
       assert t.shape == (vi, 4)
       assert t.inferred_shape == (i, 4)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
 
   def test_reshape_binary_ops(self):
     for i in range(1, 10):
@@ -124,15 +124,15 @@ class TestSymbolicReshape(unittest.TestCase):
       t = Tensor.rand(i, 4).reshape(vi, 4) + Tensor.rand(i, 4).reshape(vi, 4)
       assert t.shape == (vi, 4)
       assert t.inferred_shape == (i, 4)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
       t = Tensor.rand(i, 4).reshape(vi, 4) * Tensor.rand(i, 4).reshape(vi, 4)
       assert t.shape == (vi, 4)
       assert t.inferred_shape == (i, 4)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
       t = Tensor.rand(4, i).reshape(4, vi) @ Tensor.rand(i, 4).reshape(vi, 4)
       assert t.shape == (4, 4)
       assert t.inferred_shape == (4, 4)
-      assert t.lazydata.symbols == {}
+      assert t.lazydata.st.symbols == {}
 
   def test_reshape_reduce_ops(self):
     for i in range(1, 10):
@@ -140,11 +140,11 @@ class TestSymbolicReshape(unittest.TestCase):
       t = Tensor.rand(i, 4).reshape(vi, 4).sum(axis=0)
       assert t.shape == (4,)
       assert t.inferred_shape == (4,)
-      assert t.lazydata.symbols == {}
+      assert t.lazydata.st.symbols == {}
       t = Tensor.rand(i, 4).reshape(vi, 4).sum(axis=1)
       assert t.shape == (vi,)
       assert t.inferred_shape == (i,)
-      assert t.lazydata.symbols == {vi: i}
+      assert t.lazydata.st.symbols == {vi: i}
 
   def test_reshape_reduce_ops_2d(self):
     for i in range(1, 10):
@@ -154,16 +154,16 @@ class TestSymbolicReshape(unittest.TestCase):
         a = Tensor.rand(i, 3).reshape(vi, 3) @ Tensor.rand(3, j).reshape(3, vj)
         assert a.shape == (vi, vj)
         assert a.inferred_shape == (i, j)
-        assert a.lazydata.symbols == {vi: i, vj: j}
+        assert a.lazydata.st.symbols == {vi: i, vj: j}
         r = a.sum(axis=0)
         assert r.shape == (vj,)
         assert r.inferred_shape == (j,)
-        assert r.lazydata.symbols == {vj: j}
+        assert r.lazydata.st.symbols == {vj: j}
         r = a.sum(axis=1)
         assert r.shape == (vi,)
         assert r.inferred_shape == (i,)
-        assert r.lazydata.symbols == {vi: i}
+        assert r.lazydata.st.symbols == {vi: i}
         r = a.sum()
         assert r.shape == ()
         assert r.inferred_shape == ()
-        assert r.lazydata.symbols == {}
+        assert r.lazydata.st.symbols == {}

--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -34,3 +34,136 @@ class TestSymbolic(unittest.TestCase):
     st = t1.lazydata.st
     assert st.shape == (3, i+j+k)
     assert st.real_strides() == (i+j+k, 1)
+
+class TestSymbolicReshape(unittest.TestCase):
+  def test_reshape_into_symbols(self):
+    for i in range(1, 10):
+      vi = Variable("i", 1, 10)
+      t = Tensor.rand(i, 4).reshape(vi, 4)
+      assert t.shape == (vi, 4)
+      assert t.inferred_shape == (i, 4)
+      assert t.lazydata.symbols == {vi: i}
+      t = Tensor.rand(i, 4).reshape(vi, 4)
+      assert t.shape == (vi, 4)
+      assert t.inferred_shape == (i, 4)
+      assert t.lazydata.symbols == {vi: i}
+      t = Tensor.rand(i, 6).reshape(vi, 2, 3)
+      assert t.shape == (vi, 2, 3)
+      assert t.inferred_shape == (i, 2, 3)
+      assert t.lazydata.symbols == {vi: i}
+
+  def test_reshape_symbols_reshape_ints(self):
+    for i in range(1, 10):
+      vi = Variable("i", 1, 10)
+      t = Tensor.rand(i, 4).reshape(vi, 4).reshape(i, 4)
+      assert t.shape == (i, 4)
+      assert t.inferred_shape == (i, 4)
+      assert t.lazydata.symbols == {}
+      t = Tensor.rand(i, 4).reshape(vi, 4).reshape(i*4,)
+      assert t.shape == (i*4,)
+      assert t.inferred_shape == (i*4,)
+      assert t.lazydata.symbols == {vi: i}
+      t = Tensor.rand(i, 6).reshape(vi, 6).reshape(i*2, 3)
+      assert t.shape == (i*2, 3)
+      assert t.inferred_shape == (i*2, 3)
+      assert t.lazydata.symbols == {}
+
+  def test_reshape_into_symbols_bad_shape(self):
+    vi = Variable("i", 1, 10)
+    vj = Variable("j", 1, 10)
+    with self.assertRaises(AssertionError):
+      t = Tensor.rand(3, 4).reshape(vi, vj)
+    with self.assertRaises(AssertionError):
+      t = Tensor.rand(4, 4).reshape(vi, vi)
+    with self.assertRaises(AssertionError):
+      t = Tensor.rand(4, 6).reshape(vi, 6).reshape(vi, 4)
+    with self.assertRaises(AssertionError):
+      t = Tensor.rand(100, 4).reshape(Variable("too_small", 1, 10), 4)
+    with self.assertRaises(AssertionError):
+      t = Tensor.rand(3, 4).reshape(Variable("too_big", 100, 200), 4)
+
+  def test_full_like(self):
+    for i in range(1, 10):
+      vi = Variable("i", 1, 10)
+      t = Tensor.full_like(Tensor.rand(i, 4).reshape(vi, 4), 5)
+      assert t.shape == (vi, 4)
+      assert t.inferred_shape == (i, 4)
+      assert t.lazydata.symbols == {vi: i}
+
+  def test_reshape_move_ops(self):
+    for i in range(1, 10):
+      vi = Variable("i", 1, 10)
+      t = Tensor.rand(i, 4).reshape(vi, 4).permute((1, 0))
+      assert t.shape == (4, vi)
+      assert t.inferred_shape == (4, i)
+      assert t.lazydata.symbols == {vi: i}
+      t = Tensor.rand(i, 4).reshape(vi, 4).reshape(vi*4,)
+      assert t.shape == (vi*4,)
+      assert t.inferred_shape == (i*4,)
+      assert t.lazydata.symbols == {vi: i}
+
+  def test_reshape_unary_ops(self):
+    for i in range(1, 10):
+      vi = Variable("i", 1, 10)
+      t = Tensor.rand(i, 4).reshape(vi, 4).contiguous()
+      assert t.shape == (vi, 4)
+      assert t.inferred_shape == (i, 4)
+      assert t.lazydata.symbols == {vi: i}
+      t = Tensor.rand(i, 4).reshape(vi, 4).log()
+      assert t.shape == (vi, 4)
+      assert t.inferred_shape == (i, 4)
+      assert t.lazydata.symbols == {vi: i}
+      t = Tensor.rand(i, 4).reshape(vi, 4).relu()
+      assert t.shape == (vi, 4)
+      assert t.inferred_shape == (i, 4)
+      assert t.lazydata.symbols == {vi: i}
+
+  def test_reshape_binary_ops(self):
+    for i in range(1, 10):
+      vi = Variable("i", 1, 10)
+      t = Tensor.rand(i, 4).reshape(vi, 4) + Tensor.rand(i, 4).reshape(vi, 4)
+      assert t.shape == (vi, 4)
+      assert t.inferred_shape == (i, 4)
+      assert t.lazydata.symbols == {vi: i}
+      t = Tensor.rand(i, 4).reshape(vi, 4) * Tensor.rand(i, 4).reshape(vi, 4)
+      assert t.shape == (vi, 4)
+      assert t.inferred_shape == (i, 4)
+      assert t.lazydata.symbols == {vi: i}
+      t = Tensor.rand(4, i).reshape(4, vi) @ Tensor.rand(i, 4).reshape(vi, 4)
+      assert t.shape == (4, 4)
+      assert t.inferred_shape == (4, 4)
+      assert t.lazydata.symbols == {}
+
+  def test_reshape_reduce_ops(self):
+    for i in range(1, 10):
+      vi = Variable("i", 1, 10)
+      t = Tensor.rand(i, 4).reshape(vi, 4).sum(axis=0)
+      assert t.shape == (4,)
+      assert t.inferred_shape == (4,)
+      assert t.lazydata.symbols == {}
+      t = Tensor.rand(i, 4).reshape(vi, 4).sum(axis=1)
+      assert t.shape == (vi,)
+      assert t.inferred_shape == (i,)
+      assert t.lazydata.symbols == {vi: i}
+
+  def test_reshape_reduce_ops_2d(self):
+    for i in range(1, 10):
+      for j in range(1, 10):
+        vi = Variable("i", 1, 10)
+        vj = Variable("j", 1, 10)
+        a = Tensor.rand(i, 3).reshape(vi, 3) @ Tensor.rand(3, j).reshape(3, vj)
+        assert a.shape == (vi, vj)
+        assert a.inferred_shape == (i, j)
+        assert a.lazydata.symbols == {vi: i, vj: j}
+        r = a.sum(axis=0)
+        assert r.shape == (vj,)
+        assert r.inferred_shape == (j,)
+        assert r.lazydata.symbols == {vj: j}
+        r = a.sum(axis=1)
+        assert r.shape == (vi,)
+        assert r.inferred_shape == (i,)
+        assert r.lazydata.symbols == {vi: i}
+        r = a.sum()
+        assert r.shape == ()
+        assert r.inferred_shape == ()
+        assert r.lazydata.symbols == {}

--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -242,9 +242,9 @@ class TestSymbolicNumeric(unittest.TestCase):
 
 class TestSymbolicInfer(unittest.TestCase):
   def test_infer(self):
-    va = Variable("a", 1, 10)
-    vb = Variable("b", 1, 10)
-    vc = Variable("c", 1, 10)
+    va = Variable("a", 0, 10)
+    vb = Variable("b", 0, 10)
+    vc = Variable("c", 0, 10)
     assert va.infer({va: 5}) == 5
     assert va.infer({va: 8}) == 8
     assert NumNode(2).infer({va: 8}) == 2
@@ -257,11 +257,17 @@ class TestSymbolicInfer(unittest.TestCase):
     assert (va//3).infer({va: 5}) == 1
     assert (va%2).infer({va: 8}) == 0
     assert (va%3).infer({va: 8}) == 2
-    assert (va<2).infer({va: 5}) == False
-    assert (va<8).infer({va: 5}) == True
+    self.assertFalse((va<2).infer({va: 5}))
+    self.assertTrue((va<8).infer({va: 5}))
     assert Variable.sum([va,vb,vc]).infer({va: 1, vb: 3, vc: 7}) == 11
-    assert Variable.ands([va,vb,vc]).infer({va: 1, vb: 4, vc: 9}) == True
-    assert Variable.ands([va,vb,vc]).infer({va: 1, vb: 4, vc: 0}) == False
+    self.assertTrue(Variable.ands([va,vb,vc]).infer({va: 1, vb: 4, vc: 9}))
+    self.assertFalse(Variable.ands([va,vb,vc]).infer({va: 1, vb: 4, vc: 0}))
+
+  def test_infer_not_checking_bounds(self):
+    va = Variable("a", 1, 10)
+    assert va.infer({va: -5}) == -5
+    assert va.infer({va: 5}) == 5
+    assert va.infer({va: 20}) == 20
 
   def test_sym_infer(self):
     va = Variable("a", 1, 10)

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -94,23 +94,23 @@ def get_movementroot(root:LazyBuffer, allow_contiguous=False) -> LazyBuffer: ret
 def get_movementroot_contiguous(x:LazyBuffer) -> LazyBuffer: return get_movementroot_contiguous(cast(LazyBuffer, x.op.src[0])) if not x.realized and x.op.op == LoadOps.CONTIGUOUS else (get_movementroot(x, True) if x.optype == MovementOps and x.st.contiguous else x)
 
 lazycache: LightWeakValueDictionary = LightWeakValueDictionary()
-def create_lazybuffer(device:str, st:ShapeTracker, optype:OpType, op:LazyOp, dtype:DType, symbols:Dict[Variable, int]):
+def create_lazybuffer(device:str, st:ShapeTracker, optype:OpType, op:LazyOp, dtype:DType):
   #print("create_lazybuffer", device, shape, optype, op, dtype)
 
   # fromcpu aren't cached
-  if not LAZYCACHE or (optype is LoadOps and op.op in {LoadOps.EMPTY, LoadOps.RAND, LoadOps.CONST}): return LazyBuffer(device, st, optype, op, dtype, symbols)
+  if not LAZYCACHE or (optype is LoadOps and op.op in {LoadOps.EMPTY, LoadOps.RAND, LoadOps.CONST}): return LazyBuffer(device, st, optype, op, dtype)
 
   # wop is the deduping key. i feel this used to compare more deeply
   wop = (device, dtype, optype, ref(op))
   if wop in lazycache: return lazycache[wop]
 
-  lazycache[wop] = ret = LazyBuffer(device, st, optype, op, dtype, symbols)
+  lazycache[wop] = ret = LazyBuffer(device, st, optype, op, dtype)
   return ret
 
 class LazyBuffer:
-  __slots__ = 'st', 'device', 'shape', 'optype', 'dtype', 'op', 'realized', 'output_buffer', 'children', 'node_id', '__weakref__', 'symbols'
+  __slots__ = 'st', 'device', 'shape', 'optype', 'dtype', 'op', 'realized', 'output_buffer', 'children', 'node_id', '__weakref__'
   __deletable__ = ('op',)
-  def __init__(self, device:str, st:ShapeTracker, optype:OpType, op:LazyOp, dtype:DType, symbols:Dict[Variable, int], src:Optional[RawBuffer]=None):
+  def __init__(self, device:str, st:ShapeTracker, optype:OpType, op:LazyOp, dtype:DType, src:Optional[RawBuffer]=None):
     self.st: ShapeTracker = st  # NOTE: this is not a copy! this should be a "read-only" ShapeTracker
     self.device, self.shape, self.optype, self.dtype = device, self.st.shape, optype, dtype
     self.realized: Optional[RawBuffer] = src
@@ -119,7 +119,6 @@ class LazyBuffer:
     self.children: LightWeakSet = LightWeakSet()
     # NOTE: op should be read only after construction of LazyBuffer
     self.op: LazyOp = op
-    self.symbols = symbols
     for x in op.buffers: x.children.add(self)
     if not LAZY: self.realize()
 
@@ -128,14 +127,14 @@ class LazyBuffer:
       from tinygrad.graph import log_op
       log_op(self, self.op, phantom=True)
 
-  def __repr__(self): return f"<LB {self.shape} {self.dtype} op={self.op.op if not self.realized else self.realized} st={self.st} symbols={self.symbols}>"
+  def __repr__(self): return f"<LB {self.shape} {self.dtype} op={self.op.op if not self.realized else self.realized} st={self.st}>"
   @property
   def key(self):
     if self.realized: return (self.dtype.key, self.realized.key, self.st.key)
     return (self.dtype.key, self.op.op, self.st.key)
 
   @property
-  def inferred_shape(self): return self.st.infer_shape(self.symbols)
+  def inferred_shape(self): return self.st.inferred_shape
 
   def _device_extra_args(self) -> Dict[str, str]: return {"device": self.device.split(":", 1)[1]} if ":" in self.device else {}
 
@@ -177,16 +176,16 @@ class LazyBuffer:
 
   @staticmethod
   def loadop(op, shape, dtype, device, arg=None, src=None, symbols=None) -> LazyBuffer:
-    return create_lazybuffer(device, ShapeTracker(tuple(shape)), LoadOps, LazyOp(op, tuple() if src is None else (src,), arg), dtype, {} if symbols is None else symbols)
+    return create_lazybuffer(device, ShapeTracker(tuple(shape), symbols={} if symbols is None else symbols), LoadOps, LazyOp(op, tuple() if src is None else (src,), arg), dtype)
 
   @staticmethod
   def fromCPU(x: np.ndarray) -> LazyBuffer:
-    return LazyBuffer("CPU", ShapeTracker(x.shape, [View(x.shape, tuple(st//x.itemsize for st in x.strides))]), LoadOps, LazyOp(LoadOps.EMPTY, (), None), dtypes.from_np(x.dtype), {}, RawNumpyBuffer.fromCPU(x))
+    return LazyBuffer("CPU", ShapeTracker(x.shape, [View(x.shape, tuple(st//x.itemsize for st in x.strides))]), LoadOps, LazyOp(LoadOps.EMPTY, (), None), dtypes.from_np(x.dtype), RawNumpyBuffer.fromCPU(x))
 
   # create a constant with the shape and dtype of self
   def const_like(self, val) -> LazyBuffer:
     # NOTE: dtypes.from_np(self.dtype.np) to deal with image types
-    return self.loadop(LoadOps.CONST, tuple(), dtypes.from_np(self.dtype.np), self.device, arg=val, symbols=self.symbols).reshape((1,)*len(self.shape)).expand(self.shape)
+    return self.loadop(LoadOps.CONST, tuple(), dtypes.from_np(self.dtype.np), self.device, arg=val, symbols=self.st.symbols).reshape((1,)*len(self.shape)).expand(self.shape)
 
   # NOTE: we also have to copy the numpy array on the way out...otherwise the underlying Tensor could be freed and use after free. improve this?
   def toCPU(self):
@@ -201,12 +200,13 @@ class LazyBuffer:
   def ternary_op(self:LazyBuffer, op:TernaryOps, y: LazyBuffer, z:LazyBuffer) -> LazyBuffer: return elementwise_op(op, self, y, z)
   def contiguous(self:LazyBuffer) -> LazyBuffer:
     if not self.realized and self.op.op == LoadOps.CONTIGUOUS: return self  # two CONTIGUOUS in a row is one
-    return create_lazybuffer(self.device, ShapeTracker(self.shape), LoadOps, LazyOp(LoadOps.CONTIGUOUS, (self,), None), self.dtype, self.symbols)
+    return create_lazybuffer(self.device, ShapeTracker(self.shape, symbols=self.st.symbols), LoadOps, LazyOp(LoadOps.CONTIGUOUS, (self,), None), self.dtype)
 
   def shuffle_and_prune_movement_ops(self, st: ShapeTracker, op: MovementOps, arg: Union[Tuple[Union[Node,int], ...], Tuple[Tuple[int, int], ...]]) -> LazyBuffer:
     if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and not self.realized and (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or (op == MovementOps.RESHAPE and self.op.op in UnaryOps)) and len(self.children) == 0:
       return self.op.replace_with_movement_ops([(op, arg)])
-    ret = create_lazybuffer(self.device, st, MovementOps, LazyOp(op, (self,), arg), self.dtype, self.symbols)
+    ret = create_lazybuffer(self.device, st, MovementOps, LazyOp(op, (self,), arg), self.dtype)
+    ret.st.symbols.update(self.st.symbols)
     if REMOVE_MOVEMENT_NOPS and not self.realized and not ret.realized and ret.st.contiguous:
       # MovementOps aren't stacked any more, they each have one parent, find the root
       root = get_movementroot(self)
@@ -217,21 +217,21 @@ class LazyBuffer:
   def reduce_op(self:LazyBuffer, op:ReduceOps, new_shape:Tuple[Union[Node, int], ...]) -> LazyBuffer:
     if self.shape == tuple(new_shape): return self
     srcs = _push_movement_ops((self,)) if SHUFFLE_MOVEMENT_OPS else (self,)
-    new_symbols = {v: self.symbols[v] for s in new_shape for v in sym_vars(s)}
-    return create_lazybuffer(self.device, ShapeTracker(new_shape), ReduceOps, LazyOp(op, srcs, new_shape), self.dtype, new_symbols)
+    new_symbols = {v: self.st.symbols[v] for s in new_shape for v in sym_vars(s)}
+    return create_lazybuffer(self.device, ShapeTracker(new_shape, symbols=new_symbols), ReduceOps, LazyOp(op, srcs, new_shape), self.dtype)
 
   def reshape(self:LazyBuffer, arg:Tuple[Union[Node, int], ...]) -> LazyBuffer:
     if self.shape == arg: return self
     if not self.realized and self.op.op == MovementOps.RESHAPE:
       self.op.src[0].children.discard(self) # NOTE: this is only required in reshape and when pushing permutes, why??
-      if isinstance(self.op.src[0], LazyBuffer): self.op.src[0].symbols.update(self.symbols)
+      if isinstance(self.op.src[0], LazyBuffer): self.op.src[0].st.symbols.update(self.st.symbols)
       return self.op.src[0].reshape(arg)
     if all(isinstance(s, int) for s in self.shape) and len(arg_vars:=list(s for s in arg if isinstance(s, Variable))) > 0:
       assert len(arg_vars) == 1
       new_symbol, new_val = arg_vars[0], prod(self.inferred_shape) // prod(s for s in arg if isinstance(s, int))
-      try: assert new_symbol.min <= new_val <= new_symbol.max and self.symbols[new_symbol] == new_val
-      except KeyError: self.symbols[new_symbol] = new_val
-    elif all(isinstance(s, int) for s in arg): self.symbols = {}
+      try: assert new_symbol.min <= new_val <= new_symbol.max and self.st.symbols[new_symbol] == new_val
+      except KeyError: self.st.symbols[new_symbol] = new_val
+    elif all(isinstance(s, int) for s in arg): self.st.symbols = {}
     return self.shuffle_and_prune_movement_ops(ShapeTracker(self.st).reshape(arg), MovementOps.RESHAPE, arg)
 
   def pad(self:LazyBuffer, arg:Tuple[Tuple[int, int], ...]) -> LazyBuffer:
@@ -313,7 +313,7 @@ def elementwise_op(op:Union[UnaryOps, BinaryOps, TernaryOps], *srcs:LazyBuffer, 
   # get outputs now
   out_device, out_shape, out_dtype = srcs[0].device, srcs[0].shape, max([x.dtype for x in srcs]) if op != UnaryOps.CAST else cast(DType, arg)
   out_symbols = {}
-  for src in srcs: out_symbols.update(src.symbols)
+  for src in srcs: out_symbols.update(src.st.symbols)
 
   # push all contiguous to the end of BinaryOps. kernels 198 -> 196
   if PUSH_CONTIGUOUS and any(not x.realized and x.op.op == LoadOps.CONTIGUOUS and len(x.op.src[0].children) <= 1 for x in srcs):
@@ -330,7 +330,7 @@ def elementwise_op(op:Union[UnaryOps, BinaryOps, TernaryOps], *srcs:LazyBuffer, 
     # remove the buffers from any (childless) BinaryOps that feed into this
     srcs = tuple([x.op if x.optype == BinaryOps and len(x.children) == 0 and not x.realized else x for x in srcs])  # type: ignore
 
-  return create_lazybuffer(out_device, ShapeTracker(out_shape), BinaryOps, LazyOp(op, srcs, arg), out_dtype, out_symbols)
+  return create_lazybuffer(out_device, ShapeTracker(out_shape, symbols=out_symbols), BinaryOps, LazyOp(op, srcs, arg), out_dtype)
 
 class _Device:
   def __init__(self) -> None:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -55,7 +55,7 @@ class Tensor:
     if data.__class__ is LazyBuffer:
       data = cast(LazyBuffer, data) # NOTE: this is a noop, it makes mypy happy
       assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
-      self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data, symbols=data.symbols)
+      self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
       return
 
     if isinstance(data, (int, float)):
@@ -162,7 +162,7 @@ class Tensor:
   @staticmethod
   def full_like(tensor, fill_value, dtype:Optional[DType]=None, **kwargs):
     ret = Tensor.full(tensor.shape, fill_value=fill_value, dtype=tensor.dtype if dtype is None else dtype, **kwargs)
-    ret.lazydata.symbols.update(tensor.lazydata.symbols)
+    ret.lazydata.st.symbols.update(tensor.lazydata.st.symbols)
     return ret
 
   @staticmethod


### PR DESCRIPTION
part of #1259

support reshape into symbolic shape like `Tensor.zeros(4,4).reshape(4, Variable('i', 1, 100))`
also add `ShapeTracker.inferr_shape(self, symbols)` to get shape from symbols

the value of the variable is inferred and stored with `lazydata`. The tests try to cover all types of ops after reshape and make sure `shape`, `inferred_shape`, and `symbols` are updated correctly.

only shape from int shape to single variable shape can add symbols, and reshape back to ints and reduce can remove symbols

caveat: need to keep the type of `shape` to be `Tuple[int]`, otherwise mypy complains about all the `prod(shape)` is bad. I don't think we want to change all to `prod(inferred_shape)` which is slower and confusing.
