### PR TITLE
fix repeat_kv for JITTED llama models using grouped query attention. 

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -192,8 +192,8 @@ MODEL_PARAMS = {
     #TinyLLaMA https://github.com/jzhang38/TinyLlama
     "1B": {
       "args": {"dim": 2048, "multiple_of": 256, "n_heads": 32, "n_kv_heads": 4, "n_layers": 22, "norm_eps": 1e-05, "vocab_size": 32000},
-      "files": 1, 
-    }, 
+      "files": 1,
+    },
     "7B": {
       "args": {"dim": 4096, "multiple_of": 256, "n_heads": 32, "n_layers": 32, "norm_eps": 1e-05, "vocab_size": 32000},
       "files": 1,

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -189,11 +189,6 @@ MODEL_PARAMS = {
     },
   },
   "2": {
-    #TinyLLaMA https://github.com/jzhang38/TinyLlama
-    "1B": {
-      "args": {"dim": 2048, "multiple_of": 256, "n_heads": 32, "n_kv_heads": 4, "n_layers": 22, "norm_eps": 1e-05, "vocab_size": 32000},
-      "files": 1,
-    },
     "7B": {
       "args": {"dim": 4096, "multiple_of": 256, "n_heads": 32, "n_layers": 32, "norm_eps": 1e-05, "vocab_size": 32000},
       "files": 1,
@@ -243,6 +238,13 @@ MODEL_PARAMS = {
     "34B-Instruct": {
       "args": {"dim": 8192, "n_layers": 48, "n_heads": 64, "n_kv_heads": 8, "multiple_of": 256, "ffn_dim_multiplier": 1.0, "norm_eps": 1e-5, "rope_theta": 1000000, "vocab_size": 32000},
       "files": 4,
+    },
+  },
+  #TinyLLaMA https://github.com/jzhang38/TinyLlama
+  "tiny": {
+    "1B": {
+      "args": {"dim": 2048, "multiple_of": 256, "n_heads": 32, "n_kv_heads": 4, "n_layers": 22, "norm_eps": 1e-05, "vocab_size": 32000},
+      "files": 1,
     },
   }
 }

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -517,7 +517,7 @@ After you are done speaking, output [EOS]. You are not Chad.
 
   # *** prompt engineers stop here ****
 
-  LLAMA_SUFFIX = {"1": "", "2": "-2", "code": "-code"}[args.gen]
+  LLAMA_SUFFIX = {"1": "", "2": "-2", "code": "-code", "tiny": '-tiny'}[args.gen]
   MODEL_PATH = args.model or Path(__file__).parents[1] / f"weights/LLaMA{LLAMA_SUFFIX}/{args.size}"
   TOKENIZER_PATH = (MODEL_PATH if MODEL_PATH.is_dir() else MODEL_PATH.parent) / "tokenizer.model"
   print(f"using LLaMA{LLAMA_SUFFIX}-{args.size} model")

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -189,6 +189,11 @@ MODEL_PARAMS = {
     },
   },
   "2": {
+    #TinyLLaMA https://github.com/jzhang38/TinyLlama
+    "1B": {
+      "args": {"dim": 2048, "multiple_of": 256, "n_heads": 32, "n_kv_heads": 4, "n_layers": 22, "norm_eps": 1e-05, "vocab_size": 32000},
+      "files": 1, 
+    }, 
     "7B": {
       "args": {"dim": 4096, "multiple_of": 256, "n_heads": 32, "n_layers": 32, "norm_eps": 1e-05, "vocab_size": 32000},
       "files": 1,

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -46,7 +46,7 @@ def apply_rotary_emb(xq, xk, freqs_cis) -> Tuple[Tensor, Tensor]:
 def repeat_kv(x:Tensor, n_rep:int) -> Tensor:
   bs, seqlen, n_kv_heads, head_dim = x.shape
   if n_rep == 1: return x
-  return x[:, :, :, None, :].expand(bs, seqlen, n_kv_heads, n_rep, head_dim).reshape(bs, seqlen, n_kv_heads * n_rep, head_dim)
+  return x.reshape(bs, seqlen, n_kv_heads, 1, head_dim).expand(bs, seqlen, n_kv_heads, n_rep, head_dim).reshape(bs, seqlen, n_kv_heads * n_rep, head_dim)
 
 class RMSNorm:
   def __init__(self, dim, eps=1e-6):


### PR DESCRIPTION
Since slicing isn't supported for symbolic shapes, the models with specified `n_kv_heads` gave an error while running with JIT (found the error while writing the training script for tinyllama). 

Also added the config for [Tinyllama](https://github.com/jzhang38/TinyLlama) model.  You can test TinyLLAMA by downloading one of their model.safetensors [checkpoints](https://huggingface.co/PY007/TinyLlama-1.1B-intermediate-step-240k-503b/tree/main) (the tokenizer is the same as the official llama2) and running the following command

`python3 ./examples/llama.py  --prompt="where do you live?" --size="1B" --gen=tiny --model="./weights/model.safetensors"`