### PR TITLE
Fixing pylint errors

### DIFF
--- a/extra/accel/ane/lib/ane.py
+++ b/extra/accel/ane/lib/ane.py
@@ -214,7 +214,7 @@ if __name__ == "__main__":
   mdf = ane.pack(dd, md)
   assert(md == mdf)
 
-  comp = ane.compile(dat) 
+  comp = ane.compile(dat)
   ret = ane.run(comp, tin, tout)
   print("** after **")
   print(tind)

--- a/extra/datasets/__init__.py
+++ b/extra/datasets/__init__.py
@@ -32,7 +32,7 @@ def fetch_cifar(shuffle=False):
       X[idx:idx+bs].assign(x[order,:])
       Y[idx:idx+bs].assign(y[order])
       idx += bs
-    return X, Y  
+    return X, Y
   fn = Path(__file__).parent.resolve() / "cifar-10-python.tar.gz"
   download_file('https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz', fn)
   tt = tarfile.open(fn, mode='r:gz')

--- a/extra/datasets/coco.py
+++ b/extra/datasets/coco.py
@@ -24,7 +24,7 @@ if not pathlib.Path(BASEDIR/'val2017').is_dir():
   with zipfile.ZipFile(fn, 'r') as zip_ref:
     zip_ref.extractall(BASEDIR)
   fn.unlink()
-    
+
 
 if not pathlib.Path(BASEDIR/'annotations').is_dir():
   fn = BASEDIR/'annotations_trainval2017.zip'
@@ -178,7 +178,7 @@ def evaluate_predictions_on_coco(json_result_file, iou_type="bbox"):
   with open(json_result_file, "r") as f:
     for line in f:
       coco_results.append(json.loads(line))
-  
+
   coco_gt = COCO(str(BASEDIR/'annotations/instances_val2017.json'))
   set_of_json = remove_dup([json.dumps(d, cls=NpEncoder) for d in coco_results])
   unique_list = [json.loads(s) for s in set_of_json]
@@ -186,7 +186,7 @@ def evaluate_predictions_on_coco(json_result_file, iou_type="bbox"):
   with open(f'{json_result_file}.flattend', "w") as f:
     json.dump(unique_list, f)
 
-  coco_dt = coco_gt.loadRes(str(f'{json_result_file}.flattend')) 
+  coco_dt = coco_gt.loadRes(str(f'{json_result_file}.flattend'))
   coco_eval = COCOeval(coco_gt, coco_dt, iou_type)
   coco_eval.evaluate()
   coco_eval.accumulate()

--- a/extra/gemm/amx.py
+++ b/extra/gemm/amx.py
@@ -56,7 +56,7 @@ bufs = [c,a,b]
 module = ir.Module(name=__file__)
 func = ir.Function(module, ir.FunctionType(ir.IntType(64), [ir.FloatType().as_pointer()]*3), name='exec')
 
-# load all 
+# load all
 entry = ir.IRBuilder(func.append_basic_block(name="entry"))
 zm, xm, ym = [entry.ptrtoint(func.args[i], ir.IntType(64)) for i in range(3)]
 

--- a/extra/gemm/gemm.py
+++ b/extra/gemm/gemm.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     et = time.monotonic()
     s = et-st
     print(f"{flop/s * 1e-9:.2f} GFLOP/S, {s*1e3:.2f} ms")
-  
+
   with open("/tmp/matmul", "wb") as f:
     f.write(A.data)
     f.write(B.data)

--- a/sz.py
+++ b/sz.py
@@ -37,7 +37,7 @@ def gen_diff(table_old, table_new):
     for file in unchanged:
       file_stat_old = [stats for stats in table_old if file in stats]
       file_stat_new = [stats for stats in table_new if file in stats]
-      if file_stat_new[0][1]-file_stat_old[0][1] != 0 or file_stat_new[0][2]-file_stat_old[0][2] != 0: 
+      if file_stat_new[0][1]-file_stat_old[0][1] != 0 or file_stat_new[0][2]-file_stat_old[0][2] != 0:
         table.append([file_stat_new[0][0], file_stat_new[0][1], file_stat_new[0][1]-file_stat_old[0][1], file_stat_new[0][2], file_stat_new[0][2]-file_stat_old[0][2]])
   return table
 

--- a/test/external/external_test_image.py
+++ b/test/external/external_test_image.py
@@ -23,7 +23,7 @@ class TestImage(unittest.TestCase):
     t1 = t1.sum()
     t1.realize()
     assert t1.numpy() == 16*4*4*4, f"got {t1.numpy()}"
-  
+
   def test_add_image(self):
     t1 = Tensor.ones(16, 16, 1).reshape(16, 4, 4) + 3
     t2 = Tensor.ones(16, 16, 1).reshape(16, 4, 4) + 4
@@ -38,7 +38,7 @@ class TestImage(unittest.TestCase):
     tiny_conv = Conv2d(in_chans, out_chans, 3, bias=None, padding=1)
     tiny_dat = Tensor.ones(bs, 12, 64, 128)
     tiny_conv(tiny_dat).realize()
-  
+
   def test_op_conv(self):
     bs, in_chans, out_chans = 1,12,32
     tiny_conv = Conv2d(in_chans, out_chans, 3, bias=None, padding=1)

--- a/test/extra/test_utils.py
+++ b/test/extra/test_utils.py
@@ -32,7 +32,7 @@ class TestFetchRelative(unittest.TestCase):
     self.tempdir = tempfile.TemporaryDirectory()
     os.chdir(self.tempdir.name)
     with open('test_file.txt', 'x') as f:
-        f.write("12345")
+      f.write("12345")
 
   def tearDown(self):
     os.chdir(self.working_dir)
@@ -44,9 +44,9 @@ class TestFetchRelative(unittest.TestCase):
 
   #test ../
   def test_fetch_relative_dotdotslash(self):
-      os.mkdir('test_file_path')
-      os.chdir('test_file_path')
-      self.assertEqual(b'12345', fetch("../test_file.txt"))
+    os.mkdir('test_file_path')
+    os.chdir('test_file_path')
+    self.assertEqual(b'12345', fetch("../test_file.txt"))
 
 class TestDownloadFile(unittest.TestCase):
   def setUp(self):


### PR DESCRIPTION
this branch:
```
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

master:
```
************* Module extra.accel.ane.lib.ane
extra/accel/ane/2_compile/ane.py:217:25: C0303: Trailing whitespace (trailing-whitespace)
extra/accel/ane/lib/ane.py:217:25: C0303: Trailing whitespace (trailing-whitespace)
.... a few more
test/extra/test_utils.py:49:0: W0311: Bad indentation. Found 6 spaces, expected 4 (bad-indentation)

-------------------------------------------------------------------
Your code has been rated at 9.99/10 (previous run: 10.00/10, -0.01)
```

mainly because when running pylint locally it's hard to see which issues are from the change's diff or were just there.

I'm also checking why CI just passed on this even though when I ran the command locally it errored
