### PR TITLE
support symbolic shape codegen

### DIFF
--- a/test/test_symbolic_ops.py
+++ b/test/test_symbolic_ops.py
@@ -1,0 +1,17 @@
+import os, unittest
+from tinygrad.helpers import CI
+from tinygrad.shape.symbolic import Variable
+from tinygrad.tensor import Tensor, Device
+
+@unittest.skipUnless(Device.DEFAULT == "CLANG", "CLANG only")
+class TestSymbolicOps(unittest.TestCase):
+  def test_plus1(self):
+    os.environ["TEST_COMPILE_ONLY"] = "1"
+    vi = Variable("i", 1, 10)
+    a = Tensor.rand(3, 4).reshape(vi, 4)
+    s = a + 1
+    if not CI:
+      s.realize()
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -99,3 +99,6 @@ class TestSymbolicExpand(unittest.TestCase):
     a = Tensor.rand(3, 4).reshape(3, vi)
     a = a + 1
     assert a.shape == (3, vi)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import unittest
-from tinygrad.shape.symbolic import MulNode, SumNode, Variable, NumNode, sym_vars
+from tinygrad.shape.symbolic import MulNode, SumNode, Variable, NumNode, sym_vars, sym_render, sym_rename
 
 class TestSymbolic(unittest.TestCase):
   def helper_test_variable(self, v, n, m, s):
@@ -275,6 +275,25 @@ class TestSymbolicMinMax(unittest.TestCase):
     a = Variable("a", 1, 8)
     assert max(1, a) == max(a, 1) == a
     assert min(1, a) == min(a, 1) == 1
+
+class TestSymRender(unittest.TestCase):
+  def test_sym_render(self):
+    a = Variable("a", 1, 8)
+    assert sym_render(a) == "a"
+    assert sym_render(1) == "1"
+    assert sym_render(a+1) == "(1+a)"
+
+class TestSymRename(unittest.TestCase):
+  def test_sym_rename(self):
+    a = Variable("a", 1, 8)
+    b = Variable.num(3)
+    c = a + b
+    assert sym_rename(a) == "s0"
+    assert sym_rename(b) == "s1"
+    assert sym_rename(c) == "s2"
+    assert sym_rename(a) == "s0"
+    assert sym_rename(b) == "s1"
+    assert sym_rename(c) == "s2"
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/codegen/cstyle.py
+++ b/tinygrad/codegen/cstyle.py
@@ -64,7 +64,7 @@ class CStyleLanguage(NamedTuple):
       return f"vload_half{'' if output_dtype.sz == 1 else str(output_dtype.sz)}(0, {buf_name}+{idx.render(render_cl, strip_parens=True)})"
     if output_dtype.sz > 1:
       return f"({output_dtype.name})(*(({self.smem_prefix if local else self.buffer_prefix}{buf_dtype.name}{output_dtype.sz}*)({buf_name}+{idx.render(render_cl, strip_parens=True)})))"
-    return f"*({buf_name}+{idx.render(render_cl, strip_parens=True)})" if self.uses_ptr_arithmetic else f"{buf_name}[{sym_render(idx, render_cl)}]"
+    return f"*({buf_name}+{idx.render(render_cl, strip_parens=True)})" if self.uses_ptr_arithmetic else f"{buf_name}[{idx.render(render_cl)}]"
 
   def render_local(self, name:str, size:int):
     return self.smem_prefix + f"float {name}[{size}];"

--- a/tinygrad/codegen/wgsl.py
+++ b/tinygrad/codegen/wgsl.py
@@ -40,7 +40,7 @@ class WGSLLanguage(CStyleLanguage):
     prg += f"\n@compute @workgroup_size({','.join([str(x) for x in local_size])}) fn KERNEL_NAME_PLACEHOLDER(@builtin(workgroup_id) gindex: vec3<u32>, @builtin(local_invocation_id) lindex: vec3<u32>) {{\n" + "\n".join(kernel) + "\n}"
     return prg, global_size[::-1] if len(global_size) else [1], local_size
 
-  def render_for(self, expr:str, _min:int, _max:int) -> str:
+  def render_for(self, expr:str, _min:int, _max:Union[int,str]) -> str:
     return f"for(var {expr} = {_min}; {expr} <= {_max}; {expr}++) {{"
 
   def render_conditional(self, cond:str, x:str, y:str) -> str:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -171,9 +171,9 @@ class Compiled:
           output.realized = None
           break
 
-    # we don't have an output buffer, we have to create it
+    # we don't have an output buffer, we have to create it, and create max size if it has symbolic shape
     if not output.realized:
-      output.realized = self.buffer(prod(output.shape), output.dtype, **kwargs)
+      output.realized = self.buffer(prod(s if isinstance(s, int) else s.max for s in output.shape), output.dtype, **kwargs)
 
     # compilation time
     k = self.codegen(ast, output)
@@ -194,5 +194,6 @@ class Compiled:
 
     if prg.name == getenv("PRINT_PRG", ''): print(prg.prg)
 
+    if getenv("TEST_COMPILE_ONLY"): return output.realized
     prg.exec(k.bufs)
     return output.realized

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -242,6 +242,10 @@ def create_rednode(typ:Type[RedNode], nodes:List[Node]):
   elif typ == AndNode: ret.min, ret.max = (min([x.min for x in nodes]), max([x.max for x in nodes]))
   return create_node(ret)
 
+@functools.lru_cache(maxsize=None)
+def sym_rename(s) -> str: return f"s{sym_rename.cache_info().currsize}"
+def sym_render(a: Union[Node, int], ops=None, ctx=None) -> str: return str(a) if isinstance(a, int) else a.render(ops, ctx)
+
 render_python: Dict[Type, Callable] = {
   Variable: lambda self,ops,ctx: f"{self.expr}[{self.min}-{self.max}]" if ctx == "DEBUG" else f"{self.expr}",
   NumNode: lambda self,ops,ctx: f"{self.b}",


### PR DESCRIPTION
part of #1353 , adding codegen support for a simple example

`(Tensor.rand(3, 4).reshape(vi, 4) + 1).realize()` generates this kernel
```
void E_s0(float* restrict data0, const float* restrict data1, const int* restrict SYM_i) {
int i = SYM_i[0];
for (int gidx0 = 0; gidx0 <= ((i*4)+-1); ++gidx0) {
    float val1_0 = data1[gidx0];
    float acc2_0 = 1.0f;
    float alu0 = (acc2_0+val1_0);
    data0[gidx0] = alu0;
  } /* global+local */
}
```

add a helper function `sym_rename` to change the symbolic part in the function name to `s0`, `s1`, `s2`,...

add a temporary flag `TEST_COMPILE_ONLY` to keep this for compile only. Will remove in the next PR that will add exec support.
also temporarily exclude CI because I was hit by this outstanding pytest-xdist [issue](https://github.com/pytest-dev/pytest/issues/3216) and given that I will support exec soon that has no issue on CI. Hope this is fine

running locally with `DEBUG=4 CLANG=1 python test/test_symbolic_ops.py` looks like this
<img width="1504" alt="image" src="https://github.com/tinygrad/tinygrad/assets/2525478/ce04941f-5ad5-4499-a1c2-0efb0f1a8e21">
