### PR TITLE
support symbols in shrink and JIT freqs_cis in llama

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -151,15 +151,18 @@ class Transformer:
 
   def __call__(self, tokens:Tensor, start_pos:int):
     _bsz, seqlen = tokens.shape
-    # get only the part we are using.
-    # NOTE: if you remove contiguous here, it breaks because you can't put different ShapeTrackers into the compiled JIT
-    # NOTE: realize is not enough, since the realized buffer will have an offset that the kernel doesn't know about
-    # TODO: check that we didn't do this in the JIT and confirm the ShapeTrackers match the template
-    # TODO: support Variables in shrink
-    freqs_cis = self.freqs_cis[:, start_pos:start_pos+seqlen].contiguous()
     mask = Tensor.full((1, 1, seqlen, start_pos + seqlen), float("-inf"), dtype=dtypes.float32).triu(start_pos+1).realize() if seqlen > 1 else None
-
     do_jit = getenv("JIT") and mask is None
+
+    # get only the part of freqs_cis that we are using.
+    if do_jit:
+      pos = Variable("pos", 1, 1024)
+      assert seqlen == 1, "seqlen > 1 not supported for JIT"
+      freqs_cis = self.freqs_cis.shrink(((0, self.freqs_cis.shape[0]), (pos, pos+seqlen),(0, self.freqs_cis.shape[2]),(0, self.freqs_cis.shape[3]),(0, self.freqs_cis.shape[4])))
+      freqs_cis.lazydata.st.var_vals[pos] = start_pos
+    else:
+      freqs_cis = self.freqs_cis.shrink(((0, self.freqs_cis.shape[0]), (start_pos, start_pos+seqlen),(0, self.freqs_cis.shape[2]),(0, self.freqs_cis.shape[3]),(0, self.freqs_cis.shape[4])))
+
     h = self.jitted_tok_embeddings(tokens) if do_jit else self.tok_embeddings(tokens)
     h = h.sequential([functools.partial(layer, start_pos=start_pos, freqs_cis=freqs_cis, mask=mask) for layer in self.layers])
     return self.jitted_norm_output(h) if do_jit else self.norm_output(h)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -52,6 +52,15 @@ class TestJit(unittest.TestCase):
     with self.assertRaises(AssertionError):
       add(a, bad)
 
+  def test_jit_shape_views_mismatch(self):
+    @TinyJit
+    def add(a): return (a+1).realize()
+    with self.assertRaises(AssertionError):
+      for i in range(1,5):
+        # a has an offset that the kernel doesn't know about
+        a = Tensor.randn(10, 10).realize()[:, i:i+2]
+        add(a)
+
   def test_jit_duplicate_fail(self):
     # the jit doesn't support duplicate arguments
     @TinyJit

--- a/test/test_symbolic_ops.py
+++ b/test/test_symbolic_ops.py
@@ -112,5 +112,15 @@ class TestSymbolicOps(unittest.TestCase):
         expected = f(a, b).numpy()
         np.testing.assert_allclose(symbolic, expected, atol=1e-6, rtol=1e-6)
 
+  def test_shrink(self):
+    vi = Variable("i", 1, 10)
+    for i in range(1, 5):
+      a = Tensor.rand(7, 11)
+      symbolic = a.shrink(((3,5),(vi,vi+2)))
+      symbolic.lazydata.st.var_vals[vi] = i
+      symbolic = symbolic.numpy()
+      expected = a.shrink(((3,5),(i,i+2))).numpy()
+      np.testing.assert_allclose(symbolic, expected, atol=1e-6, rtol=1e-6)
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -127,6 +127,12 @@ class TestSymbolicExpand(unittest.TestCase):
       a = a + 1
       assert a.shape == (3, vi)
 
+class TestSymbolicShrink(unittest.TestCase):
+  def test_shrink_symbols(self):
+    vi = Variable("i", 1, 5)
+    t = Tensor.rand(3, 5).shrink(((0, 2), (vi, vi+1)))
+    assert t.shape == (2, 1)
+
 class TestSymbolicShapeExpr(unittest.TestCase):
   def test_symbolic_expr_idxs(self):
     # taken from symbolic shape llama

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -35,6 +35,7 @@ class Node:
   def __add__(self, b:Union[Node,int]): return Variable.sum([self, b if isinstance(b, Node) else Variable.num(b)])
   def __radd__(self, b:int): return self+b
   def __sub__(self, b:Union[Node,int]): return self+-b
+  def __rsub__(self, b:int): return -self+b
   def __le__(self, b:Union[Node,int]): return self < (b+1)
   def __gt__(self, b:Union[Node,int]): return (-self) < (-b)
   def __ge__(self, b:Union[Node,int]): return (-self) < (-b+1)
@@ -153,6 +154,7 @@ class NumNode(Node):
   def __init__(self, num:int):
     self.b, self.min, self.max = num, num, num
   def __int__(self): return self.b
+  def __index__(self): return self.b
   def __eq__(self, other): return self.b == other
   def __hash__(self): return self.hash  # needed with __eq__ override
 


### PR DESCRIPTION
This jits the `freqs_cis` kernel using `shrink`, and updates the jit to check `ShapeTracker.views` against the cached input. Verified that the old llama failed if we removed contiguous with this check.

Will check for the 5ms thing and jit the new sample (that uses `Tensor.argmax`) in a separate PR.

Assigning variable using `freqs_cis.lazydata.st.var_vals[pos] = start_pos` works, but it feels weird as an API. Another use case that we don't support now is reshape a 2d matrix into (variable, variable) that commavq might want?