### PR TITLE
correct children count with lazycache

### DIFF
--- a/test/test_lazybuffer.py
+++ b/test/test_lazybuffer.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 import numpy as np
 import unittest
-from tinygrad.lazy import LazyBuffer
+from tinygrad.lazy import LazyBuffer, Device
 from tinygrad.tensor import Tensor
 from tinygrad.shape.symbolic import Variable
+from tinygrad.ops import GlobalCounters
 
 class TestLazyBuffer(unittest.TestCase):
   def test_fromcpu_buffer_sharing(self):
@@ -43,6 +44,29 @@ class TestLazyBuffer(unittest.TestCase):
     y = Tensor([1]).cat(Tensor([1]).exp()).numpy()
     z = Tensor([1, np.e]).numpy()
     np.testing.assert_allclose(y, z)
+
+  @unittest.skipUnless(Device.DEFAULT in ["METAL", "CUDA", "GPU"], "Only GPU backends supports cache")
+  def test_children_count(self):
+    a = Tensor.rand(8,8,8)
+    d1 = a.sum((0))
+    d2 = a.sum((0)).reshape(32,2)
+    assert len(d1.lazydata.op.src[0].children) == 1
+    in1 = d1.reshape(16,4)
+    d3 = in1.reshape(8,8)
+    assert len(d3.lazydata.op.src[0].children) == 2
+
+    GlobalCounters.cache = []
+    l = Tensor.rand(8,8)
+    r = Tensor.rand(8,8)
+    dd = d1 + l
+    dd.realize()
+    de = d3 + r
+    de.realize()
+    assert len(GlobalCounters.cache) == 3
+    assert GlobalCounters.cache[0][0].name.startswith("r_") # Reduce should not merged 2 times.
+    assert GlobalCounters.cache[1][0].name.startswith("E_")
+    assert GlobalCounters.cache[2][0].name.startswith("E_")
+    GlobalCounters.cache = None
 
 class TestVariableBuffer(unittest.TestCase):
   def test_get_variable_buffers_no_variable(self):

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -95,14 +95,14 @@ def get_movementroot_contiguous(x:LazyBuffer) -> LazyBuffer: return get_movement
 
 lazycache: LightWeakValueDictionary = LightWeakValueDictionary()
 def create_lazybuffer(device:str, st:ShapeTracker, optype:OpType, op:LazyOp, dtype:DType):
-  #print("create_lazybuffer", device, shape, optype, op, dtype)
-
   # fromcpu aren't cached
   if not LAZYCACHE or (optype is LoadOps and op.op in {LoadOps.EMPTY, LoadOps.RAND, LoadOps.CONST}): return LazyBuffer(device, st, optype, op, dtype)
 
   # wop is the deduping key. i feel this used to compare more deeply
   wop = (device, dtype, optype, ref(op))
-  if wop in lazycache: return lazycache[wop]
+  if wop in lazycache:
+    for x in op.buffers: x.children.add(lazycache[wop])
+    return lazycache[wop]
 
   lazycache[wop] = ret = LazyBuffer(device, st, optype, op, dtype)
   return ret


### PR DESCRIPTION
Seems we count children wrong with lazycache. Because of this we got really bad kernels generated with #1387 when one (huge) reduce was merged several times into elementwise.

Measured on hlb_cifar10, efficientnet, sd, real_world_tests - no bad surprises happend, performance is the same.