### PR TITLE
PoC nerfed winograd that compiles very fast

### DIFF
--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -348,7 +348,7 @@ class OptimizedKernel(Kernel):
     # upcast leading axes first (hack-ish for winograd; we actually want to upcast masked axes with low stride first)
     for axis in range(self.first_reduce):
       # we might want to be able to split axes that are masked, or refuse to merge them in simplify_merge_adjacent
-      if self.full_shape[axis] <= 7 and any(st.axis_is_masked(axis) for st in self.sts) and prod(self.full_shape[self.shape_len - self.upcasted:]) * self.full_shape[axis] <= 7 * 7:
+      if self.full_shape[axis] <= 7 and (True or any(st.axis_is_masked(axis) for st in self.sts)) and prod(self.full_shape[self.shape_len - self.upcasted:]) * self.full_shape[axis] <= 7 * 7:
         if DEBUG >= 4: print(f"upcasting masked axis : {axis}")
         to_upcast.append(axis)
     for axis in to_upcast[::-1]:

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -345,10 +345,11 @@ class OptimizedKernel(Kernel):
     # if there are small dims with lots of valid masks, upcast them (they might be from Tensor.stack)
     # this can be made much smarter
     to_upcast = []
+    real_strides = [st.real_strides() for st in self.sts]
     # upcast leading axes first (hack-ish for winograd; we actually want to upcast masked axes with low stride first)
     for axis in range(self.first_reduce):
       # we might want to be able to split axes that are masked, or refuse to merge them in simplify_merge_adjacent
-      if self.full_shape[axis] in [3,5,6,7] and any(0 < st.real_strides()[axis] <= 7 for st in self.sts) and prod(self.full_shape[self.shape_len - self.upcasted:]) * self.full_shape[axis] <= 7 * 7:
+      if self.full_shape[axis] in [3,5,6,7] and any(0 < rs[axis] <= 7 for rs in real_strides if rs[axis] is not None) and prod(self.full_shape[self.shape_len - self.upcasted:]) * self.full_shape[axis] <= 7 * 7:
         if DEBUG >= 4: print(f"upcasting masked axis : {axis}")
         to_upcast.append(axis)
     for axis in to_upcast[::-1]:

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -348,7 +348,7 @@ class OptimizedKernel(Kernel):
     # upcast leading axes first (hack-ish for winograd; we actually want to upcast masked axes with low stride first)
     for axis in range(self.first_reduce):
       # we might want to be able to split axes that are masked, or refuse to merge them in simplify_merge_adjacent
-      if self.full_shape[axis] <= 7 and (True or any(st.axis_is_masked(axis) for st in self.sts)) and prod(self.full_shape[self.shape_len - self.upcasted:]) * self.full_shape[axis] <= 7 * 7:
+      if self.full_shape[axis] in [3,5,6,7] and any(0 < st.real_strides()[axis] <= 7 for st in self.sts) and prod(self.full_shape[self.shape_len - self.upcasted:]) * self.full_shape[axis] <= 7 * 7:
         if DEBUG >= 4: print(f"upcasting masked axis : {axis}")
         to_upcast.append(axis)
     for axis in to_upcast[::-1]:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -519,21 +519,21 @@ class Tensor:
     # todo: stride == dilation
     # use padding to round up to 4x4 output tiles
     d = self.pad2d(sum([[padding_[i*2], padding_[i*2+1] + (-(dim + sum(padding_[i * 2:(i + 1) * 2]) - 2) % 4)] for i, dim in enumerate(self.shape[-len(HW):])], []))._pool(HWI, HWO)  # (bs, cin_, tyx, HWI)
-    d = d.permute(*range(len(d.shape)-len(HW),len(d.shape)), *range(len(d.shape)-len(HW))).contiguous_backward()  # move HW to the front: # (HWI, bs, cin_, tyx)
+    d = d.permute(*range(len(d.shape)-len(HW),len(d.shape)), *range(len(d.shape)-len(HW)))  # move HW to the front: # (HWI, bs, cin_, tyx)
     tyx = d.shape[-len(HWI):]  # dim of tiling
 
     g = weight.permute(*range(len(weight.shape)-len(HW),len(weight.shape)), *range(len(weight.shape)-len(HW)))  # move HW to the front
 
     # compute 6x6 winograd tiles: GgGt, BtdB
