### PR TITLE
sparse cat cross entropy

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -121,7 +121,7 @@ net = TinyNet()
 ```
 
 We can see that the forward pass of our neural network is just the sequence of operations performed on the input tensor `x`.
-We can also see that functional operation like `leakyrelu` is not defined as a class and instead is just a method we can just call.
+We can also see that functional operations like `leakyrelu` are not defined as classes and instead are just methods we can just call.
 Finally, we just initialize an instance of our neural network, and we are ready to start training it.
 
 ## Training

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -115,13 +115,13 @@ class TinyNet:
     x = self.l1(x)
     x = x.leakyrelu()
     x = self.l2(x)
-    return x.log_softmax()
+    return x
 
 net = TinyNet()
 ```
 
 We can see that the forward pass of our neural network is just the sequence of operations performed on the input tensor `x`.
-We can also see that functional operations like `leakyrelu` and `log_softmax` are not defined as classes and instead are just methods we can just call.
+We can also see that functional operation like `leakyrelu` is not defined as a class and instead is just a method we can just call.
 Finally, we just initialize an instance of our neural network, and we are ready to start training it.
 
 ## Training
@@ -148,7 +148,7 @@ def sparse_categorical_crossentropy(out, Y, ignore_index=-1):
   y = (y_counter == Y.flatten().reshape(-1, 1)).where(-1.0, 0) 
   y = y * loss_mask.reshape(-1, 1)
   y = y.reshape(*Y.shape, num_classes)
