### PR TITLE
fix: 'is not' use with a literal

### DIFF
--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -210,7 +210,7 @@ def Xor(x:Tensor, y:Tensor): return Where((x==y), Tensor.zeros(*x.shape), Tensor
 def Not(x:Tensor): return Where((x==1), Tensor.zeros(*x.shape), Tensor.ones(*x.shape)).cast(dtypes.bool)
 
 def Trilu(x: Tensor, k: Union[Tensor, int]=0, upper=1):
-  k = int(k.numpy().item()) if k is not 0 else 0 # onnx passes k as a tensor int64 with one element, default is 0
+  k = int(k.numpy().item()) if k != 0 else 0 # onnx passes k as a tensor int64 with one element, default is 0
   return x.triu(k) if upper else x.tril(k)
 
 def ConstantOfShape(input, value:Tensor=None):


### PR DESCRIPTION
Wrong syntax for comparison to 0.