### PR TITLE
Handle variable values in GlobalCounters instead of Variable.val

### DIFF
--- a/test/test_lazybuffer.py
+++ b/test/test_lazybuffer.py
@@ -68,29 +68,5 @@ class TestLazyBuffer(unittest.TestCase):
     assert GlobalCounters.cache[2][0].name.startswith("E_")
     GlobalCounters.cache = None
 
-class TestVariableBuffer(unittest.TestCase):
-  def test_get_variable_buffers_no_variable(self):
-    t = Tensor.rand(2, 3)
-    assert t.lazydata.get_variable_buffers() == {}
-
-  def test_get_variable_buffers_one_variable(self):
-    v = Variable("v", 1, 10)
-    t = Tensor.rand(2, 3).reshape(v, 3)
-    buffers = t.lazydata.get_variable_buffers()
-    assert len(buffers) == 1 and buffers[v].realize().realized.toCPU() == 2
-    v = Variable("v", 1, 10)
-    t = Tensor.rand(2, 3).reshape(2, v)
-    buffers = t.lazydata.get_variable_buffers()
-    assert len(buffers) == 1 and buffers[v].realize().realized.toCPU() == 3
-
-  def test_get_variable_buffers_cat(self):
-    v1 = Variable("v1", 1, 10)
-    v2 = Variable("v2", 1, 10)
-    t1 = Tensor.rand(2, 3).reshape(v1, 3)
-    t2 = Tensor.rand(6, 3).reshape(v2, 3)
-    t = t1.cat(t2)
-    buffers = t.lazydata.get_variable_buffers()
-    assert len(buffers) == 2 and buffers[v1].realize().realized.toCPU() == 2 and buffers[v2].realize().realized.toCPU() == 6
-
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -2,8 +2,12 @@ import unittest
 from tinygrad.shape.shapetracker import ShapeTracker, View
 from tinygrad.shape.symbolic import Variable
 from tinygrad.tensor import Tensor
+from tinygrad.helpers import GlobalCounters
 
 class TestSymbolic(unittest.TestCase):
+  def setUp(self): GlobalCounters.var_vals = {}
+  def tearDown(self): GlobalCounters.var_vals = {}
+
   def test_symbolic_st(self):
     x = Variable("x", 1, 100)
     st = ShapeTracker((x, 3))
@@ -39,14 +43,17 @@ class TestSymbolic(unittest.TestCase):
     assert st.real_strides() == (i+j+k, 1)
 
 class TestSymbolicReshape(unittest.TestCase):
+  def setUp(self): GlobalCounters.var_vals = {}
+  def tearDown(self): GlobalCounters.var_vals = {}
+
   def test_reshape_into_symbols_simple(self):
     for i in range(1, 5):
       vi = Variable("i", 1, 10)
       assert Tensor.rand(i, 4).reshape(vi, 4).shape == (vi, 4)
-      assert vi.val == i
+      assert GlobalCounters.var_vals[vi] == i
       vi = Variable("i", 1, 10)
       assert Tensor.rand(i, 6).reshape(vi, 2, 3).shape == (vi, 2, 3)
-      assert vi.val == i
+      assert GlobalCounters.var_vals[vi] == i
 
   def test_reshape_symbols_reshape_ints(self):
     for i in range(1, 5):
@@ -62,7 +69,7 @@ class TestSymbolicReshape(unittest.TestCase):
       vi = Variable("i", 1, 10)
       a = Tensor.rand(i, 4).reshape(vi, 4)
       b = Tensor.rand(i, 3).reshape(vi, 3)
-      assert vi.val == i
+      assert GlobalCounters.var_vals[vi] == i
 
   def test_reshape_reuse_var_different_value_fail(self):
     for i in range(1, 5):
@@ -85,20 +92,44 @@ class TestSymbolicReshape(unittest.TestCase):
     with self.assertRaises(AssertionError):
       t = Tensor.rand(3, 4).reshape(Variable("too_big", 100, 200), 4)
 
+  def test_two_symbol_reshape(self):
+    for i in range(1, 6):
+      for j in range(1, 6):
+        vi = Variable("i", 1, 5)
+        vj = Variable("j", 1, 5)
+        t1 = Tensor.rand(i, 5).reshape(vi, 5)
+        t2 = Tensor.rand(5, j).reshape(5, vj)
+        t = t1@t2
+        assert t.shape == (vi, vj)
+        t = t.reshape(1, vi*vj)
+        assert t.shape == (1, vi*vj)
+        t = t.reshape(vj, vi)
+        assert t.shape == (vj, vi)
+
 class TestSymbolicExpand(unittest.TestCase):
