### PR TITLE
Revert "chore: add `py.typed` marker. (#1991)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,6 @@ setup(name='tinygrad',
       long_description=long_description,
       long_description_content_type='text/markdown',
       packages = ['tinygrad', 'tinygrad.codegen', 'tinygrad.nn', 'tinygrad.renderer', 'tinygrad.runtime', 'tinygrad.shape'],
-      package_data = {
-        'tinygrad': ['py.typed'],
-      },
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License"


### PR DESCRIPTION
This reverts commit 6d581e89113da02c031fdad82a4a8a9730ea91ca.