### PR TITLE
examples: numpy() array returns only one value, not an array

### DIFF
--- a/examples/benchmark_train_efficientnet.py
+++ b/examples/benchmark_train_efficientnet.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
       GlobalCounters.cache = None
 
     mem_used = GlobalCounters.mem_used
-    loss_cpu = loss.detach().numpy()[0]
+    loss_cpu = loss.detach().numpy()
     cl = time.monotonic()
 
     print(f"{(st-cpy)*1000.0:7.2f} ms cpy,  {(cl-st)*1000.0:7.2f} ms run, {(mt-st)*1000.0:7.2f} ms build, {(et-mt)*1000.0:7.2f} ms realize, {(cl-et)*1000.0:7.2f} ms CL, {loss_cpu:7.2f} loss, {tensors_allocated():4d} tensors, {mem_used/1e9:.2f} GB used, {GlobalCounters.global_ops*1e-9/(cl-st):9.2f} GFLOPS")


### PR DESCRIPTION
 - Python 3.11.4
 - numpy 1.24.2

Fixes issue:

```
    loss_cpu = loss.detach().numpy()[0]
               ~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: too many indices for array: array is 0-dimensional, but 1 were indexed
```