### PR TITLE
add hip kernel disk cache

### DIFF
--- a/extra/hip_wrapper.py
+++ b/extra/hip_wrapper.py
@@ -1,5 +1,6 @@
 import ctypes
 import sys
+from typing import Tuple
 
 try:
   _libhip = ctypes.cdll.LoadLibrary('libamdhip64.so')
@@ -605,3 +606,14 @@ def hiprtcGetCode(prog) -> bytes:
   status = _libhiprtc.hiprtcGetCode(prog, e_code)
   hipCheckStatus(status)
   return e_code
+
+_libhiprtc.hiprtcVersion.restype = int
+_libhiprtc.hiprtcVersion.argtypes = [ctypes.POINTER(ctypes.c_int),   # major
+                                     ctypes.POINTER(ctypes.c_int)]  # minor
+
+def hiprtcVersion() -> Tuple[int, int]:
+  major = ctypes.c_int()
+  minor = ctypes.c_int()
+  status = _libhiprtc.hiprtcVersion(ctypes.byref(major), ctypes.byref(minor))
+  hipCheckStatus(status)
+  return (major.value, minor.value)

--- a/extra/hip_wrapper.py
+++ b/extra/hip_wrapper.py
@@ -596,7 +596,7 @@ _libhiprtc.hiprtcGetCode.argtypes = [ctypes.c_void_p,               # hiprtcProg
                                      ctypes.POINTER(ctypes.c_char)]  # log
 
 
-def hiprtcGetCode(prog):
+def hiprtcGetCode(prog) -> bytes:
   code_size = ctypes.c_size_t()
   status = _libhiprtc.hiprtcGetCodeSize(prog, ctypes.byref(code_size))
   hipCheckStatus(status)

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -50,7 +50,7 @@ class HIPProgram:
           hip.hiprtcCompileProgram(prog, [f'--offload-arch={device_properties.gcnArchName}'])
           prg = hip.hiprtcGetCode(prog)
           os.makedirs(hip_cache_dir(), exist_ok=True)
-          prg_cache_path_tmp = prg_cache_path + ".tmp"
+          prg_cache_path_tmp = prg_cache_path + f".tmp.{os.getpid()}"
           with open(prg_cache_path_tmp, "wb") as f:
             f.write(prg)
           os.rename(prg_cache_path_tmp, prg_cache_path)

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -2,6 +2,7 @@ import numpy as np
 import ctypes, functools
 import os
 import hashlib
+from typing import Union
 import extra.hip_wrapper as hip
 from tinygrad.helpers import DEBUG
 from tinygrad.ops import Compiled
@@ -30,9 +31,9 @@ class RawHIPBuffer(RawBufferCopyInOut):
   def _copyout(self, x:np.ndarray): hip.hipMemcpy_dtoh(x.ctypes.data, self._buf, self.size * self.dtype.itemsize)
 
 class HIPProgram:
-  def __init__(self, name:str, prg:str, binary=False):
+  def __init__(self, name:str, prg:Union[str, bytes]):
     try:
-      if not binary:
+      if isinstance(prg, str):
         prg_hash = str(hashlib.sha256(prg.encode()).digest())
         prg_cache_path = os.path.join(HIP_CACHE_DIR, prg_hash)
         if os.path.exists(prg_cache_path):

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -17,7 +17,7 @@ if DEBUG >= 5:
 
 # The default HIP stream is used for everything.
 
-@functools.cache
+@functools.lru_cache
 def hip_cache_dir():
   version = hip.hiprtcVersion()
   cache_dir_base = os.path.expanduser("~/.cache/tinygrad-hip")

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -50,8 +50,10 @@ class HIPProgram:
           hip.hiprtcCompileProgram(prog, [f'--offload-arch={device_properties.gcnArchName}'])
           prg = hip.hiprtcGetCode(prog)
           os.makedirs(hip_cache_dir(), exist_ok=True)
-          with open(prg_cache_path, "wb") as f:
+          prg_cache_path_tmp = prg_cache_path + ".tmp"
+          with open(prg_cache_path_tmp, "wb") as f:
             f.write(prg)
+          os.rename(prg_cache_path_tmp, prg_cache_path)
     except Exception as e:
       if DEBUG >= 3: print("FAILED TO BUILD", prg)
       raise e


