### PR TITLE
[ready] perf: create buffer only when needed

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -225,13 +225,12 @@ class LazyBuffer:
   def shuffle_and_prune_movement_ops(self, st: ShapeTracker, op: MovementOps, arg: Union[Tuple[Union[Node,int], ...], Tuple[Tuple[int, int], ...]]) -> LazyBuffer:
     if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and not self.realized and (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or (op == MovementOps.RESHAPE and self.op.op in UnaryOps)) and not self.children:
       return self.op.replace_with_movement_ops([(op, arg)])
-    ret = create_lazybuffer(self.device, st, MovementOps, LazyOp(op, (self,), arg), self.dtype)
-    if REMOVE_MOVEMENT_NOPS and not self.realized and not ret.realized and ret.st.contiguous:
+    if REMOVE_MOVEMENT_NOPS and not self.realized and st.contiguous:
       # MovementOps aren't stacked any more, they each have one parent, find the root
       root = get_movementroot(self)
-      if root.st.contiguous and root != self and prod(ret.st.shape) == prod(root.shape):
-        return root.reshape(ret.st.shape)
-    return ret
+      if root.st.contiguous and root != self and prod(st.shape) == prod(root.shape):
+        return root.reshape(st.shape)
+    return create_lazybuffer(self.device, st, MovementOps, LazyOp(op, (self,), arg), self.dtype)
 
   def _reduce_op(self:LazyBuffer, op:ReduceOps, new_shape:Tuple[int, ...]) -> LazyBuffer:
     if self.shape == tuple(new_shape): return self


### PR DESCRIPTION
The `ret` is not required that early, since the `.st` is just the `st` passed in. It can also not be realized yet.

```
before

codegen         mean runtime:  298.02ms, runs:   380.94,  292.23,  294.43,  285.56,  291.13,  279.13,  287.87,  295.79,  282.54,  290.57
methodcache     mean runtime:  271.31ms, runs:   306.46,  260.52,  258.55,  261.83,  261.36,  266.73,  258.98,  285.36,  291.98,  261.37
profile         mean runtime:  940.76ms, runs:   881.74,  936.80,  973.32,  924.76,  949.20,  924.44,  956.17,  944.20,  958.76,  958.20

Total time: 3.39387 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/lazy.py
Function: shuffle_and_prune_movement_ops at line 222

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   222                                             @profile
   223                                             def shuffle_and_prune_movement_ops(self, st: ShapeTracker, op: MovementOps, arg: Union[Tuple[Union[Node,int], ...], Tuple[Tuple[int, int], ...]]) -> LazyBuffer:
   224    157216     156043.5      1.0      4.6      if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and not self.realized and (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or (op == MovementOps.RESHAPE and self.op.op in UnaryOps)) and not self.children:
   225                                                 return self.op.replace_with_movement_ops([(op, arg)])
   226    157216    2747105.3     17.5     80.9      ret = create_lazybuffer(self.device, st, MovementOps, LazyOp(op, (self,), arg), self.dtype)
   227    108900     128255.9      1.2      3.8      if REMOVE_MOVEMENT_NOPS and not self.realized and not ret.realized and ret.st.contiguous:
   228                                                 # MovementOps aren't stacked any more, they each have one parent, find the root
   229     48316      84030.0      1.7      2.5        root = get_movementroot(self)
   230     39262      42791.6      1.1      1.3        if root.st.contiguous and root != self and prod(ret.st.shape) == prod(root.shape):
   231      9054     213664.8     23.6      6.3          return root.reshape(ret.st.shape)
   232    148162      21980.3      0.1      0.6      return ret




after

codegen         mean runtime:  284.16ms, runs:   324.64,  284.61,  264.92,  272.19,  283.34,  270.38,  280.77,  279.25,  279.75,  301.76
methodcache     mean runtime:  261.02ms, runs:   318.24,  250.23,  256.11,  255.39,  252.57,  268.78,  249.78,  250.05,  251.20,  257.85
profile         mean runtime:  934.51ms, runs:   871.27,  928.98,  969.52,  922.87,  930.48,  925.49,  949.09,  936.99,  951.70,  958.69


Total time: 2.94083 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/lazy.py
Function: shuffle_and_prune_movement_ops at line 222

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   222                                             @profile
   223                                             def shuffle_and_prune_movement_ops(self, st: ShapeTracker, op: MovementOps, arg: Union[Tuple[Union[Node,int], ...], Tuple[Tuple[int, int], ...]]) -> LazyBuffer:
   224    157216     148950.6      0.9      5.1      if SHUFFLE_MOVEMENT_OPS and self.optype is BinaryOps and not self.realized and (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or (op is MovementOps.RESHAPE and self.op.op in UnaryOps)) and not self.children:
   225                                                 return self.op.replace_with_movement_ops([(op, arg)])
   226    108900     127679.0      1.2      4.3      if REMOVE_MOVEMENT_NOPS and not self.realized and st.contiguous:
   227                                                 # MovementOps aren't stacked any more, they each have one parent, find the root
   228     39262      89661.3      2.3      3.0        if (root:=get_movementroot(self)).st.contiguous and root != self and prod(st.shape) == prod(root.shape): return root.reshape(st.shape)
   229    148162    2574537.6     17.4     87.5      return create_lazybuffer(self.device, st, MovementOps, LazyOp(op, (self,), arg), self.dtype)

```