### PR TITLE
Node does not need to subclass ABC

### DIFF
--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -11,7 +11,7 @@ from typing import List, Dict, Callable, Tuple, Type, Union, Optional, Any
 
 def is_sym_int(x: Any) -> bool: return isinstance(x, (int, Node))
 
-class Node():
+class Node:
   b: Union[Node, int]
   min: int
   max: int

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from abc import abstractmethod, ABC
+from abc import abstractmethod
 import functools
 import itertools
 from math import gcd
@@ -11,7 +11,7 @@ from typing import List, Dict, Callable, Tuple, Type, Union, Optional, Any
 
 def is_sym_int(x: Any) -> bool: return isinstance(x, (int, Node))
 
-class Node(ABC):
+class Node():
   b: Union[Node, int]
   min: int
   max: int
@@ -21,9 +21,9 @@ class Node(ABC):
     return ops[type(self)](self, ops, ctx)
   def vars(self): return []
   # expand a Node into List[Node] that enumerates the underlying Variables from min to max
-  def expand(self) -> List[Node]: raise NotImplementedError(self.__class__.__name__)
-  # infer the value of a Node given Variable values in var_vals
-  def substitute(self, var_vals: Dict[Variable, Node]) -> Node: raise NotImplementedError(self.__class__.__name__)
+  def expand(self) -> List[Node]: raise RuntimeError(self.__class__.__name__)
+  # substitute Variables with the values in var_vals
+  def substitute(self, var_vals: Dict[Variable, Node]) -> Node: raise RuntimeError(self.__class__.__name__)
   @functools.cached_property
   def key(self) -> str: return self.render(ctx="DEBUG")
   @functools.cached_property


### PR DESCRIPTION
subclassing `ABC` makes `isinstance` on nodes slow because it also calls the instance check in abc. We can make `Node` concrete by raising `RuntimeError`.

`STEPS=10 WINO=1 python examples/hlb_cifar10.py`
master
```
  0 22255.78 ms run, 22255.38 ms python,    0.40 ms CL, 1187.24 loss, 0.001281 LR, 1.45 GB used,     21.33 GFLOPS
  1 4982.98 ms run, 4982.46 ms python,    0.53 ms CL, 1187.59 loss, 0.002563 LR, 5.00 GB used,     93.98 GFLOPS
  2  147.11 ms run,   19.96 ms python,  127.15 ms CL, 1903.47 loss, 0.002994 LR, 5.00 GB used,   3183.58 GFLOPS
  3  142.42 ms run,    9.98 ms python,  132.44 ms CL, 2749.10 loss, 0.002577 LR, 5.00 GB used,   3288.29 GFLOPS
  4  142.80 ms run,    8.58 ms python,  134.22 ms CL, 2304.10 loss, 0.002159 LR, 5.00 GB used,   3279.50 GFLOPS
  5  142.65 ms run,    7.66 ms python,  134.99 ms CL, 1537.12 loss, 0.001741 LR, 5.00 GB used,   3282.93 GFLOPS
  6  142.57 ms run,    7.66 ms python,  134.90 ms CL, 1697.33 loss, 0.001324 LR, 5.00 GB used,   3284.9
```
this PR
```
  0 19935.52 ms run, 19935.12 ms python,    0.40 ms CL, 1187.24 loss, 0.001281 LR, 1.45 GB used,     23.81 GFLOPS
  1 4726.30 ms run, 4725.77 ms python,    0.53 ms CL, 1187.59 loss, 0.002563 LR, 5.00 GB used,     99.09 GFLOPS
  2  144.05 ms run,   18.34 ms python,  125.72 ms CL, 1903.47 loss, 0.002994 LR, 5.00 GB used,   3251.05 GFLOPS
  3  142.86 ms run,   11.01 ms python,  131.85 ms CL, 2749.10 loss, 0.002577 LR, 5.00 GB used,   3278.24 GFLOPS
  4  142.63 ms run,    8.16 ms python,  134.48 ms CL, 2304.10 loss, 0.002159 LR, 5.00 GB used,   3283.40 GFLOPS
  5  142.88 ms run,    7.49 ms python,  135.39 ms CL, 1537.12 loss, 0.001741 LR, 5.00 GB used,   3277.81 GFLOPS
  6  142.70 ms run,    7.22 ms python,  135.47 ms CL, 1697.33 loss, 0.001324 LR, 5.00 GB used,   3281.92 GFLOPS
```

with profiler on first epoch
master
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 59980245    6.024    0.000   11.417    0.000 {built-in method builtins.isinstance}
  5449497    3.695    0.000   12.193    0.000 symbolic.py:157(substitute)
 22440662    3.316    0.000    5.393    0.000 <frozen abc>:117(__instancecheck__)
 13028499    3.201    0.000    9.071    0.000 symbolic.py:34(__eq__)
    17921    2.956    0.000   55.532    0.003 linearizer.py:88(global_load)
```
this PR
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  5449497    3.533    0.000    7.384    0.000 symbolic.py:157(substitute)
 13028499    3.002    0.000    3.597    0.000 symbolic.py:34(__eq__)
    17921    2.920    0.000   46.941    0.003 linearizer.py:88(global_load)
 59980245    2.671    0.000    2.671    0.000 {built-in method builtins.isinstance}
 10246821    2.628    0.000    3.017    0.000 symbolic.py:160(__init__)
```