### PR TITLE
use ubuntu for clang ci test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,7 +205,7 @@ jobs:
         backend: [llvm, clang, gpu, cuda]
 
     name: Tests on (${{ matrix.backend }})
-    runs-on: ${{ matrix.backend == 'gpu'  && 'ubuntu-20.04' || matrix.backend=='clang'&&'windows-latest'|| 'ubuntu-latest' }}
+    runs-on: ${{ matrix.backend == 'gpu'  && 'ubuntu-20.04' || matrix.backend=='clang'&&'ubuntu-latest'|| 'ubuntu-latest' }}
     timeout-minutes: 20
 
     steps:
@@ -263,6 +263,8 @@ jobs:
           sudo ninja install
       - name: Install dependencies
         run: pip install -e '.[testing${{matrix.backend=='llvm'&&',llvm'||matrix.backend=='cuda'&&',cuda'||''}}]' --extra-index-url https://download.pytorch.org/whl/cpu
+      - name: Check Device.DEFAULT
+        run: python -c "from tinygrad.lazy import Device; assert Device.DEFAULT in ['LLVM','CLANG','CUDA','GPU'], Device.DEFAULT"
       - name: Run pytest (not cuda)
         if: matrix.backend!='cuda'
         run: python -m pytest -n=auto test/ -k '${{matrix.backend=='llvm'&&'not (test_nn.py and test_conv_transpose2d)'||'test'}}' -m 'not exclude_${{matrix.backend}}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,27 @@ jobs:
     - name: Test EfficientNet
       run: curl https://media.istockphoto.com/photos/hen-picture-id831791190 | ./recognize | grep hen
 
+  testcpuwindows:
+    name: CPU on Windows
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+    - name: Cache pip
+      uses: actions/cache@v3
+      with:
+        path: '~\AppData\Local\pip\cache'
+        key: testing
+    - name: Install Dependencies
+      run: pip install -e '.[testing]' --extra-index-url https://download.pytorch.org/whl/cpu
+    - name: Run pytest
+      run: python -m pytest -n=auto test/ -k 'test'
+
   testtorch:
     name: Torch Tests
     runs-on: ubuntu-latest
@@ -205,7 +226,7 @@ jobs:
         backend: [llvm, clang, gpu, cuda]
 
     name: Tests on (${{ matrix.backend }})
-    runs-on: ${{ matrix.backend == 'gpu'  && 'ubuntu-20.04' || matrix.backend=='clang'&&'ubuntu-latest'|| 'ubuntu-latest' }}
+    runs-on: ${{ matrix.backend == 'gpu'  && 'ubuntu-20.04' || 'ubuntu-latest' }}
     timeout-minutes: 20
 
     steps:
@@ -218,7 +239,7 @@ jobs:
       - name: Cache pip
         uses: actions/cache@v3
         with:
-          path: ${{ matrix.backend=='clang'&&'~\AppData\Local\pip\cache'||'~/.cache/pip' }}
+          path: '~/.cache/pip'
           key: ${{ matrix.backend }}
       - name: Set env
         run: printf "${{ matrix.backend == 'llvm' && 'ENABLE_METHOD_CACHE=1\nLLVM=1' || matrix.backend == 'clang' && 'CLANG=1\nENABLED_METHOD_CACHE=1' || matrix.backend == 'gpu' && 'GPU=1' || matrix.backend == 'cuda' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\n'}}" >> $GITHUB_ENV


### PR DESCRIPTION
Fix #1366. Root cause was that windows env was not set up correctly. It needs to be a powershell command writing to `$env.GITHUB_ENV` (https://stackoverflow.com/a/65110357). windows CI was using `CPU`. It was fine before #1252  because ubuntu was covering it. Also this test is the slowest now and it takes 8 minutes.

I changed the os to `ubuntu-latest` and added a guardrail check. Verified that guardrail works with windows [link](https://github.com/chenyuxyz/tinygrad/actions/runs/5695168286/job/15437766791), and the intentionally fail test indeed failed with clang+ubuntu [link](https://github.com/chenyuxyz/tinygrad/actions/runs/5695199334).