### PR TITLE
add branch up-to-date check

### DIFF
--- a/.github/workflows/szdiff.yml
+++ b/.github/workflows/szdiff.yml
@@ -95,5 +95,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           skip_unchanged: true
           message: |
-            This branch currently is behind tinygrad/master.
-            If there is no merge conflicts, please rebase.
+            This branch currently is behind tinygrad/master. The line count difference bot is disabled.

--- a/.github/workflows/szdiff.yml
+++ b/.github/workflows/szdiff.yml
@@ -79,3 +79,21 @@ jobs:
           skip_unchanged: true
           recreate: true
           message: ${{ env.loc_content }}
+
+  rebase:
+    name: Core Library Line Difference
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: checkbranch
+    if: needs.checkbranch.outputs.branchstat == 'true'
+    steps:
+      - name: Comment Rebase
+        continue-on-error: false
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          skip_unchanged: true
+          message: |
+            This branch currently is behind tinygrad/master.
+            If there is no merge conflicts, please rebase.

--- a/.github/workflows/szdiff.yml
+++ b/.github/workflows/szdiff.yml
@@ -8,12 +8,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  checkbranch:
+    name: Check PR Branch status
+    runs-on: ubuntu-latest
+    outputs:
+      branchstat: ${{ steps.brstat.outputs.stat}}
+    steps:
+      - name: Check code from PR branch 
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Check whether branch is up-to-date
+        id: brstat
+        run: |
+          git remote add tinygrad https://github.com/tinygrad/tinygrad
+          git fetch tinygrad master
+          echo "${{ github.event.pull_request.head.sha }}"
+          git rev-list --left-right --count  tinygrad/master...${{ github.event.pull_request.head.sha }} | awk '{print "Behind "$1" - Ahead "$2""}'
+          count=$(git rev-list --left-right --count  tinygrad/master...${{ github.event.pull_request.head.sha }} | awk '{print $1}')
+          if [ $count -gt 0 ]
+          then
+            echo "Current branch is behind tinygrad master branch!"
+            echo "stat=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stat=false" >> "$GITHUB_OUTPUT"
+          fi
+
   szdiff:
     name: Core Library Line Difference
     permissions:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    needs: checkbranch
+    if: needs.checkbranch.outputs.branchstat == 'false'
     steps:
       - name: Checkout code from PR branch
         uses: actions/checkout@v4


### PR DESCRIPTION
Add a branch up-to-date check before triggering the comment bot. It utilizes the `git rev-list --left-right --count  tinygrad/master...${{ github.event.pull_request.head.sha }}` to detect the exact amount of behind/ahead of current branch compare to the tinygrad master branch. Then just condition the comment bot action only on when branch is up-to-date (this is adjustable in `$count -gt 0`).

Here is a sample outout:
```
git rev-list --left-right --count  tinygrad/master...${{ github.event.pull_request.head.sha }} | awk '{print "Behind "$1" - Ahead "$2""}'
Behind 6 - Ahead 0
```