### PR TITLE
Fix off by one error in View.expr_node

### DIFF
--- a/test/unit/test_shapetracker.py
+++ b/test/unit/test_shapetracker.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 from tinygrad.helpers import prod, DEBUG
 from tinygrad.shape.shapetracker import ShapeTracker, View, get_contraction
+from tinygrad.shape.symbolic import Variable
 
 def shapetracker_getitem(st, val):
   locals = {"idx": val, "valid": 1}
@@ -118,6 +119,44 @@ class TestRealSimplifies(unittest.TestCase):
     self.st = ShapeTracker((8, 1, 6, 10, 28, 3, 2, 1), views=[
       View((8, 3, 3, 11, 2, 28), (924, 308, 0, 28, 0, 1), 0, None),
       View((8, 1, 6, 10, 28, 3, 2, 1), (5544, 0, 0, 56, 1, 1848, 672, 0), 0, None)])
+
+class TestIndexExpressions(unittest.TestCase):
+  def setUp(self):
+    self.st = ShapeTracker((10, 10))
+    self.numel = prod(self.st.shape)
+
+  def tearDown(self):
+    for idx in ['idx', None, (0, 99), (7, 203), (2, 5), (0, 0), (0, self.numel-1), (self.numel, self.numel), (0, self.numel), (0, self.numel+1), (self.numel+100, self.numel+100)]:
+        if isinstance(idx, tuple):
+          idx = Variable("idx", idx[0], idx[1])
+        else:
+          idx = self.default_idx(self.st.shape)
+        
+        assert self.expr(idx) == self.st.expr_node(idx)[0]
+        self.check_bounds(self.expr(idx))
+
+  def default_idx(self, shape):
+    return Variable("idx", 0, prod(shape)-1)
+
+  def check_bounds(self, expr):
+    assert expr.min >= self.st.real_offset()
+    assert expr.max <= self.st.real_offset() + self.numel - 1
+
+  def test_noop(self): 
+    self.expr = lambda idx: idx%100
+
+  def test_permute(self):
+    self.st.permute((1, 0))
+    self.expr = lambda idx: idx%10*10 + idx//10%10
+
+  def test_reshape(self):
+    self.st.reshape((10, 1, 10))
+    self.expr = lambda idx: idx%10 + idx//10%10*10
+
+  def test_reshape_expand(self):
+    self.st.reshape((10, 1, 10))
+    self.st.expand((10, 10, 10))
+    self.expr = lambda idx : idx//100*10 + idx%10
 
 class TestSimplifyingShapeTracker(unittest.TestCase):
   def setUp(self):

--- a/test/unit/test_shapetracker.py
+++ b/test/unit/test_shapetracker.py
@@ -126,17 +126,17 @@ class TestIndexExpressions(unittest.TestCase):
     self.numel = prod(self.st.shape)
 
   def tearDown(self):
-    for idx in ['idx', None, (0, 99), (7, 203), (2, 5), (0, 0), (0, self.numel-1), (self.numel, self.numel), (0, self.numel), (0, self.numel+1), (self.numel+100, self.numel+100)]:
-        if isinstance(idx, tuple):
-          idx = Variable("idx", idx[0], idx[1])
+    assert self.expr(self.default_idx()) == self.st.expr_node()[0]
+    for idx in [None, (0, 99), (7, 203), (2, 5), (0, 0), (0, self.numel-1), (self.numel, self.numel), (0, self.numel), (0, self.numel+1), (self.numel+100, self.numel+100)]:
+        if idx is not None:
+          idx = test_idx = Variable("idx", idx[0], idx[1])
         else:
-          idx = self.default_idx(self.st.shape)
-        
-        assert self.expr(idx) == self.st.expr_node(idx)[0]
-        self.check_bounds(self.expr(idx))
+          test_idx = self.default_idx()
+        self.check_bounds(self.expr(test_idx))
+        assert self.expr(test_idx) == self.st.expr_node(idx)[0]
 
-  def default_idx(self, shape):
-    return Variable("idx", 0, prod(shape)-1)
+  def default_idx(self):
+    return Variable("idx", 0, prod(self.st.shape)-1)
 
   def check_bounds(self, expr):
     assert expr.min >= self.st.real_offset()

--- a/test/unit/test_shapetracker.py
+++ b/test/unit/test_shapetracker.py
@@ -156,7 +156,7 @@ class TestIndexExpressions(unittest.TestCase):
   def test_reshape_expand(self):
     self.st.reshape((10, 1, 10))
     self.st.expand((10, 10, 10))
-    self.expr = lambda idx : idx//100*10 + idx%10
+    self.expr = lambda idx: idx//100*10 + idx%10
 
 class TestSimplifyingShapeTracker(unittest.TestCase):
   def setUp(self):

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -56,7 +56,7 @@ class View(ViewInternal):
 
   # generate an expression if you have a single idx variable
   def expr_node(self, idx=None) -> Node:
-    if idx is None: idx = Variable('idx', 0, prod(self.shape))
+    if idx is None: idx = Variable('idx', 0, prod(self.shape)-1)
     ret: List[Node] = [Variable.num(self.offset)] if self.offset else []
     acc = 1
     for d,s in reversed(self.shape_strides):


### PR DESCRIPTION
Noticed that the upper bound was off by one. Essentially the same code also appears on line 199, but there it does correctly include the -1.