### PR TITLE
efficientnet: Fix output plot debug

### DIFF
--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -50,7 +50,7 @@ def infer(model, img):
   # if you want to look at the outputs
   """
   import matplotlib.pyplot as plt
-  plt.plot(out.numpy()[0])
+  plt.plot(out[0])
   plt.show()
   """
   return out, retimg


### PR DESCRIPTION
`out` is already converted to an ndarray before the matplotlib debug comment, which results in an AttributeError when .numpy() is called again.