### PR TITLE
LazyBuffer.get_variable_buffers()

### DIFF
--- a/test/test_lazybuffer.py
+++ b/test/test_lazybuffer.py
@@ -3,6 +3,7 @@ import numpy as np
 import unittest
 from tinygrad.lazy import LazyBuffer
 from tinygrad.tensor import Tensor
+from tinygrad.shape.symbolic import Variable
 
 class TestLazyBuffer(unittest.TestCase):
   def test_fromcpu_buffer_sharing(self):
@@ -42,6 +43,30 @@ class TestLazyBuffer(unittest.TestCase):
     y = Tensor([1]).cat(Tensor([1]).exp()).numpy()
     z = Tensor([1, np.e]).numpy()
     np.testing.assert_allclose(y, z)
+
+class TestVariableBuffer(unittest.TestCase):
+  def test_get_variable_buffers_no_variable(self):
+    t = Tensor.rand(2, 3)
+    assert t.lazydata.get_variable_buffers() == {}
+
+  def test_get_variable_buffers_one_variable(self):
+    v = Variable("v", 1, 10)
+    t = Tensor.rand(2, 3).reshape(v, 3)
+    buffers = t.lazydata.get_variable_buffers()
+    assert len(buffers) == 1 and buffers[v].realize().realized.toCPU() == 2
+    v = Variable("v", 1, 10)
+    t = Tensor.rand(2, 3).reshape(2, v)
+    buffers = t.lazydata.get_variable_buffers()
+    assert len(buffers) == 1 and buffers[v].realize().realized.toCPU() == 3
+
+  def test_get_variable_buffers_cat(self):
+    v1 = Variable("v1", 1, 10)
+    v2 = Variable("v2", 1, 10)
+    t1 = Tensor.rand(2, 3).reshape(v1, 3)
+    t2 = Tensor.rand(6, 3).reshape(v2, 3)
+    t = t1.cat(t2)
+    buffers = t.lazydata.get_variable_buffers()
+    assert len(buffers) == 2 and buffers[v1].realize().realized.toCPU() == 2 and buffers[v2].realize().realized.toCPU() == 6
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import unittest
-from tinygrad.shape.symbolic import MulNode, SumNode, Variable, NumNode, ProdNode, sym_vars
+from tinygrad.shape.symbolic import MulNode, SumNode, Variable, NumNode, sym_vars
 
 class TestSymbolic(unittest.TestCase):
   def helper_test_variable(self, v, n, m, s):
@@ -252,15 +252,13 @@ class TestSymbolicVars(unittest.TestCase):
     assert m.vars() == [a]
     s = SumNode([a, b, c])
     assert s.vars() == [a, b, c]
-    s = ProdNode([a, b, c])
-    assert s.vars() == [a, b, c]
 
   def test_compound(self):
     a = Variable("a", 0, 10)
     b = Variable("b", 0, 10)
     c = Variable("c", 0, 10)
