### PR TITLE
allow local + grouped reduce in hand_coded

### DIFF
--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -330,18 +330,17 @@ class OptimizedKernel(Kernel):
               self.upcast()
             return
 
-    if self.opts.has_local and self.opts.has_shared and all(isinstance(s, int) for s in self.sts[0].shape[:self.first_reduce]):
+    if self.opts.has_local and self.opts.has_shared and all(isinstance(s, int) for s in self.sts[0].shape[:self.first_reduce]) and not self.float4_axis(0):
       # are we grouping? (requires local shape support)
-      if not self.float4_axis(0) and self.first_reduce <= 2 and self.first_reduce + 1 <= self.shape_len and prod(self.sts[0].shape[:self.first_reduce]) <= 2048:
-        # TODO: use 1024 if it's allowed in a smarter way
-        for sz in (([256, 16]) if prod(self.sts[0].shape[:self.first_reduce]) <= 32 else [16]):
-          if all(st.shape[self.first_reduce] % sz == 0 or st.shape[self.first_reduce] == 1 for st in self.sts):
-            self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce + len(self.group_for_reduce))
-            self.group_for_reduce.append(sz)
-            break
+      if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
+        divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce] + 1)) if self.full_shape[self.first_reduce] % d == 0]
+        suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= 128]
+        if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.sts[0].shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 1:
+          self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce+len(self.group_for_reduce))
+          self.group_for_reduce.append(sz)
 
       # are we upcasting in mid reduce? (only for images)
-      if self.bufs[0].dtype.name.startswith('image') and not self.float4_axis(0) and self.group_for_reduce and self.first_reduce <= 2 and prod(self.sts[0].shape) > 1:
+      if self.bufs[0].dtype.name.startswith('image') and self.group_for_reduce and self.first_reduce <= 2 and prod(self.sts[0].shape) > 1:
         axes = self.sts[0].unit_stride_axes()
         assert len(axes) == 1, f"wrong number of stride 1 axis : {axes}"
         if self.sts[0].shape[axes[0]]%4 == 0:
@@ -363,7 +362,7 @@ class OptimizedKernel(Kernel):
         self.simplify_ones()
 
     # no more opt if we are grouping
-    if self.group_for_reduce: return
+    # if self.group_for_reduce: return
 
     # **** below this line need to be optional and benchmarked ****
 
@@ -401,11 +400,11 @@ class OptimizedKernel(Kernel):
         break
 
     # if last dim is small(ish) and it's a reduce dim, upcast the reduce (loop unrolling). no simplify needed since it's just an upcast. NOTE: careful, this has broken VALIDHACKS
-    if self.first_reduce < (self.shape_len-self.upcasted) and (len(list(self.shape_offsets(self.full_buf_index))) <= 4 or not any(r for _,_,r in self.upcasted_axis(self.full_buf_index))):
+    if self.first_reduce+len(self.group_for_reduce) < (self.shape_len-self.upcasted) and (len(list(self.shape_offsets(self.full_buf_index))) <= 4 or not any(r for _,_,r in self.upcasted_axis(self.full_buf_index))):
       if (s:=self.full_unupcasted_shape[-1]) <= 32 and isinstance(s, int):  # NOTE: cannot loop unroll symbolic axis
         self.upcast()
         # if it's small, upcast a second reduce dimension too
-        if self.first_reduce < (self.shape_len-self.upcasted) and s <= 3 and self.full_unupcasted_shape[-1] <= 3: self.upcast()
+        if self.first_reduce+len(self.group_for_reduce) < (self.shape_len-self.upcasted) and s <= 3 and self.full_unupcasted_shape[-1] <= 3: self.upcast()
       else:
         for splits in [4]:
           if self.full_unupcasted_shape[-1]%splits == 0:
@@ -427,7 +426,7 @@ class OptimizedKernel(Kernel):
       local_axis_ranking = [(any(self.sts[buf_index].views[-1].strides[axis] == 0 for buf_index in range(len(self.sts))), axis) for axis in range(len(self.full_shape[:self.first_reduce]))]
       to_local: List[Tuple[int, int]] = []
       for _, axis in sorted(local_axis_ranking, key=lambda x: (-x[0], -x[1])):
-        local_size = prod(sz for _, sz in to_local)
+        local_size = prod(self.group_for_reduce) * prod(sz for _, sz in to_local)
         local_sz: Optional[int] = next((x for x in ([32] * (axis == 0) + [16, 8, 4, 3, 2]) if self.full_shape[axis] % x == 0 and local_size * x <= 128), None)
         if local_sz is not None: to_local.append((axis, local_sz))
       for axis, local_sz in sorted(to_local[:3]):

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -335,7 +335,7 @@ class OptimizedKernel(Kernel):
       if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
         divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0]
         suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.full_shape[:self.first_reduce]) // 4]
