### PR TITLE
WIP: directly use Metallib instance

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -251,7 +251,7 @@ class CompiledASTRunner(ASTRunner):
     super().__init__(ast)
 
   def build(self, compiler, runtime):
-    self.lib = compiler.__wrapped__(self.prg) if getenv("DISABLE_COMPILER_CACHE") else compiler(self.prg)
+    self.lib = compiler.__wrapped__(self.prg) if getenv("DISABLE_COMPILER_CACHE") or getenv("METAL") else compiler(self.prg)
     self.clprg = runtime(self.name, self.lib)
     return self
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -251,7 +251,7 @@ class CompiledASTRunner(ASTRunner):
     super().__init__(ast)
 
   def build(self, compiler, runtime):
-    self.lib = compiler.__wrapped__(self.prg) if getenv("DISABLE_COMPILER_CACHE") or getenv("METAL") or Device.DEFAULT is "METAL" else compiler(self.prg)
+    self.lib = compiler.__wrapped__(self.prg) if getenv("DISABLE_COMPILER_CACHE") or getenv("METAL") or Device.DEFAULT == "METAL" or getenv("METAL_XCODE") else compiler(self.prg)
     self.clprg = runtime(self.name, self.lib)
     return self
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -251,7 +251,7 @@ class CompiledASTRunner(ASTRunner):
     super().__init__(ast)
 
   def build(self, compiler, runtime):
-    self.lib = compiler.__wrapped__(self.prg) if getenv("DISABLE_COMPILER_CACHE") or getenv("METAL") else compiler(self.prg)
+    self.lib = compiler.__wrapped__(self.prg) if getenv("DISABLE_COMPILER_CACHE") or getenv("METAL") or Device.DEFAULT is "METAL" else compiler(self.prg)
     self.clprg = runtime(self.name, self.lib)
     return self
 

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -45,7 +45,10 @@ def compile_metal(prg, use_xcode=bool(getenv("METAL_XCODE"))):
   if use_xcode:
     # NOTE: if you run llvm-dis on "air" you can see the llvm bytecode
     air = subprocess.check_output(['xcrun', '-sdk', 'macosx', 'metal', '-x', 'metal', '-c', '-', '-o', '-'], input=prg.encode('utf-8'))
-    return subprocess.check_output(['xcrun', '-sdk', 'macosx', 'metallib', '-', '-o', '-'], input=air)
+    metallib_bytes = subprocess.check_output(['xcrun', '-sdk', 'macosx', 'metallib', '-', '-o', '-'], input=air)
+    with tempfile.NamedTemporaryFile(delete=True) as output_file:
+      with open(output_file.name, 'wb') as f: f.write(metallib_bytes)
+      return unwrap(METAL.device.newLibraryWithURL_error_(output_file.name, None))
   options = Metal.MTLCompileOptions.new()
   library = unwrap(METAL.device.newLibraryWithSource_options_error_(prg, options, None))
   return library


### PR DESCRIPTION
dont use unexposed api and directly use `MetalLibrary`

Metal.framework will auto cache shader IR on disk for you at location:
`$(getconf DARWIN_USER_CACHE_DIR)/com.python.python/com.apple.metal`

**todo:**

- [x] include benchmark info with/without cache
- [ ] investigate why MTLLibrary is being created twice


**benchmarks:**

Initial run with no cache:

<img width="746" alt="image" src="https://github.com/tinygrad/tinygrad/assets/8665427/58f7cf3d-314b-4eef-bd46-d6472e216d1e">

Subsequent run with cache:

<img width="675" alt="image" src="https://github.com/tinygrad/tinygrad/assets/8665427/34e794b7-e156-48a6-95ff-4f475e881fa0">

Generating the MTLLibrary is the most expensive part of compilation in Metal
