### PR TITLE
Fix gpt optimization

### DIFF
--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -337,10 +337,6 @@ class OptimizedKernel(Kernel):
     # no more opt if we are grouping
     if self.group_for_reduce: return
 
-    # no more opt if there's non ints in any shapes
-    # TODO: this is due to a bug. repro by commenting this one while running GPT-2 with the JIT
-    # if self.has_variable_shape(): return
-
     # **** below this line need to be optional and benchmarked ****
 
     # if there are small dims with lots of valid masks, upcast them (they might be from Tensor.stack)
@@ -349,7 +345,7 @@ class OptimizedKernel(Kernel):
     # upcast leading axes first (hack-ish for winograd; we actually want to upcast masked axes with low stride first)
     for axis in range(self.first_reduce):
       # we might want to be able to split axes that are masked, or refuse to merge them in simplify_merge_adjacent
-      if self.full_shape[axis] <= 7 and any(st.axis_is_masked(axis) for st in self.sts) and prod(self.full_shape[self.shape_len - self.upcasted:]) * self.full_shape[axis] <= 7 * 7:
+      if isinstance(self.full_shape[axis], int) and self.full_shape[axis] <= 7 and any(st.axis_is_masked(axis) for st in self.sts) and prod(self.full_shape[self.shape_len - self.upcasted:]) * self.full_shape[axis] <= 7 * 7:
         if DEBUG >= 4: print(f"upcasting masked axis : {axis}")
         to_upcast.append(axis)
     for axis in to_upcast[::-1]:

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -345,6 +345,7 @@ class OptimizedKernel(Kernel):
     # upcast leading axes first (hack-ish for winograd; we actually want to upcast masked axes with low stride first)
     for axis in range(self.first_reduce):
       # we might want to be able to split axes that are masked, or refuse to merge them in simplify_merge_adjacent
+      # for now skip upcasting here if there is a symbolic axis
       if isinstance(self.full_shape[axis], int) and self.full_shape[axis] <= 7 and any(st.axis_is_masked(axis) for st in self.sts) and prod(self.full_shape[self.shape_len - self.upcasted:]) * self.full_shape[axis] <= 7 * 7:
         if DEBUG >= 4: print(f"upcasting masked axis : {axis}")
         to_upcast.append(axis)

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -339,7 +339,7 @@ class OptimizedKernel(Kernel):
 
     # no more opt if there's non ints in any shapes
     # TODO: this is due to a bug. repro by commenting this one while running GPT-2 with the JIT
-    if self.has_variable_shape(): return
+    # if self.has_variable_shape(): return
 
     # **** below this line need to be optional and benchmarked ****
 

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -31,7 +31,7 @@ class Node:
     return [self.substitute(dict(zip(idxs, (NumNode(x) for x in rep)))) for rep in Node.iter_idxs(idxs)]
   @staticmethod
   def iter_idxs(idxs:Tuple[VariableOrNum, ...]) -> Iterator[Tuple[int,...]]:
-    yield from (x[::-1] for x in product(*[[x for x in range(v.min, (v.max if v.max.__class__ != Variable else v.max.max) + 1)] for v in idxs[::-1]]))
+    yield from (x[::-1] for x in product(*[[x for x in range(v.min, v.max + 1)] for v in idxs[::-1]]))
   # substitute Variables with the values in var_vals
   def substitute(self, var_vals: Dict[VariableOrNum, Node]) -> Node: raise RuntimeError(self.__class__.__name__)
 

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -31,7 +31,7 @@ class Node:
     return [self.substitute(dict(zip(idxs, (NumNode(x) for x in rep)))) for rep in Node.iter_idxs(idxs)]
   @staticmethod
   def iter_idxs(idxs:Tuple[VariableOrNum, ...]) -> Iterator[Tuple[int,...]]:
-    yield from (x[::-1] for x in product(*[[x for x in range(v.min, v.max + 1)] for v in idxs[::-1]]))
+    yield from (x[::-1] for x in product(*[[x for x in range(v.min, (v.max if v.max.__class__ != Variable else v.max.max) + 1)] for v in idxs[::-1]]))
   # substitute Variables with the values in var_vals
   def substitute(self, var_vals: Dict[VariableOrNum, Node]) -> Node: raise RuntimeError(self.__class__.__name__)
 


### PR DESCRIPTION
Avoids variable check with unexpected behaviour.

This gives better optimizations for gpt2 on my quadro T1000.
`DEBUG=1 JIT=1 python examples/gpt2.py --model_size gpt2 --timing`
Before:
```
ran model in 39.70 ms, 24.71 ms on GPU, 0.34 GOPS, 0.69 GB, 27.72 GB/s
total 41.13 ms
```
After:
```
ran model in 32.58 ms, 17.46 ms on GPU, 0.34 GOPS, 0.69 GB, 39.23 GB/s
total 34.07 ms
```