### PR TITLE
Refactor and add more unit tests for disktensors

### DIFF
--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -140,8 +140,8 @@ class TestDiskTensor(unittest.TestCase):
       x[s] = y
       return x[s]
 
-    helper_test_disk_tensor("dt3", [0,1,2,3], lambda x: assign(x, slice(0,2), [13, 12]), lambda x: x[0:2].assign([13, 12]))
-    helper_test_disk_tensor("dt4", [[0,1,2,3],[4,5,6,7]], lambda x: assign(x, slice(0,1), [[13, 12, 11, 10]]), lambda x: x[0:1].assign([[13, 12, 11, 10]]))
+    helper_test_disk_tensor("dt3", [0,1,2,3], lambda x: assign(x, slice(0,2), [13, 12]))
+    helper_test_disk_tensor("dt4", [[0,1,2,3],[4,5,6,7]], lambda x: assign(x, slice(0,1), [[13, 12, 11, 10]]))
 
   def test_reshape(self):
     helper_test_disk_tensor("dt5", [1,2,3,4,5], lambda x: x.reshape((1,5)))

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -146,9 +146,5 @@ class TestDiskTensor(unittest.TestCase):
     helper_test_disk_tensor("dt5", [1,2,3,4,5], lambda x: x.reshape((1,5)))
     helper_test_disk_tensor("dt6", [1,2,3,4], lambda x: x.reshape((2,2)))
 
-  def test_permute(self):
-    helper_test_disk_tensor("dt7", [[1,2,3,4,5],[6,7,8,9,10]], lambda x: np.transpose(x, (0,1)), lambda x: x.permute(0,1))
-    # helper_test_disk_tensor("dt7", [[[1,2,3,4,5],[6,7,8,9,10],[11,12,13,14,15]]], lambda x: np.transpose(x, (0,2,1)), lambda x: x.permute(0,2,1))
-
 if __name__ == "__main__":
   unittest.main()

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -110,7 +110,9 @@ def helper_test_disk_tensor(fn, data, np_fxn, tinygrad_fxn=None):
   pathlib.Path(temp(fn)).unlink(missing_ok=True)
   tinygrad_tensor = Tensor(data, device="CPU").to(f"disk:{temp(fn)}")
   numpy_arr = np.array(data)
-  np.testing.assert_allclose(tinygrad_fxn(tinygrad_tensor).numpy(), np_fxn(numpy_arr))
+  tinygrad_fxn(tinygrad_tensor)
+  np_fxn(numpy_arr)
+  np.testing.assert_allclose(tinygrad_tensor.numpy(), numpy_arr)
 
 class TestDiskTensor(unittest.TestCase):
   def test_empty(self):
@@ -136,10 +138,7 @@ class TestDiskTensor(unittest.TestCase):
     assert np.all(out == 1.)
 
   def test_assign_slice(self):
-    def assign(x,s,y):
-      x[s] = y
-      return x
-
+    def assign(x,s,y): x[s] = y
     helper_test_disk_tensor("dt3", [0,1,2,3], lambda x: assign(x, slice(0,2), [13, 12]))
     helper_test_disk_tensor("dt4", [[0,1,2,3],[4,5,6,7]], lambda x: assign(x, slice(0,1), [[13, 12, 11, 10]]))
 

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -136,8 +136,12 @@ class TestDiskTensor(unittest.TestCase):
     assert np.all(out == 1.)
 
   def test_assign_slice(self):
