### PR TITLE
whisper: cast model output token to int32

### DIFF
--- a/examples/whisper.py
+++ b/examples/whisper.py
@@ -227,7 +227,7 @@ if __name__ == "__main__":
         log_spec = prep_audio(waveform=Tensor(total).numpy(), sr=RATE)
         encoded_audio = model.encoder(Tensor(log_spec)).realize()
       out = model.decoder(Tensor([lst]), encoded_audio).realize()
-      idx = out[0,-1].argmax().numpy()
+      idx = out[0,-1].argmax().numpy().astype(dtype=np.int32)
       lst.append(idx)
       dec = enc.decode(lst)
       print(dec) # DO NOT REMOVE PRINT. IT'S VERY IMPORTANT


### PR DESCRIPTION
Without this cast, I am getting the following error when running whisper.py on METAL - please let me know if there's a better way to fix this (or if it's not broken for everyone else).

```
Traceback (most recent call last):
  File "/Users/mmmkkaaayy/workspaces/tinygrad/examples/whisper.py", line 232, in <module>
    dec = enc.decode(lst)
          ^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/tiktoken/core.py", line 254, in decode
    return self._core_bpe.decode_bytes(tokens).decode("utf-8", errors=errors)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument 'tokens': only integer scalar arrays can be converted to a scalar index
```

`print(lst)` before the fix yields `[50257, array(50361., dtype=float32)]`