### PR TITLE
Tell newcomers to use virtualenvs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ The current recommended way to install tinygrad is from source.
 ```sh
 git clone https://github.com/tinygrad/tinygrad.git
 cd tinygrad
+python3 -m venv .venv
+. venv/bin/activate
 python3 -m pip install -e .
 ```
-Don't forget the `.` at the end!
+Don't forget the dots!
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The current recommended way to install tinygrad is from source.
 ```sh
 git clone https://github.com/tinygrad/tinygrad.git
 cd tinygrad
-python3 -m venv .venv
+python3 -m venv venv
 . venv/bin/activate
 python3 -m pip install -e .
 ```


### PR DESCRIPTION
This should fix issues of newcomers polluting their global package space and having issues with imports: #2031 

The readme update uses the built-in `venv` module that's available since 3.3. I thought about using `pyproject.toml` instead of `setup.py` to be compliant with the latest PEPs but I think it's an overkill because the setup right now works just fine.