### PR TITLE
perf: namedtuples are hashable, don't need a key

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -69,8 +69,6 @@ class DType(NamedTuple):
   np: Optional[type]  # TODO: someday this will be removed with the "remove numpy" project
   sz: int = 1
   def __repr__(self): return f"dtypes.{self.name}"
-  @property
-  def key(self): return (self.name)
 
 # dependent typing?
 class ImageDType(DType):

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -130,8 +130,8 @@ class LazyBuffer:
   def __repr__(self): return f"<LB {self.shape} {self.dtype} op={self.op.op if not self.realized else self.realized} st={self.st}>"
   @property
   def key(self):
-    if self.realized: return (self.dtype.key, self.realized.key, self.st.key)
-    return (self.dtype.key, self.op.op, self.st.key)
+    if self.realized: return (self.dtype, self.realized.key, self.st.key)
+    return (self.dtype, self.op.op, self.st.key)
 
   def _device_extra_args(self) -> Dict[str, str]: return {"device": self.device.split(":", 1)[1]} if ":" in self.device else {}
 

--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -18,7 +18,7 @@ class RawBuffer:  # pylint: disable=abstract-method
     if hasattr(self, '_allocator') and self._allocator: self._allocator.free(self._buf)
   def __repr__(self): return f"buffer<{self.size}, {self.dtype}>"
   @property
-  def key(self): return (self.size, self.dtype.key)
+  def key(self): return (self.size, self.dtype)
 
   # NOTE: this interface allows for 0 copy
   @classmethod
@@ -65,7 +65,7 @@ class RawBufferTransfer(RawBuffer):
 class RawConst(RawBuffer): # pylint: disable=abstract-method
   def __repr__(self): return f"const<{self._buf}, {self.dtype}>"
   @property
-  def key(self): return (str(self._buf), self.dtype.key)
+  def key(self): return (str(self._buf), self.dtype)
 
 def buf_is_kernel_arg(x) -> bool:
   return x.realized is not None and x.realized.__class__ is not RawConst


### PR DESCRIPTION
`namedtuple` are like Gondor, they need no key.

The intention is to use this as a key for the LazyCache, so it needs to be hashable. As `namedtuple`, `dtype` is already hashable.

If the `ShapeTracker` where a tuple of views, it would be hashable by itself as well.


`python3.11 -O test/external/external_test_speed_llama.py`
Before

```
codegen         mean runtime:  193.99ms, runs:   229.83,  246.88,  180.52,  176.26,  195.84,  178.55,  184.07,  187.23,  176.50,  184.28
methodcache     mean runtime:  175.20ms, runs:   209.10,  197.53,  162.70,  161.03,  162.69,  188.16,  163.63,  173.66,  167.63,  165.84
profile         mean runtime:  830.36ms, runs:   807.96,  892.16,  756.62,  899.99,  830.83,  803.15,  790.21,  789.10,  852.20,  881.34
```


After
```
codegen         mean runtime:  188.02ms, runs:   185.72,  238.30,  193.68,  176.52,  176.44,  176.48,  181.97,  189.14,  175.11,  186.82
methodcache     mean runtime:  169.99ms, runs:   158.11,  225.25,  166.17,  178.28,  161.48,  167.16,  161.11,  159.78,  161.47,  161.11
profile         mean runtime:  788.67ms, runs:   770.87,  798.12,  804.25,  781.07,  776.63,  750.59,  799.22,  801.23,  775.16,  829.60
```