### PR TITLE
No NumNode in shape after symbolic shrink

### DIFF
--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -157,7 +157,6 @@ class NumNode(Node):
     self.b:int = num
     self.min, self.max = num, num
   def __int__(self): return self.b
-  def __index__(self): return self.b
   def __eq__(self, other): return self.b == other
   def __hash__(self): return self.hash  # needed with __eq__ override
   def substitute(self, var_vals: Dict[VariableOrNum, Node]) -> Node: return self


### PR DESCRIPTION
Previously after symbolic shrink (e.g. `t[var:var+1]`), the resulted shape would be `NumNode(1)`, and every downstream shapes would have mixed `NumNode` and `int`. And we need `NumNode.__index__` because of that and need to explicitly convert the shape back to int in `toCPU()`.

This PR convert the `NumNode` shape into `int` in `__unsafe_resize`. We can simplify `toCPU` and remove `NumNode.__index__`. Also fixed the types and checks in `real_strides` and `real_offsets`, which previously would be `MulNode(NumNode, Variable)` and now `MulNode(Variable, int)`.