### PR TITLE
fix CIFAR jit

### DIFF
--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -42,7 +42,7 @@ hyp = {
       'kernel_size': 2,             # kernel size for the whitening layer
       'batch_norm_momentum': .5,
       'cutmix_size': 3,
-      'cutmix_steps': 588,          # original repo used epoch > 12.1 - 6 which is roughly 7*98=686 STEPS
+      'cutmix_steps': 490,          # different from original repo which used epoch > 12.1 - 6 which is roughly 7*98=686 STEPS
       'pad_amount': 2
   }
 }
@@ -189,7 +189,7 @@ def fetch_batches(X_in, Y_in, BS, seed, is_train):
     if is_train:
       X = random_crop(X, crop_size=32)
       X = Tensor.where(Tensor.rand(X.shape[0],1,1,1) < 0.5, X[..., ::-1], X) # flip LR
-      # if step >= hyp['net']['cutmix_steps']: X, Y = cutmix(X, Y_in, mask_size=hyp['net']['cutmix_size'])
+      if step >= hyp['net']['cutmix_steps']: X, Y = cutmix(X, Y, mask_size=hyp['net']['cutmix_size'])
     X, Y = X.numpy(), Y.numpy()
     for i in range(0, X.shape[0], BS):
       # pad the last batch
@@ -209,7 +209,7 @@ transform = [
 ]
 
 def train_cifar(bs=BS, eval_bs=EVAL_BS, steps=STEPS, seed=32):
-  # this import needs to be done here because this is running in a subproi >= hyp['net']['cutmix_steps']: X, Y = cutmix(X, Y, mask_size=hyp['net']['cutmix_size'])cess
+  # this import needs to be done here because this is running in a subprocess
   from extra.dist import OOB
   set_seed(seed)
   Tensor.training = True
@@ -238,7 +238,7 @@ def train_cifar(bs=BS, eval_bs=EVAL_BS, steps=STEPS, seed=32):
 
   model = SpeedyResNet(W)
 
-  # parse the training params into bias and non-biasi >= hyp['net']['cutmix_steps']: X, Y = cutmix(X, Y, mask_size=hyp['net']['cutmix_size'])
+  # parse the training params into bias and non-bias
   params_dict = get_state_dict(model)
   params_bias = []
   params_non_bias = []
@@ -254,7 +254,7 @@ def train_cifar(bs=BS, eval_bs=EVAL_BS, steps=STEPS, seed=32):
 
   # NOTE taken from the hlb_CIFAR repository, might need to be tuned
   initial_div_factor = 1e16
-  final_lr_ratio = 0.022
+  final_lr_ratio = 0.02199
   pct_start = hyp['opt']['percent_start']
   lr_sched_bias     = OneCycleLR(opt_bias,     max_lr=hyp['opt']['bias_lr']     ,pct_start=pct_start, div_factor=initial_div_factor, final_div_factor=1./(initial_div_factor*final_lr_ratio), total_steps=STEPS)
   lr_sched_non_bias = OneCycleLR(opt_non_bias, max_lr=hyp['opt']['non_bias_lr'] ,pct_start=pct_start, div_factor=initial_div_factor, final_div_factor=1./(initial_div_factor*final_lr_ratio), total_steps=STEPS)

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -42,7 +42,7 @@ hyp = {
       'kernel_size': 2,             # kernel size for the whitening layer
       'batch_norm_momentum': .5,
       'cutmix_size': 3,
-      'cutmix_steps': 418,          # original repo used epoch 6 which is roughly 6*98=588 STEPS
+      'cutmix_steps': 588,          # original repo used epoch > 12.1 - 6 which is roughly 7*98=686 STEPS
       'pad_amount': 2
   }
 }
@@ -166,9 +166,7 @@ def random_crop(X, crop_size=32):
 
   return X_cropped.reshape((-1, 3, crop_size, crop_size))
 
-def cutmix(X, Y, mask_size=3, p=0.5):
-  if Tensor.rand(1) > p: return X, Y
-
+def cutmix(X, Y, mask_size=3):
   # fill the square with randomly selected images from the same batch
   mask = make_square_mask(X.shape, mask_size)
   order = list(range(0, X.shape[0]))
@@ -191,7 +189,7 @@ def fetch_batches(X_in, Y_in, BS, seed, is_train):
     if is_train:
       X = random_crop(X, crop_size=32)
       X = Tensor.where(Tensor.rand(X.shape[0],1,1,1) < 0.5, X[..., ::-1], X) # flip LR
