### PR TITLE
Tensor.scaled_dot_product_attention to match torch, used in LLaMA, and tested

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -74,15 +74,7 @@ class Attention:
 
     # save the cache
     self.cache_k, self.cache_v = keys.realize(), values.realize()
-
-    xq = xq.transpose(1, 2)
-    keys = keys.transpose(1, 2)
-    values = values.transpose(1, 2)
-    scores = xq.matmul(keys.transpose(2, 3)) / math.sqrt(self.head_dim)
-    if mask is not None:
-      scores = scores + mask
-    scores = scores.softmax()  # this is casted to float
-    return scores.matmul(values).transpose(1, 2).reshape(bsz, seqlen, -1)
+    return Tensor.scaled_dot_product_attention(xq.transpose(1,2), keys.transpose(1,2), values.transpose(1,2), mask).reshape(bsz, seqlen, -1)
 
   # NOTE: this is not called
   def __call__(self, x:Tensor, start_pos:int, freqs_cis:Tensor, mask:Optional[Tensor]) -> Tensor:

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -74,7 +74,7 @@ class Attention:
 
     # save the cache
     self.cache_k, self.cache_v = keys.realize(), values.realize()
-    return Tensor.scaled_dot_product_attention(xq.transpose(1,2), keys.transpose(1,2), values.transpose(1,2), mask).reshape(bsz, seqlen, -1)
+    return Tensor.scaled_dot_product_attention(xq.transpose(1, 2), keys.transpose(1, 2), values.transpose(1, 2), mask).transpose(1, 2).reshape(bsz, seqlen, -1)
 
   # NOTE: this is not called
   def __call__(self, x:Tensor, start_pos:int, freqs_cis:Tensor, mask:Optional[Tensor]) -> Tensor:

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1147,7 +1147,9 @@ class TestOps(unittest.TestCase):
     self.helper_test_exception([], lambda: tor[tb,:,:,:,:].sum().backward(), lambda: ten.gather(ta, dim=0).sum().backward(), expected=(IndexError, RuntimeError)) # torch raises IndexError, Tensor raises RuntimeError
 
   def test_scaled_product_attention(self):
-     helper_test_op([(32,8,128,64), (32,8,128,64), (32,8,128,64)], lambda x,y,z: torch.nn.functional.scaled_dot_product_attention(x,y,z), lambda x,y,z: Tensor.scaled_dot_product_attention(x,y,z))
+    helper_test_op([(32,8,128,64), (32,8,128,64), (32,8,128,64)], lambda x,y,z: torch.nn.functional.scaled_dot_product_attention(x,y,z), lambda x,y,z: Tensor.scaled_dot_product_attention(x,y,z))
+    helper_test_op([(32,8,128,64), (32,8,128,64), (32,8,128,64), (32,8,128,128)], lambda x,y,z,m: torch.nn.functional.scaled_dot_product_attention(x,y,z,attn_mask=m), lambda x,y,z,m: Tensor.scaled_dot_product_attention(x,y,z,attn_mask=m))
+    helper_test_op([(32,8,128,64), (32,8,128,64), (32,8,128,64)], lambda x,y,z: torch.nn.functional.scaled_dot_product_attention(x,y,z,is_causal=True), lambda x,y,z: Tensor.scaled_dot_product_attention(x,y,z,is_causal=True))
 
 if __name__ == '__main__':
   np.random.seed(1337)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1146,6 +1146,9 @@ class TestOps(unittest.TestCase):
     tb = torch.tensor(c, requires_grad=True, dtype=torch.float32)
     self.helper_test_exception([], lambda: tor[tb,:,:,:,:].sum().backward(), lambda: ten.gather(ta, dim=0).sum().backward(), expected=(IndexError, RuntimeError)) # torch raises IndexError, Tensor raises RuntimeError
 
+  def test_scaled_product_attention(self):
+     helper_test_op([(32,8,128,64), (32,8,128,64), (32,8,128,64)], lambda x,y,z: torch.nn.functional.scaled_dot_product_attention(x,y,z), lambda x,y,z: Tensor.scaled_dot_product_attention(x,y,z), atol=1e-4)
+
 if __name__ == '__main__':
   np.random.seed(1337)
   unittest.main(verbosity=2)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1147,7 +1147,7 @@ class TestOps(unittest.TestCase):
     self.helper_test_exception([], lambda: tor[tb,:,:,:,:].sum().backward(), lambda: ten.gather(ta, dim=0).sum().backward(), expected=(IndexError, RuntimeError)) # torch raises IndexError, Tensor raises RuntimeError
 
   def test_scaled_product_attention(self):
-     helper_test_op([(32,8,128,64), (32,8,128,64), (32,8,128,64)], lambda x,y,z: torch.nn.functional.scaled_dot_product_attention(x,y,z), lambda x,y,z: Tensor.scaled_dot_product_attention(x,y,z), atol=1e-4)
+     helper_test_op([(32,8,128,64), (32,8,128,64), (32,8,128,64)], lambda x,y,z: torch.nn.functional.scaled_dot_product_attention(x,y,z), lambda x,y,z: Tensor.scaled_dot_product_attention(x,y,z))
 
 if __name__ == '__main__':
   np.random.seed(1337)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -681,7 +681,7 @@ class Tensor:
     return self * mask * (1/(1.0 - p))
 
   def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False) -> Tensor:
