### PR TITLE
hip free event + a bit faster cpu time

### DIFF
--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -66,9 +66,7 @@ class HIPProgram:
     if wait:
       start, end = hip.hipEventCreate(), hip.hipEventCreate()
       hip.hipEventRecord(start)
-    class PackageStruct(ctypes.Structure):
-      _fields_ = [(f'field{idx}', ctypes.c_void_p if not isinstance(args[idx], int) else ctypes.c_int) for idx in range(len(args))]
-    struct = PackageStruct(*[data._buf if not isinstance(data, int) else np.int32(data) for data in args])
+    struct = hip.getStructTypeForArgs(*args)(*[data._buf if not isinstance(data, int) else np.int32(data) for data in args])
     hip.hipModuleLaunchKernel(self.prgs[args[0]._device], global_size[0], global_size[1], global_size[2], local_size[0], local_size[1], local_size[2], 0, 0, struct)
     if wait:
       hip.hipEventRecord(end)

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -73,7 +73,10 @@ class HIPProgram:
     if wait:
       hip.hipEventRecord(end)
       hip.hipEventSynchronize(end)
-      return hip.hipEventElapsedTime(start, end)*1e-3
+      ret = hip.hipEventElapsedTime(start, end)*1e-3
+      hip.hipEventDestroy(start)
+      hip.hipEventDestroy(end)
+      return ret
 
   def __del__(self):
     for module in self.modules: hip.hipModuleUnload(module)


### PR DESCRIPTION
* Free events.
* Speed up cputime when no hipgraph (19ms->12ms gpt2) + less lines. Creating structure types every call is really expansive.