-    gfactors = apply_matrix(winograd_G, g).contiguous().reshape(*HWI, 1, groups, rcout, cin, *([1]*len(tyx)))  # (HWI, groups * rcout, cin) -> (HWI, bs=1, groups, rcout, cin, tyx=(1,1))
-    dfactors = apply_matrix(winograd_Bt, d).contiguous().reshape(*HWI, bs, groups, 1, cin, *tyx)  # (HWI, bs, cin_, tyx) -> (HWI, bs, groups, 1 ,cin, *tyx)
+    gfactors = apply_matrix(winograd_G, g).reshape(*HWI, 1, groups, rcout, cin, *([1]*len(tyx)))  # (HWI, groups * rcout, cin) -> (HWI, bs=1, groups, rcout, cin, tyx=(1,1))
+    dfactors = apply_matrix(winograd_Bt, d).reshape(*HWI, bs, groups, 1, cin, *tyx)  # (HWI, bs, cin_, tyx) -> (HWI, bs, groups, 1 ,cin, *tyx)
 
     ret = apply_matrix(winograd_At, (gfactors * dfactors).sum(axis=-1-len(HW)))  # matmul; sum across cin: (HWI, bs, groups, rcout, *tyx); then HWI -> HWO: (HWO, bs, groups, rcout, *tyx)
 
     ret = ret.permute([*range(len(HW), len(ret.shape)-len(HW)), *[i+o for i in range(len(HW)) for o in [len(ret.shape)-len(HW),0]]])  # interleave tyx and HWO: (bs, groups, rcout, oy, HO, ox, WO)
     ret = ret.reshape(bs, cout, *[c * HWO[i] for i, c in enumerate(tyx)]).shrink(tuple((0, s) for s in [bs, cout, *oyx]))  # merge groups and rcout, tyx and HWO: (bs, groups, cout, *yx), shrink to final
 
-    return (ret if bias is None else ret.add(bias.reshape(1, -1, *[1 for _ in range(len(HW))]))).contiguous().contiguous_backward()
+    return ret if bias is None else ret.add(bias.reshape(1, -1, *[1 for _ in range(len(HW))]))
 
   def dot(self, w:Tensor) -> Tensor:
     n1, n2 = len(self.shape), len(w.shape)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -479,7 +479,6 @@ class Tensor:
     return x.conv2d(w.reshape(w.shape[0]*w.shape[1],*w.shape[2:]), groups=groups, bias=bias, dilation=dilation, padding=padding)
 
   wino = int(getenv("WINO", "0"))
-  conv_cache = {}
   def conv2d(self, weight:Tensor, bias:Optional[Tensor]=None, groups=1, stride=1, dilation=1, padding=0) -> Tensor:
     (bs,cin_), (cout,cin), HW = self.shape[:2], weight.shape[:2], weight.shape[2:]
     assert groups*cin == cin_ and len(self.shape) == len(weight.shape), f"Input Tensor shape {self.shape} does not match the shape of the weights {weight.shape}. ({groups*cin} vs. {cin_})"

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -501,14 +501,11 @@ class Tensor:
       tmat = Tensor(mat).realize()
       fmat = None
       for dim in range(len(HW)):
+        # reshape and expand to full shape to avoid multiple kernels
         rmat = tmat.reshape([1] * dim + [tmat.shape[0]] + [1] * (len(HW) - 1) + [tmat.shape[1]] + [1] * (len(HW) - dim - 1) + [1] * (len(t.shape) - len(HW)))
         rmat = rmat.expand((tmat.shape[0],) * len(HW) + (tmat.shape[1],) * len(HW) + t.shape[len(HW):])
