### PR TITLE
fix bug in symbolic's LtNode and AndNode

### DIFF
--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -152,8 +152,6 @@ class OpNode(Node):
   def get_bounds(self) -> Tuple[int, int]: pass
 
 class LtNode(OpNode):
-  def __mul__(self, b: Union[Node, int]): return (self.a*b) < (self.b*b)
-  def __floordiv__(self, b: int, _=False): return (self.a//b) < (self.b//b)
   def get_bounds(self) -> Tuple[int, int]:
     if isinstance(self.b, int): return int(self.a.max < self.b), int(self.a.min < self.b)
     return (1, 1) if self.a.max < self.b.min else (0, 0) if self.a.min > self.b.max else (0, 1)
@@ -227,8 +225,7 @@ class SumNode(RedNode):
     return new_nodes
 
 class AndNode(RedNode):
-  def __mul__(self, b: Union[Node, int]): Variable.ands([x*b for x in self.nodes])
-  def __floordiv__(self, b: int, _=True): return Variable.ands([x//b for x in self.nodes])
+  pass
 
 def create_rednode(typ:Type[RedNode], nodes:List[Node]):
   ret = typ(nodes)


### PR DESCRIPTION
### logic bugs
* `(a < 10) * 2` is not equal to `(a*2) < 20`
* `(a < 10) // 2` is not equal to `(a//2) < 5`

same thing with `mul` and `floordiv` operations on `AndNode`.

---

solution: `Node`'s `mul` and `floordiv` are enough for `LtNode` and `AndNode`.

---

`test_shapetracker.py` does not ever invoke the methods i delete here. so i
assume that shapetracker in the "real world" does not use these methods as well.
(let's see what the CI says) (shouldn't matter anyway as i think `Node` will handle them correctly)

---

`fuzz_symbolic.py` can't catch these because it too doesn't ever invoke these
methods. (because in it, `AndNode` is never tested and all the comparison
operators are only ever appended at the last)
