### PR TITLE
add generic kernel cache

### DIFF
--- a/extra/hip_wrapper.py
+++ b/extra/hip_wrapper.py
@@ -1,5 +1,6 @@
 import ctypes
 import sys
+from typing import Tuple
 
 try:
   _libhip = ctypes.cdll.LoadLibrary('libamdhip64.so')
@@ -605,3 +606,14 @@ def hiprtcGetCode(prog) -> bytes:
   status = _libhiprtc.hiprtcGetCode(prog, e_code)
   hipCheckStatus(status)
   return e_code
+
+_libhiprtc.hiprtcVersion.restype = int
+_libhiprtc.hiprtcVersion.argtypes = [ctypes.POINTER(ctypes.c_int),   # major
+                                     ctypes.POINTER(ctypes.c_int)]  # minor
+
+def hiprtcVersion() -> Tuple[int, int]:
+  major = ctypes.c_int()
+  minor = ctypes.c_int()
+  status = _libhiprtc.hiprtcVersion(ctypes.byref(major), ctypes.byref(minor))
+  hipCheckStatus(status)
+  return (major.value, minor.value)

--- a/extra/hip_wrapper.py
+++ b/extra/hip_wrapper.py
@@ -596,7 +596,7 @@ _libhiprtc.hiprtcGetCode.argtypes = [ctypes.c_void_p,               # hiprtcProg
                                      ctypes.POINTER(ctypes.c_char)]  # log
 
 
-def hiprtcGetCode(prog):
+def hiprtcGetCode(prog) -> bytes:
   code_size = ctypes.c_size_t()
   status = _libhiprtc.hiprtcGetCodeSize(prog, ctypes.byref(code_size))
   hipCheckStatus(status)

--- a/test/test_runtime_lib.py
+++ b/test/test_runtime_lib.py
@@ -1,0 +1,26 @@
+import unittest
+import uuid
+import hashlib
+from tinygrad.runtime.lib import compile_cache, mktemp_clean
+
+class TestCache(unittest.TestCase):
+  compile_call_count = 0
+  
+  @compile_cache("test", str(uuid.uuid4()))
+  def compile(self, name:str, prg:str, binary:bool=False, extension:str=""):
+    self.compile_call_count += 1
+    return hashlib.sha256(prg.encode()).digest()
+  
+  def test_compile_cache(self):
+    prg1 = "example prg1 contents"
+    prg2 = "example prg2 contents"
+    cold_compile_res = self.compile("program", prg1)
+    warm_compile_res = self.compile("program", prg1)
+    assert len(cold_compile_res) > 0
+    assert cold_compile_res == warm_compile_res
+    assert self.compile_call_count == 1
+
+    prg2_res = self.compile("program", prg2)
+    self.compile("program", prg2)
+    assert len(prg2_res) > 0
+    assert self.compile_call_count == 2

--- a/test/test_runtime_lib.py
+++ b/test/test_runtime_lib.py
@@ -5,12 +5,10 @@ from tinygrad.runtime.lib import compile_cache, mktemp_clean
 
 class TestCache(unittest.TestCase):
   compile_call_count = 0
-  
   @compile_cache("test", str(uuid.uuid4()))
   def compile(self, name:str, prg:str, binary:bool=False, extension:str=""):
     self.compile_call_count += 1
     return hashlib.sha256(prg.encode()).digest()
-  
   def test_compile_cache(self):
     prg1 = "example prg1 contents"
     prg2 = "example prg2 contents"

--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -1,8 +1,12 @@
 import ctypes
 import numpy as np
 from collections import defaultdict, deque
-from typing import TypeVar, Type, Any, Dict, Deque, Tuple
+from typing import TypeVar, Type, Any, Dict, Deque, Tuple, Optional
+import abc
+import hashlib
+import os
 from tinygrad.helpers import DType, dtypes, prod, GlobalCounters, ImageDType
+from tinygrad.helpers import DEBUG
 
 _T = TypeVar("_T")
 class RawBuffer:  # pylint: disable=abstract-method
@@ -109,3 +113,36 @@ class LRUAllocator:
   def _cached_bufkey(self, size, dtype, device) -> Tuple[int, ...]: return (device, size, dtype, dtype.shape) if isinstance(dtype, ImageDType) else (device, size, dtype) # Provides a key for reusing device buffers with identical keys.
   def _do_alloc(self, size, dtype, device, **kwargs): raise NotImplementedError("must be implemented")
   def _do_free(self, buf): pass
