### PR TITLE
Supporting non-fp32 p1: Refactoring unsupported dtypes

### DIFF
--- a/extra/gemm/tvm_gemm.py
+++ b/extra/gemm/tvm_gemm.py
@@ -29,6 +29,7 @@ except ImportError:
 # tinygrad version
 
 import os
+from tinygrad.helpers import dtypes
 from tinygrad.tensor import Tensor
 
 # define the compute
@@ -39,7 +40,7 @@ C = (A.reshape(M, 1, K) * B.permute(1,0).reshape(1, N, K)).sum(axis=2)
 sched = C.lazydata.schedule()
 from tinygrad.codegen.linearizer import Linearizer
 from tinygrad.codegen.kernel import LinearizerOptions
-lin = Linearizer(sched[-1].ast, LinearizerOptions(has_local=False, supports_float4=False))
+lin = Linearizer(sched[-1].ast, LinearizerOptions(has_local=False, unsupported_dtypes=[dtypes._float4]))
 #lin.hand_coded_optimizations()
 lin.linearize()
 from tinygrad.runtime.ops_clang import renderer

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -112,7 +112,7 @@ def helper_realized_ast(r:Tensor):
 
 class TestFloat4(unittest.TestCase):
   def setUp(self):
-    if not isinstance(Device[Device.DEFAULT], Compiled) or not Device[Device.DEFAULT].linearizer_opts.supports_float4:
+    if not isinstance(Device[Device.DEFAULT], Compiled) or dtypes._float4 in Device[Device.DEFAULT].linearizer_opts.unsupported_dtypes:
       self.skipTest("Device does not support float4")
 
   @staticmethod

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -41,8 +41,7 @@ class LocalBuffer(NamedTuple):
 
 class LinearizerOptions(NamedTuple):
   device: str = ""
-  # TODO: make this generic with a list of supported types
-  supports_float4: bool = True
+  unsupported_dtypes: List[DType] = []
   supports_float4_alu: bool = True
   has_local: bool = True
   has_shared: bool = True
@@ -113,7 +112,7 @@ class Kernel:
     return [sum(t) for t in itertools.product(*[[y*acc_strides[i] for y in range(x[0])] for i,x in enumerate(upcasted_i[::-1])])]
 
   def get_upcast_dim(self, i) -> List[int]:
-    should_upcast = self.opts.supports_float4 and (self.bufs[i].dtype in [dtypes.float32, dtypes.float16] or isinstance(self.bufs[i].dtype, ImageDType))
+    should_upcast = dtypes._float4 not in self.opts.unsupported_dtypes and (self.bufs[i].dtype in [dtypes.float32, dtypes.float16] or isinstance(self.bufs[i].dtype, ImageDType))
     return [x for x in self.sts[i].unit_stride_axes() if should_upcast and x >= self.shape_len-self.upcasted and self.sts[i].shape[x] > 1]
 
   @property

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -2,7 +2,7 @@ import time, ctypes, subprocess, platform, functools, pathlib, tempfile
 from typing import Any
 from functools import partial, reduce
 from tinygrad.ops import Compiled
-from tinygrad.helpers import fromimport, getenv, DEBUG, CI, cache_compiled
+from tinygrad.helpers import dtypes, fromimport, getenv, DEBUG, CI, cache_compiled
 from tinygrad.runtime.lib import RawMallocBuffer
 from tinygrad.codegen.kernel import LinearizerOptions
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
@@ -82,4 +82,4 @@ class ClangProgram:
     if wait: return time.monotonic()-st
 
 renderer = fromimport("tinygrad.renderer.assembly_arm64", "uops_to_arm64_asm") if ARM64 else functools.partial(uops_to_cstyle, CStyleLanguage(kernel_prefix=args['exp'], buffer_suffix=" restrict", arg_int_prefix="const int"))
-ClangBuffer = Compiled(RawMallocBuffer, LinearizerOptions(supports_float4=False, has_local=False), renderer, ClangProgram)
+ClangBuffer = Compiled(RawMallocBuffer, LinearizerOptions(unsupported_dtypes=[dtypes._float4], has_local=False), renderer, ClangProgram)

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional
 import numpy as np
 from pycuda.compiler import compile as cuda_compile # type: ignore
