### PR TITLE
Constant Folding

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -59,6 +59,8 @@ class TestLinearizer(unittest.TestCase):
   def test_zero_fold(self):
     if not isinstance(Device[Device.DEFAULT], Compiled):
       self.skipTest("Only Compiled uses linearizer")
+    if not Device[Device.DEFAULT].linearizer_opts.supports_constant_folding:
+      self.skipTest("Device does not support constant folding")
 
     a, b = Tensor.randn(1).realize(), Tensor.randn(1).realize()
     r = Tensor.stack([a, b])
@@ -74,6 +76,8 @@ class TestLinearizer(unittest.TestCase):
   def test_constant_fold(self):
     if not isinstance(Device[Device.DEFAULT], Compiled):
       self.skipTest("Only Compiled uses linearizer")
+    if not Device[Device.DEFAULT].linearizer_opts.supports_constant_folding:
+      self.skipTest("Device does not support constant folding")
 
     a, b = Tensor(2), Tensor(3)
     r = a * b

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -71,5 +71,19 @@ class TestLinearizer(unittest.TestCase):
     num_ops = len([uop for uop in k.uops if uop.uop == UOps.ALU])
     assert num_ops == 0, "more alu uops than needed"
 
+  def test_constant_fold(self):
+    if not isinstance(Device[Device.DEFAULT], Compiled):
+      self.skipTest("Only Compiled uses linearizer")
+
+    a, b = Tensor(2), Tensor(3)
+    r = a * b
+    ast = r.lazydata.op
+    r = r.realize()  # realize an output buffer
+    k = Linearizer(ast, r.lazydata, Device[Device.DEFAULT].linearizer_opts)
+    k.process()
+    k.linearize()
+    num_ops = len([uop for uop in k.uops if uop.uop in [UOps.LOAD, UOps.ALU]])
+    assert num_ops == 0, "more load or alu uops than needed"
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -71,6 +71,7 @@ class TestLinearizer(unittest.TestCase):
     num_ops = len([uop for uop in k.uops if uop.uop == UOps.ALU])
     assert num_ops == 0, "more alu uops than needed"
 
+  @unittest.skipIf(Device.DEFAULT in ["LLVM"], "No RawConsts in LLVM")
   def test_constant_fold(self):
     if not isinstance(Device[Device.DEFAULT], Compiled):
       self.skipTest("Only Compiled uses linearizer")

--- a/tinygrad/codegen/assembly_ptx.py
+++ b/tinygrad/codegen/assembly_ptx.py
@@ -23,7 +23,7 @@ def render_cast(ins, inp, out):
 # https://docs.nvidia.com/cuda/parallel-thread-execution/#
 
 class PTXLanguage(AssemblyLanguage):
-  supports_constant_folding: bool = True
+  pass
 
 def specialize_to_ptx(lang, function_name):
   param_cnt = 0

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -503,7 +503,7 @@ class Linearizer:
       # todo: update abstractions.py with constant folding stuff
       if all(v.is_const for v in vin):
         # constant fold
-        fold_result = Token(numpy_fxn_for_op[op](*[np.array(v.name, dtype=v.dtype.np) for v in vin]), out.dtype)
+        fold_result = Token(numpy_fxn_for_op[op](*[np.array(v.name, dtype=v.dtype.np) for v in vin]).item(), out.dtype)
       else:
         # break down mulacc
         if op == TernaryOps.MULACC:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -550,6 +550,7 @@ class Linearizer:
       x = LazyOp(TernaryOps.MULACC, x.src[0].src[0].src, x.arg)
     if x.op in {BinaryOps.ADD, BinaryOps.MUL}:
       # Reorder sources to put constants first so get_grouped_maybe_float4 can fold the op
