### PR TITLE
Limit kernel buffers for metal

### DIFF
--- a/test/test_lazybuffer.py
+++ b/test/test_lazybuffer.py
@@ -68,5 +68,9 @@ class TestLazyBuffer(unittest.TestCase):
     assert cache[1][0].name.startswith("E_")
     assert cache[2][0].name.startswith("E_")
 
+  @unittest.skipUnless(Device.DEFAULT == "METAL", "testing metal backend kernel fuse buffer limits")
+  def test_big_metal_cat(self):
+    Tensor.cat(*[Tensor([1]) for _ in range(40)]).realize()
+
 if __name__ == "__main__":
   unittest.main()

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -223,7 +223,7 @@ class LazyBuffer:
     if MERGE_ELEMENTWISE_OPS:
       # remove the buffers from any (childless) BinaryOps that feed into this
       _srcs = tuple([x.op if x.optype == BinaryOps and not x.children and not x.realized else x for x in srcs])  # type: ignore
-      if len({b for b in chain(*[src.buffers for src in _srcs]) if b.realized or b.op.op is not LoadOps.CONST}) <= max_kernel_args:srcs = _srcs
+      if len({b for b in chain(*[src.buffers for src in _srcs]) if b.realized or b.op.op is not LoadOps.CONST}) <= max_kernel_args:srcs = _srcs # type: ignore
 
     return create_lazybuffer(out_device, ShapeTracker(out_shape), BinaryOps, LazyOp(op, srcs, arg), out_dtype, self.var_vals)
 

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import sys, operator, math
 from typing import Callable, Optional, Tuple, Union, List, Dict, Any, cast
 from weakref import ref, WeakSet, WeakValueDictionary
+from itertools import chain
 
 import numpy as np
 from tinygrad.graph import log_op
@@ -218,9 +219,11 @@ class LazyBuffer:
           new_srcs.append(x)
       return new_srcs[0].e(op, *new_srcs[1:], arg=arg).contiguous()
 
+    max_kernel_args = 30 if out_device == "METAL" else float('inf')
     if MERGE_ELEMENTWISE_OPS:
       # remove the buffers from any (childless) BinaryOps that feed into this
-      srcs = tuple([x.op if x.optype == BinaryOps and not x.children and not x.realized else x for x in srcs])  # type: ignore
+      _srcs = tuple([x.op if x.optype == BinaryOps and not x.children and not x.realized else x for x in srcs])  # type: ignore
+      if len({b for b in chain(*[src.buffers for src in _srcs]) if b.realized or b.op.op is not LoadOps.CONST}) <= max_kernel_args:srcs = _srcs
 
     return create_lazybuffer(out_device, ShapeTracker(out_shape), BinaryOps, LazyOp(op, srcs, arg), out_dtype, self.var_vals)
 


### PR DESCRIPTION
sorry super tired i screwed up this PR. gonna fix it tomorrow basically only the last commit is interesting. code should be valid though


continuing #1856 

I actually found a oneliner that seems too many kernel buffers on metal. (+one line for import and one for const buffern number) 

the way the kernel buffer number is determined might not be quite perfect yet. should i use dedup?

also when we decide that there are too many buffers we dissalow of the sources from being merged. This is not efficient but its the simplest solution I can come up with


stuff like Tensor.cat(*[Tensor([1]) for _ in range(35)]) should work now on metal
