### PR TITLE
fix: conditional assert to pure assert

### DIFF
--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -234,8 +234,7 @@ class ShapeTracker:
     if self.views[-1].shape == new_shape: return self
     assert all(is_sym_int(x) and x > 0 for x in new_shape), f"shape must be symbolic ints and can't contain 0 or negative numbers {new_shape}"
     # only check size for int shapes. we don't check symbolic here as long as the reshape itself can be done
-    if all(isinstance(s, int) for s in self.shape) and all(isinstance(s, int) for s in new_shape):
-      assert prod(self.shape) == prod(new_shape), f"can't reshape {self.shape} -> {new_shape}" # type: ignore  # mypy cannot resolve, all ints here
+    assert not (all(isinstance(s, int) for s in self.shape) and all(isinstance(s, int) for s in new_shape)) or prod(self.shape) == prod(new_shape), f"can't reshape {self.shape} -> {new_shape}" # type: ignore  # mypy cannot resolve, all ints here
     new_view, extra = _reshape(self.views[-1], new_shape)
     if extra: self.views.append(new_view)
     else: self.views[-1] = new_view


### PR DESCRIPTION
The condition is always evaluated, even with `-O`. Minor speedup (1%), but mainly conceptually correcter.


```
codegen         mean runtime:  201.37ms, runs:   254.74,  202.29,  177.67,  179.70,  183.37,  208.41,  185.33,  185.19,  182.95,  254.08
methodcache     mean runtime:  171.50ms, runs:   157.73,  200.32,  166.30,  163.08,  167.09,  171.66,  187.92,  165.39,  166.78,  168.74
profile         mean runtime:  861.31ms, runs:   822.05,  807.57,  999.40,  877.46,  796.26,  822.22,  821.48,  813.28,  933.58,  919.78

To

codegen         mean runtime:  199.58ms, runs:   236.73,  251.19,  192.84,  169.43,  187.07,  178.47,  179.45,  179.89,  177.31,  243.42
methodcache     mean runtime:  169.71ms, runs:   154.41,  194.46,  158.67,  201.37,  161.72,  161.37,  166.49,  174.63,  160.48,  163.53
profile         mean runtime:  841.11ms, runs:   803.19,  818.91,  879.03,  847.27,  853.15,  900.46,  939.57,  782.69,  806.71,  780.16
```