### PR TITLE
CSE at uop level

### DIFF
--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -298,7 +298,7 @@ class Linearizer:
     # uops
     self.uops: List[UOp] = []
     self.load_cache: Dict[str, Token] = {}
-    self.saved_exprs: Dict[Any, Token] = dict()
+    self.saved_exprs: Dict[Tuple[Op, Tuple[Token, ...]], Token] = dict()
 
     # add global buffers
     for buf,name in self.arg_bufs.items():
@@ -494,10 +494,7 @@ class Linearizer:
 
   def uop_alu(self, out: Token, vin: List[Token], op: Op) -> Token:
     key = (op, tuple(vin))
-    if key not in self.saved_exprs:
-      self.saved_exprs[key] = self.uop(UOps.ALU, out, vin, op)
-    else:
-      if DEBUG >= 5: print(f"    cached alu op: {self.saved_exprs[key]} <- {vin} {op}")
+    if key not in self.saved_exprs: self.saved_exprs[key] = self.uop(UOps.ALU, out, vin, op)
     return self.saved_exprs[key]
 
   def ast_parse(self, x, acc, loaded_buffers, ssa, do_reduce=False) -> List[Token]:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -298,7 +298,7 @@ class Linearizer:
     # uops
     self.uops: List[UOp] = []
     self.load_cache: Dict[str, Token] = {}
-    self.saved_exprs: Dict[Any, List[Token]] = dict()
+    self.saved_exprs: Dict[Any, Token] = dict()
 
     # add global buffers
     for buf,name in self.arg_bufs.items():

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -492,12 +492,12 @@ class Linearizer:
     if DEBUG >= 4: print(self.uops[-1])
     return out
 
-  def uop_alu(self, out: Token, vin: List[Token], arg: Op) -> Token:
-    key = (arg, tuple(vin))
+  def uop_alu(self, out: Token, vin: List[Token], op: Op) -> Token:
+    key = (op, tuple(vin))
     if key not in self.saved_exprs:
-      self.saved_exprs[key] = self.uop(UOps.ALU, out, vin, arg)
+      self.saved_exprs[key] = self.uop(UOps.ALU, out, vin, op)
     else:
-      if DEBUG >= 5: print(f"    cached alu op: {self.saved_exprs[key]} <- {vin} {arg}")
+      if DEBUG >= 5: print(f"    cached alu op: {self.saved_exprs[key]} <- {vin} {op}")
     return self.saved_exprs[key]
 
   def ast_parse(self, x, acc, loaded_buffers, ssa, do_reduce=False) -> List[Token]:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -518,7 +518,7 @@ class Linearizer:
     if x.op in ops:
       ret = [(idx, self.uop(UOps.ALU, val[-1], list(val), ops[x.op])) for idx, val in get_grouped_maybe_float4(*values, acc, grouping_allowed=self.opts.supports_float4_alu)]
     else:
-      ret = [(idx, self.uop_alu(ssa('alu', dtypes._float4) if any(x.dtype == dtypes._float4 and x.offset is None for x in val) else ssa('alu'), list(val), x.op)) for idx, val in get_grouped_maybe_float4(*values, grouping_allowed=self.opts.supports_float4_alu and x.op not in {BinaryOps.CMPEQ, TernaryOps.WHERE})]
+      ret = [(idx, self.uop_alu(ssa('alu', dtypes._float4) if any(x.dtype == dtypes._float4 and x.offset is None for x in val) else ssa('alu'), list(val), x.op)) for idx, val in get_grouped_maybe_float4(*values, grouping_allowed=self.opts.supports_float4_alu and x.op not in {BinaryOps.CMPLT, TernaryOps.WHERE})]
     ordered_ret: List[Optional[Token]] = [None]*len(values[0])
     # scatter
     for i,j in ret:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -492,7 +492,7 @@ class Linearizer:
     if DEBUG >= 4: print(self.uops[-1])
     return out
 
-  def uop_alu(self, out: _OT, vin: List[Token], arg: Op) -> _OT:
+  def uop_alu(self, out: Token, vin: List[Token], arg: Op) -> Token:
     key = (arg, tuple(vin))
     if key not in self.saved_exprs:
       self.saved_exprs[key] = self.uop(UOps.ALU, out, vin, arg)
@@ -525,7 +525,7 @@ class Linearizer:
       for o,k in enumerate(i):
         ordered_ret[k] = Token(j.name, j.dtype, o) if j.dtype == dtypes._float4 else j
     assert all(isinstance(x, Token) for x in ordered_ret), "some tokens didn't get scattered?"
