### PR TITLE
Fix stable diffusion output error on WebGPU

### DIFF
--- a/examples/stable_diffusion.py
+++ b/examples/stable_diffusion.py
@@ -652,17 +652,13 @@ if __name__ == "__main__":
   # make image correct size and scale
   x = (x + 1.0) / 2.0
   x = (x.reshape(3,512,512).permute(1,2,0).clip(0,1)*255)
+  if Device.DEFAULT != "WEBGPU": x = x.cast(dtypes.uint8)
   print(x.shape)
 
   # save image
   from PIL import Image
   import numpy as np
-
-  # TODO: without this hack numpy array will be zero. Bug in wgpu_device.queue.read_buffer?
-  if Device.DEFAULT == "WEBGPU":
-    x.numpy()
-
-  im = Image.fromarray(x.numpy().astype(np.uint8))
+  im = Image.fromarray(x.numpy().astype(np.uint8) if Device.DEFAULT == "WEBGPU" else x.numpy())
   print(f"saving {args.out}")
   im.save(args.out)
   # Open image.

--- a/examples/stable_diffusion.py
+++ b/examples/stable_diffusion.py
@@ -651,12 +651,18 @@ if __name__ == "__main__":
 
   # make image correct size and scale
   x = (x + 1.0) / 2.0
-  x = (x.reshape(3,512,512).permute(1,2,0).clip(0,1)*255).cast(dtypes.uint8)
+  x = (x.reshape(3,512,512).permute(1,2,0).clip(0,1)*255)
   print(x.shape)
 
   # save image
   from PIL import Image
-  im = Image.fromarray(x.numpy())
+  import numpy as np
+
+  # TODO: without this hack numpy array will be zero. Bug in wgpu_device.queue.read_buffer?
+  if Device.DEFAULT == "WEBGPU":
+    x.numpy()
+
+  im = Image.fromarray(x.numpy().astype(np.uint8))
   print(f"saving {args.out}")
   im.save(args.out)
   # Open image.

--- a/examples/stable_diffusion.py
+++ b/examples/stable_diffusion.py
@@ -658,7 +658,7 @@ if __name__ == "__main__":
   # save image
   from PIL import Image
   import numpy as np
-  im = Image.fromarray(x.numpy().astype(np.uint8) if Device.DEFAULT == "WEBGPU" else x.numpy())
+  im = Image.fromarray(x.numpy().astype(np.uint8, copy=False))
   print(f"saving {args.out}")
   im.save(args.out)
   # Open image.


### PR DESCRIPTION
When running `examples/stable_diffusion.py` on `WEBGPU` an error is thrown because the output cannot be casted to `uint8`, since it is not supported on `WEBGPU`.

<img width="965" alt="Screenshot 2023-10-10 at 9 12 11" src="https://github.com/tinygrad/tinygrad/assets/8374618/b03f62ad-d2fb-4837-b521-192727b38e28">

To solve this, I `numpy` cast if on webgpu, `Tensor` cast otherwise.