### PR TITLE
perf: cache empty buffer creation

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -97,7 +97,7 @@ def get_movementroot_contiguous(x:LazyBuffer) -> LazyBuffer: return get_movement
 lazycache: WeakValueDictionary = WeakValueDictionary()
 def create_lazybuffer(device:str, st:ShapeTracker, optype:OpType, op:LazyOp, dtype:DType):
   # fromcpu aren't cached
-  if not LAZYCACHE or (optype is LoadOps and op.op in {LoadOps.EMPTY, LoadOps.RAND, LoadOps.CONST}): return LazyBuffer(device, st, optype, op, dtype)
+  if not LAZYCACHE or (optype is LoadOps and op.op in {LoadOps.RAND, LoadOps.CONST}): return LazyBuffer(device, st, optype, op, dtype)
 
   # wop is the deduping key. i feel this used to compare more deeply
   wop = (device, dtype, optype, ref(op))


### PR DESCRIPTION
EDIT: Reworked

Is there a concpetual reason why LoadOps.EMPTY buffers can't be cached?

```
before
codegen         mean runtime:  189.02ms, runs:   252.44,  189.28,  175.15,  178.56,  185.46,  180.00,  179.14,  181.79,  181.79,  186.56
methodcache     mean runtime:  167.97ms, runs:   212.93,  161.90,  155.51,  156.38,  162.11,  158.54,  158.46,  181.75,  165.14,  166.99
profile         mean runtime:  787.96ms, runs:   743.97,  797.20,  818.07,  767.07,  787.93,  779.64,  807.51,  791.26,  784.00,  802.93

after
codegen         mean runtime:  187.48ms, runs:   175.15,  186.02,  218.85,  172.53,  171.30,  172.58,  203.40,  187.59,  201.51,  185.90
methodcache     mean runtime:  158.08ms, runs:   141.52,  157.60,  209.52,  147.78,  149.41,  164.51,  154.32,  150.05,  152.41,  153.67
profile         mean runtime:  770.08ms, runs:   698.85,  767.33,  761.71,  756.37,  828.15,  763.55,  780.45,  773.35,  759.76,  811.30
```