### PR TITLE
syncthreads before wmma

### DIFF
--- a/extra/gemm/hip_matmul.py
+++ b/extra/gemm/hip_matmul.py
@@ -58,6 +58,7 @@ extern "C" __global__ void test(float* c, __half* a, __half* b) {{
     }}
     for (int y = 0; y < {KY}; y++) {{
       for (int x = 0; x < {KX}; x++) {{
+        __syncthreads();
         c_frag[y][x] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_frag[x], b_frag[y], c_frag[y][x]);
       }}
     }}


### PR DESCRIPTION
Before:
```
(venv) chaos@tiny3:~/tinygrad$ KX=2 KY=2 N=2048 python extra/gemm/hip_matmul.py 
   4194304    443.88 us, would be  38703.69 GFLOPS matmul, 113.39 GB/s
```
After:
```
(venv) chaos@tiny3:~/tinygrad$ KX=2 KY=2 N=2048 python extra/gemm/hip_matmul.py
   4194304    289.60 us, would be  59322.55 GFLOPS matmul, 173.80 GB/s
```

XD