### PR TITLE
Use correct dtype in Tensor when data is an ndarray

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -230,5 +230,11 @@ class TestTinygrad(unittest.TestCase):
     assert Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32 # check if ndarray correctly casts to Tensor dtype
     assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64 # check that it works for something else
 
+  def test_tensor_list_dtype(self):
+    arr = [1]
+    assert Tensor(arr).dtype == Tensor.default_type
+    assert Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32
+    assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -223,7 +223,7 @@ class TestTinygrad(unittest.TestCase):
   def test_zerosized_tensors(self):
     Tensor([]).realize()
     Tensor([]).numpy()
-  
+
   def test_tensor_ndarray_dtype(self):
     arr = np.array([1]) # where dtype is implicitly int64
     assert Tensor(arr).dtype == dtypes.int64

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -223,6 +223,12 @@ class TestTinygrad(unittest.TestCase):
   def test_zerosized_tensors(self):
     Tensor([]).realize()
     Tensor([]).numpy()
+  
+  def test_tensor_ndarray_dtype(self):
+    arr = np.array([1]) # where dtype is implicitly int64
+    assert Tensor(arr).dtype == dtypes.int64
+    assert Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32 # check if ndarray correctly casts to Tensor dtype
+    assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64 # check that it works for something else
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -59,7 +59,7 @@ class Tensor:
       assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"
       data = LazyBuffer.fromCPU(np.array(data, dtype=(dtype or Tensor.default_type).np))
     elif isinstance(data, np.ndarray):
-      data = LazyBuffer.fromCPU(data.astype((dtype or Tensor.default_type).np))
+      data = LazyBuffer.fromCPU(data.astype(dtype.np) if dtype is not None else data)
     else: raise RuntimeError(f"can't create Tensor from {data}")
 
     self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -59,7 +59,7 @@ class Tensor:
       assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"
       data = LazyBuffer.fromCPU(np.array(data, dtype=(dtype or Tensor.default_type).np))
     elif isinstance(data, np.ndarray):
-      data = LazyBuffer.fromCPU(data)
+      data = LazyBuffer.fromCPU(data.astype((dtype or Tensor.default_type).np))
     else: raise RuntimeError(f"can't create Tensor from {data}")
 
     self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -59,7 +59,8 @@ class Tensor:
       assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"
       data = LazyBuffer.fromCPU(np.array(data, dtype=(dtype or Tensor.default_type).np))
     elif isinstance(data, np.ndarray):
-      data = LazyBuffer.fromCPU(data.astype(dtype.np) if dtype is not None else data)
+      assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"
+      data = LazyBuffer.fromCPU(data.astype(dtype.np) if dtype is not None and dtype.np is not None else data)
     else: raise RuntimeError(f"can't create Tensor from {data}")
 
     self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)


### PR DESCRIPTION
Upon tryign to run codellama example with GPU=1 on M2 Macbook Air 16GB, I was getting following errors
```
AttributeError: 'E_12_4_8_16_2_4' was not found as a program info attribute or as a kernel name
pyopencl._cl.LogicError: clCreateKernel failed: INVALID_KERNEL
```

The kernel had was taking in a `double` parameter, e.g.
`__kernel void E_12_4_8_16_2_4(__global float* data0, const __global float* data1, const __global double* data2) {`

but was assigning to float value
`float val4 = data2[(gidx1*32)+(lidx3*2)+(gidx0*128)];`

and after some digging I realized Tensor was loading in ndarray with incorrect dtype