### PR TITLE
[WIP] perf/feat: Expand support torch api

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -711,6 +711,8 @@ class TestOps(unittest.TestCase):
     arg = (4,3,2,6)
     helper_test_op([(4,3,1,6)], lambda x: x.expand(arg), lambda x: x.expand(shape=arg))
     helper_test_op([()], lambda x: x.expand([]), lambda x: x.expand(shape=[]))
+    arg = (1,2,3,4,-1,1,6)
+    helper_test_op([(4,3,1,6)], lambda x: x.expand(arg), lambda x: x.expand(shape=arg))
 
   @unittest.skip("very slow")
   def test_sd_big_conv(self):

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -276,8 +276,8 @@ class LazyBuffer:
         return src.permute(arg).reduce_op(cast(ReduceOps, rop), narg)
 
       # move permutes before expands (always, this is safe)
-      if self.op.op == MovementOps.EXPAND:
-        return self.op.src[0].permute(arg).expand(tuple([self.op.arg[a] for a in arg]))
+      #if self.op.op == MovementOps.EXPAND:
+      #  return self.op.src[0].permute(arg).expand(tuple([self.op.arg[a] for a in arg]))
 
       # move permutes before reshapes if we can
       if PUSH_PERMUTES and self.op.op == MovementOps.RESHAPE and self.op.src[0].__class__ is LazyBuffer:

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -179,7 +179,7 @@ class LazyBuffer:
   # create a constant with the shape and dtype of self
   def const(self, val:Union[float, int]) -> LazyBuffer:
     # NOTE: dtypes.from_np(self.dtype.np) to deal with image types
-    return self.loadop(LoadOps.CONST, tuple(), dtypes.from_np(self.dtype.np), self.device, arg=val).reshape((1,)*len(self.shape)).expand(self.shape)
+    return self.loadop(LoadOps.CONST, tuple(), dtypes.from_np(self.dtype.np), self.device, arg=val).expand(self.shape)
 
   def contiguous(self:LazyBuffer) -> LazyBuffer:
     if not self.realized and self.op.op == LoadOps.CONTIGUOUS: return self  # two CONTIGUOUS in a row is one

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -153,7 +153,8 @@ class Expand(Function):
     return x.expand(shape)
 
   def backward(self, grad_output:LazyBuffer) -> LazyBuffer:
-    return grad_output.reduce_op(ReduceOps.SUM, self.input_shape)
+    k = len(grad_output.shape) - len(self.input_shape)
+    return grad_output.reduce_op(ReduceOps.SUM, (1,)*k + self.input_shape).reshape(self.input_shape)
 
 class Reshape(Function):
   def forward(self, x:LazyBuffer, shape:Tuple[int, ...]) -> LazyBuffer:

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -224,7 +224,7 @@ class ShapeTracker:
     init_shape = len(self.views[-1].shape)
     assert all(is_sym_int(x) and (s == x or (s == 1 and st == 0)) for s,x,st in zip(self.shape, new_shape[-init_shape:], self.views[-1].strides)), f"can't expand {self.shape} into {new_shape}"
     # NOTE: can the mask ever be (0,0)?
-    mask = tuple([(((0,0) if m != (0,1) else (0,ns)) if s != ns else m) for m,s,ns in zip(self.views[-1].mask, self.shape, new_shape)]) if self.views[-1].mask else None
+    mask = tuple([(((0,0) if m != (0,1) else (0,ns)) if s != ns else m) for m,s,ns in zip(self.views[-1].mask, self.shape, new_shape[-init_shape:])]) if self.views[-1].mask else None
     pads = (0,) * (len(new_shape) - init_shape)
     self.views[-1] = View(new_shape, pads + self.views[-1].strides, self.views[-1].offset, mask)
     return self

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -225,7 +225,7 @@ class ShapeTracker:
     assert all(is_sym_int(x) and (s == x or (s == 1 and st == 0)) for s,x,st in zip(self.shape, new_shape[-init_shape:], self.views[-1].strides)), f"can't expand {self.shape} into {new_shape}"
     # NOTE: can the mask ever be (0,0)?
     mask = tuple([(((0,0) if m != (0,1) else (0,ns)) if s != ns else m) for m,s,ns in zip(self.views[-1].mask, self.shape, new_shape)]) if self.views[-1].mask else None
