### PR TITLE
fix #1751: align np array before copying into cl buffer 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,15 @@ jobs:
         key: testing-packages-${{ hashFiles('**/setup.py') }}
     - name: Install Dependencies
       run: pip install -e '.[testing]' --extra-index-url https://download.pytorch.org/whl/cpu
+    - name: Cache gpt2-medium
+      id: cache-gpt2-medium
+      uses: actions/cache@v3
+      with:
+        path: ${{ github.workspace }}/pytorch-gpt2-medium.bin
+        key: cache-gpt2-medium-nodownload
+    - name: Download gpt2-medium
+      if: steps.cache-gpt2-medium.cache-hit != 'true'
+      run: wget -O ${{ github.workspace }}/pytorch-gpt2-medium.bin https://huggingface.co/gpt2-medium/resolve/main/pytorch_model.bin
     - name: Run Pytest
       run: python -m pytest -n=auto test/ -k "not (test_efficientnet and models/test_train.py)" --durations=20
     - name: Compile EfficientNet to C
@@ -109,6 +118,15 @@ jobs:
         key: testing-packages-${{ hashFiles('**/setup.py') }}
     - name: Install Dependencies
       run: pip install -e '.[testing]' --extra-index-url https://download.pytorch.org/whl/cpu
+    - name: Cache gpt2-medium
+      id: cache-gpt2-medium
+      uses: actions/cache@v3
+      with:
+        path: ${{ github.workspace }}/pytorch-gpt2-medium.bin
+        key: cache-gpt2-medium-nodownload
+    - name: Download gpt2-medium
+      if: steps.cache-gpt2-medium.cache-hit != 'true'
+      run: wget -O ${{ github.workspace }}/pytorch-gpt2-medium.bin https://huggingface.co/gpt2-medium/resolve/main/pytorch_model.bin
     - name: Run Pytest
       run: TORCH=1 python -m pytest -n=auto test/ --durations=20
     - name: Run ONNX
@@ -300,6 +318,15 @@ jobs:
           sudo ninja install -d explain
       - name: Install dependencies
         run: pip install -e '.[testing${{matrix.backend=='llvm'&&',llvm'||matrix.backend=='cuda'&&',cuda'||matrix.backend=='ptx'&&',cuda'||matrix.backend=='triton'&&',triton'||''}}]' --extra-index-url https://download.pytorch.org/whl/cpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/
+      - name: Cache gpt2-medium
+        id: cache-gpt2-medium
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/pytorch-gpt2-medium.bin
+          key: cache-gpt2-medium-nodownload
+      - name: Download gpt2-medium
+        if: steps.cache-gpt2-medium.cache-hit != 'true'
+        run: wget -O ${{ github.workspace }}/pytorch-gpt2-medium.bin https://huggingface.co/gpt2-medium/resolve/main/pytorch_model.bin
       - name: Check Device.DEFAULT and print some source
         run: |
           python -c "from tinygrad.ops import Device; assert Device.DEFAULT in ['LLVM','CLANG','CUDA','GPU'], Device.DEFAULT"

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -48,6 +48,7 @@ if not getenv("DELAYED_RUNTIME_INIT", False): CL.post_init()
 class CLBuffer(RawBufferCopyInOut, RawBufferTransfer):
   def __init__(self, size, dtype, device='0'): super().__init__(size, dtype, allocator=CL.cl_allocator, **{'device': device})
   def _copyin(self, x:np.ndarray):
+    x = np.require(x, requirements=['A'])
     assert not self.dtype.name.startswith("image"), f"can't copyin images {self.dtype}"
     self.event = cl.enqueue_copy(CL.cl_queue[self._buf.device], self._buf, np.require(x, requirements='C'), is_blocking=False)
   def _copyout(self, x:np.ndarray):

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -48,9 +48,8 @@ if not getenv("DELAYED_RUNTIME_INIT", False): CL.post_init()
 class CLBuffer(RawBufferCopyInOut, RawBufferTransfer):
   def __init__(self, size, dtype, device='0'): super().__init__(size, dtype, allocator=CL.cl_allocator, **{'device': device})
   def _copyin(self, x:np.ndarray):
-    x = np.require(x, requirements=['A'])
     assert not self.dtype.name.startswith("image"), f"can't copyin images {self.dtype}"
-    self.event = cl.enqueue_copy(CL.cl_queue[self._buf.device], self._buf, np.require(x, requirements='C'), is_blocking=False)
+    self.event = cl.enqueue_copy(CL.cl_queue[self._buf.device], self._buf, np.require(x, requirements=['C', 'A']), is_blocking=False)
   def _copyout(self, x:np.ndarray):
     assert not self.dtype.name.startswith("image"), f"can't copyout images {self.dtype}"
     buf = cl.Buffer(CL.cl_ctxs[self._buf.device], cl.mem_flags.WRITE_ONLY | cl.mem_flags.USE_HOST_PTR, 0, hostbuf=x.data)


### PR DESCRIPTION
Hard to add a test for this because I was only able to reproduce with https://huggingface.co/gpt2-medium/resolve/main/pytorch_model.bin. Figured we wouldn't want a fetch happening in CI (recent effort to decrease test times).

All the weights are unaligned when sent to the CPU from disk, and roughly half of them get corrupted when they are copied into the cl buffer.

There is a performance hit as unaligned buffers need to be copied. I am seeing +~5% wall clock on M1. There is no impact on arrays that are already aligned.

Update: We may want to consider putting this in RawBufferCopyIn for sanity's sake.

#1751