### PR TITLE
separate compilers and runtimes

### DIFF
--- a/extra/datasets/__init__.py
+++ b/extra/datasets/__init__.py
@@ -18,10 +18,10 @@ cifar_mean = [0.4913997551666284, 0.48215855929893703, 0.4465309133731618]
 cifar_std = [0.24703225141799082, 0.24348516474564, 0.26158783926049628]
 
 def fetch_cifar():
-  X_train = Tensor.empty(50000, 3*32*32, device=f'disk:./cifar_train_x', dtype=dtypes.uint8)
-  Y_train = Tensor.empty(50000, device=f'disk:./cifar_train_y', dtype=dtypes.int64)
-  X_test = Tensor.empty(10000, 3*32*32, device=f'disk:./cifar_test_x', dtype=dtypes.uint8)
-  Y_test = Tensor.empty(10000, device=f'disk:./cifar_test_y', dtype=dtypes.int64)
+  X_train = Tensor.empty(50000, 3*32*32, device=f'disk:/tmp/cifar_train_x', dtype=dtypes.uint8)
+  Y_train = Tensor.empty(50000, device=f'disk:/tmp/cifar_train_y', dtype=dtypes.int64)
+  X_test = Tensor.empty(10000, 3*32*32, device=f'disk:/tmp/cifar_test_x', dtype=dtypes.uint8)
+  Y_test = Tensor.empty(10000, device=f'disk:/tmp/cifar_test_y', dtype=dtypes.int64)
 
   if not os.path.isfile("/tmp/cifar_extracted"):
     def _load_disk_tensor(X, Y, db_list):

--- a/extra/datasets/__init__.py
+++ b/extra/datasets/__init__.py
@@ -18,10 +18,10 @@ cifar_mean = [0.4913997551666284, 0.48215855929893703, 0.4465309133731618]
 cifar_std = [0.24703225141799082, 0.24348516474564, 0.26158783926049628]
 
 def fetch_cifar():
-  X_train = Tensor.empty(50000, 3*32*32, device=f'disk:/tmp/cifar_train_x', dtype=dtypes.uint8)
-  Y_train = Tensor.empty(50000, device=f'disk:/tmp/cifar_train_y', dtype=dtypes.int64)
-  X_test = Tensor.empty(10000, 3*32*32, device=f'disk:/tmp/cifar_test_x', dtype=dtypes.uint8)
-  Y_test = Tensor.empty(10000, device=f'disk:/tmp/cifar_test_y', dtype=dtypes.int64)
+  X_train = Tensor.empty(50000, 3*32*32, device=f'disk:./cifar_train_x', dtype=dtypes.uint8)
+  Y_train = Tensor.empty(50000, device=f'disk:./cifar_train_y', dtype=dtypes.int64)
+  X_test = Tensor.empty(10000, 3*32*32, device=f'disk:./cifar_test_x', dtype=dtypes.uint8)
+  Y_test = Tensor.empty(10000, device=f'disk:./cifar_test_y', dtype=dtypes.int64)
 
   if not os.path.isfile("/tmp/cifar_extracted"):
     def _load_disk_tensor(X, Y, db_list):

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -156,12 +156,11 @@ class GlobalCounters:
 # *** compiled cache decorator ***
 
 def cache_compiled(func):
-  def wrapper(self, prg:str, *args, **kwargs) -> bytes:
-    cache_path, output_file = pathlib.Path(f"{tempfile.gettempdir()}/tinygrad_cc_{hashlib.sha256(prg.encode()).hexdigest()}"), pathlib.Path(tempfile.mktemp())
-    if not cache_path.exists():
-      output_file.write_bytes(func(self, prg, *args, **kwargs))
-      output_file.rename(cache_path)
-    return cache_path.read_bytes()
+  def wrapper(prg:str, *args, **kwargs) -> bytes:
+    key = hashlib.sha256(prg.encode()).hexdigest()
+    if diskcache_get('compile_cache', key) is None:
+      diskcache_put('compile_cache', key, func(prg, *args, **kwargs))
+    return diskcache_get('compile_cache', key)
   return wrapper
 
 # *** universal database cache ***

