### PR TITLE
perf: fully cached shapetracker methods

### DIFF
--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -25,7 +25,6 @@ def is_contiguous(shape:Tuple[int, ...], strides:Tuple[int, ...]) -> bool: retur
 def filter_strides(shape:Tuple[int, ...], strides:Tuple[int, ...]) -> Tuple[int, ...]:
   return tuple(stride if shp != 1 else 0 for stride, shp in zip(strides, shape))
 
-@functools.lru_cache(maxsize=None)
 class View(NamedTuple):
   shape:Tuple[int, ...]
   strides:Tuple[int, ...]
@@ -33,6 +32,7 @@ class View(NamedTuple):
   mask:Optional[Tuple[Tuple[int, int]]] = None
 
   @staticmethod
+  @functools.lru_cache(None)
   def create(shape, strides=None, offset=0, mask=None): return View(shape, filter_strides(shape, strides) if strides else strides_for_shape(shape), offset, mask)
 
   def __repr__(self): return f"View(shape={self.shape}, strides={self.strides}, offset={self.offset}, mask={self.mask})"
@@ -42,32 +42,42 @@ class View(NamedTuple):
 
   @property
   def shape_strides(self): return to_shape_strides(self.shape, self.strides)
+  
+  def expr_node_mask(self, idx, valid=None) -> Node: return expr_node_mask(self.shape, self.mask, idx, valid)
+  def expr_node(self, idx=None) -> Node: return expr_node_view(self.shape, self.shape_strides, self.offset, idx)
+  def expr_idxs(self, idxs) -> Node: return expr_idxs_view(self.shape, self.strides, self.offset, idxs)
 
