### PR TITLE
cleanup ops_gpu

### DIFF
--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -34,7 +34,7 @@ class _CL:
     cl_platforms = cl.get_platforms()
     platform_devices: List[List[cl.Device]] = [y for y in ([x.get_devices(device_type=cl.device_type.GPU) for x in cl_platforms] + [x.get_devices(device_type=cl.device_type.CPU) for x in cl_platforms]) if len(y)]
     self.devices = [device for device in platform_devices[getenv('CL_PLATFORM', 0)] if device.name not in getenv('CL_EXCLUDE', "").split(",")]
-    self.cl_platform = cl_platforms[getenv('CL_PLATFORM', 0)]
+    self.cl_platform = self.devices[0].platform
   def post_init(self, device=None):
     self.cl_ctxs: List[cl.Context] = [cl.Context(devices=[x]) for x in self.devices] if device is None else [cl.Context(devices=[self.devices[device]])]
     if DEBUG >= 1: print(f"using devices: {[ctx.devices[0].hashable_model_and_version_identifier for ctx in self.cl_ctxs]}")


### PR DESCRIPTION
move stuff that doesn't need to be in `post_init` into `__init__`.

this lets us get a total device count before the devices are actually initialized. Needed for #1529.

this also lets us get the device names before the devices are initialized. Needed for #1545.