+
+class CachedProgram(abc.ABC):
+  def __init__(self, name:str, prg:str, binary:bool=False,extension:str=""):
+    prg_hash = hashlib.sha256(prg.encode()).digest().hex()
+    cache_dir_base = os.path.expanduser("~/.cache/tinygrad-programs")
+    cache_dir = os.path.join(cache_dir_base, self.toolchain_hash())
+    self.bin_cache_path = os.path.join(cache_dir, prg_hash)
+    if extension != "":
+      self.bin_cache_path = f"{self.bin_cache_path}.{extension}"
+    if os.path.exists(self.bin_cache_path):
+      if DEBUG >= 5: print(f"loading {name} from cache")
+    else:
+      self.bin_cache_path_tmp = self.bin_cache_path + f".tmp.{os.getpid()}"
+      # temporary file for programs that need to run an assembler
+      self.bin_cache_path_tmp_as = self.bin_cache_path + f".tmp.{os.getpid()}.1"
+      os.makedirs(cache_dir, exist_ok=True)
+      bin = self.compile(name, prg, binary=binary)
+      if bin:  
+        with open(self.bin_cache_path_tmp, "wb") as f:
+          f.write(bin)
+      os.rename(self.bin_cache_path_tmp, self.bin_cache_path)
+      if os.path.exists(self.bin_cache_path_tmp_as):
+        os.remove(self.bin_cache_path_tmp_as)
+  def bin(self) -> bytes:
+    with open(self.bin_cache_path, "rb") as f:
+      return f.read()
+  @abc.abstractmethod
+  def compile(self, name: str, prg: str, binary:bool=False) -> Optional[bytes]:
+    ...
+  @staticmethod
+  @abc.abstractmethod
+  def toolchain_hash() -> str:
+    ...

--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -117,15 +117,13 @@ class LRUAllocator:
 def compile_cache(prefix:str, toolchain_hash:str):
   cache_dir_base = os.path.expanduser("~/.cache/tinygrad-programs")
   cache_dir = os.path.join(cache_dir_base, f"{prefix}-{toolchain_hash}")
+  os.makedirs(cache_dir, exist_ok=True)
   def compile_cache_1(func):
     def compile_cache_2(self, name:str, prg:str, binary:bool=False, extension:str="") -> str:
       prg_hash = hashlib.sha256(prg.encode()).digest().hex()
-      bin_cache_path = os.path.join(cache_dir, prg_hash)
-      if extension:
-        bin_cache_path = f"{bin_cache_path}.{extension}"
+      bin_cache_path = os.path.join(cache_dir, prg_hash + extension)
       if not os.path.exists(bin_cache_path):
         bin_cache_path_tmp = bin_cache_path + f".tmp.{os.getpid()}"
-        os.makedirs(cache_dir, exist_ok=True)
         res = func(self, name, prg, binary=binary)
         with open(bin_cache_path_tmp, "wb") as f:
           f.write(res)

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -1,8 +1,8 @@
 import time, ctypes, hashlib, subprocess, platform, functools
-from functools import partial, reduce, lru_cache
+from functools import partial, reduce
 from tinygrad.ops import Compiled
 from tinygrad.helpers import fromimport, getenv, DEBUG, CI
