### PR TITLE
support symbolic jit in HIP

### DIFF
--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -60,8 +60,8 @@ class HIPProgram:
       start, end = hip.hipEventCreate(), hip.hipEventCreate()
       hip.hipEventRecord(start)
     class PackageStruct(ctypes.Structure):
-      _fields_ = [(f'field{idx}', ctypes.c_void_p) for idx in range(len(args))]
-    struct = PackageStruct(*[data._buf for data in args])
+      _fields_ = [(f'field{idx}', ctypes.c_void_p if not isinstance(args[idx], int) else ctypes.c_int) for idx in range(len(args))]
+    struct = PackageStruct(*[data._buf if not isinstance(data, int) else np.int32(data) for data in args])
     hip.hipModuleLaunchKernel(self.prgs[args[0]._device], global_size[0], global_size[1], global_size[2], local_size[0], local_size[1], local_size[2], 0, 0, struct)
     if wait:
       hip.hipEventRecord(end)
@@ -80,7 +80,7 @@ typedef float float8 __attribute__((ext_vector_type(8)));
 typedef _Float16 half16 __attribute__((ext_vector_type(16)));
 extern "C" __global__
   """, launch_bounds=True,
-  smem_prefix = "__shared__ ", barrier = "__syncthreads();", float4 = "make_float4", uses_vload=True, uses_ptr_arithmetic=True,
+  smem_prefix = "__shared__ ", barrier = "__syncthreads();", float4 = "make_float4", uses_vload=True, uses_ptr_arithmetic=True, arg_int_prefix = "const int",
   half_prekernel = "#include <hip/hip_fp16.h>\nusing half4 = HIP_vector_type<half, 4>;" + """
 __device__ float vload_half(size_t offset, const half *p) { return (float)*(p + offset); }
 __device__ float2 vload_half2(size_t offset, const half *p) { return make_float2((float)*(p + offset*2), (float)*(p + offset*2 + 1)); }


### PR DESCRIPTION
Tested on gpt2, same output with the same seed:

```
nimlgen@tiny:~/tinygrad$ DEBUG=0 JIT=1 HIP=1 python3 examples/gpt2.py --seed 1 --timing

...

ran model in 17.38 ms
total 18.95 ms
What is the answer to life, the universe, and everything?

"The simple answer is to grow old and die." --Jared Diamond

I once encountered a fan who lived an over-deft life—and then he died of a brain hemorrhage. There is no cure for this, of course, but it is just an easy way to say "happily ever after," which here I would consider a good description of life. When you die, you leave behind everything you hold dear—your friends, your relationships, the chance
```
```
nimlgen@tiny:~/tinygrad$ DEBUG=0 JIT=0 HIP=1 python3 examples/gpt2.py --seed 1 --timing

...

ran model in 2822.14 ms
total 2825.04 ms
What is the answer to life, the universe, and everything?

"The simple answer is to grow old and die." --Jared Diamond

I once encountered a fan who lived an over-deft life—and then he died of a brain hemorrhage. There is no cure for this, of course, but it is just an easy way to say "happily ever after," which here I would consider a good description of life. When you die, you leave behind everything you hold dear—your friends, your relationships, the chance
```