### PR TITLE
perf: canonicalize less, canonicalize faster

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -40,7 +40,7 @@ class Tensor:
   default_type: ClassVar[DType] = dtypes.float32
   def __init__(self, data:Union[int, float, list, LazyBuffer, np.ndarray], device:Optional[str]=None, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None):
     assert dtype is None or isinstance(dtype, DType), f"invalid dtype {dtype}"
-    device = Device.canonicalize(device)
+    device = Device.DEFAULT if device is None else device if device in Device.canonicals else Device.canonicalize(device)
     # tensors have gradients, buffers do not
     self.grad: Optional[Tensor] = None
 


### PR DESCRIPTION
Would this be acceptable? Cache the string op and define a tuple of known canonicals.