### PR TITLE
kernel cache

### DIFF
--- a/extra/hip_wrapper.py
+++ b/extra/hip_wrapper.py
@@ -681,5 +681,14 @@ try:
     status = _libhiprtc.hiprtcGetCode(prog, e_code)
     hipCheckStatus(status)
     return e_code
+
+  _libhiprtc.hiprtcVersion.restype = int
+  _libhiprtc.hiprtcVersion.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_int)]
+  def hiprtcVersion() -> Tuple[int, int]:
+    major = ctypes.c_int()
+    minor = ctypes.c_int()
+    status = _libhiprtc.hiprtcVersion(ctypes.byref(major), ctypes.byref(minor))
+    hipCheckStatus(status)
+    return (major.value, minor.value)
 except:
   if DEBUG >= 1: print("WARNING: libamdhip64.so or libhiprtc.so not found. HIP support will not work.")

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -157,9 +157,10 @@ def cache_compiled(folder:str):
 
   def decorator(func):
     def wrapper(self, prg:str, **kwargs) -> str:
-      cache_path = cache_dir / hashlib.sha256(prg.encode()).hexdigest()
+      cache_path, tmp_path = cache_dir / hashlib.sha256(prg.encode()).hexdigest(), cache_dir / f"tmp.{os.getpid()}"
       if not cache_path.exists():
-          (cache_dir / f"{cache_path.name}.tmp.{os.getpid()}").write_bytes(func(self, prg, **kwargs)).rename(cache_path)
+          tmp_path.write_bytes(func(self, prg, **kwargs))
+          tmp_path.rename(cache_path)
       return str(cache_path)
     return wrapper
   return decorator

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -159,8 +159,8 @@ def cache_compiled(folder:str):
     def wrapper(self, prg:str, **kwargs) -> str:
       cache_path, tmp_path = cache_dir / hashlib.sha256(prg.encode()).hexdigest(), cache_dir / f"tmp.{os.getpid()}"
       if not cache_path.exists():
-          tmp_path.write_bytes(func(self, prg, **kwargs))
-          tmp_path.rename(cache_path)
+        tmp_path.write_bytes(func(self, prg, **kwargs))
+        tmp_path.rename(cache_path)
       return str(cache_path)
     return wrapper
   return decorator

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -151,21 +151,7 @@ class GlobalCounters:
 
 # *** cache compiled files ***
 
-def cache_compiled(folder:str):
-  cache_dir = pathlib.Path("~/.cache/tinygrad").expanduser() / folder
-  cache_dir.mkdir(parents=True, exist_ok=True)
-
-  def decorator(func):
-    def wrapper(self, prg:str, **kwargs) -> str:
-      cache_path, tmp_path = cache_dir / hashlib.sha256(prg.encode()).hexdigest(), cache_dir / f"tmp.{os.getpid()}"
-      if not cache_path.exists():
-        tmp_path.write_bytes(func(self, prg, **kwargs))
-        tmp_path.rename(cache_path)
-      return str(cache_path)
-    return wrapper
-  return decorator
-
-def cache_filepath(folder:str, prg:str):
+def cache_filepath(folder:str, prg:str) -> pathlib.Path:
   cache_dir = pathlib.Path("~/.cache/tinygrad").expanduser() / folder
   cache_dir.mkdir(parents=True, exist_ok=True)
   return cache_dir / hashlib.sha256(prg.encode()).hexdigest()

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -164,3 +164,8 @@ def cache_compiled(folder:str):
       return str(cache_path)
     return wrapper
   return decorator
+
+def cache_filepath(folder:str, prg:str):
+  cache_dir = pathlib.Path("~/.cache/tinygrad").expanduser() / folder
+  cache_dir.mkdir(parents=True, exist_ok=True)
+  return cache_dir / hashlib.sha256(prg.encode()).hexdigest()

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -161,9 +161,8 @@ def cache_compiled(folder:str):
       cache_path = os.path.join(cache_dir, prg_hash)
 
       if not os.path.exists(cache_path):
-        result = func(self, prg, **kwargs)
         with open(f"{cache_path}.tmp.{os.getpid()}", "wb") as f:
-          f.write(result)
+          f.write(func(self, prg, **kwargs))
         os.rename(f"{cache_path}.tmp.{os.getpid()}", cache_path)
       return cache_path
 

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -156,12 +156,12 @@ def cache_compiled(folder:str):
   os.makedirs(cache_dir, exist_ok=True)
 
   def decorator(func):
-    def wrapper(self, prg:str, binary:bool=False) -> str:
+    def wrapper(self, prg:str, **kwargs) -> str:
       prg_hash = hashlib.sha256(prg.encode()).hexdigest()
       cache_path = os.path.join(cache_dir, prg_hash)
 
       if not os.path.exists(cache_path):
