### PR TITLE
fix gpu compilation of const GEP

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -199,7 +199,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp]) -> st
       bufs.append(args)
       r[u] = args[0]
     elif uop == UOps.GEP:
-      r[u] = f"{r[vin[0]]}.{'xyzw'[args]}"
+      r[u] = f"({r[vin[0]]}).{'xyzw'[args]}"
     else:
       raise RuntimeError(f"failed to render {uop}")
 


### PR DESCRIPTION
Some opencl compilers are not happy with:
```
<program source>:35:41: error: member reference base type 'float' is not a structure or union
acc0.x = (((float4)(0.0f,0.0f,0.0f,0.0f).x*val12.x)+acc0.x);
                   ~~~~~~~~~~~~~~~~~~~~~^~
```