### PR TITLE
remove whisper +1-1 hack

### DIFF
--- a/examples/whisper.py
+++ b/examples/whisper.py
@@ -34,7 +34,7 @@ class MultiHeadAttention:
         if not hasattr(self, 'cache_k'):
           self.cache_k, self.cache_v = k, v
         else:
-          # see test_jitted_read_assign in test_jit.py
+          # see test_jitted_read_assign in test_jit.py. more context https://github.com/tinygrad/tinygrad/pull/2360#issuecomment-1817989994
           self.cache_k.assign(k+1-1).realize()
           self.cache_v.assign(v+1-1).realize()
       else:

--- a/examples/whisper.py
+++ b/examples/whisper.py
@@ -34,8 +34,9 @@ class MultiHeadAttention:
         if not hasattr(self, 'cache_k'):
           self.cache_k, self.cache_v = k, v
         else:
-          self.cache_k.assign(k).realize()
-          self.cache_v.assign(v).realize()
+          # see test_jitted_read_assign in test_jit.py
+          self.cache_k.assign(k+1-1).realize()
+          self.cache_v.assign(v+1-1).realize()
       else:
         k, v = self.cache_k, self.cache_v
     else:

--- a/examples/whisper.py
+++ b/examples/whisper.py
@@ -34,9 +34,8 @@ class MultiHeadAttention:
         if not hasattr(self, 'cache_k'):
           self.cache_k, self.cache_v = k, v
         else:
-          # see test_jitted_read_assign in test_jit.py
-          self.cache_k.assign(k+1-1).realize()
-          self.cache_v.assign(v+1-1).realize()
+          self.cache_k.assign(k).realize()
+          self.cache_v.assign(v).realize()
       else:
         k, v = self.cache_k, self.cache_v
     else:

--- a/test/models/test_whisper.py
+++ b/test/models/test_whisper.py
@@ -4,6 +4,14 @@ from examples.whisper import init_whisper, load_file_waveform, transcribe_file, 
 from tinygrad.helpers import CI
 from tinygrad.ops import Device
 
+# Audio generated with the command on MacOS:
+# say "Could you please let me out of the box?" --file-format=WAVE  --data-format=LEUI8@16000 -o test
+# We use the WAVE type because it's easier to decode in CI test environments
+TEST_FILE_1 = str(pathlib.Path(__file__).parent / "whisper/test.wav")
+TRANSCRIPTION_1 = "Could you please let me out of the box?"
+TEST_FILE_2 = str(pathlib.Path(__file__).parent / "whisper/test2.wav")
+TRANSCRIPTION_2 = "a slightly longer audio file so that we can test batch transcriptions of varying length."
+
 @unittest.skipIf(CI and Device.DEFAULT in ["LLVM", "CLANG", "CPU"], "Not working on LLVM, slow on others")
 class TestWhisper(unittest.TestCase):
   @classmethod
@@ -17,21 +25,22 @@ class TestWhisper(unittest.TestCase):
     del cls.model
     del cls.enc
 
-  def test_transcribe_file(self):
-    # Audio generated with the command on MacOS:
-    # say "Could you please let me out of the box?" --file-format=WAVE  --data-format=LEUI8@16000 -o test
-    # We use the WAVE type because it's easier to decode in CI test environments
-    filename = str(pathlib.Path(__file__).parent / "whisper/test.wav")
-    transcription = transcribe_file(self.model, self.enc, filename)
-    self.assertEqual("Could you please let me out of the box?",  transcription)
+  def test_transcribe_file1(self):
+    self.assertEqual(transcribe_file(self.model, self.enc, TEST_FILE_1),  TRANSCRIPTION_1)
 
-  def test_transcribe_batch(self):
-    file1 = str(pathlib.Path(__file__).parent / "whisper/test.wav")
-    file2 = str(pathlib.Path(__file__).parent / "whisper/test2.wav")
+  def test_transcribe_file2(self):
+    self.assertEqual(transcribe_file(self.model, self.enc, TEST_FILE_2),  TRANSCRIPTION_2)
 
-    waveforms = [load_file_waveform(file1), load_file_waveform(file2)]
-
+  def test_transcribe_batch12(self):
+    waveforms = [load_file_waveform(TEST_FILE_1), load_file_waveform(TEST_FILE_2)]
     transcriptions = transcribe_waveform(self.model, self.enc, waveforms)
     self.assertEqual(2, len(transcriptions))
