### PR TITLE
[ready] ci: add py38 to linters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,19 +10,22 @@ jobs:
     name: Linters
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.11"]
 
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
-    - name: Set up Python 3.11
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: ${{ matrix.python-version }}
     - name: Cache python packages
       uses: actions/cache@v3
       with:
-        path: ${{ env.Python3_ROOT_DIR }}/lib/python3.11/site-packages
-        key: linting-packages-${{ hashFiles('*/setup.py') }}
+        path: ${{ env.Python3_ROOT_DIR }}/lib/python${{ matrix.python-version }}/site-packages
+        key: linting-packages-${{ hashFiles('*/setup.py') }}-${{ matrix.python-version }}
     - name: Install dependencies
       run: pip install -e '.[linting,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Repo line count

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,22 +10,19 @@ jobs:
     name: Linters
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.11"]
 
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.8
     - name: Cache python packages
       uses: actions/cache@v3
       with:
-        path: ${{ env.Python3_ROOT_DIR }}/lib/python${{ matrix.python-version }}/site-packages
-        key: linting-packages-${{ hashFiles('*/setup.py') }}-${{ matrix.python-version }}
+        path: ${{ env.Python3_ROOT_DIR }}/lib/python3.8/site-packages
+        key: linting-packages-${{ hashFiles('*/setup.py') }}-3.8
     - name: Install dependencies
       run: pip install -e '.[linting,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Repo line count


### PR DESCRIPTION
Running no tests on Python 3.8 makes it very easy to add features that are incompatible with that version. I suggest running at least the linters in both 3.8 and 3.11. Technically, only 3.8 would probably suffice.