### PR TITLE
conv2d: add an optional IGEMM (implicit GEMM) mode for conv2d

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -511,7 +511,7 @@ class Tensor:
     padding = flatten((((k-1)*d-p,(k-1)*d-p+op) for k,d,p,op in reversed(list(zip(HW, make_pair(dilation, len(HW)), make_pair(padding, len(HW)), make_pair(output_padding, len(HW)))))))
     return x.conv2d(w.reshape(w.shape[0]*w.shape[1],*w.shape[2:]), groups=groups, bias=bias, dilation=dilation, padding=padding)
 
-  wino, igemm = int(getenv("WINO", "0")), int(getenv("IGEMM", "0"))
+  wino, igemm = getenv("WINO"), getenv("IGEMM")
   def conv2d(self, weight:Tensor, bias:Optional[Tensor]=None, groups=1, stride=1, dilation=1, padding=0) -> Tensor:
     (bs,cin_), (cout,cin), HW = self.shape[:2], weight.shape[:2], weight.shape[2:]
     assert groups*cin == cin_ and len(self.shape) == len(weight.shape), f"Input Tensor shape {self.shape} does not match the shape of the weights {weight.shape}. ({groups*cin} vs. {cin_})"


### PR DESCRIPTION
Ideally this should be triggered when we know a tensor core will be available.