### PR TITLE
working on issue #2048

### DIFF
--- a/examples/whisper.py
+++ b/examples/whisper.py
@@ -195,16 +195,20 @@ if __name__ == "__main__":
 
   if len(sys.argv) > 1:
     # offline
-    waveform, sample_rate = librosa.load(sys.argv[1], normalize=True)
-    log_spec = prep_audio(waveform, sample_rate)
+    waveform, sample_rate = librosa.load(sys.argv[1], dtype=np.float32)        
+    log_spec = prep_audio(waveform.reshape(1, -1), sample_rate)
     lst = [enc._special_tokens["<|startoftranscript|>"]]
+    print(log_spec.shape)
     dat = model.encoder(Tensor(log_spec)).realize()
     for i in range(50):
       out = model.decoder(Tensor([lst]), dat)
       out.realize()
-      idx = out[0,-1].argmax().numpy()
-      lst.append(idx)
-      print(enc.decode(lst))
+      idx = out[0,-1].argmax().numpy().astype(dtype=np.int32)
+      lst.append(idx)        
+      dec = enc.decode(lst)
+      print(dec) # DO NOT REMOVE PRINT. IT'S VERY IMPORTANT
+      if dec.endswith("<|endoftext|>"):
+        lst = [enc._special_tokens["<|startoftranscript|>"]]
   else:
     # online
 

--- a/examples/whisper.py
+++ b/examples/whisper.py
@@ -195,16 +195,15 @@ if __name__ == "__main__":
 
   if len(sys.argv) > 1:
     # offline
-    waveform, sample_rate = librosa.load(sys.argv[1], dtype=np.float32)        
+    waveform, sample_rate = librosa.load(sys.argv[1], dtype=np.float32)
     log_spec = prep_audio(waveform.reshape(1, -1), sample_rate)
     lst = [enc._special_tokens["<|startoftranscript|>"]]
-    print(log_spec.shape)
     dat = model.encoder(Tensor(log_spec)).realize()
     for i in range(50):
       out = model.decoder(Tensor([lst]), dat)
       out.realize()
       idx = out[0,-1].argmax().numpy().astype(dtype=np.int32)
-      lst.append(idx)        
+      lst.append(idx)
       dec = enc.decode(lst)
       print(dec) # DO NOT REMOVE PRINT. IT'S VERY IMPORTANT
       if dec.endswith("<|endoftext|>"):


### PR DESCRIPTION
maybe the normalize parameter comes from a previous commit (using torchsound.load)

-  torchsound normalize substitited with librosa dtype=np.float32
-  output from librosa.load reshaped in order to fit prep_audio expected input shape 
- dtype of the model output and final print fixed (same as online version)