### PR TITLE
refactor calculate_strides and acc_offsets in kernel

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -87,12 +87,14 @@ class Kernel:
                     self.sts[i].real_strides()[self.shape_len-self.upcasted:],
                     [x!=y for x,y in zip(self.sts[0].shape[self.shape_len-self.upcasted:], self.full_shape[self.shape_len-self.upcasted:])]))
 
-  # TODO: is there a better way to write this?
+  def calculate_strides(upcasted_axis):
+      return [x * (1 - axis_info[2]) for x, axis_info in zip(strides_for_shape(tuple(1 if r else s for s, _, r in reversed(upcasted_axis))), reversed(upcasted_axis))]
+
   def acc_offsets(self, i):
-    if self.upcasted == 0: return [0]
-    upcasted_i = self.upcasted_axis(i)
-    acc_strides = [x*(1-upcasted_i[::-1][i][2]) for i,x in enumerate(strides_for_shape(tuple(1 if r else s for s,_,r in upcasted_i[::-1])))]
-    return [sum(t) for t in itertools.product(*[[y*acc_strides[i] for y in range(x[0])] for i,x in enumerate(upcasted_i[::-1])])]
+      if self.upcasted == 0: return [0]
+      upcasted_i = self.upcasted_axis(i)
+      acc_strides = self.calculate_strides(upcasted_i)
+      return [sum(product) for product in itertools.product(*([[y * acc_strides[axis_idx] for y in range(axis_info[0])] for axis_idx, axis_info in enumerate(reversed(upcasted_i))]))]
 
   def get_upcast_dim(self, i) -> List[int]:
     should_upcast = self.opts.supports_float4 and (self.bufs[i].dtype in [dtypes.float32, dtypes.float16] or isinstance(self.bufs[i].dtype, ImageDType))


### PR DESCRIPTION
I'm new to the project so wanting to pick off some low hanging fruit to contribute. 

going through `tinygrad/codgen/` and looking to propse a 'Conceptual cleanup' here.

Proposing: separate the strides calculation logic into its own method (calculate_strides) to make the acc_offsets method more concise.  Also utilizing the zip and reversed here on list comprehension
