### PR TITLE
Const pad support to pad2d and slice

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -611,7 +611,9 @@ class TestOps(unittest.TestCase):
 
   def test_pad2d(self):
     helper_test_op([(3,3,3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4)), lambda x: x.pad2d(padding=(1,2,3,4)))
-
+    helper_test_op([(3,3,3,3)], lambda x: torch.nn.functional.pad(x, (-1,2,-3,4)), lambda x: x.pad2d(padding=(-1,2,-3,4)))
+    helper_test_op([(3,3,3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4), value=5), lambda x: x.pad2d(padding=(1,2,3,4),value=5))
+    helper_test_op([(3,3,3,3)], lambda x: torch.nn.functional.pad(x, (-1,2,-3,4), value=5), lambda x: x.pad2d(padding=(-1,2,-3,4),value=5))
   def test_pad(self):
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4)),lambda x: x.pad(((3,4),(1,2))))
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4), value=5), lambda x: x.pad(((3,4), (1,2)), value=5))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -376,8 +376,8 @@ class Tensor:
   # (padding_left, padding_right, padding_top, padding_bottom) Supports N Dimension, Length needs to be even
   def pad2d(self, padding:Union[List[int], Tuple[int, ...]], value:float=0):
     arg = [(0,s) for s in self.shape[:-(len(padding)//2)]] + [(-p0, s+p1) for p0,p1,s in zip(padding[::2], padding[1::2], self.shape[::-1])][::-1]
-    pad_ = tuple([(max(0, -p[0]), max(0, p[1]-s)) for p,s in zip(arg, self.shape)])
-    return self.pad(pad_, value=value).shrink(tuple([(p[0] + pad_[i][0], p[1] + pad_[i][0]) for i,p in enumerate(arg)]))
+    pad_ = tuple([(max(0, -p0), max(0, p1-s)) for (p0, p1),s in zip(arg, self.shape)])
+    return self.pad(pad_, value=value).shrink(tuple([(p0 + pad_[i][0], p1 + pad_[i][0]) for i,(p0, p1) in enumerate(arg)]))
 
   @property
   def T(self) -> Tensor: return self.transpose()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -251,7 +251,10 @@ class Tensor:
   # ***** movement hlops *****
 
   # NOTE: using slice is discouraged and things should migrate to pad and shrink
-  def slice(self, arg: Sequence[Optional[Tuple[int, int]]]) -> Tensor: return self.pad2d(flatten(((a[1] - s, -a[0]) if a is not None else (0, 0) for s, a in zip(self.shape, arg)))[::-1])
+  def slice(self, arg: Sequence[Optional[Tuple[int, int]]], value:float=0) -> Tensor:
+    arg_ = tuple([a if a is not None else (0, s) for s, a in zip(self.shape, arg)])
+    padding = tuple([(max(0, -p[0]), max(0, p[1] - self.shape[i])) for i, p in enumerate(arg_)])
+    return self.pad(padding, value=value).shrink(tuple([(p[0] + padding[i][0], p[1] + padding[i][0]) for i, p in enumerate(arg_)]))
 
   # - Negative indices are taken relative to the end of the sequence, so X[-2] returns the 2nd-to-last element
   # - A slice i:j returns the elements with indices in [i, j)
@@ -375,9 +378,8 @@ class Tensor:
 
   # (padding_left, padding_right, padding_top, padding_bottom) Supports N Dimension, Length needs to be even
   def pad2d(self, padding:Union[List[int], Tuple[int, ...]], value:float=0):
-    arg = [(0,s) for s in self.shape[:-(len(padding)//2)]] + [(-p0, s+p1) for p0,p1,s in zip(padding[::2], padding[1::2], self.shape[::-1])][::-1]
-    pad_ = tuple([(max(0, -p0), max(0, p1-s)) for (p0, p1),s in zip(arg, self.shape)])
-    return self.pad(pad_, value=value).shrink(tuple([(p0 + pad_[i][0], p1 + pad_[i][0]) for i,(p0, p1) in enumerate(arg)]))
+    slc = [(-p0, s+p1) for p0,p1,s in zip(padding[::2], padding[1::2], self.shape[::-1])][::-1]
+    return self.slice([(0,s) for s in self.shape[:-(len(padding)//2)]] + slc, value)
 
   @property
   def T(self) -> Tensor: return self.transpose()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -251,10 +251,10 @@ class Tensor:
   # ***** movement hlops *****
 
   # NOTE: using slice is discouraged and things should migrate to pad and shrink
-  def slice(self, arg: Sequence[Optional[Tuple[int, int]]], value:float=0) -> Tensor:
-    arg_ = tuple([a if a is not None else (0, s) for s, a in zip(self.shape, arg)])
-    padding = tuple([(max(0, -p[0]), max(0, p[1] - self.shape[i])) for i, p in enumerate(arg_)])
-    return self.pad(padding, value=value).shrink(tuple([(p[0] + padding[i][0], p[1] + padding[i][0]) for i, p in enumerate(arg_)]))
+  def slice(self, arg:Sequence[Optional[Tuple[int, int]]], value:float=0) -> Tensor:
+    arg_ = tuple([a if a is not None else (0,s) for s,a in zip(self.shape, arg)])
+    padding = tuple([(max(0, -p[0]), max(0, p[1]-self.shape[i])) for i,p in enumerate(arg_)])
+    return self.pad(padding, value=value).shrink(tuple([(p[0] + padding[i][0], p[1] + padding[i][0]) for i,p in enumerate(arg_)]))
 
   # - Negative indices are taken relative to the end of the sequence, so X[-2] returns the 2nd-to-last element
   # - A slice i:j returns the elements with indices in [i, j)
@@ -376,10 +376,10 @@ class Tensor:
     if dim < 0: dim = len(self.shape) + dim + 1
     return self.reshape(self.shape[:dim] + (1,) + self.shape[dim:])
 
-  # (padding_left, padding_right, padding_top, padding_bottom) Supports N Dimension, Length needs to be even
+  # (padding_left, padding_right, padding_top, padding_bottom)
   def pad2d(self, padding:Union[List[int], Tuple[int, ...]], value:float=0):
     slc = [(-p0, s+p1) for p0,p1,s in zip(padding[::2], padding[1::2], self.shape[::-1])][::-1]
-    return self.slice([(0,s) for s in self.shape[:-(len(padding)//2)]] + slc, value)
+    return self.slice([(0,s) for s in self.shape[:-(len(padding)//2)]] + slc, value=value)
 
   @property
   def T(self) -> Tensor: return self.transpose()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -251,10 +251,7 @@ class Tensor:
   # ***** movement hlops *****
 
   # NOTE: using slice is discouraged and things should migrate to pad and shrink
-  def slice(self, arg:Sequence[Optional[Tuple[int, int]]]) -> Tensor:
-    arg_ = tuple([a if a is not None else (0,s) for s,a in zip(self.shape, arg)])
-    padding = tuple([(max(0, -p[0]), max(0, p[1]-self.shape[i])) for i,p in enumerate(arg_)])
-    return self.pad(padding).shrink(tuple([(p[0] + padding[i][0], p[1] + padding[i][0]) for i,p in enumerate(arg_)]))
+  def slice(self, arg: Sequence[Optional[Tuple[int, int]]]) -> Tensor: return self.pad2d(flatten(((a[1] - s, -a[0]) if a is not None else (0, 0) for s, a in zip(self.shape, arg)))[::-1])
 
   # - Negative indices are taken relative to the end of the sequence, so X[-2] returns the 2nd-to-last element
   # - A slice i:j returns the elements with indices in [i, j)
@@ -377,9 +374,11 @@ class Tensor:
     return self.reshape(self.shape[:dim] + (1,) + self.shape[dim:])
 
   # (padding_left, padding_right, padding_top, padding_bottom)
-  def pad2d(self, padding:Union[List[int], Tuple[int, ...]]):
-    slc = [(-p0, s+p1) for p0,p1,s in zip(padding[::2], padding[1::2], self.shape[::-1])][::-1]
-    return self.slice([(0,s) for s in self.shape[:-(len(padding)//2)]] + slc)
+  def pad2d(self, padding:Union[List[int], Tuple[int, ...]], value:float=0):
+    assert len(padding) % 2 == 0 and len(padding)//2 <= len(self.shape) # Match Pytorch Behaviour
+    arg = [(0,s) for s in self.shape[:-(len(padding)//2)]] + [(-p0, s+p1) for p0,p1,s in zip(padding[::2], padding[1::2], self.shape[::-1])][::-1]
+    padding = tuple([(max(0, -p[0]), max(0, p[1]-self.shape[i])) for i,p in enumerate(arg)])
+    return self.pad(padding, value=value).shrink(tuple([(p[0] + pad_[0], p[1] + pad_[0]) for p,pad_ in zip(arg, padding)]))
 
   @property
   def T(self) -> Tensor: return self.transpose()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -373,9 +373,8 @@ class Tensor:
     if dim < 0: dim = len(self.shape) + dim + 1
     return self.reshape(self.shape[:dim] + (1,) + self.shape[dim:])
 
-  # (padding_left, padding_right, padding_top, padding_bottom)
+  # (padding_left, padding_right, padding_top, padding_bottom) Supports N Dimension, Length needs to be even
   def pad2d(self, padding:Union[List[int], Tuple[int, ...]], value:float=0):
-    assert len(padding) % 2 == 0 and len(padding)//2 <= len(self.shape) # Match Pytorch Behaviour
     arg = [(0,s) for s in self.shape[:-(len(padding)//2)]] + [(-p0, s+p1) for p0,p1,s in zip(padding[::2], padding[1::2], self.shape[::-1])][::-1]
     padding = tuple([(max(0, -p[0]), max(0, p[1]-self.shape[i])) for i,p in enumerate(arg)])
     return self.pad(padding, value=value).shrink(tuple([(p[0] + pad_[0], p[1] + pad_[0]) for p,pad_ in zip(arg, padding)]))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -376,8 +376,8 @@ class Tensor:
   # (padding_left, padding_right, padding_top, padding_bottom) Supports N Dimension, Length needs to be even
   def pad2d(self, padding:Union[List[int], Tuple[int, ...]], value:float=0):
     arg = [(0,s) for s in self.shape[:-(len(padding)//2)]] + [(-p0, s+p1) for p0,p1,s in zip(padding[::2], padding[1::2], self.shape[::-1])][::-1]
-    padding = tuple([(max(0, -p[0]), max(0, p[1]-self.shape[i])) for i,p in enumerate(arg)])
-    return self.pad(padding, value=value).shrink(tuple([(p[0] + pad_[0], p[1] + pad_[0]) for p,pad_ in zip(arg, padding)]))
+    pad_ = tuple([(max(0, -p[0]), max(0, p[1]-s)) for p,s in zip(arg, self.shape)])
+    return self.pad(pad_, value=value).shrink(tuple([(p[0] + pad_[i][0], p[1] + pad_[i][0]) for i,p in enumerate(arg)]))
 
   @property
   def T(self) -> Tensor: return self.transpose()


### PR DESCRIPTION
This PR, refactors pad2d and slice, eventually slice and pad2d does the same thing both can shrink and pad with zeros but they do it with different formatted input. So I have merged them into one in pad2d and used it in slice.

As a result of this PR, pad2d now supports const padding

To sum up, slice and pad2d does the same thing eventually