-    pads = (0,) * (len(new_shape) - len(self.views[-1].strides))
+    pads = (0,) * (len(new_shape) - init_shape)
     self.views[-1] = View(new_shape, pads + self.views[-1].strides, self.views[-1].offset, mask)
     return self
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -676,8 +676,8 @@ class Tensor:
 
   def sparse_categorical_crossentropy(self, Y, ignore_index=-1) -> Tensor:
     loss_mask = Y != ignore_index
-    y_counter = Tensor.arange(self.shape[-1], dtype=dtypes.int32, requires_grad=False, device=self.device).unsqueeze(0).expand(Y.numel(), self.shape[-1])
-    y = ((y_counter == Y.flatten().reshape(-1, 1)).where(-1.0, 0) * loss_mask.reshape(-1, 1)).reshape(*Y.shape, self.shape[-1])
+    y_counter = Tensor.arange(self.shape[-1], dtype=dtypes.int32, requires_grad=False, device=self.device).expand(Y.numel(), self.shape[-1])
+    y = ((y_counter == Y.reshape(-1, 1)).where(-1.0, 0) * loss_mask.reshape(-1, 1)).reshape(*Y.shape, self.shape[-1])
     return self.log_softmax().mul(y).sum() / loss_mask.sum()
 
   # ***** cast ops *****

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -229,7 +229,7 @@ class Tensor:
     assert 0 not in new_shape, f"zeros not allowed in shape {new_shape}"
     return mlops.Reshape.apply(self, shape=tuple([-math.prod(self.shape) // math.prod(new_shape) if s == -1 else s for s in new_shape]))
   def expand(self, shape, *args) -> Tensor:
-    shape = tuple([x if x != -1 else self.shape[i] for i,x in enumerate(argfix(shape, *args)[::-1])][::-1])
+    shape = tuple([x if x != -1 else self.shape[-i] for i,x in enumerate(argfix(shape, *args)[::-1], start=1)][::-1])
     return mlops.Expand.apply(self, shape=shape)
   def permute(self, order, *args) -> Tensor: return mlops.Permute.apply(self, order=argfix(order, *args))
   def flip(self, axis, *args) -> Tensor: return mlops.Flip.apply(self, axis=[x if x >= 0 else x+len(self.shape) for x in argfix(axis, *args)])

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -567,7 +567,7 @@ class Tensor:
   def _broadcasted(self, y:Union[Tensor, float], reverse:bool=False) -> Tuple[Tensor, Tensor]:
     x: Tensor = self
     if not isinstance(y, Tensor):
-      y = Tensor.full(x.shape,y, device=self.device, requires_grad=False, dtype=self.dtype if self.dtype != dtypes.bool and self.dtype.__class__ is not ImageDType else dtypes.float32)
+      y = Tensor(y, device=self.device, requires_grad=False, dtype=self.dtype if self.dtype != dtypes.bool and self.dtype.__class__ is not ImageDType else dtypes.float32)
     if reverse: x, y = y, x
     if (xshape:=x.shape) == (yshape:=y.shape): return (x, y)
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -567,7 +567,7 @@ class Tensor:
   def _broadcasted(self, y:Union[Tensor, float], reverse:bool=False) -> Tuple[Tensor, Tensor]:
     x: Tensor = self
     if not isinstance(y, Tensor):
-      y = Tensor(y, device=self.device, requires_grad=False, dtype=self.dtype if self.dtype != dtypes.bool and self.dtype.__class__ is not ImageDType else dtypes.float32).expand(x.shape)
+      y = Tensor(y, device=self.device, requires_grad=False, dtype=self.dtype if self.dtype != dtypes.bool and self.dtype.__class__ is not ImageDType else dtypes.float32)#.expand(x.shape)
     if reverse: x, y = y, x
     if (xshape:=x.shape) == (yshape:=y.shape): return (x, y)
 
@@ -581,8 +581,7 @@ class Tensor:
     if yshape != shape_ret: y = y.expand(shape_ret)
     return (x, y)
 
-  def add(self, x:Union[Tensor, float], reverse=False) -> Tensor:
-    return mlops.Add.apply(*self._broadcasted(x, reverse)) if x.__class__ is Tensor or x else self
+  def add(self, x:Union[Tensor, float], reverse=False) -> Tensor: return mlops.Add.apply(*self._broadcasted(x, reverse)) if x.__class__ is Tensor or x else self
   def sub(self, x:Union[Tensor, float], reverse=False) -> Tensor: return mlops.Sub.apply(*self._broadcasted(x, reverse)) if x.__class__ is Tensor or x or reverse else self
   def mul(self, x:Union[Tensor, float], reverse=False) -> Tensor: return mlops.Mul.apply(*self._broadcasted(x, reverse)) if x.__class__ is Tensor or x != 1.0 else self
   def div(self, x:Union[Tensor, float], reverse=False) -> Tensor: return mlops.Div.apply(*self._broadcasted(x, reverse)) if x.__class__ is Tensor or reverse or not x or not dtypes.is_float(self.dtype) else self.mul(1/x)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -567,7 +567,7 @@ class Tensor:
   def _broadcasted(self, y:Union[Tensor, float], reverse:bool=False) -> Tuple[Tensor, Tensor]:
     x: Tensor = self
     if not isinstance(y, Tensor):
-      y = Tensor(y, device=self.device, requires_grad=False, dtype=self.dtype if self.dtype != dtypes.bool and self.dtype.__class__ is not ImageDType else dtypes.float32)
+      y = Tensor(y, device=self.device, requires_grad=False, dtype=self.dtype if self.dtype != dtypes.bool and self.dtype.__class__ is not ImageDType else dtypes.float32).expand(x.shape)
     if reverse: x, y = y, x
     if (xshape:=x.shape) == (yshape:=y.shape): return (x, y)
 


### PR DESCRIPTION
This basically allows expand to match torch.expand. This PR may not be worth the feature wise. 
Also, this PR adds little bit of performance but not sure if it is real or variance.
`METAL=1 python3.11 examples/llama.py --prompt "Hello." --count 10 --temperature 0 --timing --quantize`

This PR,
```
loaded weights in 32.55 ms, 6.87 GB loaded at 211.15 GB/s
Hello.
ran model in 278.31 ms
sync in 1701.45 ms
 I
ran model in 200.05 ms
sync in 272.64 ms
'
ran model in 164.75 ms
sync in 4.52 ms
m
ran model in 161.49 ms
sync in 4.52 ms
 a
ran model in 165.52 ms
sync in 4.71 ms
 new
ran model in 175.20 ms
sync in 7.14 ms
bie
ran model in 163.20 ms
sync in 4.41 ms
 here
ran model in 165.88 ms
sync in 4.69 ms
.
ran model in 176.89 ms
sync in 4.42 ms
 I
ran model in 164.72 ms
sync in 4.42 ms
```

Master,
```
loaded weights in 34.75 ms, 6.87 GB loaded at 197.81 GB/s
Hello.
ran model in 311.49 ms
sync in 2807.68 ms
 I
ran model in 182.19 ms
sync in 2029.03 ms
'
ran model in 179.55 ms
sync in 7.05 ms
m
ran model in 167.57 ms
sync in 4.53 ms
 a
ran model in 167.82 ms
sync in 4.44 ms
 new
ran model in 179.39 ms
sync in 5.91 ms
bie
ran model in 170.73 ms
sync in 4.62 ms
 here
ran model in 181.93 ms
sync in 4.46 ms
.
ran model in 166.96 ms
sync in 4.67 ms
 I
ran model in 178.66 ms
sync in 4.54 ms
```

Note: Currently it disables `# move permutes before expands (always, this is safe)` in lazy

Note: Based on feedback I can close this PR as if this adds more complexity