### PR TITLE
Synchronize Before Releasing Buffer in Metal Backend

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -1,7 +1,6 @@
 # pip3 install pyobjc-framework-Metal pyobjc-framework-Cocoa pyobjc-framework-libdispatch
 import os, subprocess, pathlib
 import Metal, Cocoa, libdispatch # type: ignore
-from typing import List, Any
 from tinygrad.codegen.cstyle import CStyleCodegen, CStyleLanguage
 from tinygrad.helpers import prod, getenv, DEBUG, DType
 from tinygrad.ops import Compiled

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -11,7 +11,6 @@ METAL_XCODE = getenv("METAL_XCODE")
 
 class _METAL:
   def __init__(self):
-    self.mtl_buffers_in_flight: List[Any] = []
     self.device = Metal.MTLCreateSystemDefaultDevice()
     self.dispatch_group = libdispatch.dispatch_group_create() 
     self.mtl_queue = self.device.newCommandQueue()
@@ -20,11 +19,9 @@ class _METAL:
     libdispatch.dispatch_group_enter(METAL.dispatch_group)
     def leave(_): libdispatch.dispatch_group_leave(self.dispatch_group)
     command_buffer.addCompletedHandler_(leave)
-    self.mtl_buffers_in_flight.append(command_buffer)
     return command_buffer
   def synchronize(self):
     libdispatch.dispatch_group_wait(self.dispatch_group, libdispatch.DISPATCH_TIME_FOREVER)
-    self.mtl_buffers_in_flight.clear()
 METAL = _METAL()
 
 class RawMetalBuffer(RawBufferMapped):

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -27,6 +27,7 @@ class RawMetalBuffer(RawBufferMapped):
   def __init__(self, size:int, dtype:DType):
     super().__init__(size, dtype, METAL.device.newBufferWithLength_options_(size*dtype.itemsize, Metal.MTLResourceStorageModeShared))
   def __del__(self):
+    METAL.synchronize()
     self._buf.release()
     super().__del__()
   def _buffer(self):

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -15,7 +15,7 @@ class _METAL:
     self.mtl_queue = self.device.newCommandQueue()
   def command_buffer(self):
     command_buffer = self.mtl_queue.commandBuffer()
-    libdispatch.dispatch_group_enter(METAL.dispatch_group)
+    libdispatch.dispatch_group_enter(self.dispatch_group)
     def leave(_): libdispatch.dispatch_group_leave(self.dispatch_group)
     command_buffer.addCompletedHandler_(leave)
     return command_buffer


### PR DESCRIPTION
This PR addresses an intermittent SIGTRAP issue observed in the Metal backend. We believe the issue is caused by attempting to release a Metal buffer while commands issued to that buffer are still in flight on the GPU.

To prevent this, we've added a call to `synchronize()` in the `__del__` method of `RawMetalBuffer`. This ensures that all commands have completed execution on the GPU before we release the buffer.

In the existing code, `synchronize()` was not called before `self._buf.release()`, which could lead to a situation where the buffer was released while GPU commands were still in flight. This behavior is not well-defined and could potentially cause the observed SIGTRAP.

This change should make the Metal backend more robust by ensuring that buffers are not released prematurely.

This fix resolves issue #1355.