### PR TITLE
llama default to JIT only if device supports JIT

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -15,10 +15,10 @@ from tinygrad.tensor import Tensor
 from tinygrad.nn import Embedding, Linear
 from tinygrad.nn.state import safe_load, torch_load, load_state_dict
 from tinygrad.ops import GlobalCounters
-from tinygrad.jit import TinyJit
+from tinygrad.jit import TinyJit, JIT_SUPPORTED_DEVICE
 from tinygrad.shape.symbolic import Variable, sym_infer
 
-JIT = getenv("JIT", 0 if CI else 1)
+JIT = getenv("JIT", 0 if CI else Device.DEFAULT in JIT_SUPPORTED_DEVICE)
 
 # https://github.com/facebookresearch/llama/blob/1076b9c51c77ad06e9d7ba8a4c6df775741732bd/llama/model.py#L47
 def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0):


### PR DESCRIPTION
very fast 15 sec per token :)

```
CPU=1 python3 examples/llama.py --temperature=0 --count=10 --prompt="Hello." --timing

using CPU backend
using LLaMA-7B model
ram used: 13.48 GB, freqs_cis                                         : 100%|█████████████████████████████████████████████████████████████████████████████████████████████████| 292/292 [00:00<00:00, 8349.61it/s]
loaded weights in 43.22 ms, 13.48 GB loaded at 311.85 GB/s
Hello.
ran model in 17725.62 ms
total 17726.15 ms, 0.06 tok/sec
 I
ran model in 16049.01 ms
total 16049.51 ms, 0.06 tok/sec
'
ran model in 14948.75 ms
total 14949.35 ms, 0.07 tok/sec
m
ran model in 15054.05 ms
total 15054.49 ms, 0.07 tok/sec
 a
ran model in 14926.72 ms
total 14927.12 ms, 0.07 tok/sec

ran model in 15016.93 ms
total 15017.35 ms, 0.07 tok/sec
2
ran model in 13707.00 ms
total 13707.40 ms, 0.07 tok/sec
0
ran model in 14474.79 ms
total 14475.29 ms, 0.07 tok/sec
 year
ran model in 15013.27 ms
total 15013.69 ms, 0.07 tok/sec
 old
ran model in 14980.76 ms
total 14981.18 ms, 0.07 tok/sec
 male
```