### PR TITLE
AndNode.substitute short circuit

### DIFF
--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -300,8 +300,7 @@ class AndNode(RedNode):
   def substitute(self, var_vals: Dict[Variable, Node]) -> Node:
     subed = []
     for node in self.nodes:
-      sub = node.substitute(var_vals)
-      if sub == 0: return NumNode(0)
+      if not (sub:=node.substitute(var_vals)): return NumNode(0)
       subed.append(sub)
     return Variable.ands(subed)
 

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -297,7 +297,13 @@ class SumNode(RedNode):
 class AndNode(RedNode):
   def __mul__(self, b: Union[Node, int]): Variable.ands([x*b for x in self.nodes])
   def __floordiv__(self, b: Union[Node, int], _=True): return Variable.ands([x//b for x in self.nodes])
-  def substitute(self, var_vals: Dict[Variable, Node]) -> Node: return Variable.ands([node.substitute(var_vals) for node in self.nodes])
+  def substitute(self, var_vals: Dict[Variable, Node]) -> Node:
+    subed = []
+    for node in self.nodes:
+      sub = node.substitute(var_vals)
+      if sub == 0: return NumNode(0)
+      subed.append(sub)
+    return Variable.ands(subed)
 
 def create_rednode(typ:Type[RedNode], nodes:List[Node]):
   ret = typ(nodes)


### PR DESCRIPTION
a huge portion of compile time is simplifying `valid`, naive short circuit AndNode 20s -> 17s. Saved about 50% of `AndNode.substitute` time and 25% calls to `isinstance`.

`STEPS=5 WINO=1 python examples/hlb_cifar10.py`
master
```
  0 20196.11 ms run, 20195.73 ms python,    0.37 ms CL, 1187.24 loss, 0.002563 LR, 1.45 GB used,     23.51 GFLOPS
  1 4702.02 ms run, 4701.55 ms python,    0.46 ms CL, 1187.59 loss, 0.002577 LR, 5.00 GB used,     99.60 GFLOPS
  2  143.23 ms run,   19.05 ms python,  124.18 ms CL, 2754.43 loss, 0.001741 LR, 5.00 GB used,   3269.73 GFLOPS
  3  143.49 ms run,   10.02 ms python,  133.47 ms CL, 2845.13 loss, 0.000906 LR, 5.00 GB used,   3263.80 GFLOPS
  4  142.64 ms run,    7.69 ms python,  134.94 ms CL, 2122.40 loss, 0.000070 LR, 5.00 GB used,   3283.31 GFLOPS
```
this PR
```
  0 17157.87 ms run, 17157.46 ms python,    0.41 ms CL, 1187.24 loss, 0.002563 LR, 1.45 GB used,     27.67 GFLOPS
  1 4529.03 ms run, 4528.52 ms python,    0.52 ms CL, 1187.59 loss, 0.002577 LR, 5.00 GB used,    103.40 GFLOPS
  2  149.42 ms run,   20.81 ms python,  128.61 ms CL, 2754.43 loss, 0.001741 LR, 5.00 GB used,   3134.19 GFLOPS
  3  147.39 ms run,   10.18 ms python,  137.21 ms CL, 2845.13 loss, 0.000906 LR, 5.00 GB used,   3177.34 GFLOPS
  4  145.42 ms run,    7.82 ms python,  137.60 ms CL, 2122.40 loss, 0.000070 LR, 5.00 GB used,   3220.47 GFLOPS
```


profiler on cifar first epoch
master
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  5449497    3.524    0.000    7.316    0.000 symbolic.py:157(substitute)
 13028499    2.955    0.000    3.545    0.000 symbolic.py:34(__eq__)
    17921    2.871    0.000   46.489    0.003 linearizer.py:88(global_load)
 59978333    2.669    0.000    2.669    0.000 {built-in method builtins.isinstance}
  3528636    2.624    0.000   18.419    0.000 symbolic.py:190(substitute)
```
this PR
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    17921    2.903    0.000   35.193    0.002 linearizer.py:88(global_load)
   784640    2.437    0.000    7.564    0.000 symbolic.py:118(sum)
  3600357    2.222    0.000    4.770    0.000 symbolic.py:157(substitute)
  9334209    2.177    0.000    2.608    0.000 symbolic.py:34(__eq__)
 46581834    2.088    0.000    2.088    0.000 {built-in method builtins.isinstance}
```

and specific to `AndNodes.substitute`
master
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
1060551/997005    0.646    0.000   22.047    0.000 symbolic.py:300(substitute)
```
this PR
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
1060551/997005    1.030    0.000   10.775    0.000 symbolic.py:300(substitute)
```