### PR TITLE
Llama ~15% faster

### DIFF
--- a/tinygrad/codegen/optimizer.py
+++ b/tinygrad/codegen/optimizer.py
@@ -68,7 +68,7 @@ class OptimizedKernel(Kernel):
   def simplify_ones(self):
     # remove places where the shape is all ones
     # TODO: this should be factored in to multi shape stride
-    if self.shape_len == 0: return
+    if self.shape_len == 0 or 1 not in self.full_shape: return
     all_ones = [s==1 for s in self.full_shape]
     self.local_dims -= sum(all_ones[self.first_reduce-self.local_dims:self.first_reduce])
     self.upcasted -= sum(all_ones[self.shape_len-self.upcasted:])

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -100,6 +100,7 @@ class dtypes:
   @staticmethod
   def is_unsigned(x: DType) -> bool: return x in (dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
   @staticmethod
+  @functools.lru_cache(None)
   def from_np(x) -> DType: return DTYPES_DICT[np.dtype(x).name]
   @staticmethod
   def fields() -> Dict[str, DType]: return DTYPES_DICT

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -49,7 +49,7 @@ class Tensor:
   default_type: ClassVar[DType] = dtypes.float32
   def __init__(self, data:Union[int, float, list, LazyBuffer, np.ndarray], device:Optional[str]=None, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None):
     assert dtype is None or isinstance(dtype, DType), f"invalid dtype {dtype}"
-    device = Device.canonicalize(device)
+    device = Device.canonicalize(device) if device is not None else Device.DEFAULT
     # tensors have gradients, buffers do not
     self.grad: Optional[Tensor] = None
 


### PR DESCRIPTION
Contains Lazyop as dataclass: https://github.com/tinygrad/tinygrad/pull/1603
Ideally, this should be frozen, but the class is modified in some tests (e.g. KOPT tests).

On my machine these changes speed up unjitted LLama from ~260ms to ~220ms.