### PR TITLE
remove cache_id

### DIFF
--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -317,7 +317,7 @@ def train_cifar():
         bucket, offset = [], 0
         for _, v in params_dict.items():
           if v.grad is not None: bucket.append(v.grad.flatten())
-        grads = collectives.allreduce(Tensor.cat(*bucket), cache_id="grads")
+        grads = collectives.allreduce(Tensor.cat(*bucket))
         for _, v in params_dict.items():
           if v.grad is not None:
             v.grad.assign(grads[offset:offset+v.grad.numel()].reshape(*v.grad.shape))

--- a/extra/dist/collectives.py
+++ b/extra/dist/collectives.py
@@ -3,9 +3,8 @@ from tinygrad.helpers import getenv
 
 from extra.dist import world
 
-def allreduce(t:Tensor, cache_id=None) -> Tensor:
+def allreduce(t:Tensor) -> Tensor:
   RANK, WORLD_SIZE = getenv("RANK"), getenv("WORLD_SIZE")
-  cache_id = f"{RANK}-{cache_id}" if cache_id is not None else None
 
   # flatten
   flattened = t.flatten()
@@ -22,8 +21,8 @@ def allreduce(t:Tensor, cache_id=None) -> Tensor:
 
   # scatter reduce
   current_chunk_index = RANK
-  for i in range(WORLD_SIZE - 1):
-    world.send(chunks[current_chunk_index], next_rank, cache_id=f"{cache_id}-{i}-s" if cache_id is not None else None)
+  for _ in range(WORLD_SIZE - 1):
+    world.send(chunks[current_chunk_index], next_rank)
     current_chunk_index = ((current_chunk_index - 1) + WORLD_SIZE) % WORLD_SIZE
     recv_buf = Tensor.empty(*chunks[current_chunk_index].shape)
     world.recv(recv_buf, prev_rank)
@@ -31,8 +30,8 @@ def allreduce(t:Tensor, cache_id=None) -> Tensor:
 
   # gather
   current_chunk_index = (RANK + 1) % WORLD_SIZE
-  for i in range(WORLD_SIZE - 1):
-    world.send(chunks[current_chunk_index], next_rank, cache_id=f"{cache_id}-{i}-g" if cache_id is not None else None)
+  for _ in range(WORLD_SIZE - 1):
+    world.send(chunks[current_chunk_index], next_rank)
     current_chunk_index = ((current_chunk_index - 1) + WORLD_SIZE) % WORLD_SIZE
     recv_buf = Tensor.empty(*chunks[current_chunk_index].shape)
     world.recv(recv_buf, prev_rank)

--- a/extra/dist/world.py
+++ b/extra/dist/world.py
@@ -34,7 +34,7 @@ def __recv_rb(args, variables=None, jit=False, force_wait=False):
   if DEBUG >= 2: print(f"{colored('****', 'magenta' if jit else None)}  rank {getenv('RANK')} recv {x} from rank {target_rank}")
 
 # send a rawbuffer from out rank to the target rank
-def _send_rb(x:RawBuffer, target_rank:int, cache_id:Optional[str]=None):
+def _send_rb(x:RawBuffer, target_rank:int):
   if RawHIPBuffer and x.__class__ is RawHIPBuffer:
     # send ipc handle
     hip.hipSetDevice(x._device)
@@ -46,21 +46,17 @@ def _send_rb(x:RawBuffer, target_rank:int, cache_id:Optional[str]=None):
     x._allocator = None # need to disconnect allocator for sent buffers
     CacheCollector.add(__send_rb, [x, target_rank, None], {})
   else:
-    # cache the shared memory so we don't have to create it every time
-    if cache_id is not None and cache_id in _send_rb.shared_memory_cache:
-      shm_name = _send_rb.shared_memory_cache[cache_id]
-    else:
-      shm_name = (s := shared_memory.SharedMemory(create=True, size=x.size * x.dtype.itemsize)).name
-      s.close()
-      if cache_id is not None: _send_rb.shared_memory_cache[cache_id] = shm_name
-    # copy the buffer into shared memory
-    device = f"{shm_name},{cache_id}" if cache_id is not None else shm_name
-    y = RawShmBuffer(x.size, x.dtype, device=device)
+    # create shared memory
+    shm_name = (s := shared_memory.SharedMemory(create=True, size=x.size * x.dtype.itemsize)).name
+    s.close()
 
+    # copy the buffer into shared memory
+    y = RawShmBuffer(x.size, x.dtype, device=shm_name)
     # fast path when we can directly copyout
     if isinstance(x, RawBufferCopyInOut): x._copyout(np.frombuffer(y._buffer(), dtype=x.dtype.np))
     else: y.fromCPU(x.toCPU())
