### PR TITLE
get the list of all function calls that lead to the current function 

### DIFF
--- a/tinygrad/get_function_stack.py
+++ b/tinygrad/get_function_stack.py
@@ -1,0 +1,5 @@
+import inspect
+
+# get the list of all function calls that lead to the current function from the stack
+def generate_stack():
+  for i in list(reversed(inspect.stack())): print(f"Function = {i.function} called from {i.filename} at line number ={i.lineno}")


### PR DESCRIPTION
get the list of all function calls before the current function from the stack.
Thereby making it more easier to understand the workflow of tinygrad, both for beginners and even for the contributors.
This function is now added in at file location tinygrad/tinygrad/get_function_stack.py
If this location seems to be worrisome, please specify the file location which is most suitable.
![image](https://github.com/tinygrad/tinygrad/assets/91129126/b80caec8-86be-4704-b330-6f18f8c65d5c)