-        if fmat is None:
-          fmat = rmat
-        else:
-          fmat = fmat * rmat
-      rt = t.reshape((1,) * len(HW) + t.shape)
-      return (rt * fmat).sum(list(range(len(HW), 2 * len(HW))))
+        fmat = rmat if fmat is None else fmat * rmat
+      return (t.reshape((1,) * len(HW) + t.shape) * fmat).sum(list(range(len(HW), 2 * len(HW))))
 
     HWI, HWO = (6,) * len(HW), (4,) * len(HW)  # F(4x4,3x3) winograd tiles
     winograd_Bt = [[4, 0, -5, 0, 1, 0], [0, -4, -4, 1, 1, 0], [0, 4, -4, -1, 1, 0], [0, -2, -1, 2, 1, 0], [0, 2, -1, -2, 1, 0], [0, 4, 0, -5, 0, 1]]


### PR DESCRIPTION
0.77ms -> 0.82ms 3090 with KOPT=0 and OPT=3. ~~We need OPT=3 for this variant because the last permute needs to be pushed, or else it will generate an excess kernel.~~ If we don't contiguous at the end, no need for OPT=3, the permute will be fused into whatever comes next.

Need to quantify how much we are losing vs theoretical best KOPT.

the hand coded optimizations are hacked up for this, so probably nothing else will run very fast as-is.

The tradeoff 7900xtx (top: this pr, bottom: baseline):

```
(venv) chaos@tiny3:~/tinygrad$ DEBUG=0 WINO=1 KOPT=0 BIG=1 HIP_VISIBLE_DEVICES=0 GPU=1 TORCHCUDA=0 python ./test/test_speed_v_torch.py TestBigSpeed.test_large_conv_3x3
/home/chaos/tinygrad/venv/lib/python3.11/site-packages/pyopencl/cache.py:495: CompilerWarning: Non-empty compiler output encountered. Set the environment variable PYOPENCL_COMPILER_OUTPUT=1 to see more.
  _create_built_program_from_source_cached(
conv bs:  4 chans:128 -> 128 k:3            193.77 ms (   40.21 GFLOPS     1.94 GB/s) in torch,    1.27 ms ( 6157.98 GFLOPS   296.72 GB/s) in tinygrad,    0.01x faster    7792.16 MOPS   375.46 MB
.
----------------------------------------------------------------------
Ran 1 test in 4.042s

OK
(venv) chaos@tiny3:~/tinygrad$ DEBUG=0 WINO=1 KOPT=0 BIG=1 HIP_VISIBLE_DEVICES=0 GPU=1 TORCHCUDA=0 python ./test/test_speed_v_torch.py TestBigSpeed.test_large_conv_3x3
/home/chaos/tinygrad/venv/lib/python3.11/site-packages/pyopencl/cache.py:495: CompilerWarning: Non-empty compiler output encountered. Set the environment variable PYOPENCL_COMPILER_OUTPUT=1 to see more.
  _create_built_program_from_source_cached(
conv bs:  4 chans:128 -> 128 k:3            193.89 ms (  135.79 GFLOPS     1.94 GB/s) in torch,    1.18 ms (22380.90 GFLOPS   319.15 GB/s) in tinygrad,    0.01x faster   26329.68 MOPS   375.46 MB
.
----------------------------------------------------------------------
Ran 1 test in 20.058s

OK
```

