### PR TITLE
fix hip segfault

### DIFF
--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -70,7 +70,7 @@ class RawHIPBuffer(RawBufferCopyInOut, RawBufferTransfer):
   def __init__(self, size, dtype, device=HIP.default_device, buf=None, allocator=HIP.allocator): super().__init__(size, dtype, buf=buf, allocator=allocator, **{'device': int(device)})
   def _copyin(self, x:np.ndarray):
     hip.hipSetDevice(self._device)
-    hip.hipMemcpyAsync(self._buf, np.require(x, requirements='C').ctypes.data, self.size * self.dtype.itemsize, hip.hipMemcpyHostToDevice, 0)
+    hip.hipMemcpyAsync(self._buf, np.require(x, requirements='C').ctypes.data_as(ctypes.c_void_p), self.size * self.dtype.itemsize, hip.hipMemcpyHostToDevice, 0)
   def _copyout(self, x:np.ndarray):
     hip.hipSetDevice(self._device)
     hip.hipMemcpy(x.ctypes.data, self._buf, self.size * self.dtype.itemsize, hip.hipMemcpyDeviceToHost)


### PR DESCRIPTION
When 'C' is applied to the array, we might get a pointer to freed memory.

Numpy comment on `.data`:
```
Note that unlike ``data_as``, a reference will not be kept to the array:
code like ``ctypes.c_void_p((a + b).ctypes.data)`` will result in a
pointer to a deallocated array, and should be spelt
``(a + b).ctypes.data_as(ctypes.c_void_p)``
```

Segfault:
```
#0  __memmove_avx_unaligned () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:222
#1  0x00007fff42909a6e in ?? () from /opt/rocm-5.7.0/lib/libamdhip64.so
#2  0x00007fff4290be87 in ?? () from /opt/rocm-5.7.0/lib/libamdhip64.so
#3  0x00007fff4290c275 in ?? () from /opt/rocm-5.7.0/lib/libamdhip64.so
#4  0x00007fff428d5f45 in ?? () from /opt/rocm-5.7.0/lib/libamdhip64.so
#5  0x00007fff4289ede4 in ?? () from /opt/rocm-5.7.0/lib/libamdhip64.so
#6  0x00007fff42735faa in ?? () from /opt/rocm-5.7.0/lib/libamdhip64.so
#7  0x00007fff427381d7 in ?? () from /opt/rocm-5.7.0/lib/libamdhip64.so
#8  0x00007fff4273a026 in hipMemcpyAsync () from /opt/rocm-5.7.0/lib/libamdhip64.so
```