### PR TITLE
cuda launch bounds, use ptrdiff_t instead of int for indices

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -6,7 +6,7 @@ from tinygrad.ops import UnaryOps, BinaryOps, TernaryOps
 from tinygrad.helpers import ImageDType, dtypes, prod, DType, strip_parens
 
 class CStyleLanguage(NamedTuple):
-  size_prefix: str = "int"
+  size_prefix: str = "ptrdiff_t"
   generic_var_prefix: str = ""
   kernel_prefix: str = ""
   buffer_prefix: str = ""

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -86,7 +86,7 @@ class CUDAProgram:
       return start.time_till(end)*1e-3
 
 renderer = functools.partial(uops_to_cstyle, CStyleLanguage(
-  kernel_prefix = "__global__", smem_prefix = "__shared__ ", arg_int_prefix = "const int", barrier = "__syncthreads();", float4 = "make_float4",
+  kernel_prefix = "__global__", smem_prefix = "__shared__ ", arg_int_prefix = "const int", barrier = "__syncthreads();", float4 = "make_float4", launch_bounds=True,
   gid = [f'blockIdx.{chr(120+i)}' for i in range(3)],
   lid = [f'threadIdx.{chr(120+i)}' for i in range(3)],
   half_prekernel = """


### PR DESCRIPTION
For large convs and other operations, int is not large enough for indices. I ran into this when playing with unet3d