-  return out.mul(y).sum() / loss_mask.sum()
+  return out.log_softmax().mul(y).sum() / loss_mask.sum()
 ```
 
 As we can see in this implementation of cross entropy loss, there are certain operations that tinygrad does not support.

--- a/examples/serious_mnist.py
+++ b/examples/serious_mnist.py
@@ -8,7 +8,7 @@ from tinygrad.nn import BatchNorm2d, optim
 from tinygrad.helpers import getenv
 from extra.datasets import fetch_mnist
 from extra.augment import augment_img
-from extra.training import train, evaluate, sparse_categorical_crossentropy
+from extra.training import train, evaluate
 GPU = getenv("GPU")
 QUICK = getenv("QUICK")
 DEBUG = getenv("DEBUG")
@@ -102,7 +102,7 @@ if __name__ == "__main__":
   BS = 32
 
   lmbd = 0.00025
-  lossfn = lambda out,y: sparse_categorical_crossentropy(out, y) + lmbd*(model.weight1.abs() + model.weight2.abs()).sum()
+  lossfn = lambda out,y: out.sparse_categorical_crossentropy(y) + lmbd*(model.weight1.abs() + model.weight2.abs()).sum()
   X_train, Y_train, X_test, Y_test = fetch_mnist()
   X_train = X_train.reshape(-1, 28, 28).astype(np.uint8)
   X_test = X_test.reshape(-1, 28, 28).astype(np.uint8)

--- a/examples/serious_mnist.py
+++ b/examples/serious_mnist.py
@@ -93,7 +93,7 @@ class BigConvNet:
     x1 = x.avg_pool2d(kernel_size=(14,14)).reshape(shape=(-1,128)) #global
     x2 = x.max_pool2d(kernel_size=(14,14)).reshape(shape=(-1,128)) #global
     xo = x1.dot(self.weight1) + x2.dot(self.weight2)
-    return xo.log_softmax()
+    return xo
 
 
 if __name__ == "__main__":

--- a/extra/training.py
+++ b/extra/training.py
@@ -24,7 +24,7 @@ def train(model, X_train, Y_train, optim, steps, BS=128, lossfn=lambda out,y: ou
     # printing
     if not noloss:
       cat = np.argmax(out.numpy(), axis=-1)
-      accuracy = (cat == y).mean()
+      accuracy = (cat == y.numpy()).mean()
 
       loss = loss.detach().numpy()
       losses.append(loss)

--- a/extra/training.py
+++ b/extra/training.py
@@ -3,24 +3,14 @@ from tqdm import trange
 from tinygrad.tensor import Tensor, Device
 from tinygrad.helpers import getenv
 
-def sparse_categorical_crossentropy(out, Y):
-  num_classes = out.shape[-1]
-  YY = Y.flatten().astype(np.int32)
-  y = np.zeros((YY.shape[0], num_classes), np.float32)
-  # correct loss for NLL, torch NLL loss returns one per row
-  y[range(y.shape[0]),YY] = -1.0*num_classes
-  y = y.reshape(list(Y.shape)+[num_classes])
-  y = Tensor(y)
-  return out.mul(y).mean()
-
-def train(model, X_train, Y_train, optim, steps, BS=128, lossfn=sparse_categorical_crossentropy,
+def train(model, X_train, Y_train, optim, steps, BS=128, lossfn=lambda out,y: out.sparse_categorical_crossentropy(y),
         transform=lambda x: x, target_transform=lambda x: x, noloss=False):
   Tensor.training = True
   losses, accuracies = [], []
   for i in (t := trange(steps, disable=getenv('CI', False))):
     samp = np.random.randint(0, X_train.shape[0], size=(BS))
     x = Tensor(transform(X_train[samp]), requires_grad=False)
-    y = target_transform(Y_train[samp])
+    y = Tensor(target_transform(Y_train[samp]))
 
     # network
     out = model.forward(x) if hasattr(model, 'forward') else model(x)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12,6 +12,17 @@ import pytest
 pytestmark = [pytest.mark.exclude_cuda]
 
 class TestNN(unittest.TestCase):
+  def test_sparse_cat_cross_entropy(self):
+    input = torch.randn(3, 5)
+    target = torch.empty(3, dtype=torch.long).random_(5)
+    loss_fun = torch.nn.CrossEntropyLoss(reduction='mean')
+    loss = loss_fun(input, target)
+
+    input_tiny = Tensor(input.detach().numpy())
+    taret_tiny = Tensor(target.detach().numpy())
+    loss_tiny = input_tiny.sparse_categorical_crossentropy(taret_tiny)
+
+    np.testing.assert_allclose(loss_tiny.numpy(), loss.detach().numpy(), atol=1e-5, rtol=1e-6)
 
   def test_batchnorm2d(self, training=False):
     szs = [4, 8, 16, 32]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1,8 +1,8 @@
 # inspired by https://github.com/karpathy/micrograd/blob/master/micrograd/engine.py
 from __future__ import annotations
-import time, operator
+import time
 from functools import partialmethod, reduce
-from itertools import accumulate, filterfalse
+from itertools import accumulate
 import numpy as np
 from typing import List, Tuple, Callable, Optional, ClassVar, Type, Union, Sequence, cast
 from math import ceil, pi, prod, sqrt, log, cos, copysign, isinf

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -710,7 +710,7 @@ class Tensor:
 
   def sparse_categorical_crossentropy(self, Y, ignore_index=-1) -> Tensor:
     loss_mask = Y != ignore_index
-    y_counter = Tensor.arange(self.shape[-1], requires_grad=False).unsqueeze(0).expand(Y.numel(), self.shape[-1])
+    y_counter = Tensor.arange(self.shape[-1], requires_grad=False, device=self.device).unsqueeze(0).expand(Y.numel(), self.shape[-1])
     y = ((y_counter == Y.flatten().reshape(-1, 1)).where(-1.0, 0) * loss_mask.reshape(-1, 1)).reshape(*Y.shape, self.shape[-1])
     return self.log_softmax().mul(y).sum() / loss_mask.sum()
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -712,7 +712,7 @@ class Tensor:
     loss_mask = Y != ignore_index
     y_counter = Tensor.arange(self.shape[-1], requires_grad=False).unsqueeze(0).expand(Y.numel(), self.shape[-1])
     y = ((y_counter == Y.flatten().reshape(-1, 1)).where(-1.0, 0) * loss_mask.reshape(-1, 1)).reshape(*Y.shape, self.shape[-1])
-    return self.mul(y).sum() / loss_mask.sum()
+    return self.log_softmax().mul(y).sum() / loss_mask.sum()
 
   # ***** cast ops *****
 


### PR DESCRIPTION
The flat training loss was due to missing the conversion to numpy in `accuracy = (cat == y).mean()`. Saw tests passed so didn't double check. Sorry.
```
loss 2.67 accuracy 0.03: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  8.38it/s]
loss 4.37 accuracy 0.22: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 96.55it/s]
loss 0.09 accuracy 0.98: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:01<00:00, 84.68it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 79/79 [00:00<00:00, 399.35it/s]
test set accuracy is 0.958800
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  9.20it/s]
loss 0.11 accuracy 0.98: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:04<00:00, 49.17it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 79/79 [00:00<00:00, 259.02it/s]
test set accuracy is 0.971700
loss 0.23 accuracy 0.93: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 600/600 [00:03<00:00, 191.01it/s]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 79/79 [00:00<00:00, 1138.75it/s]
test set accuracy is 0.957000
loss 2.49 accuracy 0.17: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 177.65it/s]
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:00<00:00, 226.81it/s]
loss 2.21 accuracy 0.25: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 191.86it/s]
.
----------------------------------------------------------------------
Ran 9 tests in 9.283s
```