--- a/tinygrad/lowering.py
+++ b/tinygrad/lowering.py
@@ -1,0 +1,21 @@
+import functools
+from typing import List
+
+from tinygrad.codegen.linearizer import UOps, Linearizer
+from tinygrad.features.image import fix_schedule_for_images
+from tinygrad.helpers import DEBUG
+
+class CompilerStack:
+  def __init__(self, name, linearizer_opts, renderer, pass_list): self.name, self.linearizer_opts, self.renderer, self.pass_list = name, linearizer_opts, renderer, pass_list
+  def compile(self, kernel_name, uops: List[UOps]):
+    prg, runtime_args = self.renderer(kernel_name, uops)
+    if DEBUG >= 4: print(prg)
+    ret = functools.reduce(lambda ir, f: f(kernel_name, ir), self.pass_list, prg)
+    return ret, runtime_args
+  def make_lin(self, ast): return Linearizer(ast, self.linearizer_opts)
+  def compile_ast(self, ast):
+    lin = self.make_lin(ast)
+    lin.hand_coded_optimizations()
+    lin.linearize()
+    return self.compile(lin.function_name, lin.uops)
+  def plus_pass(self, comp_pass): return CompilerStack(self.name, self.linearizer_opts, self.renderer, self.pass_list + [comp_pass])

--- a/tinygrad/lowering.py
+++ b/tinygrad/lowering.py
@@ -10,8 +10,12 @@ class CompilerStack:
   def compile(self, kernel_name, uops: List[UOps]):
     prg, runtime_args = self.renderer(kernel_name, uops)
     if DEBUG >= 4: print(prg)
-    ret = functools.reduce(lambda ir, f: f(kernel_name, ir), self.pass_list, prg)
-    return ret, runtime_args
+
+    for f in self.pass_list:
+      prg, args = f(kernel_name, prg)
+      runtime_args.update(args)
+
+    return prg, runtime_args
   def make_lin(self, ast): return Linearizer(ast, self.linearizer_opts)
   def compile_ast(self, ast):
     lin = self.make_lin(ast)

--- a/tinygrad/realize.py
+++ b/tinygrad/realize.py
@@ -30,6 +30,15 @@ def run_schedule(schedule:List[ScheduleItem], disable_logging=False):
     assert si.out.realized and isinstance(si.out.realized, Device[si.out.device].buffer), f"device mismatch on realized got {type(si.out.realized)} expected {si.out.device}"
     assert si.out.realized.dtype == si.out.dtype, "realized dtype is incorrect"
 
+def compile_schedule(schedule: List[ScheduleItem]):
+  # HACK: images can be not usable due to shape
+  if IMAGE >= 2: schedule = fix_schedule_for_images(schedule)
+
+  # NOTE: if you for loop the schedule it's slow because nothing frees
+  compiled = [Device[si.out.device].compiler.compile_ast(si.ast) if si.ast.op not in LoadOps else None for si in schedule]
+
+  return compiled
+
 # *** zero op LoadOps ***
 
 def _realize_empty(buffer: LazyBuffer) -> None:

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -209,4 +209,4 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp]) -> Tu
     else:
       raise RuntimeError(f"failed to render {uop}")
 
-  return lang.render_kernel(function_name, kernel, bufs, local_size, prekernel), {"binary":False}
+  return lang.render_kernel(function_name, kernel, bufs, local_size, prekernel), {}

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -106,6 +106,9 @@ class CStyleLanguage(NamedTuple):
       return f"*(({self.smem_prefix if local and self.smem_prefix_for_cast else self.buffer_prefix}{buf_dtype.name}{var_dtype.sz}*)({buf_name}+{idx})) = ({buf_dtype.name}{var_dtype.sz}){var_name};"
     return f"*({buf_name}+{idx}) = {var_name};" if self.uses_ptr_arithmetic else f"{buf_name}[{idx}] = {var_name};"
 
+  def __call__(self, function_name: str, uops: List[UOp]) -> Tuple[str, Dict]:
+    return uops_to_cstyle(self, function_name, uops)
+
 def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp]) -> Tuple[str, Dict]:
   local_size: List[int] = []
   kernel,prekernel,bufs = [],[],[]

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional, List, Any, Tuple
 import numpy as np
 from pycuda.compiler import compile as cuda_compile # type: ignore
