### PR TITLE
Searchable tensor cores

### DIFF
--- a/extra/gemm/hconv.py
+++ b/extra/gemm/hconv.py
@@ -1,0 +1,27 @@
+from tinygrad.tensor import Tensor
+from tinygrad.helpers import dtypes, getenv
+from tinygrad.realize import run_schedule
+from tinygrad.ops import Device
+import torch
+import numpy as np
+
+N = getenv("N", 224)
+CIN, COUT = getenv("CIN", 256), getenv("COUT", 256)
+K = getenv("K", 3)
+BS = getenv("BS", 1)
+ITER = getenv("ITER", 1)
+
+x = Tensor.rand(BS, CIN, N, N, dtype=dtypes.half).realize()
+k = Tensor.rand(CIN, COUT, K, K, dtype=dtypes.half).realize()
+
+c = x.conv2d(k, padding=1)
+s = c.lazydata.schedule()
+si = s[-1]
+for _ in range(ITER):
+  Device[si.out.device].exec_ast(si.ast, output=si.out, inputs=si.inputs, var_vals=si.var_vals, **si.out._device_extra_args())
+
+if getenv("TEST", 1):
+  torch_x, torch_k = torch.Tensor(x.numpy()), torch.Tensor(k.numpy())
+  torch_c = torch.nn.functional.conv2d(torch_x, torch_k, padding=1)
+
+  np.testing.assert_allclose(torch_c.numpy(), c.numpy(), atol=1e-2, rtol=1e-2)

--- a/extra/gemm/hgemm.py
+++ b/extra/gemm/hgemm.py
@@ -1,0 +1,37 @@
+from tinygrad.tensor import Tensor
+from tinygrad.helpers import dtypes, getenv
+from tinygrad.realize import run_schedule
+from tinygrad.ops import Device
+from tinygrad.codegen.linearizer import Linearizer
+from tinygrad.codegen.kernel import Opt, OptOps
+from tinygrad.features.search import time_linearizer
+import numpy as np
+
+N = getenv("N", 2048)
+BS = getenv("BS", 1)
+ITER = getenv("ITER", 10)
+
+a = Tensor.rand(BS, N, N, dtype=dtypes.half).realize()
+b = Tensor.rand(BS, N, N, dtype=dtypes.half).realize()
+
+c = (a.reshape((BS, N, 1, N)) * b.permute([0, 2, 1]).reshape((BS, 1, N, N))).cast(dtypes.float).sum(axis=-1).cast(dtypes.half)
+s = c.lazydata.schedule()
+c.realize()
+si = s[-1]
+if getenv("MANUAL", 0):
+  lin = Linearizer(si.ast)
+  lin.apply_tensor_cores(1, hand_coded=False)
+  lin.apply_opt(Opt(OptOps.UPCAST, 0, 4))
+  lin.apply_opt(Opt(OptOps.UPCAST, 1, 4))
+  lin.apply_opt(Opt(OptOps.LASTLOCAL, 1, 4))
+  rawbufs = [c.lazydata.base.realized]+[buf.base.realized for buf in si.inputs]
+  time_linearizer(lin, rawbufs, allow_test_size=False, cnt=1, disable_cache=True, clear_l2=False)
+else:
+  for _ in range(ITER):
+    Device[si.out.device].exec_ast(si.ast, output=si.out, inputs=si.inputs, var_vals=si.var_vals, **si.out._device_extra_args())
+
+if getenv("TEST", 1):
+  import torch
+  np_a, np_b = a.numpy(), b.numpy()
+  ta, tb = torch.Tensor(np_a), torch.Tensor(np_b)
+  np.testing.assert_allclose((ta @ tb).numpy(), c.numpy(), atol=1e-2, rtol=1e-2)

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -485,21 +485,26 @@ class TestLinearizerOpts(unittest.TestCase):
     if Device.DEFAULT not in tensor_cores:
       self.skipTest("No tensor cores for device")
 
+    BS = 3
     N = 128
     Tensor.manual_seed(1552)
