### PR TITLE
critical realize for unjitted llama

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -85,7 +85,7 @@ class Attention:
       keys, values = cache_k.cat(xk, dim=1), cache_v.cat(xv, dim=1)
 
     cache_k, cache_v = keys, values
-    keys, values = repeat_kv(keys, self.n_rep), repeat_kv(values, self.n_rep)
+    keys, values = repeat_kv(keys, self.n_rep).realize(), repeat_kv(values, self.n_rep).realize()
     attn = Tensor.scaled_dot_product_attention(xq.transpose(1, 2), keys.transpose(1, 2), values.transpose(1, 2), mask).transpose(1, 2).reshape(bsz, seqlen, -1)
     return self.wo(attn).realize(), cache_k.realize(), cache_v.realize()
 


### PR DESCRIPTION
performance critical `realize` for the unjitted path

this PR
```
ran model in 161.57 ms
sync in 4.14 ms
2
ran model in 162.44 ms
sync in 3.56 ms
0
ran model in 162.07 ms
sync in 3.94 ms
 year
ran model in 172.77 ms
sync in 3.67 ms
 old
ran model in 162.81 ms
sync in 3.87 ms
 male
```

master
```
ran model in 190.39 ms
sync in 6.33 ms
2
ran model in 234.34 ms
sync in 4.78 ms
0
ran model in 214.29 ms
sync in 4.13 ms
 year
ran model in 227.56 ms
sync in 4.87 ms
 old
ran model in 232.43 ms
sync in 5.71 ms
 male
```