### PR TITLE
Small Tensor.cat optimization and reformating

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1042,8 +1042,8 @@ class TestOps(unittest.TestCase):
       lambda x: Tensor.avg_pool2d(x, kernel_size=(111,28)), rtol=1e-5)
 
   def test_cat(self):
-    for dim in range(-1, 2):
-      helper_test_op([(45,65), (45,65)], lambda x,y: torch.cat((x,y), dim), lambda x,y: x.cat(y, dim=dim))
+    for dim in range(-2, 3):
+      helper_test_op([(45,65, 90), (45,65,90), (45,65,90)], lambda x,y,z: torch.cat((x,y,z), dim), lambda x,y,z: x.cat(y, z, dim=dim))
 
     with self.assertRaises(AssertionError):
       a = Tensor(3.14)

--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -157,6 +157,10 @@ class TestSpeed(unittest.TestCase):
     helper_test_generic_square('cumsum_0', 256, f0, f0, onearg=True)
     helper_test_generic_square('cumsum_1', 256, f1, f1, onearg=True)
 
+  def test_cat(self):
+    helper_test_generic_square('cat_0', 256, lambda x,y : torch.cat((x,y),dim=0), lambda x,y : x.cat(y, dim=0))
+    helper_test_generic_square('cat_1', 256, lambda x,y : torch.cat((x,y),dim=1), lambda x,y : x.cat(y, dim=1))
+
   def test_array_packing(self):
     N = 2048
     def f(a, b): return a.reshape(N, N // 32, 32).permute(1,0,2).contiguous()

--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -158,8 +158,8 @@ class TestSpeed(unittest.TestCase):
     helper_test_generic_square('cumsum_1', 256, f1, f1, onearg=True)
 
   def test_cat(self):
-    helper_test_generic_square('cat_0', 256, lambda x,y : torch.cat((x,y),dim=0), lambda x,y : x.cat(y, dim=0))
-    helper_test_generic_square('cat_1', 256, lambda x,y : torch.cat((x,y),dim=1), lambda x,y : x.cat(y, dim=1))
+    helper_test_generic_square('cat_0', 256, lambda x,y: torch.cat((x,y),dim=0), lambda x,y: x.cat(y,dim=0))
+    helper_test_generic_square('cat_1', 256, lambda x,y: torch.cat((x,y),dim=1), lambda x,y: x.cat(y,dim=1))
 
   def test_array_packing(self):
     N = 2048

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -322,7 +322,7 @@ class Tensor:
   def cat(self, *args, dim=0):
     dim = (dim + len(self.shape)) if dim < 0 else dim
     assert all(len(y.shape) == len(self.shape) and all(y.shape[i] == s for i,s in enumerate(self.shape) if i != dim) for y in args)
-    catargs = [self] + list(args)
+    catargs = [self, *args]
     assert all(t.shape for t in catargs), "zero-dimensional tensor cannot be concatenated"
     shapes = [s.shape[dim] for s in catargs]
     shape_cumsum = [0, *accumulate(shapes)]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -326,11 +326,9 @@ class Tensor:
     assert all(t.shape for t in catargs), "zero-dimensional tensor cannot be concatenated"
     shapes = [s.shape[dim] for s in catargs]
     shape_cumsum = [0, *accumulate(shapes)]
-    slc = [[(0, 0) for _ in (self.shape)] for _ in catargs]
-
-    for i,k in enumerate(shape_cumsum[:-1]):
-      slc[i][dim] = (k, shape_cumsum[-1] - k - shapes[i])
-    Tensor._reduce
+    slc = [[(0, 0) for _ in self.shape] for _ in catargs]
+    for shp,k,s  in zip(shapes, shape_cumsum[:-1], slc):
+      s[dim] = (k, shape_cumsum[-1] - k - shp)
     return reduce(Tensor.__add__, [arg.pad(tuple(s)) for arg,s in zip(catargs, slc)])
 
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -323,15 +323,14 @@ class Tensor:
     dim = (dim + len(self.shape)) if dim < 0 else dim
     assert all(len(y.shape) == len(self.shape) and all(y.shape[i] == s for i,s in enumerate(self.shape) if i != dim) for y in args)
     catargs = [self] + list(args)
-    assert all(len(t.shape) != 0 for t in catargs), "zero-dimensional tensor cannot be concatenated"
-    shps = [s.shape[dim] for s in catargs]
-    shape_cumsum = [0, *accumulate(shps)]
-
+    assert all(t.shape for t in catargs), "zero-dimensional tensor cannot be concatenated"
+    shapes = [s.shape[dim] for s in catargs]
+    shape_cumsum = [0, *accumulate(shapes)]
     slc = [[(0, 0) for _ in (self.shape)] for _ in catargs]
 
     for i,k in enumerate(shape_cumsum[:-1]):
-      slc[i][dim] = (k, sum(shps) - k - shps[i])
-
+      slc[i][dim] = (k, shape_cumsum[-1] - k - shapes[i])
+    Tensor._reduce
     return reduce(Tensor.__add__, [arg.pad(tuple(s)) for arg,s in zip(catargs, slc)])
 
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -327,7 +327,7 @@ class Tensor:
     shapes = [s.shape[dim] for s in catargs]
     shape_cumsum = [0, *accumulate(shapes)]
     slc = [[(0, 0) for _ in self.shape] for _ in catargs]
-    for shp,k,s  in zip(shapes, shape_cumsum[:-1], slc):
+    for shp,k,s in zip(shapes, shape_cumsum[:-1], slc):
       s[dim] = (k, shape_cumsum[-1] - k - shp)
     return reduce(Tensor.__add__, [arg.pad(tuple(s)) for arg,s in zip(catargs, slc)])
 


### PR DESCRIPTION
Previous implementation uses Tensor.slice which uses pad + shrink. Previous implementation used slice instead of pad so I converted the slice to pad in new one. We do not need shrink in the cat operation.

Hope it is not Chesterton's Fence.

Just a little bit optimization effect on llama but speed is volatile so practically less function call.

This branch
```
using <class 'tinygrad.runtime.ops_metal.MetalCodegen'>
testing llama python run time
built model
assigned empty tensors, doing warmup
codegen         mean runtime:  147.83ms, runs:   162.49,  170.76,  143.67,  145.73,  141.18,  143.99,  141.86,  142.29,  143.80,  142.52
methodcache     mean runtime:  135.79ms, runs:   158.25,  132.46,  133.65,  134.84,  133.17,  133.09,  132.98,  133.04,  133.33,  133.12
profile         mean runtime:  569.00ms, runs:   624.74,  556.08,  556.12,  584.91,  555.04,  560.35,  561.12,  562.85,  566.95,  561.80
         7783971 function calls (7322683 primitive calls) in 5672.633 seconds
``` 

Master
```
using <class 'tinygrad.runtime.ops_metal.MetalCodegen'>
testing llama python run time
built model
assigned empty tensors, doing warmup
codegen         mean runtime:  149.85ms, runs:   167.50,  181.94,  144.61,  143.15,  142.93,  143.16,  143.04,  144.19,  144.28,  143.74
methodcache     mean runtime:  138.88ms, runs:   166.52,  136.16,  135.52,  134.37,  135.71,  134.95,  134.44,  135.37,  138.87,  136.85
profile         mean runtime:  589.25ms, runs:   646.48,  571.32,  572.55,  604.68,  580.91,  584.71,  576.80,  582.33,  589.80,  582.95
         7852323 function calls (7391035 primitive calls) in 5874.847 seconds
```