### PR TITLE
fix: openpilot kernel fusion back to 207

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
       - if: ${{ matrix.task == 'openpilot' }}
         name: Test openpilot model compile and size
         run: |
-          DEBUG=2 ALLOWED_KERNEL_COUNT=209 FLOAT16=1 DEBUGCL=1 GPU=1 IMAGE=2 python openpilot/compile.py
+          DEBUG=2 ALLOWED_KERNEL_COUNT=207 FLOAT16=1 DEBUGCL=1 GPU=1 IMAGE=2 python openpilot/compile.py
           python -c 'import os; assert os.path.getsize("/tmp/output.thneed") < 100_000_000'
       - if: ${{ matrix.task == 'openpilot' }}
         name: Test openpilot model correctness (float32)

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -223,7 +223,7 @@ class LazyBuffer:
     return create_lazybuffer(out_device, ShapeTracker(out_shape), BinaryOps, LazyOp(op, srcs, arg), out_dtype)
 
   def shuffle_and_prune_movement_ops(self, st: ShapeTracker, op: MovementOps, arg: Union[Tuple[Union[Node,int], ...], Tuple[Tuple[int, int], ...]]) -> LazyBuffer:
-    if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and not self.realized and (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or (op == MovementOps.RESHAPE and self.op.op in UnaryOps)) and not self.children:
+    if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and self.realized is None and len(self.children) == 0 and op != MovementOps.EXPAND and (op != MovementOps.PAD or (SHUFFLE_PAD_OPS and all(x.op != BinaryOps.DIV for x in self.op.get_lazyops()))):
       return self.op.replace_with_movement_ops([(op, arg)])
     if REMOVE_MOVEMENT_NOPS and not self.realized and st.contiguous:
       # MovementOps aren't stacked any more, they each have one parent, find the root

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -223,7 +223,8 @@ class LazyBuffer:
     return create_lazybuffer(out_device, ShapeTracker(out_shape), BinaryOps, LazyOp(op, srcs, arg), out_dtype)
 
   def shuffle_and_prune_movement_ops(self, st: ShapeTracker, op: MovementOps, arg: Union[Tuple[Union[Node,int], ...], Tuple[Tuple[int, int], ...]]) -> LazyBuffer:
-    if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and not self.realized and (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or (op == MovementOps.RESHAPE and (self.op.op in UnaryOps or self.op.op is BinaryOps.SUB))) and not self.children:
+    # TODO why no reshape with BinaryOps.ADD or BinaryOps.MUL?
+    if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and not self.realized and (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or (op == MovementOps.RESHAPE and (self.op.op in UnaryOps or self.op.op in (BinaryOps.MOD, BinaryOps.DIV, BinaryOps.CMPLT, BinaryOps.DIV, BinaryOps.SUB)))) and not self.children:
       return self.op.replace_with_movement_ops([(op, arg)])
     if REMOVE_MOVEMENT_NOPS and not self.realized and st.contiguous:
       # MovementOps aren't stacked any more, they each have one parent, find the root

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -223,7 +223,13 @@ class LazyBuffer:
     return create_lazybuffer(out_device, ShapeTracker(out_shape), BinaryOps, LazyOp(op, srcs, arg), out_dtype)
 
   def shuffle_and_prune_movement_ops(self, st: ShapeTracker, op: MovementOps, arg: Union[Tuple[Union[Node,int], ...], Tuple[Tuple[int, int], ...]]) -> LazyBuffer:
-    if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and self.realized is None and len(self.children) == 0 and op != MovementOps.EXPAND and (op != MovementOps.PAD or (SHUFFLE_PAD_OPS and all(x.op != BinaryOps.DIV for x in self.op.get_lazyops()))):
+    if (SHUFFLE_MOVEMENT_OPS and
+        self.optype == BinaryOps and
+        not self.realized and
+        (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or
+         (op is MovementOps.RESHAPE and self.op.op in UnaryOps) or
+         (SHUFFLE_PAD_OPS and all(x.op is not BinaryOps.DIV for x in self.op.get_lazyops())))
+         and not self.children):
       return self.op.replace_with_movement_ops([(op, arg)])
     if REMOVE_MOVEMENT_NOPS and not self.realized and st.contiguous:
       # MovementOps aren't stacked any more, they each have one parent, find the root

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -223,13 +223,7 @@ class LazyBuffer:
     return create_lazybuffer(out_device, ShapeTracker(out_shape), BinaryOps, LazyOp(op, srcs, arg), out_dtype)
 
   def shuffle_and_prune_movement_ops(self, st: ShapeTracker, op: MovementOps, arg: Union[Tuple[Union[Node,int], ...], Tuple[Tuple[int, int], ...]]) -> LazyBuffer:
-    if (SHUFFLE_MOVEMENT_OPS and
-        self.optype == BinaryOps and
-        not self.realized and
-        (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or
-         (op is MovementOps.RESHAPE and self.op.op in UnaryOps) or
-         (SHUFFLE_PAD_OPS and all(x.op is not BinaryOps.DIV for x in self.op.get_lazyops())))
-         and not self.children):
+    if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and not self.realized and op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE, MovementOps.RESHAPE} and not self.children:
       return self.op.replace_with_movement_ops([(op, arg)])
     if REMOVE_MOVEMENT_NOPS and not self.realized and st.contiguous:
       # MovementOps aren't stacked any more, they each have one parent, find the root

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -224,7 +224,7 @@ class LazyBuffer:
 
   def shuffle_and_prune_movement_ops(self, st: ShapeTracker, op: MovementOps, arg: Union[Tuple[Union[Node,int], ...], Tuple[Tuple[int, int], ...]]) -> LazyBuffer:
     # TODO why no reshape with BinaryOps.ADD or BinaryOps.MUL?
