### PR TITLE
dataset loading speed: extract data only once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ recognize*
 disassemblers/applegpu
 disassemblers/cuda_ioctl_sniffer
 *.prof
-extra/datasets/cifar-10-python.tar.gz
+extra/datasets/cifar-10-*
 extra/datasets/librispeech/
 extra/datasets/imagenet/
 extra/datasets/kits19/


### PR DESCRIPTION
cc: @g1y5x3 

* extract once, not every time

before
```
time PYTHONPATH=. STEPS=2 WINO=0 kernprof -lv examples/hlb_cifar10.py
  0 1540.39 ms run, 1540.20 ms python,    0.19 ms CL, 1199.34 loss, 0.002262 LR, 0.84 GB used,    437.98 GFLOPS
  1  665.47 ms run,  665.23 ms python,    0.24 ms CL, 1196.44 loss, 0.000086 LR, 3.17 GB used,   1013.78 GFLOPS
Wrote profile results to hlb_cifar10.py.lprof
Timer unit: 1e-06 s


real    0m12.456s
user    0m10.720s
sys     0m2.812s
```

after (with unzipped files present)
```
time PYTHONPATH=. STEPS=2 WINO=0 kernprof -lv examples/hlb_cifar10.py
  0 1394.16 ms run, 1393.95 ms python,    0.21 ms CL, 1199.34 loss, 0.002262 LR, 0.84 GB used,    483.91 GFLOPS
  1  684.92 ms run,  684.57 ms python,    0.35 ms CL, 1196.44 loss, 0.000086 LR, 3.17 GB used,    985.00 GFLOPS
Wrote profile results to hlb_cifar10.py.lprof
Timer unit: 1e-06 s


real    0m9.643s
user    0m8.290s
sys     0m2.407s
```