-        result = func(self, prg, binary=binary)
+        result = func(self, prg, **kwargs)
         with open(f"{cache_path}.tmp.{os.getpid()}", "wb") as f:
           f.write(result)
         os.rename(f"{cache_path}.tmp.{os.getpid()}", cache_path)

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -1,7 +1,7 @@
-import os, time, ctypes, hashlib, subprocess, platform, tempfile, functools
+import time, ctypes, hashlib, subprocess, platform, tempfile, functools
 from functools import partial, reduce
 from tinygrad.ops import Compiled
-from tinygrad.helpers import fromimport, getenv, DEBUG, CI
+from tinygrad.helpers import fromimport, getenv, DEBUG, CI, cache_compiled
 from tinygrad.runtime.lib import RawMallocBuffer
 from tinygrad.codegen.kernel import LinearizerOptions
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
@@ -27,34 +27,40 @@ def emulate_ext_calls(fn, uc, address, size, user_data):
   s_in = struct.unpack('f', struct.pack('I', uc.reg_read(getattr(arm64_const, f'UC_ARM64_REG_S{fn[2][1:]}'))))[0]
   uc.reg_write(getattr(arm64_const, f'UC_ARM64_REG_S{fn[1][1:]}'), struct.unpack('I', struct.pack('f', mock_lm[fn[0]](s_in)))[0])  # type: ignore
 
+def toolchain_hash(): return hashlib.sha256(subprocess.check_output(args=("clang --version" if not ARM64 else "aarch64-linux-gnu-as --version").split())).digest().hex()
 class ClangProgram:
   def __init__(self, name:str, prg:str, binary:bool=False):
+    if binary and DEBUG >= 5: print(prg)
+
+    bin_path = self.compile(prg, binary=binary)
+    if binary and CI and ARM64:
+      prg_lines = prg.splitlines()
+      self.varsize = align(int(prg_lines[0].split(" ")[1]))
+      self.ext_calls = {(i*4+ADDRESS):ins.split(" ")[1:] for i, ins in enumerate(filter(lambda ins: ins[:4] != 'loop', prg_lines[6:-3])) if ins[:2] == 'bl'}
+      with open(bin_path, "rb") as f:
+        self.prg = f.read()
+    else:
+      self.lib = ctypes.CDLL(bin_path)
+      self.fxn = self.lib[name]
+
+  @cache_compiled(f"clang-{toolchain_hash()}")
+  def compile(self, prg:str, binary:bool=False):
     # TODO: is there a way to not write this to disk?
     # A: it seems there isn't https://stackoverflow.com/questions/28053328/ctypes-cdll-load-library-from-memory-rather-than-file
     #    because ctypes.CDLL() calls dlopen (POSIX) or LoadLibrary (Windows) which require a file
-    fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.{args['ext']}"
-    if binary and DEBUG >= 5: print(prg)
-    if not os.path.exists(fn):
-      tmp = f"{fn}.{os.getpid()}.tmp"
-      if not binary:
-        prg = CLANG_PROGRAM_HEADER + prg
-        subprocess.check_output(args=('clang -shared -O2 -Wall -Werror -x c '+args['cflags']+' - -o '+tmp).split(), input=prg.encode('utf-8'))
-        os.rename(tmp, fn)
-      else:
+    if not binary:
+      prg = CLANG_PROGRAM_HEADER + prg
+      return subprocess.check_output(args=(f'clang -shared -O2 -Wall -Werror -x c {args["cflags"]} - -o /dev/stdout').split(), input=prg.encode('utf-8'))  
+    else:
+      with tempfile.NamedTemporaryFile() as as_path:
         if CI and ARM64:
-          prg = prg.split('\n') # type: ignore
-          self.varsize = align(int(prg[0].split(" ")[1]))
-          self.ext_calls = {(i*4+ADDRESS):ins.split(" ")[1:] for i, ins in enumerate(filter(lambda ins: ins[:4] != 'loop', prg[6:-3])) if ins[:2] == 'bl'}
-          prg = "\n".join(['nop' if ins[:2] == 'bl' else ins for ins in prg[6:-3]] + ['\n'])
-          subprocess.check_output(args=('aarch64-linux-gnu-as -o '+tmp).split(), input=prg.encode('utf-8'))
-          subprocess.check_output(args=('aarch64-linux-gnu-objcopy -O binary --only-section=.text '+tmp+' '+fn+'.bin').split())
-          with open(fn + '.bin', 'rb') as f:
-            self.prg = f.read()
-          return
-        subprocess.check_output(args=('as -o' + tmp).split(), input=prg.encode('utf-8'))
-        subprocess.check_output(args=('clang -lm -shared '+tmp+' -o'+fn).split())
-    self.lib = ctypes.CDLL(fn)
-    self.fxn = self.lib[name]
+          prg = "\n".join(['nop' if ins[:2] == 'bl' else ins for ins in prg.splitlines()[6:-3]] + ['\n'])
+          subprocess.check_output(args=(f'aarch64-linux-gnu-as -o {as_path.name}').split(), input=prg.encode('utf-8'))
+          return subprocess.check_output(args=(f'aarch64-linux-gnu-objcopy -O binary --only-section=.text {as_path.name} /dev/stdout').split())
+        else:
+          subprocess.check_output(args=(f'as -o {as_path.name}').split(), input=prg.encode('utf-8'))
+          return subprocess.check_output(args=(f'clang -lm -shared {as_path.name} /dev/stdout').split())
+
   def __call__(self, global_size, local_size, *args, wait=False):
     if wait: st = time.monotonic()
     if CI and ARM64:

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -40,7 +40,7 @@ class ClangProgram:
       self.ext_calls = {(i*4+ADDRESS):ins.split(" ")[1:] for i, ins in enumerate(filter(lambda ins: ins[:4] != 'loop', prg_lines[6:-3])) if ins[:2] == 'bl'}
       self.prg = pathlib.Path(cached_file).read_bytes()
     else:
