### PR TITLE
[ready] perf: canonicalize less if not needed

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -73,6 +73,7 @@ class LazyOp:
 
 class _Device:
   def __init__(self) -> None: self._buffers: List[str] = [x.stem[len("ops_"):].upper() for x in (pathlib.Path(__file__).parent/"runtime").iterdir() if x.stem.startswith("ops_")]
+  @functools.lru_cache(maxsize=None)  # this class is a singleton, pylint: disable=method-cache-max-size-none
   def canonicalize(self, device:Optional[str]) -> str: return (device.split(":", 1)[0].upper() + ((":"+device.split(":", 1)[1]) if ':' in device else '')).replace(":0", "") if device is not None else self.DEFAULT
   @functools.lru_cache(maxsize=None)  # this class is a singleton, pylint: disable=method-cache-max-size-none
   def __getitem__(self, x:str) -> Union[Interpreted, Compiled]:


### PR DESCRIPTION
This one's pretty significant.

3 independent but related changes:
* do not canonicalize the device of the Tensor created for each function apply (always already canonicalized) <- this one's big
* do not canonicalize the device of Tensors created by other Tensors (always already canonicalized) <- medium
* cache the canonicalization (no-brainer, string operation).


```
Without profiling
Before

codegen         mean runtime:  190.98ms, runs:   235.99,  221.12,  168.53,  175.39,  183.24,  192.58,  183.82,  185.95,  184.83,  178.40
methodcache     mean runtime:  170.59ms, runs:   200.55,  171.67,  156.36,  160.09,  156.31,  216.58,  163.81,  166.38,  158.57,  155.55
profile         mean runtime:  789.09ms, runs:   738.16,  794.59,  818.53,  768.32,  797.04,  788.40,  794.39,  802.39,  781.95,  807.13

After
codegen         mean runtime:  184.74ms, runs:   229.43,  189.92,  170.70,  175.68,  180.17,  174.63,  179.50,  181.07,  179.70,  186.64
methodcache     mean runtime:  162.71ms, runs:   201.03,  168.93,  155.92,  154.23,  156.49,  161.46,  157.22,  155.86,  159.55,  156.39
profile         mean runtime:  786.69ms, runs:   708.34,  778.16,  738.20,  815.60,  774.14,  773.50,  797.29,  815.57,  853.28,  812.760

```


