### PR TITLE
Test KOPT in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,8 +104,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [optimage, openpilot, multigpu]
-    name: ${{ matrix.task=='optimage'&&'GPU OPT and IMAGE Tests'|| matrix.task=='openpilot'&&'openpilot (OpenCL) Tests'|| matrix.task=='multigpu'&&'MultiGPU Tests'}}
+        task: [optimage, openpilot, multigpu, kopt]
+    name: ${{ matrix.task=='optimage'&&'GPU OPT and IMAGE Tests'|| matrix.task=='openpilot'&&'openpilot (OpenCL) Tests'|| matrix.task=='multigpu'&&'MultiGPU Tests' || matrix.task=='kopt'&&'Kernel OPT Tests'}}
     runs-on: ubuntu-20.04
     timeout-minutes: 20
 
@@ -158,6 +158,9 @@ jobs:
         run: |
           PYTHONPATH="." python test/external/dist/test_world.py
           PYTHONPATH="." python test/external/dist/test_collectives.py
+      - if: ${{ matrix.task == 'kopt' }}
+        name: Test KOPT
+        run: PYTHONPATH="." KOPT=1 BUDGET=10 GPU=1 DEBUG=1 python -m pytest -rA -n=auto test/models/test_real_world.py
 
   testmetalwebgpu:
     name: Metal and WebGPU Tests

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -44,6 +44,7 @@ LLVMOPT             | [1]        | enable slightly more expensive LLVM optimizat
 LAZY                | [1]        | enable lazy operations (this is the default)
 OPT                 | [1-3]      | optimization level
 KOPT                | [1-2]      | kernel optimization, 1 turns it on, 2 caches the found optimizations
+BUDGET              | [#]        | kernel optimization search budget
 GRAPH               | [1]        | create a graph of all operations (requires graphviz)
 GRAPHPATH           | [/path/to] | where to put the generated graph
 PRUNEGRAPH          | [1]        | prune MovementOps and LoadOps from the graph

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(name='tinygrad',
             "safetensors",
             "types-PyYAML",
             "cloudpickle",
-            "transformers"
+            "transformers",
+            "nevergrad",
         ],
       },
       include_package_data=True)

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -5,7 +5,7 @@ from tinygrad.nn.state import get_parameters
 from tinygrad.jit import TinyJit, JIT_SUPPORTED_DEVICE
 from tinygrad.ops import GlobalCounters, LazyOp, LoadOps
 from tinygrad.ops import Device
-from tinygrad.helpers import CI, dtypes
+from tinygrad.helpers import CI, dtypes, getenv
 
 from examples.gpt2 import Transformer as GPT2Transformer, MODEL_PARAMS as GPT2_MODEL_PARAMS
 from examples.hlb_cifar10 import SpeedyResNet
@@ -61,6 +61,7 @@ class TestRealWorld(unittest.TestCase):
     derandomize_model(model)
     @TinyJit
     def test(t): return model(t, 0).realize()
+    # NOTE: only test one pass, not testing the dynamic shape autoregressive part
     helper_test("test_llama", lambda: (Tensor([[1,]]),), test, 0.22 if CI else 13.5, 126 if CI else 486)
 
     Tensor.default_type = old_type
@@ -79,6 +80,7 @@ class TestRealWorld(unittest.TestCase):
 
     Tensor.default_type = old_type
 
+  @unittest.skipIf(getenv("KOPT"), "cifar hangs with KOPT")
   @unittest.skipUnless(Device.DEFAULT in JIT_SUPPORTED_DEVICE and Device.DEFAULT not in ["LLVM"], "needs JIT, too long on CI LLVM")
   def test_train_cifar(self):
     # TODO: with default device

--- a/tinygrad/codegen/search.py
+++ b/tinygrad/codegen/search.py
@@ -38,7 +38,8 @@ def kernel_optimize_search(k:Linearizer, create_k:Callable[[], Linearizer], to_p
   if not opts: return "BASELINE"
   search_space = prod([len(x.choices) for x in opts])
   st = time.perf_counter()
-  optimizer = ng.optimizers.NGOpt(parametrization=ng.p.Tuple(*opts), budget=min(search_space, 200))
+  budget = int(getenv("BUDGET", 200))
+  optimizer = ng.optimizers.NGOpt(parametrization=ng.p.Tuple(*opts), budget=min(search_space, budget))
   recommendation = optimizer.minimize(opt)
   et = time.perf_counter() - st
   if DEBUG >= 1: print(f"optimizer({et:6.2f} s to search) space {search_space:8d} with tm {recommendation.loss:5.2f} ms vs baseline {baseline:5.2f} ms, a {baseline/recommendation.loss:5.2f}x gain : {k.colored_shape()}")

--- a/tinygrad/codegen/search.py
+++ b/tinygrad/codegen/search.py
@@ -38,7 +38,7 @@ def kernel_optimize_search(k:Linearizer, create_k:Callable[[], Linearizer], to_p
   if not opts: return "BASELINE"
   search_space = prod([len(x.choices) for x in opts])
   st = time.perf_counter()
-  budget = int(getenv("BUDGET", 200))
+  budget = getenv("BUDGET", 200)
   optimizer = ng.optimizers.NGOpt(parametrization=ng.p.Tuple(*opts), budget=min(search_space, budget))
   recommendation = optimizer.minimize(opt)
   et = time.perf_counter() - st


### PR DESCRIPTION
Add env variable `BUDGET` for search budget. Test in CI with `DEBUG=1` so we can check if it runs.

It surfaces 2 problems:
(1) llama generation is not fully covered in test, currently KOPT fails because of symbolic offset, but CI does not test it. I plan to fix this and update the test in a separate PR.
(2) cifar hangs with current KOPT. People reported it in discord. Skip in CI for now.