### PR TITLE
fix: apt-get to apt, no recommends, clean up

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Run mypy
       run: mypy tinygrad/ --ignore-missing-imports --check-untyped-defs --explicit-package-bases --warn-unreachable
     - name: Install SLOCCount
-      run: sudo apt-get install sloccount
+      run: sudo apt install sloccount
     - name: Check <5000 lines
       run: sloccount tinygrad test examples extra; if [ $(sloccount tinygrad | sed -n 's/.*Total Physical Source Lines of Code (SLOC)[ ]*= \([^ ]*\).*/\1/p' | tr -d ',') -gt 5000 ]; then exit 1; fi
 
@@ -114,14 +114,13 @@ jobs:
         uses: actions/checkout@v3
       # - name: Find faster apt mirror
       #   uses: vegardit/fast-apt-mirror.sh@v1
-      - name: Update packages
+      - name: Install OpenCL
+        #run: sudo apt install -y pocl-opencl-icd
         run: |
           wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-          sudo apt-get update
-      - name: Install OpenCL
-        #run: sudo apt-get install -y pocl-opencl-icd
-        run: sudo apt-get install -y intel-oneapi-runtime-compilers intel-oneapi-runtime-opencl
+          sudo apt update
+          sudo apt install -y --no-install-recommends intel-oneapi-runtime-compilers intel-oneapi-runtime-opencl
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
@@ -228,13 +227,13 @@ jobs:
         run: |
           wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-          sudo apt-get update -y && \
-          sudo apt-get install -y intel-oneapi-runtime-compilers intel-oneapi-runtime-opencl
+          sudo apt update -y
+          sudo apt install -y --no-install-recommends intel-oneapi-runtime-compilers intel-oneapi-runtime-opencl
       - name: Install packages (cuda)
         if: matrix.backend == 'cuda' || matrix.backend == 'ptx'
         run: |
-          sudo apt-get update -y && \
-          sudo apt-get install -y --no-install-recommends git g++ cmake ninja-build llvm-15-dev zlib1g-dev libglew-dev flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-toolkit-gcc
+          sudo apt update -y
+          sudo apt install -y --no-install-recommends git g++ cmake ninja-build llvm-15-dev zlib1g-dev libglew-dev flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-toolkit-gcc
       - name: Cache gpuocelot
         if: matrix.backend == 'cuda' || matrix.backend == 'ptx'
         id: cache-build
@@ -291,8 +290,8 @@ jobs:
           key: unicorn
       - name: Install cross-assembler
         run: |
-          sudo apt-get update -y && \
-          sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
+          sudo apt update -y
+          sudo apt install -y --no-install-recommends gcc-aarch64-linux-gnu
       - name: Install dependencies
         run: pip install -e '.[testing,arm]' --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Test arm


### PR DESCRIPTION
* Adds `--no-install-recommends` to intel installation
* Changes `apt-get` to `apt`
* Consolidates update and install step