### PR TITLE
Do not import typing_extensions at runtime

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 import os, functools, platform, time, re, contextlib, operator
 import numpy as np
-from typing import Dict, Tuple, Union, List, NamedTuple, Final, Iterator, ClassVar, Optional, Iterable, Any, TypeVar
-from typing_extensions import TypeGuard
+from typing import Dict, Tuple, Union, List, NamedTuple, Final, Iterator, ClassVar, Optional, Iterable, Any, TypeVar, TYPE_CHECKING
+if TYPE_CHECKING:  # TODO: remove this and import TypeGuard from typing once minimum python supported version is 3.10
+  from typing_extensions import TypeGuard
 
 T = TypeVar("T")
 # NOTE: it returns int 1 if x is empty regardless of the type of x


### PR DESCRIPTION
https://github.com/tinygrad/tinygrad/pull/1852 introduced typing_extensions as a runtime requirement, but the package is only noted as a requirement for linting. So trying to use `python -c 'from tinygrad.tensor import Tensor'` after `pip install -e .` on python 3.11 will fail.

It seems that this does not happens before 3.11 only because typing_extensions was a downstream dependency of pyopencl. Anyway this commit makes it clear that typing_extensions is only needed for linting, as written in setup.py.