### PR TITLE
[windows+clang fails now, don't merge] replace ubuntu clang CI with windows clang CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,27 +76,6 @@ jobs:
     - name: Test EfficientNet
       run: curl https://media.istockphoto.com/photos/hen-picture-id831791190 | ./recognize | grep hen
 
-  testcpuwindows:
-    name: CPU on Windows
-    runs-on: windows-latest
-    timeout-minutes: 20
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-    - name: Cache pip
-      uses: actions/cache@v3
-      with:
-        path: '~\AppData\Local\pip\cache'
-        key: testing
-    - name: Install Dependencies
-      run: pip install -e '.[testing]' --extra-index-url https://download.pytorch.org/whl/cpu
-    - name: Run pytest
-      run: python -m pytest -n=auto test/ -k 'test'
-
   testtorch:
     name: Torch Tests
     runs-on: ubuntu-latest
@@ -226,7 +205,7 @@ jobs:
         backend: [llvm, clang, gpu, cuda]
 
     name: Tests on (${{ matrix.backend }})
-    runs-on: ${{ matrix.backend == 'gpu'  && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.backend == 'gpu'  && 'ubuntu-20.04' || matrix.backend == 'clang'  && 'windows-latest' || 'ubuntu-latest' }}
     timeout-minutes: 20
 
     steps:
@@ -239,10 +218,14 @@ jobs:
       - name: Cache pip
         uses: actions/cache@v3
         with:
-          path: '~/.cache/pip'
+          path: ${{ runner.os == 'Linux' && '~/.cache/pip' || runner.os == 'Windows' && '~\AppData\Local\pip\cache' }}
           key: ${{ matrix.backend }}
-      - name: Set env
-        run: printf "${{ matrix.backend == 'llvm' && 'ENABLE_METHOD_CACHE=1\nLLVM=1' || matrix.backend == 'clang' && 'CLANG=1\nENABLED_METHOD_CACHE=1' || matrix.backend == 'gpu' && 'GPU=1' || matrix.backend == 'cuda' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\n'}}" >> $GITHUB_ENV
+      - name: Set env (Linux)
+        if: runner.os == 'Linux'
+        run: printf "${{ matrix.backend == 'llvm' && 'LLVM=1' || matrix.backend == 'clang' && 'CLANG=1' || matrix.backend == 'gpu' && 'GPU=1' || matrix.backend == 'cuda' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1'}}" >> $GITHUB_ENV
+      - name: Set env (Windows)
+        if: runner.os == 'Windows'
+        run: echo "${{ matrix.backend == 'clang' && 'CLANG=1' }}" >> $env:GITHUB_ENV
       - name: Install packages (gpu)
         if: matrix.backend == 'gpu'
         run: |


### PR DESCRIPTION
This is a follow-up to #1368. This PR replaced the ubuntu+clang setup with a updated windows+clang setup, and removed the temporary windows+CPU tests. Also removed the flag `ENABLE_METHOD_CACHE`, which is the default now, and there was a typo so it was a noop in clang anyway.

The problem is that windows+clang has 26 failed tests on master, so we cannot merge this yet. ubuntu+clang is green.

few options
(1) skip failed in CI windows tests and merge this, which is a pure test coverage drop
(2) wait until someone review/fix/skip the failed tests, then merge this
(3) update this PR to include both ubuntu+clang and windows+clang, and skip the failed windows tests. Improves coverage. Drawback is more CI resource and slow
(3+) do (3) and we pick a meaningful subset to test for clang to make clang CI fast again

I personally like (3), @wozeparrot what do you think?