### PR TITLE
fix ops tests in test_dtype

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -81,25 +81,17 @@ class TestDType(unittest.TestCase):
     get_available_cast_dtypes(self.DTYPE)
   ))
   def test_upcast_to_ops(self): list(map(
-    lambda dtype: _test_ops(a_dtype=dtype, b_dtype=self.DTYPE, target_dtype=min([dtype, self.DTYPE], key=lambda x: x.priority)) if dtype.itemsize < self.DTYPE.itemsize else None,
+    lambda dtype: _test_ops(a_dtype=dtype, b_dtype=self.DTYPE, target_dtype=max([dtype, self.DTYPE], key=lambda x: x.priority)) if dtype.itemsize < self.DTYPE.itemsize else None,
     get_available_cast_dtypes(self.DTYPE)
   ))
 
 def _test_ops(a_dtype:DType, b_dtype:DType, target_dtype:DType):
-  if not is_dtype_supported(a_dtype) or not is_dtype_supported(b_dtype): raise unittest.SkipTest("dtype not supported")
-  if a_dtype == dtypes.bool or b_dtype == dtypes.bool: raise unittest.SkipTest("bool not supported")
-
-  try: _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)+Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [2,4,6,8])
-  except AssertionError as e: raise AssertionError(f"[0] {a_dtype} + {b_dtype} does not match target {target_dtype}")
-
-  try: _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)*Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [1,4,9,16])
-  except AssertionError as e: raise AssertionError(f"[1] {a_dtype} * {b_dtype} does not match target {target_dtype}")
-
-  try: _assert_eq(Tensor([[1,2],[3,4]], dtype=a_dtype)@Tensor.eye(2, dtype=b_dtype), target_dtype, [[1,2],[3,4]])
-  except AssertionError as e: raise AssertionError(f"[2] {a_dtype} eye {b_dtype} does not match target {target_dtype}")
-
-  try: _assert_eq(Tensor([1,1,1,1], dtype=a_dtype)+Tensor.ones((4,4), dtype=b_dtype), target_dtype, 2*Tensor.ones(4,4).numpy())
-  except AssertionError as e: raise AssertionError(f"[3] {a_dtype} [] {b_dtype} does not match target {target_dtype}")
+  if not is_dtype_supported(a_dtype) or not is_dtype_supported(b_dtype): return
+  if a_dtype == dtypes.bool or b_dtype == dtypes.bool: return
+  _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)+Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [2,4,6,8])
+  _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)*Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [1,4,9,16])
+  _assert_eq(Tensor([[1,2],[3,4]], dtype=a_dtype)@Tensor.eye(2, dtype=b_dtype), target_dtype, [[1,2],[3,4]])
+  _assert_eq(Tensor([1,1,1,1], dtype=a_dtype)+Tensor.ones((4,4), dtype=b_dtype), target_dtype, 2*Tensor.ones(4,4).numpy())
 
 class TestBFloat16DType(unittest.TestCase):
   def setUp(self):

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -88,10 +88,18 @@ class TestDType(unittest.TestCase):
 def _test_ops(a_dtype:DType, b_dtype:DType, target_dtype:DType):
   if not is_dtype_supported(a_dtype) or not is_dtype_supported(b_dtype): raise unittest.SkipTest("dtype not supported")
   if a_dtype == dtypes.bool or b_dtype == dtypes.bool: raise unittest.SkipTest("bool not supported")
-  _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)+Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [2,4,6,8])
-  _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)*Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [1,4,9,16])
-  _assert_eq(Tensor([[1,2],[3,4]], dtype=a_dtype)@Tensor.eye(2, dtype=b_dtype), target_dtype, [[1,2],[3,4]])
-  _assert_eq(Tensor([1,1,1,1], dtype=a_dtype)+Tensor.ones((4,4), dtype=b_dtype), target_dtype, 2*Tensor.ones(4,4).numpy())
+
+  try: _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)+Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [2,4,6,8])
+  except AssertionError as e: raise AssertionError(f"[0] {a_dtype} + {b_dtype} does not match target {target_dtype}")
+
+  try: _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)*Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [1,4,9,16])
+  except AssertionError as e: raise AssertionError(f"[1] {a_dtype} * {b_dtype} does not match target {target_dtype}")
+
+  try: _assert_eq(Tensor([[1,2],[3,4]], dtype=a_dtype)@Tensor.eye(2, dtype=b_dtype), target_dtype, [[1,2],[3,4]])
+  except AssertionError as e: raise AssertionError(f"[2] {a_dtype} eye {b_dtype} does not match target {target_dtype}")
+
+  try: _assert_eq(Tensor([1,1,1,1], dtype=a_dtype)+Tensor.ones((4,4), dtype=b_dtype), target_dtype, 2*Tensor.ones(4,4).numpy())
+  except AssertionError as e: raise AssertionError(f"[3] {a_dtype} [] {b_dtype} does not match target {target_dtype}")
 
 class TestBFloat16DType(unittest.TestCase):
   def setUp(self):

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -68,17 +68,26 @@ class TestDType(unittest.TestCase):
     get_available_cast_dtypes(self.DTYPE)
   ))
 
