### PR TITLE
fix: point supercombo model download to release version

### DIFF
--- a/openpilot/compile.py
+++ b/openpilot/compile.py
@@ -25,7 +25,7 @@ from extra.utils import fetch
 from extra.onnx import get_run_onnx
 from tinygrad.tensor import Tensor
 
-OPENPILOT_MODEL = "https://github.com/commaai/openpilot/raw/6c5693e965b9c63f8678f52b9e9b5abe35f23feb/selfdrive/modeld/models/supercombo.onnx"
+OPENPILOT_MODEL = "https://github.com/commaai/openpilot/raw/v0.9.0/selfdrive/modeld/models/supercombo.onnx"
 
 np.random.seed(1337)
 def get_random_input_tensors(input_shapes):

--- a/test/external/external_model_benchmark.py
+++ b/test/external/external_model_benchmark.py
@@ -14,7 +14,7 @@ from tinygrad.ops import Device
 
 MODELS = {
   "resnet50": "https://github.com/onnx/models/raw/main/vision/classification/resnet/model/resnet50-caffe2-v1-9.onnx",
-  "openpilot": "https://github.com/commaai/openpilot/raw/7da48ebdba5e3cf4c0b8078c934bee9a199f0280/selfdrive/modeld/models/supercombo.onnx",
+  "openpilot": "https://github.com/commaai/openpilot/raw/v0.9.0/selfdrive/modeld/models/supercombo.onnx",
   "efficientnet": "https://github.com/onnx/models/raw/main/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx",
   "shufflenet": "https://github.com/onnx/models/raw/main/vision/classification/shufflenet/model/shufflenet-9.onnx",
   "commavq": "https://github.com/commaai/commavq/raw/master/models/gpt2m.onnx",

--- a/test/models/test_onnx.py
+++ b/test/models/test_onnx.py
@@ -21,7 +21,7 @@ def run_onnx_torch(onnx_model, inputs):
     torch_out = torch_model(*[torch.tensor(x) for x in inputs.values()])
   return torch_out
 
-OPENPILOT_MODEL = "https://github.com/commaai/openpilot/raw/7da48ebdba5e3cf4c0b8078c934bee9a199f0280/selfdrive/modeld/models/supercombo.onnx"
+OPENPILOT_MODEL = "https://github.com/commaai/openpilot/raw/v0.9.0/selfdrive/modeld/models/supercombo.onnx"
 #OPENPILOT_MODEL = "https://github.com/commaai/openpilot/raw/1f2f9ea9c9dc37bdea9c6e32e4cb8f88ea0a34bf/selfdrive/modeld/models/supercombo.onnx"
 
 np.random.seed(1337)


### PR DESCRIPTION
Fixes broken job. See https://github.com/tinygrad/tinygrad/actions/runs/5983616654/job/16233940956?pr=1674

The root cause is that the comma.ai/openpilot is over the quota:

```
curl -X POST \
> -H "Accept: application/vnd.git-lfs+json" \
> -H "Content-type: application/json" \
> -d '{
>   "operation": "download", 
>   "transfer": ["basic"], 
>   "objects": [
>       {"oid": "{sha256:c4d37af666344af6bb218e0b939b1152ad3784c15ac79e37bcf0124643c8286a}", "size": 58539563}
>   ]
> }' \
> https://github.com/commaai/openpilot.git/info/lfs/objects/batch
```

Yields
```
{
  "message": "This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data packs to restore access.",
  "documentation_url": "https://docs.github.com/articles/purchasing-additional-storage-and-bandwidth-for-an-organization/"
}
```