-from tinygrad.helpers import DEBUG, getenv, colored, fromimport
+from tinygrad.helpers import DEBUG, dtypes, getenv, colored, fromimport
 from tinygrad.ops import Compiled
 from tinygrad.runtime.lib import RawBufferCopyInOut, RawMallocBuffer, LRUAllocator
 from tinygrad.codegen.kernel import LinearizerOptions
@@ -101,6 +101,6 @@ renderer = functools.partial(uops_to_cstyle, CStyleLanguage(
 if getenv("TRITON") == 1:
   from tinygrad.renderer.triton import uops_to_triton
   renderer = uops_to_triton
-  CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=False, supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024], has_shared=False), renderer, CUDAProgram, cuda.Context.synchronize)
+  CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(unsupported_dtypes=[dtypes._float4], supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024], has_shared=False), renderer, CUDAProgram, cuda.Context.synchronize)
 else:
-  CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=False if getenv("PTX") else True, supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024]), renderer, CUDAProgram, cuda.Context.synchronize)
+  CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(unsupported_dtypes=[dtypes._float4] if getenv("PTX") else [], supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024]), renderer, CUDAProgram, cuda.Context.synchronize)

--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -1,7 +1,7 @@
 import time, hashlib, ctypes
 from typing import ClassVar
 from tinygrad.ops import Compiled
-from tinygrad.helpers import getenv, DEBUG
+from tinygrad.helpers import dtypes, getenv, DEBUG
 from ctypes import CFUNCTYPE
 from tinygrad.codegen.kernel import LinearizerOptions
 from tinygrad.renderer.llvmir import uops_to_llvm_ir
@@ -64,4 +64,4 @@ class LLVMProgram:
     cfunc(*[x._buf if not isinstance(x, int) else x for x in bufs])
     if wait: return time.monotonic()-st
 
-LLVMBuffer = Compiled(RawMallocBuffer, LinearizerOptions(supports_float4=False, has_local=False, has_shared=False), uops_to_llvm_ir, LLVMProgram)
+LLVMBuffer = Compiled(RawMallocBuffer, LinearizerOptions(unsupported_dtypes=[dtypes._float4], has_local=False, has_shared=False), uops_to_llvm_ir, LLVMProgram)

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -42,4 +42,4 @@ class RawWebGPUBuffer(RawBufferCopyIn):
   def toCPU(self) -> np.ndarray: return np.frombuffer(wgpu_device.queue.read_buffer(self._buf, 0), dtype=np.dtype(self.dtype.np, metadata={"backing": self})) # type: ignore
 
 renderer = functools.partial(uops_to_cstyle, WGSLLanguage())
-WebGpuBuffer = Compiled(RawWebGPUBuffer, LinearizerOptions(supports_float4=False, local_max=[256, 256, 64], global_max=[65535, 65535, 65535]), renderer, WebGPUProgram)
+WebGpuBuffer = Compiled(RawWebGPUBuffer, LinearizerOptions(unsupported_dtypes=[dtypes._float4], local_max=[256, 256, 64], global_max=[65535, 65535, 65535]), renderer, WebGPUProgram)


### PR DESCRIPTION
a reasonable implementation of bitcast requires non-fp32 support - These changes allow for a direct usage of float16 dtypes on OpenCL backend devices that allow it.

This comment doesn't apply if we want non-fp32 support:
https://github.com/tinygrad/tinygrad/blob/cea2bc7964de32e474054a69d563456903ba1233/test/test_dtype.py#L85

this code is valid opencl:
```
#pragma OPENCL EXTENSION cl_khr_fp16 : enable
kernel void E_3(device half* data0, const device unsigned char* data1, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int lidx0 = lid.x; /* 3 */
  half val0 = (half)(*(data1+lidx0));
  *(data0+lidx0) = val0;
}
```
but not for GPUs (eg. [github actions](https://github.com/tinygrad/tinygrad/actions/runs/6508596058/job/17678264259?pr=2046#step:13:117))

Though OpenCL on M1 works with this extension. This PR implements a one-time function `has_fp16_support` that checks this on-device by running a dummy kernel.