### PR TITLE
Add warning when casting disk tensor

### DIFF
--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -1,7 +1,7 @@
 import os, mmap
 from typing import Optional
 from typing import Callable, Dict, Tuple
-from tinygrad.helpers import prod, DType
+from tinygrad.helpers import prod, DType, DEBUG
 from tinygrad.runtime.lib import RawBufferMapped
 from tinygrad.ops import Interpreted, Op, MovementOps, UnaryOps
 
@@ -21,7 +21,9 @@ class RawDiskBuffer(RawBufferMapped):
   def __del__(self):
     self._buf[2] -= 1
     if self._buf[2] == 0: self._buf[0].close()
-  def cast(self, arg:Tuple[DType, bool]): return RawDiskBuffer(self.size, arg[0], buf=self._buf, shape=self.shape, offset=self.offset)
+  def cast(self, arg:Tuple[DType, bool]):
+    if DEBUG >= 1 and (not arg[1] or arg[0].itemsize != self.dtype.itemsize): print(f"WARNING: casting disk tensor with different itemsizes {self.dtype}:{self.dtype.itemsize} to {arg[0]}:{arg[0].itemsize}. You might want to use another device for correct casting")
+    return RawDiskBuffer(self.size, arg[0], buf=self._buf, shape=self.shape, offset=self.offset)
   def reshape(self, arg): return RawDiskBuffer(self.size, self.dtype, buf=self._buf, shape=arg, offset=self.offset)
   def shrink(self, arg):
     assert arg[1:] == tuple([(0,x) for x in self.shape[1:]]), f"can only slice the first dim of disk tensor {arg}"


### PR DESCRIPTION
Related to issue https://github.com/tinygrad/tinygrad/issues/1767

We still want to keep casting for disk tensors but there can sometimes be unexpected behaviour from the user side. This warning could help.