### PR TITLE
beam=12 makes gpt2 gpu-time < 5ms on 3090

### DIFF
--- a/examples/gpt2.py
+++ b/examples/gpt2.py
@@ -50,7 +50,7 @@ class Attention:
       keys, values = cache_k.cat(xk, dim=1), cache_v.cat(xv, dim=1)
 
     # save the cache
-    cache_k, cache_v = keys, values
+    cache_k, cache_v = keys.realize(), values.realize()
     xq, keys, values = xq.transpose(1, 2), keys.transpose(1, 2), values.transpose(1, 2)
     output = xq.scaled_dot_product_attention(keys, values, mask).transpose(1, 2).reshape(bsz, seqlen, -1)
     return self.c_proj(output), cache_k, cache_v

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -9,13 +9,11 @@ from collections import defaultdict
 from tinygrad.codegen.optimizer import Opt, OptOps
 actions = flatten([[Opt(op=OptOps.UPCAST, axis=axis, amt=amt) for amt in [0,2,3,4,7]] for axis in range(6)])
 actions += flatten([[Opt(op=OptOps.UNROLL, axis=axis, amt=amt) for amt in [0,4]] for axis in range(4)])
-actions += flatten([[Opt(op=OptOps.LOCAL, axis=axis, amt=amt) for amt in [2,3,4,8,16]] for axis in range(5)])
+actions += flatten([[Opt(op=OptOps.LOCAL, axis=axis, amt=amt) for amt in [2,3,4,8,13,16,29]] for axis in range(5)])
+actions += flatten([[Opt(op=OptOps.GROUPTOP, axis=axis, amt=amt) for amt in [13,16,29,32,256]] for axis in range(3)])
 actions += [
   Opt(op=OptOps.LOCAL, axis=0, amt=32),
   Opt(op=OptOps.GROUP, axis=0, amt=4), Opt(op=OptOps.GROUP, axis=0, amt=8), Opt(op=OptOps.GROUP, axis=1, amt=8),
-  Opt(op=OptOps.GROUPTOP, axis=0, amt=16), Opt(op=OptOps.GROUPTOP, axis=0, amt=256),
-  Opt(op=OptOps.GROUPTOP, axis=1, amt=16), Opt(op=OptOps.GROUPTOP, axis=1, amt=256),
-  Opt(op=OptOps.GROUPTOP, axis=2, amt=16), Opt(op=OptOps.GROUPTOP, axis=2, amt=256),
   Opt(op=OptOps.UPCASTMID, axis=1, amt=4),
 ]
 


### PR DESCRIPTION
Made slight modifications to the search space, so Beam=12 gets kernels to achieve ~3ms execution time for gpt2. 

In theory, with CudaGraph we should get <5ms on 13900k+3090 (don't have any machine to check this). On the og tiny, I managed to achieve sub 5ms as well applying more CPU-related optimizations (caching sym_infer + asserts in jit.py). However, I'm sure about the cleanliness of these changes, so I focused on achieving the sub 5ms on the 13900k.

I would greatly appreciate it if you could run a test on the 13900k.