-    helper_test_disk_tensor("dt3", [0,1,2,3], lambda x: (x.__setitem__(slice(0,2), [13, 12]), x[0:2])[1], lambda x: x[0:2].assign([13, 12]))
-    helper_test_disk_tensor("dt4", [[0,1,2,3],[4,5,6,7]], lambda x: ((x.__setitem__(slice(0,1), [[13, 12, 11, 10]]), x[0:1])[1]), lambda x: x[0:1].assign([[13, 12, 11, 10]]))
+    def assign(x,s,y): 
+      x[s] = y
+      return x[s]
+
+    helper_test_disk_tensor("dt3", [0,1,2,3], lambda x: assign(x, slice(0,2), [13, 12]), lambda x: x[0:2].assign([13, 12]))
+    helper_test_disk_tensor("dt4", [[0,1,2,3],[4,5,6,7]], lambda x: assign(x, slice(0,1), [[13, 12, 11, 10]]), lambda x: x[0:1].assign([[13, 12, 11, 10]]))
 
   def test_reshape(self):
     helper_test_disk_tensor("dt5", [1,2,3,4,5], lambda x: x.reshape((1,5)))

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -134,15 +134,9 @@ class TestDiskTensor(unittest.TestCase):
     out = reloaded.numpy()
     assert np.all(out == 1.)
 
-
   def test_assign_slice(self):
-    pathlib.Path(temp("dt4")).unlink(missing_ok=True)
-    cc = Tensor.arange(10, device="CPU").to(f"disk:{temp('dt4')}").realize()
-
-    #cc.assign(np.ones(10)).realize()
-    print(cc[3:5].numpy())
-    cc[3:5].assign([13, 12]).realize()
-    print(cc.numpy())
+    def assign_slice(x): x[0:2] = [13, 12]; return x[0:2]
+    helper_test_disk_tensor("dt4", [0,1,2,3], lambda x: assign_slice(x), lambda x: x[0:2].assign([13, 12]))
 
   def test_reshape(self):
     helper_test_disk_tensor("dt6", [1,2,3,4,5], lambda x: x.reshape((1,5)), lambda x: x.reshape((1,5)))

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -135,18 +135,19 @@ class TestDiskTensor(unittest.TestCase):
     assert np.all(out == 1.)
 
   def test_assign_slice(self):
-    def assign_slice(x):
-      x[0:2] = [13, 12]
-      return x[0:2]
-    helper_test_disk_tensor("dt4", [0,1,2,3], lambda x: assign_slice(x), lambda x: x[0:2].assign([13, 12]))
+    def assign_slice(x, slice, val):
+      x[slice] = val
+      return x[slice]
+    helper_test_disk_tensor("dt3", [0,1,2,3], lambda x: assign_slice(x, slice(0,2), [13, 12]), lambda x: x[0:2].assign([13, 12]))
+    helper_test_disk_tensor("dt4", [[0,1,2,3],[4,5,6,7]], lambda x: assign_slice(x, slice(0,1), [[13, 12, 11, 10]]), lambda x: x[0:1].assign([[13, 12, 11, 10]]))
 
   def test_reshape(self):
-    helper_test_disk_tensor("dt6", [1,2,3,4,5], lambda x: x.reshape((1,5)), lambda x: x.reshape((1,5)))
+    helper_test_disk_tensor("dt5", [1,2,3,4,5], lambda x: x.reshape((1,5)), lambda x: x.reshape((1,5)))
     helper_test_disk_tensor("dt6", [1,2,3,4], lambda x: x.reshape((2,2)), lambda x: x.reshape((2,2)))
 
   def test_permute(self):
     helper_test_disk_tensor("dt7", [[1,2,3,4,5],[6,7,8,9,10]], lambda x: np.transpose(x, (0,1)), lambda x: x.permute(0,1))
-    # TODO permute 2D broken helper_test_disk_tensor("dt7", [[[1,2,3,4,5],[6,7,8,9,10],[11,12,13,14,15]]], lambda x: np.transpose(x, (0,2,1)), lambda x: x.permute(0,2,1))
+    # helper_test_disk_tensor("dt7", [[[1,2,3,4,5],[6,7,8,9,10],[11,12,13,14,15]]], lambda x: np.transpose(x, (0,2,1)), lambda x: x.permute(0,2,1))
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -105,7 +105,8 @@ class TestSafetensors(unittest.TestCase):
     import json
     assert json.loads(dat[8:8+sz])['__metadata__']['hello'] == 'world'
 
