### PR TITLE
Change static methods to class methods

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -183,9 +183,9 @@ class LazyBuffer:
     if not self.realized and self.op.op == LoadOps.CONTIGUOUS: return self  # two CONTIGUOUS in a row is one
     return create_lazybuffer(self.device, ShapeTracker(self.shape), LoadOps, LazyOp(LoadOps.CONTIGUOUS, (self,), None), self.dtype)
 
-  @staticmethod
-  def fromCPU(x: np.ndarray) -> LazyBuffer:
-    return LazyBuffer("CPU", ShapeTracker(x.shape, [View(x.shape, tuple(st//x.itemsize for st in x.strides))]), LoadOps, LazyOp(LoadOps.EMPTY, (), None), dtypes.from_np(x.dtype), RawNumpyBuffer.fromCPU(x))
+  @classmethod
+  def fromCPU(cls, x: np.ndarray) -> LazyBuffer:
+    return cls("CPU", ShapeTracker(x.shape, [View(x.shape, tuple(st//x.itemsize for st in x.strides))]), LoadOps, LazyOp(LoadOps.EMPTY, (), None), dtypes.from_np(x.dtype), RawNumpyBuffer.fromCPU(x))
 
   def toCPU(self) -> np.ndarray:
     assert self.dtype.np, f"{self.dtype} is not supported in toCPU"

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -368,11 +368,12 @@ class Tensor:
       s[dim] = (k, shape_cumsum[-1] - k - shp)
     return reduce(Tensor.__add__, [arg.pad(tuple(s)) for arg,s in zip(catargs, slc)])
 
-  @classmethod
-  def stack(cls, tensors, dim=0):
+  @staticmethod
+  def stack(tensors, dim=0):
+    first = tensors[0].unsqueeze(dim)
     unsqueezed_tensors = [tensor.unsqueeze(dim) for tensor in tensors[1:]]
     # checks for shapes and number of dimensions delegated to cat
-    return cls.cat(*unsqueezed_tensors, dim=dim)
+    return first.cat(*unsqueezed_tensors, dim=dim)
 
   def repeat(self, repeats):
     base_shape = (1,) * (len(repeats) - self.ndim) + self.shape

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -372,7 +372,7 @@ class Tensor:
   def stack(cls, tensors, dim=0):
     unsqueezed_tensors = [tensor.unsqueeze(cls, dim) for tensor in tensors[1:]]
     # checks for shapes and number of dimensions delegated to cat
-    return first.cat(*unsqueezed_tensors, dim=dim)
+    return cls.cat(*unsqueezed_tensors, dim=dim)
 
   def repeat(self, repeats):
     base_shape = (1,) * (len(repeats) - self.ndim) + self.shape

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -370,7 +370,7 @@ class Tensor:
 
   @classmethod
   def stack(cls, tensors, dim=0):
-    unsqueezed_tensors = [tensor.unsqueeze(cls, dim) for tensor in tensors[1:]]
+    unsqueezed_tensors = [tensor.unsqueeze(dim) for tensor in tensors[1:]]
     # checks for shapes and number of dimensions delegated to cat
     return cls.cat(*unsqueezed_tensors, dim=dim)
 


### PR DESCRIPTION
Static methods that use their own class, e.g. to create a new instance of its own class should be class methods. This makes the methods also work on subclasses.

Closes #1695.