### PR TITLE
Extend reshape hack

### DIFF
--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -119,6 +119,13 @@ class TestSymbolicExpand(unittest.TestCase):
     a = a.reshape(3, vi, 1).expand((3, vi, vj))
     assert a.shape == (3, vi, vj)
     assert a.lazydata.var_vals == {}
+  
+  def test_expand_into_reshape_with_symbols(self):
+    vi = Variable("i", 1, 5)
+    a = Tensor([[1], [2], [3]]).expand((3, 4))
+    a = a.reshape(3, vi)
+    assert a.shape == (3, vi)
+    assert a.lazydata.var_vals == {vi: 4}
 
   def test_plus_expands_constant(self):
     vi = Variable("i", 1, 5)

--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -109,6 +109,13 @@ class TestSymbolicReshape(unittest.TestCase):
         t = t.reshape(vj, vi)
         assert t.shape == (vj, vi)
 
+  def test_reshape_non_contiguous(self):
+    vi = Variable("i", 1, 5)
+    t = Tensor.rand(3,4)
+    t = t.permute(1,0)
+    t = t.reshape(4, vi)
+    assert t.shape == (4, vi)
+
 class TestSymbolicExpand(unittest.TestCase):
   def test_expand_into_symbols(self):
     vi = Variable("i", 1, 5)
@@ -119,7 +126,7 @@ class TestSymbolicExpand(unittest.TestCase):
     a = a.reshape(3, vi, 1).expand((3, vi, vj))
     assert a.shape == (3, vi, vj)
     assert a.lazydata.var_vals == {}
-  
+
   def test_expand_into_reshape_with_symbols(self):
     vi = Variable("i", 1, 5)
     a = Tensor([[1], [2], [3]]).expand((3, 4))

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -99,7 +99,8 @@ class View:
     # check if this is adding or removing 1s with [x for x in self.shape if x != 1] == [x for x in new_shape if x != 1].
     # extend the above to include cases like (3,4) --> (3,i) where we add or remove 1s and add/remove a "dummy" variable.
     # NOTE: this is optional, but removes most calls to (expensive!) merge_views (with mask, not optional)
-    variable_added_or_removed = (sum(1 for a,b in zip_longest([x for x in self.shape if x != 1],[x for x in new_shape if x != 1]) if a != b) == 1)
+    diff_between_shapes = [(a,b) for a,b in zip_longest([x for x in self.shape if x != 1],[x for x in new_shape if x != 1]) if a != b]
+    variable_added_or_removed = (len(diff_between_shapes) == 1) and any(isinstance(x, Node) for x in diff_between_shapes[0])
     if ([x for x in self.shape if x != 1] == [x for x in new_shape if x != 1]) or variable_added_or_removed:
       new_strides: List[sint] = [y for x,y in zip(self.shape, self.strides) if x != 1]
       new_strides_tuple: Tuple[sint, ...] = tuple([0 if x == 1 else new_strides.pop(0) for x in new_shape])

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -99,7 +99,8 @@ class View:
     # check if this is adding or removing 1s with [x for x in self.shape if x != 1] == [x for x in new_shape if x != 1].
     # extend the above to include cases like (3,4) --> (3,i) where we add or remove 1s and add/remove a "dummy" variable.
     # NOTE: this is optional, but removes most calls to (expensive!) merge_views (with mask, not optional)
-    if sum(1 for a,b in zip_longest([x for x in self.shape if x != 1],[x for x in new_shape if x != 1]) if a != b) <= 1:
+    variable_added_or_removed = (sum(1 for a,b in zip_longest([x for x in self.shape if x != 1],[x for x in new_shape if x != 1]) if a != b) == 1)
+    if ([x for x in self.shape if x != 1] == [x for x in new_shape if x != 1]) or variable_added_or_removed:
       new_strides: List[sint] = [y for x,y in zip(self.shape, self.strides) if x != 1]
       new_strides_tuple: Tuple[sint, ...] = tuple([0 if x == 1 else new_strides.pop(0) for x in new_shape])
       new_mask_tuple: Optional[Tuple[Tuple[sint, sint], ...]] = None

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -96,12 +96,16 @@ class View:
     # after the asserts, it's okay to check contiguous
     if self.contiguous: return View.create(new_shape)
 
-    # check if this is adding or removing 1s with [x for x in self.shape if x != 1] == [x for x in new_shape if x != 1].
+    # check if this is adding or removing 1s
     # extend the above to include cases like (3,4) --> (3,i) where we add or remove 1s and add/remove a "dummy" variable.
     # NOTE: this is optional, but removes most calls to (expensive!) merge_views (with mask, not optional)
