### PR TITLE
One more optimization for `mod` on a `MulNode`

### DIFF
--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -126,9 +126,16 @@ class TestSymbolic(unittest.TestCase):
   def test_sum_div_no_factor(self):
     self.helper_test_variable(Variable.sum([Variable("a", 0, 7)*5, Variable("b", 0, 3)*5]) // 2, 0, 25, "(((a*5)+(b*5))//2)")
 
+  def test_mul_mod_gcd(self):
+    self.helper_test_variable(Variable("a", 0, 9)*50  % 100, 0, 50, "((a%2)*50)")
+    self.helper_test_variable(Variable("a", 0, 9)*-75 % 100, 0, 75, "((a%4)*25)")
+    self.helper_test_variable(Variable("a", 0, 9)*75  % 100, 0, 75, "(((a*3)%4)*25)")
+    self.helper_test_variable(Variable("a", 0, 9)*-25 % 100, 0, 75, "(((a*3)%4)*25)")
+    self.helper_test_variable(Variable("a", 0, 9)*33  % 100, 0, 99, "((a*33)%100)")
+    self.helper_test_variable(Variable("a", 0, 9)*-33 % 100, 0, 99, "((a*67)%100)")
+
   def test_mod_factor(self):
-    # NOTE: even though the mod max is 50, it can't know this without knowing about the mul
-    self.helper_test_variable(Variable.sum([Variable("a", 0, 7)*100, Variable("b", 0, 3)*50]) % 100, 0, 99, "((b*50)%100)")
+    self.helper_test_variable(Variable.sum([Variable("a", 0, 7)*100, Variable("b", 0, 3)*50]) % 100, 0, 50, "((b%2)*50)")
 
   def test_sum_div_const(self):
     self.helper_test_variable(Variable.sum([Variable("a", 0, 7)*4, Variable.num(3)]) // 4, 0, 7, "a")


### PR DESCRIPTION
Inspired by this note in `test_symbolic.py` i tried to implement it and it works!
```python
# NOTE: even though the mod max is 50, it can't know this without knowing about the mul
self.helper_test_variable(Variable.sum([Variable("a", 0, 7)*100, Variable("b", 0, 3)*50]) % 100, 0, 99, "((b*50)%100)")
```

I ran a fuzzer few times and it didn't find anything :)

For the record, my text-editor-math-proof(?):

```
i % m
where,
  m <= i
  m = g * gcd
  i = x * (f * gcd)
  i = (a*m + b), 0 <= b < m, i % m = b
  x*f = (p*g + q), 0 <= q < g, x*f % g = q

i = x * (f * gcd)
i = x*f * gcd
i = (p*g + q) * gcd
i = p*(g*gcd) + q*gcd
i = p*m + (x*f % g)*gcd
i % m = (x*f % g)*gcd
(x * f * gcd) % (g * gcd) = (x*f % g)*gcd

0 <= q < g
0 <= q*gcd < g*gcd
0 <= i % m < m

(t * 75) % 100 = (t * 3 * 25) % (4 * 25) = (t*3 % 4) * 25
(t * 15) % 9 = (t * 6) % 9 = (t * 2 * 3) % (3 * 3) = (t*2 % 3) * 3

if f == 1:
(t * 50) % 100 = (t % 2) * 50
(t * 12) % 9 = (t * 3) % 9 = (t % 3) * 3
```

