### PR TITLE
Ensure Metal commands complete before releasing raw metal buffer

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -27,6 +27,7 @@ class RawMetalBuffer(RawBufferMapped):
   def __init__(self, size:int, dtype:DType):
     super().__init__(size, dtype, METAL.device.newBufferWithLength_options_(size*dtype.itemsize, Metal.MTLResourceStorageModeShared))
   def __del__(self):
+    METAL.synchronize()
     self._buf.release()
     super().__del__()
   def _buffer(self):


### PR DESCRIPTION
This PR addresses an intermittent SIGTRAP issue observed in the Metal backend. We believe the issue is caused by attempting to release a Metal buffer while commands issued to that buffer are still in flight on the GPU.

To prevent this, we've added a call to `synchronize()` in the `__del__` method of `RawMetalBuffer`. This ensures that all commands have completed execution on the GPU before we release the buffer.

In the existing code, `synchronize()` was not called before `self._buf.release()`, which could lead to a situation where the buffer was released while GPU commands were still in flight. This behavior is not well-defined and could potentially cause the observed SIGTRAP.

This change should make the Metal backend more robust by ensuring that buffers are not released prematurely.

This fix resolves issue #1355.