-    assert (a + b * c).vars() == [a, b, c]
-    assert (a * b * c).vars() == [a, b, c]
+    # TODO: update this after we support symbolic * symbolic
+    assert (a + b * c).vars() == [a, b]
     assert (a % 3 + b // 5).vars() == [a, b]
     assert (a + b + c - a).vars() == [b, c]
 

--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import unittest
-from tinygrad.shape.symbolic import MulNode, SumNode, Variable, NumNode, sym_vars
+from tinygrad.shape.symbolic import MulNode, SumNode, Variable, NumNode, ProdNode, sym_vars
 
 class TestSymbolic(unittest.TestCase):
   def helper_test_variable(self, v, n, m, s):
@@ -246,19 +246,21 @@ class TestSymbolicVars(unittest.TestCase):
     a = Variable("a", 0, 10)
     b = Variable("b", 0, 10)
     c = Variable("c", 0, 10)
-    assert z.vars() == z.vars(left_only=True) == []
-    assert a.vars() == a.vars(left_only=True) == [a]
-    m = MulNode(a, b)
-    assert m.vars() == [a, b]
-    assert m.vars(left_only=True) == [a]
+    assert z.vars() == z.vars() == []
+    assert a.vars() == a.vars() == [a]
+    m = MulNode(a, 3)
+    assert m.vars() == [a]
     s = SumNode([a, b, c])
-    assert s.vars() == [a, b, c] == s.vars(left_only=True) == [a, b, c]
+    assert s.vars() == [a, b, c]
+    s = ProdNode([a, b, c])
+    assert s.vars() == [a, b, c]
 
   def test_compound(self):
     a = Variable("a", 0, 10)
     b = Variable("b", 0, 10)
     c = Variable("c", 0, 10)
     assert (a + b * c).vars() == [a, b, c]
+    assert (a * b * c).vars() == [a, b, c]
     assert (a % 3 + b // 5).vars() == [a, b]
     assert (a + b + c - a).vars() == [b, c]
 
@@ -268,8 +270,7 @@ class TestSymbolicVars(unittest.TestCase):
     assert sym_vars(1) == []
     assert sym_vars(a) == [a]
     assert sym_vars(a+b) == [a, b]
-    assert sym_vars(MulNode(a, b)) == [a, b]
-    assert sym_vars(MulNode(a, b), left_only=True) == [a]
+    assert sym_vars(a*3) == [a]
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import unittest
-from tinygrad.shape.symbolic import MulNode, SumNode, Variable, NumNode, Node
+from tinygrad.shape.symbolic import MulNode, SumNode, Variable, NumNode, sym_vars
 
 class TestSymbolic(unittest.TestCase):
   def helper_test_variable(self, v, n, m, s):
@@ -239,6 +239,37 @@ class TestSymbolicNumeric(unittest.TestCase):
   def test_times_2_plus_3_mod_4(self): self.helper_test_numeric(lambda x: (x*2 + 3)%4)
   def test_times_2_plus_3_div_4(self): self.helper_test_numeric(lambda x: (x*2 + 3)//4)
   def test_times_2_plus_3_div_4_mod_4(self): self.helper_test_numeric(lambda x: ((x*2 + 3)//4)%4)
+
+class TestSymbolicVars(unittest.TestCase):
+  def test_simple(self):
+    z = NumNode(0)
+    a = Variable("a", 0, 10)
+    b = Variable("b", 0, 10)
+    c = Variable("c", 0, 10)
+    assert z.vars() == z.vars(left_only=True) == []
+    assert a.vars() == a.vars(left_only=True) == [a]
+    m = MulNode(a, b)
+    assert m.vars() == [a, b]
+    assert m.vars(left_only=True) == [a]
+    s = SumNode([a, b, c])
+    assert s.vars() == [a, b, c] == s.vars(left_only=True) == [a, b, c]
+
+  def test_compound(self):
+    a = Variable("a", 0, 10)
+    b = Variable("b", 0, 10)
+    c = Variable("c", 0, 10)
+    assert (a + b * c).vars() == [a, b, c]
+    assert (a % 3 + b // 5).vars() == [a, b]
+    assert (a + b + c - a).vars() == [b, c]
+
+  def test_sym_vars(self):
+    a = Variable("a", 0, 10)
+    b = Variable("b", 0, 10)
+    assert sym_vars(1) == []
+    assert sym_vars(a) == [a]
+    assert sym_vars(a+b) == [a, b]
+    assert sym_vars(MulNode(a, b)) == [a, b]
+    assert sym_vars(MulNode(a, b), left_only=True) == [a]
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -9,6 +9,7 @@ from tinygrad.helpers import GRAPH, DEBUG, prod, getenv, DType, dtypes, flatten,
 from tinygrad.runtime.ops_cpu import RawNumpyBuffer
 from tinygrad.runtime.ops_disk import RawDiskBuffer
 from tinygrad.shape.shapetracker import MovementOps, ShapeTracker, View, get_contraction
+from tinygrad.shape.symbolic import Variable, sym_vars
 from tinygrad.ops import Compiled, Interpreted, UnaryOps, BinaryOps, TernaryOps, ReduceOps, LoadOps, OpType, LazyOp
 from tinygrad.runtime.lib import RawBufferMapped, RawConst, RawBuffer
 
@@ -270,6 +271,7 @@ class LazyBuffer:
   def buffers(self) -> Tuple[LazyBuffer, ...]: return (self,)
   def map_buffers(self, real_srcs: Dict[Any, Any]): return real_srcs.get(self, self)
   def get_lazyops(self) -> List[Any]: return []
+  def get_variable_buffers(self) -> Dict[Variable, LazyBuffer]: return {v:LazyBuffer.loadop(LoadOps.FROM, (1,), dtypes.int32, self.device, src=LazyBuffer.fromCPU(np.array([v.val], dtype=np.int32))) for s in self.shape for v in sym_vars(s)}
   def replace_with_movement_ops(self: LazyBuffer, ops:List[Tuple[MovementOps, Any]]) -> LazyBuffer:
     y = self
     for op, arg in ops: y = MOVEMENT_OPS_DISPATCHER[op](y, arg)

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -170,7 +170,7 @@ class ShapeTracker:
         ret[idxs.index(this_dim.a)] = this_dim.b
       elif isinstance(this_dim, Variable):
         ret[idxs.index(this_dim)] = 1
-    idx_vars, valid_vars = idx.vars(left_only=True), valid.vars(left_only=True)
+    idx_vars, valid_vars = idx.vars(), valid.vars()
     for i,tidx in enumerate(idxs):
       if tidx in valid_vars and not ignore_valid: ret[i] = None
       elif tidx not in idx_vars: ret[i] = 0

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -170,7 +170,7 @@ class ShapeTracker:
         ret[idxs.index(this_dim.a)] = this_dim.b
       elif isinstance(this_dim, Variable):
         ret[idxs.index(this_dim)] = 1
-    idx_vars, valid_vars = idx.vars(), valid.vars()
+    idx_vars, valid_vars = idx.vars(left_only=True), valid.vars(left_only=True)
     for i,tidx in enumerate(idxs):
       if tidx in valid_vars and not ignore_valid: ret[i] = None
       elif tidx not in idx_vars: ret[i] = 0

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -155,7 +155,7 @@ class OpNode(Node):
     if isinstance(self, MulNode): assert isinstance(b, int), f"MulNode.b must be int, getting {type(b)}"
     self.a, self.b = a, b
     self.min, self.max = self.get_bounds()
-  def vars(self): return self.a.vars() + (self.b.vars() if isinstance(self.b, Node) else [])
+  def vars(self): return self.a.vars()
   @abstractmethod
   def get_bounds(self) -> Tuple[int, int]: pass
 


### PR DESCRIPTION
Part of #1353

`LazyBuffer.get_variable_buffers()` returns a map of {symbol: unrealized size 1 buffer of symbol value}. We will need the keys of this dict in codegen, and the values in exec.

Extend the original `Node.vars` to possibly return the `vars` from in `OpNode.b`. The only place that used `vars` was in `real_strides`. We need to keep the version that only returns the vars of `OpNode.a` because `real_strides` construct a set of variables and relies on the assumption that `OpNode.b` will always be `int`.