-    return (query @ key.transpose(-2,-1) / sqrt(query.shape[-1])).softmax(-1).dropout(dropout_p) @ value
+    return (query @ key.transpose(-2,-1) / sqrt(query.shape[-1]) + attn_mask).softmax(-1).dropout(dropout_p) @ value
 
   # ***** cast ops *****
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -680,6 +680,9 @@ class Tensor:
     mask = (Tensor.rand(*self.shape, requires_grad=False) >= p).cast(dtypes.bool)
     return self * mask * (1/(1.0 - p))
 
+  def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False) -> Tensor:
+    return (query @ key.transpose(-2,-1) / sqrt(query.shape[-1])).softmax(-1).dropout(dropout_p) @ value
+
   # ***** cast ops *****
 
   def cast(self, dtype:DType) -> Tensor: return mlops.Cast.apply(self, dtype=dtype) if self.dtype != dtype else self

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -680,6 +680,7 @@ class Tensor:
     mask = (Tensor.rand(*self.shape, requires_grad=False) >= p).cast(dtypes.bool)
     return self * mask * (1/(1.0 - p))
 
+  @staticmethod
   def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False) -> Tensor:
     if is_causal: attn_mask = Tensor.ones(query.shape[-2], key.shape[-2]).tril(0).cast(dtypes.bool)
     if attn_mask is not None and attn_mask.dtype == dtypes.bool: attn_mask = (attn_mask == 0).where(-float("inf"), attn_mask)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -680,11 +680,10 @@ class Tensor:
     mask = (Tensor.rand(*self.shape, requires_grad=False) >= p).cast(dtypes.bool)
     return self * mask * (1/(1.0 - p))
 
-  @staticmethod
-  def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False) -> Tensor:
-    if is_causal: attn_mask = Tensor.ones(query.shape[-2], key.shape[-2], requires_grad=False).tril(0).cast(dtypes.bool)
+  def scaled_dot_product_attention(self, key: Tensor, value: Tensor, attn_mask:Optional[Tensor]=None, dropout_p:float=0.0, is_causal:bool=False) -> Tensor:
+    if is_causal: attn_mask = Tensor.ones(self.shape[-2], key.shape[-2], requires_grad=False).tril(0).cast(dtypes.bool)
     if attn_mask is not None and attn_mask.dtype == dtypes.bool: attn_mask = (attn_mask == 0).where(-float("inf"), attn_mask)
-    return (query @ key.transpose(-2,-1) / sqrt(query.shape[-1]) + attn_mask).softmax(-1).dropout(dropout_p) @ value
+    return (self @ key.transpose(-2,-1) / sqrt(self.shape[-1]) + attn_mask).softmax(-1).dropout(dropout_p) @ value
 
   # ***** cast ops *****
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -682,7 +682,7 @@ class Tensor:
 
   @staticmethod
   def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False) -> Tensor:
-    if is_causal: attn_mask = Tensor.ones(query.shape[-2], key.shape[-2]).tril(0).cast(dtypes.bool)
+    if is_causal: attn_mask = Tensor.ones(query.shape[-2], key.shape[-2], requires_grad=False).tril(0).cast(dtypes.bool)
     if attn_mask is not None and attn_mask.dtype == dtypes.bool: attn_mask = (attn_mask == 0).where(-float("inf"), attn_mask)
     return (query @ key.transpose(-2,-1) / sqrt(query.shape[-1]) + attn_mask).softmax(-1).dropout(dropout_p) @ value
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -681,6 +681,8 @@ class Tensor:
     return self * mask * (1/(1.0 - p))
 
   def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False) -> Tensor:
+    if is_causal: attn_mask = Tensor.ones(query.shape[-2], key.shape[-2]).tril(0).cast(dtypes.bool)
+    if attn_mask is not None and attn_mask.dtype == dtypes.bool: attn_mask = (attn_mask == 0).where(-float("inf"), attn_mask)
     return (query @ key.transpose(-2,-1) / sqrt(query.shape[-1]) + attn_mask).softmax(-1).dropout(dropout_p) @ value
 
   # ***** cast ops *****

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -680,7 +680,7 @@ class Tensor:
     mask = (Tensor.rand(*self.shape, requires_grad=False) >= p).cast(dtypes.bool)
     return self * mask * (1/(1.0 - p))
 
-  def scaled_dot_product_attention(self, key: Tensor, value: Tensor, attn_mask:Optional[Tensor]=None, dropout_p:float=0.0, is_causal:bool=False) -> Tensor:
+  def scaled_dot_product_attention(self, key:Tensor, value:Tensor, attn_mask:Optional[Tensor]=None, dropout_p:float=0.0, is_causal:bool=False) -> Tensor:
     if is_causal: attn_mask = Tensor.ones(self.shape[-2], key.shape[-2], requires_grad=False).tril(0).cast(dtypes.bool)
     if attn_mask is not None and attn_mask.dtype == dtypes.bool: attn_mask = (attn_mask == 0).where(-float("inf"), attn_mask)
     return (self @ key.transpose(-2,-1) / sqrt(self.shape[-1]) + attn_mask).softmax(-1).dropout(dropout_p) @ value


### PR DESCRIPTION
changes made (so far)
- implemented function
  - support is_causal and attn_mask
- wrote test cases
- use function in LLaMA