-    return ordered_ret
+    return cast(List[Token], ordered_ret)
 
   @property
   def first_reduce(self) -> int: return [x!=y for x,y in zip(self.sts[0].shape[:self.shape_len-self.upcasted]+(0,), self.full_shape[:self.shape_len-self.upcasted]+(1,))].index(True)

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from enum import Enum, auto
 
 from tinygrad.helpers import dedup, colored, ImageDType, DEBUG, prod, dtypes, mnum, DType, all_same, partition
-from tinygrad.ops import LazyOp, FlopCounter, get_lazyop_info, UnaryOps
+from tinygrad.ops import LazyOp, FlopCounter, get_lazyop_info, UnaryOps, Op
 from tinygrad.lazy import LazyBuffer
 from tinygrad.ops import MovementOps, ReduceOps, BinaryOps, TernaryOps
 from tinygrad.runtime.lib import RawConst, buf_is_kernel_arg
@@ -298,7 +298,7 @@ class Linearizer:
     # uops
     self.uops: List[UOp] = []
     self.load_cache: Dict[str, Token] = {}
-    self.saved_exprs: Dict[LazyOp, List[Token]] = dict()
+    self.saved_exprs: Dict[Any, List[Token]] = dict()
 
     # add global buffers
     for buf,name in self.arg_bufs.items():
@@ -492,6 +492,14 @@ class Linearizer:
     if DEBUG >= 4: print(self.uops[-1])
     return out
 
+  def uop_alu(self, out: _OT, vin: List[Token], arg: Op) -> _OT:
+    key = (arg, tuple(vin))
+    if key not in self.saved_exprs:
+      self.saved_exprs[key] = self.uop(UOps.ALU, out, vin, arg)
+    else:
+      if DEBUG >= 5: print(f"    cached alu op: {self.saved_exprs[key]} <- {vin} {arg}")
+    return self.saved_exprs[key]
+
   def ast_parse(self, x, acc, loaded_buffers, ssa, do_reduce=False) -> List[Token]:
     if x.__class__ is not LazyOp: return loaded_buffers[x]
     if x.op in [UnaryOps.NOOP, UnaryOps.CAST]: return self.ast_parse(x.src[0], acc, loaded_buffers, ssa)  # cast isn't an ALU op
@@ -505,21 +513,19 @@ class Linearizer:
       # Reorder sources to put constants first so get_grouped_maybe_float4 can fold the op
       srcs = sorted(x.src, key=lambda x: (x.realized.__class__ != RawConst) if x.__class__ == LazyBuffer else 0)
       x.src = tuple(srcs)
-    if x not in self.saved_exprs:
-      values = [self.ast_parse(v, acc, loaded_buffers, ssa) for v in x.src]
-      ops = {ReduceOps.SUM:BinaryOps.ADD, ReduceOps.MAX:BinaryOps.MAX, TernaryOps.MULACC:TernaryOps.MULACC}
-      if x.op in ops:
-        ret = [(idx, self.uop(UOps.ALU, val[-1], list(val), ops[x.op])) for idx, val in get_grouped_maybe_float4(*values, acc, grouping_allowed=self.opts.supports_float4_alu)]
-      else:
-        ret = [(idx, self.uop(UOps.ALU, ssa('alu', dtypes._float4) if any(x.dtype == dtypes._float4 and x.offset is None for x in val) else ssa('alu'), list(val), x.op)) for idx, val in get_grouped_maybe_float4(*values, grouping_allowed=self.opts.supports_float4_alu and x.op not in {BinaryOps.CMPLT, TernaryOps.WHERE})]
-      ordered_ret: List[Optional[Token]] = [None]*len(values[0])
-      # scatter
-      for i,j in ret:
-        for o,k in enumerate(i):
-          ordered_ret[k] = Token(j.name, j.dtype, o) if j.dtype == dtypes._float4 else j
-      assert all(isinstance(x, Token) for x in ordered_ret), "some tokens didn't get scattered?"
-      self.saved_exprs[x] = cast(List[Token], ordered_ret)
-    return self.saved_exprs[x]
+    values = [self.ast_parse(v, acc, loaded_buffers, ssa) for v in x.src]
+    ops = {ReduceOps.SUM:BinaryOps.ADD, ReduceOps.MAX:BinaryOps.MAX, TernaryOps.MULACC:TernaryOps.MULACC}
+    if x.op in ops:
+      ret = [(idx, self.uop(UOps.ALU, val[-1], list(val), ops[x.op])) for idx, val in get_grouped_maybe_float4(*values, acc, grouping_allowed=self.opts.supports_float4_alu)]
+    else:
+      ret = [(idx, self.uop_alu(ssa('alu', dtypes._float4) if any(x.dtype == dtypes._float4 and x.offset is None for x in val) else ssa('alu'), list(val), x.op)) for idx, val in get_grouped_maybe_float4(*values, grouping_allowed=self.opts.supports_float4_alu and x.op not in {BinaryOps.CMPEQ, TernaryOps.WHERE})]
+    ordered_ret: List[Optional[Token]] = [None]*len(values[0])
+    # scatter
+    for i,j in ret:
+      for o,k in enumerate(i):
+        ordered_ret[k] = Token(j.name, j.dtype, o) if j.dtype == dtypes._float4 else j
+    assert all(isinstance(x, Token) for x in ordered_ret), "some tokens didn't get scattered?"
+    return ordered_ret
 
   @property
   def first_reduce(self) -> int: return [x!=y for x,y in zip(self.sts[0].shape[:self.shape_len-self.upcasted]+(0,), self.full_shape[:self.shape_len-self.upcasted]+(1,))].index(True)


