### PR TITLE
chore: add `py.typed` marker.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ setup(name='tinygrad',
       long_description=long_description,
       long_description_content_type='text/markdown',
       packages = ['tinygrad', 'tinygrad.codegen', 'tinygrad.nn', 'tinygrad.renderer', 'tinygrad.runtime', 'tinygrad.shape'],
+      package_data = {
+        'tinygrad': ['py.typed'],
+      }
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License"

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='tinygrad',
       packages = ['tinygrad', 'tinygrad.codegen', 'tinygrad.nn', 'tinygrad.renderer', 'tinygrad.runtime', 'tinygrad.shape'],
       package_data = {
         'tinygrad': ['py.typed'],
-      }
+      },
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License"


### PR DESCRIPTION
closes #1990.

can confirm that installing from git with my fork stops pylance from complaining, solving the issue.