### PR TITLE
Comparable performance reports

### DIFF
--- a/extra/perf_report.py
+++ b/extra/perf_report.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import atexit, csv, functools, hashlib, os, subprocess, sys
+from datetime import datetime
+
+from tinygrad.helpers import CI, colored
+from tinygrad.lazy import Device
+
+"""
+How to use:
+
+$ mkdir reports  # after creating the reports directory, every run of test_speed_v_torch.py will produce a new report
+$ SETBASELINE=1 python ./test/test_speed_v_torch.py  # record a baseline. compares to torch.
+$ cat ./reports/latest  # check out the latest report. notice how a git commit hash and git diff are included, for reproducibility
+$ cat ./reports/baseline  # check out the baseline report
+$ #  make some changes to your code...
+$ python ./test/test_speed_v_torch.py  # compares against baseline
+$ RPT=0 python ./test/test_speed_v_torch.py  # compares against torch again (or just rm ./reports/baseline)
+$ python extra/perf_report.py ./reports/baseline ./reports/latest  # compare two reports from command line
+"""
+
+@functools.lru_cache
+def git_info():
+  try:
+    git_hash = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("Latin-1").strip()
+    git_diff = subprocess.check_output(["git", "diff"]).decode("Latin-1").strip()
+  except:
+    print("WARNING: failed to detect git info; will not record in performance report.")
+    if RPT >= 2: raise
+    git_hash, git_diff = None, None
+  return git_hash, git_diff
+
+def capture_env(env_vars):
+  return {k: os.getenv(k, None) for k in env_vars}
+
+def colorize_float(x):
+  ret = f"{x:7.2f}x"
+  if x < 0.75:
+    return colored(ret, "green")
+  elif x > 1.15:
+    return colored(ret, "red")
+  else:
+    return colored(ret, "yellow")
+
+RPT = int(os.getenv("RPT", 1))
+class PerfReport:
+  required_fields = ["name", "device", "et_tinygrad", "flops", "mem"]
+  stratification = ["name", "device"]
+  env_to_capture = ["DEBUG", "KOPT", "OPT"]
+  def __init__(self, perf_data, baseline=None, **metadata):
+    self.perf_data = {PerfReport._stratum(row): row for row in perf_data}
+    self.baseline = baseline
+    self.metadata = metadata
+
+  @staticmethod
+  def _stratum(row): return tuple([row.get(s, None) for s in PerfReport.stratification])
+
+  @staticmethod
+  def new(baseline=None):
+    git_hash, git_diff = git_info()
+    return PerfReport([], baseline=baseline, **capture_env(PerfReport.env_to_capture), git_hash=git_hash, git_diff=git_diff)
+
+  def get_fn(self):
+    fn = datetime.utcnow().strftime("%Y-%m-%d_%H-%M-%S")
+    if "git_hash" in self.metadata and self.metadata["git_hash"] is not None:
+      fn += f"_{self.metadata['git_hash'][:7]}"
+      if "git_diff" in self.metadata and self.metadata["git_diff"]: fn += f"_{hashlib.sha256(self.metadata['git_diff'].encode('Latin-1')).hexdigest()[:4]}"
+
+    return f"{fn}.csv"
+
+  @staticmethod
+  def from_file(fn):
+    with open(fn, newline="") as f: perf_data = list(csv.DictReader(f, delimiter=",", quotechar='"', escapechar="\\", quoting=csv.QUOTE_NONNUMERIC))
+    # if the last row only contains metadata, that metadata applies to all rows in the file
+    if perf_data[-1]["name"] == "metadata":
+      perf_data, metadata = perf_data[:-1], {k: v for k, v in perf_data[-1].items() if k not in PerfReport.required_fields}
+    else:
+      metadata = {}
+    return PerfReport(perf_data, **metadata)
+
+  def write(self, dir="./reports/", fn=None, update_baseline=False):
+    update_latest = fn is None
+    if fn is None: fn = self.get_fn()
+    if not self.perf_data: return  # don"t write if no perf data
+
+    with open(os.path.join(dir, fn), "w", newline="") as f:
+      fields = [*PerfReport.required_fields, *self.metadata.keys()]
+      fw = csv.DictWriter(f, fields, delimiter=",", quotechar='"', escapechar="\\", quoting=csv.QUOTE_NONNUMERIC, lineterminator="\n")
+      fw.writeheader()
+      for row in self.perf_data.values(): fw.writerow(row)
+      fw.writerow({"name": "metadata", **self.metadata})
+
+    print(f"Wrote report to {os.path.join(dir, fn)}")
+
+    if update_latest:
+      if os.path.exists(os.path.join(dir, "latest")): os.unlink(os.path.join(dir, "latest"))
+      os.symlink(fn, os.path.join(dir, "latest"))
+    if update_baseline:
+      if os.path.exists(os.path.join(dir, "baseline")):
+        print(f"Replacing old baseline: {os.readlink(os.path.join(dir, 'baseline'))}")
+        os.unlink(os.path.join(dir, "baseline"))
+      os.symlink(fn, os.path.join(dir, "baseline"))
+
+  @staticmethod
+  def show_row(name, et_tinygrad, flops, mem, baseline=None, baseline_flops=None, baseline_mem=None, baseline_name="torch"):
+    print(("\r" if not CI else "") + f"{name:42s} "
+                                     + (f"{baseline:7.2f} ms ({(baseline_flops or flops) / baseline:8.2f} GFLOPS {(baseline_mem or mem) / baseline:8.2f} GB/s) in {baseline_name}, " if baseline is not None else " " * (48 + len(baseline_name))) +
+                                     f"{et_tinygrad:7.2f} ms ({flops / et_tinygrad:8.2f} GFLOPS {mem / et_tinygrad:8.2f} GB/s) in tinygrad, "
+                                     + (f"{colorize_float(et_tinygrad / baseline)} {'faster' if baseline > et_tinygrad else 'slower'} " if baseline is not None else " " * 16) +
+                                     f"{flops:10.2f} MOPS {mem:8.2f} MB")
+
+  def compare(self, baseline: PerfReport):
+    for row in self.perf_data.values(): self.compare_row(row, baseline)
+
+  @staticmethod
+  def compare_row(row, baseline):
+    if PerfReport._stratum(row) not in baseline.perf_data:
+      PerfReport.show_row(row["name"], row["et_tinygrad"], row["flops"], row["mem"], baseline_name="baseline")  # no baseline for this row
+    else:
+      baseline_row = baseline.perf_data[PerfReport._stratum(row)]
+      PerfReport.show_row(row["name"], row["et_tinygrad"], row["flops"], row["mem"],
+                          baseline=baseline_row["et_tinygrad"], baseline_flops=baseline_row["flops"], baseline_mem=baseline_row["mem"], baseline_name="baseline")
+
+  def log_perf(self, name, et_tinygrad, flops, mem, device=Device.DEFAULT, embed_git_info=False, show=True, baseline=None):
+    row = {"name": name, "device": device, "et_tinygrad": et_tinygrad, "flops": flops, "mem": mem}
+    if embed_git_info: row.update(dict(zip(["git_hash", "git_diff"], git_info())))
+    self.perf_data[PerfReport._stratum(row)] = row
+
+    if show:
+      if self.baseline is not None:
+        PerfReport.compare_row(row, self.baseline)
+      else:
+        PerfReport.show_row(name, et_tinygrad, flops, mem, baseline=baseline)
+
+
+if __name__ != "__main__":
+  def _init_report():
+    baseline_path = os.getenv("BASELINE", "./reports/baseline")
+    baselinerpt = PerfReport.from_file(baseline_path) if os.path.exists(baseline_path) and RPT >= 2 else None
+    rpt = PerfReport.new(baseline=baselinerpt)
+    if RPT != 0 and os.path.exists("./reports"):
+      atexit.register(lambda: rpt.write("./reports", update_baseline=bool(os.getenv("SETBASELINE"))))
+    return rpt
+  rpt = _init_report()
+else:
+  # compare two reports from command line
+  # usage: python extra/perf_report.py <baseline> <new>
+  fn1, fn2 = sys.argv[1], sys.argv[2]
+  baseline, rpt = PerfReport.from_file(fn1), PerfReport.from_file(fn2)
+  rpt.compare(baseline)
+
+
+