-    dist.OOB.send((shm_name, cache_id), target_rank)
+
+    dist.OOB.send(shm_name, target_rank)
 
     # jit support
     CacheCollector.add(__send_rb, [x, target_rank, y], {})
@@ -81,26 +77,21 @@ def _recv_rb(x:RawBuffer, target_rank:int):
     if DEBUG >= 2: print(f"****  rank {getenv('RANK')} got {x} from rank {target_rank}")
     CacheCollector.add(__recv_rb, [x, target_rank, y], {})
   else:
-    extra = dist.OOB.recv(target_rank)
-    device = f"{extra[0]},{extra[1]}" if extra[1] is not None else f"{extra[0]}"
-    y = RawShmBuffer(x.size, x.dtype, device=device)
+    shm_name = dist.OOB.recv(target_rank)
+    y = RawShmBuffer(x.size, x.dtype, device=shm_name)
 
     # fast path when we can directly copyin
     if isinstance(x, RawBufferCopyIn): x._copyin(y.toCPU())
     else: x.fromCPU(y.toCPU())
     if DEBUG >= 2: print(f"****  rank {getenv('RANK')} got {x} from rank {target_rank}")
 
-    if extra[1] is None:
-      (s := shared_memory.SharedMemory(name=extra[0])).close()
-      s.unlink()
-
     # jit support
     CacheCollector.add(__recv_rb, [x, target_rank, y], {})
 
 # sends a lazybuffer from our rank to the target rank
-def _send_lb(x:LazyBuffer, target_rank:int, cache_id:Optional[str]=None) -> None:
+def _send_lb(x:LazyBuffer, target_rank:int) -> None:
   assert x.st.contiguous and x.realized, "sending buffer must be contiguous and realized"
-  _send_rb(x.realized, target_rank, cache_id=cache_id)
+  _send_rb(x.realized, target_rank)
 
 # receive a lazybuffer from the target rank
 def _recv_lb(x:LazyBuffer, target_rank:int) -> LazyBuffer:
@@ -109,15 +100,15 @@ def _recv_lb(x:LazyBuffer, target_rank:int) -> LazyBuffer:
   return x
 
 class Send(Function):
-  def forward(self, x:LazyBuffer, target_rank:int, cache_id:Optional[str]=None) -> LazyBuffer:
+  def forward(self, x:LazyBuffer, target_rank:int) -> LazyBuffer:
     self.target_rank, self.shape, self.dtype = target_rank, x.shape, x.dtype
-    _send_lb(x, target_rank, cache_id=cache_id)
+    _send_lb(x, target_rank)
     return x
 
 class Recv(Function):
-  def forward(self, x:LazyBuffer, target_rank:int, cache_id:Optional[str]=None) -> LazyBuffer:
-    self.target_rank, self.cache_id = target_rank, cache_id
+  def forward(self, x:LazyBuffer, target_rank:int) -> LazyBuffer:
+    self.target_rank = target_rank
     return _recv_lb(x, target_rank)
 
-def send(x:Tensor, target_rank:int, cache_id:Optional[str]=None) -> Tensor: return Send.apply(x.contiguous().realize(), target_rank=target_rank, cache_id=cache_id)
-def recv(x:Tensor, target_rank:int, cache_id:Optional[str]=None) -> Tensor: return Recv.apply(x.contiguous().realize(), target_rank=target_rank, cache_id=cache_id)
+def send(x:Tensor, target_rank:int) -> Tensor: return Send.apply(x.contiguous().realize(), target_rank=target_rank)
+def recv(x:Tensor, target_rank:int) -> Tensor: return Recv.apply(x.contiguous().realize(), target_rank=target_rank)

--- a/test/external/dist/test_collectives.py
+++ b/test/external/dist/test_collectives.py
@@ -9,8 +9,8 @@ from tinygrad.tensor import Tensor
 import numpy as np
 
 @TinyJit
-def allreduce_jit(t:Tensor, cache_id=None) -> Tensor:
-  return collectives.allreduce(t, cache_id=cache_id).realize()
+def allreduce_jit(t:Tensor) -> Tensor:
+  return collectives.allreduce(t).realize()
 
 SIZE = 2048 if not CI else 2
 SIZE_2 = 255 if not CI else 3
@@ -25,7 +25,7 @@ def run():
   for _ in range(3):
     # create a tensor to send
     t = Tensor.zeros(SIZE, SIZE) if rank != 0 else Tensor.ones(SIZE, SIZE)
-    t2 = allreduce_jit(t.contiguous().realize(), cache_id="test")
+    t2 = allreduce_jit(t.contiguous().realize())
     assert np.allclose(np.ones((SIZE, SIZE)), t2.numpy()), f"{t2.numpy()} wasn't ones"
 
   # reset jit