-from tinygrad.helpers import DEBUG, getenv, colored
+from tinygrad.helpers import DEBUG, getenv, colored, cache_compiled
 from tinygrad.ops import Compiled, GraphBatchExecutor, ASTRunner
 from tinygrad.runtime.lib import RawBufferCopyInOut, RawMallocBuffer, LRUAllocator
 from tinygrad.codegen.kernel import LinearizerOptions
@@ -89,12 +89,7 @@ class CUDAGraph(GraphBatchExecutor):
   def exec_instance(self, instid): self.graphs[instid][0].launch()
 
 class CUDAProgram:
-  def __init__(self, name:str, prg:str, binary=False, shared = 0, local_size_override=None):
-    if not binary:
-      try: prg = cuda_compile(prg, target="ptx", no_extern_c=True, options=['-Wno-deprecated-gpu-targets']).decode('utf-8')
-      except cuda.CompileError as e:
-        if DEBUG >= 3: print("FAILED TO BUILD", prg)
-        raise e
+  def __init__(self, name:str, prg:str, shared = 0, local_size_override=None):
     if DEBUG >= 5: print(pretty_ptx(prg))
     if DEBUG >= 6:
       try:
@@ -105,6 +100,15 @@ class CUDAProgram:
       except Exception as e: print("failed to generate SASS", str(e))
     # TODO: name is wrong, so we get it from the ptx using hacks
     self.prg, self.shared, self.local_size_override = cuda.module_from_buffer(prg.encode('utf-8')).get_function(prg.split(".visible .entry ")[1].split("(")[0]), shared, local_size_override
+
+  @staticmethod
+  @cache_compiled
+  def compile(name, prg):
+    try:
+      return cuda_compile(prg, target="ptx", no_extern_c=True, options=['-Wno-deprecated-gpu-targets']).decode('utf-8'), {}
+    except cuda.CompileError as e:
+      if DEBUG >= 3: print("FAILED TO BUILD", prg)
+      raise e
 
   def __call__(self, global_size, local_size, *args, wait=False):
     if wait:

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -70,7 +70,7 @@ def pyopencl_compile(name: str, prg: str, options=None):
     if DEBUG >= 3: print("FAILED TO BUILD", prg)
     raise e
   binaries = [clp.get_info(cl.program_info.BINARIES) for clp in clprograms]
-  return binaries
+  return binaries, {}
 
 def scatter_binary(name: str, prg: bytes):
   return [[prg] for _ in CL.cl_ctxs]

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -81,12 +81,11 @@ class CLProgram:
     self.local_size_override = local_size_override
     if function_name_override is not None: name=function_name_override
     try:
-      pass
-      #self._clprgs = [clprogram.build(options=options) for clprogram in self.clprograms]
+      for clprogram in self.clprograms: clprogram.build(options=options)
     except cl.RuntimeError as e:
       if DEBUG >= 3: print("FAILED TO BUILD", prg)
       raise e
-    self.clprgs = [clprg.__getattr__(name) for clprg in self._clprgs]
+    self.clprgs = [clprg.__getattr__(name) for clprg in self.clprograms]
     if DEBUG >= 5 and not OSX:
       if 'Adreno' in CL.cl_ctxs[0].devices[0].name:
         fromimport('disassemblers.adreno', 'disasm')(self.binary())

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -81,7 +81,8 @@ class CLProgram:
     self.local_size_override = local_size_override
     if function_name_override is not None: name=function_name_override
     try:
-      self._clprgs = [clprogram.build(options=options) for clprogram in self.clprograms]
+      pass
+      #self._clprgs = [clprogram.build(options=options) for clprogram in self.clprograms]
     except cl.RuntimeError as e:
       if DEBUG >= 3: print("FAILED TO BUILD", prg)
       raise e
@@ -126,8 +127,8 @@ if getenv("TRITON") == 1:
   from tinygrad.renderer.triton import uops_to_triton
   amdgcn_triton = CompilerStack("TRITON_AMDGCN", LinearizerOptions(supports_float4=False, supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024], has_shared=False), functools.partial(uops_to_triton, "hsaco"), [scatter_binary])
 if getenv("HIP_GPU") == 1:
-  from tinygrad.runtime.ops_hip import hipcc_compile, renderer as hip_renderer
-  hipcc_gpu = CompilerStack("HIPCC_GPU", LinearizerOptions(device="HIP"), hip_renderer, [hipcc_compile, scatter_binary])
+  from tinygrad.runtime.ops_hip import hip_compiler
+  hipcc_gpu = hip_compiler.plus_pass(scatter_binary)
 
 pyopencl_compiler = CompilerStack("PYOPENCL", LinearizerOptions(), OpenCLRenderer, [pyopencl_compile])
 GPUBuffer = Compiled(CLBuffer, amdgcn_triton if getenv("TRITON") else hipcc_gpu if getenv("HIP_GPU") else pyopencl_compiler, CLProgram, CL.synchronize)

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -142,5 +142,5 @@ __device__ void vstore_half4(float4 data, size_t offset, half *p) { *(p + offset
   """,
   gid = [f'blockIdx.{chr(120+i)}' for i in range(3)],
   lid = [f'threadIdx.{chr(120+i)}' for i in range(3)]))
-hip_compiler = CompilerStack("HIP", LinearizerOptions(device="HIP"), renderer, [hipcc_compile])
+hip_compiler = CompilerStack("HIPCC", LinearizerOptions(device="HIP"), renderer, [hipcc_compile])
 HIPBuffer = Compiled(RawHIPBuffer, hip_compiler, HIPProgram, hip.hipDeviceSynchronize, HIPGraph)

--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -1,7 +1,9 @@
 import time, hashlib, ctypes
 from typing import ClassVar
+
+from tinygrad.lowering import CompilerStack
 from tinygrad.ops import Compiled
-from tinygrad.helpers import getenv, DEBUG
+from tinygrad.helpers import getenv, DEBUG, cache_compiled
 from ctypes import CFUNCTYPE
 from tinygrad.codegen.kernel import LinearizerOptions
 from tinygrad.renderer.llvmir import uops_to_llvm_ir
@@ -64,4 +66,5 @@ class LLVMProgram:
     cfunc(*[x._buf if not isinstance(x, int) else x for x in bufs])
     if wait: return time.monotonic()-st
 
-LLVMBuffer = Compiled(RawMallocBuffer, LinearizerOptions(supports_float4=False, has_local=False, has_shared=False), uops_to_llvm_ir, LLVMProgram)
+LLVMCompiler = CompilerStack('LLVM', LinearizerOptions(supports_float4=False, has_local=False, has_shared=False), uops_to_llvm_ir, [])
+LLVMBuffer = Compiled(RawMallocBuffer, LLVMCompiler, LLVMProgram)

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -7,6 +7,7 @@ from tinygrad.helpers import prod, getenv, DEBUG, DType, dtypes
 from tinygrad.ops import Compiled, ASTRunner, BasicBatchExecutor
 from tinygrad.renderer.metal import MetalRenderer
 from tinygrad.runtime.lib import RawBufferMapped, LRUAllocator
+from tinygrad.lowering import CompilerStack
 
 METAL_XCODE = getenv("METAL_XCODE")
 
@@ -100,4 +101,5 @@ class MetalProgram:
       return command_buffer.GPUEndTime() - command_buffer.GPUStartTime()
     METAL.mtl_buffers_in_flight.append(command_buffer)
 
-MetalBuffer = Compiled(RawMetalBuffer, LinearizerOptions(device="METAL"), MetalRenderer, MetalProgram, METAL.synchronize, MetalBatchExecutor)
+metal_compiler = CompilerStack("METAL", LinearizerOptions(device="METAL"), MetalRenderer, )
+MetalBuffer = Compiled(RawMetalBuffer, metal_compiler, MetalProgram, METAL.synchronize, MetalBatchExecutor)


### PR DESCRIPTION
just small ideas in here so far (most of the code here is dead code, just trying things)

on amd, turns out both hip and pyopencl produce hsaco binaries that you can pass between each other. similar can be done with nvidia / ptx. is it possible to get/set sass from opencl?

abstraction goals (not code to include in this pr):
- support parallel comp
- support amd triton
- support persistent ast -> binary cache
- support het. devices
- make testing easier (eg make cstyle params queryable, probably unnecessary)