### PR TITLE
Update loss calculation in quickstart documentation

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -188,7 +188,7 @@ with Tensor.train():
     out = net(batch)
 
     # compute loss
-    loss = sparse_categorical_crossentropy(out, labels)
+    loss = out.sparse_categorical_crossentropy(labels)
 
     # zero gradients
     opt.zero_grad()


### PR DESCRIPTION
# Overview
This pull request updates `quickstart.md` for the tinygrad MNIST example when computing the loss. When looking at how it is implemented now, it is directly part of `Tensor` and not as a standalone function. So I'm updating this documentation along the way.