### PR TITLE
for issue #1555, int64 and int8 in CI=1 ARM64=1 CLANG=1

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -48,6 +48,7 @@ def _test_ops(a_dtype:DType, b_dtype:DType, target_dtype:DType):
   _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)+Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [2,4,6,8])
   _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)*Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [1,4,9,16])
   _assert_eq(Tensor([[1,2],[3,4]], dtype=a_dtype)@Tensor.eye(2, dtype=b_dtype), target_dtype, [[1,2],[3,4]])
+  _assert_eq(Tensor([1,1,1,1], dtype=a_dtype)+Tensor.ones((4,4), dtype=b_dtype), target_dtype, 2*Tensor.ones(4,4).numpy())
 
 class TestBFloat16DType(unittest.TestCase):
   def test_bf16_to_float(self):

--- a/tinygrad/codegen/assembly_arm64.py
+++ b/tinygrad/codegen/assembly_arm64.py
@@ -144,7 +144,7 @@ def specialize_to_arm64(fn_nm, asm):
       reg_out = (type_to_reg[arg[2]] + ('0' if dtypes.is_float(arg[2]) else '12') if arg[2] is not None else rtor[vin[1].nm])
       if arg[2] is not None: ins.append(f"fcvt{'zs' if arg[2] not in [dtypes.half, dtypes.double] else '' } {reg_out}, {rtor[vin[1].nm]}")
       ins.append(f"mov x15, #{arg[0]}")
-      ins.append(f"str {reg_out}, [{rtor[vin[0].nm]}, x15, lsl {shifts[arg[2]] if arg[2] is not None and arg[2] in shifts else '#0'}]")
+      ins.append(f"str {reg_out}, [{rtor[vin[0].nm]}, x15, lsl #0]")
     elif uop == UOps.COND_BRANCH:
       #TODO: this is a hack it shouldn't always be a cmp before a cond branch?
       if prev_uop == UOps.LOAD:

--- a/tinygrad/codegen/assembly_arm64.py
+++ b/tinygrad/codegen/assembly_arm64.py
@@ -139,7 +139,6 @@ def specialize_to_arm64(fn_nm, asm):
         ins.append(f"ldr{'sb' if arg[2] is not None and arg[2] in (dtypes.int8, dtypes.uint8, dtypes.bool) else ''} {reg_in}, [x15]")
         if arg[2] is not None: ins.append(f"{'fcvt' if arg[2] in [dtypes.half, dtypes.double] else 'scvtf'} {rtor[out.nm]}, {reg_in}")
     elif uop == UOps.STORE:
-      shifts = {dtypes.int64: "#3", dtypes.half: "#1", dtypes.int8:"#2", dtypes.uint8: "#2", dtypes.bool: "#2"}
       #NOTE: if need casting load var in s/h0 or x/w12 temp regs
       reg_out = (type_to_reg[arg[2]] + ('0' if dtypes.is_float(arg[2]) else '12') if arg[2] is not None else rtor[vin[1].nm])
       if arg[2] is not None: ins.append(f"fcvt{'zs' if arg[2] not in [dtypes.half, dtypes.double] else '' } {reg_out}, {rtor[vin[1].nm]}")


### PR DESCRIPTION
broadcasting using CI=1 ARM64=1 CLANG=1 was incorrect since the stored values were shifted depending on dtype. When the assembler copied the tensor into the broadcasted array it would do so incorrectly because of this shift. This error would only occur when the broadcasted array shape was a multiple of 4. By default int32 was shifting by #0 so I removed the shift condition and all the tests passing again.

these are the tests I ran below:
```
CI=1 ARM64=1 CLANG=1 python -m pytest -n=auto test/ -k 'not (test_nn.py and (test_conv_transpose2d or test_conv2d))' --ignore=test/models --ignore=test/test_speed_v_torch.py --ignore=test/test_net_speed.py --ignore=test/test_specific_conv.py  --ignore=test/unit/test_disk_tensor.py
```