### PR TITLE
dtype promotion priorities

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -109,23 +109,23 @@ class dtypes:
   @staticmethod
   def fields() -> Dict[str, DType]: return DTYPES_DICT
   bool: Final[DType] = DType(0, 1, "bool", np.bool_)
-  float16: Final[DType] = DType(8, 2, "half", np.float16)
+  float16: Final[DType] = DType(9, 2, "half", np.float16)
   half = float16
-  float32: Final[DType] = DType(9, 4, "float", np.float32)
+  float32: Final[DType] = DType(10, 4, "float", np.float32)
   float = float32
-  float64: Final[DType] = DType(10, 8, "double", np.float64)
+  float64: Final[DType] = DType(11, 8, "double", np.float64)
   double = float64
-  int8: Final[DType] = DType(0, 1, "char", np.int8)
-  int16: Final[DType] = DType(2, 2, "short", np.int16)
-  int32: Final[DType] = DType(4, 4, "int", np.int32)
-  int64: Final[DType] = DType(6, 8, "long", np.int64)
-  uint8: Final[DType] = DType(1, 1, "unsigned char", np.uint8)
-  uint16: Final[DType] = DType(3, 2, "unsigned short", np.uint16)
-  uint32: Final[DType] = DType(5, 4, "unsigned int", np.uint32)
-  uint64: Final[DType] = DType(7, 8, "unsigned long", np.uint64)
+  int8: Final[DType] = DType(1, 1, "char", np.int8)
+  int16: Final[DType] = DType(3, 2, "short", np.int16)
+  int32: Final[DType] = DType(5, 4, "int", np.int32)
+  int64: Final[DType] = DType(7, 8, "long", np.int64)
+  uint8: Final[DType] = DType(2, 1, "unsigned char", np.uint8)
+  uint16: Final[DType] = DType(4, 2, "unsigned short", np.uint16)
+  uint32: Final[DType] = DType(6, 4, "unsigned int", np.uint32)
+  uint64: Final[DType] = DType(8, 8, "unsigned long", np.uint64)
 
   # NOTE: bfloat16 isn't supported in numpy
-  bfloat16: Final[DType] = DType(0, 2, "__bf16", None)
+  bfloat16: Final[DType] = DType(9, 2, "__bf16", None)
 
   # NOTE: these are internal dtypes, should probably check for that
   _int2: Final[DType] = DType(2, 4*2, "int2", None, 2)


### PR DESCRIPTION
[883679b31e35969afc622a3f7922491fda18e8d8 ](https://github.com/tinygrad/tinygrad/pull/2306/commits/883679b31e35969afc622a3f7922491fda18e8d8) already did some of this, this PR expands on it.

I read through the JAX and numpy design docs to see how they do it.
The final changes make sure:
1. bool gets promoted to int8
2. bfloat16 and float16 have the same priority

![Figure_1](https://github.com/tinygrad/tinygrad/assets/77887910/dfd8b260-3899-4490-b0ca-c13613a4838e)

The difference with numpy's is that they promote uint+int ops to an int one level higher to avoid data loss in negative numbers:
```
(np.uint16(1) + np.int16(1)).dtype # dtype('int32')
```
If we also wanna do this then it'd probably require some more logic than [`max(dtypes)` ](https://github.com/tinygrad/tinygrad/blob/master/tinygrad/lazy.py#L217)