+      # todo: reorder by consts in values?
       srcs = sorted(x.src, key=lambda x: (x.realized.__class__ != RawConst) if x.__class__ == LazyBuffer else 0)
       x.src = tuple(srcs)
     values = [self.ast_parse(v, acc, loaded_buffers, ssa) for v in x.src]

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -510,7 +510,7 @@ class Linearizer:
           if 0 in [vin[0].name, vin[1].name]: fold_result = vin[2]
           elif vin[2].name == 0: op, vin = BinaryOps.MUL, vin[:2]
           elif 1 in [vin[0].name, vin[1].name]: op, vin = BinaryOps.ADD, [vin[0], vin[2]] if vin[1].name == 1 else [vin[1], vin[2]]
-          if DEBUG >= 5 and op != TernaryOps.MULACC: print(f"    MULACC decomposition")
+          if DEBUG >= 5 and op != TernaryOps.MULACC: print("    MULACC decomposition")
         if any(v.name == 0 for v in vin):
           # identity/absorber fold zeroes
           if   op == BinaryOps.ADD: fold_result = vin[1] if vin[0].name == 0 else vin[0]
@@ -551,7 +551,7 @@ class Linearizer:
       srcs = sorted(x.src, key=lambda x: (x.realized.__class__ != RawConst) if x.__class__ == LazyBuffer else 0)
       x.src = tuple(srcs)
     values = [self.ast_parse(v, acc, loaded_buffers, ssa) for v in x.src]
-    ops = {ReduceOps.SUM:BinaryOps.ADD, ReduceOps.MAX:BinaryOps.MAX, TernaryOps.MULACC:TernaryOps.MULACC}
+    ops: Dict[Op, Op] = {ReduceOps.SUM:BinaryOps.ADD, ReduceOps.MAX:BinaryOps.MAX, TernaryOps.MULACC:TernaryOps.MULACC}
     if x.op in ops:
       ret = [(idx, self.uop_alu(val[-1], list(val), ops[x.op], cache=False)) for idx, val in get_grouped_maybe_float4(*values, acc, grouping_allowed=self.opts.supports_float4_alu)]
     else:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -258,7 +258,7 @@ class Linearizer:
       if key not in self.load_cache:
         if isinstance(self.bufs[i].dtype, ImageDType): idx = to_image_idx(self.bufs[i].dtype.shape, idx, valid)
         self.load_cache[key] = self.uop(UOps.LOAD, Token(f"val{mnum(i)}_{load_i}", localtype), [], MemOp(self.get_buffer_name(i), idx, self.bufs[i].__class__ is LocalBuffer, self.bufs[i].dtype, valid, invalid_value)) if this_const is None else \
-                               self.uop(UOps.LOAD, Token(f"{'const' if acc is None else 'acc'}{mnum(i)}_{load_i}", localtype), [], ConstOp(this_const, valid)) if acc is not None or valid.min == 0 else \
+                               self.uop(UOps.LOAD, Token(f"{'const' if acc is None else 'acc'}{mnum(i)}_{load_i}", localtype), [], ConstOp(this_const, valid)) if acc is not None or valid.min == 0 or not self.opts.supports_constant_folding else \
                                Token(this_const, localtype)
       ret.append(Token(self.load_cache[key].name, self.load_cache[key].dtype, expanded_nodes[dim].index(_idx[dim])) if localtype != dtypes.float else self.load_cache[key])
     return ret

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -248,7 +248,7 @@ class Linearizer:
       dim, amt = upcast_dim[0], len(expanded_nodes[upcast_dim[0]])
 
     ret = []
-    invalid_value = 0 if dtypes.is_int(self.bufs[i].dtype) else 0.0
+    invalid_value = 0.0  # we only support loading float types right now
     for load_i, _idx in enumerate(_idxs):
       if amt > 1:
         idx, valid = self.sts[i].expr_idxs((_idx[:dim] + (expanded_nodes[dim][0],) + _idx[dim+1:]))
@@ -528,7 +528,7 @@ class Linearizer:
     # todo: identity/absorber folding for where
 
     if fold_result is not None:
