### PR TITLE
unused: persistent load

### DIFF
--- a/extra/utils.py
+++ b/extra/utils.py
@@ -89,10 +89,6 @@ def my_unpickle(fb0):
           return super().find_class(module, name)
         except Exception:
           return Dummy
-
-    def persistent_load(self, pid):
-      return pid
-
   return MyPickle(fb0).load(), key_prelookup
 
 def load_single_weight(t:Tensor, myfile, shape, strides, dtype, storage_offset, mmap_allowed=False):

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -98,7 +98,6 @@ def torch_load(fn:str):
         if DEBUG >= 2: print(f"WARNING: returning Dummy for {module} {name}")
         return Dummy
       return intercept[name] if module_root == "torch" else super().find_class(module, name)
-    def persistent_load(self, pid): return pid
 
   if tuple(t[0:2].numpy()) == (0x50, 0x4b):
     myzip = zipfile.ZipFile(fn, 'r')


### PR DESCRIPTION
Most of these were found with `vulture`.

Can we automate this? Not reliably.