### PR TITLE
perf: shapetracker to tuple of views

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -3,7 +3,7 @@ import functools, time
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Union, Type, Tuple, Any, List, Optional, Dict, Callable, cast
 from tinygrad.helpers import ansilen, prod, DEBUG, getenv, GlobalCounters, DType, colored, dedup
-from tinygrad.shape.shapetracker import MovementOps
+from tinygrad.shape.shapetracker import MovementOps, View
 from tinygrad.runtime.lib import RawBuffer, RawConst, buf_is_kernel_arg
 if TYPE_CHECKING:
   from tinygrad.lazy import LazyBuffer
@@ -117,7 +117,7 @@ shape_fxn_for_op: Dict[Op, Callable] = {
   **{op:lambda self: (self.shape, self.dtype, self.consume_flops() + prod(self.shape)) for op in UnaryOps if op != UnaryOps.CAST},
   **{op:lambda self,y: (self.shape, max(self.dtype, y.dtype), self.consume_flops() + y.consume_flops() + prod(self.shape)) for op in BinaryOps},
   **{op:lambda self,new_shape: (new_shape, self.dtype, self.consume_flops() + prod(self.shape)) for op in ReduceOps},
-  **{op:functools.partial(lambda mop,self,arg: (ShapeTracker(self.shape).movement_op(mop, arg).shape, self.dtype, self.consume_flops()), op) for op in MovementOps},
+  **{op:functools.partial(lambda mop,self,arg: (ShapeTracker.movement_op((View(self.shape),), mop, arg).shape, self.dtype, self.consume_flops()), op) for op in MovementOps},
   TernaryOps.WHERE: lambda self,y,z: (self.shape, self.dtype, self.consume_flops() + y.consume_flops() + z.consume_flops() + prod(self.shape))}
 InterpretedFlopCounter = Interpreted(FlopCounter, shape_fxn_for_op, lambda x: FlopCounter((x.shape, x.dtype, 0)), lambda x: x)
 def get_lazyop_info(ast:LazyOp) -> FlopCounter: return InterpretedFlopCounter.exec_ast(ast)

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from enum import Enum, auto
 import functools
-from typing import Dict, Tuple, Union, List, Optional, Callable, cast, NamedTuple
+from typing import Dict, Tuple, Union, List, Optional, Callable, NamedTuple
 from tinygrad.helpers import prod, DEBUG
 from tinygrad.shape.symbolic import Variable, MulNode, NumNode, Node, SumNode, is_sym_int
 
