### PR TITLE
move Node.__lt__ SumNode special case to SumNode.__lt__

### DIFF
--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -42,22 +42,7 @@ class Node:
   def __le__(self, b:Union[Node,int]): return self < (b+1)
   def __gt__(self, b:Union[Node,int]): return (-self) < (-b)
   def __ge__(self, b:Union[Node,int]): return (-self) < (-b+1)
-  def __lt__(self, b:Union[Node,int]):
-    #if self.min >= (b.max if isinstance(b, Node) else b): return Variable.num(0)
-    lhs = self
-    if isinstance(lhs, SumNode) and isinstance(b, int):
-      muls, others = partition(lhs.nodes, lambda x: isinstance(x, MulNode) and x.b > 0 and x.max >= b)
-      if muls:
-        # NOTE: gcd in python 3.8 takes exactly 2 args
-        mul_gcd = muls[0].b
-        for x in muls[1:]: mul_gcd = gcd(mul_gcd, x.b)
-        if b%mul_gcd == 0:
-          all_others = Variable.sum(others)
-          #print(mul_gcd, muls, all_others)
-          if all_others.min >= 0 and all_others.max < mul_gcd:
-            # TODO: should we divide both by mul_gcd here?
-            lhs = Variable.sum(muls)
-    return create_node(LtNode(lhs, b))
+  def __lt__(self, b:Union[Node,int]): return create_node(LtNode(self, b))
   def __mul__(self, b:Union[Node, int]):
     if b == 0: return NumNode(0)
     if b == 1: return self
@@ -276,14 +261,26 @@ class SumNode(RedNode):
     return Node.__mod__(Node.sum(new_nodes), b)
 
   def __lt__(self, b:Union[Node,int]):
+    lhs: Node = self
     if isinstance(b, int):
       new_sum = []
       for x in self.nodes:
         # TODO: should we just force the last one to always be the number
         if isinstance(x, NumNode): b -= x.b
         else: new_sum.append(x)
-      return Node.__lt__(Node.sum(new_sum), b)
-    return Node.__lt__(self, b)
+      lhs = Node.sum(new_sum)
+      if isinstance(lhs, SumNode):
+        muls, others = partition(lhs.nodes, lambda x: isinstance(x, MulNode) and x.b > 0 and x.max >= b)
+        if muls:
+          # NOTE: gcd in python 3.8 takes exactly 2 args
+          mul_gcd = muls[0].b
+          for x in muls[1:]: mul_gcd = gcd(mul_gcd, x.b)  # type: ignore  # mypy cannot tell x.b is int here
+          if b%mul_gcd == 0:
+            all_others = Variable.sum(others)
+            if all_others.min >= 0 and all_others.max < mul_gcd:
+              # TODO: should we divide both by mul_gcd here?
+              lhs = Variable.sum(muls)
+    return Node.__lt__(lhs, b)
 
   def expand(self) -> List[Node]: return [Variable.sum(list(it)) for it in itertools.product(*[x.expand() for x in self.nodes])]
   def substitute(self, var_vals: Dict[Variable, Node]) -> Node: return Variable.sum([node.substitute(var_vals) for node in self.nodes])


### PR DESCRIPTION
`Node.__lt__` is cleaner now

I did not modify any logic in this PR, the subtraction then factoring gcd out can be simpler. Will do the rewrite in a separate PR. Need to add a type ignore for the gcd part, mypy does not know that `__lt__` is only used for idx and not symbolic shape.

comes with a tiny perf improvement, 2% faster wino cifar and 5% less call to isinstance

master
```
PYTHONPATH=. STEPS=5 WINO=1 python -O examples/hlb_cifar10.py
  0 16106.11 ms run, 16105.71 ms python,    0.40 ms CL, 1187.24 loss, 0.002563 LR, 1.45 GB used,     29.47 GFLOPS
  1 4303.18 ms run, 4302.69 ms python,    0.49 ms CL, 1187.59 loss, 0.002577 LR, 5.00 GB used,    108.83 GFLOPS
  2  142.45 ms run,   17.51 ms python,  124.94 ms CL, 2754.43 loss, 0.001741 LR, 5.00 GB used,   3287.59 GFLOPS
  3  142.49 ms run,    8.90 ms python,  133.59 ms CL, 2845.13 loss, 0.000906 LR, 5.00 GB used,   3286.63 GFLOPS
  4  142.76 ms run,    7.37 ms python,  135.39 ms CL, 2122.40 loss, 0.000070 LR, 5.00 GB used,   3280.47 GFLOPS
```

this PR
```
PYTHONPATH=. STEPS=5 WINO=1 python -O examples/hlb_cifar10.py
  0 15780.34 ms run, 15779.96 ms python,    0.39 ms CL, 1187.24 loss, 0.002563 LR, 1.45 GB used,     30.08 GFLOPS
  1 4284.24 ms run, 4283.75 ms python,    0.49 ms CL, 1187.59 loss, 0.002577 LR, 5.00 GB used,    109.31 GFLOPS
  2  142.29 ms run,   17.24 ms python,  125.05 ms CL, 2754.43 loss, 0.001741 LR, 5.00 GB used,   3291.31 GFLOPS
  3  142.11 ms run,    8.94 ms python,  133.18 ms CL, 2845.13 loss, 0.000906 LR, 5.00 GB used,   3295.40 GFLOPS
  4  142.49 ms run,    6.79 ms python,  135.70 ms CL, 2122.40 loss, 0.000070 LR, 5.00 GB used,   3286.70 GFLOPS
```

with profiler
master
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 35681482    1.689    0.000    1.689    0.000 {built-in method builtins.isinstance}
```

this PR
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 33646943    1.568    0.000    1.568    0.000 {built-in method builtins.isinstance}
```