### PR TITLE
Get all passing Metal tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,23 +198,12 @@ jobs:
         key: metal-webgpu-testing-packages-${{ hashFiles('*/setup.py') }}
     - name: Install Dependencies
       run: pip install -e '.[metal,webgpu,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
+    - name: Run Pytest
+      run: METAL=1 python -m pytest -n=auto test/
     - name: Test LLaMA compile speed
       run: PYTHONPATH="." METAL=1 python test/external/external_test_speed_llama.py
-    #- name: Run dtype test
-    #  run: DEBUG=4 METAL=1 python -m pytest -n=auto test/test_dtype.py
-    # dtype test has issues on test_half_to_int8
-    - name: Run metal ops test
-      run: DEBUG=2 METAL=1 python -m pytest -n=auto test/test_ops.py
-    - name: Run JIT test
-      run: DEBUG=2 METAL=1 python -m pytest -n=auto test/test_jit.py
-    - name: Run symbolic shapetracker test
-      run: METAL=1 python -m pytest -n=auto test/test_symbolic_shapetracker.py test/test_symbolic_ops.py test/test_symbolic_jit.py
-    - name: Run whisper test
-      run: METAL=1 python -m pytest test/models/test_whisper.py
     - name: Check Device.DEFAULT
       run: WEBGPU=1 python -c "from tinygrad.ops import Device; assert Device.DEFAULT == 'WEBGPU', Device.DEFAULT"
-    - name: Run linearizer and tensor core test
-      run: METAL=1 python -m pytest -n=auto test/test_linearizer.py
     #- name: Run webgpu pytest
     #  run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto
     - name: Run webgpu dtype tests

--- a/test/models/test_mnist.py
+++ b/test/models/test_mnist.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
+
+from tinygrad.helpers import CI
 from tinygrad.nn.state import get_parameters
 from tinygrad.tensor import Tensor, Device
 from tinygrad.nn import optim, BatchNorm2d
@@ -98,6 +100,7 @@ class TestMNIST(unittest.TestCase):
     train(model, X_train, Y_train, optimizer, steps=100)
     assert evaluate(model, X_test, Y_test) > 0.93   # torch gets 0.9415 sometimes
 
+  @unittest.skipIf(CI and Device.DEFAULT == "METAL", "broken on macos-13 github runner, but works on local M2 macos-14")
   def test_conv_with_bn(self):
     np.random.seed(1337)
     model = TinyConvNet(has_batchnorm=True)

--- a/test/models/test_onnx.py
+++ b/test/models/test_onnx.py
@@ -7,6 +7,7 @@ import numpy as np
 import onnx
 from extra.utils import fetch, temp
 from extra.onnx import get_run_onnx
+from tinygrad.ops import Device
 from tinygrad.tensor import Tensor
 from tinygrad.helpers import CI
 import pytest
@@ -26,6 +27,8 @@ OPENPILOT_MODEL = "https://github.com/commaai/openpilot/raw/v0.9.4/selfdrive/mod
 np.random.seed(1337)
 
 class TestOnnxModel(unittest.TestCase):
+
+  @unittest.skipIf(CI and Device.DEFAULT == "METAL", "broken on macos-13 github runner, but works on local M2 macos-14")
   def test_benchmark_openpilot_model(self):
     dat = fetch(OPENPILOT_MODEL)
     onnx_model = onnx.load(io.BytesIO(dat))

--- a/test/models/test_train.py
+++ b/test/models/test_train.py
@@ -49,7 +49,7 @@ class TestTrain(unittest.TestCase):
     train_one_step(model,X,Y)
     check_gc()
 
-  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "too many buffers for webgpu")
+  @unittest.skipIf(Device.DEFAULT in ["WEBGPU", "METAL"], "too many buffers for webgpu/metal")
   def test_vit(self):
     model = ViT()
     X = np.zeros((BS,3,224,224), dtype=np.float32)

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -84,10 +84,11 @@ class TestBFloat16DType(unittest.TestCase):
 
 # for GPU, cl_khr_fp16 isn't supported (except now we don't need it!)
 # for LLVM, it segfaults because it can't link to the casting function
