### PR TITLE
wmma: add test and tensor core shape

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,6 +201,8 @@ jobs:
       run: METAL=1 python -m pytest -n=auto test/test_symbolic_shapetracker.py test/test_symbolic_ops.py test/test_symbolic_jit.py
     - name: Check Device.DEFAULT
       run: WEBGPU=1 python -c "from tinygrad.ops import Device; assert Device.DEFAULT == 'WEBGPU', Device.DEFAULT"
+    - name: Run linearizer and tensor core test
+      run: METAL=1 python -m pytest -n=auto test/test_linearizer.py
     #- name: Run webgpu pytest
     #  run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto --ignore test/models/ --ignore test/unit/test_example.py --ignore test/extra/test_lr_scheduler.py --ignore test/test_linearizer.py test/
     #- name: Build WEBGPU Efficientnet

--- a/extra/gemm/simple_matmul.py
+++ b/extra/gemm/simple_matmul.py
@@ -2,9 +2,12 @@ import numpy as np
 from tinygrad.helpers import getenv
 from tinygrad.tensor import Tensor
 from tinygrad.helpers import dtypes
-dtype = dtypes.half if getenv("HALF") else dtypes.float
-N = 4096
-a, b = Tensor.rand(N, N, dtype=dtype).realize(), Tensor.rand(N, N, dtype=dtype).realize()
-for i in range(10):
-  c = (a.reshape(N, 1, N) * b.permute(1,0).reshape(1, N, N)).float().sum(axis=2).realize()
-print((c.numpy() - (a.numpy().astype(np.float32) @ b.numpy().astype(np.float32))).mean())
+dtype_in = dtypes.half if getenv("HALF") else dtypes.float
+N = getenv("N", 4096)
+CNT = getenv("CNT", 10)
+a, b = Tensor.rand(N, N, dtype=dtype_in).realize(), Tensor.rand(N, N, dtype=dtype_in).realize()
+for i in range(CNT):
+  c = (a.reshape(N, 1, N) * b.permute(1,0).reshape(1, N, N)).float().sum(axis=2).realize() if getenv("ACCUM_FP32") else (a @ b).realize()
+comp = a.numpy().astype(np.float32) @ b.numpy().astype(np.float32)
+nc = c.numpy()
+np.testing.assert_allclose(nc, comp, atol=1e-4, rtol=1e-2)


### PR DESCRIPTION
As per @geohot 's suggestion, here are the test changes along with just the shapes and no logic changes.

We can see that running `METAL=1 python3 ./test/test_linearizer.py TestLinearizer.test_tensor_cores` passes, but running on a HIP with `HIP=1 python3 ./test/test_linearizer.py TestLinearizer.test_tensor_cores`, the tensor core is triggered but with numerical errors in the output:

```
======================================================================
FAIL: test_tensor_cores (__main__.TestLinearizer.test_tensor_cores)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/flammit/tinygrad/./test/test_linearizer.py", line 112, in test_tensor_cores
    np.testing.assert_allclose(np_c, r.numpy(), atol=5e-3, rtol=1e-4)
  File "/home/flammit/.pyenv/versions/3.11.5/lib/python3.11/site-packages/numpy/testing/_private/utils.py", line 1504, in assert_allclose
    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),
  File "/home/flammit/.pyenv/versions/3.11.5/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/flammit/.pyenv/versions/3.11.5/lib/python3.11/site-packages/numpy/testing/_private/utils.py", line 797, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Not equal to tolerance rtol=0.0001, atol=0.005

Mismatched elements: 222 / 256 (86.7%)
Max absolute difference: 2.1311564
Max relative difference: 0.877945
```

This PR is now the prerequisite to #1882 which fixes the HIP error and also generalizes the tensor core code.