### PR TITLE
Quickstart: Use tensors to compute train accuracy

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -205,11 +205,11 @@ for step in range(1000):
   opt.step()
 
   # calculate accuracy
-  pred = out.argmax(axis=-1).numpy()
+  pred = out.argmax(axis=-1)
   acc = (pred == labels).mean()
 
   if step % 100 == 0:
-    print(f"Step {step+1} | Loss: {loss.numpy()} | Accuracy: {acc}")
+    print(f"Step {step+1} | Loss: {loss.numpy()} | Accuracy: {acc.numpy()}")
 ```
 
 ## Evaluation


### PR DESCRIPTION
In the quickstart MNIST training example, only convert final accuracy tensor to numpy, to avoid mixed type comparison in `pred == labels`, which yields `True` everywhere and thus accuracy `1.0`.