-  def expr_node_mask(self, idx, valid=None) -> Node:
-    expr = [valid] if valid is not None else []
-    if self.mask is not None:
-      acc = 1
-      for ns,(x,y) in reversed(list(zip(self.shape, self.mask))):
-        if x != 0 or y != ns:
-          base = ((idx//acc) % ns)
-          expr += [base >= x, base < y]
-        acc *= ns
-    return Variable.ands(expr)
-
-  # generate an expression if you have a single idx variable
-  def expr_node(self, idx=None) -> Node:
-    if idx is None: idx = Variable('idx', 0, prod(self.shape)-1)
-    ret: List[Node] = [Variable.num(self.offset) if isinstance(self.offset, int) else self.offset] if self.offset else []
+@functools.lru_cache(maxsize=None)
+def expr_node_mask(shape, mask, idx, valid) -> Node:
+  expr = [valid] if valid is not None else []
+  if mask is not None:
     acc = 1
-    for d,s in reversed(self.shape_strides):
-      ret.append(((idx//acc)%d)*s)
-      acc *= d
-    return Variable.sum(ret)
+    for ns,(x,y) in reversed(list(zip(shape, mask))):
+      if x != 0 or y != ns:
+        base = ((idx//acc) % ns)
+        expr += [base >= x, base < y]
+      acc *= ns
+  return Variable.ands(expr)
 
-  # generate an expression if you have a variable or expression for each index
-  def expr_idxs(self, idxs) -> Node:
-    assert len(idxs) == len(self.shape), f"need an idx for all dimensions {idxs} vs {self.shape}"
-    return Variable.sum([Variable.num(self.offset) if isinstance(self.offset, int) else self.offset] + [idx*st for idx,sh,st in zip(idxs, self.shape, self.strides) if sh != 1 and st != 0])
+# generate an expression if you have a single idx variable
+@functools.lru_cache(maxsize=None)
+def expr_node_view(shape, shape_strides, offset, idx) -> Node:
+  if idx is None: idx = Variable('idx', 0, prod(shape)-1)
+  ret: List[Node] = [Variable.num(offset) if isinstance(offset, int) else offset] if offset else []
+  acc = 1
+  for d,s in reversed(shape_strides):
+    ret.append(((idx//acc)%d)*s)
+    acc *= d
+  return Variable.sum(ret)
+
+# generate an expression if you have a variable or expression for each index
+@functools.lru_cache(maxsize=None)
+def expr_idxs_view(shape, strides, offset, idxs) -> Node:
+  assert len(idxs) == len(shape), f"need an idx for all dimensions {idxs} vs {shape}"
+  return Variable.sum([Variable.num(offset) if isinstance(offset, int) else offset] + [idx*st for idx,sh,st in zip(idxs, shape, strides) if sh != 1 and st != 0])
+
+@functools.lru_cache(maxsize=None)
+def size(view: View): return prod([s for s,st in zip(view.shape, view.strides) if st != 0])
 
 @functools.lru_cache(maxsize=None)
 def idxs_to_idx(shape:Tuple[int, ...], idxs) -> Node:
@@ -85,16 +95,167 @@ def strides_for_shape(shape:Tuple[int, ...]) -> Tuple[int, ...]:
   for d in shape[::-1][:-1]: strides = [d*strides[0]] + strides
   return filter_strides(shape, tuple(strides))
 
-@functools.lru_cache(maxsize=None)
 def merge_views(vm2:View, vm1:View) -> Optional[View]:
   if vm2.mask: return None  # this isn't supported yet
-  mst = ShapeTracker(vm1.shape, [vm2, vm1])
-  strides = mst.real_strides()
+  strides = real_strides((vm2,vm1))
   if None in strides: return None
-  return View.create(vm1.shape, strides, mst.real_offset(), vm1.mask)
+  return View.create(vm1.shape, strides, real_offset((vm2, vm1)), vm1.mask)
 
 @functools.lru_cache(maxsize=None)
-def _reshape(view: View, new_shape:Tuple[int, ...]) -> Tuple[View, bool]:
+def get_pad_args(shape:Tuple[int,...], arg:Tuple[Tuple[int, int], ...]):
+  return tuple([(-b,s+e) for s,(b,e) in zip(shape, arg)]), tuple([(b,s+b) for s,(b,_) in zip(shape, arg)])
+
+@functools.lru_cache(maxsize=None)
+def get_unsafe_resize_offset(strides, arg):
+  return sum([s * x[0] for s, x in zip(strides,arg)])
+
+class ShapeTracker:
+  __slots__ = "views"
+  def __init__(self, shape:Union[ShapeTracker, Tuple[Union[Node,int], ...]], views:Optional[Union[Tuple[View,...],List[View]]]=None):
+    self.views: Tuple[View, ...] = tuple(views) if views is not None else tuple([*shape.views]) if isinstance(shape, ShapeTracker) else (View.create(shape),)
+  def __repr__(self): return f"ShapeTracker(shape={self.views[-1].shape}, views={self.views})"
+  def copy(self) -> ShapeTracker: return ShapeTracker(self.views[-1].shape, tuple([*self.views]))
+
+  def reshape(self, new_shape): 
+    if self.views[-1].shape == new_shape: return self
+    self.views = self.views[:-1] + reshape(self.views[-1], new_shape)
+    return self
+  def expand(self, new_shape):
+    self.views = self.views[:-1] + (expand(self.views[-1], new_shape),)
+    return self
+  def shrink(self, arg):
+    self.views = self.views[:-1] + (shrink(self.views[-1], arg),)
+    return self
+  def stride(self, mul):
+    self.views = self.views[:-1] + (stride(self.views[-1], mul),)
+    return self
+  def permute(self, axis):
+    self.views = self.views[:-1] + (permute(self.views[-1], axis),)
+    return self
+  def pad(self, arg):
+    self.views = self.views[:-1] + (pad(self.views[-1], arg),)
+    return self
+  
+  def size(self): return size(self.views[-1])  # this is the real size (ish)
+  def simplify(self): self.views = simplify(self.views)
+  def unit_stride_axes(self, ignore_valid=False) -> List[int]: return unit_stride_axes(self.views, ignore_valid)
+  def expr_idxs(self, idxs=None): return expr_idxs(self.views, None if idxs is None else tuple(idxs))
+  def real_strides(self, ignore_valid=False) -> Tuple[Optional[Union[Node, int]], ...]: return real_strides(self.views, ignore_valid)
+  def axis_is_masked(self, axis) -> bool: return axis_is_masked(self.views, axis)
+  def expr_node(self, idx='idx'): return expr_node(self.views, idx)
+
+  @property
+  def contiguous(self) -> bool: return len(self.views) == 1 and self.views[0].contiguous
+
+  @property
+  def shape(self) -> Tuple[int, ...]: return self.views[-1].shape # NOTE: real type is Tuple[Union[Node, int], ...] but mypy complains about prod(shape)
+
+  @property
+  def key(self) -> Tuple[View, ...]: return self.views
+
+# these are multiview strides, value is None if it's not a simple strided dimension
+# TODO: this can be shared code between simplify and merge_views
+@functools.lru_cache(maxsize=None)
+def real_offset(views) -> int:
+  real_offset, mask = expr_node(views, Variable('zero', 0, 0))
+  assert real_offset.__class__ is NumNode, f"how is the offset not a number? {real_offset} {mask}"
+  return real_offset.b
+
+# NOTE: if a stride is not always valid, it will be None
+@functools.lru_cache(maxsize=None)
+def real_strides(views: Tuple[View], ignore_valid=False) -> Tuple[Optional[Union[Node, int]], ...]:
+  if len(views) == 1 and views[-1].mask is None: return views[-1].strides
+  idxs = tuple([Variable(f"idx{i}", 0, s-1) for i,s in enumerate(views[-1].shape)])
+  idx, valid = expr_idxs(views, idxs)
+  ret: List[Optional[Union[Node, int]]] = [None] * len(views[-1].shape)
+  for this_dim in (idx.nodes if isinstance(idx, SumNode) else [idx]):
+    if isinstance(this_dim, MulNode) and isinstance(this_dim.a, Variable) and this_dim.a in idxs:
+      ret[idxs.index(this_dim.a)] = this_dim.b
+    elif isinstance(this_dim, Variable):
+      ret[idxs.index(this_dim)] = 1
+  idx_vars, valid_vars = idx.vars(), valid.vars()
+  for i,tidx in enumerate(idxs):
+    if tidx in valid_vars and not ignore_valid: ret[i] = None
+    elif tidx not in idx_vars: ret[i] = 0
+  return tuple(ret)
+
+@functools.lru_cache(maxsize=None)
+def unit_stride_axes(views: Tuple[View], ignore_valid=False) -> List[int]: return [i for i,st in enumerate(real_strides(views, ignore_valid)) if st == 1]
+
+@functools.lru_cache(maxsize=None)
+def _expr_idx(views, idx, valid) -> Tuple[Node, Node]:
+  for v in reversed(views[:-1]):
+    if valid.max == 0: return Variable.num(-1), valid
+    valid = v.expr_node_mask(idx, valid)
+    idx = v.expr_node(idx)
+  return idx, valid
+
+@functools.lru_cache(maxsize=None)
+def simplify(views):
+  if len(views) >= 2:
+    new_view = merge_views(views[-2], views[-1])
+    if new_view:
+      if DEBUG >= 4: print(f"st simplify : {views[-2]} + {views[-1]} = {new_view}")
+      views = views[:-2] + (new_view,)
+      if len(views) == 1: return views
+      views = simplify(views)
+  return views
+
+@functools.lru_cache(maxsize=None)
+def expr_idxs(views: Tuple[View], idxs=None):
+  if idxs is None: idxs = tuple([Variable(f"idx{i}", 0, s-1) for i,s in enumerate(views[-1].shape)])
+  idx = views[-1].expr_idxs(idxs)
+  valid = views[-1].expr_node_mask(idxs_to_idx(views[-1].shape, idxs))
+  return _expr_idx(views, idx, valid)
+
+@functools.lru_cache(maxsize=None)
+def expr_node(views: Tuple[View], idx='idx'):
+  if idx.__class__ is str: idx = Variable(idx, 0, prod(views[-1].shape)-1)
+  return _expr_idx(views, views[-1].expr_node(idx), views[-1].expr_node_mask(idx))
+
+@functools.lru_cache(maxsize=None)
+def axis_is_masked(view, axis) -> bool: 
+  _, valid = expr_idxs(view)
+  return f'idx{axis}' in [v.expr for v in valid.vars()]
+  # *** under this line are the movement ops ***
+
+@functools.lru_cache(maxsize=None)
+def __unsafe_resize(view: View, arg: Tuple[Tuple[int, int], ...], mask=None) -> View:
+  offset = get_unsafe_resize_offset(view.strides, arg)
+  if view.mask:
+    # move the old mask
+    nmask = tuple([(max(mx-ax, 0), min(my-ax, ay-ax)) for (mx,my),(ax,ay) in zip(view.mask, arg)])
+    # merge the masks if we have two
+    mask = tuple([(max(mx1, mx2), min(my1, my2)) for (mx1, my1), (mx2, my2) in zip(nmask, mask)]) if mask is not None else nmask
+  return View.create(tuple([y-x for x,y in arg]), view.strides, view.offset+offset, mask)
+
+@functools.lru_cache(maxsize=None)
+def pad(view: View, arg: Tuple[Tuple[int, int], ...]) -> View:
+  assert all((b>=0 and e>=0) for b,e in arg) and len(arg) == len(view.shape)
+  if any(b or e for b, e in arg):
+    zvarg, mask = get_pad_args(view.shape, arg)
+    view = __unsafe_resize(view, zvarg, mask=mask)
+  return view
+
+@functools.lru_cache(maxsize=None)
+def shrink(view: View, arg: Tuple[Tuple[int, int], ...]) -> View:
+  assert all((b>=0 and e<=s) for s,(b,e) in zip(view.shape,arg)) and len(arg) == len(view.shape)
+  return __unsafe_resize(view, arg)
+
+@functools.lru_cache(maxsize=None)
+def expand(view: View, new_shape: Tuple[Union[Node,int], ...]) -> View:
+  assert len(new_shape) == len(view.shape)
+  assert all(is_sym_int(x) and (s == x or (s == 1 and st == 0)) for s,x,st in zip(view.shape, new_shape, view.strides)), f"can't expand {view.shape} into {new_shape}"
+  # NOTE: can the mask ever be (0,0)?
+  mask = tuple([(((0,0) if m != (0,1) else (0,ns)) if s != ns else m) for m,s,ns in zip(view.mask, view.shape, new_shape)]) if view.mask else None
+  return View.create(new_shape, view.strides, view.offset, mask)
+
+@functools.lru_cache(maxsize=None)
+def reshape(view: View, new_shape: Tuple[Union[Node,int], ...]):
+  if view.shape == new_shape: return (view,)
+  assert all(is_sym_int(x) and x > 0 for x in new_shape), f"shape must be symbolic ints and can't contain 0 or negative numbers {new_shape}"
+  # only check size for int shapes. we don't check symbolic here as long as the reshape itself can be done
+  assert not (all(isinstance(s, int) for s in view.shape) and all(isinstance(s, int) for s in new_shape)) or prod(view.shape) == prod(new_shape), f"can't reshape {view.shape} -> {new_shape}" # type: ignore  # mypy cannot resolve, all ints here
   shape, mask, strides, offset = view.shape, view.mask, view.strides, view.offset
   # check if this is adding or removing 1s (only)
   # NOTE: this is optional, but removes most calls to (expensive!) merge_views (with mask, not optional)
@@ -110,153 +271,30 @@ def _reshape(view: View, new_shape:Tuple[int, ...]) -> Tuple[View, bool]:
       else:
         new_mask: List[Tuple[int, int]] = [y for x,y in zip(shape, mask) if x != 1]
         new_mask_tuple = tuple([(0,1) if x == 1 else new_mask.pop(0) for x in new_shape])
-    return View.create(new_shape, new_strides_tuple, offset, new_mask_tuple), False
-
+    return (View.create(new_shape, new_strides_tuple, offset, new_mask_tuple),)
   new_view = View.create(new_shape)
-  if view.contiguous: return new_view, False # NOTE: if it's contiguous it can't have an offset
-  if (merged_view := merge_views(view, new_view)) is not None: return merged_view, False
+  if view.contiguous: return (new_view,) # NOTE: if it's contiguous it can't have an offset
+  if (merged_view:=merge_views(view, new_view)) is not None: return (merged_view,)
   if DEBUG >= 5: print(f"WARNING: creating new view with reshape {view} -> {new_shape}")
-  return new_view, True
+  return (view, new_view)
+
 
 @functools.lru_cache(maxsize=None)
-def get_pad_args(shape:Tuple[int,...], arg:Tuple[Tuple[int, int], ...]):
-  return tuple([(-b,s+e) for s,(b,e) in zip(shape, arg)]), tuple([(b,s+b) for s,(b,_) in zip(shape, arg)])
+def permute(view: View, axis: Tuple[int, ...]) -> View:
+  assert all(isinstance(x, int) and x >= 0 and x < len(view.shape) for x in axis), f"invalid permute {axis} for {view.shape}"
+  assert len(set(axis)) == len(axis) and len(axis) == len(view.shape), f"can't permute {view.shape} with {axis}"
+  return View.create(tuple([view.shape[a] for a in axis]), tuple([view.strides[a] for a in axis]), view.offset, tuple([view.mask[a] for a in axis]) if view.mask is not None else None)
 
+# except for the negative case, you can build this from the others. invertible in the negative case
 @functools.lru_cache(maxsize=None)
-def get_unsafe_resize_offset(strides, arg):
-  return sum([s * x[0] for s, x in zip(strides,arg)])
-
-class ShapeTracker:
-  __slots__ = "views"
-  def __init__(self, shape:Union[ShapeTracker, Tuple[Union[Node,int], ...]], views:Optional[List[View]]=None):
-    self.views: List[View] = views if views is not None else [*shape.views] if isinstance(shape, ShapeTracker) else [View.create(shape)]
-  def __repr__(self): return f"ShapeTracker(shape={self.views[-1].shape}, views={self.views})"
-  def copy(self) -> ShapeTracker: return ShapeTracker(self.views[-1].shape, [*self.views])
-
-  @property
-  def contiguous(self) -> bool: return len(self.views) == 1 and self.views[0].contiguous
-
-  @property
-  def shape(self) -> Tuple[int, ...]: return self.views[-1].shape # NOTE: real type is Tuple[Union[Node, int], ...] but mypy complains about prod(shape)
-
-  @property
-  def key(self) -> Tuple[View, ...]: return tuple(self.views)
-
-  # this is the real size (ish)
-  def size(self): return prod([s for s,st in zip(self.views[-1].shape, self.views[-1].strides) if st != 0])
-
-  # these are multiview strides, value is None if it's not a simple strided dimension
-  # TODO: this can be shared code between simplify and merge_views
-  def real_offset(self) -> int:
-    real_offset, mask = self.expr_node(Variable('zero', 0, 0))
-    assert real_offset.__class__ is NumNode, f"how is the offset not a number? {real_offset} {mask}"
-    return real_offset.b
-
-  # NOTE: if a stride is not always valid, it will be None
-  def real_strides(self, ignore_valid=False) -> Tuple[Optional[Union[Node, int]], ...]:
-    if len(self.views) == 1 and self.views[-1].mask is None: return self.views[-1].strides
-    idxs = [Variable(f"idx{i}", 0, s-1) for i,s in enumerate(self.shape)]
-    idx, valid = self.expr_idxs(idxs)
-    ret: List[Optional[Union[Node, int]]] = [None] * len(self.views[-1].shape)
-    for this_dim in (idx.nodes if isinstance(idx, SumNode) else [idx]):
-      if isinstance(this_dim, MulNode) and isinstance(this_dim.a, Variable) and this_dim.a in idxs:
-        ret[idxs.index(this_dim.a)] = this_dim.b
-      elif isinstance(this_dim, Variable):
-        ret[idxs.index(this_dim)] = 1
-    idx_vars, valid_vars = idx.vars(), valid.vars()
-    for i,tidx in enumerate(idxs):
-      if tidx in valid_vars and not ignore_valid: ret[i] = None
-      elif tidx not in idx_vars: ret[i] = 0
-    return tuple(ret)
-  def unit_stride_axes(self, ignore_valid=False) -> List[int]: return [i for i,st in enumerate(self.real_strides(ignore_valid)) if st == 1]
-
-  def _expr_idx(self, idx, valid) -> Tuple[Node, Node]:
-    for v in reversed(self.views[0:-1]):
-      if valid.max == 0: return Variable.num(-1), valid
-      valid = v.expr_node_mask(idx, valid)
-      idx = v.expr_node(idx)
-    return idx, valid
-
-  def simplify(self):
-    if len(self.views) >= 2:
-      new_view = merge_views(self.views[-2], self.views[-1])
-      if new_view:
-        if DEBUG >= 4: print(f"st simplify : {self.views[-2]} + {self.views[-1]} = {new_view}")
-        self.views = self.views[:-2] + [new_view]
-        self.simplify()
-
-  def expr_idxs(self, idxs=None):
-    if idxs is None: idxs = [Variable(f"idx{i}", 0, s-1) for i,s in enumerate(self.shape)]
-    idx = self.views[-1].expr_idxs(tuple(idxs))
-    valid = self.views[-1].expr_node_mask(idxs_to_idx(self.views[-1].shape, tuple(idxs)))
-    return self._expr_idx(idx, valid)
-
-  def expr_node(self, idx='idx'):
-    if idx.__class__ is str: idx = Variable(idx, 0, prod(self.shape)-1)
-    return self._expr_idx(self.views[-1].expr_node(idx), self.views[-1].expr_node_mask(idx))
-
-  def axis_is_masked(self, axis) -> bool:
-    _, valid = self.expr_idxs()
-    return f'idx{axis}' in [v.expr for v in valid.vars()]
-
-  # *** under this line are the movement ops ***
-
-  def __unsafe_resize(self, arg: Tuple[Tuple[int, int], ...], mask=None):
-    offset = get_unsafe_resize_offset(self.views[-1].strides, arg)
-    if self.views[-1].mask:
-      # move the old mask
-      nmask = tuple([(max(mx-ax, 0), min(my-ax, ay-ax)) for (mx,my),(ax,ay) in zip(self.views[-1].mask, arg)])
-      # merge the masks if we have two
-      mask = tuple([(max(mx1, mx2), min(my1, my2)) for (mx1, my1), (mx2, my2) in zip(nmask, mask)]) if mask is not None else nmask
-    self.views[-1] = View.create(tuple([y-x for x,y in arg]), self.views[-1].strides, self.views[-1].offset+offset, mask)
-
-  def pad(self, arg: Tuple[Tuple[int, int], ...]):
-    assert all((b>=0 and e>=0) for b,e in arg) and len(arg) == len(self.shape)
-    if any(b or e for b, e in arg):
-      zvarg, mask = get_pad_args(self.shape, arg)
-      self.__unsafe_resize(zvarg, mask=mask)
-    return self
-
-  def shrink(self, arg: Tuple[Tuple[int, int], ...]):
-    assert all((b>=0 and e<=s) for s,(b,e) in zip(self.shape,arg)) and len(arg) == len(self.shape)
-    self.__unsafe_resize(arg)
-    return self
-
-  def expand(self, new_shape: Tuple[Union[Node,int], ...]) -> ShapeTracker:
-    assert len(new_shape) == len(self.views[-1].shape)
-    assert all(is_sym_int(x) and (s == x or (s == 1 and st == 0)) for s,x,st in zip(self.shape, new_shape, self.views[-1].strides)), f"can't expand {self.shape} into {new_shape}"
-    # NOTE: can the mask ever be (0,0)?
-    mask = tuple([(((0,0) if m != (0,1) else (0,ns)) if s != ns else m) for m,s,ns in zip(self.views[-1].mask, self.shape, new_shape)]) if self.views[-1].mask else None
-    self.views[-1] = View.create(new_shape, self.views[-1].strides, self.views[-1].offset, mask)
-    return self
-
-  def reshape(self, new_shape: Tuple[Union[Node,int], ...]):
-    if self.views[-1].shape == new_shape: return self
-    assert all(is_sym_int(x) and x > 0 for x in new_shape), f"shape must be symbolic ints and can't contain 0 or negative numbers {new_shape}"
-    # only check size for int shapes. we don't check symbolic here as long as the reshape itself can be done
-    if all(isinstance(s, int) for s in self.shape) and all(isinstance(s, int) for s in new_shape):
-      assert prod(self.shape) == prod(new_shape), f"can't reshape {self.shape} -> {new_shape}" # type: ignore  # mypy cannot resolve, all ints here
-    new_view, extra = _reshape(self.views[-1], new_shape)
-    if extra: self.views.append(new_view)
-    else: self.views[-1] = new_view
-    return self
-
-  def permute(self, axis: Tuple[int, ...]):
-    assert all(isinstance(x, int) and x >= 0 and x < len(self.shape) for x in axis), f"invalid permute {axis} for {self.shape}"
-    assert len(set(axis)) == len(axis) and len(axis) == len(self.shape), f"can't permute {self.shape} with {axis}"
-    self.views[-1] = View.create(tuple([self.views[-1].shape[a] for a in axis]), tuple([self.views[-1].strides[a] for a in axis]), self.views[-1].offset, tuple([self.views[-1].mask[a] for a in axis]) if self.views[-1].mask is not None else None)
-    return self
-
-  # except for the negative case, you can build this from the others. invertible in the negative case
-  def stride(self, mul: Tuple[int, ...]):
-    assert all(isinstance(x, int) and x != 0 for x in mul), f"invalid stride {mul} for {self.shape}"
-    strides = tuple([z*m for z,m in zip(self.views[-1].strides, mul)])
-    new_shape = tuple([(s+(abs(m)-1))//abs(m) for s,m in zip(self.views[-1].shape, mul)])
-    offset = sum([(s-1)*z for s,z,m in zip(self.views[-1].shape, self.views[-1].strides, mul) if m < 0])
-    mask = tuple([(((mx if m > 0 else s-my)+(abs(m)-1))//abs(m), ((my if m > 0 else s-mx)+(abs(m)-1))//abs(m)) for (mx,my),s,m in zip(self.views[-1].mask, self.views[-1].shape, mul)]) if self.views[-1].mask is not None else None
-    self.views[-1] = View.create(new_shape, strides, self.views[-1].offset + offset, mask)
-    return self
-
+def stride(view: View, mul: Tuple[int, ...]):
+  assert all(isinstance(x, int) and x != 0 for x in mul), f"invalid stride {mul} for {view.shape}"
+  strides = tuple([z*m for z,m in zip(view.strides, mul)])
+  new_shape = tuple([(s+(abs(m)-1))//abs(m) for s,m in zip(view.shape, mul)])
+  offset = sum([(s-1)*z for s,z,m in zip(view.shape, view.strides, mul) if m < 0])
+  mask = tuple([(((mx if m > 0 else s-my)+(abs(m)-1))//abs(m), ((my if m > 0 else s-mx)+(abs(m)-1))//abs(m)) for (mx,my),s,m in zip(view.mask, view.shape, mul)]) if view.mask is not None else None
+  return View.create(new_shape, strides, view.offset + offset, mask)
+  
 # returns the axes to create new_shape if new_shape can be created by combining axis from old_shape
 def get_contraction(old_shape:Tuple[int, ...], new_shape:Tuple[int, ...]) -> Optional[List[List[int]]]:
   # Pre-allocate all groups.

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -183,7 +183,7 @@ def real_strides(views: Tuple[View], ignore_valid=False) -> Tuple[Optional[Union
 def unit_stride_axes(views: Tuple[View], ignore_valid=False) -> List[int]: return [i for i,st in enumerate(real_strides(views, ignore_valid)) if st == 1]
 
 @functools.lru_cache(maxsize=None)
-def _expr_idx(views, idx, valid) -> Tuple[Node, Node]:
+def _expr_idx(views: Tuple[View], idx, valid) -> Tuple[Node, Node]:
   for v in reversed(views[:-1]):
     if valid.max == 0: return Variable.num(-1), valid
     valid = v.expr_node_mask(idx, valid)
@@ -191,7 +191,7 @@ def _expr_idx(views, idx, valid) -> Tuple[Node, Node]:
   return idx, valid
 
 @functools.lru_cache(maxsize=None)
-def simplify(views):
+def simplify(views: Tuple[View]):
   if len(views) >= 2:
     new_view = merge_views(views[-2], views[-1])
     if new_view:
@@ -214,8 +214,8 @@ def expr_node(views: Tuple[View], idx='idx'):
   return _expr_idx(views, views[-1].expr_node(idx), views[-1].expr_node_mask(idx))
 
 @functools.lru_cache(maxsize=None)
-def axis_is_masked(view, axis) -> bool: 
-  _, valid = expr_idxs(view)
+def axis_is_masked(views: Tuple[View], axis) -> bool: 
+  _, valid = expr_idxs(views)
   return f'idx{axis}' in [v.expr for v in valid.vars()]
   # *** under this line are the movement ops ***
 


### PR DESCRIPTION
Not necessarily for merge, mainly to show @chaosagent.

Kept the external shapetracker interfaces, this will be a bit faster still (and way less lines) if those are rewritten in lazy etc.

LLama:

Before
```
codegen         mean runtime:  238.50ms, runs:   293.03,  224.61,  220.70,  243.19,  222.52,  229.64,  224.70,  224.93,  223.50,  278.18
methodcache     mean runtime:  212.00ms, runs:   189.93,  210.70,  216.78,  207.13,  207.24,  235.79,  232.11,  211.25,  203.36,  205.74
profile         mean runtime: 1082.35ms, runs:  1013.85, 1055.22, 1052.08, 1030.62, 1129.18, 1271.14, 1087.14, 1049.98, 1069.15, 1065.08
```


After
```
codegen         mean runtime:  211.45ms, runs:   267.03,  200.79,  203.35,  192.95,  193.02,  194.79,  262.67,  202.87,  197.08,  199.89
methodcache     mean runtime:  185.16ms, runs:   162.61,  181.66,  190.57,  176.26,  176.46,  178.97,  189.02,  240.30,  180.14,  175.58
profile         mean runtime:  860.25ms, runs:   789.98,  791.11,  792.08,  841.22,  948.47,  920.92,  902.69,  857.30,  887.20,  871.53
```


CIFAR
Before
```
 PYTHONPATH=. STEPS=5 WINO=1 python3.11 -O examples/hlb_cifar10.py
  0 34880.25 ms run, 34880.09 ms python,    0.16 ms CL, 1187.23 loss, 0.002563 LR, 0.84 GB used,     13.61 GFLOPS
  1 8163.48 ms run, 8163.33 ms python,    0.15 ms CL, 1187.59 loss, 0.002577 LR, 4.39 GB used,     57.37 GFLOPS
  2  218.71 ms run,    8.44 ms python,  210.27 ms CL, 2760.15 loss, 0.001741 LR, 4.39 GB used,   2141.32 GFLOPS
  3  222.95 ms run,    8.38 ms python,  214.57 ms CL, 2844.72 loss, 0.000906 LR, 4.39 GB used,   2100.54 GFLOPS
  4  228.68 ms run,    8.68 ms python,  220.00 ms CL, 2118.59 loss, 0.000070 LR, 4.39 GB used,   2047.96 GFLOPS
```

After
```
  0 28633.72 ms run, 28633.58 ms python,    0.14 ms CL, 1187.23 loss, 0.002563 LR, 0.84 GB used,     16.58 GFLOPS
  1 7006.18 ms run, 7006.04 ms python,    0.14 ms CL, 1187.59 loss, 0.002577 LR, 4.39 GB used,     66.84 GFLOPS
  2  218.80 ms run,    8.20 ms python,  210.59 ms CL, 2760.15 loss, 0.001741 LR, 4.39 GB used,   2140.45 GFLOPS
  3  224.61 ms run,   12.93 ms python,  211.67 ms CL, 2844.72 loss, 0.000906 LR, 4.39 GB used,   2085.09 GFLOPS
  4  227.51 ms run,   11.21 ms python,  216.30 ms CL, 2118.59 loss, 0.000070 LR, 4.39 GB used,   2058.45 GFLOPS
```