-    diff_between_shapes = [(a,b) for a,b in zip_longest([x for x in self.shape if x != 1],[x for x in new_shape if x != 1]) if a != b]
-    variable_added_or_removed = (len(diff_between_shapes) == 1) and any(isinstance(x, Node) for x in diff_between_shapes[0])
-    if ([x for x in self.shape if x != 1] == [x for x in new_shape if x != 1]) or variable_added_or_removed:
+    filtered_shape = [x for x in self.shape if x != 1]
+    filtered_new_shape = [x for x in new_shape if x != 1]
+    # if all the values in both shapes are ints, the number of differences between shapes must be even. 
+    # this is due to the product of shapes being equal.
+    # therefore when we only get 1 diff, we must be in a symbolic case where a variable has either been added, removed or replaced.
+    diff_count_filtered_shapes = sum([1 for a,b in zip_longest(filtered_shape, filtered_new_shape) if a != b])
+    if (filtered_shape == filtered_new_shape) or (diff_count_filtered_shapes == 1):
       new_strides: List[sint] = [y for x,y in zip(self.shape, self.strides) if x != 1]
       new_strides_tuple: Tuple[sint, ...] = tuple([0 if x == 1 else new_strides.pop(0) for x in new_shape])
       new_mask_tuple: Optional[Tuple[Tuple[sint, sint], ...]] = None

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -96,7 +96,8 @@ class View:
     # after the asserts, it's okay to check contiguous
     if self.contiguous: return View.create(new_shape)
 
-    # check if this is adding or removing 1s (only)
+    # check if this is adding or removing 1s with [x for x in self.shape if x != 1] == [x for x in new_shape if x != 1].
+    # extend the above to include cases like (3,4) --> (3,i) where we add or remove 1s and add/remove a "dummy" variable.
     # NOTE: this is optional, but removes most calls to (expensive!) merge_views (with mask, not optional)
     if sum(1 for a,b in zip_longest([x for x in self.shape if x != 1],[x for x in new_shape if x != 1]) if a != b) <= 1:
       new_strides: List[sint] = [y for x,y in zip(self.shape, self.strides) if x != 1]

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -99,13 +99,12 @@ class View:
     # check if this is adding or removing 1s
     # extend the above to include cases like (3,4) --> (3,i) where we add or remove 1s and add/remove a "dummy" variable.
     # NOTE: this is optional, but removes most calls to (expensive!) merge_views (with mask, not optional)
-    filtered_shape = [x for x in self.shape if x != 1]
-    filtered_new_shape = [x for x in new_shape if x != 1]
+    # when the diff is 0, we are adding or removing 1s.
     # if all the values in both shapes are ints, the number of differences between shapes must be even. 
     # this is due to the product of shapes being equal.
     # therefore when we only get 1 diff, we must be in a symbolic case where a variable has either been added, removed or replaced.
-    diff_count_filtered_shapes = sum([1 for a,b in zip_longest(filtered_shape, filtered_new_shape) if a != b])
-    if (filtered_shape == filtered_new_shape) or (diff_count_filtered_shapes == 1):
+    diff_count_filtered_shapes = sum([1 for a,b in zip_longest([x for x in self.shape if x != 1], [x for x in new_shape if x != 1]) if a != b])
+    if diff_count_filtered_shapes <= 1:
       new_strides: List[sint] = [y for x,y in zip(self.shape, self.strides) if x != 1]
       new_strides_tuple: Tuple[sint, ...] = tuple([0 if x == 1 else new_strides.pop(0) for x in new_shape])
       new_mask_tuple: Optional[Tuple[Tuple[sint, sint], ...]] = None

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import functools
+from itertools import zip_longest
 from dataclasses import dataclass
 from typing import Tuple, List, Optional
 from tinygrad.helpers import prod, all_int
@@ -97,7 +98,7 @@ class View:
 
     # check if this is adding or removing 1s (only)
     # NOTE: this is optional, but removes most calls to (expensive!) merge_views (with mask, not optional)
-    if [x for x in self.shape if x != 1] == [x for x in new_shape if x != 1]:
+    if sum(1 for a,b in zip_longest([x for x in self.shape if x != 1],[x for x in new_shape if x != 1]) if a != b) <= 1:
       new_strides: List[sint] = [y for x,y in zip(self.shape, self.strides) if x != 1]
       new_strides_tuple: Tuple[sint, ...] = tuple([0 if x == 1 else new_strides.pop(0) for x in new_shape])
       new_mask_tuple: Optional[Tuple[Tuple[sint, sint], ...]] = None


### PR DESCRIPTION
Avoid merge views in certain symbolic cases as well.

This test:

```python
  def test_expand_into_reshape_with_symbols(self):
    vi = Variable("i", 1, 5)
    a = Tensor([[1], [2], [3]]).expand((3, 4))
    a = a.reshape(3, vi)
    assert a.shape == (3, vi)
    assert a.lazydata.var_vals == {vi: 4}
```
currently fails on master due to a type error. Need to think if thats a bug or intentional