### PR TITLE
relops float==nan fix and tests

### DIFF
--- a/test/test_binops.py
+++ b/test/test_binops.py
@@ -22,14 +22,13 @@ class TestBinaryOperations(unittest.TestCase):
       actual = op_func(tensor_a, tensor_b).numpy()[0]
       desired = op_func(val_a, val_b)
       self.assertEqual(actual, desired, msg=f"For operation {op_name} with values {val_a} and {val_b}")
-    
-    def test_eq(self):        self.check_operation(ops_dict["eq"], "eq")
-    def test_lt(self):        self.check_operation(ops_dict["lt"], "lt")    def test_gt(self):        self.check_operation(ops_dict["gt"], "gt")
-    def test_le(self):        self.check_operation(ops_dict["le"], "le")
-  
+
+  def test_eq(self):        self.check_operation(ops_dict["eq"], "eq")
+  def test_lt(self):        self.check_operation(ops_dict["lt"], "lt")
+  def test_gt(self):        self.check_operation(ops_dict["gt"], "gt")
+  def test_le(self):        self.check_operation(ops_dict["le"], "le")
   def test_ge(self):        self.check_operation(ops_dict["ge"], "ge")
-  def test_ne(self):
-        self.check_operation(ops_dict["ne"], "ne")
-    
+  def test_ne(self):        self.check_operation(ops_dict["ne"], "ne")
+
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/test/test_binops.py
+++ b/test/test_binops.py
@@ -1,0 +1,46 @@
+import unittest
+from tinygrad.tensor import Tensor
+import operator
+import itertools
+
+values = [float('inf'), float('-inf'), float('nan'), 0.0, -0.0, 5.0, -5.0]
+tensors = [Tensor([value]) for value in values]
+ops_dict = {
+    "eq": operator.eq,
+    "lt": operator.lt,
+    "gt": operator.gt,
+    "le": operator.le,
+    "ge": operator.ge,
+    "ne": operator.ne
+}
+
+class TestBinaryOperations(unittest.TestCase):
+
+    def check_operation(self, op_func, op_name):
+        for val_a, val_b in itertools.product(values, repeat=2):
+            tensor_a, tensor_b = Tensor([val_a]), Tensor([val_b])
+            actual = op_func(tensor_a, tensor_b).numpy()[0]
+            desired = op_func(val_a, val_b)
+            self.assertEqual(actual, desired, msg=f"For operation {op_name} with values {val_a} and {val_b}")
+    
+    def test_eq(self):
+        self.check_operation(ops_dict["eq"], "eq")
+        
+    def test_lt(self):
+        self.check_operation(ops_dict["lt"], "lt")
+        
+    def test_gt(self):
+        self.check_operation(ops_dict["gt"], "gt")
+    
+    def test_le(self):
+        self.check_operation(ops_dict["le"], "le")
+    
+    def test_ge(self):
+        self.check_operation(ops_dict["ge"], "ge")
+
+    def test_ne(self):
+        self.check_operation(ops_dict["ne"], "ne")
+    
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_binops.py
+++ b/test/test_binops.py
@@ -16,31 +16,20 @@ ops_dict = {
 
 class TestBinaryOperations(unittest.TestCase):
 
-    def check_operation(self, op_func, op_name):
-        for val_a, val_b in itertools.product(values, repeat=2):
-            tensor_a, tensor_b = Tensor([val_a]), Tensor([val_b])
-            actual = op_func(tensor_a, tensor_b).numpy()[0]
-            desired = op_func(val_a, val_b)
-            self.assertEqual(actual, desired, msg=f"For operation {op_name} with values {val_a} and {val_b}")
+  def check_operation(self, op_func, op_name):
+    for val_a, val_b in itertools.product(values, repeat=2):
+      tensor_a, tensor_b = Tensor([val_a]), Tensor([val_b])
+      actual = op_func(tensor_a, tensor_b).numpy()[0]
+      desired = op_func(val_a, val_b)
+      self.assertEqual(actual, desired, msg=f"For operation {op_name} with values {val_a} and {val_b}")
     
-    def test_eq(self):
-        self.check_operation(ops_dict["eq"], "eq")
-        
-    def test_lt(self):
-        self.check_operation(ops_dict["lt"], "lt")
-        
-    def test_gt(self):
-        self.check_operation(ops_dict["gt"], "gt")
-    
-    def test_le(self):
-        self.check_operation(ops_dict["le"], "le")
-    
-    def test_ge(self):
-        self.check_operation(ops_dict["ge"], "ge")
-
-    def test_ne(self):
+    def test_eq(self):        self.check_operation(ops_dict["eq"], "eq")
+    def test_lt(self):        self.check_operation(ops_dict["lt"], "lt")    def test_gt(self):        self.check_operation(ops_dict["gt"], "gt")
+    def test_le(self):        self.check_operation(ops_dict["le"], "le")
+  
+  def test_ge(self):        self.check_operation(ops_dict["ge"], "ge")
+  def test_ne(self):
         self.check_operation(ops_dict["ne"], "ne")
     
-
 if __name__ == '__main__':
     unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -678,8 +678,8 @@ class Tensor:
   def __gt__(self, x) -> Tensor: return mlops.Less.apply(*self._broadcasted(x, True))
   def __ge__(self, x) -> Tensor: return (((self*self)+(x*x))>-1) - (self<x)
   def __le__(self, x) -> Tensor: return (((self*self)+(x*x))>-1) - (self>x)
-  def __ne__(self, x) -> Tensor: return 1.0 - (self==x)
-  def __eq__(self, x) -> Tensor: return (((self*self)+(x*x))>-1) - (self<x) - (self>x)
+  def __ne__(self, x) -> Tensor: return 1.0 - (self==x)                                 #type:ignore
+  def __eq__(self, x) -> Tensor: return (((self*self)+(x*x))>-1) - (self<x) - (self>x)  #type:ignore
 
   # ***** functional nn ops *****
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -676,10 +676,10 @@ class Tensor:
 
   def __lt__(self, x) -> Tensor: return mlops.Less.apply(*self._broadcasted(x, False))
   def __gt__(self, x) -> Tensor: return mlops.Less.apply(*self._broadcasted(x, True))
-  def __ge__(self, x) -> Tensor: return 1.0-(self<x)
-  def __le__(self, x) -> Tensor: return 1.0-(self>x)
-  def __ne__(self, x) -> Tensor: return (self<x) + (self>x)   # type: ignore
-  def __eq__(self, x) -> Tensor: return 1.0-(self != x)       # type: ignore
+  def __ge__(self, x) -> Tensor: return (((self*self)+(x*x))>-1) - (self<x)
+  def __le__(self, x) -> Tensor: return (((self*self)+(x*x))>-1) - (self>x)
+  def __ne__(self, x) -> Tensor: return 1.0 - (self==x)
+  def __eq__(self, x) -> Tensor: return (((self*self)+(x*x))>-1) - (self<x) - (self>x)
 
   # ***** functional nn ops *****
 


### PR DESCRIPTION
This fixes issue #1556 and I added a test to make sure all relative operation functionality on tensors is the same as on floats. 

By squaring self and x, then checking if their sum is greater than -1, it works as a not-nan checker. 

Slightly slower than existing code, but faster/cleaner than any alternatives I could find that account for comparisons with nan and inf values.