### PR TITLE
Fix view, CI cpu test with python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,14 +50,14 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
-    - name: Set up Python 3.11
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.8
     - name: Cache python packages
       uses: actions/cache@v3
       with:
-        path: ${{ env.Python3_ROOT_DIR }}/lib/python3.11/site-packages
+        path: ${{ env.Python3_ROOT_DIR }}/lib/python3.8/site-packages
         key: testing-packages-${{ hashFiles('*/setup.py') }}
     - name: Install Dependencies
       run: pip install -e '.[testing]' --extra-index-url https://download.pytorch.org/whl/cpu

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -30,7 +30,6 @@ def strides_for_shape(shape:Tuple[int, ...]) -> Tuple[int, ...]:
 # symbolic int
 sint = Union[Node, int]
 
-@functools.lru_cache(maxsize=None)
 class View(NamedTuple):
   shape:Tuple[sint, ...]
   strides:Tuple[sint, ...]
@@ -39,12 +38,11 @@ class View(NamedTuple):
   contiguous:bool
 
   @staticmethod
+  @functools.lru_cache(maxsize=None)
   def create(shape:Tuple[sint, ...], strides:Optional[Tuple[sint, ...]]=None, offset:sint=0, mask:Optional[Tuple[Tuple[sint, sint], ...]]=None):
     strides = filter_strides(shape, strides) if strides else strides_for_shape(shape)
     contiguous = offset == 0 and mask is None and all(s1 == s2 for s1,s2 in zip(strides, strides_for_shape(shape)))
     return View(shape, strides, offset, mask, contiguous)
-
-  def __repr__(self): return f"View(shape={self.shape}, strides={self.strides}, offset={self.offset}, mask={self.mask})"
 
   def expr_node_mask(self, idx, valid=None) -> Node:
     expr = [valid] if valid is not None else []


### PR DESCRIPTION
reapply the fix in #1842, the patch had reverted the fix. Also downgrade CPU CI test to python 3.8 to catch this. It's about one minute slower in CI, but still faster than clang and cuda.

also test locally with `python3.8 test/external/external_model_benchmark.py`