### PR TITLE
use unique table name for each disk_cache test

### DIFF
--- a/test/unit/test_disk_cache.py
+++ b/test/unit/test_disk_cache.py
@@ -2,58 +2,65 @@ import unittest
 import pickle
 from tinygrad.helpers import diskcache_get, diskcache_put
 
-def remote_get(q,k): q.put(diskcache_get("test", k))
-def remote_put(k,v): diskcache_put("test", k, v)
+def remote_get(table,q,k): q.put(diskcache_get(table, k))
+def remote_put(table,k,v): diskcache_put(table, k, v)
 
 class DiskCache(unittest.TestCase):
   def test_putget(self):
-    diskcache_put("test", "hello", "world")
-    self.assertEqual(diskcache_get("test", "hello"), "world")
-    diskcache_put("test", "hello", "world2")
-    self.assertEqual(diskcache_get("test", "hello"), "world2")
+    table = "test_putget"
+    diskcache_put(table, "hello", "world")
+    self.assertEqual(diskcache_get(table, "hello"), "world")
+    diskcache_put(table, "hello", "world2")
+    self.assertEqual(diskcache_get(table, "hello"), "world2")
 
   def test_putcomplex(self):
-    diskcache_put("test", "k", ("complex", 123, "object"))
-    ret = diskcache_get("test", "k")
+    table = "test_putcomplex"
+    diskcache_put(table, "k", ("complex", 123, "object"))
+    ret = diskcache_get(table, "k")
     self.assertEqual(ret, ("complex", 123, "object"))
 
   def test_getotherprocess(self):
+    table = "test_getotherprocess"
     from multiprocessing import Process, Queue
-    diskcache_put("test", "k", "getme")
+    diskcache_put(table, "k", "getme")
     q = Queue()
-    p = Process(target=remote_get, args=(q,"k"))
+    p = Process(target=remote_get, args=(table,q,"k"))
     p.start()
     p.join()
     self.assertEqual(q.get(), "getme")
 
   def test_putotherprocess(self):
+    table = "test_putotherprocess"
     from multiprocessing import Process
-    p = Process(target=remote_put, args=("k", "remote"))
+    p = Process(target=remote_put, args=(table,"k", "remote"))
     p.start()
     p.join()
-    self.assertEqual(diskcache_get("test", "k"), "remote")
+    self.assertEqual(diskcache_get(table, "k"), "remote")
 
   def test_no_table(self):
     self.assertIsNone(diskcache_get("faketable", "k"))
 
   def test_ret(self):
-    self.assertEqual(diskcache_put("test", "key", ("vvs",)), ("vvs",))
+    table = "test_ret"
+    self.assertEqual(diskcache_put(table, "key", ("vvs",)), ("vvs",))
 
   def test_non_str_key(self):
-    diskcache_put("test", 4, 5)
-    self.assertEqual(diskcache_get("test", 4), 5)
-    self.assertEqual(diskcache_get("test", "4"), 5)
+    table = "test_non_str_key"
+    diskcache_put(table, 4, 5)
+    self.assertEqual(diskcache_get(table, 4), 5)
+    self.assertEqual(diskcache_get(table, "4"), 5)
 
   def test_dict_key(self):
+    table = "test_dict_key"
     fancy_key = {"hello": "world", "goodbye": 7, "good": True, "pkl": pickle.dumps("cat")}
     fancy_key2 = {"hello": "world", "goodbye": 8, "good": True, "pkl": pickle.dumps("cat")}
     fancy_key3 = {"hello": "world", "goodbye": 8, "good": True, "pkl": pickle.dumps("dog")}
-    diskcache_put("test2", fancy_key, 5)
-    self.assertEqual(diskcache_get("test2", fancy_key), 5)
-    diskcache_put("test2", fancy_key2, 8)
-    self.assertEqual(diskcache_get("test2", fancy_key2), 8)
-    self.assertEqual(diskcache_get("test2", fancy_key), 5)
-    self.assertEqual(diskcache_get("test2", fancy_key3), None)
+    diskcache_put(table, fancy_key, 5)
+    self.assertEqual(diskcache_get(table, fancy_key), 5)
+    diskcache_put(table, fancy_key2, 8)
+    self.assertEqual(diskcache_get(table, fancy_key2), 8)
+    self.assertEqual(diskcache_get(table, fancy_key), 5)
+    self.assertEqual(diskcache_get(table, fancy_key3), None)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
there can be race with multiple workers modifying the same table, can have some errors locally with `GPU=1 python -m pytest -n=10 test/unit/test_disk_cache.py`

fixed by assigning unique table name for each test