@@ -36,7 +36,7 @@ def run():
   for _ in range(3):
     # create a tensor to send
     t = Tensor.ones(SIZE_2, SIZE_2, SIZE_2) if rank == 0 else Tensor.zeros(SIZE_2, SIZE_2, SIZE_2)
-    t2 = allreduce_jit(t.contiguous().realize(), cache_id="test2")
+    t2 = allreduce_jit(t.contiguous().realize())
     assert np.allclose(np.ones((SIZE_2, SIZE_2, SIZE_2)), t2.numpy()), f"{t2.numpy()} wasn't ones"
 
   print(f"rank {rank} passed")

--- a/test/external/dist/test_world.py
+++ b/test/external/dist/test_world.py
@@ -9,12 +9,12 @@ from tinygrad.tensor import Tensor
 import numpy as np
 
 @TinyJit
-def send_jit(t, target_rank, cache_id=None) -> Tensor:
-  return world.send(t, target_rank, cache_id=cache_id).realize()
+def send_jit(t, target_rank) -> Tensor:
+  return world.send(t, target_rank).realize()
 
 @TinyJit
-def recv_jit(t, target_rank, cache_id=None) -> Tensor:
-  return world.recv(t, target_rank, cache_id=cache_id).realize()
+def recv_jit(t, target_rank) -> Tensor:
+  return world.recv(t, target_rank).realize()
 
 SIZE = 2048 if not CI else 2
 
@@ -31,17 +31,17 @@ def run():
 
     # send to rank 1
     if rank == 0:
-      send_jit(t, 1, cache_id="test")
+      send_jit(t, 1)
     elif rank == 1:
       t2 = Tensor.empty(SIZE, SIZE)
-      recv_jit(t2, 0, cache_id="test")
+      recv_jit(t2, 0)
 
     # recv from rank 1
     if rank == 0:
       t2 = Tensor.empty(SIZE, SIZE)
-      recv_jit(t2, 1, cache_id="test2")
+      recv_jit(t2, 1)
     elif rank == 1:
-      send_jit(t2, 0, cache_id="test2")
+      send_jit(t2, 0)
 
     # check that the received tensor is the same as the sent tensor
     if rank == 0:

--- a/tinygrad/runtime/ops_shm.py
+++ b/tinygrad/runtime/ops_shm.py
@@ -6,28 +6,21 @@ from tinygrad.helpers import DType, OSX
 from tinygrad.runtime.lib import RawBufferMapped
 from tinygrad.ops import Interpreted, Op, UnaryOps, MovementOps, BufferOps
 
-SHM_CACHE: Dict[str, mmap.mmap] = {}
 class RawShmBuffer(RawBufferMapped):
   def __init__(self, size, dtype:DType, device:str):
-    device, self.cache_id = device.split(",")[0], None if "," not in device else device.split(",")[1]
-
-    if self.cache_id is not None and self.cache_id in SHM_CACHE: shm = SHM_CACHE[self.cache_id]
+    if OSX:
+      with open(f"/tmp/shm_{device}", "w+b") as f:
+        f.truncate(size * dtype.itemsize)
+        shm = mmap.mmap(f.fileno(), size * dtype.itemsize, flags=mmap.MAP_SHARED)
     else:
-      if OSX:
-        with open(f"/tmp/shm_{device}", "w+b") as f:
-          f.truncate(size * dtype.itemsize)
-          shm = mmap.mmap(f.fileno(), size * dtype.itemsize, flags=mmap.MAP_SHARED)
-      else:
-        fd = _posixshmem.shm_open(device, os.O_RDWR, 0o600)
-        # TODO: these flags are somewhat platform specific, but python doesn't expose the ones we need
-        shm = mmap.mmap(fd, size * dtype.itemsize, flags=mmap.MAP_SHARED | 0x2000 | 0x008000)
-        shm.madvise(mmap.MADV_HUGEPAGE)    # type: ignore
-        os.close(fd)
-      if self.cache_id is not None: SHM_CACHE[self.cache_id] = shm
+      fd = _posixshmem.shm_open(device, os.O_RDWR, 0o600)
+      # TODO: these flags are somewhat platform specific, but python doesn't expose the ones we need
+      shm = mmap.mmap(fd, size * dtype.itemsize, flags=mmap.MAP_SHARED | 0x2000 | 0x008000)
+      shm.madvise(mmap.MADV_HUGEPAGE)    # type: ignore
+      os.close(fd)
 
     super().__init__(size, dtype, shm)
-  def __del__(self):
-    if self.cache_id is None: self._buf.close()
+  def __del__(self): self._buf.close()
   def _buffer(self): return memoryview(self._buf)
 
 # TODO: is this wrong?


### PR DESCRIPTION
Before HIP multigpu, this was used to make shm faster by caching the shared memory allocations. But really that shouldn't be an issue since JIT should be caching them anyways.

This really just became a terribly ugly hack that got everywhere with multigpu.
