### PR TITLE
annotate failed webgpu tests

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -152,6 +152,7 @@ class TestInt32Dtype(unittest.TestCase):
   @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu does not support int64")
   def test_int32_upcast_int64(self): _test_ops(a_dtype=dtypes.int32, b_dtype=dtypes.int64, target_dtype=dtypes.int64)
 
+@unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu does not support dtypes.bool")
 class TestBoolDtype(unittest.TestCase):
   def test_casts_from_bool(self): _test_casts_from([0,1,1,0], source_dtype=dtypes.bool, target_dtypes=[dtypes.float32, dtypes.int32])
   def test_casts_to_bool(self): _test_casts_to([0,1,1,0], source_dtypes=[dtypes.float32, dtypes.int32], target_dtype=dtypes.bool)

--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -3,12 +3,13 @@ import gc
 import unittest
 import numpy as np
 from tinygrad.tensor import Tensor
+from tinygrad.ops import Device
 
 def tensors_allocated():
   return sum([isinstance(x, Tensor) for x in gc.get_objects()])
 
+@unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu might not gc properly if tested with other tests")
 class TestGC(unittest.TestCase):
-
   def test_gc(self):
     a = Tensor.zeros(4, 4, requires_grad=True)
     b = Tensor.zeros(4, 4, requires_grad=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12,6 +12,7 @@ import pytest
 pytestmark = [pytest.mark.exclude_cuda]
 
 class TestNN(unittest.TestCase):
+  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu does not support dtypes.long")
   def test_sparse_cat_cross_entropy(self):
     input = torch.randn(3, 5)
     target = torch.empty(3, dtype=torch.long).random_(5)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -211,8 +211,9 @@ class TestOps(unittest.TestCase):
   def test_maximum(self):
     helper_test_op([(45,65), (45,65)], torch.maximum, Tensor.maximum)
     helper_test_op([(), ()], torch.maximum, Tensor.maximum)
-    helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[1., 0., 3., 4.], [1., 2., 3., 0.]])
-    helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[1, 0, 3, 4], [1, 2, 3, 0]], forward_only=True)
+    if not Device.DEFAULT == "WEBGPU": # AssertionError: dtype dtypes.long not supported on WEBGPU
+      helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[1., 0., 3., 4.], [1., 2., 3., 0.]])
+      helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[1, 0, 3, 4], [1, 2, 3, 0]], forward_only=True)
   def test_minimum(self):
     helper_test_op([(45,65), (45,65)], torch.minimum, Tensor.minimum)
     helper_test_op([(), ()], torch.minimum, Tensor.minimum)
@@ -246,8 +247,9 @@ class TestOps(unittest.TestCase):
   def test_div(self):
     helper_test_op([(45,65), (45,65)], lambda x,y: x/y, Tensor.div)
     helper_test_op([(), ()], lambda x,y: x/y, Tensor.div)
-    helper_test_op(None, lambda x,y: x/y, Tensor.div, forward_only=True, vals=[[5],[1]])
-    helper_test_op(None, lambda x: (x/2).to(torch.int), lambda x: x/2, forward_only=True, vals=[[3]])
+    if not Device.DEFAULT == "WEBGPU": # AssertionError: dtype dtypes.long not supported on WEBGPU
+      helper_test_op(None, lambda x,y: x/y, Tensor.div, forward_only=True, vals=[[5],[1]])
+      helper_test_op(None, lambda x: (x/2).to(torch.int), lambda x: x/2, forward_only=True, vals=[[3]])
   def test_div_const(self):
     helper_test_op([(45,65)], lambda x: x/255, lambda x: x/255)
     helper_test_op([(45,65)], lambda x: x/1, lambda x: x/1)
@@ -643,6 +645,8 @@ class TestOps(unittest.TestCase):
   def test_pad(self):
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4)),lambda x: x.pad(((3,4),(1,2))))
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4), value=5), lambda x: x.pad(((3,4), (1,2)), value=5))
+  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu does not support inf")
+  def test_pad_inf(self):
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4), value=float("inf")), lambda x: x.pad(((3,4), (1,2)), value=float("inf")))
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4), value=float("-inf")), lambda x: x.pad(((3,4), (1,2)), value=float("-inf")))
 

--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -80,7 +80,7 @@ class TestFloatUOps(TestUOps):
   def test_where(self): self._test_top_fxn(TernaryOps.WHERE, lambda a,b,c: b if a!=0 else c)
 
 # TODO: fix this on all the backends
-@unittest.skipIf(not isinstance(Device[Device.DEFAULT], Compiled) or getenv('ARM64', False), "only test for compiled backends, broken on some")
+@unittest.skipIf(not isinstance(Device[Device.DEFAULT], Compiled) or getenv('ARM64', False) or getenv('WEBGPU', False), "only test for compiled backends, broken on some")
 class TestNonFloatUOps(TestUOps):
   def test_add_int32(self): self._test_bop_fxn(BinaryOps.ADD, lambda a,b: int(a)+int(b), dtypes.int32)
   def test_sub_int32(self): self._test_bop_fxn(BinaryOps.SUB, lambda a,b: int(a)-int(b), dtypes.int32)


### PR DESCRIPTION
WEBGPU is not tested in CI due to flakiness, and many newly added tests would fail with WEBGPU backend. This PR skips those tests and annotates the failure reason, so that the CI WEBGPU command can pass locally.

Previous [flaky runs](https://github.com/tinygrad/tinygrad/actions/runs/5780589178/job/15664459463) had some other test failure, probably not ready to re-enable CI test before understanding the issue. Maybe we want to re-enable `Build WEBGPU Efficientnet` in CI since that's mentioned in the release note?