### PR TITLE
Metal conv tensor cores

### DIFF
--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -139,7 +139,7 @@ class TestBigSpeed(unittest.TestCase):
     helper_test_generic_square('gemm', 4096, f, f)
   def test_large_conv_1x1(self): helper_test_conv(bs=32, in_chans=128, out_chans=128, kernel_size=1, img_size_y=128, img_size_x=128)
   def test_large_conv_3x3(self): helper_test_conv(bs=4, in_chans=128, out_chans=128, kernel_size=3, img_size_y=130, img_size_x=130)
-  def test_large_conv_5x5(self): helper_test_conv(bs=4, in_chans=128, out_chans=128, kernel_size=5, img_size_y=130, img_size_x=130)
+  def test_large_conv_5x5(self): helper_test_conv(bs=4, in_chans=128, out_chans=128, kernel_size=5, img_size_y=132, img_size_x=132)
   def test_matvec_4096_16384(self): helper_test_matvec('matvec_4096_16384', 4096, 16384)
   def test_matvec_16384_4096(self): helper_test_matvec('matvec_16384_4096', 16384, 4096)
 

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -239,7 +239,8 @@ class OptimizedKernel(Kernel):
       buf1_strides = self.sts[buf1].real_strides()
       axis_buf0 = [(i,self.full_shape[i],buf1_strides[i]) for i,s in enumerate(buf0_strides) if s == 0 and self.full_shape[i]%8 == 0 and i < self.first_reduce]
       axis_buf1 = [(i,self.full_shape[i],buf0_strides[i]) for i,s in enumerate(buf1_strides) if s == 0 and self.full_shape[i]%8 == 0 and i < self.first_reduce]
-      if axis_buf0 and axis_buf1 and self.full_shape[self.first_reduce]%8 == 0 and (self.shape_len-self.first_reduce) == 1:
+      optim_conv2d = (self.shape_len-self.first_reduce) == 3 and self.full_shape[self.first_reduce+1]%2 == 1 and self.full_shape[self.first_reduce+2]%2 == 1 and max(self.full_shape[self.first_reduce+1:self.first_reduce+3]) < 21
+      if axis_buf0 and axis_buf1 and self.full_shape[self.first_reduce]%8 == 0 and (self.shape_len-self.first_reduce == 1 or optim_conv2d):
         if DEBUG >= 3: print("METAL TENSOR CORES", axis_buf0, axis_buf1)
         self.use_tensor_cores = getenv("TC", 1) == 1  # TC=2 will do the shape ops without the WMMA
 
@@ -262,18 +263,36 @@ class OptimizedKernel(Kernel):
         self.upcast()
 
         # final global upcast
-        for ax in [s1, s0]:
-          for upc in [4,3,2]:
-            if self.full_shape[ax]%upc == 0:
-              self.shift_to(ax, upc)
-              self.upcast()
-              break
+        if not optim_conv2d:
+          for ax in [s1, s0]:
+            for upc in [4,3,2]:
+              if self.full_shape[ax]%upc == 0:
+                self.shift_to(ax, upc)
+                self.upcast()
+                break
 
         # alias buffer
         self.local_dims = self.first_reduce - global_count
         alias_pattern = [0]*global_count + [2] * self.local_dims + [0] * (self.shape_len-self.upcasted-self.first_reduce) + [1,1] + [3] * (self.upcasted-2)
         self.alias_buffer(buf0, alias_pattern)
         self.alias_buffer(buf1, alias_pattern)
+
+        if self.use_tensor_cores and optim_conv2d:
+          self.upcast()
+
+          if max(self.full_shape[self.first_reduce+1:self.first_reduce+3]) < 5:
+            self.upcast()
+            for upc in range(8, 1, -1):
+              if self.full_shape[global_count-2]%upc == 0:
+                self.shift_to(global_count-2, upc)
+                self.upcast()
+                break
+          else:
+            for upc in range(16, 1, -1):
+              if self.full_shape[global_count-1]%upc == 0:
+                self.shift_to(global_count-1, upc)
+                self.upcast()
+                break
 
         # very late upcast to run group at the same time. only if actually using real tensor cores, otherwise local isn't a simdgroup
         if self.use_tensor_cores and self.full_shape[s0] % 2 == 0:


### PR DESCRIPTION
This PR enables tensor cores with 2D convolutions. Depending on the kernel size, this results in a speedup of up to 1.63 on my machine (M1 Max with 24 GPU cores).

