### PR TITLE
perf: if argument order (mops)

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -310,7 +310,7 @@ def _push_movement_ops(srcs:Tuple[LazyBuffer, ...]) -> Tuple[LazyBuffer, ...]:
       bx = cast(LazyBuffer, bx.op.src[0])
     # NOTE: can't push pads past anything where f(0, 0) != 0 or f(0) != 0
     unsafe_pad_ops = {BinaryOps.DIV, BinaryOps.CMPLT, UnaryOps.LOG2, UnaryOps.EXP2, UnaryOps.RECIP}
-    if not bx.realized and bx.optype == BinaryOps and len(bx.children) <= 1 and len(mops) and (all(x[0] != MovementOps.PAD for x in mops) or all(x.op not in unsafe_pad_ops for x in bx.op.get_lazyops())):
+    if mops and not bx.realized and bx.optype == BinaryOps and len(bx.children) <= 1 and (all(x[0] != MovementOps.PAD for x in mops) or all(x.op not in unsafe_pad_ops for x in bx.op.get_lazyops())):
       new_srcs.append(bx.op.replace_with_movement_ops(mops[::-1]))
     else:
       new_srcs.append(x)


### PR DESCRIPTION
One of my favourites.

Before

```
Total time: 0.813725 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/lazy.py
Function: _push_movement_ops at line 300

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   300                                           @profile
   301                                           def _push_movement_ops(srcs:Tuple[LazyBuffer, ...]) -> Tuple[LazyBuffer, ...]:
   302     53865      17066.2      0.3      2.1    new_srcs = []
   303     96942      25955.3      0.3      3.2    for x in srcs:
   304     96942      19403.3      0.2      2.4      mops: List[Tuple[MovementOps, Any]] = []
   305     96942      13880.5      0.1      1.7      bx = x
   306                                               # backwalk all the movement ops. don't push PAD or EXPAND
   307     96942      54723.5      0.6      6.7      while not bx.realized and bx.optype == MovementOps and bx.op.op != MovementOps.EXPAND and (SHUFFLE_PAD_OPS or bx.op.op != MovementOps.PAD) and len(bx.children) <= 1:
   308     47766      19821.1      0.4      2.4        assert isinstance(bx.op.op, MovementOps)
   309     47766      24150.7      0.5      3.0        mops.append((bx.op.op, bx.op.arg))
   310     47766      30929.6      0.6      3.8        bx = cast(LazyBuffer, bx.op.src[0])
   311                                               # NOTE: can't push pads past anything where f(0, 0) != 0 or f(0) != 0
   312     96942     229746.6      2.4     28.2      unsafe_pad_ops = {BinaryOps.DIV, BinaryOps.CMPLT, UnaryOps.LOG2, UnaryOps.EXP2, UnaryOps.RECIP}
-->313     93766      60441.9      0.6      7.4      if not bx.realized and bx.optype == BinaryOps and len(bx.children) <= 1 and len(mops) and (all(x[0] != MovementOps.PAD for x in mops) or all(x.op  not in unsafe_pad_ops for x in bx.op.get_lazyops())):
   314      3176     266418.4     83.9     32.7        new_srcs.append(bx.op.replace_with_movement_ops(mops[::-1]))
   315                                               else:
   316     93766      34212.7      0.4      4.2        new_srcs.append(x)
   317     53865      16974.9      0.3      2.1    return tuple(new_srcs)
```

after
```
Total time: 0.720267 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/lazy.py
Function: _push_movement_ops at line 300

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   300                                           @profile
   301                                           def _push_movement_ops(srcs:Tuple[LazyBuffer, ...]) -> Tuple[LazyBuffer, ...]:
   302     53865      13512.1      0.3      1.9    new_srcs = []
   303     96942      24711.2      0.3      3.4    for x in srcs:
   304     96942      17340.4      0.2      2.4      mops: List[Tuple[MovementOps, Any]] = []
   305     96942      13940.4      0.1      1.9      bx = x
   306                                               # backwalk all the movement ops. don't push PAD or EXPAND
   307     96942      52226.4      0.5      7.3      while not bx.realized and bx.optype == MovementOps and bx.op.op != MovementOps.EXPAND and (SHUFFLE_PAD_OPS or bx.op.op != MovementOps.PAD) and len(bx.children) <= 1:
   308     47766      17932.2      0.4      2.5        assert isinstance(bx.op.op, MovementOps)
   309     47766      23198.4      0.5      3.2        mops.append((bx.op.op, bx.op.arg))
   310     47766      30109.9      0.6      4.2        bx = cast(LazyBuffer, bx.op.src[0])
   311                                               # NOTE: can't push pads past anything where f(0, 0) != 0 or f(0) != 0
   312     96942     205588.6      2.1     28.5      unsafe_pad_ops = {BinaryOps.DIV, BinaryOps.CMPLT, UnaryOps.LOG2, UnaryOps.EXP2, UnaryOps.RECIP}
-->313     93766      21233.4      0.2      2.9      if mops and not bx.realized and bx.optype == BinaryOps and len(bx.children) <= 1 and (all(x[0] != MovementOps.PAD for x in mops) or all(x.op not in unsafe_pad_ops for x in bx.op.get_lazyops())):
   314      3176     254019.7     80.0     35.3        new_srcs.append(bx.op.replace_with_movement_ops(mops[::-1]))
   315                                               else:
   316     93766      30831.2      0.3      4.3        new_srcs.append(x)
   317     53865      15623.0      0.3      2.2    return tuple(new_srcs)
````