```
before

codegen         mean runtime:  258.08ms, runs:   360.10,  244.65,  242.15,  245.46,  248.41,  247.40,  248.89,  249.00,  253.23,  241.53
methodcache     mean runtime:  229.76ms, runs:   273.21,  225.02,  227.45,  224.92,  224.72,  225.82,  220.41,  226.86,  223.39,  225.81
profile         mean runtime:  916.90ms, runs:   875.55,  925.40,  950.51,  894.19,  924.95,  906.47,  926.29,  922.02,  912.15,  931.44


Total time: 0.904921 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/tensor.py
Function: __init__ at line 41

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    41                                             @profile
    42                                             def __init__(self, data:Union[int, float, list, LazyBuffer, np.ndarray], device:Optional[str]=None, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None):
    43    180222      44281.2      0.2      4.9      assert dtype is None or isinstance(dtype, DType), f"invalid dtype {dtype}"
    44    180222     424881.2      2.4     47.0      device = Device.canonicalize(device)
    45                                               # tensors have gradients, buffers do not
    46    180222      40268.6      0.2      4.4      self.grad: Optional[Tensor] = None
    47                                           
    48                                               # NOTE: this can be in three states. False and None: no gradient, True: gradient
    49                                               # None (the default) will be updated to True if it's put in an optimizer
    50    180222      32515.0      0.2      3.6      self.requires_grad: Optional[bool] = requires_grad
    51                                           
    52                                               # internal variables used for autograd graph construction
    53    180222      29731.1      0.2      3.3      self._ctx: Optional[Function] = None
    54    172831      85998.5      0.5      9.5      if isinstance(data, LazyBuffer):
    55    172831      25849.1      0.1      2.9        assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
    56    172831      63402.7      0.4      7.0        self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
    57    172831      27054.2      0.2      3.0        return
    58                                           
    59      7360       5057.1      0.7      0.6      if isinstance(data, (int, float)):
    60      7360     121427.4     16.5     13.4        self.lazydata = LazyBuffer.loadop(LoadOps.CONST, tuple(), dtype or Tensor.default_type, device, data)
    61      7360       1352.2      0.2      0.1        return
    62                                           
    63        30         12.1      0.4      0.0      if data.__class__ is list:
    64        30          4.7      0.2      0.0        assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"
    65        30        351.9     11.7      0.0        data = np.array(data, dtype=(dtype or Tensor.default_type).np)
    66                                           
    67        31         28.5      0.9      0.0      if isinstance(data, np.ndarray):
    68        31       1738.4     56.1      0.2        data = LazyBuffer.fromCPU(data)
    69        31        960.5     31.0      0.1        self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
    70        31          6.6      0.2      0.0        return
    71                                           
    72                                               raise RuntimeError(f"can't create Tensor from {data}")

after

codegen         mean runtime:  251.78ms, runs:   314.03,  236.78,  229.81,  231.56,  256.63,  263.96,  242.74,  253.05,  242.64,  246.60
methodcache     mean runtime:  224.45ms, runs:   282.30,  209.91,  215.56,  221.77,  216.04,  222.71,  220.82,  215.22,  223.85,  216.27
profile         mean runtime:  901.08ms, runs:   837.04,  897.04,  927.78,  874.25,  902.91,  897.65,  910.16,  900.86,  892.45,  970.66


Total time: 0.531269 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/tensor.py
Function: __init__ at line 41

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    41                                             @profile
    42                                             def __init__(self, data:Union[int, float, list, LazyBuffer, np.ndarray], device:Optional[str]=None, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None, canonicalize=True):
    43    180222      46097.6      0.3      8.7      assert dtype is None or isinstance(dtype, DType), f"invalid dtype {dtype}"
    44    180222      47931.6      0.3      9.0      device = device if not canonicalize else Device.DEFAULT if device is None else Device.canonicalize(device)
    45                                               # tensors have gradients, buffers do not
    46    180222      41075.1      0.2      7.7      self.grad: Optional[Tensor] = None
    47                                           
    48                                               # NOTE: this can be in three states. False and None: no gradient, True: gradient
    49                                               # None (the default) will be updated to True if it's put in an optimizer
    50    180222      30689.4      0.2      5.8      self.requires_grad: Optional[bool] = requires_grad
    51                                           
    52                                               # internal variables used for autograd graph construction
    53    180222      31899.2      0.2      6.0      self._ctx: Optional[Function] = None
    54    172831      95724.7      0.6     18.0      if isinstance(data, LazyBuffer):
    55    172831      25532.7      0.1      4.8        assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
    56    172831      57394.6      0.3     10.8        self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
    57    172831      28969.9      0.2      5.5        return
    58                                           
    59      7360       4923.3      0.7      0.9      if isinstance(data, (int, float)):
    60      7360     116644.8     15.8     22.0        self.lazydata = LazyBuffer.loadop(LoadOps.CONST, tuple(), dtype or Tensor.default_type, device, data)
    61      7360       1301.3      0.2      0.2        return
    62                                           
    63        30         11.0      0.4      0.0      if data.__class__ is list:
    64        30          4.9      0.2      0.0        assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"
    65        30        363.0     12.1      0.1        data = np.array(data, dtype=(dtype or Tensor.default_type).np)
    66                                           
    67        31         31.0      1.0      0.0      if isinstance(data, np.ndarray):
    68        31       1724.0     55.6      0.3        data = LazyBuffer.fromCPU(data)
    69        31        944.1     30.5      0.2        self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
    70        31          6.6      0.2      0.0        return
    71                                           
    72                                               raise RuntimeError(f"can't create Tensor from {data}")



```