### PR TITLE
Fix llama with empty prompt

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -149,7 +149,7 @@ class Transformer:
 
   def __call__(self, tokens:Tensor, start_pos:int, temperature:Optional[float]=None):
     _bsz, seqlen = tokens.shape
-    if seqlen == 1 and JIT:
+    if seqlen == 1 and start_pos > 0 and JIT:
       pos = Variable("pos", 1, 1024)
       # get only the part of freqs_cis that we are using.
       freqs_cis = self.freqs_cis.shrink(((0, self.freqs_cis.shape[0]), (pos, pos+seqlen),(0, self.freqs_cis.shape[2]),(0, self.freqs_cis.shape[3]),(0, self.freqs_cis.shape[4])))

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -98,7 +98,7 @@ class TestRealWorld(unittest.TestCase):
     @TinyJit
     def test(t): return model(t, 0).realize()
     # NOTE: only test one pass, not testing the dynamic shape autoregressive part
-    helper_test("test_llama", lambda: (Tensor([[1,]]),), test, 0.22 if CI else 13.5, 126 if CI else 486)
+    helper_test("test_llama", lambda: (Tensor([[1,]]),), test, 0.22 if CI else 13.5, 126 if CI else 486, all_jitted=True)
 
   @unittest.skipUnless(Device.DEFAULT in JIT_SUPPORTED_DEVICE and Device.DEFAULT not in ["LLVM"], "needs JIT, too long on CI LLVM")
   def test_gpt2(self):
@@ -109,7 +109,7 @@ class TestRealWorld(unittest.TestCase):
     derandomize_model(model)
     @TinyJit
     def test(t): return model(t, 0).realize()
-    helper_test("test_gpt2", lambda: (Tensor([[1,]]),), test, 0.21 if CI else 0.9, 129 if CI else 369, True)
+    helper_test("test_gpt2", lambda: (Tensor([[1,]]),), test, 0.21 if CI else 0.9, 129 if CI else 369, all_jitted=True)
 
   @unittest.skipIf(getenv("KOPT"), "cifar hangs with KOPT")
   @unittest.skipUnless(Device.DEFAULT in JIT_SUPPORTED_DEVICE and Device.DEFAULT not in ["LLVM"], "needs JIT, too long on CI LLVM")


### PR DESCRIPTION
Fixed the branching with empty prompt (just one BOS token, this is the current test case in test_real_world that breaks with non-CI). Also applied `all_jitted` test.

master
```
PYTHONPATH=. GPU=1 python3 examples/llama.py --prompt "" --count 20 --temperature 0
using GPU backend
using LLaMA-7B model
ram used: 13.48 GB, freqs_cis                                         : 100%|█████████████████████████████████████████████████████████████████████████████████████████████████| 292/292 [00:00<00:00, 2551.49it/s]
loaded weights in 123.70 ms, 13.48 GB loaded at 108.95 GB/s
Traceback (most recent call last):
  File "/Users/chenyu/code/tinygrad/examples/llama.py", line 569, in <module>
    probs = llama.model(Tensor([toks[start_pos:]]), start_pos, args.temperature).realize()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chenyu/code/tinygrad/examples/llama.py", line 159, in __call__
    h, cache_k, cache_v = layer(h, cache_k, cache_v, start_pos=start_pos, freqs_cis=freqs_cis, mask=None, jit_ctx={pos: start_pos})
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chenyu/code/tinygrad/tinygrad/jit.py", line 66, in __call__
    self.ret = self.fxn(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chenyu/code/tinygrad/examples/llama.py", line 119, in __call__
    assert cache_k is not None and cache_v is not None, "no cache"
                                   ^^^^^^^^^^^^^^^^^^^
AssertionError: no cache
```

this PR
```
PYTHONPATH=. GPU=1 python3 examples/llama.py --prompt "" --count 20 --temperature 0
using GPU backend
using LLaMA-7B model
ram used: 13.48 GB, freqs_cis                                         : 100%|█████████████████████████████████████████████████████████████████████████████████████████████████| 292/292 [00:00<00:00, 2677.52it/s]
loaded weights in 117.60 ms, 13.48 GB loaded at 114.60 GB/s
The 2018-2019 school year is off to a great start!%
```