### PR TITLE
[ready] perf: faster lazyop init

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -26,16 +26,11 @@ class LazyOp:
   src: Tuple[Union[LazyOp, LazyBuffer], ...]
   arg: Any
   buffers: Tuple[LazyBuffer, ...]
-
   def __init__(self, op: Op, src: Tuple[Union[LazyOp, LazyBuffer], ...], arg: Any = None):
-    self.op = op
-    self.src = src
-    self.arg = arg
-    try:
-      self.buffers = tuple([y for x in src for y in x.buffers])
-    except AttributeError:
-      # NOTE: the linearizer's key function maps the buffers to ints, and LOCAL_BUFFER is used. we don't care about buffers in these cases
-      pass
+    self.op, self.src, self.arg, self.buffers = op, src, arg, ()
+    try:  # NOTE: the linearizer's key function maps the buffers to ints, and LOCAL_BUFFER is used. we don't care about buffers in these cases
+      for x in src: self.buffers += x.buffers
+    except AttributeError: pass
 
   def __repr__(self): return f"LazyOp(op={self.op}, src={self.src}, arg={self.arg})"
   def __eq__(self, __value: object) -> bool:


### PR DESCRIPTION
Pulled out the buffers init line from https://github.com/tinygrad/tinygrad/pull/1603


```
before

codegen         mean runtime:  286.26ms, runs:   269.69,  334.04,  290.90,  271.43,  274.94,  275.24,  279.90,  289.45,  284.85,  292.20
methodcache     mean runtime:  271.34ms, runs:   289.39,  279.17,  283.27,  266.64,  251.71,  253.12,  306.11,  263.08,  264.54,  256.33
profile         mean runtime: 1005.80ms, runs:   887.07, 1040.87, 1005.02,  979.29, 1043.24,  974.64, 1016.84, 1007.91, 1001.12, 1101.99

Total time: 1.02049 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/ops.py
Function: __init__ at line 29

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    29                                             @profile
    30                                             def __init__(self, op: Op, src: Tuple[Union[LazyOp, LazyBuffer], ...], arg: Any = None):
    31    377351      98915.2      0.3      9.7      self.op = op
    32    377351      75907.1      0.2      7.4      self.src = src
    33    377351      59114.3      0.2      5.8      self.arg = arg
    34    377351      47174.4      0.1      4.6      try:
    35    306065     697729.9      2.3     68.4        self.buffers = tuple([y for x in src for y in x.buffers])
    36     71286      16744.2      0.2      1.6      except AttributeError:
    37                                                 # NOTE: the linearizer's key function maps the buffers to ints, and LOCAL_BUFFER is used. we don't care about buffers in these cases
    38     71286      24901.1      0.3      2.4        pass




after

codegen         mean runtime:  276.62ms, runs:   270.08,  333.16,  273.70,  261.70,  269.95,  263.76,  275.57,  265.84,  274.75,  277.74
methodcache     mean runtime:  258.76ms, runs:   293.57,  271.59,  255.24,  247.76,  248.11,  269.59,  254.02,  251.78,  248.24,  247.67
profile         mean runtime: 1076.48ms, runs:   869.55,  955.79, 1006.19, 1182.13, 1182.35, 1105.51, 1109.59, 1039.74, 1093.83, 1220.15


Total time: 0.863868 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/ops.py
Function: __init__ at line 28

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    28                                             @profile
    29                                             def __init__(self, op: Op, src: Tuple[Union[LazyOp, LazyBuffer], ...], arg: Any = None):
    30    377351      87385.0      0.2     10.1      self.op = op
    31    377351      67899.7      0.2      7.9      self.src = src
    32    377351      67401.8      0.2      7.8      self.arg = arg
    33    377351      67015.8      0.2      7.8      self.buffers = ()
    34    377351      49642.9      0.1      5.7      try:
    35    895447     524523.3      0.6     60.7        for x in self.src: self.buffers += x.buffers if isinstance(x, LazyOp) else (x,)
    36                                               except AttributeError:
    37                                                 # NOTE: the linearizer's key function maps the buffers to ints, and LOCAL_BUFFER is used. we don't care about buffers in these cases
    38                                                 pass

```