-        if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.full_shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 2:
+        if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.full_shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 1:
           self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce+len(self.group_for_reduce))
           self.group_for_reduce.append(sz)
 

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -340,7 +340,7 @@ class OptimizedKernel(Kernel):
       if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
         divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0] # type: ignore
         divisors = [d for d in divisors if d % 4 == 0 and (self.full_shape[self.first_reduce] // d) % 4 == 0] if has_images else divisors # images need a unit stride axis (see required_optimizations()).
-        suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.full_shape[:self.first_reduce]) // 4]
+        suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.full_shape[:self.first_reduce]) // 8]
         if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.full_shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 1:
           self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce+len(self.group_for_reduce))
           self.group_for_reduce.append(sz)

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -334,7 +334,7 @@ class OptimizedKernel(Kernel):
       # are we grouping? (requires local shape support)
       if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
         divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce] + 1)) if self.full_shape[self.first_reduce] % d == 0]
-        suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.sts[0].shape[:self.first_reduce]) * 32]
+        suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.sts[0].shape[:self.first_reduce]) // 8]
         if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.sts[0].shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 1:
           self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce+len(self.group_for_reduce))
           self.group_for_reduce.append(sz)

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -333,7 +333,7 @@ class OptimizedKernel(Kernel):
     if self.opts.has_local and self.opts.has_shared and all(isinstance(s, int) for s in self.sts[0].shape[:self.first_reduce]) and not self.float4_axis(0):
       # are we grouping? (requires local shape support)
       if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
-        divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce] + 1)) if self.full_shape[self.first_reduce] % d == 0]
+        divisors = [d for d in range(3, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0]
         suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.sts[0].shape[:self.first_reduce]) // 4]
         if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.sts[0].shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 1:
           self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce+len(self.group_for_reduce))

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -336,7 +336,7 @@ class OptimizedKernel(Kernel):
       # - The decision depends on the desired number of elements to be retained in the reduction loop.
       # - As the global dimensions increase, a larger reduction loop becomes acceptable.
       if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
-        divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0] # type: ignore
+        divisors = [d for d in range(2, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0] # type: ignore
         divisors = [d for d in divisors if (self.full_shape[self.first_reduce] // d) % 4 == 0] if self.bufs[0].dtype.name.startswith('image') else divisors # images need a unit stride axis.
         suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.full_shape[:self.first_reduce]) // 4]
         if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.full_shape[:self.first_reduce]) > 512 else divisors[-1])):

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -334,7 +334,7 @@ class OptimizedKernel(Kernel):
       # are we grouping? (requires local shape support)
       if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
         divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce] + 1)) if self.full_shape[self.first_reduce] % d == 0]
-        suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= 128]
+        suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.sts[0].shape[:self.first_reduce]) * 32]
         if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.sts[0].shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 1:
           self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce+len(self.group_for_reduce))
           self.group_for_reduce.append(sz)

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -333,9 +333,9 @@ class OptimizedKernel(Kernel):
     if self.opts.has_local and self.opts.has_shared and all(isinstance(s, int) for s in self.sts[0].shape[:self.first_reduce]) and not self.float4_axis(0):
       # are we grouping? (requires local shape support)
       if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
-        divisors = [d for d in range(3, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0]
-        suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.sts[0].shape[:self.first_reduce]) // 4]
-        if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.sts[0].shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 1:
+        divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0]
+        suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.full_shape[:self.first_reduce]) // 4]
+        if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.full_shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 2:
           self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce+len(self.group_for_reduce))
           self.group_for_reduce.append(sz)
 

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -334,7 +334,7 @@ class OptimizedKernel(Kernel):
       # are we grouping? (requires local shape support)
       if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
         divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce] + 1)) if self.full_shape[self.first_reduce] % d == 0]
-        suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.sts[0].shape[:self.first_reduce]) // 8]
+        suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.sts[0].shape[:self.first_reduce]) // 4]
         if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.sts[0].shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 1:
           self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce+len(self.group_for_reduce))
           self.group_for_reduce.append(sz)

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -336,10 +336,10 @@ class OptimizedKernel(Kernel):
       # - The decision depends on the desired number of elements to be retained in the reduction loop.
       # - As the global dimensions increase, a larger reduction loop becomes acceptable.
       if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
