### PR TITLE
[ready] perf: faster lazyop eq

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -32,10 +32,7 @@ class LazyOp:
     except AttributeError: pass
 
   def __repr__(self): return f"LazyOp(op={self.op}, src={self.src}, arg={self.arg})"
-  def __eq__(self, __value: object) -> bool:
-    if __value.__class__ is not LazyOp: return False
-    __value = cast(LazyOp, __value)
-    return self.op == __value.op and self.src == __value.src and self.arg == __value.arg
+  def __eq__(self, __value: object) -> bool: return isinstance(__value, LazyOp) and self.op is __value.op and self.src == __value.src and self.arg == __value.arg
   def __hash__(self) -> int: return hash((self.op, self.src, self.arg))
   @property
   def key(self): return (self.op, tuple(map(lambda x: getattr(x, "key", x), self.src)), getattr(self.arg, "key", self.arg))


### PR DESCRIPTION
The cast was killing the performance of `LazyOp.__eq__`


```
from:

Total time: 0.13719 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/ops.py
Function: __eq__ at line 35

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    35                                             @profile
    36                                             def __eq__(self, __value: object) -> bool:
    37     46378      14344.3      0.3     10.5      if __value.__class__ is not LazyOp: return False
    38     46378      98018.8      2.1     71.4      __value = cast(LazyOp, __value)
    39     46366      24826.8      0.5     18.1      return self.op == __value.op and self.src == __value.src and self.arg == __value.arg


to:

Total time: 0.0412131 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/ops.py
Function: __eq__ at line 35

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    35                                             @profile
    36     46378      41213.1      0.9    100.0    def __eq__(self, __value: object) -> bool: return isinstance(__value, LazyOp) and self.op is __value.op and self.src == __value.src and self.arg == __value.arg

```