### PR TITLE
fix deepwalk ctx check crash

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -213,5 +213,12 @@ class TestTinygrad(unittest.TestCase):
     for _, dtype in dtypes.fields().items():
       assert dtype.itemsize == Tensor.randn(3, dtype=dtype).element_size(), f"Tensor.element_size() not matching Tensor.dtype.itemsize for {dtype}"
 
+  def test_deepwalk_ctx_check(self):
+    layer = Tensor.uniform(1, 1, requires_grad=True)
+    x = Tensor.randn(1, 1, 1)
+    x.dot(layer).mean().backward()
+    x = Tensor.randn(1, 1, 1)
+    x.dot(layer).mean().backward()
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -207,7 +207,7 @@ class Tensor:
   def deepwalk(self):
     def _deepwalk(node, visited, nodes):
       visited.add(node)
-      if node._ctx:
+      if getattr(node, "_ctx", None):
         for i in node._ctx.parents:
           if i not in visited: _deepwalk(i, visited, nodes)
         nodes.append(node)


### PR DESCRIPTION
_ctx is deleted after `backwalk()` [here](https://github.com/tinygrad/tinygrad/blob/master/tinygrad/tensor.py#L236), and crashes because we weren't doing the proper check for deleted attribute

 ```
 ERROR: test_deepwalk_ctx_check (__main__.TestTinygrad)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/yiminghan/tinygrad/test/test_tensor.py", line 221, in test_ctx
    x.dot(layer).mean().backward()
  File "/Users/yiminghan/tinygrad/tinygrad/tensor.py", line 224, in backward
    for t0 in reversed(self.deepwalk()):
  File "/Users/yiminghan/tinygrad/tinygrad/tensor.py", line 215, in deepwalk
    return _deepwalk(self, set(), [])
  File "/Users/yiminghan/tinygrad/tinygrad/tensor.py", line 212, in _deepwalk
    if i not in visited: _deepwalk(i, visited, nodes)
  File "/Users/yiminghan/tinygrad/tinygrad/tensor.py", line 212, in _deepwalk
    if i not in visited: _deepwalk(i, visited, nodes)
  File "/Users/yiminghan/tinygrad/tinygrad/tensor.py", line 212, in _deepwalk
    if i not in visited: _deepwalk(i, visited, nodes)
  [Previous line repeated 5 more times]
  File "/Users/yiminghan/tinygrad/tinygrad/tensor.py", line 210, in _deepwalk
    if node._ctx:
AttributeError: 'Tensor' object has no attribute '_ctx'
```

Not sure we even need a test here, happy to delete the test 