### PR TITLE
cast types in render_load

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -61,9 +61,10 @@ class CStyleLanguage(NamedTuple):
       return f"read_imagef({buf_name}, smp, {idx})"
     if self.uses_vload and buf_dtype == dtypes.float16:
       return f"vload_half{'' if output_dtype.sz == 1 else str(output_dtype.sz)}(0, {buf_name}+{idx})"
+    cast = f"({output_dtype.name})" if output_dtype != buf_dtype else ""
     if output_dtype.sz > 1:
-      return f"({output_dtype.name})(*(({self.smem_prefix if local else self.buffer_prefix}{buf_dtype.name}{output_dtype.sz}*)({buf_name}+{idx})))"
-    return f"*({buf_name}+{idx})" if self.uses_ptr_arithmetic else f"{buf_name}[{idx}]"
+      return f"{cast}(*(({self.smem_prefix if local else self.buffer_prefix}{buf_dtype.name}{output_dtype.sz}*)({buf_name}+{idx})))"
+    return f"{cast}(*({buf_name}+{idx}))" if self.uses_ptr_arithmetic else f"{cast}({buf_name}[{idx}])"
 
   def render_local(self, name:str, size:int):
     return self.smem_prefix + f"float {name}[{size}];"


### PR DESCRIPTION
We already did this for dtypes.sz > 1, but nvcc wants this for half->float casts.

Fixes compile problem with `FP16=1 JIT=1 CUDA=1 python3 examples/gpt2.py`:
```
kernel.cu(21): error: ambiguous "?" operation: second operand of type "const half" can be converted to third operand type "float", and vice versa
    float val2 = (alu0)?(data3[gidx1+1024]):0.0f;
```