### PR TITLE
llvmir support for bool <-> float casting

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -143,10 +143,10 @@ class TestInt32Dtype(unittest.TestCase):
   @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu does not support int64")
   def test_int32_upcast_int64(self): _test_ops(a_dtype=dtypes.int32, b_dtype=dtypes.int64, target_dtype=dtypes.int64)
 
-@unittest.skipIf(Device.DEFAULT == "CUDA")
+@unittest.skipIf((getenv("CI", "") != "" and Device.DEFAULT in ["LLVM"]) or Device.DEFAULT == "CUDA", "float16 broken LLVM CI and not sure why CUDA fails")
 class TestBoolDtype(unittest.TestCase):
-  def test_casts_from_bool(self): _test_casts_from([0,1,1,0], source_dtype=dtypes.bool, target_dtypes=[dtypes.float32, dtypes.int32])
-  def test_casts_to_bool(self): _test_casts_to([0,1,1,0], source_dtypes=[dtypes.float32, dtypes.int32], target_dtype=dtypes.bool)
+  def test_casts_from_bool(self): _test_casts_from([0,1,1,0], source_dtype=dtypes.bool, target_dtypes=[dtypes.float32, dtypes.float16, dtypes.int32])
+  def test_casts_to_bool(self): _test_casts_to([0,1,1,0], source_dtypes=[dtypes.float32, dtypes.float16, dtypes.int32], target_dtype=dtypes.bool)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -143,10 +143,9 @@ class TestInt32Dtype(unittest.TestCase):
   @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu does not support int64")
   def test_int32_upcast_int64(self): _test_ops(a_dtype=dtypes.int32, b_dtype=dtypes.int64, target_dtype=dtypes.int64)
 
-@unittest.skipIf((getenv("CI", "") != "" and Device.DEFAULT in ["LLVM"]) or Device.DEFAULT == "CUDA", "float16 broken LLVM CI and not sure why CUDA fails")
 class TestBoolDtype(unittest.TestCase):
-  def test_casts_from_bool(self): _test_casts_from([0,1,1,0], source_dtype=dtypes.bool, target_dtypes=[dtypes.float32, dtypes.float16, dtypes.int32])
-  def test_casts_to_bool(self): _test_casts_to([0,1,1,0], source_dtypes=[dtypes.float32, dtypes.float16, dtypes.int32], target_dtype=dtypes.bool)
+  def test_casts_from_bool(self): _test_casts_from([0,1,1,0], source_dtype=dtypes.bool, target_dtypes=[dtypes.float32, dtypes.int32])
+  def test_casts_to_bool(self): _test_casts_to([0,1,1,0], source_dtypes=[dtypes.float32, dtypes.int32], target_dtype=dtypes.bool)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -143,5 +143,9 @@ class TestInt32Dtype(unittest.TestCase):
   @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu does not support int64")
   def test_int32_upcast_int64(self): _test_ops(a_dtype=dtypes.int32, b_dtype=dtypes.int64, target_dtype=dtypes.int64)
 
+class TestBoolDtype(unittest.TestCase):
+  def test_casts_from_bool(self): _test_casts_from([0,1,1,0], source_dtype=dtypes.bool, target_dtypes=[dtypes.float32, dtypes.float16, dtypes.int32])
+  def test_casts_to_bool(self): _test_casts_to([0,1,1,0], source_dtypes=[dtypes.float32, dtypes.float16, dtypes.int32], target_dtype=dtypes.bool)
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -143,9 +143,10 @@ class TestInt32Dtype(unittest.TestCase):
   @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu does not support int64")
   def test_int32_upcast_int64(self): _test_ops(a_dtype=dtypes.int32, b_dtype=dtypes.int64, target_dtype=dtypes.int64)
 
+@unittest.skipIf(Device.DEFAULT == "CUDA")
 class TestBoolDtype(unittest.TestCase):
-  def test_casts_from_bool(self): _test_casts_from([0,1,1,0], source_dtype=dtypes.bool, target_dtypes=[dtypes.float32, dtypes.float16, dtypes.int32])
-  def test_casts_to_bool(self): _test_casts_to([0,1,1,0], source_dtypes=[dtypes.float32, dtypes.float16, dtypes.int32], target_dtype=dtypes.bool)
+  def test_casts_from_bool(self): _test_casts_from([0,1,1,0], source_dtype=dtypes.bool, target_dtypes=[dtypes.float32, dtypes.int32])
+  def test_casts_to_bool(self): _test_casts_to([0,1,1,0], source_dtypes=[dtypes.float32, dtypes.int32], target_dtype=dtypes.bool)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -150,10 +150,6 @@ class TestOps(unittest.TestCase):
       lambda x: torch.where(x > 0.5, 4, 2).permute((1, 0)),
       lambda x: (x > 0.5).where(4, 2).permute((1, 0)), forward_only=True)
 
-  def test_where_bool(self): # Fixes #1479.
-    helper_test_op([(1,), (1,)], lambda x,y: torch.where(x==y, torch.tensor([1,1], dtype=torch.bool), 0),
-      lambda x,y: (x==y).where(Tensor([1,1], dtype=dtypes.bool), 0), forward_only=True, vals=[[0,1],[1,1]])
-
   def _test_cmp(self, fxn, reverse=True):
     for shps in [[(3, 4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]:
       helper_test_op(shps, fxn, fxn, forward_only=True)

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -118,8 +118,8 @@ def uops_to_llvm_ir(function_name:str, uops:List[UOp]) -> Tuple[str, Optional[Li
       idx = args.idx.render(render_llvm, bb[-1])
       element = lvars[vin[0]]
       if args.memory_dtype != vin[0].dtype:
-        if dtypes.is_int(args.memory_dtype):
-          element = bb[-1].fptoui(element, dtype_to_llvm_dtype[args.memory_dtype]) if dtypes.is_unsigned(args.memory_dtype) else bb[-1].fptosi(element, dtype_to_llvm_dtype[args.memory_dtype])
+        if dtypes.is_int(args.memory_dtype) or args.memory_dtype == dtypes.bool:
+          element = bb[-1].fptoui(element, dtype_to_llvm_dtype[args.memory_dtype]) if dtypes.is_unsigned(args.memory_dtype) or args.memory_dtype == dtypes.bool else bb[-1].fptosi(element, dtype_to_llvm_dtype[args.memory_dtype])
         elif args.memory_dtype == dtypes.bfloat16:
           element = bb[-1].bitcast(element, ir.IntType(32))
           element = bb[-1].lshr(element, ir.Constant(ir.IntType(32), 16))


### PR DESCRIPTION
Whoops, I got a little lax with my llvmir issue... sry
Add to #1480 

it's not a `Tensor.where()` issue that was causing it, it was simply a dtype cast `Tensor([...], dtype.bool).float()` issue
and as such there's also a `Tensor([...], dtypes.float32).cast(dtypes.bool)` issue too.

I deleted the `test_where_bool` test in `test_op.py` and added `TestBoolDtype` in `test_dtype.py`

thanks nimlgen for helping with my issue though
I was just careless.

