### PR TITLE
use host ptr for speed on copyouts

### DIFF
--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -48,7 +48,7 @@ class CLBuffer(RawBufferCopyInOut):
     CL.events_in_flight.append(cl.enqueue_copy(CL.cl_queue[self._buf.device], self._buf, np.require(x, requirements='C'), is_blocking=False))
   def _copyout(self, x:np.ndarray):
     assert not self.dtype.name.startswith("image"), f"can't copyout images {self.dtype}"
-    buf = cl.Buffer(CL.cl_ctxs[self._buf.device], cl.mem_flags.WRITE_ONLY | cl.mem_flags.USE_HOST_PTR, 0, hostbuf=memoryview(x))
+    buf = cl.Buffer(CL.cl_ctxs[self._buf.device], cl.mem_flags.WRITE_ONLY | cl.mem_flags.USE_HOST_PTR, 0, hostbuf=x.data)
     mapped = cl.enqueue_map_buffer(CL.cl_queue[self._buf.device], buf, cl.map_flags.WRITE, 0, self.size, dtype=self.dtype.np)
     CL.synchronize()
     with mapped[0].base: cl.enqueue_copy(CL.cl_queue[self._buf.device], mapped[0], self._buf, is_blocking=True, wait_for=[mapped[1]])

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -51,7 +51,7 @@ class CLBuffer(RawBufferCopyInOut):
     buf = cl.Buffer(CL.cl_ctxs[self._buf.device], cl.mem_flags.WRITE_ONLY | cl.mem_flags.USE_HOST_PTR, 0, hostbuf=memoryview(x))
     mapped = cl.enqueue_map_buffer(CL.cl_queue[self._buf.device], buf, cl.map_flags.WRITE, 0, self.size, dtype=self.dtype.np)
     CL.synchronize()
-    with mapped[0].base: cl.enqueue_copy(CL.cl_queue[self._buf.device], mapped[0], self._buf, is_blocking=True, wait_for=[mapped[1]] + CL.events_in_flight)
+    with mapped[0].base: cl.enqueue_copy(CL.cl_queue[self._buf.device], mapped[0], self._buf, is_blocking=True, wait_for=[mapped[1]])
 
 class CLProgram:
   def __init__(self, name:str, prg:str, binary=False, argdtypes=None, options=None):

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -43,13 +43,15 @@ class CLBuffer(RawBufferCopyInOut):
     setattr(buf, 'device', int(device))  # device is tracked on the underlying buffer
     super().__init__(size, dtype, buf)
 
-  def _copyin(self, x: np.ndarray):
+  def _copyin(self, x:np.ndarray):
     assert not self.dtype.name.startswith("image"), f"can't copyin images {self.dtype}"
     CL.events_in_flight.append(cl.enqueue_copy(CL.cl_queue[self._buf.device], self._buf, np.require(x, requirements='C'), is_blocking=False))
   def _copyout(self, x:np.ndarray):
-    CL.synchronize()
     assert not self.dtype.name.startswith("image"), f"can't copyout images {self.dtype}"
-    cl.enqueue_copy(CL.cl_queue[self._buf.device], x, self._buf, is_blocking=True)
+    buf = cl.Buffer(CL.cl_ctxs[self._buf.device], cl.mem_flags.WRITE_ONLY | cl.mem_flags.USE_HOST_PTR, 0, hostbuf=memoryview(x))
+    mapped = cl.enqueue_map_buffer(CL.cl_queue[self._buf.device], buf, cl.map_flags.WRITE, 0, self.size, dtype=self.dtype.np)
+    CL.synchronize()
+    with mapped[0].base: cl.enqueue_copy(CL.cl_queue[self._buf.device], mapped[0], self._buf, is_blocking=True, wait_for=[mapped[1]] + CL.events_in_flight)
 
 class CLProgram:
   def __init__(self, name:str, prg:str, binary=False, argdtypes=None, options=None):


### PR DESCRIPTION
splitting #963 into smaller prs.

Before:
```
gpu:0, 0.01195 s, 2.80894 GB/s, 2048x2048x2, 33554.43200 KB
gpu:0, 0.01724 s, 3.89176 GB/s, 2048x2048x4, 67108.86400 KB
gpu:0, 0.03089 s, 4.34465 GB/s, 2048x2048x8, 134217.72800 KB
gpu:0, 0.05452 s, 4.92342 GB/s, 2048x2048x16, 268435.45600 KB
gpu:0, 0.09634 s, 5.57272 GB/s, 2048x2048x32, 536870.91200 KB
```

After:
```
gpu:0, 0.00438 s, 7.65615 GB/s, 2048x2048x2, 33554.43200 KB
gpu:0, 0.00800 s, 8.38438 GB/s, 2048x2048x4, 67108.86400 KB
gpu:0, 0.01542 s, 8.70673 GB/s, 2048x2048x8, 134217.72800 KB
gpu:0, 0.03976 s, 6.75204 GB/s, 2048x2048x16, 268435.45600 KB
gpu:0, 0.08238 s, 6.51688 GB/s, 2048x2048x32, 536870.91200 KB
```