### PR TITLE
unit test dtypes to prevent bugs

### DIFF
--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,5 +1,6 @@
 import unittest
-from tinygrad.helpers import Context, ContextVar, merge_dicts
+import numpy as np
+from tinygrad.helpers import Context, ContextVar, DType, dtypes, merge_dicts
 
 VARIABLE = ContextVar("VARIABLE", 0)
 
@@ -117,6 +118,12 @@ class TestMergeDicts(unittest.TestCase):
     assert merge_dicts([a, b, c]) == {"a": 1, "b": 2, "c": 3}
     with self.assertRaises(AssertionError):
       merge_dicts([a, d])
+
+class TestDtypes(unittest.TestCase):
+  def test_dtypes_fields(self):
+    fields = dtypes.fields()
+    self.assertTrue(all(isinstance(value, DType) for value in fields.values()))
+    self.assertTrue(all(issubclass(value.np, np.generic) for value in fields.values() if value.np is not None))
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
A test case after the `dtypes.bool` bug that was a native python bool instead of `np.bool_`.
![image](https://github.com/tinygrad/tinygrad/assets/77887910/cec7aa45-ef90-454c-b257-4cdd792f37e1)

The bug originally was noticed and fixed here when building teenygrad https://github.com/tinygrad/tinygrad/pull/1589/files#diff-50df1fc0be73d15ad0f20907e19fbba15df16e785af95ea82f8f5910b22e707bL96

The test case here checks that all the fields in dtypes extend from a numpy type