### PR DESCRIPTION
```

"""
How to use:
$ mkdir reports  # after creating the reports directory, every run of test_speed_v_torch.py will produce a new report
$ SETBASELINE=1 python ./test/test_speed_v_torch.py  # record a baseline. compares to torch.
$ cat ./reports/latest  # check out the latest report. notice how a git commit hash and git diff are included, for reproducibility
$ cat ./reports/baseline  # check out the baseline report
$ #  make some changes to your code...
$ python ./test/test_speed_v_torch.py  # compares against baseline
$ RPT=0 python ./test/test_speed_v_torch.py  # compares against torch again (or just rm ./reports/baseline)
$ python extra/perf_report.py ./reports/baseline ./reports/latest  # compare two reports from command line
"""
```

Example:

```
(tinygrad) ~/tinygrad$ SETBASELINE=1 DEBUG=0 KOPT=0 BIG=0 CUDA_VISIBLE_DEVICES=0 CUDA=1 TORCHCUDA=1 python ./test/test_speed_v_torch.py 
sssssssss/home/ubuntu/.virtualenvs/tinygrad/lib/python3.10/site-packages/pycuda/compyte/dtypes.py:120: DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)
  reg.get_or_register_dtype("bool", np.bool8)
add                                1x    1    0.08 ms (    0.00 GFLOPS     0.00 GB/s) in baseline,    0.08 ms (    0.00 GFLOPS     0.00 GB/s) in tinygrad,    0.93x faster       0.00 MOPS     0.00 MB
add                             1024x 1024    0.08 ms (   12.49 GFLOPS   149.83 GB/s) in baseline,    0.09 ms (   11.78 GFLOPS   141.41 GB/s) in tinygrad,    1.06x slower       1.05 MOPS    12.58 MB
add                             4096x 4096    0.32 ms (   51.93 GFLOPS   623.18 GB/s) in baseline,    0.33 ms (   50.78 GFLOPS   609.33 GB/s) in tinygrad,    1.02x slower      16.78 MOPS   201.33 MB
add_constant                    4096x 4096    0.25 ms (   67.85 GFLOPS   542.82 GB/s) in baseline,    0.25 ms (   66.79 GFLOPS   534.32 GB/s) in tinygrad,    1.02x slower      16.78 MOPS   134.22 MB
add_sq                          4096x 4096    0.32 ms (  154.99 GFLOPS   619.96 GB/s) in baseline,    0.33 ms (  152.56 GFLOPS   610.23 GB/s) in tinygrad,    1.02x slower      50.33 MOPS   201.33 MB
array_packing                   2048x 2048    0.11 ms (   36.83 GFLOPS   294.62 GB/s) in baseline,    0.12 ms (   35.31 GFLOPS   282.47 GB/s) in tinygrad,    1.04x slower       4.19 MOPS    33.55 MB
cat_0                            256x  256    0.07 ms (    1.79 GFLOPS    14.33 GB/s) in baseline,    0.08 ms (    1.56 GFLOPS    12.47 GB/s) in tinygrad,    1.15x slower       0.13 MOPS     1.05 MB
cat_1                            256x  256    0.08 ms (    1.74 GFLOPS    13.90 GB/s) in baseline,    0.08 ms (    1.59 GFLOPS    12.70 GB/s) in tinygrad,    1.09x slower       0.13 MOPS     1.05 MB
conv bs: 32 chans:  4 ->  32 k:3              0.08 ms (  965.11 GFLOPS    61.24 GB/s) in baseline,    0.08 ms (  929.40 GFLOPS    58.98 GB/s) in tinygrad,    1.04x slower      75.50 MOPS     4.79 MB
conv bs: 32 chans: 16 ->  32 k:3              0.11 ms ( 2801.57 GFLOPS    61.04 GB/s) in baseline,    0.11 ms ( 2789.95 GFLOPS    60.79 GB/s) in tinygrad,    1.00x slower     301.99 MOPS     6.58 MB
conv bs: 32 chans: 64 ->  32 k:3              0.22 ms ( 5551.11 GFLOPS    63.13 GB/s) in baseline,    0.21 ms ( 5645.60 GFLOPS    64.21 GB/s) in tinygrad,    0.98x faster    1207.96 MOPS    13.74 MB
double_permute (64, 64, 64, 64)               0.48 ms (   34.96 GFLOPS   279.71 GB/s) in baseline,    0.48 ms (   35.10 GFLOPS   280.76 GB/s) in tinygrad,    1.00x faster      16.78 MOPS   134.22 MB
exp                             2048x 2048    0.12 ms (   70.23 GFLOPS   280.91 GB/s) in baseline,    0.13 ms (   66.44 GFLOPS   265.76 GB/s) in tinygrad,    1.06x slower       8.39 MOPS    33.55 MB
gemm                            1024x 1024    0.27 ms ( 8045.39 GFLOPS    47.14 GB/s) in baseline,    0.27 ms ( 7986.77 GFLOPS    46.80 GB/s) in tinygrad,    1.01x slower    2147.48 MOPS    12.58 MB
gemm                             256x  256    0.10 ms (  338.51 GFLOPS     7.93 GB/s) in baseline,    0.10 ms (  331.29 GFLOPS     7.76 GB/s) in tinygrad,    1.02x slower      33.55 MOPS     0.79 MB
gemm_unrolled                    512x  512    0.16 ms ( 1675.74 GFLOPS    19.64 GB/s) in baseline,    0.16 ms ( 1670.29 GFLOPS    19.57 GB/s) in tinygrad,    1.00x slower     268.44 MOPS     3.15 MB
gemm_unrolled_permute_l          512x  512    0.17 ms ( 1533.99 GFLOPS    17.98 GB/s) in baseline,    0.17 ms ( 1574.33 GFLOPS    18.45 GB/s) in tinygrad,    0.97x faster     268.44 MOPS     3.15 MB
gemm_unrolled_permute_lr         512x  512    0.12 ms ( 2205.39 GFLOPS    25.84 GB/s) in baseline,    0.12 ms ( 2160.32 GFLOPS    25.32 GB/s) in tinygrad,    1.02x slower     268.44 MOPS     3.15 MB
gemm_unrolled_permute_r          512x  512    0.13 ms ( 2144.99 GFLOPS    25.14 GB/s) in baseline,    0.13 ms ( 2090.05 GFLOPS    24.49 GB/s) in tinygrad,    1.03x slower     268.44 MOPS     3.15 MB
matvec_1024_1024                1024x 1024    0.09 ms (   22.53 GFLOPS    45.16 GB/s) in baseline,    0.10 ms (   21.94 GFLOPS    43.97 GB/s) in tinygrad,    1.03x slower       2.10 MOPS     4.20 MB
matvec_1024_4096                1024x 4096    0.17 ms (   48.26 GFLOPS    96.65 GB/s) in baseline,    0.17 ms (   48.95 GFLOPS    98.02 GB/s) in tinygrad,    0.99x faster       8.39 MOPS    16.80 MB
matvec_4096_1024                4096x 1024    0.15 ms (   55.16 GFLOPS   110.46 GB/s) in baseline,    0.15 ms (   56.65 GFLOPS   113.44 GB/s) in tinygrad,    0.97x faster       8.39 MOPS    16.80 MB
matvec_4096_4096                4096x 4096    0.46 ms (   73.41 GFLOPS   146.89 GB/s) in baseline,    0.45 ms (   73.83 GFLOPS   147.73 GB/s) in tinygrad,    0.99x faster      33.55 MOPS    67.14 MB
max                             4096x 4096    0.36 ms (   46.42 GFLOPS   186.38 GB/s) in baseline,    0.37 ms (   46.09 GFLOPS   185.07 GB/s) in tinygrad,    1.01x slower      16.84 MOPS    67.63 MB
mul_sum                         4096x 4096    0.73 ms (   46.17 GFLOPS   185.04 GB/s) in baseline,    0.73 ms (   46.36 GFLOPS   185.78 GB/s) in tinygrad,    1.00x faster      33.62 MOPS   134.74 MB
neg                             4096x 4096    0.26 ms (   65.61 GFLOPS   524.88 GB/s) in baseline,    0.26 ms (   65.24 GFLOPS   521.90 GB/s) in tinygrad,    1.01x slower      16.78 MOPS   134.22 MB
conv bs:  1 chans: 12 ->  32 k:3              0.09 ms (  616.00 GFLOPS    15.84 GB/s) in baseline,    0.09 ms (  598.50 GFLOPS    15.39 GB/s) in tinygrad,    1.03x slower      56.62 MOPS     1.46 MB
partial_sum                     4096x 4096    0.33 ms (   51.50 GFLOPS   206.82 GB/s) in baseline,    0.33 ms (   51.52 GFLOPS   206.90 GB/s) in tinygrad,    1.00x faster      16.84 MOPS    67.63 MB
permute                         1024x 1024    0.09 ms (   12.02 GFLOPS    96.19 GB/s) in baseline,    0.09 ms (   11.64 GFLOPS    93.10 GB/s) in tinygrad,    1.03x slower       1.05 MOPS     8.39 MB
permute                         4096x 4096    0.27 ms (   62.63 GFLOPS   501.01 GB/s) in baseline,    0.27 ms (   62.06 GFLOPS   496.48 GB/s) in tinygrad,    1.01x slower      16.78 MOPS   134.22 MB
pow                             2048x 2048    0.20 ms ( 1340.95 GFLOPS   502.86 GB/s) in baseline,    0.20 ms ( 1370.18 GFLOPS   513.82 GB/s) in tinygrad,    0.98x faster     268.44 MOPS   100.66 MB
relu                            4096x 4096    0.25 ms (   65.92 GFLOPS   527.35 GB/s) in baseline,    0.26 ms (   64.66 GFLOPS   517.25 GB/s) in tinygrad,    1.02x slower      16.78 MOPS   134.22 MB
sub                             4096x 4096    0.33 ms (   50.11 GFLOPS   601.33 GB/s) in baseline,    0.34 ms (   49.67 GFLOPS   595.99 GB/s) in tinygrad,    1.01x slower      16.78 MOPS   201.33 MB
sum                             2048x 2048    0.12 ms (   34.40 GFLOPS   138.13 GB/s) in baseline,    0.12 ms (   35.40 GFLOPS   142.16 GB/s) in tinygrad,    0.97x faster       4.21 MOPS    16.91 MB
sum                             4096x 4096    0.37 ms (   45.66 GFLOPS   183.36 GB/s) in baseline,    0.37 ms (   45.40 GFLOPS   182.32 GB/s) in tinygrad,    1.01x slower      16.84 MOPS    67.63 MB
.
----------------------------------------------------------------------
Ran 38 tests in 22.695s

OK (skipped=10)
Wrote report to ./reports/2023-08-23_22-39-26_6eca877_ee33.csv
Replacing old baseline: 2023-08-23_22-33-16_6eca877_6db8.csv
```