### PR TITLE
remove tokei badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ tinygrad: For something between [PyTorch](https://github.com/pytorch/pytorch) an
 [![GitHub Repo stars](https://img.shields.io/github/stars/tinygrad/tinygrad)](https://github.com/tinygrad/tinygrad/stargazers)
 [![Unit Tests](https://github.com/tinygrad/tinygrad/actions/workflows/test.yml/badge.svg)](https://github.com/tinygrad/tinygrad/actions/workflows/test.yml)
 [![Discord](https://img.shields.io/discord/1068976834382925865)](https://discord.gg/ZjZadyC7PK)
-[![Lines of code](https://img.shields.io/tokei/lines/github/tinygrad/tinygrad)](https://github.com/tinygrad/tinygrad)
 
 </div>
 


### PR DESCRIPTION
this has been broken for a while and upstream wants to deprecate it anyways.