-      self.lib = ctypes.CDLL(cached_file)
+      self.lib = ctypes.CDLL(str(cached_file))
       self.fxn = self.lib[name]
 
   def compile(self, prg, binary, cachefile_path):

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -1,6 +1,5 @@
 import os, time, ctypes, hashlib, subprocess, platform, tempfile, functools, pathlib
 from functools import partial, reduce
-from typing import Tuple, Optional, Any
 from tinygrad.ops import Compiled
 from tinygrad.helpers import fromimport, getenv, DEBUG, CI, cache_filepath
 from tinygrad.runtime.lib import RawMallocBuffer

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -88,7 +88,7 @@ class RawHIPBuffer(RawBufferCopyInOut, RawBufferTransfer):
 
 class HIPProgram:
   def __init__(self, name:str, prg:str, binary=False):
-    bin_path = self.compile(name, prg, binary=binary)
+    bin_path = self.compile(prg, name=name, binary=binary)
     with open(bin_path, "rb") as f:
       prg_bin = f.read()
     if DEBUG >= 6:
@@ -102,7 +102,7 @@ class HIPProgram:
       self.prgs.append(hip.hipModuleGetFunction(module, name))
 
   @cache_compiled(f"hip{'-'.join(map(str, hip.hiprtcVersion()))}")
-  def compile(self, name:str, prg:str, binary=False):
+  def compile(self, prg:str, name="", binary=False):
     try:
       if not binary:
         prog = hip.hiprtcCreateProgram(prg, name, [], [])

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -1,7 +1,7 @@
 import numpy as np
 import ctypes, functools, math, collections, pathlib
 import extra.hip_wrapper as hip
-from typing import Tuple, Any, List
+from typing import Tuple, Any, List, Optional
 from tinygrad.helpers import DEBUG, getenv, cache_compiled
 from tinygrad.ops import Compiled, ASTRunner, BasicBatchExecutor
 from tinygrad.runtime.lib import RawBufferCopyInOut, LRUAllocator, RawBufferTransfer

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -1,5 +1,5 @@
 import numpy as np
-import os, ctypes, functools, math, collections, pathlib
+import os, ctypes, functools, math, collections
 import extra.hip_wrapper as hip
 from typing import Tuple, Any, List
 from tinygrad.helpers import DEBUG, getenv, cache_filepath

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -89,9 +89,7 @@ class RawHIPBuffer(RawBufferCopyInOut, RawBufferTransfer):
 class HIPProgram:
   def __init__(self, name:str, prg:str, binary=False):
     cached_file = cache_filepath(f"hip{'-'.join(map(str, hip.hiprtcVersion()))}", prg)
-    if cached_file.exists(): prg_bin = pathlib.Path(cached_file).read_bytes()
-    else: prg_bin = self.compile(prg, name, binary, cached_file)
-
+    prg_bin = cached_file.read_bytes() if cached_file.exists() else self.compile(prg, name, binary, cached_file)
     if DEBUG >= 6:
       asm = early_exec((["/opt/rocm/llvm/bin/llvm-objdump", '-d', '-'], prg_bin))
       print('\n'.join([x for x in asm.decode('utf-8').split("\n") if 's_code_end' not in x]))

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -93,11 +93,10 @@ class HIPProgram:
       asm = early_exec((["/opt/rocm/llvm/bin/llvm-objdump", '-d', '-'], prg_bin))
       print('\n'.join([x for x in asm.decode('utf-8').split("\n") if 's_code_end' not in x]))
 
-    self.module = hip.hipModuleLoadData(prg_bin)
     self.prgs = []
     for i in range(HIP.device_count):
       hip.hipSetDevice(i)
-      self.prgs.append(hip.hipModuleGetFunction(self.module, name))
+      self.prgs.append(hip.hipModuleGetFunction(hip.hipModuleLoadData(prg_bin), name))
 
   @cache_compiled(f"hip{'-'.join(map(str, hip.hiprtcVersion()))}")
   def compile(self, prg:str, name="", binary=False):


### PR DESCRIPTION
Kernel cache for hip/clang.

Compile time for `WINO=1 HIP=1 python3 examples/hlb_cifar10.py` is 76s -> 21s for reruns.

Tried to make as simple as possible without overcomplicated decorators (imho). But this also support toolchain versions which, so it will recompile kernels when new toolchains are available.

Closes #2025