-      if fold_result.is_const: fold_result = Token(fold_result.name, out.dtype, out.offset)
+      if fold_result.is_const: fold_result = Token(fold_result.name, out.dtype, out.offset)  # copy float4 typing if we are folding
       if DEBUG >= 5: print(f"    constant fold alu op: {fold_result} <- {vin} {op}")
       return fold_result
 

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -550,8 +550,7 @@ class Linearizer:
       x = LazyOp(TernaryOps.MULACC, x.src[0].src[0].src, x.arg)
     if x.op in {BinaryOps.ADD, BinaryOps.MUL}:
       # Reorder sources to put constants first so get_grouped_maybe_float4 can fold the op
-      srcs = sorted(x.src, key=lambda x: (x.realized.__class__ != RawConst) if x.__class__ == LazyBuffer else 0)
-      x.src = tuple(srcs)
+      x.src = tuple(sorted(x.src, key=lambda x: (x.realized.__class__ != RawConst) if x.__class__ == LazyBuffer else not x.is_const))  # todo: what is going on here?
     values = [self.ast_parse(v, acc, loaded_buffers, ssa) for v in x.src]
     ops = {ReduceOps.SUM:BinaryOps.ADD, ReduceOps.MAX:BinaryOps.MAX, TernaryOps.MULACC:TernaryOps.MULACC}
     if x.op in ops:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -550,7 +550,8 @@ class Linearizer:
       x = LazyOp(TernaryOps.MULACC, x.src[0].src[0].src, x.arg)
     if x.op in {BinaryOps.ADD, BinaryOps.MUL}:
       # Reorder sources to put constants first so get_grouped_maybe_float4 can fold the op
-      x.src = tuple(sorted(x.src, key=lambda x: (x.realized.__class__ != RawConst) if x.__class__ == LazyBuffer else not x.is_const))  # todo: what is going on here?
+      srcs = sorted(x.src, key=lambda x: (x.realized.__class__ != RawConst) if x.__class__ == LazyBuffer else 0)
+      x.src = tuple(srcs)
     values = [self.ast_parse(v, acc, loaded_buffers, ssa) for v in x.src]
     ops = {ReduceOps.SUM:BinaryOps.ADD, ReduceOps.MAX:BinaryOps.MAX, TernaryOps.MULACC:TernaryOps.MULACC}
     if x.op in ops:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -560,7 +560,7 @@ class Linearizer:
     # scatter
     for i,j in ret:
       for o,k in enumerate(i):
-        ordered_ret[k] = Token(j.name, j.dtype, o+j.offset) if j.dtype == dtypes._float4 else j
+        ordered_ret[k] = Token(j.name, j.dtype, o+(0 if j.offset is None else j.offset)) if j.dtype == dtypes._float4 else j
     assert all(isinstance(x, Token) for x in ordered_ret), "some tokens didn't get scattered?"
     return cast(List[Token], ordered_ret)
 

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -510,18 +510,19 @@ class Linearizer:
           if 0 in [vin[0].name, vin[1].name]: fold_result = vin[2]
           elif vin[2].name == 0: op, vin = BinaryOps.MUL, vin[:2]
           elif 1 in [vin[0].name, vin[1].name]: op, vin = BinaryOps.ADD, [vin[0], vin[2]] if vin[1].name == 1 else [vin[1], vin[2]]
-          if op != TernaryOps.MULACC: print(f"    MULACC decomposition")
+          if DEBUG >= 5 and op != TernaryOps.MULACC: print(f"    MULACC decomposition")
         if any(v.name == 0 for v in vin):
           # identity/absorber fold zeroes
           if   op == BinaryOps.ADD: fold_result = vin[1] if vin[0].name == 0 else vin[0]
           elif op == BinaryOps.SUB: fold_result = vin[0] if vin[1].name == 0 else fold_result
           elif op == BinaryOps.MUL: fold_result = vin[0] if vin[0].name == 0 else vin[1]