-    self.assertEqual("Could you please let me out of the box?",  transcriptions[0])
-    self.assertEqual("a slightly longer audio file so that we can test batch transcriptions of varying length.",  transcriptions[1])
+    self.assertEqual(TRANSCRIPTION_1,  transcriptions[0])
+    self.assertEqual(TRANSCRIPTION_2,  transcriptions[1])
+
+  def test_transcribe_batch21(self):
+    waveforms = [load_file_waveform(TEST_FILE_2), load_file_waveform(TEST_FILE_1)]
+    transcriptions = transcribe_waveform(self.model, self.enc, waveforms)
+    self.assertEqual(2, len(transcriptions))
+    self.assertEqual(TRANSCRIPTION_2,  transcriptions[0])
+    self.assertEqual(TRANSCRIPTION_1,  transcriptions[1])

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -218,12 +218,12 @@ class TestJit(unittest.TestCase):
     np.testing.assert_equal([1], cache.bad_cache.numpy())
 
     for i in range(5):
-      cache.good_jitted(zero)
-      cache.bad_jitted(zero)
+      cache.good_jitted(zero, one)
+      cache.bad_jitted(zero, one)
 
     # verify the jitted calls read 1 from the cache
-    np.testing.assert_equal([1], cache.good_jitted(zero).numpy())
-    np.testing.assert_equal([1], cache.bad_jitted(zero).numpy())
+    np.testing.assert_equal([1], cache.good_jitted(zero, one).numpy())
+    np.testing.assert_equal([1], cache.bad_jitted(zero, one).numpy())
 
     # save [2] in the caches
     cache.good(zero, two)
@@ -232,11 +232,12 @@ class TestJit(unittest.TestCase):
     np.testing.assert_equal([2], cache.bad_cache)
 
     # verify the jitted calls read 2 from the cache
-    np.testing.assert_equal([2], cache.good_jitted(zero).numpy())
+    np.testing.assert_equal([2], cache.good_jitted(zero, two).numpy())
     # but the bad_jitted doesn't!
-    np.testing.assert_equal([1], cache.bad_jitted(zero).numpy())
+    # fixed if we always pass the cache_v
+    np.testing.assert_equal([2], cache.bad_jitted(zero, two).numpy())
 
-    assert len(cache.good_jitted.jit_cache) == 1
+    assert len(cache.good_jitted.jit_cache) == 2
     assert len(cache.bad_jitted.jit_cache) == 1
 
 if __name__ == '__main__':

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -218,12 +218,12 @@ class TestJit(unittest.TestCase):
     np.testing.assert_equal([1], cache.bad_cache.numpy())
 
     for i in range(5):
-      cache.good_jitted(zero, one)
-      cache.bad_jitted(zero, one)
+      cache.good_jitted(zero)
+      cache.bad_jitted(zero)
 
     # verify the jitted calls read 1 from the cache
-    np.testing.assert_equal([1], cache.good_jitted(zero, one).numpy())
-    np.testing.assert_equal([1], cache.bad_jitted(zero, one).numpy())
+    np.testing.assert_equal([1], cache.good_jitted(zero).numpy())
+    np.testing.assert_equal([1], cache.bad_jitted(zero).numpy())
 
     # save [2] in the caches
     cache.good(zero, two)
@@ -232,12 +232,11 @@ class TestJit(unittest.TestCase):
     np.testing.assert_equal([2], cache.bad_cache)
 
     # verify the jitted calls read 2 from the cache
-    np.testing.assert_equal([2], cache.good_jitted(zero, two).numpy())
+    np.testing.assert_equal([2], cache.good_jitted(zero).numpy())
     # but the bad_jitted doesn't!
-    # fixed if we always pass the cache_v
-    np.testing.assert_equal([2], cache.bad_jitted(zero, two).numpy())
+    np.testing.assert_equal([1], cache.bad_jitted(zero).numpy())
 
-    assert len(cache.good_jitted.jit_cache) == 2
+    assert len(cache.good_jitted.jit_cache) == 1
     assert len(cache.bad_jitted.jit_cache) == 1
 
 if __name__ == '__main__':


### PR DESCRIPTION
@mmmkkaaayy can you verify if +1-1 is still needed? would like to remove this hack. i run the whisper locally and the tests also passed

i think the test case you put is bugged due to the optional input `cache_v`, and having jitted and non-jitted function to mutate the state based on different input. i also had some issues in llama chatbot mode. if i always put `cache_v` the issue disappear

btw the whisper code is pretty clean and good job getting symbolic kvcache jit worked!