### PR TITLE
fix sqlite cache path on Windows

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -157,7 +157,7 @@ class GlobalCounters:
 # *** universal database cache ***
 
 _cache_dir: str = getenv("XDG_CACHE_HOME", os.path.expanduser("~/Library/Caches" if OSX else "~/.cache"))
-CACHEDB: str = getenv("CACHEDB", os.path.join(_cache_dir, "tinygrad", "cache.db"))
+CACHEDB: str = getenv("CACHEDB", os.path.abspath(os.path.join(_cache_dir, "tinygrad", "cache.db")))
 CACHELEVEL = getenv("CACHELEVEL", 2)
 
 VERSION = 6
@@ -165,11 +165,12 @@ _db_connection = None
 def db_connection():
   global _db_connection
   if _db_connection is None:
-    os.makedirs(CACHEDB.rsplit("/", 1)[0], exist_ok=True)
+    os.makedirs(CACHEDB.rsplit(os.sep, 1)[0], exist_ok=True)
     _db_connection = sqlite3.connect(CACHEDB)
     if DEBUG >= 7: _db_connection.set_trace_callback(print)
     if diskcache_get("meta", "version") != VERSION:
       print("cache is out of date, clearing it")
+      _db_connection.close()
       del _db_connection
       os.unlink(CACHEDB)
       _db_connection = sqlite3.connect(CACHEDB)


### PR DESCRIPTION
Fixed #2229.

Trying the sample code from the front page:

```python
from tinygrad.tensor import Tensor

x = Tensor.eye(3, requires_grad=True)
y = Tensor([[2.0,0,-2.0]], requires_grad=True)
z = y.matmul(x).sum()
z.backward()

print(x.grad.numpy())  # dz/dx
print(y.grad.numpy())  # dz/dy
```
fails on Windows with this exception:
```python
Traceback (most recent call last):
  File "hello.py", line 8, in <module>
  File "tinygrad\tensor.py", line 126, in numpy
  File "tinygrad\tensor.py", line 105, in realize
  File "tinygrad\realize.py", line 27, in run_schedule
  File "tinygrad\ops.py", line 292, in exec_ast
  File "tinygrad\ops.py", line 289, in get_program
  File "tinygrad\ops.py", line 239, in to_program
  File "tinygrad\ops.py", line 193, in build
  File "tinygrad\helpers.py", line 212, in wrapper
  File "tinygrad\helpers.py", line 183, in diskcache_get
  File "tinygrad\helpers.py", line 169, in db_connection
    _db_connection = sqlite3.connect(CACHEDB)
                     ^^^^^^^^^^^^^^^^^^^^^^^^
sqlite3.OperationalError: unable to open database file
```

With this PR applied the sample code works:
```
[[ 2.  2.  2.]
 [ 0.  0.  0.]
 [-2. -2. -2.]]
[[1. 1. 1.]]
```