### PR TITLE
Tracking down metal ci failing tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,9 +190,8 @@ jobs:
       run: pip install -e '.[metal,webgpu,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Test LLaMA compile speed
       run: PYTHONPATH="." METAL=1 python test/external/external_test_speed_llama.py
-    #- name: Run dtype test
-    #  run: DEBUG=4 METAL=1 python -m pytest -n=auto test/test_dtype.py
-    # dtype test has issues on test_half_to_int8
+    - name: Run dtype test
+      run: DEBUG=4 METAL=1 python -m pytest -n=auto test/test_dtype.py
     - name: Run metal ops test
       run: DEBUG=2 METAL=1 python -m pytest -n=auto test/test_ops.py
     - name: Run JIT test

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -388,13 +388,6 @@ class OptimizedKernel(Kernel):
             self.upcast()
             break
 
-    # if nothing at all is upcasted and it's easy to, do an upcast
-    # TODO: this is breaking the tests
-    for splits in [4]:
-      if self.upcasted == 0 and self.full_unupcasted_shape and self.full_unupcasted_shape[-1] % splits == 0:
-        self.shift_to(len(self.full_unupcasted_shape)-1, splits, insert_before=len(self.full_unupcasted_shape))
-        self.upcast()
-
     # **** local groups ****
 
     if self.opts.has_local:


### PR DESCRIPTION
related to [#1019](https://github.com/tinygrad/tinygrad/issues/1019)

### The issue

Metal CI tests were failing on [this test case](https://github.com/tinygrad/tinygrad/blob/master/test/test_dtype.py#L91). Specifically, in the case that casting a tensor with data ` [1, 2, 3, 4] ` and dtype `half` to a `unit8` returned `[1 0 3 4]`!

```
AssertionError: 
tensor [1 0 3 4] dtype dtypes.char does not match target [1, 2, 3, 4] with dtype dtypes.char
```

This only happened in the specific combination of scenarios described below:

### Reproducing

There are two parts to reproducing the bug:
1. Hardware / software compatibility
2. Specific inputs to `cast`

Github actions only run on Intel macs, [apple silicon has been in the roadmap for 1y+](https://github.com/github/roadmap/issues/528).

[Wikipedia's "Supported GPUs" list](https://en.wikipedia.org/wiki/Metal_(API)) says only some generations of Intel-based macs support Metal 3. Though the hardware on actions runs Metal 2, you can see it by running `echo $(system_profiler SPDisplaysDataType)`:

![image](https://github.com/Qazalin/tinyfork/assets/77887910/a11ea973-b16d-4776-a50f-b697d99f3042)

So at first it might seem like Metal 2's entire casting is broken. But only certain kernels that do [this upcasting optimization](https://github.com/tinygrad/tinygrad/blob/master/tinygrad/codegen/optimizer.py#L393) have the problem.

To see the kernels in action, try running the following program with `METAL=1 DEBUG=4`:

```py
from tinygrad.helpers import dtypes
from tinygrad.tensor import Tensor

data = [1,2,3,4]
src = Tensor(data, dtype=dtypes.float16)
t = src.cast(dtypes.int8)
print(src.realize(), t.realize())

data = [1,2,3,4,5,6,7,8]
src = Tensor(data, dtype=dtypes.float16)
t = src.cast(dtypes.int8)
print(src.realize(), t.realize())
```

If you try doing the second cast on Metal 2 it'll work but the kernel that gets generated for the first type of casting won't working.

### This PR's diff

Removing the hand-coded optimization was the shortest path to getting back a working CI, though I acknowledge it's suboptimal. With some guidance on how to improve the optimization, I can work on cleaning it up and making it work with Metal 2.