### PR TITLE
perf: faster LB init

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -121,9 +121,7 @@ class LazyBuffer:
     self.output_buffer: Optional[RawBuffer] = None   # TODO: do we really need this? or can we just use realized
     # TODO: does children have to be a ref count instead of a set? can a Buffer be a double child?
     self.children: WeakSet = WeakSet()
-    if op.buffers: 
-      op.buffers[0].children.add(self)
-      for x in op.buffers[1:]: x.children.add(self)
+    for x in op.buffers: x.children.add(self)
     if not LAZY: self.realize()
 
     # log phantom ops to the graph


### PR DESCRIPTION
```
Total time: 1.76618 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/lazy.py
Function: __init__ at line 116

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   116                                             @profile
   117                                             def __init__(self, device:str, st:ShapeTracker, optype:OpType, op:LazyOp, dtype:DType, src:Optional[RawBuffer]=None):
   118    238541      60450.9      0.3      3.4      self.st: ShapeTracker = st  # NOTE: this is not a copy! this should be a "read-only" ShapeTracker
   119    238541     307227.4      1.3     17.4      self.device, self.shape, self.optype, self.dtype = device, self.st.shape, optype, dtype
   120    238541      41496.5      0.2      2.3      self.realized: Optional[RawBuffer] = src
   121    238541      41646.2      0.2      2.4      self.output_buffer: Optional[RawBuffer] = None   # TODO: do we really need this? or can we just use realized
   122                                               # TODO: does children have to be a ref count instead of a set? can a Buffer be a double child?
   123    238541     468698.1      2.0     26.5      self.children: WeakSet = WeakSet()
   124                                               # NOTE: op should be read only after construction of LazyBuffer
   125    238541      38128.4      0.2      2.2      self.op: LazyOp = op
   126    369743     704621.1      1.9     39.9      for x in op.buffers: x.children.add(self)
   127    238541      43805.1      0.2      2.5      if not LAZY: self.realize()
   128                                           
   129                                               # log phantom ops to the graph
   130    238541      60107.5      0.3      3.4      if GRAPH >= 3:
   131                                                 log_op(self, self.op, phantom=True)


Total time: 1.38607 s
File: /home/rvd/src/roelofvandijk/tinygrad/tinygrad/lazy.py
Function: __init__ at line 116

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   116                                             @profile
   117                                             def __init__(self, device:str, st:ShapeTracker, optype:OpType, op:LazyOp, dtype:DType, src:Optional[RawBuffer]=None):
   118                                               # NOTE: st is not a copy! this should be a "read-only" ShapeTracker
   119                                               # NOTE: op should be read only after construction of LazyBuffer
   120    238541     217257.3      0.9     15.7      self.device, self.st, self.op, self.optype, self.dtype, self.shape = device, st, op, optype, dtype, st.views[-1].shape
   121    238541      54124.9      0.2      3.9      self.realized: Optional[RawBuffer] = src
   122    238541      43928.9      0.2      3.2      self.output_buffer: Optional[RawBuffer] = None   # TODO: do we really need this? or can we just use realized
   123                                               # TODO: does children have to be a ref count instead of a set? can a Buffer be a double child?
   124    238541     457231.9      1.9     33.0      self.children: WeakSet = WeakSet()
   125    226582      55748.0      0.2      4.0      if op.buffers: 
   126    226582     370025.0      1.6     26.7        op.buffers[0].children.add(self)
   127    226582      80229.4      0.4      5.8        for x in op.buffers[1:]: x.children.add(self)
   128    238541      47681.2      0.2      3.4      if not LAZY: self.realize()
   129                                           
   130                                               # log phantom ops to the graph
   131    238541      59839.4      0.3      4.3      if GRAPH >= 3: log_op(self, self.op, phantom=True)
```