### PR TITLE
Fix cast error in render_load in wgsl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,9 +203,11 @@ jobs:
     - name: Run linearizer and tensor core test
       run: METAL=1 python -m pytest -n=auto test/test_linearizer.py
     #- name: Run webgpu pytest
-    #  run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto --ignore test/models/ --ignore test/unit/test_example.py --ignore test/extra/test_lr_scheduler.py --ignore test/test_linearizer.py test/
-    #- name: Build WEBGPU Efficientnet
-    #  run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m examples.compile_efficientnet
+    #  run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto
+    - name: Run webgpu dtype tests
+      run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto test/test_dtype.py
+    - name: Build WEBGPU Efficientnet
+      run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m examples.compile_efficientnet
 
   tests:
     strategy:

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -152,6 +152,7 @@ class TestInt32Dtype(unittest.TestCase):
   @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu does not support int64")
   def test_int32_upcast_int64(self): _test_ops(a_dtype=dtypes.int32, b_dtype=dtypes.int64, target_dtype=dtypes.int64)
 
+@unittest.skipIf(Device.DEFAULT == "WEBGPU", "host-shareablity is a requirement for storage buffers, but 'bool' type is not host-shareable")
 class TestBoolDtype(unittest.TestCase):
   def test_casts_from_bool(self): _test_casts_from([0,1,1,0], source_dtype=dtypes.bool, target_dtypes=[dtypes.float32, dtypes.int32])
   def test_casts_to_bool(self): _test_casts_to([0,1,1,0], source_dtypes=[dtypes.float32, dtypes.int32], target_dtype=dtypes.bool)

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -40,6 +40,7 @@ class CStyleLanguage(NamedTuple):
 
   # returns a str expression of the casted xs with the given type
   def render_cast(self, x:List[str], var_dtype:DType) -> str:
+    if len(x) == 1: return f"({var_dtype.name})({x[0]})"
     assert len(x) == var_dtype.sz, f"cast is wrong size {len(x)} != {var_dtype.sz}"
     assert self.float4 is not None, "cast is not supported on this platform"
     if var_dtype == dtypes._float4: return f"{self.float4}({','.join(x)})"
@@ -47,9 +48,6 @@ class CStyleLanguage(NamedTuple):
     if var_dtype == dtypes._int2: return f"{self.float4.replace('float4', 'int2')}({','.join(x)})"
     raise NotImplementedError(f"no cast for {var_dtype}")
 
-  def render_cast_scalar(self, x:str, var_dtype:DType) -> str:
-    return f"({var_dtype.name})({x})"
-  
   # returns a str expression of the const with the given type
   def render_const(self, x:Union[float,int], var_dtype) -> str:
     if math.isnan(x): val = "NAN"
@@ -71,7 +69,7 @@ class CStyleLanguage(NamedTuple):
     else:
       out_val = f"*({buf_name}+{idx})" if self.uses_ptr_arithmetic else f"{buf_name}[{idx}]"
 
-    return self.render_cast_scalar(out_val, output_dtype) if output_dtype != buf_dtype else out_val
+    return self.render_cast([out_val], output_dtype) if output_dtype != buf_dtype else out_val
 
   def render_local(self, name:str, size:int):
     return self.smem_prefix + f"float {name}[{size}];"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -47,6 +47,9 @@ class CStyleLanguage(NamedTuple):
     if var_dtype == dtypes._int2: return f"{self.float4.replace('float4', 'int2')}({','.join(x)})"
     raise NotImplementedError(f"no cast for {var_dtype}")
 
+  def render_cast_scalar(self, x:str, var_dtype:DType) -> str:
+    return f"({var_dtype.name})({x})"
+  
   # returns a str expression of the const with the given type
   def render_const(self, x:Union[float,int], var_dtype) -> str:
     if math.isnan(x): val = "NAN"
@@ -61,10 +64,14 @@ class CStyleLanguage(NamedTuple):
       return f"read_imagef({buf_name}, smp, {idx})"
     if self.uses_vload and buf_dtype == dtypes.float16:
       return f"vload_half{'' if output_dtype.sz == 1 else str(output_dtype.sz)}(0, {buf_name}+{idx})"
