### PR TITLE
Fix mmaped in jit

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -168,5 +168,27 @@ class TestJit(unittest.TestCase):
     assert len(res3) == 5, "All values should be different, rand works in jit."
     assert res3 != res2, "Jit rand is diff with diff seeds"
 
+  def test_jit_realization_and_sampling(self):
+    w = Tensor.eye(5)
+
+    @TinyJit
+    def foo (x): return w.dot(x).realize()
+
+    arg  = [
+        Tensor([1,2,3,4,5]),
+        Tensor([1,3,3,4,6]),
+        Tensor([1,2,5,4,7]),
+        Tensor([0,2,3,1,0]),
+    ]
+
+    Y = [foo(e).numpy() for e in arg]
+
+    foo(Tensor([7,7,7,7,7]))
+    want = [[1., 3., 3., 4., 5.],
+            [1., 3., 3., 4., 6.],
+            [1., 3., 3., 4., 7.],
+            [0., 2., 3., 1., 0.]]
+    np.testing.assert_allclose(want, Y)
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -184,9 +184,9 @@ class TestJit(unittest.TestCase):
     Y = [foo(e).numpy() for e in arg]
 
     foo(Tensor([7,7,7,7,7]))
-    want = [[1., 3., 3., 4., 5.],
+    want = [[1., 2., 3., 4., 5.],
             [1., 3., 3., 4., 6.],
-            [1., 3., 3., 4., 7.],
+            [1., 2., 5., 4., 7.],
             [0., 2., 3., 1., 0.]]
     np.testing.assert_allclose(want, Y)
 

--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -38,8 +38,9 @@ class RawBufferCopyIn(RawBuffer):
 class RawBufferMapped(RawBufferCopyIn):
   def _buffer(self) -> memoryview: raise NotImplementedError("must be implemented")
   # NOTE: this metadata prevents the backing buffer from being freed. hack can be removed with PEP688
-  def toCPU(self) -> np.ndarray: return np.frombuffer(self._buffer(), dtype=np.dtype(self.dtype.np, metadata={"backing": self}), count=self.size)  # type: ignore
-  def _copyin(self, x:np.ndarray) -> None: np.copyto(self.toCPU(), x.reshape(-1))
+  def buffer_view(self) -> np.ndarray: return np.frombuffer(self._buffer(), dtype=np.dtype(self.dtype.np, metadata={"backing": self}), count=self.size)  # type: ignore
+  def toCPU(self) -> np.ndarray: return self.buffer_view().copy()
+  def _copyin(self, x:np.ndarray) -> None: np.copyto(self.buffer_view(), x.reshape(-1))
 
 # this one is simple enough that i moved it out of the runtimes
 class RawMallocBuffer(RawBufferMapped):

--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -39,7 +39,7 @@ class RawBufferMapped(RawBufferCopyIn):
   def _buffer(self) -> memoryview: raise NotImplementedError("must be implemented")
   # NOTE: this metadata prevents the backing buffer from being freed. hack can be removed with PEP688
   def buffer_view(self) -> np.ndarray: return np.frombuffer(self._buffer(), dtype=np.dtype(self.dtype.np, metadata={"backing": self}), count=self.size)  # type: ignore
-  def toCPU(self) -> np.ndarray: return self.buffer_view().copy()
+  def toCPU(self) -> np.ndarray: return self.buffer_view().copy() # Need a copy, since jit will write to the same buffer.
   def _copyin(self, x:np.ndarray) -> None: np.copyto(self.buffer_view(), x.reshape(-1))
 
 # this one is simple enough that i moved it out of the runtimes


### PR DESCRIPTION
Fixes a problem when jit overwrites the same buffer for backends which use mmaped buffer. This now makes a copy when .toCPU() is called, so several different numpy buffers do not share the same memory.