+          elif op == TernaryOps.WHERE: fold_result = vin[2] if vin[0].name == 0 else fold_result
         if any(v.name == 1 for v in vin):
           # identity fold ones
           if   op == BinaryOps.MUL: fold_result = vin[1] if vin[0].name == 1 else vin[0]
           elif op == BinaryOps.DIV: fold_result = vin[0] if vin[1].name == 1 else fold_result
           elif op == BinaryOps.MOD: fold_result = Token(0 if dtypes.is_int(out.dtype) else 0.0, out.dtype) if vin[1].name == 1 else fold_result
-        # todo: identity/absorber folding for where
+        if op == TernaryOps.WHERE and vin[0].is_const and vin[0].name != 0: fold_result = vin[1]
 
       if fold_result is not None:
         if fold_result.is_const: fold_result = Token(fold_result.name, out.dtype, out.offset)  # copy float4 typing if we are folding

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -264,7 +264,8 @@ class Linearizer:
     return ret
 
   def const_load(self, v: Token):
-    if v not in self.const_cache: self.const_cache[v] = self.uop(UOps.LOAD, Token(f"const{len(self.const_cache)}", v.dtype, v.offset), [], ConstOp(v.name, Variable.num(1)))
+    assert v.is_const
+    if v not in self.const_cache: self.const_cache[v] = self.uop(UOps.LOAD, Token(f"const{len(self.const_cache)}", v.dtype, v.offset), [], ConstOp(cast(Union[float, int], v.name), Variable.num(1)))
     return self.const_cache[v]
 
   def global_store(self, i, idxs:List[VariableOrNum], store:List[Token], ssa) -> None:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -504,23 +504,6 @@ class Linearizer:
       if all(v.is_const for v in vin):
         # constant fold
         fold_result = Token(numpy_fxn_for_op[op](*[np.array(v.name, dtype=v.dtype.np) for v in vin]), out.dtype)
-      elif False:
-        vars = [Variable.num(v.name) if v.is_const else Variable(v, 0, 1) for v in vin]
-        sym_out = None
-        if op == TernaryOps.MULACC: sym_out = vars[0] * vars[1] + vars[2]
-        if op == BinaryOps.ADD: sym_out = vars[0] + vars[1]
-        # if op == BinaryOps.SUB: sym_out = vars[0] + vars[1]
-        if op == BinaryOps.MUL: sym_out = vars[0] * vars[1]
-        render_ops = {
-          NumNode: lambda self, ops, ctx: (None, None, Token(self.b, out.dtype, out.offset)),
-          Variable: lambda self, ops, ctx: (None, None, self.expr),
-          SumNode: lambda self, ops, ctx: (BinaryOps.ADD, [self.nodes[0].render(ops, ctx)[2], self.nodes[1].render(ops, ctx)[2]], None) \
-                                            if self.nodes[0].__class__ is not MulNode else \
-                                            (TernaryOps.MULACC, [self.nodes[0].a.render(ops, ctx)[2], self.nodes[0].b.render(ops, ctx)[2], self.nodes[1].render(ops, ctx)[2]], None),
-          MulNode: lambda self, ops, ctx: (BinaryOps.MUL, [self.a.render(ops, ctx)[2], self.b.render(ops, ctx)[2] if isinstance(self.b, Node) else Token(self.b, out.dtype, out.offset)], None)
-        }
-        if sym_out is not None:
-          op, vin, fold_result = sym_out.render(render_ops)
       else:
         # break down mulacc
         if op == TernaryOps.MULACC:

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, NamedTuple, Tuple, Union
+from typing import Dict, List, Optional, NamedTuple, Tuple, Union, cast
 import math
 from tinygrad.codegen.linearizer import UOps, UOp, MemOp, ConstOp, Token
 from tinygrad.ops import UnaryOps, BinaryOps, TernaryOps
@@ -62,10 +62,10 @@ class CStyleLanguage(NamedTuple):
     if with_type:
       assert x.offset is None
       return f"{x.dtype.name} {x.name}"
