### PR TITLE
Raise NotImplementedError instead of RuntimeError:

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1,9 +1,7 @@
-import dataclasses
 import numpy as np
 import torch
 import unittest
-import itertools
-from tinygrad.tensor import Tensor, Device
+from tinygrad.tensor import Tensor
 from tinygrad.helpers import dtypes
 from extra.gradcheck import numerical_jacobian, jacobian, gradcheck
 import pytest

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -20,7 +20,7 @@ class Function:
     if self.requires_grad: self.parents = tensors
 
   def forward(self, *args, **kwargs): raise NotImplementedError(f"forward not implemented for {type(self)}")
-  def backward(self, *args, **kwargs): raise RuntimeError(f"backward not implemented for {type(self)}")
+  def backward(self, *args, **kwargs): raise NotImplementedError(f"backward not implemented for {type(self)}")
 
   @classmethod
   def apply(fxn:Type[Function], *x:Tensor, **kwargs) -> Tensor:


### PR DESCRIPTION
This represents the error better, and also matches the error in the `forward` method.

Also in this commit: Clean up unneeded imports in test_tensor.py.