### PR TITLE
PoC only substitute expandable nodes and if not valid, don't sub idx

### DIFF
--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -102,11 +102,12 @@ class Linearizer(OptimizedKernel):
     g_idx_vars = set(v for v in g_idx.vars() if v.expr.startswith("_uidx"))
     g_valid_vars = set(v for v in g_valid.vars() if v.expr.startswith("_uidx"))
     expand_vars = g_idx_vars | g_valid_vars
+    substitute_dim = [i for i,v in enumerate(fake_idxs) if v in expand_vars]
 
     ret = []
     invalid_value = 0 if dtypes.is_int(self.bufs[i].dtype) else 0.0
     for _idx in _idxs:
-      substitute: Dict[VariableOrNum, Node] = {a: b for a, b in zip(fake_idxs, _idx) if a in expand_vars} if expand_vars else {}
+      substitute: Dict[VariableOrNum, Node] = {fake_idxs[i]:_idx[i] for i in substitute_dim}
       if amt > 1:
         float4_substitute = {**substitute, fake_idxs[dim]: expanded_nodes[dim][0]}
         idx, valid = g_idx.substitute(float4_substitute), g_valid.substitute(float4_substitute)

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -187,7 +187,10 @@ class LtNode(OpNode):
   def get_bounds(self) -> Tuple[int, int]:
     if isinstance(self.b, int): return int(self.a.max < self.b), int(self.a.min < self.b)
     return (1, 1) if self.a.max < self.b.min else (0, 0) if self.a.min > self.b.max else (0, 1)
-  def substitute(self, var_vals: Dict[Variable, Node]) -> Node: return self.a.substitute(var_vals) < (self.b if isinstance(self.b, int) else self.b.substitute(var_vals))
+  def substitute(self, var_vals: Dict[Variable, Node]) -> Node:
+    lhs = self.a.substitute(var_vals)
+    if isinstance(self.b, int): return NumNode(1) if lhs.max < self.b else NumNode(0) if lhs.min >= self.b else lhs < self.b
+    return NumNode(1) if lhs.max < self.b.min else NumNode(0) if lhs.min >= self.b.max else lhs < self.b.substitute(var_vals)
 
 class MulNode(OpNode):
   def __mul__(self, b: Union[Node, int]): return self.a*(self.b*b) # two muls in one mul

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -154,7 +154,9 @@ class Variable(Node):
     self.expr, self.min, self.max = expr, nmin, nmax
   def vars(self): return [self]
   def expand(self) -> List[Node]: return [self] if self.expr is not None else [Variable.num(j) for j in range(self.min, self.max+1)]
-  def substitute(self, var_vals: Dict[Variable, Node]) -> Node: return var_vals[self] if self in var_vals else self
+  def substitute(self, var_vals: Dict[Variable, Node]) -> Node:
+    try: return var_vals[self]
+    except KeyError: return self
 
 class NumNode(Node):
   def __init__(self, num:int):
@@ -212,7 +214,7 @@ class DivNode(OpNode):
     assert self.a.min >= 0 and isinstance(self.b, int)
     return self.a.min//self.b, self.a.max//self.b
   def expand(self) -> List[Node]: return [x//self.b for x in self.a.expand()]
-  def substitute(self, var_vals: Dict[Variable, Node]) -> Node: return self.a.substitute(var_vals) // (self.b if isinstance(self.b, int) else self.b.substitute(var_vals))
+  def substitute(self, var_vals: Dict[Variable, Node]) -> Node: return self.a.substitute(var_vals) // self.b
 
 class ModNode(OpNode):
   def __floordiv__(self, b: Union[Node, int], factoring_allowed=True):


### PR DESCRIPTION
16.6s -> 14s. Only substitute Nodes that expand and if `valid` is 0, don't substitute `idx`. Not very clean though. The bigger opportunity is probably either cache these sums by prefix, or reuse something across different calls to `global_load` inside `linearize`.

PYTHONPATH=. STEPS=5 WINO=1 python examples/hlb_cifar10.py
  0 14021.02 ms run, 14020.64 ms python,    0.38 ms CL, 1187.24 loss, 0.002563 LR, 1.45 GB used,     33.86 GFLOPS
  1 4107.60 ms run, 4107.13 ms python,    0.47 ms CL, 1187.59 loss, 0.002577 LR, 5.00 GB used,    114.01 GFLOPS
  2  143.65 ms run,   17.98 ms python,  125.67 ms CL, 2754.43 loss, 0.001741 LR, 5.00 GB used,   3260.13 GFLOPS
  3  143.58 ms run,   10.43 ms python,  133.15 ms CL, 2845.13 loss, 0.000906 LR, 5.00 GB used,   3261.86 GFLOPS
  4  142.75 ms run,    7.22 ms python,  135.54 ms CL, 2122.40 loss, 0.000070 LR, 5.00 GB used,   3280.66 GFLOPS