### PR TITLE
revert typo in external_multi_gpu.py

### DIFF
--- a/test/external/external_multi_gpu.py
+++ b/test/external/external_multi_gpu.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
   sz = 1024*1024*256  # 1 GB
   #sz = 1024*64
 
-  with ("CPU creation: ", on_exit=lambda x: f", {(sz*4*2)/x:.2f} GB/sec"):
+  with Timing("CPU creation: ", on_exit=lambda x: f", {(sz*4*2)/x:.2f} GB/sec"):
     c0 = Tensor.ones(sz, device="cpu").realize()
     c1 = (Tensor.ones(sz, device="cpu")/2).realize()
 


### PR DESCRIPTION
introduced by fb1cc6bf4be9325a6161dbabcb35c393c7b50dee