### PR TITLE
Increase MaxCommandBufferCount in ops_metal to 1024

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -19,7 +19,7 @@ class _METAL:
   def __init__(self):
     self.mtl_buffers_in_flight: List[Any] = []
     self.device = Metal.MTLCreateSystemDefaultDevice()
-    self.mtl_queue = self.device.newCommandQueue()
+    self.mtl_queue = self.device.newCommandQueueWithMaxCommandBufferCount_(1024)
     self.allocator = MetalAllocator(self.device.dedicatedMemorySize() or self.device.sharedMemorySize())
   # TODO: is there a better way to do this?
   def synchronize(self):


### PR DESCRIPTION
This should fix the Metal blocking issue. From [doc](https://developer.apple.com/documentation/metal/mtlcommandqueue/3553957-makecommandbuffer)
"Each command queue has a fixed number of command buffers for its lifetime (see [makeCommandQueue(maxCommandBufferCount:)](https://developer.apple.com/documentation/metal/mtldevice/1433433-makecommandqueue)). This method blocks the calling CPU thread when the queue doesn’t have any free command buffers, and returns after the GPU finishes executing one."

The default `newCommandQueue` set the number to 64 [(doc)](https://developer.apple.com/documentation/metal/mtldevice/1433388-makecommandqueue). This PR increases it to 1024. I could not find a guidance on the limit of this number. A stackoverflow [comment](https://stackoverflow.com/questions/41206620/metal-on-ios-newcommandqueuewithmaxcommandbuffercount-not-working#comment129866164_41206620) claimed RealityKit is using 1024. 1024 works on my M1 Max and it's enough for stable diffusion and llama.

```
JIT=1 python -O examples/llama.py --prompt "Hello." --count 10 --temperature=0 --timing
using METAL backend
using LLaMA-7B model
ram used: 13.48 GB, freqs_cis                                         : 100%|█| 292/292 [00:01<00:00, 153.
loaded weights in 1915.31 ms, 13.48 GB loaded at 7.04 GB/s
Hello.
ran model in 5807.81 ms
sync in 187.28 ms
 I
ran model in 217.31 ms
sync in 7.55 ms
'
ran model in 145.67 ms
sync in 4.16 ms
m
ran model in 26.82 ms
sync in 61.14 ms
 a
ran model in 21.98 ms
sync in 64.84 ms

ran model in 20.41 ms
sync in 66.90 ms
2
ran model in 19.68 ms
sync in 68.31 ms
0
ran model in 19.92 ms
sync in 68.15 ms
 year
ran model in 20.21 ms
sync in 68.86 ms
 old
ran model in 19.64 ms
sync in 69.37 ms
 male
```