master:
```
conv bs: 32 chans:128 -> 128 k:1              4.32 ms ( 3976.36 GFLOPS   124.28 GB/s) in torch,    3.21 ms ( 5355.60 GFLOPS   167.38 GB/s) in tinygrad,    0.74x faster   17179.87 MOPS   536.94 MB
conv bs:  4 chans:128 -> 128 k:3              2.68 ms ( 7210.13 GFLOPS    25.65 GB/s) in torch,    5.43 ms ( 3561.77 GFLOPS    12.67 GB/s) in tinygrad,    2.02x slower   19327.35 MOPS    68.76 MB
conv bs:  4 chans:128 -> 128 k:5             12.48 ms ( 4302.68 GFLOPS     5.68 GB/s) in torch,   14.29 ms ( 3756.84 GFLOPS     4.96 GB/s) in tinygrad,    1.15x slower   53687.09 MOPS    70.88 MB
conv bs:  4 chans:128 -> 128 k:7             24.18 ms ( 4351.90 GFLOPS     3.04 GB/s) in torch,   27.63 ms ( 3809.01 GFLOPS     2.66 GB/s) in tinygrad,    1.14x slower  105226.70 MOPS    73.54 MB
conv bs:  4 chans:128 -> 128 k:9             38.99 ms ( 4461.06 GFLOPS     1.97 GB/s) in torch,   38.26 ms ( 4546.10 GFLOPS     2.01 GB/s) in tinygrad,    0.98x faster  173946.18 MOPS    76.74 MB
conv bs:  4 chans:128 -> 128 k:11            58.82 ms ( 4417.64 GFLOPS     1.37 GB/s) in torch,   57.75 ms ( 4499.20 GFLOPS     1.39 GB/s) in tinygrad,    0.98x faster  259845.52 MOPS    80.49 MB
conv bs:  4 chans:128 -> 128 k:13            81.42 ms ( 4457.64 GFLOPS     1.04 GB/s) in torch,   73.89 ms ( 4911.57 GFLOPS     1.15 GB/s) in tinygrad,    0.91x faster  362924.74 MOPS    84.77 MB
conv bs:  4 chans:128 -> 128 k:15           108.51 ms ( 4452.85 GFLOPS     0.83 GB/s) in torch,   98.16 ms ( 4922.40 GFLOPS     0.91 GB/s) in tinygrad,    0.90x faster  483183.82 MOPS    89.60 MB
conv bs:  4 chans:128 -> 128 k:17           138.27 ms ( 4488.60 GFLOPS     0.69 GB/s) in torch,  134.43 ms ( 4616.76 GFLOPS     0.71 GB/s) in tinygrad,    0.97x faster  620622.77 MOPS    94.96 MB
conv bs:  4 chans:128 -> 128 k:19           173.26 ms ( 4474.53 GFLOPS     0.58 GB/s) in torch,  165.60 ms ( 4681.52 GFLOPS     0.61 GB/s) in tinygrad,    0.96x faster  775241.60 MOPS   100.87 MB
```

this PR:
```
conv bs: 32 chans:128 -> 128 k:1              4.32 ms ( 3975.52 GFLOPS   124.25 GB/s) in torch,    3.20 ms ( 5362.29 GFLOPS   167.59 GB/s) in tinygrad,    0.74x faster   17179.87 MOPS   536.94 MB
conv bs:  4 chans:128 -> 128 k:3              2.69 ms ( 7194.47 GFLOPS    25.59 GB/s) in torch,    3.33 ms ( 5805.61 GFLOPS    20.65 GB/s) in tinygrad,    1.24x slower   19327.35 MOPS    68.76 MB
conv bs:  4 chans:128 -> 128 k:5             12.49 ms ( 4299.19 GFLOPS     5.68 GB/s) in torch,   11.27 ms ( 4764.00 GFLOPS     6.29 GB/s) in tinygrad,    0.90x faster   53687.09 MOPS    70.88 MB
conv bs:  4 chans:128 -> 128 k:7             24.18 ms ( 4351.22 GFLOPS     3.04 GB/s) in torch,   19.45 ms ( 5410.97 GFLOPS     3.78 GB/s) in tinygrad,    0.80x faster  105226.70 MOPS    73.54 MB
conv bs:  4 chans:128 -> 128 k:9             39.02 ms ( 4458.04 GFLOPS     1.97 GB/s) in torch,   28.96 ms ( 6006.66 GFLOPS     2.65 GB/s) in tinygrad,    0.74x faster  173946.18 MOPS    76.74 MB
conv bs:  4 chans:128 -> 128 k:11            58.80 ms ( 4419.47 GFLOPS     1.37 GB/s) in torch,   43.86 ms ( 5924.30 GFLOPS     1.84 GB/s) in tinygrad,    0.75x faster  259845.52 MOPS    80.49 MB
conv bs:  4 chans:128 -> 128 k:13            81.37 ms ( 4460.02 GFLOPS     1.04 GB/s) in torch,   61.58 ms ( 5893.86 GFLOPS     1.38 GB/s) in tinygrad,    0.76x faster  362924.74 MOPS    84.77 MB
conv bs:  4 chans:128 -> 128 k:15           108.54 ms ( 4451.53 GFLOPS     0.83 GB/s) in torch,   83.95 ms ( 5755.33 GFLOPS     1.07 GB/s) in tinygrad,    0.77x faster  483183.82 MOPS    89.60 MB
conv bs:  4 chans:128 -> 128 k:17           138.04 ms ( 4496.09 GFLOPS     0.69 GB/s) in torch,  116.95 ms ( 5306.79 GFLOPS     0.81 GB/s) in tinygrad,    0.85x faster  620622.77 MOPS    94.96 MB
conv bs:  4 chans:128 -> 128 k:19           173.14 ms ( 4477.58 GFLOPS     0.58 GB/s) in torch,  149.15 ms ( 5197.83 GFLOPS     0.68 GB/s) in tinygrad,    0.86x faster  775241.60 MOPS   100.87 MB
```

We can reduce the total number of computations by letting each SIMD group compute a larger output window while not exceeding the threadgroup memory. I've tinkered around with that and it seems that for a 3x3 kernel it's best is to have a 8x8x8 window while for larger kernels it's best to expand the window in width-direction.