-        divisors = [d for d in range(2, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0] # type: ignore
+        divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0] # type: ignore
         divisors = [d for d in divisors if (self.full_shape[self.first_reduce] // d) % 4 == 0] if self.bufs[0].dtype.name.startswith('image') else divisors # images need a unit stride axis.
         suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.full_shape[:self.first_reduce]) // 4]
-        if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.full_shape[:self.first_reduce]) > 512 else divisors[-1])):
+        if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.full_shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 1:
           self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce+len(self.group_for_reduce))
           self.group_for_reduce.append(sz)
 

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -333,9 +333,9 @@ class OptimizedKernel(Kernel):
     if self.opts.has_local and self.opts.has_shared and all(isinstance(s, int) for s in self.sts[0].shape[:self.first_reduce]) and not self.float4_axis(0):
       # are we grouping? (requires local shape support)
       if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
-        divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0]
+        divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0] # type: ignore
         suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.full_shape[:self.first_reduce]) // 4]
-        if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.full_shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 1:
+        if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.full_shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 2:
           self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce+len(self.group_for_reduce))
           self.group_for_reduce.append(sz)
 

--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -337,7 +337,7 @@ class OptimizedKernel(Kernel):
       # - As the global dimensions increase, a larger reduction loop becomes acceptable.
       if self.first_reduce + 1 <= self.shape_len and isinstance(self.full_shape[self.first_reduce], int):
         divisors = [d for d in range(1, min(257, self.full_shape[self.first_reduce])) if self.full_shape[self.first_reduce] % d == 0] # type: ignore
-        divisors = [d for d in divisors if (self.full_shape[self.first_reduce] // d) % 4 == 0] if self.bufs[0].dtype.name.startswith('image') else divisors # images need a unit stride axis.
+        divisors = [d for d in divisors if d % 4 == 0 and (self.full_shape[self.first_reduce] // d) % 4 == 0] if self.bufs[0].dtype.name.startswith('image') else divisors # images need a unit stride axis.
         suitable_divisors = [d for d in divisors if self.full_shape[self.first_reduce] // d <= prod(self.full_shape[:self.first_reduce]) // 4]
         if divisors and (sz := (suitable_divisors[0] if suitable_divisors and prod(self.full_shape[:self.first_reduce]) > 512 else divisors[-1])) and sz > 1:
           self.shift_to(self.first_reduce, sz, top=True, insert_before=self.first_reduce+len(self.group_for_reduce))


### PR DESCRIPTION
I tried to test it on all hw I have. gpt2 gets the most noticeable boost, while the other models remained relatively stable with no significant performance drop or gain.

### 7900xtx (hip)

| **Model**         | **Master** | **New**   | **Improvement (%)** |
|:-----------------:|:----------:|:---------:|:-------------------:|
| **GPT2 total**    | 10.75 ms   | 7.62 ms   | 29.2% ↑             |
| **LLAMA**         | N/A        | N/A       | N/A                 |
| **SD step**       | 367.60 ms  | 368.48 ms | 0.24% ↓             |
| **HLB CIFAR run** | 15.63 ms   | 15.48 ms  | 0.96% ↑             |

### 3090 (cuda)

| **Model**         | **Master** | **New**   | **Improvement (%)** |
|:-----------------:|:----------:|:---------:|:-------------------:|
| **GPT2 total**    | 11.91 ms   | 10.83 ms  | 9.08% ↑             |
| **LLAMA total**   | 41.52 ms   | 41.64 ms  | 0.29% ↓             |
| **SD step**       | 579.83 ms  | 571.83 ms | 1.38% ↑             |
| **HLB CIFAR run** | 31.56 ms   | 31.74 ms  | 0.57% ↓             |

### 4070ti (cuda)

| **Model**         | **Master** | **New**   | **Improvement (%)** |
|:-----------------:|:----------:|:---------:|:-------------------:|
| **GPT2 total**    | 12.66 ms   | 9.35 ms   | 26.18% ↑            |
| **SD step**       | 519.08 ms  | 518.16 ms | 0.18% ↑             |
| **HLB CIFAR run** | 30.01 ms   | 29.98 ms  | 0.1% ↑              |

### M1pro (metal)

| **Model**         | **Master** | **New**   | **Improvement (%)** |
|:-----------------:|:----------:|:---------:|:-------------------:|
| **GPT2 total**    | 45.39 ms   | 20.71 ms  | 54.39% ↑            |
| **LLAMA total**   | 138.40 ms  | 138.86 ms | 0.33% ↓             |
| **SD total**      | 1618.79 ms | 1617.58 ms| 0.07% ↑             |
| **HLB CIFAR run** | 202.6 ms   | 202.82 ms | 0.11% ↓             |
