### PR TITLE
fix lru on hip

### DIFF
--- a/extra/hip_wrapper.py
+++ b/extra/hip_wrapper.py
@@ -93,7 +93,7 @@ def hipMalloc(count):
   ptr = ctypes.c_void_p()
   status = _libhip.hipMalloc(ctypes.byref(ptr), count)
   hipCheckStatus(status)
-  return ptr
+  return ptr.value
 
 
 _libhip.hipFree.restype = int


### PR DESCRIPTION
`c_void_p` can't be hashed, but we can hash the underlying pointer value,

and `int` gets auto upcasted to `c_void_p` when passed to a ctypes function that takes `c_void_p`