+  def setUp(self): GlobalCounters.var_vals = {}
+  def tearDown(self): GlobalCounters.var_vals = {}
+
   def test_expand_into_symbols(self):
-    vi = Variable("i", 1, 10)
-    a = Tensor([[1], [2], [3]]).expand((3, vi))
-    assert a.shape == (3, vi)
-    vj = Variable("j", 1, 10)
-    a = a.reshape(3, vi, 1).expand((3, vi, vj))
-    assert a.shape == (3, vi, vj)
+    for i in range(1, 6):
+      for j in range(1, 6):
+        vi = Variable("i", 1, 5)
+        vj = Variable("j", 1, 5)
+        # this sets values for vi, vj, which is required if we want to expand into it
+        Tensor.rand(i).reshape(vi)
+        Tensor.rand(j).reshape(vj)
+
+        a = Tensor([[1], [2], [3]]).expand((3, vi))
+        assert a.shape == (3, vi)
+        a = a.reshape(3, vi, 1).expand((3, vi, vj))
+        assert a.shape == (3, vi, vj)
 
   def test_plus_expands_constant(self):
-    vi = Variable("i", 1, 10)
-    a = Tensor.rand(3, 4).reshape(3, vi)
-    a = a + 1
-    assert a.shape == (3, vi)
+    for i in range(1, 6):
+      vi = Variable("i", 1, 5)
+      a = Tensor.rand(3, i).reshape(3, vi)
+      a = a + 1
+      assert a.shape == (3, vi)
 
 class TestSymbolicShapeExpr(unittest.TestCase):
   def test_symbolic_expr_idxs(self):
@@ -113,6 +144,47 @@ class TestSymbolicShapeExpr(unittest.TestCase):
     st = ShapeTracker(shape, [view])
     idx, valid = st.expr_idxs(idx)
     assert idx.render() == "(((1+i)*1)+(lidx1*((i*4)+4))+gidx0)"
+
+class TestSymbolicSameVariables(unittest.TestCase):
+  def setUp(self): GlobalCounters.var_vals = {}
+  def tearDown(self): GlobalCounters.var_vals = {}
+
+  def test_same_var_same_value_work(self):
+    for i in range(1, 6):
+      vi = Variable("i", 1, 5)
+      a = Tensor.rand(3, i).reshape(3, vi)
+      b = Tensor.rand(i, 5).reshape(vi, 5)
+      c = a@b
+      assert c.shape == (3, 5)
+
+  def test_same_name_different_var_same_value_work(self):
+    vi1 = Variable("i", 1, 10)
+    vi2 = Variable("i", 1, 10)
+    a = Tensor.rand(3, 4).reshape(3, vi1)
+    b = Tensor.rand(4, 5).reshape(vi2, 5)
+    c = a@b
+    assert c.shape == (3, 5)
+
+  def test_same_name_different_var_different_value_overwrite(self):
+    vi1 = Variable("i", 1, 10)
+    a = Tensor.rand(3, 4).reshape(3, vi1)
+    assert GlobalCounters.var_vals[vi1] == 4
+    vi2 = Variable("i", 1, 10)
+    b = Tensor.rand(4, 5).reshape(4, vi2)
+    assert GlobalCounters.var_vals[vi1] == 5
+    assert GlobalCounters.var_vals[vi2] == 5
+
+  def test_different_var_same_value_fail(self):
+    a = Tensor.rand(3, 4).reshape(3, Variable("i", 1, 10))
+    b = Tensor.rand(4, 5).reshape(Variable("j", 1, 10), 5)
+    with self.assertRaises(AssertionError):
+      c = a@b
+
+  def test_same_var_different_value_fail(self):
+    vi = Variable("i", 1, 10)
+    a = Tensor.rand(3, 4).reshape(3, vi)
+    with self.assertRaises(AssertionError):
+      b = Tensor.rand(7, 5).reshape(vi, 5)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -124,6 +124,7 @@ class GlobalCounters:
   kernel_count: ClassVar[int] = 0
   mem_used: ClassVar[int] = 0   # NOTE: this is not reset
   cache: ClassVar[Optional[List[Tuple[Callable, Any]]]] = None
+  var_vals: ClassVar[Dict[Any, int]] = {}  # Dict[Variable, int]
   @staticmethod
   def reset(): GlobalCounters.global_ops, GlobalCounters.global_mem, GlobalCounters.time_sum_s, GlobalCounters.kernel_count, GlobalCounters.cache = 0,0,0.0,0,None
 

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from enum import Enum, auto
 import functools
 from typing import Dict, Tuple, Union, List, Optional, Callable, cast, NamedTuple
