### PR TITLE
fix: retain or promote dtype for Unaryops.NEG

### DIFF
--- a/examples/beautiful_mnist.py
+++ b/examples/beautiful_mnist.py
@@ -23,12 +23,12 @@ if __name__ == "__main__":
   model = Model()
   opt = nn.optim.Adam(nn.state.get_parameters(model))
 
-  # TODO: there's a compiler error if you comment out TinyJit since randint isn't being realized and there's something weird with int
   @TinyJit
-  def train_step(samples:Tensor) -> Tensor:
+  def train_step() -> Tensor:
     with Tensor.train():
       opt.zero_grad()
       # TODO: this "gather" of samples is very slow. will be under 5s when this is fixed
+      samples = Tensor.randint(512, high=X_train.shape[0])
       loss = model(X_train[samples]).sparse_categorical_crossentropy(Y_train[samples]).backward()
       opt.step()
       return loss.realize()
@@ -39,7 +39,6 @@ if __name__ == "__main__":
   test_acc = float('nan')
   for i in (t:=trange(70)):
     GlobalCounters.reset()   # NOTE: this makes it nice for DEBUG=2 timing
-    samples = Tensor.randint(512, high=X_train.shape[0])  # TODO: put this in the JIT when rand is fixed
-    loss = train_step(samples)
+    loss = train_step()
     if i%10 == 9: test_acc = get_test_acc().item()
     t.set_description(f"loss: {loss.item():6.2f} test_accuracy: {test_acc:5.2f}%")

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -495,7 +495,7 @@ class Linearizer(Kernel):
         if input_acc[off] != acc[off]:
           acc[off] = self.uop(UOps.PHI, dtypes.float32, (input_acc[off], acc[off]) + tuple(loop_ctx))
     else:
-      ret = [(idx, self.uop(UOps.ALU, dtypes.float32, val, x.op)) for idx, val in zip([[i] for i in range(len(values[0]))], zip(*values))]
+      ret = [(idx, self.uop(UOps.ALU, val[0].dtype if x.op is UnaryOps.NEG else dtypes.float32, val, x.op)) for idx, val in zip([[i] for i in range(len(values[0]))], zip(*values))] 
     ordered_ret: List[Optional[UOp]] = [None]*len(values[0])
     # scatter
     for i,j in ret:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -495,7 +495,7 @@ class Linearizer(Kernel):
         if input_acc[off] != acc[off]:
           acc[off] = self.uop(UOps.PHI, dtypes.float32, (input_acc[off], acc[off]) + tuple(loop_ctx))
     else:
-      ret = [(idx, self.uop(UOps.ALU, val[0].dtype if x.op is UnaryOps.NEG else dtypes.float32, val, x.op)) for idx, val in zip([[i] for i in range(len(values[0]))], zip(*values))] 
+      ret = [(idx, self.uop(UOps.ALU, dtypes.promote_on_negation(val[0].dtype) if x.op is UnaryOps.NEG else dtypes.float32, val, x.op)) for idx, val in zip([[i] for i in range(len(values[0]))], zip(*values))] 
     ordered_ret: List[Optional[UOp]] = [None]*len(values[0])
     # scatter
     for i,j in ret:

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -154,6 +154,14 @@ class dtypes:
   @staticmethod
   def imagef(shp): return ImageDType(100, 4, "imagef", np.float32, shp)
 
+  @staticmethod
+  @functools.lru_cache(None)
+  def promote_on_negation(t):
+    return {dtypes.uint8:dtypes.int8,
+            dtypes.uint16:dtypes.int16,
+            dtypes.uint32:dtypes.int32,
+            dtypes.uint64:dtypes.int64}.get(t, t)
+
 # HACK: staticmethods are not callable in 3.8 so we have to compare the class
 DTYPES_DICT = {k: v for k, v in dtypes.__dict__.items() if not k.startswith('__') and not callable(v) and not v.__class__ == staticmethod}
 INVERSE_DTYPES_DICT = {v:k for k,v in DTYPES_DICT.items()}


### PR DESCRIPTION
The linearizer did not retain the dtype on `UnaryOps.NEG`, which meant the linearizer did not re-add a cast for `MAX` ops.

```
#include <metal_stdlib>
using namespace metal;
kernel void E_4_32_4(device int* data0, const device float* data1, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int gidx0 = gid.x; /* 4 */
  int lidx1 = lid.x; /* 32 */
  float4 val0 = (float4)(*((device float4*)(data1+(gidx0*128)+(lidx1*4))));
  int cast0 = (int)(((val0).x*60000.0f));
  int cast1 = (int)(((val0).y*60000.0f));
  int cast2 = (int)(((val0).z*60000.0f));
  int cast3 = (int)(((val0).w*60000.0f));
  float alu0 = max((float)(cast0),0.0f);
  float alu1 = max((float)(cast1),0.0f);
  float alu2 = max((float)(cast2),0.0f);
  float alu3 = max((float)(cast3),0.0f);
  float alu4 = max((-cast0),0.0f); <---- int vs float
  float alu5 = max((-cast1),0.0f);
  float alu6 = max((-cast2),0.0f);
  float alu7 = max((-cast3),0.0f);
  *(data0+(gidx0*128)+(lidx1*4)) = (cast0/(alu0+alu4+1e-10f));
  *(data0+(gidx0*128)+(lidx1*4)+1) = (cast1/(alu1+alu5+1e-10f));
  *(data0+(gidx0*128)+(lidx1*4)+2) = (cast2/(alu2+alu6+1e-10f));
  *(data0+(gidx0*128)+(lidx1*4)+3) = (cast3/(alu3+alu7+1e-10f));
}
```

Causing ambiguous behavior:

```
METAL_FUNC int max(int x, int y)
               ^
program_source:16:16: error: call to 'max' is ambiguous
  float alu5 = max((-cast1),0.0f);
```

This MR allows the linearizer to retain the dtype for `UnaryOps.NEG`, which allows the example to run without `@TinyJit`, and the sample generation can be pulled in.

I also added type unsigned -> signed type promotion on negation.