### PR TITLE
fix: clean up View

### DIFF
--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -120,7 +120,7 @@ class OptimizedKernel(Kernel):
           stride[j] = bst
           bst *= shp[j]
 
-    self.sts.append(ShapeTracker(tuple(shp), [View(tuple(shp), tuple(stride))]))
+    self.sts.append(ShapeTracker(tuple(shp), [View.create(tuple(shp), tuple(stride))]))
     self.bufs.append(LocalBuffer(name=f"ldata{i}", size=self.sts[-1].size()))
     if DEBUG >= 4: print("aliasing buffer", self.sts[i])
     self.local_alias[i] = self.bufs[-1]


### PR DESCRIPTION
1. NamedTuple already supplies the (identical) `__repr__`
2. Use `View.create` everywhere
3. Correctly cache the instantiantion via `View.create`
4. `shape_strides` was only used once

Comes with a minor speedgain (4%), but this one is more correctness.

```
codegen         mean runtime:  203.41ms, runs:   246.02,  200.11,  178.07,  179.18,  182.85,  181.67,  193.41,  183.10,  185.06,  304.62
methodcache     mean runtime:  170.13ms, runs:   154.47,  173.37,  185.78,  177.96,  172.94,  164.38,  170.64,  168.89,  163.49,  169.36
profile         mean runtime:  789.72ms, runs:   774.23,  774.34,  851.13,  764.46,  776.03,  801.11,  780.29,  779.02,  805.98,  790.56

to

codegen         mean runtime:  195.06ms, runs:   255.96,  186.99,  182.53,  175.61,  180.32,  181.48,  178.95,  178.96,  181.35,  248.47
methodcache     mean runtime:  166.51ms, runs:   175.08,  188.36,  159.07,  167.33,  165.10,  160.04,  162.93,  168.07,  158.59,  160.50
profile         mean runtime:  774.96ms, runs:   789.43,  740.55,  808.50,  777.28,  749.96,  768.48,  795.02,  761.97,  786.76,  771.60
```