### PR DESCRIPTION
Supports #1037. Depends on #1482, merge that to see a good diff.

Before, CSE was done by comparing AST subtrees. When upcasting, there may be common expressions within a single subtree (eg a.expand([2]) + b.expand([2]), see the tests). Additionally, doing CSE at a uop level gives us a place to add zero-folding, which is much easier to implement at a uop level.

Before (running the test, note two adds):
```
*** exec  0.00 GB    0.02 ms op: BinaryOps.ADD        out(float): (2,)                           in(2): [(2,)] 
UOps.DEFINE_GLOBAL  :                           []                               ('data0', dtypes.float)
UOps.DEFINE_GLOBAL  :                           []                               ('data1', dtypes.float)
UOps.DEFINE_GLOBAL  :                           []                               ('data2', dtypes.float)
   0 buffer<2, dtypes.float>                         [View(shape=(2,), strides=(1,), offset=0, mask=None, contiguous=True, shape_strides=((2, 1),))]
   1 buffer<1, dtypes.float>                         [View(shape=(2,), strides=(0,), offset=0, mask=None, contiguous=False, shape_strides=((2, 0),))]
   2 buffer<1, dtypes.float>                         [View(shape=(2,), strides=(0,), offset=0, mask=None, contiguous=False, shape_strides=((2, 0),))]
   2
UOps.LOOP           :                           []                               ([], 'global')
UOps.LOOP           :                           []                               ([], 'local')
UOps.LOAD           : <val1_0>                  []                               MemOp(name='data1', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
UOps.LOAD           : <val2_0>                  []                               MemOp(name='data2', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
UOps.ALU            : <alu0>                    [<val1_0>, <val2_0>]             BinaryOps.ADD
UOps.ALU            : <alu1>                    [<val1_0>, <val2_0>]             BinaryOps.ADD
UOps.CAST           : <alu2:float2:None>        [<alu0>, <alu1>]                 None
UOps.STORE          :                           [<alu2:float2:None>]             MemOp(name='data0', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
UOps.ENDLOOP        :                           []                               ([], 'global+local')
```

After:

```
*** exec  0.00 GB    0.01 ms op: BinaryOps.ADD        out(float): (2,)                           in(2): [(2,)] 
UOps.DEFINE_GLOBAL  :                           []                               ('data0', dtypes.float)
UOps.DEFINE_GLOBAL  :                           []                               ('data1', dtypes.float)
UOps.DEFINE_GLOBAL  :                           []                               ('data2', dtypes.float)
   0 buffer<2, dtypes.float>                         [View(shape=(2,), strides=(1,), offset=0, mask=None, contiguous=True, shape_strides=((2, 1),))]
   1 buffer<1, dtypes.float>                         [View(shape=(2,), strides=(0,), offset=0, mask=None, contiguous=False, shape_strides=((2, 0),))]
   2 buffer<1, dtypes.float>                         [View(shape=(2,), strides=(0,), offset=0, mask=None, contiguous=False, shape_strides=((2, 0),))]
   2
UOps.LOOP           :                           []                               ([], 'global')
UOps.LOOP           :                           []                               ([], 'local')
UOps.LOAD           : <val1_0>                  []                               MemOp(name='data1', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
UOps.LOAD           : <val2_0>                  []                               MemOp(name='data2', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
UOps.ALU            : <alu0>                    [<val1_0>, <val2_0>]             BinaryOps.ADD
    cached alu op: <alu0> <- [<val1_0>, <val2_0>] BinaryOps.ADD
UOps.CAST           : <alu2:float2:None>        [<alu0>, <alu0>]                 None
UOps.STORE          :                           [<alu2:float2:None>]             MemOp(name='data0', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
UOps.ENDLOOP        :                           []                               ([], 'global+local')
```