-def helper_test_disk_tensor(fn, data, np_fxn, tinygrad_fxn):
+def helper_test_disk_tensor(fn, data, np_fxn, tinygrad_fxn=None):
+  if tinygrad_fxn is None: tinygrad_fxn = np_fxn
   pathlib.Path(temp(fn)).unlink(missing_ok=True)
   tinygrad_tensor = Tensor(data, device="CPU").to(f"disk:{temp(fn)}")
   numpy_arr = np.array(data)
@@ -139,8 +140,8 @@ class TestDiskTensor(unittest.TestCase):
     helper_test_disk_tensor("dt4", [[0,1,2,3],[4,5,6,7]], lambda x: ((x.__setitem__(slice(0,1), [[13, 12, 11, 10]]), x[0:1])[1]), lambda x: x[0:1].assign([[13, 12, 11, 10]]))
 
   def test_reshape(self):
-    helper_test_disk_tensor("dt5", [1,2,3,4,5],lambda x: x.reshape((1,5)), lambda x: x.reshape((1,5)))
-    helper_test_disk_tensor("dt6", [1,2,3,4], lambda x: x.reshape((2,2)), lambda x: x.reshape((2,2)))
+    helper_test_disk_tensor("dt5", [1,2,3,4,5], lambda x: x.reshape((1,5)))
+    helper_test_disk_tensor("dt6", [1,2,3,4], lambda x: x.reshape((2,2)))
 
   def test_permute(self):
     helper_test_disk_tensor("dt7", [[1,2,3,4,5],[6,7,8,9,10]], lambda x: np.transpose(x, (0,1)), lambda x: x.permute(0,1))

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -135,14 +135,11 @@ class TestDiskTensor(unittest.TestCase):
     assert np.all(out == 1.)
 
   def test_assign_slice(self):
-    def assign_slice(x, slice, val):
-      x[slice] = val
-      return x[slice]
-    helper_test_disk_tensor("dt3", [0,1,2,3], lambda x: assign_slice(x, slice(0,2), [13, 12]), lambda x: x[0:2].assign([13, 12]))
-    helper_test_disk_tensor("dt4", [[0,1,2,3],[4,5,6,7]], lambda x: assign_slice(x, slice(0,1), [[13, 12, 11, 10]]), lambda x: x[0:1].assign([[13, 12, 11, 10]]))
+    helper_test_disk_tensor("dt3", [0,1,2,3], lambda x: (x.__setitem__(slice(0,2), [13, 12]), x[0:2])[1], lambda x: x[0:2].assign([13, 12]))
+    helper_test_disk_tensor("dt4", [[0,1,2,3],[4,5,6,7]], lambda x: ((x.__setitem__(slice(0,1), [[13, 12, 11, 10]]), x[0:1])[1]), lambda x: x[0:1].assign([[13, 12, 11, 10]]))
 
   def test_reshape(self):
-    helper_test_disk_tensor("dt5", [1,2,3,4,5], lambda x: x.reshape((1,5)), lambda x: x.reshape((1,5)))
+    helper_test_disk_tensor("dt5", [1,2,3,4,5],lambda x: x.reshape((1,5)), lambda x: x.reshape((1,5)))
     helper_test_disk_tensor("dt6", [1,2,3,4], lambda x: x.reshape((2,2)), lambda x: x.reshape((2,2)))
 
   def test_permute(self):

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -135,7 +135,9 @@ class TestDiskTensor(unittest.TestCase):
     assert np.all(out == 1.)
 
   def test_assign_slice(self):
-    def assign_slice(x): x[0:2] = [13, 12]; return x[0:2]
+    def assign_slice(x):
+      x[0:2] = [13, 12]
+      return x[0:2]
     helper_test_disk_tensor("dt4", [0,1,2,3], lambda x: assign_slice(x), lambda x: x[0:2].assign([13, 12]))
 
   def test_reshape(self):

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -105,6 +105,12 @@ class TestSafetensors(unittest.TestCase):
     import json
     assert json.loads(dat[8:8+sz])['__metadata__']['hello'] == 'world'
 