-from tinygrad.runtime.lib import CachedProgram, RawMallocBuffer
+from tinygrad.runtime.lib import RawMallocBuffer, compile_cache, mktemp_clean
 from tinygrad.codegen.linearizer import LinearizerOptions
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 import struct
@@ -20,6 +20,13 @@ args = {
 CLANG_PROGRAM_HEADER = '#include <math.h>\n#define max(x,y) ((x>y)?x:y)\n#define int64 long\n#define half __fp16\n#define uchar unsigned char\n#define bool uchar\n'
 ADDRESS = 0x10000
 
+def toolchain_hash():
+  version_cmd = "clang --version"
+  if ARM64:
+    version_cmd = "aarch64-linux-gnu-as --version"
+  version_hash = hashlib.sha256(subprocess.check_output(args=(version_cmd).split())).digest().hex()
+  return f"clang-{version_hash}"
+
 # Unicorn doesn't support external calls
 def align(addr): return (addr+4095) & ~(4095)
 mock_lm = {"sinf": np.sin, "sqrtf": np.sqrt, "exp2f": np.exp2, "log2f": np.log2}
@@ -27,44 +34,43 @@ def emulate_ext_calls(fn, uc, address, size, user_data):
   s_in = struct.unpack('f', struct.pack('I', uc.reg_read(getattr(arm64_const, f'UC_ARM64_REG_S{fn[2][1:]}'))))[0]
   uc.reg_write(getattr(arm64_const, f'UC_ARM64_REG_S{fn[1][1:]}'), struct.unpack('I', struct.pack('f', mock_lm[fn[0]](s_in)))[0])  # type: ignore
 
-class ClangProgram(CachedProgram):
+class ClangProgram():
   def __init__(self, name:str, prg:str, binary:bool=False):
     if binary and DEBUG >= 5: print(prg)
     extension = args['ext'] if not binary else 'bin'
-    CachedProgram.__init__(self, name, prg, binary=binary, extension=extension)
+    bin_path = self.compile(name, prg, binary=binary, extension=extension)
     if binary and CI and ARM64:
       prg_lines = prg.split('\n')
       self.varsize = align(int(prg_lines[0].split(" ")[1]))
       self.ext_calls = {(i*4+ADDRESS):ins.split(" ")[1:] for i, ins in enumerate(filter(lambda ins: ins[:4] != 'loop', prg_lines[6:-3])) if ins[:2] == 'bl'}
-      with open(self.bin_cache_path, "rb") as f:
+      with open(bin_path, "rb") as f:
         self.prg = f.read()
     else:
-      self.lib = ctypes.CDLL(self.bin_cache_path)
+      self.lib = ctypes.CDLL(bin_path)
       self.fxn = self.lib[name]
-  def compile(self, name:str, prg:str, binary:bool=False):
+  @compile_cache("hip",toolchain_hash())
+  def compile(self, name:str, prg:str, binary:bool=False, extension:str=""):
     # TODO: is there a way to not write this to disk?
     # A: it seems there isn't https://stackoverflow.com/questions/28053328/ctypes-cdll-load-library-from-memory-rather-than-file
     #    because ctypes.CDLL() calls dlopen (POSIX) or LoadLibrary (Windows) which require a file
     if not binary:
       prg = CLANG_PROGRAM_HEADER + prg
-      subprocess.check_output(args=('clang -shared -O2 -Wall -Werror -x c '+args['cflags']+' - -o '+self.bin_cache_path_tmp).split(), input=prg.encode('utf-8'))
+      with mktemp_clean() as path:
+        subprocess.check_output(args=('clang -shared -O2 -Wall -Werror -x c '+args['cflags']+' - -o '+path).split(), input=prg.encode('utf-8'))
+        with open(path, "rb") as f:
+          return f.read()
     else:
-      if CI and ARM64:
-        prg_lines = prg.split('\n')
-        prg = "\n".join(['nop' if ins[:2] == 'bl' else ins for ins in prg_lines[6:-3]] + ['\n'])
-        subprocess.check_output(args=(f'aarch64-linux-gnu-as -o {self.bin_cache_path_tmp_as}').split(), input=prg.encode('utf-8'))
-        subprocess.check_output(args=(f'aarch64-linux-gnu-objcopy -O binary --only-section=.text {self.bin_cache_path_tmp_as} {self.bin_cache_path_tmp}').split())
-      else:
-        subprocess.check_output(args=(f'as -o {self.bin_cache_path_tmp_as}').split(), input=prg.encode('utf-8'))
-        subprocess.check_output(args=(f'clang -lm -shared {self.bin_cache_path_tmp_as} {self.bin_cache_path}').split())
-  @staticmethod
-  @lru_cache
-  def toolchain_hash():
-    version_cmd = "clang --version"
-    if ARM64:
-      version_cmd = "aarch64-linux-gnu-as --version"
-    version_hash = hashlib.sha256(subprocess.check_output(args=(version_cmd).split())).digest().hex()
-    return f"clang-{version_hash}"
+      with mktemp_clean() as as_path, mktemp_clean() as final_path:
+        if CI and ARM64:
+          prg_lines = prg.split('\n')
+          prg = "\n".join(['nop' if ins[:2] == 'bl' else ins for ins in prg_lines[6:-3]] + ['\n'])
+          subprocess.check_output(args=(f'aarch64-linux-gnu-as -o {as_path}').split(), input=prg.encode('utf-8'))
+          subprocess.check_output(args=(f'aarch64-linux-gnu-objcopy -O binary --only-section=.text {as_path} {final_path}').split())
+        else:
+          subprocess.check_output(args=(f'as -o {as_path}').split(), input=prg.encode('utf-8'))
+          subprocess.check_output(args=(f'clang -lm -shared {as_path} {final_path}').split())
+        with open(final_path, "rb") as f:
+          return f.read()
   def __call__(self, global_size, local_size, *args, wait=False):
     if wait: st = time.monotonic()
     if CI and ARM64:

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -1,8 +1,8 @@
-import os, time, ctypes, hashlib, subprocess, platform, tempfile, functools
-from functools import partial, reduce
+import time, ctypes, hashlib, subprocess, platform, functools
+from functools import partial, reduce, lru_cache
 from tinygrad.ops import Compiled
 from tinygrad.helpers import fromimport, getenv, DEBUG, CI
-from tinygrad.runtime.lib import RawMallocBuffer
+from tinygrad.runtime.lib import CachedProgram, RawMallocBuffer
 from tinygrad.codegen.linearizer import LinearizerOptions
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 import struct
@@ -27,33 +27,44 @@ def emulate_ext_calls(fn, uc, address, size, user_data):
   s_in = struct.unpack('f', struct.pack('I', uc.reg_read(getattr(arm64_const, f'UC_ARM64_REG_S{fn[2][1:]}'))))[0]
   uc.reg_write(getattr(arm64_const, f'UC_ARM64_REG_S{fn[1][1:]}'), struct.unpack('I', struct.pack('f', mock_lm[fn[0]](s_in)))[0])  # type: ignore
 
-class ClangProgram:
+class ClangProgram(CachedProgram):
   def __init__(self, name:str, prg:str, binary:bool=False):
+    if binary and DEBUG >= 5: print(prg)
+    extension = args['ext'] if not binary else 'bin'
+    CachedProgram.__init__(self, name, prg, binary=binary, extension=extension)
+    if binary and CI and ARM64:
+      prg_lines = prg.split('\n')
+      self.varsize = align(int(prg_lines[0].split(" ")[1]))
+      self.ext_calls = {(i*4+ADDRESS):ins.split(" ")[1:] for i, ins in enumerate(filter(lambda ins: ins[:4] != 'loop', prg_lines[6:-3])) if ins[:2] == 'bl'}
+      with open(self.bin_cache_path, "rb") as f:
+        self.prg = f.read()
+    else:
+      self.lib = ctypes.CDLL(self.bin_cache_path)
+      self.fxn = self.lib[name]
+  def compile(self, name:str, prg:str, binary:bool=False):
     # TODO: is there a way to not write this to disk?
     # A: it seems there isn't https://stackoverflow.com/questions/28053328/ctypes-cdll-load-library-from-memory-rather-than-file
     #    because ctypes.CDLL() calls dlopen (POSIX) or LoadLibrary (Windows) which require a file
-    fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.{args['ext']}"
-    if binary and DEBUG >= 5: print(prg)
-    if not os.path.exists(fn):
-      tmp = f"{fn}.{os.getpid()}.tmp"
-      if not binary:
-        prg = CLANG_PROGRAM_HEADER + prg
-        subprocess.check_output(args=('clang -shared -O2 -Wall -Werror -x c '+args['cflags']+' - -o '+tmp).split(), input=prg.encode('utf-8'))
-        os.rename(tmp, fn)
+    if not binary:
+      prg = CLANG_PROGRAM_HEADER + prg
+      subprocess.check_output(args=('clang -shared -O2 -Wall -Werror -x c '+args['cflags']+' - -o '+self.bin_cache_path_tmp).split(), input=prg.encode('utf-8'))
+    else:
+      if CI and ARM64:
+        prg_lines = prg.split('\n')
+        prg = "\n".join(['nop' if ins[:2] == 'bl' else ins for ins in prg_lines[6:-3]] + ['\n'])
+        subprocess.check_output(args=(f'aarch64-linux-gnu-as -o {self.bin_cache_path_tmp_as}').split(), input=prg.encode('utf-8'))
+        subprocess.check_output(args=(f'aarch64-linux-gnu-objcopy -O binary --only-section=.text {self.bin_cache_path_tmp_as} {self.bin_cache_path_tmp}').split())
       else:
-        if CI and ARM64:
-          prg = prg.split('\n') # type: ignore
-          self.varsize = align(int(prg[0].split(" ")[1]))
-          self.ext_calls = {(i*4+ADDRESS):ins.split(" ")[1:] for i, ins in enumerate(filter(lambda ins: ins[:4] != 'loop', prg[6:-3])) if ins[:2] == 'bl'}
-          prg = "\n".join(['nop' if ins[:2] == 'bl' else ins for ins in prg[6:-3]] + ['\n'])
-          subprocess.check_output(args=('aarch64-linux-gnu-as -o '+tmp).split(), input=prg.encode('utf-8'))
-          subprocess.check_output(args=('aarch64-linux-gnu-objcopy -O binary --only-section=.text '+tmp+' '+fn+'.bin').split())
-          self.prg = open(fn + '.bin', 'rb').read()
-          return
-        subprocess.check_output(args=('as -o' + tmp).split(), input=prg.encode('utf-8'))
-        subprocess.check_output(args=('clang -lm -shared '+tmp+' -o'+fn).split())
-    self.lib = ctypes.CDLL(fn)
-    self.fxn = self.lib[name]
+        subprocess.check_output(args=(f'as -o {self.bin_cache_path_tmp_as}').split(), input=prg.encode('utf-8'))
+        subprocess.check_output(args=(f'clang -lm -shared {self.bin_cache_path_tmp_as} {self.bin_cache_path}').split())
+  @staticmethod
+  @lru_cache
+  def toolchain_hash():
+    version_cmd = "clang --version"
+    if ARM64:
+      version_cmd = "aarch64-linux-gnu-as --version"
+    version_hash = hashlib.sha256(subprocess.check_output(args=(version_cmd).split())).digest().hex()
+    return f"clang-{version_hash}"
   def __call__(self, global_size, local_size, *args, wait=False):
     if wait: st = time.monotonic()
     if CI and ARM64:

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -50,7 +50,7 @@ class HIPProgram:
           hip.hiprtcCompileProgram(prog, [f'--offload-arch={device_properties.gcnArchName}'])
           prg = hip.hiprtcGetCode(prog)
           os.makedirs(hip_cache_dir(), exist_ok=True)
-          prg_cache_path_tmp = prg_cache_path + ".tmp"
+          prg_cache_path_tmp = prg_cache_path + f".tmp.{os.getpid()}"
           with open(prg_cache_path_tmp, "wb") as f:
             f.write(prg)
           os.rename(prg_cache_path_tmp, prg_cache_path)

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -2,6 +2,7 @@ import numpy as np
 import ctypes, functools
 import os
 import hashlib
+from typing import Union
 import extra.hip_wrapper as hip
 from tinygrad.helpers import DEBUG
 from tinygrad.ops import Compiled
@@ -30,9 +31,9 @@ class RawHIPBuffer(RawBufferCopyInOut):
   def _copyout(self, x:np.ndarray): hip.hipMemcpy_dtoh(x.ctypes.data, self._buf, self.size * self.dtype.itemsize)
 
 class HIPProgram:
-  def __init__(self, name:str, prg:str, binary=False):
+  def __init__(self, name:str, prg:Union[str, bytes]):
     try:
-      if not binary:
+      if isinstance(prg, str):
         prg_hash = str(hashlib.sha256(prg.encode()).digest())
         prg_cache_path = os.path.join(HIP_CACHE_DIR, prg_hash)
         if os.path.exists(prg_cache_path):

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -17,7 +17,7 @@ if DEBUG >= 5:
 
 # The default HIP stream is used for everything.
 
-@functools.cache
+@functools.lru_cache
 def hip_cache_dir():
   version = hip.hiprtcVersion()
   cache_dir_base = os.path.expanduser("~/.cache/tinygrad-hip")

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -50,8 +50,10 @@ class HIPProgram:
           hip.hiprtcCompileProgram(prog, [f'--offload-arch={device_properties.gcnArchName}'])
           prg = hip.hiprtcGetCode(prog)
           os.makedirs(hip_cache_dir(), exist_ok=True)
-          with open(prg_cache_path, "wb") as f:
+          prg_cache_path_tmp = prg_cache_path + ".tmp"
+          with open(prg_cache_path_tmp, "wb") as f:
             f.write(prg)
+          os.rename(prg_cache_path_tmp, prg_cache_path)
     except Exception as e:
       if DEBUG >= 3: print("FAILED TO BUILD", prg)
       raise e


### PR DESCRIPTION
Add a generic version of #1577. Should be pretty easy to expand to metal too. The `compile` method must return the bytes of the program binary. `compile_cache` decorator returns a path to that binary.