-@unittest.skipIf((getenv("CI", "") != "" and Device.DEFAULT in ["LLVM"]) or Device.DEFAULT == "WEBGPU", "float16 broken in some CI backends")
+@unittest.skipIf((CI and Device.DEFAULT in ["LLVM"]) or Device.DEFAULT == "WEBGPU", "float16 broken in some CI backends")
 class TestHalfDtype(unittest.TestCase):
   def test_float16_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.float16), np.float16, [1,2,3,4])
   def test_casts_to_half(self): _test_casts_to([1,2,3,4], source_dtypes=[dtypes.float32, dtypes.int8, dtypes.uint8], target_dtype=dtypes.float16)
+  @unittest.skipIf(CI and Device.DEFAULT == "METAL", "broken on macos-13 github runner, but works on local M2 macos-14")
   def test_casts_from_half(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.float16, target_dtypes=[dtypes.int8, dtypes.uint8, dtypes.float32, dtypes.int32, dtypes.int64])
   def test_half_upcast_ops(self): _test_ops(a_dtype=dtypes.float16, b_dtype=dtypes.float32, target_dtype=dtypes.float32)
   def test_upcast_to_half_ops(self): _test_ops(a_dtype=dtypes.int8, b_dtype=dtypes.float16, target_dtype=dtypes.float16)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7,8 +7,7 @@ import pytest
 
 pytestmark = pytest.mark.webgpu
 
-# NOTE: METAL fails, might be platform and optimization options dependent.
-@unittest.skipUnless(Device.DEFAULT in JIT_SUPPORTED_DEVICE and Device.DEFAULT not in ["METAL", "WEBGPU"], f"no JIT on {Device.DEFAULT}")
+@unittest.skipUnless(Device.DEFAULT in JIT_SUPPORTED_DEVICE and Device.DEFAULT != "WEBGPU", f"no JIT on {Device.DEFAULT}")
 class TestJit(unittest.TestCase):
   def test_simple_jit(self):
     @TinyJit

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -830,7 +830,7 @@ class TestOps(unittest.TestCase):
         lambda x,w: torch.nn.functional.conv_transpose2d(x,w, stride=stride).relu(),
         lambda x,w: Tensor.conv_transpose2d(x,w,stride=stride).relu(), atol=1e-4, grad_rtol=1e-5)
 
-  @unittest.skipIf(Device.DEFAULT == "METAL" and getenv("CI", "") != "", "broken in METAL CI")
+  @unittest.skipIf(CI and Device.DEFAULT == "METAL", "broken on macos-13 github runner, but works on local M2 macos-14")
   def test_output_padded_conv_transpose2d(self):
     for output_padding, stride in [((1,1), (2,3)), ((2,1), (3,2))]:
       helper_test_op([(2,4,6,5), (4,4,3,3),(4,)],
@@ -999,14 +999,14 @@ class TestOps(unittest.TestCase):
               lambda x,w: torch.nn.functional.conv2d(torch.nn.functional.pad(x, p),w).relu(),
               lambda x,w: Tensor.conv2d(x,w,padding=p).relu(), atol=1e-4)
 
-  @unittest.skipIf(Device.DEFAULT == "METAL" and getenv("CI", "") != "", "broken in METAL CI")
+  @unittest.skipIf(CI and Device.DEFAULT == "METAL", "broken on macos-13 github runner, but works on local M2 macos-14")
   def test_padded_conv2d_p21(self):
     bs,cin,H,W,padding = 4, 3, 3, 3, (2,1)
     helper_test_op([(bs,cin,11,28), (4,cin,H,W)],
       lambda x,w: torch.nn.functional.conv2d(x,w,padding=padding).relu(),
       lambda x,w: Tensor.conv2d(x,w,padding=padding).relu(), atol=1e-4)
 
