### PR TITLE
keep only one comment from git action bot

### DIFF
--- a/.github/workflows/szdiff.yml
+++ b/.github/workflows/szdiff.yml
@@ -74,7 +74,6 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          header: LOC
           ignore_empty: true
           skip_unchanged: true
           recreate: true

--- a/.github/workflows/szdiff.yml
+++ b/.github/workflows/szdiff.yml
@@ -94,5 +94,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           skip_unchanged: true
+          recreate: true
           message: |
             This branch currently is behind tinygrad/master. The line count difference bot is disabled.


### PR DESCRIPTION
The `header` tag allows you to manage comments independently so removing the tag makes it default to keep only one comment per PR.
Test done in my own [branch](https://github.com/g1y5x3/tinygrad/pull/17)

When branch is behind:
![image](https://github.com/tinygrad/tinygrad/assets/17937555/55c95342-cc6f-42be-960b-921dbd827e03)

When branch is updated:
![image](https://github.com/tinygrad/tinygrad/assets/17937555/6907eb1a-aa6f-4898-ae51-43f5796a5465)
