### PR TITLE
Fix NOUNROLL

### DIFF
--- a/tinygrad/codegen/cstyle.py
+++ b/tinygrad/codegen/cstyle.py
@@ -127,7 +127,7 @@ def uops_to_cstyle(uops:List[UOp], lang:CStyleLanguage) -> Tuple[str, List[int],
         elif args[1] == "local" and lang.lid:
           kk(add_gl_dimension(lang.size_prefix, args, i, var, local_size, lang.lid))
         else:
-          if getenv("NOUNROLL"): kk("#pragma unroll(1)")   # prevent loop unrolling
+          if getenv("NOUNROLL") and not isinstance(var, NumNode): kk("#pragma unroll(1)")   # prevent loop unrolling
           kk("{" if isinstance(var, NumNode) else lang.render_for(var.expr, var.min, var.max))
       depth += 1
     elif uop == UOps.BARRIER:


### PR DESCRIPTION
The `NOUNROLL` option is currently broken. Does it make sense to add a test run of `test/test_ops.py` with `NOUNROLL` enabled to catch this in future?
Also I've noticed that the currently failing Metal tests do pass with `NOUNROLL` enabled. Should we maybe enable these tests and run them like that?