### PR TITLE
sym_infer is noop for int input

### DIFF
--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -309,7 +309,8 @@ def create_rednode(typ:Type[RedNode], nodes:List[Node]):
 def sym_rename(s) -> str: return f"s{sym_rename.cache_info().currsize}"
 def sym_render(a: Union[Node, int], ops=None, ctx=None) -> str: return str(a) if isinstance(a, int) else a.render(ops, ctx)
 def sym_infer(a: Union[Node, int], var_vals: Dict[Variable, int]) -> int:
-  ret = (Variable.num(a) if isinstance(a, int) else a).substitute({k:Variable.num(v) for k, v in var_vals.items()})
+  if isinstance(a, int): return a
+  ret = a.substitute({k:Variable.num(v) for k, v in var_vals.items()})
   assert isinstance(ret, NumNode)
   return ret.b
 


### PR DESCRIPTION
no need to make the input a `NumNode` and get the int back, this is significant for jitted path because inputs to infer global_size, local_szie and ops are mostly int.

jitted llama on M1 Max `GPU=1 JIT=1 python -O examples/llama.py --prompt="Hello." --count=10 --temperature=0 --timing`

master
```
ran model in 6.49 ms
total 95.54 ms, 10.47 tok/sec
 year
ran model in 6.97 ms
total 95.47 ms, 10.47 tok/sec
 old
ran model in 6.47 ms
total 95.80 ms, 10.44 tok/sec
 male
```

this PR
```
ran model in 5.54 ms
total 94.95 ms, 10.53 tok/sec
 year
ran model in 5.45 ms
total 95.34 ms, 10.49 tok/sec
 old
ran model in 5.59 ms
total 95.64 ms, 10.46 tok/sec
 male
```