### PR TITLE
fix file race condition in ops_clang via pid in the filename

### DIFF
--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -17,7 +17,7 @@ class ClangProgram:
     # TODO: is there a way to not write this to disk?
     fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.{args['ext']}"
     if not os.path.exists(fn):
-      _, tmp = tempfile.mkstemp()
+      tmp = f"{fn}.{os.getpid()}.tmp"
       subprocess.check_output(args=('clang -shared -O2 -Wall -Werror -x c '+args['cflags']+' - -o '+tmp).split(), input=prg.encode('utf-8'))
       os.rename(tmp, fn)
     self.lib = ctypes.CDLL(fn)

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -15,6 +15,8 @@ class ClangProgram:
   def __init__(self, name:str, prg:str):
     prg = CLANG_PROGRAM_HEADER + prg
     # TODO: is there a way to not write this to disk?
+    # A: it seems there isn't https://stackoverflow.com/questions/28053328/ctypes-cdll-load-library-from-memory-rather-than-file
+    #    because ctypes.CDLL() calls dlopen (POSIX) or LoadLibrary (Windows) which require a file
     fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.{args['ext']}"
     if not os.path.exists(fn):
       tmp = f"{fn}.{os.getpid()}.tmp"


### PR DESCRIPTION
as suggested by @wozeparrot in https://github.com/tinygrad/tinygrad/pull/1458/files#r1292819054