### PR TITLE
Reenable limit_dims_to_max

### DIFF
--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -151,8 +151,7 @@ class Linearizer(OptimizedKernel):
     self.saved_exprs: Dict[Tuple, UOp] = dict()
 
     # limit dims if we need to
-    # TODO: broken, and doesn't really belong here
-    #if self.opts.global_max and self.opts.local_max: self.limit_dims_to_max(self.opts.global_max, self.opts.local_max)
+    if self.opts.global_max and self.opts.local_max: self.limit_dims_to_max(self.opts.global_max, self.opts.local_max)
 
     # uops
     self.uops: List[UOp] = []


### PR DESCRIPTION
It got removed [here](https://github.com/tinygrad/tinygrad/pull/1723/files), and I added back during the webgpu stable diffusion [port](https://github.com/tinygrad/tinygrad/pull/1370#discussion_r1362754621) only on webgpu, but it can be used anywhere else, so we're adding it back.