### PR TITLE
Cache view expr idxs

### DIFF
--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -65,6 +65,7 @@ class View(ViewInternal):
     return Variable.sum(ret)
 
   # generate an expression if you have a variable or expression for each index
+  @functools.lru_cache(maxsize=None)
   def expr_idxs(self, idxs) -> Node:
     assert len(idxs) == len(self.shape), f"need an idx for all dimensions {idxs} vs {self.shape}"
     return Variable.sum([Variable.num(self.offset) if isinstance(self.offset, int) else self.offset] + [idx*st for idx,sh,st in zip(idxs, self.shape, self.strides) if sh != 1 and st != 0])

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -65,7 +65,7 @@ class View(ViewInternal):
     return Variable.sum(ret)
 
   # generate an expression if you have a variable or expression for each index
-  @functools.lru_cache(maxsize=None)
+  @functools.lru_cache(maxsize=None)  # pylint: disable=method-cache-max-size-none
   def expr_idxs(self, idxs) -> Node:
     assert len(idxs) == len(self.shape), f"need an idx for all dimensions {idxs} vs {self.shape}"
     return Variable.sum([Variable.num(self.offset) if isinstance(self.offset, int) else self.offset] + [idx*st for idx,sh,st in zip(idxs, self.shape, self.strides) if sh != 1 and st != 0])


### PR DESCRIPTION
3.5% improvement.

After #1818, this: 
```
(venv) chaos@tiny3:~/tinygrad$ git log | head -n1 && STEPS=10 DEBUG=0 TC=0 OPT=2 WINO=1 GPU=1 JIT=1 python examples/hlb_cifar10.py
commit 58cbe12141da7119a0e23457ea6f64265a10025e
/home/chaos/tinygrad/venv/lib/python3.11/site-packages/pyopencl/cache.py:495: CompilerWarning: Non-empty compiler output encountered. Set the environment variable PYOPENCL_COMPILER_OUTPUT=1 to see more.
  _create_built_program_from_source_cached(
  0 13698.57 ms run, 13698.36 ms python,    0.21 ms CL, 1187.23 loss, 0.001281 LR, 0.84 GB used,     34.65 GFLOPS
  1 5117.91 ms run, 5117.42 ms python,    0.49 ms CL, 1187.59 loss, 0.002563 LR, 4.39 GB used,     91.51 GFLOPS
  2   50.63 ms run,    2.31 ms python,   48.31 ms CL, 1903.44 loss, 0.002994 LR, 4.39 GB used,   9250.17 GFLOPS
  3   45.85 ms run,    2.22 ms python,   43.63 ms CL, 2734.18 loss, 0.002577 LR, 4.39 GB used,  10214.40 GFLOPS
  4   45.77 ms run,    4.17 ms python,   41.59 ms CL, 2271.15 loss, 0.002159 LR, 4.39 GB used,  10232.78 GFLOPS
  5   46.53 ms run,    4.44 ms python,   42.10 ms CL, 1536.44 loss, 0.001741 LR, 4.39 GB used,  10064.31 GFLOPS
  6   46.19 ms run,    4.44 ms python,   41.74 ms CL, 1705.61 loss, 0.001324 LR, 4.39 GB used,  10140.08 GFLOPS
  7   46.01 ms run,    4.43 ms python,   41.58 ms CL, 1326.56 loss, 0.000906 LR, 4.39 GB used,  10179.22 GFLOPS
  8   45.99 ms run,    4.43 ms python,   41.56 ms CL, 1631.36 loss, 0.000488 LR, 4.39 GB used,  10182.85 GFLOPS
  9   46.79 ms run,    4.38 ms python,   42.41 ms CL, 1257.01 loss, 0.000070 LR, 4.39 GB used,  10009.85 GFLOPS
```
After 1818:
```
(venv) chaos@tiny3:~/tinygrad$ git log | head -n1 && STEPS=10 DEBUG=0 TC=0 OPT=2 WINO=1 GPU=1 JIT=1 python examples/hlb_cifar10.py
commit 25b23bca153f50e343de390a12355ffa79b7f948
/home/chaos/tinygrad/venv/lib/python3.11/site-packages/pyopencl/cache.py:495: CompilerWarning: Non-empty compiler output encountered. Set the environment variable PYOPENCL_COMPILER_OUTPUT=1 to see more.
  _create_built_program_from_source_cached(
  0 14222.26 ms run, 14222.03 ms python,    0.23 ms CL, 1187.23 loss, 0.001281 LR, 0.84 GB used,     33.38 GFLOPS
  1 5466.86 ms run, 5466.27 ms python,    0.59 ms CL, 1187.59 loss, 0.002563 LR, 4.39 GB used,     85.67 GFLOPS
  2   50.29 ms run,    2.75 ms python,   47.55 ms CL, 1903.44 loss, 0.002994 LR, 4.39 GB used,   9311.58 GFLOPS
  3   46.18 ms run,    2.81 ms python,   43.38 ms CL, 2734.18 loss, 0.002577 LR, 4.39 GB used,  10140.28 GFLOPS
  4   45.77 ms run,    5.15 ms python,   40.62 ms CL, 2271.15 loss, 0.002159 LR, 4.39 GB used,  10232.62 GFLOPS
  5   47.10 ms run,    5.15 ms python,   41.95 ms CL, 1536.44 loss, 0.001741 LR, 4.39 GB used,   9944.04 GFLOPS
  6   46.21 ms run,    5.11 ms python,   41.11 ms CL, 1705.61 loss, 0.001324 LR, 4.39 GB used,  10133.82 GFLOPS
  7   46.84 ms run,    5.08 ms python,   41.76 ms CL, 1326.56 loss, 0.000906 LR, 4.39 GB used,   9999.37 GFLOPS
  8   46.60 ms run,    5.13 ms python,   41.47 ms CL, 1631.36 loss, 0.000488 LR, 4.39 GB used,  10048.82 GFLOPS
  9   46.87 ms run,    5.07 ms python,   41.79 ms CL, 1257.01 loss, 0.000070 LR, 4.39 GB used,   9992.77 GFLOPS
```