### PR TITLE
Fix cuda half2 cast

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -128,6 +128,7 @@ class dtypes:
 
   # NOTE: these are internal dtypes, should probably check for that
   _int2: Final[DType] = DType(2, 4*2, "int2", None, 2)
+  _half2: Final[DType] = DType(4, 2*2, "half2", None, 2)
   _half4: Final[DType] = DType(0, 2*4, "half4", None, 4)
   _float2: Final[DType] = DType(4, 4*2, "float2", None, 2)
   _float4: Final[DType] = DType(4, 4*4, "float4", None, 4)

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -42,14 +42,14 @@ class CStyleLanguage(NamedTuple):
   }
 
   # returns a str expression of the casted xs with the given type
-  def render_cast(self, x:List[str], var_dtype:DType) -> str:
-    if len(x) == 1: return f"({var_dtype.name})({x[0]})"
-    assert len(x) == var_dtype.sz, f"cast is wrong size {len(x)} != {var_dtype.sz}"
+  def render_cast(self, x:List[str], output_dtype:DType, buf_dtype:DType|None=None) -> str:
+    if len(x) == 1: return f"({output_dtype.name})({x[0]})"
+    assert len(x) == output_dtype.sz, f"cast is wrong size {len(x)} != {output_dtype.sz}"
     assert self.float4 is not None, "cast is not supported on this platform"
-    if var_dtype == dtypes._float4: return f"{self.float4}({','.join(x)})"
-    if var_dtype == dtypes._float2: return f"{self.float4.replace('float4', 'float2')}({','.join(x)})"
-    if var_dtype == dtypes._int2: return f"{self.float4.replace('float4', 'int2')}({','.join(x)})"
-    raise NotImplementedError(f"no cast for {var_dtype}")
+    if output_dtype == dtypes._float4: return f"{self.float4}({','.join(x)})"
+    if output_dtype == dtypes._float2: return f"{self.float4.replace('float4', 'float2')}({','.join(x)})"
+    if output_dtype == dtypes._int2: return f"{self.float4.replace('float4', 'int2')}({','.join(x)})"
+    raise NotImplementedError(f"no cast for {output_dtype}")
 
   # returns a str expression of the const with the given type
   def render_const(self, x:Union[float,int], var_dtype) -> str:
@@ -70,7 +70,7 @@ class CStyleLanguage(NamedTuple):
     else:
       out_val = f"*({buf_name}+{idx})" if self.uses_ptr_arithmetic else f"{buf_name}[{idx}]"
 
-    return self.render_cast([out_val], output_dtype) if output_dtype != buf_dtype else out_val
+    return self.render_cast([out_val], output_dtype, buf_dtype) if output_dtype != buf_dtype else out_val
 
   def render_local(self, name:str, size:int):
     return self.smem_align + self.smem_prefix + f"float {name}[{size}];"

--- a/tinygrad/renderer/cuda.py
+++ b/tinygrad/renderer/cuda.py
@@ -1,0 +1,27 @@
+import functools
+from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
+from tinygrad.helpers import dtypes
+class CUDALanguage(CStyleLanguage):
+  kernel_prefix = "__global__ "
+  smem_prefix = "__shared__ "
+  smem_prefix_for_cast=False
+  arg_int_prefix = "const int"
+  barrier = "__syncthreads();"
+  float4 = "make_float4"
+  gid = [f'blockIdx.{chr(120+i)}' for i in range(3)]
+  lid = [f'threadIdx.{chr(120+i)}' for i in range(3)]
+  xid = [f'(blockIdx.{chr(120+i)}*blockDim.{chr(120+i)}+threadIdx.{chr(120+i)})' for i in range(3)]
+  half_prekernel = """
+    #include <cuda_fp16.h>
+    struct __align__(8) half4 {
+      half2 x, y;
+      __device__ __forceinline__ explicit half4(const float4& a): x(make_half2(__float2half(a.x), __float2half(a.y))), y(make_half2(__float2half(a.z),__float2half(a.w))) {}
+      __device__ __forceinline__ explicit operator float4() const {return make_float4(__half2float(x.x), __half2float(x.y), __half2float(y.x), __half2float(y.y)); }
+    };
+    """
+
+  def render_cast(self, x, output_dtype, buf_dtype) -> str:
+    if output_dtype == dtypes._float2 and buf_dtype == dtypes._half2: return f"__half2float({','.join(x)})"
+    return super().render_cast(x, output_dtype, buf_dtype)
+
+CUDARenderer = functools.partial(uops_to_cstyle, CUDALanguage())


### PR DESCRIPTION
`test/test_dtype.py TestHalfDtype::test_half_upcast_ops` fails on a real CUDA (I used a v100 from google colab, but i think this is universally true). The error is: 

```
kernel.cu(12): error: no suitable user-defined conversion from "half2" to "float2" exists
```

because in this AST `Tensor([[1,2],[3,2]], dtype=dtypes.half)@Tensor.eye(2, dtype=dtypes.float32`
the tensor has elements of len 2 the dtype defaults to half2. I couldn't find a one-liner flag to disable this optimization (i suspect there's some pycuda thing for it when we create the CUDA buffer in the first place?)

This one fixes it at the renderer level by using `__half2float` and destructing the half2 to half

Kernel diff for the ast above:

```diff
__global__ void r_2_2_2(float* data0, const half* data1) {
  int lidx0 = threadIdx.x; /* 2 */
  float2 acc0 = make_float2(0.0f,0.0f);
- float2 val0 = (float2)(*((half2*)(data1+lidx0*2)));
+ float2 val0 = make_float2(__half2float(((half2*)(data1+lidx0*2))->x), __half2float(((half2*)(data1+lidx0*2))->y));;
  (acc0).x = (((val0).x*1.0f)+(acc0).x);
  (acc0).y = (((val0).x*0.0f)+(acc0).y);
  (acc0).x = (((val0).y*0.0f)+(acc0).x);
  (acc0).y = (((val0).y*1.0f)+(acc0).y);
  *((float2*)(data0+lidx0*2)) = (float2)make_float2((acc0).x,(acc0).y);
}
```