### PR TITLE
init cudagraph

### DIFF
--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -77,9 +77,9 @@ class CUDAGraph(GraphBatchExecutor):
         self.jc_info.append(graph_node)
 
       self.graphs.append((graph.instantiate(), graph))
-    except (RuntimeError, AttributeError):
+    except Exception as e:
       # CudaGraph might not be suported with the installed version of pycuda.
-      return
+      if DEBUG>=3: print(f"Error creating CUDAGraph: {e}")
 
   def update_node(self, instid, jcid, prg, pargs, variables, updated_args=None):
     global_size, local_size = prg.launch_dims(variables)

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -1,10 +1,10 @@
 import subprocess, time, re, hashlib, tempfile, functools
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List, Any, Tuple
 import numpy as np
 from pycuda.compiler import compile as cuda_compile # type: ignore
 from tinygrad.helpers import DEBUG, getenv, colored, fromimport
-from tinygrad.ops import Compiled
+from tinygrad.ops import Compiled, GraphBatchExecutor, ASTRunner
 from tinygrad.runtime.lib import RawBufferCopyInOut, RawMallocBuffer, LRUAllocator
 from tinygrad.codegen.kernel import LinearizerOptions
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
@@ -19,6 +19,37 @@ def pretty_ptx(s):
   s = re.sub(r'(\.)(version|target|address_size|visible|entry)', lambda m:m[1]+colored(m[2], "magenta"), s, flags=re.M) # derivatives
   return s
 def arch(): return "sm_" + "".join([str(x) for x in pycuda.driver.Context.get_device().compute_capability()])
+
+class CUDAGraph(GraphBatchExecutor):
+  def __init__(self, jit_cache: List[Tuple[Any, Any, Any]]):
+    super().__init__(jit_cache)
+    self.jc_info: List[Any] = []
+
+    # Check if CUDAGraph could run the given jit_cache.
+    if DEBUG>0 or getenv("CUDACPU") or not all(isinstance(prg, ASTRunner) and isinstance(prg.clprg, CUDAProgram) for prg,_,_ in jit_cache): return # Only CUDAProgram can be captured.
+    self.split_into_graphs(jit_cache)
+
+  def create_graph(self, jit_cache: List[Tuple[Any, Any, Any]]):
+    try:
+      graph, graph_node = cuda.Graph(), None
+
+      for prg, pargs, variables in jit_cache:
+        global_size, local_size = prg.launch_dims(variables)
+        cuda_args = [x._buf if isinstance(x, RawCUDABuffer) else np.int32(x) for x in [*pargs, *variables.values()]]
+        graph_node = graph.add_kernel_node(*cuda_args, block=tuple(local_size), grid=tuple(global_size), func=prg.clprg.prg, dependencies=[graph_node] if graph_node else [])
+        self.jc_info.append(graph_node)
+
+      self.graphs.append((graph.instantiate(), graph))
+    except (RuntimeError, AttributeError):
+      # CudaGraph might not be suported with the installed version of pycuda.
+      return
+
+  def update_node(self, instid, jcid, prg, pargs, variables, updated_args=None):
+    global_size, local_size = prg.launch_dims(variables)
+    cuda_args = [x._buf if isinstance(x, RawCUDABuffer) else np.int32(x) for x in [*pargs, *variables.values()]]
+    self.graphs[instid][0].kernel_node_set_params(*cuda_args, block=tuple(local_size), grid=tuple(global_size), func=prg.clprg.prg, kernel_node=self.jc_info[jcid])
+
+  def exec_instance(self, instid): self.graphs[instid][0].launch()
 
 if getenv("CUDACPU", 0) == 1:
   import ctypes, ctypes.util
@@ -103,4 +134,4 @@ if getenv("TRITON") == 1:
   renderer = uops_to_triton
   CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=False, supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024], has_shared=False), renderer, CUDAProgram, cuda.Context.synchronize)
 else:
-  CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=False if getenv("PTX") else True, supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024]), renderer, CUDAProgram, cuda.Context.synchronize)
+  CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=False if getenv("PTX") else True, supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024]), renderer, CUDAProgram, cuda.Context.synchronize, CUDAGraph)


### PR DESCRIPTION
Support for cudagraph. CUDAGraph will run if PyCUDA has the CudaGraph API; otherwise, the regular BatchExecutor will be used

For now I decided to go [with fork](https://github.com/nimlgen/pycuda/tree/dev.cg2) if this is fine for merging, the API should not change a lot from what I have now. Will get it merge, it's just taking a lot of time on communication.