### PR TITLE
Fix llvm int->bool cast

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -105,6 +105,7 @@ class TestInt8Dtype(unittest.TestCase):
   def test_int64_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.int64), np.int64, [1,2,3,4])
 
   def test_casts_to_int8(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.float32, target_dtypes=[dtypes.int8, dtypes.uint8, dtypes.int32, dtypes.int64])
+  def test_casts_to_bool(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.int8, target_dtypes=[dtypes.bool], target_contents=[True, True, True, True])
   def test_casts_from_int8(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.int8, target_dtypes=[dtypes.float32, dtypes.uint8, dtypes.int32, dtypes.int64])
   def test_casts_from_uint8(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.uint8, target_dtypes=[dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64])
 

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -105,7 +105,7 @@ class TestInt8Dtype(unittest.TestCase):
   def test_int64_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.int64), np.int64, [1,2,3,4])
 
   def test_casts_to_int8(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.float32, target_dtypes=[dtypes.int8, dtypes.uint8, dtypes.int32, dtypes.int64])
-  def test_casts_to_bool(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.int8, target_dtypes=[dtypes.bool], target_contents=[True, True, True, True])
+  #def test_casts_to_bool(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.int8, target_dtypes=[dtypes.bool], target_contents=[True, True, True, True])
   def test_casts_from_int8(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.int8, target_dtypes=[dtypes.float32, dtypes.uint8, dtypes.int32, dtypes.int64])
   def test_casts_from_uint8(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.uint8, target_dtypes=[dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64])
 

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -105,7 +105,8 @@ class TestInt8Dtype(unittest.TestCase):
   def test_int64_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.int64), np.int64, [1,2,3,4])
 
   def test_casts_to_int8(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.float32, target_dtypes=[dtypes.int8, dtypes.uint8, dtypes.int32, dtypes.int64])
-  #def test_casts_to_bool(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.int8, target_dtypes=[dtypes.bool], target_contents=[True, True, True, True])
+  def test_casts_to_bool_1(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.int8, target_dtypes=[dtypes.bool], target_contents=[True, True, True, True])
+  def test_casts_to_bool_2(self): _test_casts_from([1,0,3,4], source_dtype=dtypes.int8, target_dtypes=[dtypes.bool], target_contents=[True, False, True, True])
   def test_casts_from_int8(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.int8, target_dtypes=[dtypes.float32, dtypes.uint8, dtypes.int32, dtypes.int64])
   def test_casts_from_uint8(self): _test_casts_from([1,2,3,4], source_dtype=dtypes.uint8, target_dtypes=[dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64])
 

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -44,10 +44,8 @@ def cast(bb, val, input_type, output_type):
 
   if input_type == dtypes.float32:
     if dtypes.is_int(output_type) or output_type == dtypes.bool:
-      if dtypes.is_unsigned(output_type):
-        val = bb[-1].fptoui(val, dtype_to_llvm_dtype[output_type])
-      if output_type == dtypes.bool:
-        val = bb[-1].fcmp_ordered("!=", val, ir.Constant(ir.FloatType(), 0))
+      if dtypes.is_unsigned(output_type): val = bb[-1].fptoui(val, dtype_to_llvm_dtype[output_type])
+      elif output_type == dtypes.bool: val = bb[-1].fcmp_ordered("!=", val, ir.Constant(ir.FloatType(), 0))
       else: val = bb[-1].fptosi(val, dtype_to_llvm_dtype[output_type])
     elif output_type == dtypes.bfloat16:
       val = bb[-1].bitcast(val, ir.IntType(32))

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -44,7 +44,10 @@ def cast(bb, val, input_type, output_type):
 
   if input_type == dtypes.float32:
     if dtypes.is_int(output_type) or output_type == dtypes.bool:
-      val = bb[-1].fptoui(val, dtype_to_llvm_dtype[output_type]) if dtypes.is_unsigned(output_type) or output_type == dtypes.bool else bb[-1].fptosi(val, dtype_to_llvm_dtype[output_type])
+      if dtypes.is_unsigned(output_type):
+        val = bb[-1].fptoui(val, dtype_to_llvm_dtype[output_type])
+      if output_type == dtypes.bool:
+        val = bb[-1].fcmp_ordered("!=", val, ir.Constant(ir.FloatType(), 0))
     elif output_type == dtypes.bfloat16:
       val = bb[-1].bitcast(val, ir.IntType(32))
       val = bb[-1].lshr(val, ir.Constant(ir.IntType(32), 16))

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -45,7 +45,7 @@ def cast(bb, val, input_type, output_type):
   if input_type == dtypes.float32:
     if dtypes.is_int(output_type) or output_type == dtypes.bool:
       if dtypes.is_unsigned(output_type): val = bb[-1].fptoui(val, dtype_to_llvm_dtype[output_type])
-      elif output_type == dtypes.bool: val = bb[-1].fcmp_ordered("!=", val, ir.Constant(ir.FloatType(), 0))
+      elif output_type == dtypes.bool: val = bb[-1].fptoui(val, dtype_to_llvm_dtype[output_type])
       else: val = bb[-1].fptosi(val, dtype_to_llvm_dtype[output_type])
     elif output_type == dtypes.bfloat16:
       val = bb[-1].bitcast(val, ir.IntType(32))

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -45,7 +45,7 @@ def cast(bb, val, input_type, output_type):
   if input_type == dtypes.float32:
     if dtypes.is_int(output_type) or output_type == dtypes.bool:
       if dtypes.is_unsigned(output_type): val = bb[-1].fptoui(val, dtype_to_llvm_dtype[output_type])
-      elif output_type == dtypes.bool: val = bb[-1].fptoui(val, dtype_to_llvm_dtype[output_type])
+      elif output_type == dtypes.bool: val = bb[-1].fcmp_ordered("!=", val, ir.Constant(ir.FloatType(), 0), flags=LLVM_FAST_MATH_FLAGS)
       else: val = bb[-1].fptosi(val, dtype_to_llvm_dtype[output_type])
     elif output_type == dtypes.bfloat16:
       val = bb[-1].bitcast(val, ir.IntType(32))

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -48,6 +48,7 @@ def cast(bb, val, input_type, output_type):
         val = bb[-1].fptoui(val, dtype_to_llvm_dtype[output_type])
       if output_type == dtypes.bool:
         val = bb[-1].fcmp_ordered("!=", val, ir.Constant(ir.FloatType(), 0))
+      else: val = bb[-1].fptosi(val, dtype_to_llvm_dtype[output_type])
     elif output_type == dtypes.bfloat16:
       val = bb[-1].bitcast(val, ir.IntType(32))
       val = bb[-1].lshr(val, ir.Constant(ir.IntType(32), 16))


### PR DESCRIPTION
This cast in master:
```py
Tensor([1,2,3,4], dtype=dtypes.int32, device="LLVM").cast(dtypes.bool) # or any other int
```
returns:
```
[ True False  True False]
```

this PR fixes it by using a compare instead of a cast.

The test case added here only supports the new line in llvmir.
I'm writing a more comprehensive test suite for casting in #2156. Ran these changes through every casting combination in that PR as well