-    a = Tensor.rand(N, N)
-    b = Tensor.rand(N, N)
+    a = Tensor.rand(BS, N, N)
+    b = Tensor.rand(BS, N, N)
     r = a@b
     helper_linearizer_opt(r, [
-      [Opt(OptOps.UPCAST, 0, 4)],
       [Opt(OptOps.UPCAST, 1, 4)],
-      [Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.UPCAST, 1, 4)], # check upcasts
+      [Opt(OptOps.UPCAST, 2, 4)],
+      [Opt(OptOps.UPCAST, 1, 4), Opt(OptOps.UPCAST, 2, 4)], # check upcasts
       [Opt(OptOps.UNROLL, 0, 2)], # check last unroll
-      [Opt(OptOps.LASTLOCAL, 0, 4)], # check last local
-      [Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.UNROLL, 0, 2)], # check combo of last unroll and last local
-      [Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.UPCAST, 1, 4), Opt(OptOps.UNROLL, 0, 2)],
-      [Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.UPCAST, 1, 4), Opt(OptOps.UNROLL, 0, 4)],
-      [Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.UPCAST, 1, 4), Opt(OptOps.UNROLL, 0, 4), Opt(OptOps.LASTLOCAL, 0, 2)],
+      [Opt(OptOps.LASTLOCAL, 1, 4)], # check last local
+      [Opt(OptOps.UPCAST, 1, 4), Opt(OptOps.UNROLL, 0, 2)], # check combo of last unroll and last local
+      [Opt(OptOps.UPCAST, 1, 4), Opt(OptOps.UPCAST, 2, 4), Opt(OptOps.UNROLL, 0, 2)],
+      [Opt(OptOps.UPCAST, 1, 4), Opt(OptOps.UPCAST, 2, 4), Opt(OptOps.UNROLL, 0, 4)],
+      [Opt(OptOps.UPCAST, 1, 4), Opt(OptOps.UPCAST, 2, 4), Opt(OptOps.UNROLL, 0, 4), Opt(OptOps.LASTLOCAL, 1, 2)],
+
+      [Opt(OptOps.UPCAST, 2, 4), Opt(OptOps.UPCAST, 1, 4)], # check flipped upcasts
+      [Opt(OptOps.UPCAST, 0, 3)], # check upcast bs
+      [Opt(OptOps.UPCAST, 2, 4), Opt(OptOps.UPCAST, 1, 4), Opt(OptOps.UNROLL, 0, 4), Opt(OptOps.LASTLOCAL, 1, 2), Opt(OptOps.UPCAST, 0, 3)], # check upcast all
       # [Opt(OptOps.GROUP, 0, 2)] # doesn't work because group_for_reduce dims become early locals (conflicting with TC)
     ], apply_tc=True)
 

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -91,10 +91,10 @@ def get_linearizer_actions(lin:Linearizer, include_0=True) -> Dict[int, Lineariz
     try:
       lin2.apply_opt(a)
       up, lcl = 1, 1
-      for s,c in zip(lin2.full_shape, lin2.colors()):
-        if c in {"magenta", "yellow"}: up *= s
+      for j,(s,c) in enumerate(zip(lin2.full_shape, lin2.colors())):
+        if c in {"magenta", "yellow"} and j >= lin2.shape_len-lin2.upcasted+lin2.simd_upcasted: up *= s  # exclude simdupcasted
         if c in {"cyan", "green", "white"}: lcl *= s
-      if up > 256 or lcl > 256: continue
+      if up > 256 or lcl > 256 or ("green" in lin2.colors() and up * lcl >= 2 ** 14): continue
       acted_lins[i+1] = lin2
     except Exception:
       pass

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -102,8 +102,8 @@ def get_linearizer_actions(lin:Linearizer, include_0=True) -> Dict[int, Lineariz
 
 def tuplize_uops(uops:List[UOp]) -> Tuple: return tuple([(x.uop, x.dtype, tuple(uops.index(x) for x in x.vin), x.arg) for x in uops])
 
-def beam_search(lin:Linearizer, rawbufs, amt:int, allow_test_size=True) -> Linearizer:
-  key = {"ast": str(lin.ast), "amt": amt, "allow_test_size": allow_test_size}
+def beam_search(lin:Linearizer, rawbufs, amt:int, allow_test_size=True, variant="") -> Linearizer:
+  key = {"ast": str(lin.ast), "amt": amt, "allow_test_size": allow_test_size, "variant": variant}
   if (val:=diskcache_get("beam_search", key)) is not None and not getenv("IGNORE_BEAM_CACHE") and CACHELEVEL >= 1:
     ret = lin.copy()
     for o in val[len(lin.applied_opts):]: ret.apply_opt(o)

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -162,7 +162,7 @@ _cache_dir: str = getenv("XDG_CACHE_HOME", os.path.expanduser("~/Library/Caches"
 CACHEDB: str = getenv("CACHEDB", os.path.abspath(os.path.join(_cache_dir, "tinygrad", "cache.db")))
 CACHELEVEL = getenv("CACHELEVEL", 2)
 
-VERSION = 6
+VERSION = 7
 _db_connection = None
 def db_connection():
   global _db_connection

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -176,6 +176,7 @@ class NumNode(Node):
   def __eq__(self, other): return self.b == other
   def __hash__(self): return self.hash  # needed with __eq__ override
   def substitute(self, var_vals: Dict[VariableOrNum, Node]) -> Node: return self
+  def unwrap(self): return self.b
 
 def create_node(ret:Node):
   assert ret.min <= ret.max, f"min greater than max! {ret.min} {ret.max} when creating {type(ret)} {ret}"


### PR DESCRIPTION
Adds searchable tensor cores. The approach is to mark some dimensions as SIMD dimensions, and prevent them from being touched. I believe this is not privileging TC, and is general for all SIMD.

The upcast indexing calculations for TC were incorrect. I redid them to use ast_parse mechanisms as much as possible. The plan is to push down the stack until WMMA is just a part of ast_parse.

A small test suite for WMMA is included. I tested on HIP before and after (there is currently a bug with casting that beaks WMMA, cherry-pick the last two commits from https://github.com/chaosagent/tinygrad/tree/simdlocal_push_pre to make it work). I don't have a metal device, so I can't test on METAL.

The search results are OK, maybe a few tens of percent gain on some kernels. Nothing drastic.

flammit had TC be an action in the space. Should be simple to add, maybe next PR...

WINO=1 HALF=1 HIP=1 hlb_cifar is same speed as on master with no beam.

**I have arranged the commits for this PR to be individually reviewable. Hope this helps.**