### PR TITLE
hotfix for broken ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,8 +112,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Find faster apt mirror
-        uses: vegardit/fast-apt-mirror.sh@v1
+      # - name: Find faster apt mirror
+      #   uses: vegardit/fast-apt-mirror.sh@v1
       - name: Update packages
         run: |
           wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
@@ -220,8 +220,8 @@ jobs:
       - name: Set env
         run: printf "${{ matrix.backend == 'llvm' && 'ENABLE_METHOD_CACHE=1\nLLVM=1' || matrix.backend == 'clang' && 'CLANG=1\nENABLED_METHOD_CACHE=1' || matrix.backend == 'gpu' && 'GPU=1' || matrix.backend == 'cuda' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\n'}}" >> $GITHUB_ENV
       - name: Find faster apt mirror
-        uses: vegardit/fast-apt-mirror.sh@v1
-      - name: Install packages (gpu)
+      #   uses: vegardit/fast-apt-mirror.sh@v1
+      # - name: Install packages (gpu)
         if: matrix.backend == 'gpu'
         run: |
           wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null


### PR DESCRIPTION
github updated their runner images, and fast-apt-mirror due to that.

just disable it for now, tracking upstream: https://github.com/vegardit/fast-apt-mirror.sh/issues/2

