### PR TITLE
Fix output size in WebGPU model export

### DIFF
--- a/extra/export_model.py
+++ b/extra/export_model.py
@@ -121,7 +121,7 @@ const setupNet = async (device, safetensor) => {{
         device.queue.submit([gpuCommands]);
 
         await gpuReadBuffer.mapAsync(GPUMapMode.READ);
-        const resultBuffer = new Float32Array(gpuReadBuffer.size);
+        const resultBuffer = new Float32Array(gpuReadBuffer.size/4);
         resultBuffer.set(new Float32Array(gpuReadBuffer.getMappedRange()));
         gpuReadBuffer.unmap();
         return resultBuffer;


### PR DESCRIPTION
We're creating wrong sized `Float32Array`s during webgpu model export. We use the buffer size for the `Float32Array` size when reading the inference output, although we only need 1/4 of that size.

In the efficient net compilation example for 1000 output classes we had a 4000-sized f32 array:

<img width="334" alt="Screenshot 2023-10-17 at 23 38 23" src="https://github.com/tinygrad/tinygrad/assets/8374618/bf78d533-9eda-4282-83d0-895c05c6d843">

Should be:

<img width="326" alt="Screenshot 2023-10-17 at 23 39 49" src="https://github.com/tinygrad/tinygrad/assets/8374618/519ddc24-cb2e-473b-80ad-b70497c78db7">

