### PR TITLE
Add assert for wrong matmul/dot shapes

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -372,9 +372,29 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65), (65)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     helper_test_op([(32,45,65), (65)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     helper_test_op([(65), (32,65,45)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+    with self.assertRaises(AssertionError):
+      a = Tensor.ones(2)
+      b = Tensor.ones(1, 2)
+      a.matmul(b)
+    with self.assertRaises(AssertionError):
+      a = Tensor.ones(2, 4)
+      b = Tensor.ones(1)
+      a.matmul(b)
+    with self.assertRaises(AssertionError):
+      a = Tensor.ones(4)
+      b = Tensor.ones(1)
+      a.matmul(b)
   def test_dot(self):
     helper_test_op([(45,65), (65,100)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     helper_test_op([(32,45,65), (32,65,100)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+    with self.assertRaises(AssertionError):
+      a = Tensor.ones(2,4)
+      b = Tensor.ones(1,3)
+      a.matmul(b)
+    with self.assertRaises(AssertionError):
+      a = Tensor.ones(2,1)
+      b = Tensor.ones(4,3)
+      a.matmul(b)
     with self.assertRaises(AssertionError):
       a = Tensor(3.14)
       a.matmul(a)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -372,29 +372,14 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65), (65)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     helper_test_op([(32,45,65), (65)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     helper_test_op([(65), (32,65,45)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
-    with self.assertRaises(AssertionError):
-      a = Tensor.ones(2)
-      b = Tensor.ones(1, 2)
-      a.matmul(b)
-    with self.assertRaises(AssertionError):
-      a = Tensor.ones(2, 4)
-      b = Tensor.ones(1)
-      a.matmul(b)
-    with self.assertRaises(AssertionError):
-      a = Tensor.ones(4)
-      b = Tensor.ones(1)
-      a.matmul(b)
+    self.helper_test_exception([(4), (1,2)], lambda x, y: x.matmul(y), Tensor.dot, expected=(RuntimeError, AssertionError))
+    self.helper_test_exception([(2,1), (4)], lambda x, y: x.matmul(y), Tensor.dot, expected=(RuntimeError, AssertionError))
+    self.helper_test_exception([(1), (4)], lambda x, y: x.matmul(y), Tensor.dot, expected=(RuntimeError, AssertionError))
   def test_dot(self):
     helper_test_op([(45,65), (65,100)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     helper_test_op([(32,45,65), (32,65,100)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
-    with self.assertRaises(AssertionError):
-      a = Tensor.ones(2,4)
-      b = Tensor.ones(1,3)
-      a.matmul(b)
-    with self.assertRaises(AssertionError):
-      a = Tensor.ones(2,1)
-      b = Tensor.ones(4,3)
-      a.matmul(b)
+    self.helper_test_exception([(2, 4), (1, 3)], lambda x, y: x.matmul(y), Tensor.dot, expected=(RuntimeError, AssertionError))
+    self.helper_test_exception([(2, 1), (4, 3)], lambda x, y: x.matmul(y), Tensor.dot, expected=(RuntimeError, AssertionError))
     with self.assertRaises(AssertionError):
       a = Tensor(3.14)
       a.matmul(a)

--- a/tinygrad/nn/image.py
+++ b/tinygrad/nn/image.py
@@ -9,6 +9,7 @@ def image_dot(self, w):
   # NOTE: we use a 1x1 conv2d to do the matmul. mxk @ kxn = (1,k,m,1).conv2d(n,k,1,1)
   n1, n2 = len(self.shape), len(w.shape)
   assert n1 != 0 and n2 != 0, f"both arguments to matmul need to be at least 1D, but they are {n1}D and {n2}D"
+  assert self.shape[-1] == w.shape[-min(n2, 2)], f"Input Tensor shapes {self.shape} and {w.shape} cannot be multiplied ({self.shape[-1]} != {w.shape[-min(n2, 2)]})"
   bs, groups = prod(self.shape[0:-2]), prod(w.shape[0:-2])
   cin, cout = w.shape[-2], w.shape[-1]
   out_shape_t = self.shape[0:-2] + (cout,-1)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -496,6 +496,7 @@ class Tensor:
   def dot(self, w:Tensor) -> Tensor:
     n1, n2 = len(self.shape), len(w.shape)
     assert n1 != 0 and n2 != 0, f"both arguments to matmul need to be at least 1D, but they are {n1}D and {n2}D"
+    # assert self.shape[-1] == w.shape[-min(n2, 2)], f"Input Tensor shapes {self.shape} and {w.shape} cannot be multiplied ({self.shape[-1]} != {w.shape[-min(n2, 2)]})"
     x = self.reshape(*self.shape[0:-1], *[1]*min(n1-1, n2-1, 1), self.shape[-1])
     w = w.reshape(*w.shape[0:-2], *[1]*min(n1-1, n2-1, 1), *w.shape[-min(n2, 2):]).transpose(-1, -min(n2, 2))
     return (x*w).sum(-1)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -496,7 +496,7 @@ class Tensor:
   def dot(self, w:Tensor) -> Tensor:
     n1, n2 = len(self.shape), len(w.shape)
     assert n1 != 0 and n2 != 0, f"both arguments to matmul need to be at least 1D, but they are {n1}D and {n2}D"
-    # assert self.shape[-1] == w.shape[-min(n2, 2)], f"Input Tensor shapes {self.shape} and {w.shape} cannot be multiplied ({self.shape[-1]} != {w.shape[-min(n2, 2)]})"
+    assert self.shape[-1] == w.shape[-min(n2, 2)], f"Input Tensor shapes {self.shape} and {w.shape} cannot be multiplied ({self.shape[-1]} != {w.shape[-min(n2, 2)]})"
     x = self.reshape(*self.shape[0:-1], *[1]*min(n1-1, n2-1, 1), self.shape[-1])
     w = w.reshape(*w.shape[0:-2], *[1]*min(n1-1, n2-1, 1), *w.shape[-min(n2, 2):]).transpose(-1, -min(n2, 2))
     return (x*w).sum(-1)


### PR DESCRIPTION
Currently Tensor.dot works even with wrong shapes: mxa @ bxn, when a != b but either one of a or b is 1 (see #1364). 

Added an assert on the shapes to have the same behavior as numpy/torch.