-from tinygrad.helpers import prod, DEBUG
-from tinygrad.shape.symbolic import Variable, MulNode, NumNode, Node, SumNode, is_sym_int
+from tinygrad.helpers import prod, DEBUG, GlobalCounters
+from tinygrad.shape.symbolic import Variable, MulNode, NumNode, Node, SumNode, is_sym_int, sym_infer
 
 # these ops live here
 class MovementOps(Enum): RESHAPE = auto(); PERMUTE = auto(); EXPAND = auto(); PAD = auto(); SHRINK = auto(); STRIDE = auto() # noqa: E702
@@ -130,7 +130,7 @@ def get_unsafe_resize_offset(strides, arg):
 
 class ShapeTracker:
   __slots__ = "views"
-  def __init__(self, shape:Union[ShapeTracker, Tuple[int, ...]], views:Optional[List[View]]=None):
+  def __init__(self, shape:Union[ShapeTracker, Tuple[Union[Node,int], ...]], views:Optional[List[View]]=None):
     self.views: List[View] = views if views is not None else ([*cast(ShapeTracker, shape).views] if shape.__class__ is ShapeTracker else [View(shape)])
   def __repr__(self): return f"ShapeTracker(shape={self.views[-1].shape}, views={self.views})"
   def copy(self) -> ShapeTracker: return ShapeTracker(self.views[-1].shape, [*self.views])
@@ -139,7 +139,7 @@ class ShapeTracker:
   def contiguous(self) -> bool: return len(self.views) == 1 and self.views[0].contiguous
 
   @property
-  def shape(self) -> Tuple[int, ...]: return self.views[-1].shape
+  def shape(self) -> Tuple[int, ...]: return self.views[-1].shape # NOTE: real type is Tuple[Union[Node, int], ...] but mypy complains about prod(shape)
 
   @property
   def key(self) -> Tuple[View, ...]: return tuple(self.views)
@@ -235,16 +235,14 @@ class ShapeTracker:
     if all(isinstance(s, int) for s in self.shape) and len(new_vars:=list(s for s in new_shape if isinstance(s, Variable))) > 0:
       assert len(new_vars) == 1, "only one variable is supported in a shape"
       new_var, new_val = new_vars[0], prod(self.shape) // prod(s for s in new_shape if isinstance(s, int))
-      if new_var.val is None:
+      if new_var.set: assert GlobalCounters.var_vals[new_var] == new_val, f"value conflicts, was {GlobalCounters.var_vals[new_var]}, set to {new_val}"
+      else:
         assert new_var.min <= new_val <= new_var.max, f"variable value {new_val} out of range [{new_var.min}, {new_var.max}]"
-        new_var.val = new_val
-      else: assert new_var.val == new_val, f"value conflicts, was {new_var.val}, set to {new_val}"
-
+        new_var.set = True
+        GlobalCounters.var_vals[new_var] = new_val
     if self.views[-1].shape == new_shape: return self
     assert all(is_sym_int(x) and x > 0 for x in new_shape), f"shape must be symbolic ints and can't contain 0 or negative numbers {new_shape}"
-    # only check size for int shapes. we don't check symbolic here as long as the reshape itself can be done
-    if all(isinstance(s, int) for s in self.shape) and all(isinstance(s, int) for s in new_shape):
-      assert prod(self.shape) == prod(new_shape), f"can't reshape {self.shape} -> {new_shape}" # type: ignore  # mypy cannot resolve, all ints here
+    assert prod(sym_infer(s) for s in self.shape) == prod(sym_infer(s) for s in new_shape), f"can't reshape {self.shape} -> {new_shape}"
     new_view, extra = _reshape(self.views[-1], new_shape)
     if extra: self.views.append(new_view)
     else: self.views[-1] = new_view


### PR DESCRIPTION
part of #1353

It turns out that stateful `Variable` is a bad idea because all the shapetracker cached functions either returned the cached symbolic shape with old values, or if we try to update the `Variable.key` to include `val`, the cache become less effective. The new design use a global state to store variable values.

Added `sym_infer` which is used in reshape size check, and also later when we need to infer the real global_size, local_size, and op_estimate of kernel call.

Removed old `LazyBuffer.get_variable_buffers`, which is also a bad design. I have implemented passing `int` directly into kernel function for CLANG, GPU, METAL in the main PR.