### PR TITLE
Fix llama .index.json loading

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -256,7 +256,7 @@ def concat_weights(models):
 def load(fn:str):
   if fn.endswith('.index.json'):
     with open(fn) as fp: weight_map = json.load(fp)['weight_map']
-    parts = {n: load(Path(fn).parent / Path(n).name) for n in set(weight_map.values())}
+    parts = {n: load(str(Path(fn).parent / Path(n).name)) for n in set(weight_map.values())}
     return {k: parts[n][k] for k, n in weight_map.items()}
   elif fn.endswith(".safetensors"):
     return safe_load(fn)


### PR DESCRIPTION
When pointed at a .index.json file it tries to recurse with a pathlib.Path when it needs a str:

```
  File "/home/spinlock/src/tinygrad/tinygrad/examples/llama.py", line 259, in <dictcomp>                                        
    parts = {n: load(Path(fn).parent / Path(n).name) for n in set(weight_map.values())}                                         
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                            
  File "/home/spinlock/src/tinygrad/tinygrad/examples/llama.py", line 257, in load                                              
    if fn.endswith('.index.json'):                       
       ^^^^^^^^^^^                                                                                                              
AttributeError: 'PosixPath' object has no attribute 'endswith'                                                                  
```

Loads fine with fix.