-  @unittest.skipIf(Device.DEFAULT == "METAL" and getenv("CI", "") != "", "broken in METAL CI")
+  @unittest.skipIf(CI and Device.DEFAULT == "METAL", "broken on macos-13 github runner, but works on local M2 macos-14")
   def test_padded_conv2d_p22(self):
     bs,cin,H,W,padding = 4, 3, 3, 3, (2,2)
     helper_test_op([(bs,cin,11,28), (4,cin,H,W)],

--- a/test/unit/test_example.py
+++ b/test/unit/test_example.py
@@ -1,5 +1,4 @@
 import unittest
-import numpy as np
 from tinygrad.ops import Device
 from tinygrad.tensor import Tensor
 from tinygrad.helpers import getenv, CI
@@ -10,7 +9,7 @@ def multidevice_test(fxn):
     for device in Device._buffers:
       if device in ["DISK", "SHM", "FAKE"]: continue
       if not CI: print(device)
-      if device in exclude_devices:
+      if device in exclude_devices or (CI and device != Device.DEFAULT):
         if not CI: print(f"WARNING: {device} test is excluded")
         continue
       with self.subTest(device=device):


### PR DESCRIPTION
I might be underestimating the complexity of this bounty (or whether it's still up for grabs), but this is how I interpreted it!

```
tinygrad % METAL=1 python3 -m pytest test/                                    
========================================================================================= test session starts ==========================================================================================
platform darwin -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0
rootdir: /Users/mmmkkaaayy/workspaces/tinygrad
configfile: pytest.ini
collected 815 items                                                                                                                                                                                    

test/test_allocators.py ...                                                                                                                                                                      [  0%]
test/test_assign.py ....                                                                                                                                                                         [  0%]
test/test_cache_collector.py ........                                                                                                                                                            [  1%]
test/test_conv.py .............s                                                                                                                                                                 [  3%]
test/test_conv_shapetracker.py s                                                                                                                                                                 [  3%]
test/test_custom_function.py sss                                                                                                                                                                 [  4%]
test/test_dtype.py ss.......sss............ssssssss........                                                                                                                                      [  8%]
test/test_gc.py ..                                                                                                                                                                               [  9%]
test/test_jit.py ....s.......                                                                                                                                                                    [ 10%]
test/test_kernel_cache.py .s                                                                                                                                                                     [ 10%]
test/test_lazybuffer.py .......                                                                                                                                                                  [ 11%]
test/test_linearizer.py .s.............                                                                                                                                                          [ 13%]
test/test_linearizer_failures.py s                                                                                                                                                               [ 13%]
test/test_net_speed.py .                                                                                                                                                                         [ 13%]
test/test_nn.py ....s..........                                                                                                                                                                  [ 15%]
test/test_ops.py .............................................s........................ss.............s...............s..................................s................s.s........s..s....... [ 37%]
.........................                                                                                                                                                                        [ 40%]
test/test_optim.py .........................                                                                                                                                                     [ 43%]
test/test_randomness.py ...........                                                                                                                                                              [ 44%]
test/test_schedule.py ........s..s......s....s......ssss....                                                                                                                                     [ 49%]
test/test_specific_conv.py ......                                                                                                                                                                [ 50%]
test/test_speed_v_torch.py sssssssss......s......................                                                                                                                                [ 54%]
test/test_symbolic_jit.py .............                                                                                                                                                          [ 56%]
test/test_symbolic_ops.py ...........                                                                                                                                                            [ 57%]
test/test_symbolic_shapetracker.py .....................                                                                                                                                         [ 60%]
test/test_tensor.py ......................                                                                                                                                                       [ 62%]
test/test_uops.py .....................                                                                                                                                                          [ 65%]
test/test_winograd.py ..                                                                                                                                                                         [ 65%]
test/extra/test_export_model.py .                                                                                                                                                                [ 65%]
test/extra/test_extra_helpers.py .......                                                                                                                                                         [ 66%]
test/extra/test_lr_scheduler.py ...........s                                                                                                                                                     [ 68%]
test/extra/test_utils.py ........                                                                                                                                                                [ 69%]
test/models/test_bert.py .                                                                                                                                                                       [ 69%]
test/models/test_efficientnet.py .......                                                                                                                                                         [ 70%]
test/models/test_end2end.py .....                                                                                                                                                                [ 70%]
test/models/test_mnist.py .........                                                                                                                                                              [ 71%]
test/models/test_onnx.py ...s.                                                                                                                                                                   [ 72%]
test/models/test_real_world.py ....                                                                                                                                                              [ 73%]
test/models/test_rnnt.py .                                                                                                                                                                       [ 73%]
test/models/test_train.py .....s                                                                                                                                                                 [ 73%]
test/models/test_whisper.py .                                                                                                                                                                    [ 73%]
test/unit/test_disk_tensor.py .............                                                                                                                                                      [ 75%]
test/unit/test_example.py ....                                                                                                                                                                   [ 76%]
test/unit/test_flopcounter.py .....                                                                                                                                                              [ 76%]
test/unit/test_helpers.py ......................                                                                                                                                                 [ 79%]
test/unit/test_shapetracker.py ..................................s...............................................                                                                                [ 89%]
test/unit/test_shm_tensor.py ..                                                                                                                                                                  [ 89%]
test/unit/test_symbolic.py ....................................................................................                                                                                  [100%]

=========================================================================================== warnings summary ===========================================================================================
test/test_gc.py::TestGC::test_gc
test/test_gc.py::TestGC::test_gc_complex
  /opt/homebrew/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:347: UserWarning: torch.distributed.reduce_op is deprecated, please use torch.distributed.ReduceOp instead
    warnings.warn(

test/models/test_whisper.py::TestWhisper::test_transcribe_file
  /opt/homebrew/lib/python3.11/site-packages/librosa/core/intervals.py:8: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import resource_filename

test/models/test_whisper.py::TestWhisper::test_transcribe_file
  /opt/homebrew/lib/python3.11/site-packages/audioread/rawread.py:16: DeprecationWarning: 'aifc' is deprecated and slated for removal in Python 3.13
    import aifc

test/models/test_whisper.py::TestWhisper::test_transcribe_file
  /opt/homebrew/lib/python3.11/site-packages/audioread/rawread.py:17: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
    import audioop

test/models/test_whisper.py::TestWhisper::test_transcribe_file
  /opt/homebrew/lib/python3.11/site-packages/audioread/rawread.py:19: DeprecationWarning: 'sunau' is deprecated and slated for removal in Python 3.13
    import sunau

test/models/test_whisper.py::TestWhisper::test_transcribe_file
  /opt/homebrew/lib/python3.11/site-packages/librosa/core/spectrum.py:362: ComplexWarning: Casting complex values to real discards the imaginary part
    stft_matrix[..., :off_start] = fft.rfft(fft_window * y_frames_pre, axis=-2)

test/models/test_whisper.py::TestWhisper::test_transcribe_file
  /opt/homebrew/lib/python3.11/site-packages/librosa/core/spectrum.py:366: ComplexWarning: Casting complex values to real discards the imaginary part
    stft_matrix[..., -off_end:] = fft.rfft(fft_window * y_frames_post, axis=-2)

test/models/test_whisper.py::TestWhisper::test_transcribe_file
  /opt/homebrew/lib/python3.11/site-packages/librosa/core/spectrum.py:378: ComplexWarning: Casting complex values to real discards the imaginary part
    stft_matrix[..., bl_s + off_start : bl_t + off_start] = fft.rfft(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== 760 passed, 55 skipped, 9 warnings in 69.88s (0:01:09) ========================================================================
```