-    if x.is_const: return self.render_const(x.name, x.dtype)
+    if x.is_const: return self.render_const(cast(Union[float, int], x.name), x.dtype)
     if x.offset is None: return str(x.name)
     assert x.dtype in [dtypes._float4, dtypes._float2], f"{x.dtype} isn't okay with offset {x.offset}"
-    return x.name + "." + "xyzw"[int(x.offset)]
+    return cast(str, x.name) + "." + "xyzw"[int(x.offset)]
 
   # returns a str expression of the loaded value with the output type
   def render_load(self, output_dtype, buf_name, buf_dtype, idx, local=False) -> str:

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -178,6 +178,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp])  -> T
         val = lang.render_load(newvar.dtype, args.name, args.memory_dtype, args.idx, args.local)
       if args.valid.min == 0 and args.valid.max == 1: val = lang.render_conditional(args.valid.render(render_cl), val, lang.render_const(args.invalid_value, newvar.dtype))
       kk(f"{lang.generic_var_prefix}{newvar.render(lang.generic_var_prefix == '')} = {val};")
+      if args.valid.max == 0: kk(f"(void) {newvar.render()};")  # Don't warn unused if var is masked out
     elif uop == UOps.STORE:
       assert args.valid.min == 1 and isinstance(args, MemOp), "store must be valid and to memory"
       # TODO: instead of dtypes.float, a base type

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -168,7 +168,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp])  -> T
         raise NotImplementedError(f"WMMA not implemented for {args}")
     elif uop == UOps.ALU:
       assert newvar is not None
-      kk(f"{lang.generic_var_prefix if newvar not in vin else ''}{newvar.render(newvar not in vin and lang.generic_var_prefix == '')} = {lang.code_for_op[args](*[x.render() for x in vin])};")
+      kk(f"{lang.generic_var_prefix if newvar not in vin else ''}{newvar.render(newvar not in vin and lang.generic_var_prefix == '')} = {lang.code_for_op[args](*[lang.render_const(x.name, x.dtype) if x.is_const else x.render() for x in vin])};")
     elif uop == UOps.LOAD:
       assert newvar is not None and isinstance(args, (MemOp, ConstOp))
       # valids are handled here
@@ -182,7 +182,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp])  -> T
     elif uop == UOps.STORE:
       assert args.valid.min == 1 and isinstance(args, MemOp), "store must be valid and to memory"
       # TODO: instead of dtypes.float, a base type
-      kk(lang.render_store(args.name, args.memory_dtype, vin[0].render(), vin[0].dtype if vin[0].offset is None else dtypes.float, args.idx, args.local))
+      kk(lang.render_store(args.name, args.memory_dtype, lang.render_const(vin[0].name, vin[0].dtype) if vin[0].is_const else vin[0].render(), vin[0].dtype if vin[0].offset is None else dtypes.float, args.idx, args.local))
     elif uop == UOps.CAST and newvar is not None and newvar.dtype.sz > 1:
       kk(f"{newvar.render(True)} = {lang.render_cast([x.render() for x in vin], newvar.dtype)};")
     elif uop == UOps.DEFINE_LOCAL:

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -78,4 +78,4 @@ class ClangProgram:
     if wait: return time.monotonic()-st
 
 renderer = fromimport("tinygrad.codegen.assembly_arm64", "uops_to_arm64_asm") if ARM64 else functools.partial(uops_to_cstyle, CStyleLanguage(kernel_prefix=args['exp'], buffer_suffix=" restrict", arg_int_prefix="const int"))
-ClangBuffer = Compiled(RawMallocBuffer, LinearizerOptions(supports_float4=False, has_local=False), renderer, ClangProgram)
+ClangBuffer = Compiled(RawMallocBuffer, LinearizerOptions(supports_float4=False, has_local=False, supports_constant_folding=not ARM64), renderer, ClangProgram)

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -38,7 +38,7 @@ class ClangProgram:
       tmp = f"{fn}.{os.getpid()}.tmp"
       if not binary:
         prg = CLANG_PROGRAM_HEADER + prg
