### PR TITLE
Update pytest.ini format

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
-markers = ['exclude_cuda', 'exclude_gpu', 'exclude_clang', 'webgpu']
+markers =
+  exclude_cuda
+  exclude_gpu
+  exclude_clang
+  webgpu


### PR DESCRIPTION
Update per instruction in https://doc.pytest.org/en/latest/example/markers.html#registering-markers

This gets rid of all the spammy warnings

PytestUnknownMarkWarning: Unknown pytest.mark.exclude_gpu - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytestmark = [pytest.mark.exclude_gpu, pytest.mark.exclude_clang]