-      if step >= hyp['net']['cutmix_steps']: X, Y = cutmix(X, Y_in, mask_size=hyp['net']['cutmix_size'])
+      # if step >= hyp['net']['cutmix_steps']: X, Y = cutmix(X, Y_in, mask_size=hyp['net']['cutmix_size'])
     X, Y = X.numpy(), Y.numpy()
     for i in range(0, X.shape[0], BS):
       # pad the last batch
@@ -235,7 +233,7 @@ def train_cifar(bs=BS, eval_bs=EVAL_BS, steps=STEPS, seed=32):
   # precompute whitening patches
   W = whitening(X_train)
 
-  # padding is not timed in the original repo since it can be done all at once 
+  # padding is not timed in the original repo since it can be done all at once
   X_train = pad_reflect(X_train, size=hyp['net']['pad_amount'])
 
   model = SpeedyResNet(W)

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -143,14 +143,14 @@ def pad_reflect(X, size=2) -> Tensor:
   return X
 
 # return a binary mask in the format of BS x C x H x W where H x W contains a random square mask
-def make_square_mask(X, mask_size):
+def make_square_mask(shape, mask_size):
   is_even = int(mask_size % 2 == 0)
-  center_max = X.shape[-2]-mask_size//2-is_even
+  center_max = shape[-2]-mask_size//2-is_even
   center_min = mask_size//2-is_even
-  center = Tensor.rand(X.shape[0])*(center_max-center_min)+center_min
+  center = Tensor.rand(shape[0])*(center_max-center_min)+center_min
 
-  d_y = Tensor.arange(0, X.shape[-2]).reshape((1,1,X.shape[-2],1))
-  d_x = Tensor.arange(0, X.shape[-1]).reshape((1,1,1,X.shape[-1]))
+  d_y = Tensor.arange(0, shape[-2]).reshape((1,1,shape[-2],1))
+  d_x = Tensor.arange(0, shape[-1]).reshape((1,1,1,shape[-1]))
   d_y = d_y - center.reshape((-1,1,1,1))
   d_x = d_x - center.reshape((-1,1,1,1))
   d_y =(d_y >= -(mask_size / 2)) * (d_y <= mask_size / 2)
@@ -160,7 +160,7 @@ def make_square_mask(X, mask_size):
   return mask
 
 def random_crop(X, crop_size=32):
-  mask = make_square_mask(X, crop_size)
+  mask = make_square_mask(X.shape, crop_size)
   mask = mask.repeat((1,3,1,1))
   X_cropped = Tensor(X.flatten().numpy()[mask.flatten().numpy().astype(bool)])
 
@@ -187,7 +187,7 @@ def cutmix(X, Y, mask_size=3, p=0.5):
   if Tensor.rand(1) > p: return X, Y
 
   # fill the square with randomly selected images from the same batch
-  mask = make_square_mask(X, mask_size)
+  mask = make_square_mask(X.shape, mask_size)
   order = list(range(0, X.shape[0]))
   random.shuffle(order)
   X_patch = Tensor(X.numpy()[order,...])


### PR DESCRIPTION
```
999   86.53 ms run,    3.84 ms python,   82.68 ms CL,  491.54 loss, 0.000070 LR, 6.90 GB used,   7793.55 GFLOPS
eval 9404.0/10000 94.04%,    0.40 val_loss STEP=1000
```
1. move to device, cast to float, normalize, reshape, one-hot encode labels, and pad to 36x36 all technically need to be done only once, thus take them out of the `fetch_batch`.
2. The left pre-processing operations that need to be done while batching are random crop, random flip, and cutmix with random masks. They are currently applied on all 50,000 training data every 98 STEPS and are not **jitted**. This is also what [hlb_CIFAR10](https://github.com/tysam-code/hlb-CIFAR10/blob/ff53cac99dc71a66b1ada43d63d1307debd592a7/main.py#L460C22-L460C22) is doing.
3. There's still 3 places inside `fetch_batch` that makes a `numpy` copy.  Mainly for applying random transformations (shuffle, random mask). Essentially we need a `random.choice` and a much faster `gather`, since random transformations must be timed for [mlperf](https://github.com/mlcommons/training_policies/blob/master/training_rules.adoc#62-preprocessing-during-the-run). The kernel of numpy's gather is actually really simple but not sure we can achieve it now maybe with UAST.
```
numpy.take(a, indices, axis=None, out=None, mode='raise')

Ni, Nk = a.shape[:axis], a.shape[axis+1:]
Nj = indices.shape
for ii in ndindex(Ni):
    for jj in ndindex(Nj):
        for kk in ndindex(Nk):
            out[ii + jj + kk] = a[ii + (indices[jj],) + kk]
```