-    if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and not self.realized and (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or (op == MovementOps.RESHAPE and (self.op.op in UnaryOps or self.op.op in (BinaryOps.MOD, BinaryOps.DIV, BinaryOps.CMPLT, BinaryOps.DIV, BinaryOps.SUB)))) and not self.children:
+    if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and not self.realized and (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or (op == MovementOps.RESHAPE and (self.op.op in UnaryOps or self.op.op in (BinaryOps.MOD, BinaryOps.CMPLT, BinaryOps.SUB, BinaryOps.MAX)))) and not self.children:
       return self.op.replace_with_movement_ops([(op, arg)])
     if REMOVE_MOVEMENT_NOPS and not self.realized and st.contiguous:
       # MovementOps aren't stacked any more, they each have one parent, find the root

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -223,7 +223,7 @@ class LazyBuffer:
     return create_lazybuffer(out_device, ShapeTracker(out_shape), BinaryOps, LazyOp(op, srcs, arg), out_dtype)
 
   def shuffle_and_prune_movement_ops(self, st: ShapeTracker, op: MovementOps, arg: Union[Tuple[Union[Node,int], ...], Tuple[Tuple[int, int], ...]]) -> LazyBuffer:
-    if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and not self.realized and op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE, MovementOps.RESHAPE} and not self.children:
+    if SHUFFLE_MOVEMENT_OPS and self.optype == BinaryOps and not self.realized and (op in {MovementOps.SHRINK, MovementOps.STRIDE, MovementOps.PERMUTE} or (op == MovementOps.RESHAPE and (self.op.op in UnaryOps or self.op.op is BinaryOps.SUB))) and not self.children:
       return self.op.replace_with_movement_ops([(op, arg)])
     if REMOVE_MOVEMENT_NOPS and not self.realized and st.contiguous:
       # MovementOps aren't stacked any more, they each have one parent, find the root


### PR DESCRIPTION
Ref: https://github.com/tinygrad/tinygrad/issues/1781

Not 100% sure about the logic, but this restores the kernel fusion to 207.

openpilot/go.sh

<details>
  <summary>go.sh</summary>

