### PR TITLE
perf: no ret needed

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -188,8 +188,7 @@ class LazyBuffer:
   def toCPU(self):
     assert self.dtype.np, f"{self.dtype} is not supported in toCPU"
     realized = self.cast((dtypes.from_np(self.dtype.np), False)).contiguous().realize().realized
-    ret = cast(RawBuffer, realized).toCPU().reshape(self.shape)
-    return ret
+    return cast(RawBuffer, realized).toCPU().reshape(self.shape)
 
   def cast(self:LazyBuffer, arg:Tuple[DType, bool]) -> LazyBuffer:
     assert not arg[1] or self.dtype.itemsize == arg[0].itemsize, "can't bitcast mismatched dtype itemsizes"


### PR DESCRIPTION
`CPU=1 kernprof -lv pytest -s test/unit`

before
```
Total time: 1.27732 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/lazy.py
Function: toCPU at line 188

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   188                                             @profile
   189                                             def toCPU(self):
   190      2569       1848.9      0.7      0.1      assert self.dtype.np, f"{self.dtype} is not supported in toCPU"
   191      2446    1012422.5    413.9     79.3      realized = self.cast((dtypes.from_np(self.dtype.np), False)).contiguous().realize().realized
   192      2569     262520.3    102.2     20.6      ret = cast(RawBuffer, realized).toCPU().reshape(self.shape)
   193      2569        524.2      0.2      0.0      return ret
```

after:
```
Total time: 1.17143 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/lazy.py
Function: toCPU at line 188

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   188                                             @profile
   189                                             def toCPU(self):
   190      2569       1926.9      0.8      0.2      assert self.dtype.np, f"{self.dtype} is not supported in toCPU"
   191      2446     929674.8    380.1     79.4      realized = self.cast((dtypes.from_np(self.dtype.np), False)).contiguous().realize().realized
   192      2569     239825.5     93.4     20.5      return cast(RawBuffer, realized).toCPU().reshape(self.shape)
````