-    cast = f"({output_dtype.name})" if output_dtype != buf_dtype else ""
+    
+    out_val = ""
     if output_dtype.sz > 1:
-      return f"{cast}(*(({self.smem_prefix if local else self.buffer_prefix}{buf_dtype.name}{output_dtype.sz}*)({buf_name}+{idx})))"
-    return f"{cast}(*({buf_name}+{idx}))" if self.uses_ptr_arithmetic else f"{cast}({buf_name}[{idx}])"
+      out_val = f"*(({self.smem_prefix if local else self.buffer_prefix}{buf_dtype.name}{output_dtype.sz}*)({buf_name}+{idx}))" 
+    else:
+      out_val = f"*({buf_name}+{idx})" if self.uses_ptr_arithmetic else f"{buf_name}[{idx}]"
+
+    return self.render_cast_scalar(out_val, output_dtype) if output_dtype != buf_dtype else out_val
 
   def render_local(self, name:str, size:int):
     return self.smem_prefix + f"float {name}[{size}];"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -62,8 +62,6 @@ class CStyleLanguage(NamedTuple):
       return f"read_imagef({buf_name}, smp, {idx})"
     if self.uses_vload and buf_dtype == dtypes.float16:
       return f"vload_half{'' if output_dtype.sz == 1 else str(output_dtype.sz)}(0, {buf_name}+{idx})"
-    
-    out_val = ""
     if output_dtype.sz > 1:
       out_val = f"*(({self.smem_prefix if local else self.buffer_prefix}{buf_dtype.name}{output_dtype.sz}*)({buf_name}+{idx}))" 
     else:

--- a/tinygrad/renderer/wgsl.py
+++ b/tinygrad/renderer/wgsl.py
@@ -46,8 +46,9 @@ class WGSLLanguage(CStyleLanguage):
   def render_conditional(self, cond:str, x:str, y:str) -> str:
     return f"select(f32({y}), {x}, bool({cond}))"
   
-  def render_cast_scalar(self, x:str, var_dtype:DType) -> str:
-    return f"{type_map[var_dtype]}({x})"
+  def render_cast(self, x:List[str], var_dtype:DType) -> str:
+    if type_map[var_dtype]: return f"{type_map[var_dtype]}({x[0]})"
+    raise NotImplementedError(f"no cast for {var_dtype}")
 
   def render_load(self, output_dtype, buf_name, buf_dtype, idx, local=False) -> str:
     return f"f32({super().render_load(output_dtype, buf_name, buf_dtype, idx, local)})"

--- a/tinygrad/renderer/wgsl.py
+++ b/tinygrad/renderer/wgsl.py
@@ -45,6 +45,9 @@ class WGSLLanguage(CStyleLanguage):
 
   def render_conditional(self, cond:str, x:str, y:str) -> str:
     return f"select(f32({y}), {x}, bool({cond}))"
+  
+  def render_cast_scalar(self, x:str, var_dtype:DType) -> str:
+    return f"{type_map[var_dtype]}({x})"
 
   def render_load(self, output_dtype, buf_name, buf_dtype, idx, local=False) -> str:
     return f"f32({super().render_load(output_dtype, buf_name, buf_dtype, idx, local)})"


### PR DESCRIPTION
I noticed an error when running `stable_diffusion` on `webgpu` (but it can affect any other model when running on `webgpu`):

<img width="482" alt="Screenshot 2023-10-02 at 13 49 19" src="https://github.com/tinygrad/tinygrad/assets/8374618/350558c6-faf3-42b2-af68-8a7c3ae2f92b">

The cast that is generated inside `render_load` is wrong, because `float` is not defined in wgsl, and because in wgsl this style of cast `(f32)(some_var)` is invalid. The correct syntax is `f32(some_var)`.

I added `render_cast` to wgsl and modified the cstyle version as well to solve this.