-        subprocess.check_output(args=('clang -shared -O2 -Wall -Werror -x c '+args['cflags']+' - -o '+tmp).split(), input=prg.encode('utf-8'))
+        subprocess.check_output(args=('clang -shared -O2 -Wall -Werror -Wno-unused-variable -x c '+args['cflags']+' - -o '+tmp).split(), input=prg.encode('utf-8'))
         os.rename(tmp, fn)
       else:
         if CI and ARM64:

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -78,4 +78,4 @@ class ClangProgram:
     if wait: return time.monotonic()-st
 
 renderer = fromimport("tinygrad.codegen.assembly_arm64", "uops_to_arm64_asm") if ARM64 else functools.partial(uops_to_cstyle, CStyleLanguage(kernel_prefix=args['exp'], buffer_suffix=" restrict", arg_int_prefix="const int"))
-ClangBuffer = Compiled(RawMallocBuffer, LinearizerOptions(supports_float4=False, has_local=False, supports_constant_folding=not ARM64), renderer, ClangProgram)
+ClangBuffer = Compiled(RawMallocBuffer, LinearizerOptions(supports_float4=False, has_local=False, supports_inline_constants=not ARM64), renderer, ClangProgram)

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -96,5 +96,5 @@ renderer = functools.partial(uops_to_cstyle, CStyleLanguage(
       __device__ __forceinline__ explicit operator float4() const {return make_float4(__half2float(x.x), __half2float(x.y), __half2float(y.x), __half2float(y.y)); }
     };
   """)) if not getenv("PTX") else fromimport("tinygrad.codegen.assembly_ptx", "uops_to_ptx_asm")
-CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=not getenv("PTX"), supports_float4_alu=False, supports_constant_folding=not getenv("PTX"),
+CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=not getenv("PTX"), supports_float4_alu=False, supports_inline_constants=not getenv("PTX"),
                                                        global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024]), renderer, CUDAProgram, cuda.Context.synchronize)

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -96,4 +96,5 @@ renderer = functools.partial(uops_to_cstyle, CStyleLanguage(
       __device__ __forceinline__ explicit operator float4() const {return make_float4(__half2float(x.x), __half2float(x.y), __half2float(y.x), __half2float(y.y)); }
     };
   """)) if not getenv("PTX") else fromimport("tinygrad.codegen.assembly_ptx", "uops_to_ptx_asm")
-CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=False if getenv("PTX") else True, supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024]), renderer, CUDAProgram, cuda.Context.synchronize)
+CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=not getenv("PTX"), supports_float4_alu=False, supports_constant_folding=not getenv("PTX"),
+                                                       global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024]), renderer, CUDAProgram, cuda.Context.synchronize)

--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -64,4 +64,4 @@ class LLVMProgram:
     cfunc(*[x._buf for x in bufs])
     if wait: return time.monotonic()-st
 
-LLVMBuffer = Compiled(RawMallocBuffer, LinearizerOptions(supports_float4=False, has_local=False), uops_to_llvm_ir, LLVMProgram)
+LLVMBuffer = Compiled(RawMallocBuffer, LinearizerOptions(supports_float4=False, has_local=False, supports_constant_folding=False), uops_to_llvm_ir, LLVMProgram)

--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -64,4 +64,4 @@ class LLVMProgram:
     cfunc(*[x._buf for x in bufs])
     if wait: return time.monotonic()-st
 
-LLVMBuffer = Compiled(RawMallocBuffer, LinearizerOptions(supports_float4=False, has_local=False, supports_constant_folding=False), uops_to_llvm_ir, LLVMProgram)
+LLVMBuffer = Compiled(RawMallocBuffer, LinearizerOptions(supports_float4=False, has_local=False, supports_inline_constants=False), uops_to_llvm_ir, LLVMProgram)


### PR DESCRIPTION
Depends on #1483 . Diff against that.

When valid.max == 0, the variable is const 0, and we can write 0 + a = a etc. Useful especially for upcasted Tensor.stack, which produces many masked out variables.