### PR DESCRIPTION
Add simple hip kernel cache based on the sha256 of the source. Put hip version in cache path to try to rebuild if rocm version changes.

```
(venv) ➜  tinygrad git:(hip-cache) time HIP=1 HALF=1 DEBUG=2 python3 extra/gemm/simple_matmul.py
***    0 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/   0.00G  mem  0.13 GB tm   2185.70us/     2.19ms (62881.06 GFLOPS,   61.41 GB/s)
***    1 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 137.44G  mem  0.20 GB tm   5763.91us/     7.95ms (23844.73 GFLOPS,   23.29 GB/s)
***    2 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 274.88G  mem  0.20 GB tm   3247.80us/    11.20ms (42317.54 GFLOPS,   41.33 GB/s)
***    3 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 412.32G  mem  0.20 GB tm   2528.54us/    13.73ms (54355.02 GFLOPS,   53.08 GB/s)
***    4 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 549.76G  mem  0.20 GB tm   2412.38us/    16.14ms (56972.33 GFLOPS,   55.64 GB/s)
***    5 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 687.19G  mem  0.20 GB tm   2670.57us/    18.81ms (51464.22 GFLOPS,   50.26 GB/s)
***    6 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 824.63G  mem  0.20 GB tm   2626.93us/    21.44ms (52319.17 GFLOPS,   51.09 GB/s)
***    7 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 962.07G  mem  0.20 GB tm   2474.51us/    23.91ms (55541.87 GFLOPS,   54.24 GB/s)
***    8 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/1099.51G  mem  0.20 GB tm   2310.87us/    26.22ms (59475.01 GFLOPS,   58.08 GB/s)
***    9 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/1236.95G  mem  0.20 GB tm   2583.85us/    28.81ms (53191.49 GFLOPS,   51.94 GB/s)
0.10673287
avg: 47713.46 GFLOPS    46.60 GB/s           total:    10 kernels  1374.39 GOPS     1.34 GB    28.81 ms
HIP=1 HALF=1 DEBUG=2 python3 extra/gemm/simple_matmul.py  3.64s user 3.00s system 551% cpu 1.202 total
(venv) ➜  tinygrad git:(hip-cache) rm -rf ~/.cache/tinygrad-hip
(venv) ➜  tinygrad git:(hip-cache) time HIP=1 HALF=1 DEBUG=2 python3 extra/gemm/simple_matmul.py
***    0 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/   0.00G  mem  0.13 GB tm   2161.65us/     2.16ms (63580.66 GFLOPS,   62.09 GB/s)
***    1 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 137.44G  mem  0.20 GB tm   2832.56us/     4.99ms (48521.18 GFLOPS,   47.38 GB/s)
***    2 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 274.88G  mem  0.20 GB tm   2538.63us/     7.53ms (54138.98 GFLOPS,   52.87 GB/s)
***    3 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 412.32G  mem  0.20 GB tm   2626.31us/    10.16ms (52331.52 GFLOPS,   51.11 GB/s)
***    4 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 549.76G  mem  0.20 GB tm   2464.35us/    12.62ms (55770.85 GFLOPS,   54.46 GB/s)
***    5 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 687.19G  mem  0.20 GB tm   2535.27us/    15.16ms (54210.74 GFLOPS,   52.94 GB/s)
***    6 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 824.63G  mem  0.20 GB tm   2670.37us/    17.83ms (51468.06 GFLOPS,   50.26 GB/s)
***    7 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/ 962.07G  mem  0.20 GB tm   2580.01us/    20.41ms (53270.66 GFLOPS,   52.02 GB/s)
***    8 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/1099.51G  mem  0.20 GB tm   2468.83us/    22.88ms (55669.63 GFLOPS,   54.36 GB/s)
***    9 r_64_64_2_2_8_256_16_8_4_4        arg   3 sz [64, 64]           [8, 2, 2]    OPs 137438M/1236.95G  mem  0.20 GB tm   2499.84us/    25.38ms (54979.06 GFLOPS,   53.69 GB/s)
-0.06592194
avg: 54157.09 GFLOPS    52.89 GB/s           total:    10 kernels  1374.39 GOPS     1.34 GB    25.38 ms
HIP=1 HALF=1 DEBUG=2 python3 extra/gemm/simple_matmul.py  4.59s user 2.31s system 333% cpu 2.073 total
```