### PR TITLE
Fix llama lm_eval

### DIFF
--- a/test/external/external_test_opt.py
+++ b/test/external/external_test_opt.py
@@ -85,7 +85,6 @@ class TestInferenceMinKernels(unittest.TestCase):
 
   def test_llama(self):
     from examples.llama import Transformer
-    from tinygrad.shape.symbolic import Variable
     args_tiny = {"dim": 512, "multiple_of": 256, "n_heads": 8, "n_layers": 4, "norm_eps": 1e-05, "vocab_size": 1000}
     model = Transformer(**args_tiny)
     for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=p.dtype.np))

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -56,6 +56,7 @@ class TestRealWorld(unittest.TestCase):
     derandomize_model(model)
     @TinyJit
     def test(t): return model(t, 0).realize()
+    # TODO: calling model like this is pretty wrong with kvcache, also memory test is broken with CacheCollector
     # NOTE: only test one pass, not testing the dynamic shape autoregressive part
     helper_test("test_llama", lambda: (Tensor([[1,]]),), test, 0.22 if CI else 13.5, 137 if CI else 521, all_jitted=True)
 


### PR DESCRIPTION
model call takes int and converts to Variable internally, don't use Variable when not jitted and when Mask is not None.

added an option to return logits that's used by lm_eval