```
realizing
realizing
kernel count: 207
saving thneed to /tmp/output.thneed
buffers to save: 399, inputs: ['input_imgs', 'big_input_imgs', 'desire', 'traffic_convention', 'nav_features', 'features_buffer'], outputs: [<pyopencl._cl.Buffer object at 0x7f6c682e8cb0>]
submit in 16.52 ms, total runtime is 323.23 ms
  0 time  0.00 ms running E_16_48_8_16_4       with [768, 128, 1]   [16, 8, 1]      count  2 runtime  645.60 us      0.00 GFLOPS -> (768, 128)
  1 time  0.65 ms running r_64_2_16_8_3_3_3_4_4_4 with [16, 1024, 1]   [8, 16, 1]      count  4 runtime 15007.70 us      3.90 GFLOPS -> (1024, 64)
  2 time 15.65 ms running r_64_2_16_8_3_3_4_4  with [16, 1024, 1]   [8, 16, 1]      count  4 runtime 3333.60 us      1.97 GFLOPS -> (1024, 64)
  3 time 18.99 ms running r_64_2_16_4_8_4_4_4  with [8, 1024, 1]    [4, 16, 1]      count  4 runtime 1979.20 us      4.30 GFLOPS -> (512, 64)
  4 time 20.97 ms running r_64_2_16_4_3_3_4_4  with [8, 1024, 1]    [4, 16, 1]      count  4 runtime 1468.40 us      2.23 GFLOPS -> (512, 64)
  5 time 22.43 ms running r_64_2_16_4_4_4_4_4  with [8, 1024, 1]    [4, 16, 1]      count  5 runtime 1146.70 us      3.89 GFLOPS -> (512, 64)
  6 time 23.58 ms running r_64_2_3_16_8_4_4_4_4 with [24, 32, 64]    [8, 16, 1]      count  4 runtime 6802.90 us      4.51 GFLOPS -> (3072, 64)
  7 time 30.38 ms running r_32_3_16_8_3_3_4_4  with [24, 512, 1]    [8, 16, 1]      count  4 runtime 1805.70 us      2.72 GFLOPS -> (1536, 32)
  8 time 32.19 ms running r_32_2_16_3_24_4_4_4 with [6, 512, 1]     [3, 16, 1]      count  4 runtime 2959.80 us      3.21 GFLOPS -> (384, 32)
  9 time 35.15 ms running r_32_9_16_4_6_4_4_4  with [36, 512, 1]    [4, 16, 1]      count  4 runtime 3584.90 us      4.52 GFLOPS -> (2304, 32)
 10 time 38.73 ms running r_32_9_16_4_3_3_4_4  with [36, 512, 1]    [4, 16, 1]      count  4 runtime 2760.80 us      2.67 GFLOPS -> (2304, 32)
 11 time 41.50 ms running r_32_2_16_3_36_4_4_4 with [6, 512, 1]     [3, 16, 1]      count  5 runtime 2611.80 us      5.46 GFLOPS -> (384, 32)
 12 time 44.11 ms running r_32_9_16_4_6_4_4_4  with [36, 512, 1]    [4, 16, 1]      count  4 runtime 3290.70 us      4.93 GFLOPS -> (2304, 32)
 13 time 47.40 ms running r_32_9_16_4_3_3_4_4  with [36, 512, 1]    [4, 16, 1]      count  4 runtime 2528.50 us      2.92 GFLOPS -> (2304, 32)
 14 time 49.93 ms running r_32_2_16_3_36_4_4_4 with [6, 512, 1]     [3, 16, 1]      count  5 runtime 2841.70 us      5.02 GFLOPS -> (384, 32)
 15 time 52.77 ms running r_32_9_16_4_6_4_4_4  with [36, 512, 1]    [4, 16, 1]      count  4 runtime 3964.10 us      4.09 GFLOPS -> (2304, 32)
 16 time 56.73 ms running r_4_9_4_8_4_5_5_4_4  with [36, 32, 4]     [4, 8, 4]       count  4 runtime 1313.90 us      3.20 GFLOPS -> (1152, 16)
 17 time 58.05 ms running r_4_3_4_8_4_36_4_4_4 with [12, 32, 4]     [4, 8, 4]       count  4 runtime 1970.60 us      3.60 GFLOPS -> (384, 16)
 18 time 60.02 ms running r_16_9_8_8_12_4_4_4  with [72, 128, 1]    [8, 8, 1]       count  4 runtime 2556.00 us      5.94 GFLOPS -> (2304, 16)
 19 time 62.57 ms running r_16_9_8_8_5_5_4_4   with [72, 128, 1]    [8, 8, 1]       count  4 runtime 2160.90 us      3.89 GFLOPS -> (2304, 16)
 20 time 64.73 ms running r_4_3_4_8_4_72_4_4_4 with [12, 32, 4]     [4, 8, 4]       count  5 runtime 2378.20 us      5.97 GFLOPS -> (384, 16)
 21 time 67.11 ms running r_16_9_8_8_12_4_4_4  with [72, 128, 1]    [8, 8, 1]       count  4 runtime 3061.90 us      4.96 GFLOPS -> (2304, 16)
 22 time 70.17 ms running r_16_9_8_8_5_5_4_4   with [72, 128, 1]    [8, 8, 1]       count  4 runtime 1958.30 us      4.29 GFLOPS -> (2304, 16)
 23 time 72.13 ms running r_4_3_4_8_4_72_4_4_4 with [12, 32, 4]     [4, 8, 4]       count  5 runtime 2196.50 us      6.47 GFLOPS -> (384, 16)
 24 time 74.33 ms running r_16_9_8_8_12_4_4_4  with [72, 128, 1]    [8, 8, 1]       count  4 runtime 2551.10 us      5.95 GFLOPS -> (2304, 16)
 25 time 76.88 ms running r_2_9_4_4_8_3_3_4_4  with [72, 8, 4]      [8, 4, 4]       count  4 runtime  478.70 us      1.93 GFLOPS -> (1152, 8)
 26 time 77.36 ms running r_22_8_4_72_4_4_4    with [88, 8, 1]      [4, 8, 1]       count  4 runtime 1532.70 us      4.24 GFLOPS -> (352, 8)
 27 time 78.89 ms running r_33_8_4_4_22_4_4_4  with [132, 4, 8]     [4, 4, 8]       count  4 runtime 3159.20 us      3.91 GFLOPS -> (2112, 8)
 28 time 82.05 ms running r_33_8_4_4_3_3_4_4   with [132, 4, 8]     [4, 4, 8]       count  4 runtime  760.90 us      2.22 GFLOPS -> (2112, 8)
 29 time 82.81 ms running r_22_8_4_132_4_4_4   with [88, 8, 1]      [4, 8, 1]       count  5 runtime 2506.90 us      4.75 GFLOPS -> (352, 8)
 30 time 85.32 ms running r_33_8_4_4_22_4_4_4  with [132, 4, 8]     [4, 4, 8]       count  4 runtime 2390.30 us      5.17 GFLOPS -> (2112, 8)
 31 time 87.71 ms running r_33_8_4_4_3_3_4_4   with [132, 4, 8]     [4, 4, 8]       count  4 runtime  801.60 us      2.11 GFLOPS -> (2112, 8)
 32 time 88.51 ms running r_22_8_4_132_4_4_4   with [88, 8, 1]      [4, 8, 1]       count  5 runtime 2085.60 us      5.71 GFLOPS -> (352, 8)
 33 time 90.60 ms running r_33_8_4_4_22_4_4_4  with [132, 4, 8]     [4, 4, 8]       count  4 runtime 2555.60 us      4.84 GFLOPS -> (2112, 8)
 34 time 93.15 ms running r_33_8_4_4_3_3_4_4   with [132, 4, 8]     [4, 4, 8]       count  4 runtime  856.40 us      1.97 GFLOPS -> (2112, 8)
 35 time 94.01 ms running r_22_8_4_132_4_4_4   with [88, 8, 1]      [4, 8, 1]       count  5 runtime 2177.30 us      5.47 GFLOPS -> (352, 8)
 36 time 96.18 ms running r_33_8_4_4_22_4_4_4  with [132, 4, 8]     [4, 4, 8]       count  4 runtime 3069.50 us      4.03 GFLOPS -> (2112, 8)
 37 time 99.25 ms running r_33_8_4_4_5_5_4_4   with [132, 4, 8]     [4, 4, 8]       count  4 runtime 1070.80 us      3.60 GFLOPS -> (2112, 8)
 38 time 100.33 ms running r_10_8_4_3_132_4_4_4 with [30, 4, 8]      [3, 4, 8]       count  4 runtime 3359.20 us      4.83 GFLOPS -> (480, 8)
 39 time 103.68 ms running r_45_8_4_4_30_4_4_4  with [180, 4, 8]     [4, 4, 8]       count  4 runtime 4226.20 us      5.39 GFLOPS -> (2880, 8)
 40 time 107.91 ms running r_45_8_4_4_5_5_4_4   with [180, 4, 8]     [4, 4, 8]       count  4 runtime 1135.40 us      4.63 GFLOPS -> (2880, 8)
 41 time 109.05 ms running r_10_8_4_3_180_4_4_4 with [30, 4, 8]      [3, 4, 8]       count  5 runtime 2600.70 us      8.52 GFLOPS -> (480, 8)
 42 time 111.65 ms running r_45_8_4_4_30_4_4_4  with [180, 4, 8]     [4, 4, 8]       count  4 runtime 3502.70 us      6.50 GFLOPS -> (2880, 8)
 43 time 115.15 ms running r_45_8_4_4_5_5_4_4   with [180, 4, 8]     [4, 4, 8]       count  4 runtime 1026.60 us      5.12 GFLOPS -> (2880, 8)
 44 time 116.18 ms running r_10_8_4_3_180_4_4_4 with [30, 4, 8]      [3, 4, 8]       count  5 runtime 2351.70 us      9.42 GFLOPS -> (480, 8)
 45 time 118.53 ms running r_45_8_4_4_30_4_4_4  with [180, 4, 8]     [4, 4, 8]       count  4 runtime 3299.60 us      6.90 GFLOPS -> (2880, 8)
 46 time 121.83 ms running r_45_8_4_4_5_5_4_4   with [180, 4, 8]     [4, 4, 8]       count  4 runtime  971.20 us      5.41 GFLOPS -> (2880, 8)
 47 time 122.80 ms running r_10_8_4_3_180_4_4_4 with [30, 4, 8]      [3, 4, 8]       count  5 runtime 2276.00 us      9.73 GFLOPS -> (480, 8)
 48 time 125.07 ms running r_45_8_4_4_30_4_4_4  with [180, 4, 8]     [4, 4, 8]       count  4 runtime 3690.50 us      6.17 GFLOPS -> (2880, 8)
 49 time 128.76 ms running r_45_8_4_5_5_4_4     with [180, 8, 1]     [4, 8, 1]       count  4 runtime  568.90 us      2.31 GFLOPS -> (1440, 4)
 50 time 129.33 ms running r_2_13_4_4_180_4_4_4 with [52, 8, 1]      [4, 4, 1]       count  4 runtime 1929.90 us      4.97 GFLOPS -> (416, 4)
 51 time 131.26 ms running r_2_39_4_8_52_4_4_4  with [312, 8, 1]     [8, 4, 1]       count  4 runtime 2647.10 us      6.38 GFLOPS -> (2496, 4)
 52 time 133.91 ms running r_39_8_8_5_5_4_4     with [312, 8, 1]     [8, 8, 1]       count  4 runtime  800.50 us      2.84 GFLOPS -> (2496, 4)
 53 time 134.71 ms running r_2_13_4_4_312_4_4_4 with [52, 8, 1]      [4, 4, 1]       count  5 runtime 2110.20 us      7.88 GFLOPS -> (416, 4)
 54 time 136.82 ms running r_2_39_4_8_52_4_4_4  with [312, 8, 1]     [8, 4, 1]       count  4 runtime 2532.40 us      6.67 GFLOPS -> (2496, 4)
 55 time 139.35 ms running r_39_8_8_5_5_4_4     with [312, 8, 1]     [8, 8, 1]       count  4 runtime  674.50 us      3.37 GFLOPS -> (2496, 4)
 56 time 140.03 ms running r_2_13_4_4_312_4_4_4 with [52, 8, 1]      [4, 4, 1]       count  5 runtime 2022.20 us      8.22 GFLOPS -> (416, 4)
 57 time 142.05 ms running r_2_39_4_8_52_4_4_4  with [312, 8, 1]     [8, 4, 1]       count  4 runtime 2872.70 us      5.88 GFLOPS -> (2496, 4)
 58 time 144.92 ms running r_39_8_8_5_5_4_4     with [312, 8, 1]     [8, 8, 1]       count  4 runtime  695.50 us      3.27 GFLOPS -> (2496, 4)
 59 time 145.62 ms running r_2_13_4_4_312_4_4_4 with [52, 8, 1]      [4, 4, 1]       count  5 runtime 2139.00 us      7.77 GFLOPS -> (416, 4)
 60 time 147.76 ms running r_2_39_4_8_52_4_4_4  with [312, 8, 1]     [8, 4, 1]       count  4 runtime 2573.10 us      6.57 GFLOPS -> (2496, 4)
 61 time 150.33 ms running r_39_8_8_5_5_4_4     with [312, 8, 1]     [8, 8, 1]       count  4 runtime  617.30 us      3.69 GFLOPS -> (2496, 4)
 62 time 150.95 ms running r_2_13_4_4_312_4_4_4 with [52, 8, 1]      [4, 4, 1]       count  5 runtime 2342.60 us      7.10 GFLOPS -> (416, 4)
 63 time 153.29 ms running r_2_39_4_8_52_4_4_4  with [312, 8, 1]     [8, 4, 1]       count  4 runtime 2698.00 us      6.26 GFLOPS -> (2496, 4)
 64 time 155.99 ms running r_39_8_8_3_3_4_4     with [312, 8, 1]     [8, 8, 1]       count  4 runtime  343.20 us      2.91 GFLOPS -> (2496, 4)
 65 time 156.33 ms running r_2_11_4_8_312_4_4_4 with [88, 8, 1]      [8, 4, 1]       count  4 runtime 4839.20 us      5.81 GFLOPS -> (704, 4)
 66 time 161.17 ms running r_2_33_4_16_88_4_4_4 with [528, 8, 1]     [16, 4, 1]      count  4 runtime 7072.90 us      6.79 GFLOPS -> (4224, 4)
 67 time 168.24 ms running r_33_8_16_3_3_4_4    with [528, 8, 1]     [16, 8, 1]      count  4 runtime  441.10 us      3.83 GFLOPS -> (4224, 4)
 68 time 168.69 ms running r_2_11_4_8_528_4_4_4 with [88, 8, 1]      [8, 4, 1]       count  7 runtime 5742.60 us      8.30 GFLOPS -> (704, 4)
 69 time 174.43 ms running r_2_8_16_88_4_4      with [32, 8, 1]      [16, 8, 1]      count  3 runtime  723.40 us      1.00 GFLOPS -> 4096
 70 time 175.15 ms running E_16_48_8_16_4       with [768, 128, 1]   [16, 8, 1]      count  2 runtime  300.10 us      0.00 GFLOPS -> (768, 128)
 71 time 175.45 ms running r_64_2_16_8_3_3_3_4_4_4 with [16, 1024, 1]   [8, 16, 1]      count  4 runtime 10128.90 us      5.77 GFLOPS -> (1024, 64)
 72 time 185.58 ms running r_64_2_16_8_3_3_4_4  with [16, 1024, 1]   [8, 16, 1]      count  4 runtime 1792.30 us      3.66 GFLOPS -> (1024, 64)
 73 time 187.37 ms running r_64_2_16_4_8_4_4_4  with [8, 1024, 1]    [4, 16, 1]      count  4 runtime 1851.30 us      4.60 GFLOPS -> (512, 64)
 74 time 189.22 ms running r_64_2_3_16_8_4_4_4_4 with [24, 32, 64]    [8, 16, 1]      count  4 runtime 4114.90 us      7.45 GFLOPS -> (3072, 64)
 75 time 193.34 ms running r_32_3_16_8_3_3_4_4  with [24, 512, 1]    [8, 16, 1]      count  4 runtime 1237.70 us      3.97 GFLOPS -> (1536, 32)
 76 time 194.58 ms running r_32_2_16_3_24_4_4_4 with [6, 512, 1]     [3, 16, 1]      count  4 runtime 1776.00 us      5.34 GFLOPS -> (384, 32)
 77 time 196.35 ms running r_32_9_16_4_6_4_4_4  with [36, 512, 1]    [4, 16, 1]      count  4 runtime 2379.40 us      6.82 GFLOPS -> (2304, 32)
 78 time 198.73 ms running r_32_9_16_4_3_3_4_4  with [36, 512, 1]    [4, 16, 1]      count  4 runtime 2428.10 us      3.04 GFLOPS -> (2304, 32)
 79 time 201.16 ms running r_32_2_16_3_36_4_4_4 with [6, 512, 1]     [3, 16, 1]      count  5 runtime 1658.40 us      8.60 GFLOPS -> (384, 32)
 80 time 202.82 ms running r_32_9_16_4_6_4_4_4  with [36, 512, 1]    [4, 16, 1]      count  4 runtime 2213.00 us      7.33 GFLOPS -> (2304, 32)
 81 time 205.03 ms running r_4_9_4_8_4_5_5_4_4  with [36, 32, 4]     [4, 8, 4]       count  4 runtime 1067.20 us      3.94 GFLOPS -> (1152, 16)
 82 time 206.10 ms running r_10_16_8_36_4_4_4   with [80, 16, 1]     [8, 16, 1]      count  4 runtime 1072.50 us      5.52 GFLOPS -> (320, 16)
 83 time 207.17 ms running r_4_15_4_8_4_10_4_4_4 with [60, 32, 4]     [4, 8, 4]       count  4 runtime 1463.00 us      7.31 GFLOPS -> (1920, 16)
 84 time 208.63 ms running r_4_15_4_8_4_5_5_4_4 with [60, 32, 4]     [4, 8, 4]       count  4 runtime 1232.50 us      5.68 GFLOPS -> (1920, 16)
 85 time 209.87 ms running r_10_16_8_60_4_4_4   with [80, 16, 1]     [8, 16, 1]      count  5 runtime 1260.80 us      7.83 GFLOPS -> (320, 16)
 86 time 211.13 ms running r_4_15_4_8_4_10_4_4_4 with [60, 32, 4]     [4, 8, 4]       count  4 runtime 1269.50 us      8.42 GFLOPS -> (1920, 16)
 87 time 212.40 ms running r_15_8_4_4_3_3_4_4   with [60, 4, 8]      [4, 4, 8]       count  4 runtime  403.30 us      1.90 GFLOPS -> (960, 8)
 88 time 212.80 ms running r_5_8_4_4_60_4_4_4   with [20, 4, 8]      [4, 4, 8]       count  4 runtime 1038.30 us      4.74 GFLOPS -> (320, 8)
 89 time 213.84 ms running r_2_15_4_4_8_20_4_4_4 with [120, 8, 4]     [8, 4, 4]       count  4 runtime 1371.90 us      7.48 GFLOPS -> (1920, 8)
 90 time 215.21 ms running r_2_15_4_4_8_3_3_4_4 with [120, 8, 4]     [8, 4, 4]       count  4 runtime  560.40 us      2.74 GFLOPS -> (1920, 8)
 91 time 215.77 ms running r_5_8_4_4_120_4_4_4  with [20, 4, 8]      [4, 4, 8]       count  5 runtime 1295.00 us      7.61 GFLOPS -> (320, 8)
 92 time 217.07 ms running r_2_15_4_4_8_20_4_4_4 with [120, 8, 4]     [8, 4, 4]       count  4 runtime 1195.20 us      8.58 GFLOPS -> (1920, 8)
 93 time 218.26 ms running r_2_15_4_4_8_3_3_4_4 with [120, 8, 4]     [8, 4, 4]       count  4 runtime  426.50 us      3.60 GFLOPS -> (1920, 8)
 94 time 218.69 ms running r_5_8_4_4_120_4_4_4  with [20, 4, 8]      [4, 4, 8]       count  5 runtime 1253.30 us      7.86 GFLOPS -> (320, 8)
 95 time 219.94 ms running r_2_15_4_4_8_20_4_4_4 with [120, 8, 4]     [8, 4, 4]       count  4 runtime 1196.20 us      8.58 GFLOPS -> (1920, 8)
 96 time 221.14 ms running r_2_15_4_4_8_5_5_4_4 with [120, 8, 4]     [8, 4, 4]       count  4 runtime  693.00 us      5.05 GFLOPS -> (1920, 8)
 97 time 221.83 ms running r_7_8_4_4_120_4_4_4  with [28, 4, 8]      [4, 4, 8]       count  4 runtime 2993.80 us      4.60 GFLOPS -> (448, 8)
 98 time 224.82 ms running r_2_21_4_4_8_28_4_4_4 with [168, 8, 4]     [8, 4, 4]       count  4 runtime 2657.70 us      7.48 GFLOPS -> (2688, 8)
 99 time 227.48 ms running r_2_21_4_4_8_5_5_4_4 with [168, 8, 4]     [8, 4, 4]       count  4 runtime 1050.00 us      4.67 GFLOPS -> (2688, 8)
100 time 228.53 ms running r_7_8_4_4_168_4_4_4  with [28, 4, 8]      [4, 4, 8]       count  5 runtime 3065.50 us      6.29 GFLOPS -> (448, 8)
101 time 231.60 ms running r_2_21_4_4_8_28_4_4_4 with [168, 8, 4]     [8, 4, 4]       count  4 runtime 2231.40 us      8.90 GFLOPS -> (2688, 8)
102 time 233.83 ms running r_2_21_4_4_8_5_5_4_4 with [168, 8, 4]     [8, 4, 4]       count  4 runtime  721.40 us      6.80 GFLOPS -> (2688, 8)
103 time 234.55 ms running r_7_8_4_4_168_4_4_4  with [28, 4, 8]      [4, 4, 8]       count  5 runtime 2799.00 us      6.89 GFLOPS -> (448, 8)
104 time 237.35 ms running r_2_21_4_4_8_28_4_4_4 with [168, 8, 4]     [8, 4, 4]       count  4 runtime 2266.70 us      8.77 GFLOPS -> (2688, 8)
105 time 239.62 ms running r_21_8_8_5_5_4_4     with [168, 8, 1]     [8, 8, 1]       count  4 runtime  519.10 us      2.36 GFLOPS -> (1344, 4)
106 time 240.13 ms running r_2_3_4_16_168_4_4_4 with [48, 8, 1]      [16, 4, 1]      count  4 runtime 1297.80 us      6.37 GFLOPS -> (384, 4)
107 time 241.43 ms running r_2_18_4_16_48_4_4_4 with [288, 8, 1]     [16, 4, 1]      count  4 runtime 1948.80 us      7.40 GFLOPS -> (2304, 4)
108 time 243.38 ms running r_18_8_16_5_5_4_4    with [288, 8, 1]     [16, 8, 1]      count  4 runtime  727.90 us      2.89 GFLOPS -> (2304, 4)
109 time 244.11 ms running r_2_3_4_16_288_4_4_4 with [48, 8, 1]      [16, 4, 1]      count  5 runtime 2624.60 us      5.40 GFLOPS -> (384, 4)
110 time 246.73 ms running r_2_18_4_16_48_4_4_4 with [288, 8, 1]     [16, 4, 1]      count  4 runtime 1854.10 us      7.77 GFLOPS -> (2304, 4)
111 time 248.59 ms running r_18_8_16_5_5_4_4    with [288, 8, 1]     [16, 8, 1]      count  4 runtime  575.00 us      3.65 GFLOPS -> (2304, 4)
112 time 249.16 ms running r_2_3_4_16_288_4_4_4 with [48, 8, 1]      [16, 4, 1]      count  5 runtime 1400.10 us     10.12 GFLOPS -> (384, 4)
113 time 250.56 ms running r_2_18_4_16_48_4_4_4 with [288, 8, 1]     [16, 4, 1]      count  4 runtime 1607.70 us      8.97 GFLOPS -> (2304, 4)
114 time 252.17 ms running r_18_8_16_5_5_4_4    with [288, 8, 1]     [16, 8, 1]      count  4 runtime  633.30 us      3.32 GFLOPS -> (2304, 4)
115 time 252.80 ms running r_2_3_4_16_288_4_4_4 with [48, 8, 1]      [16, 4, 1]      count  5 runtime 1461.30 us      9.70 GFLOPS -> (384, 4)
116 time 254.26 ms running r_2_18_4_16_48_4_4_4 with [288, 8, 1]     [16, 4, 1]      count  4 runtime 1853.00 us      7.78 GFLOPS -> (2304, 4)
117 time 256.12 ms running r_18_8_16_3_3_4_4    with [288, 8, 1]     [16, 8, 1]      count  4 runtime  270.70 us      3.40 GFLOPS -> (2304, 4)
118 time 256.39 ms running r_2_5_4_16_288_4_4_4 with [80, 8, 1]      [16, 4, 1]      count  6 runtime 2655.90 us      8.92 GFLOPS -> (640, 4)
119 time 259.04 ms running r_8_32_16_5_4_4      with [512, 8, 1]     [16, 1, 1]      count  3 runtime  315.60 us      2.08 GFLOPS -> 4096
120 time 259.36 ms running E_16_32_4            with [512, 1, 1]     [32, 1, 1]      count  5 runtime  132.50 us      0.05 GFLOPS -> 8192
121 time 259.49 ms running r_128_16_4_32_4      with [512, 16, 1]    [4, 16, 1]      count  4 runtime  606.70 us      3.46 GFLOPS -> (128, 1)
122 time 260.10 ms running r_256_16_4_8_4       with [1024, 16, 1]   [4, 16, 1]      count  4 runtime  562.90 us      1.87 GFLOPS -> (256, 1)
123 time 260.66 ms running r_128_16_4_16_4      with [512, 16, 1]    [4, 16, 1]      count  5 runtime  597.40 us      1.76 GFLOPS -> (128, 1)
124 time 261.26 ms running r_256_16_4_8_4       with [1024, 16, 1]   [4, 16, 1]      count  4 runtime  458.90 us      2.29 GFLOPS -> (256, 1)
125 time 261.72 ms running r_128_16_4_16_4      with [512, 16, 1]    [4, 16, 1]      count  5 runtime  471.90 us      2.23 GFLOPS -> (128, 1)
126 time 262.19 ms running r_128_4_16_8_4       with [64, 128, 1]    [16, 1, 1]      count  3 runtime  405.20 us      1.29 GFLOPS -> 2048
127 time 262.60 ms running r_256_2              with [256, 1, 1]     [256, 1, 1]     count  3 runtime  123.90 us      0.01 GFLOPS -> 4
128 time 262.72 ms running E_4_32_4             with [128, 1, 1]     [32, 1, 1]      count  4 runtime  163.40 us      0.01 GFLOPS -> (128, 1)
129 time 262.88 ms running E_2_32_4n1           with [64, 1, 1]      [32, 1, 1]      count  2 runtime   97.60 us      0.00 GFLOPS -> (64, 1)
130 time 262.98 ms running r_128_16_4_4_4       with [512, 16, 1]    [4, 16, 1]      count  4 runtime  246.90 us      1.07 GFLOPS -> (128, 1)
131 time 263.23 ms running r_64_16_4_8_4        with [256, 16, 1]    [4, 16, 1]      count  5 runtime  253.00 us      1.04 GFLOPS -> (64, 1)
132 time 263.48 ms running r_128_16_4_4_4       with [512, 16, 1]    [4, 16, 1]      count  4 runtime  154.60 us      1.70 GFLOPS -> (128, 1)
133 time 263.64 ms running r_64_16_4_8_4n1      with [256, 16, 1]    [4, 16, 1]      count  5 runtime  296.90 us      0.89 GFLOPS -> (64, 1)
134 time 263.93 ms running r_64_4_16_4_4        with [64, 64, 1]     [16, 1, 1]      count  3 runtime  239.20 us      0.55 GFLOPS -> 1024
135 time 264.17 ms running E_265_4              with [265, 1, 1]     [1, 1, 1]       count  5 runtime  167.90 us      0.03 GFLOPS -> 4240
136 time 264.34 ms running r_4_32_4_265_4       with [16, 32, 1]     [4, 32, 1]      count  3 runtime  513.10 us      2.12 GFLOPS -> 2048
137 time 264.85 ms running E_16_32_4n1          with [512, 1, 1]     [32, 1, 1]      count  5 runtime  152.10 us      0.15 GFLOPS -> 8192
138 time 265.00 ms running r_128_16_4_32_4      with [512, 16, 1]    [4, 16, 1]      count  4 runtime  508.40 us      4.13 GFLOPS -> (128, 1)
139 time 265.51 ms running r_256_16_4_8_4       with [1024, 16, 1]   [4, 16, 1]      count  4 runtime  461.10 us      2.28 GFLOPS -> (256, 1)
140 time 265.97 ms running r_128_16_4_16_4      with [512, 16, 1]    [4, 16, 1]      count  5 runtime  476.50 us      2.20 GFLOPS -> (128, 1)
141 time 266.45 ms running r_256_16_4_8_4       with [1024, 16, 1]   [4, 16, 1]      count  4 runtime  505.90 us      2.08 GFLOPS -> (256, 1)
142 time 266.96 ms running r_128_16_4_16_4      with [512, 16, 1]    [4, 16, 1]      count  5 runtime  452.50 us      2.32 GFLOPS -> (128, 1)
143 time 267.41 ms running r_64_16_4_8_4n2      with [256, 16, 1]    [4, 16, 1]      count  4 runtime  300.40 us      0.87 GFLOPS -> (64, 1)
144 time 267.71 ms running r_64_16_4_4_4        with [256, 16, 1]    [4, 16, 1]      count  4 runtime  204.90 us      0.64 GFLOPS -> (64, 1)
145 time 267.91 ms running r_64_16_4_4_4n1      with [256, 16, 1]    [4, 16, 1]      count  5 runtime  241.60 us      0.55 GFLOPS -> (64, 1)
146 time 268.16 ms running r_413_3_64_4_4       with [1239, 1, 1]    [3, 1, 1]       count  3 runtime  732.80 us      3.46 GFLOPS -> 19824
147 time 268.89 ms running r_16_16_4_8_4        with [64, 16, 1]     [4, 16, 1]      count  4 runtime  209.60 us      0.31 GFLOPS -> (16, 1)
148 time 269.10 ms running r_16_16_4_4          with [64, 16, 1]     [4, 16, 1]      count  4 runtime  211.90 us      0.04 GFLOPS -> (16, 1)
149 time 269.31 ms running r_16_16_4_4n1        with [64, 16, 1]     [4, 16, 1]      count  5 runtime  179.60 us      0.05 GFLOPS -> (16, 1)
150 time 269.49 ms running r_132_4_16_4         with [64, 132, 1]    [16, 1, 1]      count  3 runtime  217.10 us      0.31 GFLOPS -> 2112
151 time 269.71 ms running r_4_16_4_8_4         with [16, 16, 1]     [4, 16, 1]      count  4 runtime  181.30 us      0.09 GFLOPS -> (4, 1)
152 time 269.89 ms running r_4_4_4_4            with [4, 1, 1]       [4, 1, 1]       count  4 runtime  157.60 us      0.00 GFLOPS -> (4, 1)
153 time 270.05 ms running r_4_4_4_4n1          with [4, 1, 1]       [4, 1, 1]       count  5 runtime  153.80 us      0.00 GFLOPS -> (4, 1)
154 time 270.20 ms running r_2_4_4_4            with [8, 1, 1]       [4, 1, 1]       count  3 runtime  172.40 us      0.00 GFLOPS -> 32
155 time 270.37 ms running r_8_16_4_8_4         with [32, 16, 1]     [4, 16, 1]      count  4 runtime  191.80 us      0.17 GFLOPS -> (8, 1)
156 time 270.56 ms running r_8_8_4_4            with [8, 1, 1]       [8, 1, 1]       count  4 runtime  154.90 us      0.01 GFLOPS -> (8, 1)
157 time 270.72 ms running r_8_8_4_4n1          with [8, 1, 1]       [8, 1, 1]       count  5 runtime  154.80 us      0.01 GFLOPS -> (8, 1)
158 time 270.87 ms running r_22_3_4_8_4         with [88, 3, 1]      [4, 3, 1]       count  3 runtime  173.00 us      0.10 GFLOPS -> 1056
159 time 271.05 ms running r_16_16_4_8_4        with [64, 16, 1]     [4, 16, 1]      count  4 runtime   79.50 us      0.83 GFLOPS -> (16, 1)
160 time 271.13 ms running r_16_16_4_4          with [64, 16, 1]     [4, 16, 1]      count  4 runtime   50.90 us      0.16 GFLOPS -> (16, 1)
161 time 271.18 ms running r_16_16_4_4n1        with [64, 16, 1]     [4, 16, 1]      count  5 runtime   55.10 us      0.15 GFLOPS -> (16, 1)
162 time 271.23 ms running r_26_4_16_4          with [64, 26, 1]     [16, 1, 1]      count  3 runtime  175.50 us      0.08 GFLOPS -> 416
163 time 271.41 ms running r_4_16_4_8_4         with [16, 16, 1]     [4, 16, 1]      count  4 runtime   51.10 us      0.32 GFLOPS -> (4, 1)
164 time 271.46 ms running r_4_4_4_4            with [4, 1, 1]       [4, 1, 1]       count  4 runtime   35.20 us      0.02 GFLOPS -> (4, 1)
165 time 271.49 ms running r_4_4_4_4n1          with [4, 1, 1]       [4, 1, 1]       count  5 runtime   38.40 us      0.01 GFLOPS -> (4, 1)
166 time 271.53 ms running r_4_4_4              with [4, 1, 1]       [4, 1, 1]       count  3 runtime  157.00 us      0.00 GFLOPS -> 16
167 time 271.69 ms running r_8_16_4_8_4         with [32, 16, 1]     [4, 16, 1]      count  4 runtime   65.90 us      0.50 GFLOPS -> (8, 1)
168 time 271.75 ms running r_8_8_4_4            with [8, 1, 1]       [8, 1, 1]       count  4 runtime   35.10 us      0.06 GFLOPS -> (8, 1)
169 time 271.79 ms running r_8_8_4_4n1          with [8, 1, 1]       [8, 1, 1]       count  5 runtime   48.40 us      0.04 GFLOPS -> (8, 1)
170 time 271.84 ms running r_2_4_8_4            with [8, 1, 1]       [4, 1, 1]       count  3 runtime  166.80 us      0.00 GFLOPS -> 32
171 time 272.01 ms running r_128_16_4_32_4      with [512, 16, 1]    [4, 16, 1]      count  4 runtime  517.50 us      4.05 GFLOPS -> (128, 1)
172 time 272.52 ms running r_256_16_4_8_4       with [1024, 16, 1]   [4, 16, 1]      count  4 runtime  467.60 us      2.25 GFLOPS -> (256, 1)
173 time 272.99 ms running r_128_16_4_16_4      with [512, 16, 1]    [4, 16, 1]      count  5 runtime  451.10 us      2.33 GFLOPS -> (128, 1)
174 time 273.44 ms running r_256_16_4_8_4       with [1024, 16, 1]   [4, 16, 1]      count  4 runtime  470.80 us      2.23 GFLOPS -> (256, 1)
175 time 273.91 ms running r_128_16_4_16_4      with [512, 16, 1]    [4, 16, 1]      count  5 runtime  449.90 us      2.33 GFLOPS -> (128, 1)
176 time 274.36 ms running r_256_16_4_8_4       with [1024, 16, 1]   [4, 16, 1]      count  4 runtime  484.50 us      2.17 GFLOPS -> (256, 1)
177 time 274.85 ms running r_128_16_4_16_4      with [512, 16, 1]    [4, 16, 1]      count  5 runtime  491.50 us      2.14 GFLOPS -> (128, 1)
178 time 275.34 ms running r_256_16_4_8_4       with [1024, 16, 1]   [4, 16, 1]      count  4 runtime  458.10 us      2.29 GFLOPS -> (256, 1)
179 time 275.80 ms running r_128_16_4_16_4      with [512, 16, 1]    [4, 16, 1]      count  5 runtime  480.60 us      2.19 GFLOPS -> (128, 1)
180 time 276.28 ms running r_16_16_4_8_4        with [64, 16, 1]     [4, 16, 1]      count  4 runtime   94.90 us      0.69 GFLOPS -> (16, 1)
181 time 276.37 ms running r_16_16_4_4          with [64, 16, 1]     [4, 16, 1]      count  4 runtime   64.90 us      0.13 GFLOPS -> (16, 1)
182 time 276.44 ms running r_16_16_4_4n1        with [64, 16, 1]     [4, 16, 1]      count  5 runtime   55.50 us      0.15 GFLOPS -> (16, 1)
183 time 276.49 ms running r_12_4_16_4          with [64, 12, 1]     [16, 1, 1]      count  3 runtime  190.30 us      0.03 GFLOPS -> 192
184 time 276.68 ms running r_8_16_4_8_4         with [32, 16, 1]     [4, 16, 1]      count  4 runtime   72.20 us      0.45 GFLOPS -> (8, 1)
185 time 276.75 ms running r_8_8_4_4            with [8, 1, 1]       [8, 1, 1]       count  4 runtime   35.10 us      0.06 GFLOPS -> (8, 1)
186 time 276.79 ms running r_8_8_4_4n1          with [8, 1, 1]       [8, 1, 1]       count  5 runtime   38.70 us      0.06 GFLOPS -> (8, 1)
187 time 276.83 ms running r_8_4_8_4            with [4, 8, 1]       [4, 8, 1]       count  3 runtime  158.60 us      0.01 GFLOPS -> 128
188 time 276.99 ms running r_8_16_4_8_4         with [32, 16, 1]     [4, 16, 1]      count  4 runtime   80.80 us      0.41 GFLOPS -> (8, 1)
189 time 277.07 ms running r_8_8_4_4            with [8, 1, 1]       [8, 1, 1]       count  4 runtime   33.70 us      0.06 GFLOPS -> (8, 1)
190 time 277.10 ms running r_8_8_4_4n1          with [8, 1, 1]       [8, 1, 1]       count  5 runtime   35.70 us      0.06 GFLOPS -> (8, 1)
191 time 277.14 ms running r_3_4_8_4            with [4, 3, 1]       [4, 3, 1]       count  3 runtime  154.50 us      0.00 GFLOPS -> 48
192 time 277.29 ms running r_8_16_4_8_4         with [32, 16, 1]     [4, 16, 1]      count  4 runtime   71.70 us      0.46 GFLOPS -> (8, 1)
193 time 277.36 ms running r_8_8_4_4            with [8, 1, 1]       [8, 1, 1]       count  4 runtime   36.60 us      0.06 GFLOPS -> (8, 1)
194 time 277.40 ms running r_8_8_4_4n1          with [8, 1, 1]       [8, 1, 1]       count  5 runtime    3.90 us      0.55 GFLOPS -> (8, 1)
195 time 277.40 ms running r_2_4_8_4n1          with [8, 1, 1]       [4, 1, 1]       count  3 runtime  170.80 us      0.00 GFLOPS -> 32
196 time 277.57 ms running r_8_16_4_8_4         with [32, 16, 1]     [4, 16, 1]      count  4 runtime   67.90 us      0.48 GFLOPS -> (8, 1)
197 time 277.64 ms running r_8_8_4_4            with [8, 1, 1]       [8, 1, 1]       count  4 runtime   36.10 us      0.06 GFLOPS -> (8, 1)
198 time 277.68 ms running r_8_8_4_4n1          with [8, 1, 1]       [8, 1, 1]       count  5 runtime   35.10 us      0.06 GFLOPS -> (8, 1)
199 time 277.71 ms running r_3_4_8_4            with [4, 3, 1]       [4, 3, 1]       count  3 runtime   45.10 us      0.02 GFLOPS -> 48
200 time 277.76 ms running r_8_16_4_8_4         with [32, 16, 1]     [4, 16, 1]      count  4 runtime   80.50 us      0.41 GFLOPS -> (8, 1)
201 time 277.84 ms running r_8_8_4_4            with [8, 1, 1]       [8, 1, 1]       count  4 runtime   36.20 us      0.06 GFLOPS -> (8, 1)
202 time 277.88 ms running r_8_8_4_4n1          with [8, 1, 1]       [8, 1, 1]       count  5 runtime   37.10 us      0.06 GFLOPS -> (8, 1)
203 time 277.91 ms running r_3_4_8_4            with [4, 3, 1]       [4, 3, 1]       count  3 runtime   34.50 us      0.02 GFLOPS -> 48
204 time 277.95 ms running r_128_16_4_8_4       with [512, 16, 1]    [4, 16, 1]      count  5 runtime  571.50 us      0.92 GFLOPS -> (128, 1)
205 time 278.52 ms running r_32_4_16_8_4        with [64, 32, 1]     [16, 1, 1]      count  3 runtime  249.70 us      0.52 GFLOPS -> 512
206 time 278.77 ms running E_255_8_3            with [2040, 1, 1]    [8, 1, 1]       count 30 runtime  223.40 us      0.79 GFLOPS -> 24480
total runtime: 278.99 ms   wall time: 323.23 ms
network using 1.49 GOPS with runtime 278.99 ms that's 5.33 GFLOPS
```
</details>