### PR TITLE
get the list of all function calls that leads to the current function from the stack

### DIFF
--- a/tinygrad/get_func_stack.py
+++ b/tinygrad/get_func_stack.py
@@ -1,0 +1,4 @@
+import inspect
+# get the list of all function calls taht leads to the current function from the stack
+def generate_stack():
+  for i in list(reversed(inspect.stack())): print(f"Function = {i.function} called from {i.filename} at line number ={i.lineno}")


### PR DESCRIPTION
get the list of all function calls before the current function from the stack.
Thereby making it more easier to understand the workflow of tinygrad, both for beginners and even for the contributors.
This function is now added in at file location tinygrad/tinygrad/get_function_stack.py
If this location seems to be worrisome, please specify the file location which is most suitable.
![image](https://github.com/tinygrad/tinygrad/assets/91129126/8c07fe53-1a64-48a8-adca-cd4ee5cb79aa)
