### PR TITLE
fix symbolic_ops tests with Tensor.training=True

### DIFF
--- a/test/test_symbolic_jit.py
+++ b/test/test_symbolic_jit.py
@@ -58,7 +58,6 @@ class TestSymbolicJit(unittest.TestCase):
       np.testing.assert_allclose(symbolic, expected, atol=1e-6, rtol=1e-6)
     assert len(jf.jit_cache) == 2
 
-  @unittest.skipIf(Device.DEFAULT == "CLANG", "broken on CLANG CI")
   def test_attention(self):
     def f(q, k, v): return Tensor.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)).realize()
     jf = TinyJit(f)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -670,7 +670,7 @@ class Tensor:
     return (ret + bias.reshape(shape=[1, -1, 1, 1])) if bias else ret
 
   def dropout(self, p=0.5) -> Tensor:
-    if not Tensor.training: return self
+    if not Tensor.training or p == 0: return self
     mask = (Tensor.rand(*self.shape, requires_grad=False, device=self.device) >= p).cast(dtypes.bool)
     return self * mask * (1/(1.0 - p))
 


### PR DESCRIPTION
`scaled_dot_product_attention` in training mode always creates a dropout mask before, so symbolic tests will fail in training mode because we don't support `Tensor.rand` for symbolic shape. `test_nn.py` might set `Tensor.training` to true, and `test_symbolic_ops.py` fails if it's run after.

Fix by not creating a dropout mask if `dropout_p==0`, which is the default for `scaled_dot_product_attention`