### PR TITLE
[ready] perf: simpler Tensor init

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -38,7 +38,6 @@ class Tensor:
   training: ClassVar[bool] = False
   no_grad: ClassVar[bool] = False
   default_type: ClassVar[DType] = dtypes.float32
-
   def __init__(self, data:Union[int, float, list, LazyBuffer, np.ndarray], device:Optional[str]=None, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None):
     assert dtype is None or isinstance(dtype, DType), f"invalid dtype {dtype}"
     device = Device.canonicalize(device)
@@ -51,25 +50,18 @@ class Tensor:
 
     # internal variables used for autograd graph construction
     self._ctx: Optional[Function] = None
-    if isinstance(data, LazyBuffer):
-      assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
-      self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
-      return
-
-    if isinstance(data, (int, float)):
+    if isinstance(data, LazyBuffer): assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
+    elif isinstance(data, (int, float)):
       self.lazydata = LazyBuffer.loadop(LoadOps.CONST, tuple(), dtype or Tensor.default_type, device, data)
       return
-
-    if data.__class__ is list:
+    elif data.__class__ is list:
       assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"
-      data = np.array(data, dtype=(dtype or Tensor.default_type).np)
-
-    if isinstance(data, np.ndarray):
+      data = LazyBuffer.fromCPU(np.array(data, dtype=(dtype or Tensor.default_type).np))
+    elif isinstance(data, np.ndarray):
       data = LazyBuffer.fromCPU(data)
-      self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
-      return
+    else: raise RuntimeError(f"can't create Tensor from {data}")
 
-    raise RuntimeError(f"can't create Tensor from {data}")
+    self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
 
   def __repr__(self):
     return f"<Tensor {self.lazydata!r} on {self.device} with grad {(self.grad.lazydata if self.grad else None)!r}>"


### PR DESCRIPTION
Note the enormous fraction of time that `canonicalize` consumes... This can be avoided (https://github.com/tinygrad/tinygrad/pull/1680).


```
before

codegen         mean runtime:  266.70ms, runs:   412.61,  276.13,  244.64,  247.40,  247.41,  241.40,  249.70,  241.22,  249.48,  257.01
methodcache     mean runtime:  259.77ms, runs:   290.15,  280.88,  272.47,  238.81,  280.16,  292.18,  229.41,  224.18,  230.08,  259.41
profile         mean runtime: 1108.83ms, runs:  1011.89, 1157.24, 1211.69, 1231.71, 1039.94, 1129.84,  991.76, 1167.78, 1080.75, 1065.67

Total time: 1.01743 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/tensor.py
Function: __init__ at line 41

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    41                                             @profile
    42                                             def __init__(self, data:Union[int, float, list, LazyBuffer, np.ndarray], device:Optional[str]=None, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None):
    43    180222      55110.4      0.3      5.4      assert dtype is None or isinstance(dtype, DType), f"invalid dtype {dtype}"
    44    180222     490747.3      2.7     48.2      device = Device.canonicalize(device)
    45                                               # tensors have gradients, buffers do not
    46    180222      43018.9      0.2      4.2      self.grad: Optional[Tensor] = None
    47                                           
    48                                               # NOTE: this can be in three states. False and None: no gradient, True: gradient
    49                                               # None (the default) will be updated to True if it's put in an optimizer
    50    180222      33440.9      0.2      3.3      self.requires_grad: Optional[bool] = requires_grad
    51                                           
    52                                               # internal variables used for autograd graph construction
    53    180222      30294.9      0.2      3.0      self._ctx: Optional[Function] = None
    54    172831      97698.2      0.6      9.6      if isinstance(data, LazyBuffer):
    55    172831      31618.4      0.2      3.1        assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
    56    172831      68487.6      0.4      6.7        self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
    57    172831      29463.0      0.2      2.9        return
    58                                           
    59      7360       5583.5      0.8      0.5      if isinstance(data, (int, float)):
    60      7360     127251.8     17.3     12.5        self.lazydata = LazyBuffer.loadop(LoadOps.CONST, tuple(), dtype or Tensor.default_type, device, data)
    61      7360       1299.1      0.2      0.1        return
    62                                           
    63        30         15.1      0.5      0.0      if data.__class__ is list:
    64        30          5.6      0.2      0.0        assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"
    65        30        413.9     13.8      0.0        data = np.array(data, dtype=(dtype or Tensor.default_type).np)
    66                                           
    67        31         69.9      2.3      0.0      if isinstance(data, np.ndarray):
    68        31       1883.2     60.7      0.2        data = LazyBuffer.fromCPU(data)
    69        31       1019.0     32.9      0.1        self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
    70        31          6.7      0.2      0.0        return
    71                                           
    72                                               raise RuntimeError(f"can't create Tensor from {data}")

after

codegen         mean runtime:  251.15ms, runs:   319.05,  243.83,  251.40,  232.18,  244.09,  242.72,  246.94,  240.47,  241.75,  249.05
methodcache     mean runtime:  227.42ms, runs:   282.72,  219.08,  219.63,  219.43,  222.26,  225.81,  221.75,  217.42,  221.90,  224.18
profile         mean runtime:  954.50ms, runs:   838.10,  908.86,  934.76,  918.80,  994.06, 1122.59,  960.94,  908.76,  979.71,  978.39



Total time: 0.861154 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/tensor.py
Function: __init__ at line 41

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    41                                             @profile
    42                                             def __init__(self, data:Union[int, float, list, LazyBuffer, np.ndarray], device:Optional[str]=None, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None):
    43    180222      42270.2      0.2      4.9      assert dtype is None or isinstance(dtype, DType), f"invalid dtype {dtype}"
    44    180222     432389.4      2.4     50.2      device = Device.canonicalize(device)
    45                                               # tensors have gradients, buffers do not
    46    180222      40182.5      0.2      4.7      self.grad: Optional[Tensor] = None
    47                                           
    48                                               # NOTE: this can be in three states. False and None: no gradient, True: gradient
    49                                               # None (the default) will be updated to True if it's put in an optimizer
    50    180222      33321.7      0.2      3.9      self.requires_grad: Optional[bool] = requires_grad
    51                                           
    52                                               # internal variables used for autograd graph construction
    53    180222      27603.1      0.2      3.2      self._ctx: Optional[Function] = None
    54    172831      93082.6      0.5     10.8      if isinstance(data, LazyBuffer): assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
    55      7360       4755.1      0.6      0.6      elif isinstance(data, (int, float)): 
    56      7360     112440.9     15.3     13.1        self.lazydata = LazyBuffer.loadop(LoadOps.CONST, tuple(), dtype or Tensor.default_type, device, data)
    57      7360       1214.2      0.2      0.1        return
    58        30          9.2      0.3      0.0      elif data.__class__ is list:
    59        30          7.6      0.3      0.0        assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"
    60        30       2007.0     66.9      0.2        data = LazyBuffer.fromCPU(np.array(data, dtype=(dtype or Tensor.default_type).np))
    61         1          1.5      1.5      0.0      elif isinstance(data, np.ndarray):
    62         1        181.6    181.6      0.0        data = LazyBuffer.fromCPU(data)
    63                                               else: raise RuntimeError(f"can't create Tensor from {data}")
    64                                           
    65    172862      71687.7      0.4      8.3      self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)


```