### PR TITLE
fix file race condition in ops_clang

### DIFF
--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -17,8 +17,9 @@ class ClangProgram:
     # TODO: is there a way to not write this to disk?
     fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.{args['ext']}"
     if not os.path.exists(fn):
-      subprocess.check_output(args=('clang -shared -O2 -Wall -Werror -x c '+args['cflags']+' - -o '+fn+'.tmp').split(), input=prg.encode('utf-8'))
-      os.rename(fn+'.tmp', fn)
+      _, tmp = tempfile.mkstemp()
+      subprocess.check_output(args=('clang -shared -O2 -Wall -Werror -x c '+args['cflags']+' - -o '+tmp).split(), input=prg.encode('utf-8'))
+      os.rename(tmp, fn)
     self.lib = ctypes.CDLL(fn)
     self.fxn = self.lib[name]
 


### PR DESCRIPTION
attempt to fix file race condition described in https://github.com/tinygrad/tinygrad/issues/1258