### PR TITLE
[Need feedback] Metal three_Conv Issue fix

### DIFF
--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -119,8 +119,11 @@ def hand_coded_optimizations(k:Linearizer):
       if DEBUG >= 3: print("TENSOR CORES", axis_buf0, axis_buf1)
       k.use_tensor_cores = getenv("TC", 1) == 1  # TC=2 will do the shape ops without the WMMA
 
+      s0 = max(axis_buf0, key=lambda x:x[1])[0]
+      s1 = max(axis_buf1, key=lambda x:x[1])[0]
+
       # TODO: select axis in smart way
-      s0, s1 = axis_buf0[-1][0], axis_buf1[-1][0]
+      #s0, s1 = axis_buf0[-1][0], axis_buf1[-1][0]
       global_count = k.first_reduce
 
       # upcast first


### PR DESCRIPTION
Kinda fixes #1302 

Why this is working currently is that only for the test_first_three there is a 3 length axis_buffer. For all of the other cases it is always 1 so it does not matter if there is max or not. So this is not a legitimate fix but saves the day for now.

Also, I believe somehow Tensor.expand is broken

Using max instead of the previous implementation is just by trial error and observing, somehow it fixed METAL=1 TC=1

When changing ones -> rand in the test case code perfectly runs with older implementation
