### PR TITLE
no import when Python is shutting down

### DIFF
--- a/test/external/external_test_allocator_on_models.py
+++ b/test/external/external_test_allocator_on_models.py
@@ -25,6 +25,9 @@ class FakeAllocator(LRUAllocator):
   def _do_free(self, buf):
     buf.id -= 1
     assert buf.id == 0, f"Free should be called once, but {buf.id}"
+  def __del__(self): # Fake allocator should clear all buffers after each test.
+    for v in self.cached_buffers.values():
+      for buf, _ in v: self._free_buffer(buf)
 
 FAKE_GLOBAL_ALLOCATOR = None
 class FakeBuffer(RawBuffer):

--- a/test/test_allocators.py
+++ b/test/test_allocators.py
@@ -26,6 +26,9 @@ class FakeAllocator(LRUAllocator):
   def _do_free(self, buf):
     buf.id -= 1
     assert buf.id == 0, f"Free should be called once, but {buf.id}"
+  def __del__(self): # Fake allocator should clear all buffers after each test.
+    for v in self.cached_buffers.values():
+      for buf, _ in v: self._free_buffer(buf)
 
 FAKE_GLOBAL_ALLOCATOR = None
 class FakeBuffer(RawBuffer):

--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -80,9 +80,6 @@ class LRUAllocator:
     self.buffer_info: Dict[Any, Tuple[int, DType, str]] = dict()
     self.cached_buffers: Dict[Tuple[int, ...], Deque[Tuple[Any, int]]] = defaultdict(deque) # Cached buffer storage, splitted by type and size, newest first.
     self.aging_order: Dict[Any, Deque[Tuple[Tuple[int, ...], int]]] = defaultdict(deque) # Keys of cached_buffers, ordered from oldest to newest updates.
-  def __del__(self):
-    for v in self.cached_buffers.values():
-      for buf, _ in v: self._free_buffer(buf)
   def _cache_reuse_buffer(self, rawbufs: Deque[Tuple[Any, int]]): # The newest cached buffer is reused.
     GlobalCounters.mem_cached -= self._underlying_buf_memsz(rawbufs[0][0])
     return rawbufs.popleft()[0]


### PR DESCRIPTION
This fixes import error when python is exiting: `ImportError: sys.meta_path is None, Python is likely shutting down` (from `extra/gemm/hip_matmul.py`).