### PR TITLE
34% LLaMa speed

### DIFF
--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -13,7 +13,7 @@ class TestSymbolic(unittest.TestCase):
   def test_expr_idxs(self):
     x = Variable("x", 1, 100)
     st = ShapeTracker.from_shape((x, 3))
-    idxs = [Variable("x", 0, 100), Variable("y", 0, 100)]
+    idxs = (Variable("x", 0, 100), Variable("y", 0, 100))
     e1, e2 = st.expr_idxs(idxs)
     assert e1.render() == "((x*3)+y)"
     assert e2.render() == "1"

--- a/test/unit/test_shapetracker.py
+++ b/test/unit/test_shapetracker.py
@@ -160,7 +160,7 @@ class TestIndexExpressions2d(unittest.TestCase):
       idx1s = [(0,0), (0, min(1, st.shape[1]-1)), (0, st.shape[1]-1), (min(3, st.shape[1]-1), min(6, st.shape[1]-1)), (st.shape[1]-1, st.shape[1]-1)]
       idx2s = [(0,0), (0, min(1, st.shape[2]-1)), (0, st.shape[2]-1), (min(3, st.shape[2]-1), min(6, st.shape[2]-1)), (st.shape[2]-1, st.shape[2]-1)] if len(st.shape) == 3 else [None for _ in idx0s]
       for idx0, idx1, idx2 in product(idx0s, idx1s, idx2s):
-        idxs = [Variable(f"idx{i}", idx[0], idx[1]) for i, idx in enumerate((idx0, idx1, idx2)) if idx is not None]
+        idxs = tuple([Variable(f"idx{i}", idx[0], idx[1]) for i, idx in enumerate((idx0, idx1, idx2)) if idx is not None])
         assert idxs_expr(idxs) == st.expr_idxs(idxs)[0]
         self.check_bounds(idxs_expr(idxs), offset, numel)
 

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -232,12 +232,12 @@ class Kernel:
   def simplify_ones(self) -> bool:
     # remove places where the shape is all ones
     # TODO: this should be factored in to multi shape stride
-    if self.shape_len == 0: return False
+    if 1 not in self.full_shape: return False
     all_ones = [s==1 for s in self.full_shape]
     self.local_dims -= sum(all_ones[self.first_reduce-self.local_dims:self.first_reduce])
     self.upcasted -= sum(all_ones[self.shape_len-self.upcasted:])
     self.reshape_and_permute(lambda shape: [x for i,x in enumerate(shape) if not all_ones[i]], None)
-    return any(all_ones)
+    return True
 
   def simplify_merge_adjacent(self):
     if self.shape_len == 0: return

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -68,13 +68,13 @@ class Linearizer(Kernel):
       dim, amt = upcast_dim[0], len(float4_expand)
 
     expand_vars = tuple([rename_var(idx.expand_idx(), f"_uidx{j}") for j, idx in enumerate(idxs)])
-    fake_idxs = [idx.substitute({idx.expand_idx(): ev}) for idx, ev in zip(idxs, expand_vars)]
+    fake_idxs = tuple([idx.substitute({idx.expand_idx(): ev}) for idx, ev in zip(idxs, expand_vars)])
     if dim is not None:
-      g_idx, g_valid = self.sts[i].expr_idxs(fake_idxs[:dim] + [float4_expand[0]] + fake_idxs[dim+1:])
+      g_idx, g_valid = self.sts[i].expr_idxs(fake_idxs[:dim] + (float4_expand[0],) + fake_idxs[dim+1:])
       if (g_idx // amt * amt).render() != g_idx.render():
         (g_idx, g_valid), amt, dim = self.sts[i].expr_idxs(fake_idxs), 1, None
     else:
-      g_idx, g_valid = self.sts[i].expr_idxs(fake_idxs)
+      g_idx, g_valid = self.sts[i].expr_idxs(tuple(fake_idxs))
     localtype = dtypes.float32 if amt == 1 else dtypes._float4 if amt == 4 else dtypes._float2
 
     e_idxs, e_valids = g_idx.expand(expand_vars), g_valid.expand(expand_vars)
@@ -320,7 +320,7 @@ class Linearizer(Kernel):
         if self.opts.has_local:
           fake_idxs = [NumNode(0)]*len(self.sts[-1].shape)
           fake_idxs[self.global_dims+self.local_dims:self.global_dims+len(local_idxs)] = local_idxs[self.local_dims:]
-          if_cond: UOp = (self.sts[-1].expr_idxs(fake_idxs)[0]<1).render(self.render_ops, self)
+          if_cond: UOp = (self.sts[-1].expr_idxs(tuple(fake_idxs))[0]<1).render(self.render_ops, self)
           barrier = self.uop(UOps.IF, None, (if_cond, barrier), cachable=False)
 
         # create new late reduce local loops and replace local_idxs that have been used

--- a/tinygrad/realize.py
+++ b/tinygrad/realize.py
@@ -14,7 +14,7 @@ def run_schedule(schedule:List[ScheduleItem], disable_logging=False):
   if IMAGE >= 2: schedule = fix_schedule_for_images(schedule)
 
   # NOTE: if you for loop the schedule it's slow because nothing frees
-  while len(schedule):
+  while schedule:
     si = schedule.pop(0)
     if not disable_logging: log_schedule_item(si)
     assert all(x.realized for x in si.inputs), "can't run schedule, some inputs aren't realized"

--- a/tinygrad/realize.py
+++ b/tinygrad/realize.py
@@ -25,7 +25,8 @@ def run_schedule(schedule:List[ScheduleItem], disable_logging=False):
     else:
       Device[si.out.device].exec_ast(si.ast, output=si.out, inputs=si.inputs, var_vals=si.var_vals, **si.out._device_extra_args())
     del si.out.op
-    for v in si.out.views: del v.op
+    for vr in si.out.views:
+      if (v:=vr()) is not None: del v.op
     assert si.out.realized and isinstance(si.out.realized, Device[si.out.device].buffer), f"device mismatch on realized got {type(si.out.realized)} expected {si.out.device}"
     assert si.out.realized.dtype == si.out.dtype, f"realized dtype is incorrect, {si.out.realized.dtype} != {si.out.dtype}"
 

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -79,7 +79,7 @@ class ShapeTracker:
 
   def size(self): return 0 if (0 in self.shape) else self.expr_idxs()[0].max+1
 
-  def vars(self) -> Set[Variable]: return functools.reduce(operator.or_, [v.vars() for v in self.views], set())
+  def vars(self) -> Set[Variable]: return functools.reduce(operator.or_, [v.vars for v in self.views], set())
 
   @property
   def var_vals(self) -> Dict[Variable, int]: return merge_dicts([dict([v.unbind()]) for v in self.vars()])


### PR DESCRIPTION
 175.67/131.16=1.34 -> 34% faster

Easier to review commit-by-commit.

A stack of performance improvements, mainly.
* set of `WeakRef` instead of a (slow) `WeakRefSet`
* faster handling of buffer info (not recalculating memsize)
* views and shapetrackers expose whether they are symbolic or not (now `view.is_all_int`, could be `view.symbolic` (@chenyuxyz what do you think of this?)
* caches on shapetracker

I suggest splitting this up in one MR per commit. There are some gains left by moving things from `shapetracker.py` to `view.py` that belong there, such as the `merge_view` logic, but then this diff would explode.

Timed on M2 Pro.

Before (0eb0defa6f72eed5c75c8ffe16745d7b9904341a):
```
using METAL backend
using LLaMA-7B model
ram used: 13.48 GB, freqs_cis                                         : 100%|███████████████████████████████████████████████████████████████████████████████████████████████| 292/292 [00:02<00:00, 109.22it/s]
loaded weights in 2681.46 ms, 13.48 GB loaded at 5.03 GB/s
Hello.
ran model in 286.69 ms
total 881.30 ms, 1.13 tok/sec
 I
ran model in 195.53 ms
total 198.68 ms, 5.03 tok/sec
'
ran model in 188.31 ms
total 192.09 ms, 5.21 tok/sec
m
ran model in 176.73 ms
total 180.47 ms, 5.54 tok/sec
 a
ran model in 176.38 ms
total 179.07 ms, 5.58 tok/sec
 
ran model in 175.67 ms
total 179.38 ms, 5.57 tok/sec
2
ran model in 177.33 ms
total 181.07 ms, 5.52 tok/sec
0
ran model in 199.06 ms
total 201.85 ms, 4.95 tok/sec
 year
ran model in 177.85 ms
total 181.59 ms, 5.51 tok/sec
 old
ran model in 179.50 ms
total 183.27 ms, 5.46 tok/sec
```


After:
```
using METAL backend
using LLaMA-7B model
ram used: 13.48 GB, freqs_cis                                         : 100%|████████████████████████████████████████████████████████████████| 292/292 [00:02<00:00, 132.27it/s]
loaded weights in 2215.31 ms, 13.48 GB loaded at 6.08 GB/s
Hello.
ran model in 256.14 ms
total 685.87 ms, 1.46 tok/sec
 I
ran model in 167.88 ms
total 170.09 ms, 5.88 tok/sec
'
ran model in 131.16 ms
total 134.32 ms, 7.44 tok/sec
m
ran model in 150.92 ms
total 154.02 ms, 6.49 tok/sec
 a
ran model in 150.25 ms
total 154.25 ms, 6.48 tok/sec
 
ran model in 135.83 ms
total 138.93 ms, 7.20 tok/sec
2
ran model in 152.59 ms
total 155.65 ms, 6.42 tok/sec
0
ran model in 136.45 ms
total 140.21 ms, 7.13 tok/sec
 year
ran model in 154.36 ms
total 157.38 ms, 6.35 tok/sec
 old
ran model in 131.42 ms
total 134.59 ms, 7.43 tok/sec
```
