### PR TITLE
rng hlops: add normal and kaiming_normal

### DIFF
--- a/test/test_randomness.py
+++ b/test/test_randomness.py
@@ -67,6 +67,10 @@ class TestRandomness(unittest.TestCase):
     self.assertTrue(normal_test(Tensor.randn))
     self.assertTrue(equal_distribution(Tensor.randn, torch.randn, lambda x: np.random.randn(*x)))
 
+  def test_normal(self):
+    self.assertTrue(normal_test(Tensor.normal))
+    self.assertTrue(equal_distribution(Tensor.normal, lambda x: torch.nn.init.normal_(torch.empty(x), mean=0, std=1), lambda x: np.random.normal(loc=0, scale=1, size=x)))
+
   def test_uniform(self):
     self.assertFalse(normal_test(Tensor.uniform))
     self.assertTrue(equal_distribution(Tensor.uniform, lambda x: torch.nn.init.uniform_(torch.empty(x), a=-1, b=1), lambda x: np.random.uniform(low=-1, high=1, size=x)))
@@ -85,6 +89,13 @@ class TestRandomness(unittest.TestCase):
     np.random.seed(1337)
     for shape in [(128, 64, 3, 3), (20, 24)]:
       self.assertTrue(equal_distribution(Tensor.kaiming_uniform, lambda x: torch.nn.init.kaiming_uniform_(torch.empty(x)), shape=shape))
+
+  def test_kaiming_normal(self):
+    Tensor.manual_seed(1337)
+    torch.manual_seed(1337)
+    np.random.seed(1337)
+    for shape in [(128, 64, 3, 3), (20, 24)]:
+      self.assertTrue(equal_distribution(Tensor.kaiming_normal, lambda x: torch.nn.init.kaiming_normal_(torch.empty(x)), shape=shape))
 
   def test_conv2d_init(self):
     params = (128, 256, (3,3))

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -140,7 +140,7 @@ class TestTinygrad(unittest.TestCase):
     self.assertFalse(gradcheck(tiny_func, tiny_x, eps = 1e-5))
 
   def test_random_fns_are_deterministic_with_seed(self):
-    for random_fn in [Tensor.randn, Tensor.uniform, Tensor.scaled_uniform, Tensor.glorot_uniform]:
+    for random_fn in [Tensor.randn, Tensor.normal, Tensor.uniform, Tensor.scaled_uniform, Tensor.glorot_uniform, Tensor.kaiming_normal]:
       with self.subTest(msg=f"Tensor.{random_fn.__name__}"):
         Tensor.manual_seed(1337)
         a = random_fn(10,10).realize()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -179,6 +179,9 @@ class Tensor:
     return src[0].mul(2*pi).cos().mul((1 - src[1]).log().mul(-2).sqrt()).cast(Tensor.default_type if dtype is None else dtype)
 
   @staticmethod
+  def normal(*shape, mean=0.0, std=1.0, **kwargs) -> Tensor: return (std * Tensor.randn(*shape, **kwargs)) + mean
+
+  @staticmethod
   def uniform(*shape, low=-1.0, high=1.0, **kwargs) -> Tensor: return ((high-low) * Tensor.rand(*shape, **kwargs)) + low
 
   @staticmethod
@@ -193,6 +196,12 @@ class Tensor:
   def kaiming_uniform(*shape, a:float = 0.01, **kwargs) -> Tensor:
     bound = sqrt(3.0) * sqrt(2.0 / (1 + a ** 2)) / sqrt(prod(shape[1:]))
     return Tensor.uniform(*shape, low=-bound, high=bound, **kwargs)
+
+  # https://pytorch.org/docs/stable/_modules/torch/nn/init.html#kaiming_normal_
+  @staticmethod
+  def kaiming_normal(*shape, a:float = 0.01, **kwargs) -> Tensor:
+    std = sqrt(2.0 / (1 + a ** 2)) / sqrt(prod(shape[1:]))
+    return Tensor.normal(*shape, mean=0, std=std, **kwargs)
 
   # ***** toposort and backward pass *****
   def deepwalk(self):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -201,7 +201,7 @@ class Tensor:
   @staticmethod
   def kaiming_normal(*shape, a:float = 0.01, **kwargs) -> Tensor:
     std = sqrt(2.0 / (1 + a ** 2)) / sqrt(prod(shape[1:]))
-    return Tensor.normal(*shape, mean=0, std=std, **kwargs)
+    return Tensor.normal(*shape, mean=0.0, std=std, **kwargs)
 
   # ***** toposort and backward pass *****
   def deepwalk(self):


### PR DESCRIPTION
Could use this in #1371  to implement the contentvec from  https://github.com/auspicious3000/contentvec .

**Tensor::normal:** normal dist can be computed from standard dist by factoring in std and adding mean. See notes in: https://numpy.org/doc/stable/reference/random/generated/numpy.random.randn.html

**Tensor::kaiman_normal:** analog to Tensor::kaiman_uniform.

Includes tests.


Also any reason why Tensor::uniform default args are low=-1.0 and high=1.0 and torch::init::uniform are a=0 and b=1? (https://pytorch.org/docs/stable/nn.init.html#torch.nn.init.uniform_ )