### PR TITLE
Remove Token from abstractions.py

### DIFF
--- a/docs/abstractions.py
+++ b/docs/abstractions.py
@@ -247,6 +247,7 @@ class UOps(Enum): LOOP = auto(); DEFINE_LOCAL = auto(); LOAD = auto(); ALU = aut
 
 class UOp:
   uop: UOps
+  dtype: Optional[DType]
   vin: Tuple[UOp, ...]
   arg: Any
   num: int  # UOps are unique


### PR DESCRIPTION
In #1723, the Token class was removed.