### PR TITLE
mute hip warnings

### DIFF
--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -139,7 +139,7 @@ typedef float float8 __attribute__((ext_vector_type(8)));
 typedef _Float16 half16 __attribute__((ext_vector_type(16)));
 extern "C" __global__
   """, launch_bounds=True,
-  smem_prefix = "__shared__ ", barrier = "__syncthreads();", float4 = "make_float4", uses_vload=True, uses_ptr_arithmetic=True, arg_int_prefix = "const int",
+  smem_prefix = "__shared__ ", smem_prefix_for_cast=False, barrier = "__syncthreads();", float4 = "make_float4", uses_vload=True, uses_ptr_arithmetic=True, arg_int_prefix = "const int",
   half_prekernel = "#include <hip/hip_fp16.h>\nusing half4 = HIP_vector_type<half, 4>;" + """
 __device__ float vload_half(size_t offset, const half *p) { return (float)*(p + offset); }
 __device__ float2 vload_half2(size_t offset, const half *p) { return make_float2((float)*(p + offset*2), (float)*(p + offset*2 + 1)); }


### PR DESCRIPTION
Hip also warns like CUDA

```
/tmp/comgr-020f91/input/r_13_512_32_8_2_4:34:6: warning: 'shared' attribute ignored when parsing type [-Wignored-attributes]
  *((__shared__ float2*)(temp+(lidx1*64)+(lidx2*2))) = (float2)acc0;
     ^~~~~~~~~~
/long_pathname_so_that_rpms_can_package_the_debug_info/src/out/ubuntu-22.04/22.04/build/hip-on-rocclr/hipamd/src/hiprtc/hip_rtc_gen/hipRTC_header.h:15:35: note: expanded from macro '__shared__'
#define __shared__ __attribute__((shared))
                                  ^~~~~~
/tmp/comgr-020f91/input/r_13_512_32_8_2_4:38:31: warning: 'shared' attribute ignored when parsing type [-Wignored-attributes]
    float2 val5 = (float2)(*((__shared__ float2*)(temp+(lidx1*64)+(ridx1*2))));
                              ^~~~~~~~~~
/long_pathname_so_that_rpms_can_package_the_debug_info/src/out/ubuntu-22.04/22.04/build/hip-on-rocclr/hipamd/src/hiprtc/hip_rtc_gen/hipRTC_header.h:15:35: note: expanded from macro '__shared__'
#define __shared__ __attribute__((shared))
                                  ^~~~~~
2 warnings generated when compiling for gfx1100.
```