+  def test_same_size_ops(self):
+    def get_target_dtype(dtype):
+      if any([dtypes.is_float(dtype), dtypes.is_float(self.DTYPE)]): return max([dtype, self.DTYPE], key=lambda x: x.priority)
+      return dtype if dtypes.is_unsigned(dtype) else self.DTYPE
+    list(map(
+      lambda dtype: _test_ops(a_dtype=self.DTYPE, b_dtype=dtype, target_dtype=get_target_dtype(dtype)) if dtype.itemsize == self.DTYPE.itemsize else None,
+      get_available_cast_dtypes(self.DTYPE)
+    ))
   def test_upcast_ops(self): list(map(
-    lambda dtype: _test_ops(a_dtype=self.DTYPE, b_dtype=dtype, target_dtype=dtype) if dtype.sz > self.DTYPE.sz else None,
+    lambda dtype: _test_ops(a_dtype=self.DTYPE, b_dtype=dtype, target_dtype=max([dtype, self.DTYPE], key=lambda x: x.priority)) if dtype.itemsize > self.DTYPE.itemsize else None,
     get_available_cast_dtypes(self.DTYPE)
   ))
   def test_upcast_to_ops(self): list(map(
-    lambda dtype: _test_ops(a_dtype=dtype, b_dtype=self.DTYPE, target_dtype=self.DTYPE) if dtype.sz < self.DTYPE.sz else None,
+    lambda dtype: _test_ops(a_dtype=dtype, b_dtype=self.DTYPE, target_dtype=min([dtype, self.DTYPE], key=lambda x: x.priority)) if dtype.itemsize < self.DTYPE.itemsize else None,
     get_available_cast_dtypes(self.DTYPE)
   ))
 
 def _test_ops(a_dtype:DType, b_dtype:DType, target_dtype:DType):
   if not is_dtype_supported(a_dtype) or not is_dtype_supported(b_dtype): raise unittest.SkipTest("dtype not supported")
+  if a_dtype == dtypes.bool or b_dtype == dtypes.bool: raise unittest.SkipTest("bool not supported")
   _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)+Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [2,4,6,8])
   _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)*Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [1,4,9,16])
   _assert_eq(Tensor([[1,2],[3,4]], dtype=a_dtype)@Tensor.eye(2, dtype=b_dtype), target_dtype, [[1,2],[3,4]])

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -77,17 +77,19 @@ class TestDType(unittest.TestCase):
       get_available_cast_dtypes(self.DTYPE)
     ))
   def test_upcast_ops(self): list(map(
-    lambda dtype: _test_ops(a_dtype=self.DTYPE, b_dtype=dtype, target_dtype=max([dtype, self.DTYPE], key=lambda x: x.priority)) if dtype.itemsize > self.DTYPE.itemsize else None,
+    lambda dtype: _test_ops(a_dtype=self.DTYPE, b_dtype=dtype) if dtype.itemsize > self.DTYPE.itemsize else None,
     get_available_cast_dtypes(self.DTYPE)
   ))
-  def test_upcast_to_ops(self): list(map(
-    lambda dtype: _test_ops(a_dtype=dtype, b_dtype=self.DTYPE, target_dtype=max([dtype, self.DTYPE], key=lambda x: x.priority)) if dtype.itemsize < self.DTYPE.itemsize else None,
+  def test_upcast_to_ops(self):
+    list(map(
+    lambda dtype: _test_ops(a_dtype=dtype, b_dtype=self.DTYPE) if dtype.itemsize < self.DTYPE.itemsize else None,
     get_available_cast_dtypes(self.DTYPE)
   ))
 
-def _test_ops(a_dtype:DType, b_dtype:DType, target_dtype:DType):
+def _test_ops(a_dtype:DType, b_dtype:DType, target_dtype=None):
   if not is_dtype_supported(a_dtype) or not is_dtype_supported(b_dtype): return
   if a_dtype == dtypes.bool or b_dtype == dtypes.bool: return
+  target_dtype = target_dtype or (max([a_dtype, b_dtype], key=lambda x: x.priority) if a_dtype.priority != b_dtype.priority else max([a_dtype, b_dtype], key=lambda x: x.itemsize))
   _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)+Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [2,4,6,8])
   _assert_eq(Tensor([1,2,3,4], dtype=a_dtype)*Tensor([1,2,3,4], dtype=b_dtype), target_dtype, [1,4,9,16])
   _assert_eq(Tensor([[1,2],[3,4]], dtype=a_dtype)@Tensor.eye(2, dtype=b_dtype), target_dtype, [[1,2],[3,4]])

--- a/tinygrad/runtime/ops_torch.py
+++ b/tinygrad/runtime/ops_torch.py
@@ -7,7 +7,7 @@ from tinygrad.runtime.ops_cpu import base_fxn_for_op, einsum_mulacc
 from tinygrad.runtime.lib import RawBuffer
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else ("mps" if getenv("MPS", 0) else "cpu"))
-type_map = {torch.float64: dtypes.float64, torch.float16: dtypes.float16, torch.float32: dtypes.float32, torch.int8: dtypes.int8, torch.int32: dtypes.int32, torch.int64: dtypes.int64, torch.uint8: dtypes.uint8, torch.bool: dtypes.bool}
+type_map = {torch.float64: dtypes.float64, torch.float16: dtypes.float16, torch.float32: dtypes.float32, torch.int8: dtypes.int8, torch.int32: dtypes.int32, torch.int64: dtypes.int64, torch.uint8: dtypes.uint8, torch.bool: dtypes.bool, torch.int16: dtypes.int16}
 inverse_type_map = {v:k for k,v in type_map.items()}
 
 def as_strided(x, arg):


### PR DESCRIPTION
I had mistakenly used `size` instead of `itemsize` for upcasts, fixed here + asserts the upcast/downcast result dtype based on `priority` + one more test for same size ops