@@ -21,7 +21,7 @@ def to_shape_strides(shape:Tuple[int, ...], strides:Tuple[int, ...]) -> Tuple[Tu
   return tuple(ret)
 
 @functools.lru_cache(maxsize=None)
-def is_contiguous(shape:Tuple[int, ...], strides:Tuple[int, ...]) -> bool: return all(s1 == s2 or s == 1 for s,s1,s2 in zip(shape, strides, strides_for_shape(shape)))
+def shape_strides_contiguous(shape:Tuple[int, ...], strides:Tuple[int, ...]) -> bool: return all(s1 == s2 or s == 1 for s,s1,s2 in zip(shape, strides, strides_for_shape(shape)))
 
 @functools.lru_cache(maxsize=None)
 def filter_strides(shape:Tuple[int, ...], strides:Tuple[int, ...]) -> Tuple[int, ...]:
@@ -40,7 +40,7 @@ class View(ViewInternal):
   def __new__(cls, shape, strides=None, offset=0, mask=None):
     strides_from_shape = strides_for_shape(shape)
     strides = strides_from_shape if not strides else filter_strides(shape, strides)
-    contiguous = offset == 0 and is_contiguous(shape, strides) and mask is None
+    contiguous = offset == 0 and shape_strides_contiguous(shape, strides) and mask is None
     return super().__new__(cls, shape, strides, offset, mask, contiguous, to_shape_strides(shape, strides))
   def __init__(self, shape, strides=None, offset=0, mask=None, contiguous=False, shape_strides=()): super().__init__()
 
@@ -69,6 +69,7 @@ class View(ViewInternal):
     assert len(idxs) == len(self.shape), f"need an idx for all dimensions {idxs} vs {self.shape}"
     return Variable.sum([Variable.num(self.offset)] + [idx*st for idx,sh,st in zip(idxs, self.shape, self.strides) if sh != 1 and st != 0])
 
+
 @functools.lru_cache(maxsize=None)
 def idxs_to_idx(shape:Tuple[int, ...], idxs) -> Node:
   assert len(idxs) == len(shape), "need an idx for all dimensions"
@@ -85,18 +86,13 @@ def strides_for_shape(shape:Tuple[int, ...]) -> Tuple[int, ...]:
   for d in shape[::-1][:-1]: strides = [d*strides[0]] + strides
   return tuple([st if s != 1 else 0 for st, s in zip(strides, shape)])
 
-@functools.lru_cache(maxsize=None)
-def view_from_shape(shape:Tuple[Union[Node, int], ...]) -> View:
-  assert all(is_sym_int(x) for x in shape)
-  return View(tuple(shape), strides_for_shape(shape))
 
 @functools.lru_cache(maxsize=None)
 def merge_views(vm2:View, vm1:View) -> Optional[View]:
   if vm2.mask: return None  # this isn't supported yet
-  mst = ShapeTracker(vm1.shape, [vm2, vm1])
-  strides = mst.real_strides()
+  strides = ShapeTracker.real_strides((vm2, vm1))
   if None in strides: return None
-  return View(vm1.shape, strides, mst.real_offset(), vm1.mask)
+  return View(vm1.shape, strides, ShapeTracker.real_offset((vm2, vm1)), vm1.mask)
 
 @functools.lru_cache(maxsize=None)
 def _reshape(view: View, new_shape:Tuple[int, ...]) -> Tuple[View, bool]:
@@ -131,40 +127,39 @@ def get_pad_args(shape:Tuple[int,...], arg:Tuple[Tuple[int, int], ...]):
 def get_unsafe_resize_offset(strides, arg):
   return sum([s * x[0] for s, x in zip(strides,arg)])
 
-class ShapeTracker:
-  __slots__ = "views"
-  def __init__(self, shape:Union[ShapeTracker, Tuple[int, ...]], views:Optional[List[View]]=None):
-    self.views: List[View] = views if views is not None else ([*cast(ShapeTracker, shape).views] if shape.__class__ is ShapeTracker else [view_from_shape(shape)])
-  def __repr__(self): return f"ShapeTracker(shape={self.views[-1].shape}, views={self.views})"
-  def copy(self) -> ShapeTracker: return ShapeTracker(self.views[-1].shape, [*self.views])
+class ShapeTracker(NamedTuple):
+  views: Tuple[View]
 
   @property
-  def contiguous(self) -> bool: return len(self.views) == 1 and self.views[0].contiguous
-
+  def contiguous(self) -> bool: return self.views[-1].contiguous and len(self.views) == 1
   @property
   def shape(self) -> Tuple[int, ...]: return self.views[-1].shape
 
-  @property
-  def key(self) -> Tuple[View, ...]: return tuple(self.views)
+  @staticmethod
+  @functools.lru_cache(None)
+  def from_shape(shape: Tuple[int]) -> ShapeTracker: return ShapeTracker((View(shape),))
 
   # this is the real size (ish)
   def size(self): return prod([s for s,st in zip(self.views[-1].shape, self.views[-1].strides) if st != 0])
 
   # these are multiview strides, value is None if it's not a simple strided dimension
   # TODO: this can be shared code between simplify and merge_views
-  def real_offset(self) -> int:
-    real_offset, mask = self.expr_node(Variable('zero', 0, 0))
+  @staticmethod
+  def real_offset(views: Tuple[View, ...]) -> int:
+    real_offset, mask = ShapeTracker.expr_node(views, Variable('zero', 0, 0))
     assert real_offset.__class__ is NumNode, f"how is the offset not a number? {real_offset} {mask}"
     return real_offset.b
 
   # NOTE: if a stride is not always valid, it will be None
-  def real_strides(self, ignore_valid=False) -> Tuple[Optional[Union[Node, int]], ...]:
-    if len(self.views) == 1 and self.views[-1].mask is None: return self.views[-1].strides
-    idxs = [Variable(f"idx{i}", 0, s-1) for i,s in enumerate(self.shape)]
-    idx, valid = self.expr_idxs(idxs)
-    ret: List[Optional[Union[Node, int]]] = [None] * len(self.views[-1].shape)
+  @staticmethod
+  @functools.lru_cache(None)
+  def real_strides(views: Tuple[View], ignore_valid=False) -> Tuple[Optional[int], ...]:
+    if len(views) == 1 and views[-1].mask is None: return views[-1].strides
+    idxs = [Variable(f"idx{i}", 0, s-1) for i,s in enumerate(views[-1].shape)]
+    idx, valid = ShapeTracker.expr_idxs(views, tuple(idxs))
+    ret: List[Optional[int]] = [None] * len(views[-1].shape)
     for this_dim in (idx.nodes if isinstance(idx, SumNode) else [idx]):
-      if isinstance(this_dim, MulNode) and isinstance(this_dim.a, Variable):
+      if isinstance(this_dim, MulNode) and isinstance(this_dim.a, Variable) and isinstance(this_dim.b, int):
         ret[idxs.index(this_dim.a)] = this_dim.b
       elif isinstance(this_dim, Variable):
         ret[idxs.index(this_dim)] = 1
@@ -173,104 +168,116 @@ class ShapeTracker:
       if tidx in valid_vars and not ignore_valid: ret[i] = None
       elif tidx not in idx_vars: ret[i] = 0
     return tuple(ret)
-  def unit_stride_axes(self, ignore_valid=False) -> List[int]: return [i for i,st in enumerate(self.real_strides(ignore_valid)) if st == 1]
 
-  def _expr_idx(self, idx, valid):
-    for v in reversed(self.views[0:-1]):
+
+  @staticmethod
+  @functools.lru_cache(None)
+  def _expr_idx(views: Tuple[View], idx, valid):
+    for v in reversed(views[:-1]):    # type: ignore
       valid = v.expr_node_mask(idx, valid)
       idx = v.expr_node(idx)
     return idx, valid
 
-  def simplify(self):
-    if len(self.views) >= 2:
-      new_view = merge_views(self.views[-2], self.views[-1])
+  @staticmethod
+  def simplify(views: Tuple[View]) -> Tuple[View]:
+    if len(views) >= 2:
+      new_view = merge_views(views[-2], views[-1])  # type: ignore
       if new_view:
-        if DEBUG >= 4: print(f"st simplify : {self.views[-2]} + {self.views[-1]} = {new_view}")
-        self.views = self.views[:-2] + [new_view]
-        self.simplify()
+        if DEBUG >= 4: print(f"st simplify : {views[-2]} + {views[-1]} = {new_view}")  # type: ignore
+        return ShapeTracker.simplify((*views[:-2], new_view))
+    return views
 
-  def expr_idxs(self, idxs=None):
-    if idxs is None: idxs = [Variable(f"idx{i}", 0, s-1) for i,s in enumerate(self.shape)]
-    idx = self.views[-1].expr_idxs(tuple(idxs))
-    valid = self.views[-1].expr_node_mask(idxs_to_idx(self.views[-1].shape, tuple(idxs)))
-    return self._expr_idx(idx, valid)
+  @staticmethod
+  @functools.lru_cache(None)
+  def expr_idxs(views: Tuple[View], idxs=None):
+    if idxs is None: idxs = [Variable(f"idx{i}", 0, s-1) for i,s in enumerate(views[-1].shape)]
+    return ShapeTracker._expr_idx(views, views[-1].expr_idxs(idxs), views[-1].expr_node_mask(idxs_to_idx(views[-1].shape, idxs)))
+  
+  @staticmethod
+  def expr_node(views: Tuple[View,...], idx='idx'):
+    if idx.__class__ is str: idx = Variable(idx, 0, prod(views[-1].shape)-1)
+    return ShapeTracker._expr_idx(views, views[-1].expr_node(idx), views[-1].expr_node_mask(idx))
 
-  def expr_node(self, idx='idx'):
-    if idx.__class__ is str: idx = Variable(idx, 0, prod(self.shape)-1)
-    return self._expr_idx(self.views[-1].expr_node(idx), self.views[-1].expr_node_mask(idx))
-
-  def needs_valid(self) -> bool:
-    return any(v.mask is not None for v in self.views)
+  @staticmethod
+  def needs_valid(views: Tuple[View]) -> bool: return any(v.mask is not None for v in views)
 
   # *** under this line are the movement ops ***
 
-  def __unsafe_resize(self, arg: Tuple[Tuple[int, int], ...], mask=None):
-    offset = get_unsafe_resize_offset(self.views[-1].strides, arg)
-    if self.views[-1].mask:
+  @staticmethod
+  def __unsafe_resize(view: View, arg: Tuple[Tuple[int, int], ...], mask=None) -> View:
+    offset = get_unsafe_resize_offset(view.strides, arg)
+    if view.mask:
       # move the old mask
-      nmask = tuple([(max(mx-ax, 0), min(my-ax, ay-ax)) for (mx,my),(ax,ay) in zip(self.views[-1].mask, arg)])
+      nmask = tuple([(max(mx-ax, 0), min(my-ax, ay-ax)) for (mx,my),(ax,ay) in zip(view.mask, arg)])
       # merge the masks if we have two
       mask = tuple([(max(mx1, mx2), min(my1, my2)) for (mx1, my1), (mx2, my2) in zip(nmask, mask)]) if mask is not None else nmask
-    self.views[-1] = View(tuple([y-x for x,y in arg]), self.views[-1].strides, self.views[-1].offset+offset, mask)
+    return View(tuple([y-x for x,y in arg]), view.strides, view.offset+offset, mask)
 
-  def pad(self, arg: Tuple[Tuple[int, int], ...]):
-    assert all((b>=0 and e>=0) for b,e in arg) and len(arg) == len(self.shape)
+  @staticmethod
+  def pad(view: View, arg: Tuple[Tuple[int, int], ...]) -> View:
+    assert all((b>=0 and e>=0) for b,e in arg) and len(arg) == len(view.shape)
     if any(b or e for b, e in arg):
-      zvarg, mask = get_pad_args(self.shape, arg)
-      self.__unsafe_resize(zvarg, mask=mask)
-    return self
+      zvarg, mask = get_pad_args(view.shape, arg)
+    return ShapeTracker.__unsafe_resize(view, zvarg, mask=mask)
 
-  def shrink(self, arg: Tuple[Tuple[int, int], ...]):
-    assert all((b>=0 and e<=s) for s,(b,e) in zip(self.shape,arg)) and len(arg) == len(self.shape)
-    self.__unsafe_resize(arg)
-    return self
+  @staticmethod
+  def shrink(view: View, arg: Tuple[Tuple[int, int], ...]) -> View:
+    assert all((b>=0 and e<=s) for s,(b,e) in zip(view.shape,arg)) and len(arg) == len(view.shape)
+    return ShapeTracker.__unsafe_resize(view, arg)
 
-  def expand(self, new_shape: Tuple[int, ...]) -> ShapeTracker:
-    assert len(new_shape) == len(self.views[-1].shape)
-    assert all(isinstance(x, int) and (s == x or (s == 1 and st == 0)) for s,x,st in zip(self.shape, new_shape, self.views[-1].strides)), f"can't expand {self.shape} into {new_shape}"
+  @staticmethod
+  @functools.lru_cache(None)
+  def expand(view: View, new_shape:Tuple[int, ...]) -> View:
+    assert len(new_shape) == len(view.shape)
+    assert all(isinstance(x, int) and (s == x or (s == 1 and st == 0)) for s,x,st in zip(view.shape, new_shape, view.strides)), f"can't expand {view.shape} into {new_shape}"
     # NOTE: can the mask ever be (0,0)?
-    mask = tuple([(((0,0) if m != (0,1) else (0,ns)) if s != ns else m) for m,s,ns in zip(self.views[-1].mask, self.shape, new_shape)]) if self.views[-1].mask else None
-    self.views[-1] = View(new_shape, self.views[-1].strides, self.views[-1].offset, mask)
-    return self
+    mask = tuple([(((0,0) if m != (0,1) else (0,ns)) if s != ns else m) for m,s,ns in zip(view.mask, view.shape, new_shape)]) if view.mask else None
+    return View(new_shape, view.strides, view.offset, mask)
 
-  def reshape(self, new_shape: Tuple[int, ...]):
-    if self.views[-1].shape == new_shape: return self
+  @staticmethod
+  @functools.lru_cache(None)
+  def reshape(views: Tuple[View], new_shape: Tuple[int, ...]):
+    if views[-1].shape == new_shape: return views
     assert all(is_sym_int(x) and x > 0 for x in new_shape), f"shape must be symbolic ints and can't contain 0 or negative numbers {new_shape}"
     # only check size for int shapes. we don't check symbolic here as long as the reshape itself can be done
-    if all(isinstance(s, int) for s in self.shape) and all(isinstance(s, int) for s in new_shape):
-      assert prod(self.shape) == prod(new_shape), f"can't reshape {self.shape} -> {new_shape}"
-    new_view, extra = _reshape(self.views[-1], new_shape)
-    if extra: self.views.append(new_view)
-    else: self.views[-1] = new_view
-    return self
+    if all(isinstance(s, int) for s in views[-1].shape) and all(isinstance(s, int) for s in new_shape):
+      assert prod(views[-1].shape) == prod(new_shape), f"can't reshape {views[-1].shape} -> {new_shape}"
+    new_view, extra = _reshape(views[-1], new_shape)
+    return (views if extra else views[:-1]) + (new_view, )
 
-  def permute(self, axis: Tuple[int, ...]):
-    assert all(isinstance(x, int) and x >= 0 and x < len(self.shape) for x in axis), f"invalid permute {axis} for {self.shape}"
-    assert len(set(axis)) == len(axis) and len(axis) == len(self.shape), f"can't permute {self.shape} with {axis}"
-    self.views[-1] = View(tuple([self.views[-1].shape[a] for a in axis]), tuple([self.views[-1].strides[a] for a in axis]), self.views[-1].offset, tuple([self.views[-1].mask[a] for a in axis]) if self.views[-1].mask is not None else None)
-    return self
+  @staticmethod
+  def permute(view: View, axis: Tuple[int, ...]) -> View:
+    assert all(isinstance(x, int) and x >= 0 and x < len(view.shape) for x in axis), f"invalid permute {axis} for {view.shape}"
+    assert len(set(axis)) == len(axis) == len(view.shape), f"can't permute {view.shape} with {axis}"
+    return View(tuple([view.shape[a] for a in axis]), tuple([view.strides[a] for a in axis]), view.offset, tuple([view.mask[a] for a in axis]) if view.mask is not None else None)
 
   # except for the negative case, you can build this from the others. invertible in the negative case
-  def stride(self, mul: Tuple[int, ...]):
-    assert all(isinstance(x, int) and x != 0 for x in mul), f"invalid stride {mul} for {self.shape}"
-    strides = tuple([z*m for z,m in zip(self.views[-1].strides, mul)])
-    new_shape = tuple([(s+(abs(m)-1))//abs(m) for s,m in zip(self.views[-1].shape, mul)])
-    offset = sum([(s-1)*z for s,z,m in zip(self.views[-1].shape, self.views[-1].strides, mul) if m < 0])
-    mask = tuple([(((mx if m > 0 else s-my)+(abs(m)-1))//abs(m), ((my if m > 0 else s-mx)+(abs(m)-1))//abs(m)) for (mx,my),s,m in zip(self.views[-1].mask, self.views[-1].shape, mul)]) if self.views[-1].mask is not None else None
-    self.views[-1] = View(new_shape, strides, self.views[-1].offset + offset, mask)
-    return self
+  @staticmethod
+  def stride(view: View, mul: Tuple[int, ...]) -> View:
+    assert all(isinstance(x, int) and x != 0 for x in mul), f"invalid stride {mul} for {view.shape}"
+    strides = tuple([z*m for z,m in zip(view.strides, mul)])
+    new_shape = tuple([(s+(abs(m)-1))//abs(m) for s,m in zip(view.shape, mul)])
+    offset = sum([(s-1)*z for s,z,m in zip(view.shape, view.strides, mul) if m < 0])
+    mask = tuple([(((mx if m > 0 else s-my)+(abs(m)-1))//abs(m), ((my if m > 0 else s-mx)+(abs(m)-1))//abs(m)) for (mx,my),s,m in zip(view.mask, view.shape, mul)]) if view.mask is not None else None
+    return View(new_shape, strides, view.offset + offset, mask)
 
   # *** entry point for external ***
 
-  def movement_op(self, op: MovementOps, arg:Union[Tuple[int, ...], Tuple[Tuple[int, int], ...]]) -> ShapeTracker:
-    assert isinstance(arg, tuple) and (len(arg) == len(self.shape) or op == MovementOps.RESHAPE), f"arg {arg} for {op} doesn't match dim of shape {self.shape}"
-    dispatch[op](self, arg)
-    return self
+  @staticmethod
+  @functools.lru_cache(None)
+  def movement_op(views: Tuple[View], op: MovementOps, arg:Union[Tuple[int, ...], Tuple[Tuple[int, int], ...]]) -> ShapeTracker:
+    assert isinstance(arg, tuple) and (len(arg) == len(views[-1].shape) or op == MovementOps.RESHAPE), f"arg {arg} for {op} doesn't match dim of shape {views[-1].shape}"
+    return op_func[op](views if op is MovementOps.RESHAPE else views[-1], arg)
+ 
 
-dispatch: Dict[MovementOps, Callable] = {MovementOps.RESHAPE: ShapeTracker.reshape, MovementOps.EXPAND: ShapeTracker.expand, MovementOps.PAD: ShapeTracker.pad,
+op_func: Dict[MovementOps, Callable] = {MovementOps.RESHAPE: ShapeTracker.reshape, MovementOps.EXPAND: ShapeTracker.expand, MovementOps.PAD: ShapeTracker.pad,
                                          MovementOps.SHRINK: ShapeTracker.shrink, MovementOps.PERMUTE: ShapeTracker.permute, MovementOps.STRIDE: ShapeTracker.stride}
 
+@functools.lru_cache(maxsize=None)
+def unit_stride_axes(views, ignore_valid=False) -> List[int]: return [i for i,st in enumerate(ShapeTracker.real_strides(views, ignore_valid)) if st == 1]
+
 # returns the axes to create new_shape if new_shape can be created by combining axis from old_shape
+@functools.lru_cache(maxsize=None)
 def get_contraction(old_shape:Tuple[int, ...], new_shape:Tuple[int, ...]) -> Optional[List[List[int]]]:
   # Pre-allocate all groups.
   axis_groups: List[List[int]] = [[] for _ in range(len(new_shape))]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -126,7 +126,7 @@ class Tensor:
 
   @staticmethod
   def _loadop(op, sz, device:Optional[str]=None, dtype:Optional[DType]=None, arg=None, **kwargs):
-    return Tensor(LazyBuffer.loadop(op, [sz], Tensor.default_type if dtype is None else dtype, Device.canonicalize(device), arg), dtype=dtype, device=device, **kwargs)
+    return Tensor(LazyBuffer.loadop(op, (sz,), Tensor.default_type if dtype is None else dtype, Device.canonicalize(device), arg), dtype=dtype, device=device, **kwargs)
 
   @staticmethod
   def empty(*shape, **kwargs): return Tensor._loadop(LoadOps.EMPTY, prod(shape), **kwargs).reshape(shape)


### PR DESCRIPTION
Conceptual refactor:
* ShapeTrackers into a NamedTuple.
* Reduce inputs of shapetracker methods
* better caching of methods
* Replace Lazycache with small lru_cache (shapetracker is now hashable)

Minor speed gain, ~9,4%

Part of the work towards https://github.com/tinygrad/tinygrad/issues/1209.

Together with other minor changes I should achieve 20%. 

I'll make another MR that combines all changes.

## TODO

- [ ] Tests

## Benchmarks

master
```
codegen         mean runtime:  148.19ms, runs:   164.08,  132.56,  195.60,  142.20,  136.55,  140.03,  140.54,  140.76,  142.42,  147.12
methodcache     mean runtime:  142.41ms, runs:   137.83,  133.41,  190.43,  138.24,  137.90,  132.92,  134.28,  140.02,  140.68,  138.38
profile         mean runtime:  631.34ms, runs:   711.69,  621.92,  613.62,  606.61,  659.79,  610.61,  614.25,  622.88,  629.94,  622.05
```

branch
```
codegen         mean runtime:  121.63ms, runs:   143.90,  115.64,  123.02,  122.06,  118.10,  118.78,  120.01,  119.78,  119.96,  115.06
methodcache     mean runtime:  109.72ms, runs:   108.67,  112.51,  111.18,  110.02,  110.97,  110.00,  111.16,  111.31,  106.20,  105.19
profile         mean runtime:  469.68ms, runs:   487.88,  468.68,  462.18,  469.44,  456.86,  466.85,  465.30,  482.63,  466.75,  470.25
```


master

fastest: 437.51 ms (not counting the first, see https://github.com/tinygrad/tinygrad/issues/1356)

```
ran model in 401.60 ms
sync in 32156.58 ms
 I
ran model in 1498.51 ms
sync in 180.15 ms
'
ran model in 452.35 ms
sync in 335.45 ms
m
ran model in 497.65 ms
sync in 327.55 ms
 a
ran model in 464.49 ms
sync in 333.33 ms
 
ran model in 478.68 ms
sync in 346.87 ms
2
ran model in 458.87 ms
sync in 345.90 ms
0
ran model in 442.85 ms
sync in 345.12 ms
 year
ran model in 437.51 ms
sync in 350.30 ms
 old
ran model in 472.58 ms
sync in 316.63 ms
```

branch

fastest: 396.17 ms (not counting the first, see https://github.com/tinygrad/tinygrad/issues/1356)

```
ran model in 382.85 ms
sync in 31975.68 ms
 I
ran model in 860.98 ms
sync in 306.12 ms
'
ran model in 407.66 ms
sync in 386.02 ms
m
ran model in 418.58 ms
sync in 380.16 ms
 a
ran model in 420.70 ms
sync in 373.58 ms
 
ran model in 434.08 ms
sync in 370.63 ms
2
ran model in 413.64 ms
sync in 373.21 ms
0
ran model in 410.82 ms
sync in 430.54 ms
 year
ran model in 396.17 ms
sync in 395.70 ms
 old
ran model in 420.56 ms
sync in 386.05 ms
```