DEBUG=2 to see the kernels:
```
(venv) chaos@tiny3:~/tinygrad$ DEBUG=2 WINO=1 KOPT=0 BIG=1 HIP_VISIBLE_DEVICES=0 GPU=1 TORCHCUDA=0 python ./test/test_speed_v_torch.py TestBigSpeed.test_large_conv_3x3
using devices: [('v1', 'Advanced Micro Devices, Inc.', 4098, 'gfx1100', 'OpenCL 2.0 '), ('v1', 'Advanced Micro Devices, Inc.', 4098, 'gfx1100', 'OpenCL 2.0 '), ('v1', 'Advanced Micro Devices, Inc.', 4098, 'gfx1100', 'OpenCL 2.0 ')]
/home/chaos/tinygrad/venv/lib/python3.11/site-packages/pyopencl/cache.py:495: CompilerWarning: Non-empty compiler output encountered. Set the environment variable PYOPENCL_COMPILER_OUTPUT=1 to see more.
  _create_built_program_from_source_cached(
***    0 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/   0.00G  mem  0.07 GB tm     91.28us/     0.09ms (   94.79 GFLOPS,  758.34 GB/s)
***    1 r_512_32_3_3_6_6                  arg   3 sz [512]              [32]         OPs     15M/   0.00G  mem  0.07 GB tm      9.08us/     0.10ms ( 1753.88 GFLOPS,  324.80 GB/s)
***    2 r_512_4_2_8_16_6_6_6_6            arg   3 sz [2, 4, 512]        [16, 8]      OPs   2038M/   0.02G  mem  0.15 GB tm    208.92us/     0.31ms ( 9756.90 GFLOPS,  527.03 GB/s)
***    3 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/   2.05G  mem  0.22 GB tm    618.85us/     0.93ms ( 7807.83 GFLOPS,  247.81 GB/s)
***    4 r_8192_4_16_6_6_4_4               arg   3 sz [8192]             [16, 4]      OPs    905M/   6.89G  mem  0.18 GB tm    148.88us/     1.08ms ( 6085.19 GFLOPS,  732.48 GB/s)
***    5 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/   7.79G  mem  0.14 GB tm    105.88us/     1.18ms (   81.72 GFLOPS,  653.78 GB/s)
***    6 r_512_32_3_3_6_6                  arg   3 sz [512]              [32]         OPs     15M/   0.00G  mem  0.11 GB tm     14.84us/     1.20ms ( 1073.13 GFLOPS,  198.73 GB/s)
***    7 r_512_4_2_8_16_6_6_6_6            arg   3 sz [2, 4, 512]        [16, 8]      OPs   2038M/   0.02G  mem  0.18 GB tm    207.60us/     1.41ms ( 9818.94 GFLOPS,  530.38 GB/s)
***    8 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/   2.05G  mem  0.26 GB tm    607.85us/     2.01ms ( 7949.13 GFLOPS,  252.29 GB/s)
***    9 r_8192_4_16_6_6_4_4               arg   3 sz [8192]             [16, 4]      OPs    905M/   6.89G  mem  0.21 GB tm    146.16us/     2.16ms ( 6198.44 GFLOPS,  746.11 GB/s)
JIT captured 4 kernels with 1 inputs
***   10 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/   7.79G  mem  0.29 GB tm    106.48us/     2.27ms (   81.26 GFLOPS,  650.09 GB/s)
***   11 r_512_32_3_3_6_6                  arg   3 sz [512]              [32]         OPs     15M/   0.00G  mem  0.26 GB tm      7.92us/     2.27ms ( 2010.76 GFLOPS,  372.37 GB/s)
***   12 r_512_4_2_8_16_6_6_6_6            arg   3 sz [2, 4, 512]        [16, 8]      OPs   2038M/   0.02G  mem  0.26 GB tm    206.20us/     2.48ms ( 9885.65 GFLOPS,  533.99 GB/s)
***   13 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/   2.05G  mem  0.26 GB tm    633.85us/     3.11ms ( 7623.06 GFLOPS,  241.94 GB/s)
***   14 r_8192_4_16_6_6_4_4               arg   3 sz [8192]             [16, 4]      OPs    905M/   6.89G  mem  0.26 GB tm    102.20us/     3.22ms ( 8864.59 GFLOPS, 1067.03 GB/s)
***   15 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/   7.79G  mem  0.29 GB tm     68.76us/     3.28ms (  125.84 GFLOPS, 1006.72 GB/s)
***   16 r_512_32_3_3_6_6                  arg   3 sz [512]              [32]         OPs     15M/   0.00G  mem  0.26 GB tm      8.08us/     3.29ms ( 1970.95 GFLOPS,  365.00 GB/s)
***   17 r_512_4_2_8_16_6_6_6_6            arg   3 sz [2, 4, 512]        [16, 8]      OPs   2038M/   0.02G  mem  0.26 GB tm    206.04us/     3.50ms ( 9893.33 GFLOPS,  534.40 GB/s)
***   18 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/   2.05G  mem  0.26 GB tm    631.04us/     4.13ms ( 7656.88 GFLOPS,  243.02 GB/s)
***   19 r_8192_4_16_6_6_4_4               arg   3 sz [8192]             [16, 4]      OPs    905M/   6.89G  mem  0.26 GB tm    100.44us/     4.23ms ( 9019.92 GFLOPS, 1085.73 GB/s)
***   20 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/   7.79G  mem  0.29 GB tm     68.28us/     4.30ms (  126.73 GFLOPS, 1013.80 GB/s)
***   21 r_512_32_3_3_6_6                  arg   3 sz [512]              [32]         OPs     15M/   0.00G  mem  0.26 GB tm      8.16us/     4.31ms ( 1951.38 GFLOPS,  361.38 GB/s)
***   22 r_512_4_2_8_16_6_6_6_6            arg   3 sz [2, 4, 512]        [16, 8]      OPs   2038M/   0.02G  mem  0.26 GB tm    206.40us/     4.51ms ( 9876.07 GFLOPS,  533.47 GB/s)
***   23 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/   2.05G  mem  0.26 GB tm    649.21us/     5.16ms ( 7442.70 GFLOPS,  236.22 GB/s)
***   24 r_8192_4_16_6_6_4_4               arg   3 sz [8192]             [16, 4]      OPs    905M/   6.89G  mem  0.26 GB tm     99.76us/     5.26ms ( 9081.40 GFLOPS, 1093.13 GB/s)
***   25 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/   7.79G  mem  0.29 GB tm     69.04us/     5.33ms (  125.33 GFLOPS, 1002.64 GB/s)
***   26 r_512_32_3_3_6_6                  arg   3 sz [512]              [32]         OPs     15M/   0.00G  mem  0.26 GB tm      8.16us/     5.34ms ( 1951.62 GFLOPS,  361.42 GB/s)
***   27 r_512_4_2_8_16_6_6_6_6            arg   3 sz [2, 4, 512]        [16, 8]      OPs   2038M/   0.02G  mem  0.26 GB tm    206.48us/     5.55ms ( 9872.20 GFLOPS,  533.26 GB/s)
***   28 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/   2.05G  mem  0.26 GB tm    675.89us/     6.22ms ( 7148.91 GFLOPS,  226.89 GB/s)
***   29 r_8192_4_16_6_6_4_4               arg   3 sz [8192]             [16, 4]      OPs    905M/   6.89G  mem  0.26 GB tm    100.84us/     6.32ms ( 8984.14 GFLOPS, 1081.43 GB/s)
***   30 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/   7.79G  mem  0.29 GB tm     68.24us/     6.39ms (  126.80 GFLOPS, 1014.40 GB/s)
***   31 r_512_32_3_3_6_6                  arg   3 sz [512]              [32]         OPs     15M/   0.00G  mem  0.26 GB tm      8.08us/     6.40ms ( 1970.95 GFLOPS,  365.00 GB/s)
***   32 r_512_4_2_8_16_6_6_6_6            arg   3 sz [2, 4, 512]        [16, 8]      OPs   2038M/   0.02G  mem  0.26 GB tm    206.44us/     6.61ms ( 9874.11 GFLOPS,  533.36 GB/s)
***   33 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/   2.05G  mem  0.26 GB tm    661.40us/     7.27ms ( 7305.42 GFLOPS,  231.86 GB/s)
***   34 r_8192_4_16_6_6_4_4               arg   3 sz [8192]             [16, 4]      OPs    905M/   6.89G  mem  0.26 GB tm    102.80us/     7.37ms ( 8812.85 GFLOPS, 1060.81 GB/s)
***   35 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/   7.79G  mem  0.29 GB tm     69.00us/     7.44ms (  125.40 GFLOPS, 1003.22 GB/s)
***   36 r_512_32_3_3_6_6                  arg   3 sz [512]              [32]         OPs     15M/   0.00G  mem  0.26 GB tm      8.12us/     7.45ms ( 1961.24 GFLOPS,  363.20 GB/s)
***   37 r_512_4_2_8_16_6_6_6_6            arg   3 sz [2, 4, 512]        [16, 8]      OPs   2038M/   0.02G  mem  0.26 GB tm    205.52us/     7.65ms ( 9918.31 GFLOPS,  535.75 GB/s)
***   38 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/   2.05G  mem  0.26 GB tm    633.88us/     8.29ms ( 7622.58 GFLOPS,  241.93 GB/s)
***   39 r_8192_4_16_6_6_4_4               arg   3 sz [8192]             [16, 4]      OPs    905M/   6.89G  mem  0.26 GB tm    100.56us/     8.39ms ( 9009.16 GFLOPS, 1084.44 GB/s)
***   40 E_512_16_2_8_16_4                 arg   2 sz [2, 16, 512]       [16, 8]      OPs      8M/   7.79G  mem  0.29 GB tm     52.32us/     8.44ms (  160.33 GFLOPS, 1282.66 GB/s)
conv bs:  4 chans:128 -> 128 k:3            193.73 ms (   40.22 GFLOPS     1.94 GB/s) in torch,    1.60 ms ( 4861.00 GFLOPS   234.23 GB/s) in tinygrad,    0.01x faster    7792.16 MOPS   375.46 MB
.
----------------------------------------------------------------------
Ran 1 test in 4.020s

OK
avg:   924.35 GFLOPS    52.44 GB/s           total:    41 kernels     7.80 GOPS     0.44 GB     8.44 ms
(venv) chaos@tiny3:~/tinygrad$ DEBUG=2 WINO=1 KOPT=0 BIG=1 HIP_VISIBLE_DEVICES=0 GPU=1 TORCHCUDA=0 python ./test/test_speed_v_torch.py TestBigSpeed.test_large_conv_3x3
using devices: [('v1', 'Advanced Micro Devices, Inc.', 4098, 'gfx1100', 'OpenCL 2.0 '), ('v1', 'Advanced Micro Devices, Inc.', 4098, 'gfx1100', 'OpenCL 2.0 '), ('v1', 'Advanced Micro Devices, Inc.', 4098, 'gfx1100', 'OpenCL 2.0 ')]
/home/chaos/tinygrad/venv/lib/python3.11/site-packages/pyopencl/cache.py:495: CompilerWarning: Non-empty compiler output encountered. Set the environment variable PYOPENCL_COMPILER_OUTPUT=1 to see more.
  _create_built_program_from_source_cached(
***    0 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/   0.00G  mem  0.07 GB tm     89.84us/     0.09ms (   96.31 GFLOPS,  770.50 GB/s)
***    1 E_512_32_6_6                      arg   2 sz [512]              [32]         OPs    268M/   0.00G  mem  0.07 GB tm      9.28us/     0.10ms (28919.17 GFLOPS,  317.79 GB/s)
***    2 E_512_4_2_8_16_6_6                arg   2 sz [2, 4, 512]        [16, 8]      OPs  17043M/   0.27G  mem  0.15 GB tm    190.76us/     0.29ms (89345.07 GFLOPS,  577.21 GB/s)
***    3 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/  17.31G  mem  0.22 GB tm   2508.06us/     2.80ms ( 1926.52 GFLOPS,   61.14 GB/s)
***    4 E_2048_2_8_16_4_4                 arg   2 sz [2, 2048]          [16, 8]      OPs   4185M/  22.14G  mem  0.18 GB tm    252.92us/     3.05ms (16550.22 GFLOPS,  431.17 GB/s)
***    5 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/  26.33G  mem  0.14 GB tm    235.76us/     3.29ms (   36.70 GFLOPS,  293.61 GB/s)
***    6 E_512_32_6_6                      arg   2 sz [512]              [32]         OPs    268M/   0.00G  mem  0.11 GB tm     11.96us/     3.30ms (22438.96 GFLOPS,  246.58 GB/s)
***    7 E_512_4_2_8_16_6_6                arg   2 sz [2, 4, 512]        [16, 8]      OPs  17043M/   0.27G  mem  0.18 GB tm     84.72us/     3.38ms (201172.72 GFLOPS, 1299.66 GB/s)
***    8 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/  17.31G  mem  0.26 GB tm    601.88us/     3.99ms ( 8027.84 GFLOPS,  254.79 GB/s)
***    9 E_2048_2_8_16_4_4                 arg   2 sz [2, 2048]          [16, 8]      OPs   4185M/  22.14G  mem  0.21 GB tm    156.32us/     4.14ms (26777.52 GFLOPS,  697.61 GB/s)
JIT captured 4 kernels with 1 inputs
***   10 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/  26.33G  mem  0.29 GB tm    105.64us/     4.25ms (   81.91 GFLOPS,  655.26 GB/s)
***   11 E_512_32_6_6                      arg   2 sz [512]              [32]         OPs    268M/   0.00G  mem  0.26 GB tm      9.68us/     4.26ms (27724.17 GFLOPS,  304.66 GB/s)
***   12 E_512_4_2_8_16_6_6                arg   2 sz [2, 4, 512]        [16, 8]      OPs  17043M/   0.27G  mem  0.26 GB tm     81.32us/     4.34ms (209583.68 GFLOPS, 1354.00 GB/s)
***   13 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/  17.31G  mem  0.26 GB tm    606.93us/     4.95ms ( 7961.18 GFLOPS,  252.67 GB/s)
***   14 E_2048_2_8_16_4_4                 arg   2 sz [2, 2048]          [16, 8]      OPs   4185M/  22.14G  mem  0.26 GB tm    156.84us/     5.10ms (26688.74 GFLOPS,  695.30 GB/s)
***   15 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/  26.33G  mem  0.29 GB tm    104.44us/     5.21ms (   82.85 GFLOPS,  662.80 GB/s)
***   16 E_512_32_6_6                      arg   2 sz [512]              [32]         OPs    268M/   0.00G  mem  0.26 GB tm      8.12us/     5.21ms (33050.48 GFLOPS,  363.19 GB/s)
***   17 E_512_4_2_8_16_6_6                arg   2 sz [2, 4, 512]        [16, 8]      OPs  17043M/   0.27G  mem  0.26 GB tm     67.28us/     5.28ms (253318.98 GFLOPS, 1636.55 GB/s)
***   18 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/  17.31G  mem  0.26 GB tm    644.45us/     5.93ms ( 7497.67 GFLOPS,  237.96 GB/s)
***   19 E_2048_2_8_16_4_4                 arg   2 sz [2, 2048]          [16, 8]      OPs   4185M/  22.14G  mem  0.26 GB tm    102.44us/     6.03ms (40861.72 GFLOPS, 1064.53 GB/s)
***   20 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/  26.33G  mem  0.29 GB tm     67.56us/     6.10ms (  128.08 GFLOPS, 1024.61 GB/s)
***   21 E_512_32_6_6                      arg   2 sz [512]              [32]         OPs    268M/   0.00G  mem  0.26 GB tm      8.08us/     6.10ms (33214.10 GFLOPS,  364.99 GB/s)
***   22 E_512_4_2_8_16_6_6                arg   2 sz [2, 4, 512]        [16, 8]      OPs  17043M/   0.27G  mem  0.26 GB tm     67.68us/     6.17ms (251821.85 GFLOPS, 1626.88 GB/s)
***   23 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/  17.31G  mem  0.26 GB tm    636.04us/     6.81ms ( 7596.69 GFLOPS,  241.11 GB/s)
***   24 E_2048_2_8_16_4_4                 arg   2 sz [2, 2048]          [16, 8]      OPs   4185M/  22.14G  mem  0.26 GB tm    102.44us/     6.91ms (40861.72 GFLOPS, 1064.53 GB/s)
***   25 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/  26.33G  mem  0.29 GB tm     67.60us/     6.98ms (  128.00 GFLOPS, 1023.98 GB/s)
***   26 E_512_32_6_6                      arg   2 sz [512]              [32]         OPs    268M/   0.00G  mem  0.26 GB tm      8.08us/     6.99ms (33214.10 GFLOPS,  364.99 GB/s)
***   27 E_512_4_2_8_16_6_6                arg   2 sz [2, 4, 512]        [16, 8]      OPs  17043M/   0.27G  mem  0.26 GB tm     68.52us/     7.05ms (248734.76 GFLOPS, 1606.93 GB/s)
***   28 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/  17.31G  mem  0.26 GB tm    670.49us/     7.73ms ( 7206.47 GFLOPS,  228.72 GB/s)
***   29 E_2048_2_8_16_4_4                 arg   2 sz [2, 2048]          [16, 8]      OPs   4185M/  22.14G  mem  0.26 GB tm    102.44us/     7.83ms (40861.72 GFLOPS, 1064.53 GB/s)
***   30 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/  26.33G  mem  0.29 GB tm     67.40us/     7.89ms (  128.38 GFLOPS, 1027.04 GB/s)
***   31 E_512_32_6_6                      arg   2 sz [512]              [32]         OPs    268M/   0.00G  mem  0.26 GB tm      7.92us/     7.90ms (33885.09 GFLOPS,  372.36 GB/s)
***   32 E_512_4_2_8_16_6_6                arg   2 sz [2, 4, 512]        [16, 8]      OPs  17043M/   0.27G  mem  0.26 GB tm     68.52us/     7.97ms (248734.76 GFLOPS, 1606.93 GB/s)
***   33 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/  17.31G  mem  0.26 GB tm    658.73us/     8.63ms ( 7335.14 GFLOPS,  232.80 GB/s)
***   34 E_2048_2_8_16_4_4                 arg   2 sz [2, 2048]          [16, 8]      OPs   4185M/  22.14G  mem  0.26 GB tm    102.20us/     8.73ms (40957.68 GFLOPS, 1067.03 GB/s)
***   35 E_67600_32_4                      arg   2 sz [67600]            [32]         OPs      8M/  26.33G  mem  0.29 GB tm     67.64us/     8.80ms (  127.92 GFLOPS, 1023.38 GB/s)
***   36 E_512_32_6_6                      arg   2 sz [512]              [32]         OPs    268M/   0.00G  mem  0.26 GB tm      8.12us/     8.81ms (33050.48 GFLOPS,  363.19 GB/s)
***   37 E_512_4_2_8_16_6_6                arg   2 sz [2, 4, 512]        [16, 8]      OPs  17043M/   0.27G  mem  0.26 GB tm     68.68us/     8.88ms (248155.30 GFLOPS, 1603.19 GB/s)
***   38 r_36_4_4_16_8_16_32_4_4_4         arg   3 sz [64, 4, 36]        [16, 8]      OPs   4831M/  17.31G  mem  0.26 GB tm    682.53us/     9.56ms ( 7079.35 GFLOPS,  224.69 GB/s)
***   39 E_2048_2_8_16_4_4                 arg   2 sz [2, 2048]          [16, 8]      OPs   4185M/  22.14G  mem  0.26 GB tm    103.68us/     9.66ms (40373.41 GFLOPS, 1051.81 GB/s)
conv bs:  4 chans:128 -> 128 k:3            193.65 ms (  135.97 GFLOPS     1.94 GB/s) in torch,    1.50 ms (17511.48 GFLOPS   249.72 GB/s) in tinygrad,    0.01x faster   26329.68 MOPS   375.46 MB
.
----------------------------------------------------------------------
Ran 1 test in 20.319s

OK
avg:  2724.79 GFLOPS    38.86 GB/s           total:    40 kernels    26.33 GOPS     0.38 GB     9.66 ms
```