+def helper_test_disk_tensor(fn, data, np_fxn, tinygrad_fxn):
+  pathlib.Path(temp(fn)).unlink(missing_ok=True)
+  tinygrad_tensor = Tensor(data, device="CPU").to(f"disk:{temp(fn)}")
+  numpy_arr = np.array(data)
+  np.testing.assert_allclose(tinygrad_fxn(tinygrad_tensor).numpy(), np_fxn(numpy_arr))
+
 class TestDiskTensor(unittest.TestCase):
   def test_empty(self):
     pathlib.Path(temp("dt1")).unlink(missing_ok=True)
@@ -128,22 +134,6 @@ class TestDiskTensor(unittest.TestCase):
     out = reloaded.numpy()
     assert np.all(out == 1.)
 
-  def test_slice(self):
-    pathlib.Path(temp("dt3")).unlink(missing_ok=True)
-    Tensor.arange(10, device="CPU").to(f"disk:{temp('dt3')}").realize()
-
-    slice_me = Tensor.empty(10, device=f"disk:{temp('dt3')}")
-    print(slice_me)
-    is_3 = slice_me[3:4].cpu()
-    assert is_3.numpy()[0] == 3
-
-  def test_slice_2d(self):
-    pathlib.Path(temp("dt5")).unlink(missing_ok=True)
-    Tensor.arange(100, device="CPU").to(f"disk:{temp('dt5')}").realize()
-    slice_me = Tensor.empty(10, 10, device=f"disk:{temp('dt5')}")
-    tst = slice_me[1].numpy()
-    print(tst)
-    np.testing.assert_allclose(tst, np.arange(10, 20))
 
   def test_assign_slice(self):
     pathlib.Path(temp("dt4")).unlink(missing_ok=True)
@@ -154,6 +144,13 @@ class TestDiskTensor(unittest.TestCase):
     cc[3:5].assign([13, 12]).realize()
     print(cc.numpy())
 
+  def test_reshape(self):
+    helper_test_disk_tensor("dt6", [1,2,3,4,5], lambda x: x.reshape((1,5)), lambda x: x.reshape((1,5)))
+    helper_test_disk_tensor("dt6", [1,2,3,4], lambda x: x.reshape((2,2)), lambda x: x.reshape((2,2)))
+
+  def test_permute(self):
+    helper_test_disk_tensor("dt7", [[1,2,3,4,5],[6,7,8,9,10]], lambda x: np.transpose(x, (0,1)), lambda x: x.permute(0,1))
+    # TODO permute 2D broken helper_test_disk_tensor("dt7", [[[1,2,3,4,5],[6,7,8,9,10],[11,12,13,14,15]]], lambda x: np.transpose(x, (0,2,1)), lambda x: x.permute(0,2,1))
+
 if __name__ == "__main__":
   unittest.main()
-

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -136,9 +136,9 @@ class TestDiskTensor(unittest.TestCase):
     assert np.all(out == 1.)
 
   def test_assign_slice(self):
-    def assign(x,s,y): 
+    def assign(x,s,y):
       x[s] = y
-      return x[s]
+      return x
 
     helper_test_disk_tensor("dt3", [0,1,2,3], lambda x: assign(x, slice(0,2), [13, 12]))
     helper_test_disk_tensor("dt4", [[0,1,2,3],[4,5,6,7]], lambda x: assign(x, slice(0,1), [[13, 12, 11, 10]]))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -350,6 +350,8 @@ class Tensor:
         ret = ret.permute(ret_dims[dim[0]:dim[0]+max_dim] + ret_dims[:dim[0]] + ret_dims[dim[0]+max_dim:])
     return ret
 
+  def __setitem__(self,s,v): return self.__getitem__(s).assign(v)
+
   # NOTE: using slice is discouraged and things should migrate to pad and shrink
   def slice(self, arg:Sequence[Optional[Tuple[int, sint]]], value:float=0) -> Tensor:
     arg_ = tuple([a if a is not None else (0,s) for s,a in zip(self.shape, arg)])


### PR DESCRIPTION
This refactors existing disktensor movement ops tests and adds new ones for `reshape`