Before:
```
*** exec  0.00 GB    0.01 ms op: BinaryOps.ADD        out(float): (2, 1)                         in(2): [(2, 1)] 
UOps.DEFINE_GLOBAL  :                           []                               ('data0', dtypes.float)
UOps.DEFINE_GLOBAL  :                           []                               ('data1', dtypes.float)
UOps.DEFINE_GLOBAL  :                           []                               ('data2', dtypes.float)
   0 buffer<2, dtypes.float>                         [View(shape=(2,), strides=(1,), offset=0, mask=None, contiguous=True, shape_strides=((2, 1),))]
   1 buffer<1, dtypes.float>                         [View(shape=(2,), strides=(0,), offset=0, mask=((0, 1),), contiguous=False, shape_strides=((2, 0),))]
   2 buffer<1, dtypes.float>                         [View(shape=(2,), strides=(0,), offset=0, mask=((1, 2),), contiguous=False, shape_strides=((2, 0),))]
   2
UOps.LOOP           :                           []                               ([], 'global')
UOps.LOOP           :                           []                               ([], 'local')
UOps.LOAD           : <val1_0>                  []                               MemOp(name='data1', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
UOps.LOAD           : <val1_1>                  []                               MemOp(name='data1', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<0>, invalid_value=0.0)
UOps.LOAD           : <val2_0>                  []                               MemOp(name='data2', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<0>, invalid_value=0.0)
UOps.LOAD           : <val2_1>                  []                               MemOp(name='data2', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
UOps.ALU            : <alu0>                    [<val1_0>, <val2_0>]             BinaryOps.ADD
UOps.ALU            : <alu1>                    [<val1_1>, <val2_1>]             BinaryOps.ADD
UOps.CAST           : <alu2:float2:None>        [<alu0>, <alu1>]                 None
UOps.STORE          :                           [<alu2:float2:None>]             MemOp(name='data0', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
UOps.ENDLOOP        :                           []                               ([], 'global+local')

```

After:

```
*** exec  0.00 GB    0.01 ms op: BinaryOps.ADD        out(float): (2, 1)                         in(2): [(2, 1)] 
UOps.DEFINE_GLOBAL  :                           []                               ('data0', dtypes.float)
UOps.DEFINE_GLOBAL  :                           []                               ('data1', dtypes.float)
UOps.DEFINE_GLOBAL  :                           []                               ('data2', dtypes.float)
   0 buffer<2, dtypes.float>                         [View(shape=(2,), strides=(1,), offset=0, mask=None, contiguous=True, shape_strides=((2, 1),))]
   1 buffer<1, dtypes.float>                         [View(shape=(2,), strides=(0,), offset=0, mask=((0, 1),), contiguous=False, shape_strides=((2, 0),))]
   2 buffer<1, dtypes.float>                         [View(shape=(2,), strides=(0,), offset=0, mask=((1, 2),), contiguous=False, shape_strides=((2, 0),))]
   2
UOps.LOOP           :                           []                               ([], 'global')
UOps.LOOP           :                           []                               ([], 'local')
UOps.LOAD           : <val1_0>                  []                               MemOp(name='data1', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
UOps.LOAD           : <val1_1>                  []                               MemOp(name='data1', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<0>, invalid_value=0.0)
UOps.LOAD           : <val2_0>                  []                               MemOp(name='data2', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<0>, invalid_value=0.0)
UOps.LOAD           : <val2_1>                  []                               MemOp(name='data2', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
    zero fold alu op: <val1_0> <- [<val1_0>, <val2_0>] BinaryOps.ADD
    zero fold alu op: <val2_1> <- [<val1_1>, <val2_1>] BinaryOps.ADD
UOps.CAST           : <alu2:float2:None>        [<val1_0>, <val2_1>]             None
UOps.STORE          :                           [<alu2:float2:None>]             MemOp(name='data0', idx=<0>, local=False, memory_dtype=dtypes.float, valid=<1>, invalid_value=0.0)
UOps.ENDLOOP        :                           []                               ([], 'global+local')
```