### PR TITLE
autopad shapetracker for BEAM

### DIFF
--- a/extra/autopad.py
+++ b/extra/autopad.py
@@ -12,7 +12,8 @@ lin = Linearizer(sched[0].ast)
 # lin.apply_opt(Opt(op=OptOps.LOCAL, axis=0, amt=32))
 
 lin.apply_opt(Opt(op=OptOps.PADTO, axis=0, amt=32))
-# lin.hand_coded_optimizations()
+lin.apply_opt(Opt(op=OptOps.PADTO, axis=1, amt=32))
+lin.hand_coded_optimizations()
 lin.linearize()
 
 run_linearizer(lin)

--- a/extra/autopad.py
+++ b/extra/autopad.py
@@ -4,6 +4,33 @@ from tinygrad.codegen.linearizer import Linearizer
 from test.external.fuzz_linearizer import run_linearizer
 from tinygrad.codegen.kernel import Opt, OptOps
 
+N = 17**3
+# N = 4096
+# a = Tensor.rand(N,N)
+# b = Tensor.rand(N,N)
+# (a @ b).realize()
+
+# quit()
+
+a = Tensor.rand(N, N)
+b = Tensor.rand(N, N)
+c = a @ b
+sched = [si for si in c.lazydata.schedule() if si.ast.op not in LoadOps]
+assert len(sched) == 1
+lin = Linearizer(sched[0].ast)
+
+lin.apply_opt(Opt(op=OptOps.PADTO, axis=0, amt=32))
+lin.apply_opt(Opt(op=OptOps.PADTO, axis=1, amt=32))
+lin.apply_opt(Opt(op=OptOps.PADTO, axis=2, amt=32))
+lin.hand_coded_optimizations()
+lin.linearize()
+print(f"{lin.applied_opts=}")
+
+run_linearizer(lin)
+quit()
+
+###
+
 a = Tensor.rand(61, 61).sum(axis=0)
 sched = [si for si in a.lazydata.schedule() if si.ast.op not in LoadOps]
 assert len(sched) == 1

--- a/extra/autopad.py
+++ b/extra/autopad.py
@@ -1,0 +1,21 @@
+from tinygrad.tensor import Tensor
+from tinygrad.ops import LoadOps
+from tinygrad.codegen.linearizer import Linearizer
+from test.external.fuzz_linearizer import run_linearizer
+from tinygrad.codegen.kernel import Opt, OptOps
+
+a = Tensor.rand(64, 61).sum(axis=0)
+sched = [si for si in a.lazydata.schedule() if si.ast.op not in LoadOps]
+assert len(sched) == 1
+lin = Linearizer(sched[0].ast)
+
+for i, st in enumerate(lin.sts):
+  p = ((0, 3),) + ((0, 0),) * (len(st.shape)-1)
+  lin.sts[i] = st.pad(p)
+
+# lin.apply_opt(Opt(op=OptOps.LOCAL, axis=0, amt=32))
+
+lin.hand_coded_optimizations()
+lin.linearize()
+
+run_linearizer(lin)

--- a/extra/autopad.py
+++ b/extra/autopad.py
@@ -4,18 +4,15 @@ from tinygrad.codegen.linearizer import Linearizer
 from test.external.fuzz_linearizer import run_linearizer
 from tinygrad.codegen.kernel import Opt, OptOps
 
-a = Tensor.rand(64, 61).sum(axis=0)
+a = Tensor.rand(61, 61).sum(axis=0)
 sched = [si for si in a.lazydata.schedule() if si.ast.op not in LoadOps]
 assert len(sched) == 1
 lin = Linearizer(sched[0].ast)
 
-for i, st in enumerate(lin.sts):
-  p = ((0, 3),) + ((0, 0),) * (len(st.shape)-1)
-  lin.sts[i] = st.pad(p)
-
 # lin.apply_opt(Opt(op=OptOps.LOCAL, axis=0, amt=32))
 
-lin.hand_coded_optimizations()
+lin.apply_opt(Opt(op=OptOps.PADTO, axis=0, amt=32))
+# lin.hand_coded_optimizations()
 lin.linearize()
 
 run_linearizer(lin)

--- a/extra/autopad.py
+++ b/extra/autopad.py
@@ -5,12 +5,6 @@ from test.external.fuzz_linearizer import run_linearizer
 from tinygrad.codegen.kernel import Opt, OptOps
 
 N = 17**3
-# N = 4096
-# a = Tensor.rand(N,N)
-# b = Tensor.rand(N,N)
-# (a @ b).realize()
-
-# quit()
 
 a = Tensor.rand(N, N)
 b = Tensor.rand(N, N)

--- a/extra/optimization/test_beam_search.py
+++ b/extra/optimization/test_beam_search.py
@@ -17,6 +17,25 @@ class TestBeamSearch(unittest.TestCase):
     a = Tensor.rand(3, 3).reshape((Variable("a", 1, 10).bind(3), 3))
     a = (a+1).realize()
 
+  def test_big_prime_number(self):
+    a = Tensor.rand(367, 367)
+    b = Tensor.rand(367, 367)
+    c = (a@b).realize()
+    np.testing.assert_allclose(c.numpy(), a.numpy() @ b.numpy(), atol=1e-4, rtol=1e-4)
+
+  def test_variable_big_prime_number(self):
+    v = Variable("v", 1, 400).bind(367)
+    a = Tensor.rand(367, 367)
+    b = Tensor.rand(367, 367)
+    c = (a.reshape(367, v) @ b.reshape(v, 367)).realize()
+    np.testing.assert_allclose(c.numpy(), a.numpy() @ b.numpy(), atol=1e-4, rtol=1e-4)
+
+  def test_variable_shrink_prime_number(self):
+    v = Variable("v", 1, 400).bind(367)
+    a = Tensor.rand(400, 367)
+    b = (a.shrink(((0,v), None))+1).reshape(367,367).realize()
+    np.testing.assert_allclose(b.numpy(), a.numpy()[:367]+1, atol=1e-4, rtol=1e-4)
+
   def test_no_mutate_rawbuffers(self):
     a = Tensor.rand(3, 3).realize()
     desired = a.numpy() + 1

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -184,6 +184,10 @@ if (getenv('LLVM') or getenv('CUDA')) and CI:
 # error: casting to type 'half' is not allowed
 backend_test.exclude('test_dequantizelinear_e4m3fn_float16_cpu')
 
+# TODO: investigate this. bugged only with hand_coded_optimizations, with NOOPT it's fine
+if getenv('GPU') or getenv('METAL') or getenv('LLVM') or getenv('CLANG'):
+  backend_test.exclude('test_MaxPool3d_stride_padding_cpu')
+
 # disable model tests for now since they are slow
 if not getenv("MODELTESTS"):
   for x in backend_test.test_suite:

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -184,9 +184,9 @@ if (getenv('LLVM') or getenv('CUDA')) and CI:
 # error: casting to type 'half' is not allowed
 backend_test.exclude('test_dequantizelinear_e4m3fn_float16_cpu')
 
-# # TODO: this does not pass if run locally
-# if getenv('GPU') or getenv('METAL') or getenv('LLVM') or getenv('CLANG'):
-#   backend_test.exclude('test_MaxPool3d_stride_padding_cpu')
+# TODO: this somehow passes in CI but does not pass if run locally
+if getenv('GPU') or getenv('METAL') or getenv('LLVM') or getenv('CLANG'):
+  backend_test.exclude('test_MaxPool3d_stride_padding_cpu')
 
 # disable model tests for now since they are slow
 if not getenv("MODELTESTS"):

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -184,9 +184,9 @@ if (getenv('LLVM') or getenv('CUDA')) and CI:
 # error: casting to type 'half' is not allowed
 backend_test.exclude('test_dequantizelinear_e4m3fn_float16_cpu')
 
-# TODO: investigate this. bugged only with hand_coded_optimizations, with NOOPT it's fine
-if getenv('GPU') or getenv('METAL') or getenv('LLVM') or getenv('CLANG'):
-  backend_test.exclude('test_MaxPool3d_stride_padding_cpu')
+# # TODO: this does not pass if run locally
+# if getenv('GPU') or getenv('METAL') or getenv('LLVM') or getenv('CLANG'):
+#   backend_test.exclude('test_MaxPool3d_stride_padding_cpu')
 
 # disable model tests for now since they are slow
 if not getenv("MODELTESTS"):

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -489,7 +489,7 @@ class TestLinearizerOpts(unittest.TestCase):
 
   def test_padto_matmul(self):
     if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
-    if Device.DEFAULT in ["LLVM"]: self.skipTest("no supported for triton and LLVM")
+    if Device.DEFAULT in ["CUDA", "LLVM"]: self.skipTest("no supported for triton and LLVM")
     N = 17 * 17
     Tensor.manual_seed(289)
     a = Tensor.rand(N, N)
@@ -506,7 +506,7 @@ class TestLinearizerOpts(unittest.TestCase):
   def test_padto_max(self):
     # pad uses invalid value 0, so max is not allowed
     if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
-    if Device.DEFAULT in ["LLVM"]: self.skipTest("no supported for triton and LLVM")
+    if Device.DEFAULT in ["CUDA", "LLVM"]: self.skipTest("no supported for triton and LLVM")
     N = 17 * 17
     a = -Tensor.ones(N, N)
     with self.assertRaises(AssertionError):

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -487,7 +487,7 @@ class TestLinearizerOpts(unittest.TestCase):
       # [Opt(OptOps.GROUP, 0, 2)] # doesn't work because group_for_reduce dims become early locals (conflicting with TC)
     ], apply_tc=True)
 
-  def test_padto(self):
+  def test_padto_matmul(self):
     if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
     if Device.DEFAULT in ["CUDA", "LLVM"]: self.skipTest("no supported for triton and LLVM")
     N = 17 * 17
@@ -502,6 +502,15 @@ class TestLinearizerOpts(unittest.TestCase):
       # can optimize further post PADTO
       [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32), Opt(OptOps.PADTO, 2, 32), Opt(OptOps.UPCAST, 0, 2), Opt(OptOps.UNROLL, 0, 4)],
     ])
+
+  def test_padto_max(self):
+    # pad uses invalid value 0, so max is not allowed
+    if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
+    if Device.DEFAULT in ["CUDA", "LLVM"]: self.skipTest("no supported for triton and LLVM")
+    N = 17 * 17
+    a = -Tensor.ones(N, N)
+    with self.assertRaises(AssertionError):
+      helper_linearizer_opt(a.max(), [[Opt(OptOps.PADTO, 0, 32)],])
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -510,5 +510,13 @@ class TestLinearizerOpts(unittest.TestCase):
     with self.assertRaises(AssertionError):
       helper_linearizer_opt(a.max(), [[Opt(OptOps.PADTO, 0, 32)],])
 
+  def test_padto_where(self):
+    # pad uses invalid value 0, so kernel with max is not allowed
+    if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
+    N = 17 * 17
+    a = (Tensor.rand(N, N).max(axis=0) > 1).where(1, 0)
+    with self.assertRaises(AssertionError):
+      helper_linearizer_opt(a.max(), [[Opt(OptOps.PADTO, 0, 32)],])
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -489,7 +489,7 @@ class TestLinearizerOpts(unittest.TestCase):
 
   def test_padto_matmul(self):
     if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
-    if Device.DEFAULT in ["CUDA", "LLVM"]: self.skipTest("no supported for triton and LLVM")
+    if Device.DEFAULT in ["LLVM"]: self.skipTest("no supported for triton and LLVM")
     N = 17 * 17
     Tensor.manual_seed(289)
     a = Tensor.rand(N, N)
@@ -506,7 +506,7 @@ class TestLinearizerOpts(unittest.TestCase):
   def test_padto_max(self):
     # pad uses invalid value 0, so max is not allowed
     if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
-    if Device.DEFAULT in ["CUDA", "LLVM"]: self.skipTest("no supported for triton and LLVM")
+    if Device.DEFAULT in ["LLVM"]: self.skipTest("no supported for triton and LLVM")
     N = 17 * 17
     a = -Tensor.ones(N, N)
     with self.assertRaises(AssertionError):

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -7,7 +7,7 @@ from tinygrad.ops import Compiled, Device, LoadOps
 from tinygrad.tensor import Tensor
 from tinygrad.jit import CacheCollector
 from tinygrad.realize import run_schedule
-from tinygrad.helpers import dtypes, prod
+from tinygrad.helpers import dtypes, prod, getenv, CI
 
 class TestLinearizer(unittest.TestCase):
   def test_arg_dedup(self):
@@ -489,6 +489,7 @@ class TestLinearizerOpts(unittest.TestCase):
 
   def test_padto_matmul(self):
     if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
+    if getenv("TRITON") and CI: self.skipTest("works locally, hangs in CI")
     N = 17 * 17
     Tensor.manual_seed(289)
     a = Tensor.rand(N, N)

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -489,7 +489,6 @@ class TestLinearizerOpts(unittest.TestCase):
 
   def test_padto_matmul(self):
     if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
-    if getenv("TRITON") and CI: self.skipTest("works locally, hangs in CI")
     N = 17 * 17
     Tensor.manual_seed(289)
     a = Tensor.rand(N, N)

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -488,8 +488,8 @@ class TestLinearizerOpts(unittest.TestCase):
     ], apply_tc=True)
 
   def test_padto(self):
-    if not isinstance(Device[Device.DEFAULT], Compiled):
-      self.skipTest("Only Compiled uses linearizer")
+    if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
+    if Device.DEFAULT in ["CUDA", "LLVM"]: self.skipTest("no supported for triton and LLVM")
     N = 17 * 17
     Tensor.manual_seed(289)
     a = Tensor.rand(N, N)

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -489,7 +489,6 @@ class TestLinearizerOpts(unittest.TestCase):
 
   def test_padto_matmul(self):
     if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
-    if Device.DEFAULT in ["LLVM"]: self.skipTest("no supported for triton and LLVM")
     N = 17 * 17
     Tensor.manual_seed(289)
     a = Tensor.rand(N, N)
@@ -506,7 +505,6 @@ class TestLinearizerOpts(unittest.TestCase):
   def test_padto_max(self):
     # pad uses invalid value 0, so max is not allowed
     if not isinstance(Device[Device.DEFAULT], Compiled): self.skipTest("Only Compiled uses linearizer")
-    if Device.DEFAULT in ["LLVM"]: self.skipTest("no supported for triton and LLVM")
     N = 17 * 17
     a = -Tensor.ones(N, N)
     with self.assertRaises(AssertionError):

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -361,6 +361,9 @@ def helper_linearizer_opt(r:Tensor, opts=[], apply_tc=False):
   for x in opts: # Check custom transformations if any.
     check_opt(x, lambda: Linearizer(realized_ast), Device[Device.DEFAULT].to_program)
 
+class TestLinearizerPadShapetracker(unittest.TestCase):
+  pass
+
 class TestLinearizerOpts(unittest.TestCase):
   def test_local_and_grouped_reduce(self):
     if not isinstance(Device[Device.DEFAULT], Compiled) or not Device[Device.DEFAULT].linearizer_opts.has_local or not Device[Device.DEFAULT].linearizer_opts.has_shared:

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -452,7 +452,7 @@ class Kernel:
       assert not self.dont_use_locals, "already not using locals"
       self.dont_use_locals = True
     elif opt.op == OptOps.PADTO:
-      assert Device.DEFAULT not in ["CUDA", "LLVM"], "not supported for triton and LLVM"
+      assert Device.DEFAULT not in ["LLVM"], "not supported for triton and LLVM"
       assert not vars_from_ast(self.ast), "does not work with symbolic shape"
       assert all(op.op is not ReduceOps.MAX for op in self.ast.get_lazyops()), "cannot pad with MAX"
       padded = False

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -453,7 +453,7 @@ class Kernel:
       self.dont_use_locals = True
     elif opt.op == OptOps.PADTO:
       assert not vars_from_ast(self.ast), "does not work with symbolic shape"
-      assert self.reduceop is None or self.reduceop is not ReduceOps.MAX, "cannot pad with MAX"
+      assert all(op.op is not ReduceOps.MAX for op in self.ast.get_lazyops()), "cannot pad with MAX"
       padded = False
       for i,st in enumerate(self.sts):
         if self.sts[i].shape[axis] != 1:

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -451,7 +451,7 @@ class Kernel:
       assert not self.dont_use_locals, "already not using locals"
       self.dont_use_locals = True
     elif opt.op == OptOps.PADTO:
-      assert Device.DEFAULT not in ["CUDA", "LLVM"], "no supported for triton and LLVM"
+      assert Device.DEFAULT not in ["CUDA", "LLVM"], "not supported for triton and LLVM"
       padded = False
       for i,st in enumerate(self.sts):
         if self.sts[i].shape[axis] != 1:

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -456,11 +456,14 @@ class Kernel:
       assert not self.dont_use_locals, "already not using locals"
       self.dont_use_locals = True
     elif opt.op == OptOps.PADTO:
-      ru = round_up(self.sts[0].shape[axis], amt) - self.sts[0].shape[axis]
-      print(f"{self.sts[0].shape[axis]=}, {amt=}, {ru=}")
-      # TODO: does it matter if you pad left or pad right?
+      padded = False
       for i,st in enumerate(self.sts):
-        self.sts[i] = st.pad(((0,0),) * axis + ((0,ru),) + ((0,0),) * (len(st.shape)-axis-1))
+        if self.sts[i].shape[axis] != 1:
+          if (ru := round_up(self.sts[i].shape[axis], amt) - self.sts[i].shape[axis]):
+            # TODO: does it matter if you pad left or pad right?
+            self.sts[i] = st.pad(((0,0),) * axis + ((0,ru),) + ((0,0),) * (len(st.shape)-axis-1))
+            padded = True
+      assert padded, "nothing was padded"
     return self.simplify_ones()
 
   def required_optimizations(self, early_only=False):

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -452,7 +452,6 @@ class Kernel:
       assert not self.dont_use_locals, "already not using locals"
       self.dont_use_locals = True
     elif opt.op == OptOps.PADTO:
-      assert Device.DEFAULT not in ["LLVM"], "not supported for triton and LLVM"
       assert not vars_from_ast(self.ast), "does not work with symbolic shape"
       assert all(op.op is not ReduceOps.MAX for op in self.ast.get_lazyops()), "cannot pad with MAX"
       padded = False

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -453,7 +453,7 @@ class Kernel:
       self.dont_use_locals = True
     elif opt.op == OptOps.PADTO:
       assert not vars_from_ast(self.ast), "does not work with symbolic shape"
-      assert all(op.op is not ReduceOps.MAX for op in self.ast.get_lazyops()), "cannot pad with MAX"
+      assert self.reduceop is None or self.reduceop is not ReduceOps.MAX, "cannot pad with MAX"
       padded = False
       for i,st in enumerate(self.sts):
         if self.sts[i].shape[axis] != 1:

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -459,6 +459,7 @@ class Kernel:
       padded = False
       for i,st in enumerate(self.sts):
         if self.sts[i].shape[axis] != 1:
+          assert self.sts[i].shape[axis] > 16, "too slow"
           if (ru := round_up(self.sts[i].shape[axis], amt) - self.sts[i].shape[axis]):
             # TODO: does it matter if you pad left or pad right?
             self.sts[i] = st.pad(((0,0),) * axis + ((0,ru),) + ((0,0),) * (len(st.shape)-axis-1))

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -454,6 +454,7 @@ class Kernel:
     elif opt.op == OptOps.PADTO:
       assert Device.DEFAULT not in ["CUDA", "LLVM"], "not supported for triton and LLVM"
       assert not vars_from_ast(self.ast), "does not work with symbolic shape"
+      assert all(op.op is not ReduceOps.MAX for op in self.ast.get_lazyops()), "cannot pad with MAX"
       padded = False
       for i,st in enumerate(self.sts):
         if self.sts[i].shape[axis] != 1:

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os, math, itertools
 from typing import NamedTuple, Optional, List, Tuple, cast, Dict, Union
+from tinygrad.lazy import vars_from_ast
 from tinygrad.ops import LazyOp, FlopCounter, get_lazyop_info, UnaryOps, BinaryOps, ReduceOps, MemBuffer, ConstBuffer, BufferOps, Device, Compiled
 from tinygrad.helpers import dedup, dtypes, colored, ImageDType, DType, ansilen, getenv, prod, DEBUG, round_up
 from tinygrad.shape.shapetracker import ShapeTracker, get_contraction
@@ -452,6 +453,7 @@ class Kernel:
       self.dont_use_locals = True
     elif opt.op == OptOps.PADTO:
       assert Device.DEFAULT not in ["CUDA", "LLVM"], "not supported for triton and LLVM"
+      assert not vars_from_ast(self.ast), "does not work with symbolic shape"
       padded = False
       for i,st in enumerate(self.sts):
         if self.sts[i].shape[axis] != 1:

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -400,10 +400,8 @@ class Kernel:
       axis = -1
     if opt.amt is not None:
       amt = opt.amt if opt.amt != 0 else self.full_shape[axis]
-      assert isinstance(amt, int), "no symbolic amt"
-      if opt.op != OptOps.PADTO:
-        assert self.full_shape[axis] % amt == 0, "no longer valid shift"
-        assert isinstance(amt, int) and amt != 1, "shift of amt 1 or Node is meaningless"
+      assert isinstance(amt, int) and amt != 1, "shift/padto of amt 1 or Node is meaningless"
+      if opt.op != OptOps.PADTO: assert self.full_shape[axis] % amt == 0, "no longer valid shift"
     else:
       amt = -1
     if opt.op == OptOps.LOCAL:        # cyan
@@ -453,6 +451,7 @@ class Kernel:
       assert not self.dont_use_locals, "already not using locals"
       self.dont_use_locals = True
     elif opt.op == OptOps.PADTO:
+      assert Device.DEFAULT not in ["CUDA", "LLVM"], "no supported for triton and LLVM"
       padded = False
       for i,st in enumerate(self.sts):
         if self.sts[i].shape[axis] != 1:

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -452,7 +452,7 @@ class Kernel:
       assert not self.dont_use_locals, "already not using locals"
       self.dont_use_locals = True
     elif opt.op == OptOps.PADTO:
-      assert Device.DEFAULT not in ["LLVM"], "not supported for triton and LLVM"
+      assert Device.DEFAULT not in ["CUDA", "LLVM"], "not supported for triton and LLVM"
       assert not vars_from_ast(self.ast), "does not work with symbolic shape"
       assert all(op.op is not ReduceOps.MAX for op in self.ast.get_lazyops()), "cannot pad with MAX"
       padded = False

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -131,8 +131,8 @@ class Linearizer(Kernel):
         amt = len(out_tokens)
         idx, valid = self.sts[i].expr_idxs(k)
         assert idx.render() == ((idx//amt)*amt).render(), "float4 stores are always aligned"
-        assert valid.min == 1, "stores are always valid"
-        store_offset_new[k] = self.uop(UOps.CAST, dtypes.float.vec(amt), tuple(out_tokens))
+        # assert valid.min == 1, "stores are always valid"
+        store_offset_new[k] = self.uop(UOps.CAST, dtypes._float4 if amt == 4 else dtypes._float2, tuple(out_tokens))
       store_offset = store_offset_new
 
     stores = []

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -130,7 +130,7 @@ class Linearizer(Kernel):
         amt = len(out_tokens)
         idx, valid = self.sts[i].expr_idxs(k)
         assert idx.render() == ((idx//amt)*amt).render(), "float4 stores are always aligned"
-        store_offset_new[k] = self.uop(UOps.CAST, dtypes._float4 if amt == 4 else dtypes._float2, tuple(out_tokens))
+        store_offset_new[k] = self.uop(UOps.CAST, dtypes.float.vec(amt), tuple(out_tokens))
       store_offset = store_offset_new
 
     stores = []

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -388,7 +388,7 @@ class Linearizer(Kernel):
         u.vin = tuple(new if x is old else x for x in u.vin)
       self.uops.remove(old)
 
-    # fix loop scope, push CONST and ALU out of loop
+    # fix loop scope, push CONST and ALU upward out of loop if it does not depend on the loop
     loop_stack: List[List[UOp]] = [[]]
     for u in self.uops:
       if not loop_stack[-1]: loop_stack[-1].append(u)

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -395,7 +395,7 @@ class Linearizer(Kernel):
     # fix loop scope, push CONST and ALU out of loop
     # TODO: what if we have 2 independent for loop? is it fine?
     # TODO: how about if?
-    loop_stack = [[]]
+    loop_stack: List[List[UOp]] = [[]]
     for u in self.uops:
       if not loop_stack[-1]: loop_stack[-1].append(u)
       elif u.uop == UOps.LOOP: loop_stack.append([u])

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -13,6 +13,7 @@ actions = flatten([[Opt(op=OptOps.UPCAST, axis=axis, amt=amt) for amt in [0,2,3,
 actions += flatten([[Opt(op=OptOps.UNROLL, axis=axis, amt=amt) for amt in [0,4]] for axis in range(4)])
 actions += flatten([[Opt(op=OptOps.LOCAL, axis=axis, amt=amt) for amt in [2,3,4,8,13,16,29]] for axis in range(5)])
 actions += flatten([[Opt(op=OptOps.GROUPTOP, axis=axis, amt=amt) for amt in [13,16,29,32,256]] for axis in range(3)])
+actions += flatten([[Opt(op=OptOps.PADTO, axis=axis, amt=amt) for amt in [4,32]] for axis in range(4)])
 actions += [
   Opt(op=OptOps.LOCAL, axis=0, amt=32),
   Opt(op=OptOps.GROUP, axis=0, amt=4), Opt(op=OptOps.GROUP, axis=0, amt=8), Opt(op=OptOps.GROUP, axis=1, amt=8),

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -13,7 +13,7 @@ actions = flatten([[Opt(op=OptOps.UPCAST, axis=axis, amt=amt) for amt in [0,2,3,
 actions += flatten([[Opt(op=OptOps.UNROLL, axis=axis, amt=amt) for amt in [0,4]] for axis in range(4)])
 actions += flatten([[Opt(op=OptOps.LOCAL, axis=axis, amt=amt) for amt in [2,3,4,8,13,16,29]] for axis in range(5)])
 actions += flatten([[Opt(op=OptOps.GROUPTOP, axis=axis, amt=amt) for amt in [13,16,29,32,256]] for axis in range(3)])
-actions += flatten([[Opt(op=OptOps.PADTO, axis=axis, amt=amt) for amt in [4,32]] for axis in range(4)])
+actions += flatten([[Opt(op=OptOps.PADTO, axis=axis, amt=amt) for amt in [32]] for axis in range(7)])
 actions += [
   Opt(op=OptOps.LOCAL, axis=0, amt=32),
   Opt(op=OptOps.GROUP, axis=0, amt=4), Opt(op=OptOps.GROUP, axis=0, amt=8), Opt(op=OptOps.GROUP, axis=1, amt=8),

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -177,7 +177,7 @@ _cache_dir: str = getenv("XDG_CACHE_HOME", os.path.expanduser("~/Library/Caches"
 CACHEDB: str = getenv("CACHEDB", os.path.abspath(os.path.join(_cache_dir, "tinygrad", "cache.db")))
 CACHELEVEL = getenv("CACHELEVEL", 2)
 
-VERSION = 9
+VERSION = 10
 _db_connection = None
 def db_connection():
   global _db_connection

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -177,7 +177,7 @@ _cache_dir: str = getenv("XDG_CACHE_HOME", os.path.expanduser("~/Library/Caches"
 CACHEDB: str = getenv("CACHEDB", os.path.abspath(os.path.join(_cache_dir, "tinygrad", "cache.db")))
 CACHELEVEL = getenv("CACHELEVEL", 2)
 
-VERSION = 10
+VERSION = 9
 _db_connection = None
 def db_connection():
   global _db_connection

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -324,7 +324,7 @@ class Compiled:
       for i,a in enumerate(inputs):
         # TODO: if this is contiguous it's fine
         if a.realized == output.realized:
-          if any(not x.arg.st.contiguous for x in ast.get_lazyops() if x.op == BufferOps.MEM and x.arg.idx == i+1):
+          if any(x.arg.st != output.st for x in ast.get_lazyops() if x.op == BufferOps.MEM and x.arg.idx == i+1):
             output.realized = None
             break
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -324,7 +324,7 @@ class Compiled:
       for i,a in enumerate(inputs):
         # TODO: if this is contiguous it's fine
         if a.realized == output.realized:
-          if any(x.arg.st != output.st for x in ast.get_lazyops() if x.op == BufferOps.MEM and x.arg.idx == i+1):
+          if any(not x.arg.st.contiguous for x in ast.get_lazyops() if x.op == BufferOps.MEM and x.arg.idx == i+1):
             output.realized = None
             break
 

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -78,9 +78,6 @@ class CStyleLanguage(NamedTuple):
   def render_if(self, cond: str):
     return f"if ({cond}) {{"
 
-  def render_inline_if(self, cond: str, body:str):
-    return f"if ({cond}) {{ {body} }}"
-
   def render_conditional(self, cond: str, x:str, y:str) -> str:
     return f"({cond})?({x}):{y}"
 
@@ -190,9 +187,9 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp]) -> Tu
       r[u] = r[vin[0]]
     elif uop == UOps.STORE:
       assert vin[0].dtype is not None and vin[2].dtype is not None
-      store = lang.render_store(r[vin[0]], vin[0].dtype, r[vin[2]], vin[2].dtype, strip_parens(r[vin[1]]), vin[0].uop == UOps.DEFINE_LOCAL)
-      if len(vin) > 3: kk(lang.render_inline_if(r[vin[3]], store))
-      else: kk(store)
+      if len(vin) > 3: kk(lang.render_if(r[vin[3]]))
+      kk(lang.render_store(r[vin[0]], vin[0].dtype, r[vin[2]], vin[2].dtype, strip_parens(r[vin[1]]), vin[0].uop == UOps.DEFINE_LOCAL))
+      if len(vin) > 3: kk("}")
     elif uop == UOps.CAST and dtype is not None:
       val = lang.render_cast([r[x] for x in vin], dtype)
       if child_count[u] <= 1: r[u] = val

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -78,6 +78,9 @@ class CStyleLanguage(NamedTuple):
   def render_if(self, cond: str):
     return f"if ({cond}) {{"
 
+  def render_inline_if(self, cond: str, body:str):
+    return f"if ({cond}) {{ {body} }}"
+
   def render_conditional(self, cond: str, x:str, y:str) -> str:
     return f"({cond})?({x}):{y}"
 
@@ -187,7 +190,9 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp]) -> Tu
       r[u] = r[vin[0]]
     elif uop == UOps.STORE:
       assert vin[0].dtype is not None and vin[2].dtype is not None
-      kk(lang.render_store(r[vin[0]], vin[0].dtype, r[vin[2]], vin[2].dtype, strip_parens(r[vin[1]]), vin[0].uop == UOps.DEFINE_LOCAL))
+      store = lang.render_store(r[vin[0]], vin[0].dtype, r[vin[2]], vin[2].dtype, strip_parens(r[vin[1]]), vin[0].uop == UOps.DEFINE_LOCAL)
+      if len(vin) > 3: kk(lang.render_inline_if(r[vin[3]], store))
+      else: kk(store)
     elif uop == UOps.CAST and dtype is not None:
       val = lang.render_cast([r[x] for x in vin], dtype)
       if child_count[u] <= 1: r[u] = val

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -140,7 +140,10 @@ def uops_to_llvm_ir(function_name:str, uops:List[UOp]) -> Tuple[str, Dict]:
       lvars[backward] = lvars[u]
     if uop == UOps.STORE:
       element = cast(bb, lvars[vin[2]], vin[2].dtype, vin[0].dtype)
-      bb[-1].store(element, bb[-1].gep(lvars[vin[0]], [lvars[vin[1]]], inbounds=True))
+      def store_op(): bb[-1].store(element, bb[-1].gep(lvars[vin[0]], [lvars[vin[1]]], inbounds=True))
+      if len(vin) > 3:
+        with bb[-1].if_then(bb[-1].trunc(lvars[vin[3]], ir.IntType(1))): store_op()
+      else: store_op()
     if uop == UOps.ALU:
       lvars[u] = cast(bb, code_for_op[args](bb[-1], *[cast(bb, lvars[x], x.dtype, dtypes.float) for x in vin]), dtypes.float, dtype)
     if uop == UOps.CAST: lvars[u] = cast(bb, lvars[vin[0]], vin[0].dtype, dtype)

--- a/tinygrad/renderer/triton.py
+++ b/tinygrad/renderer/triton.py
@@ -95,7 +95,7 @@ def uops_to_triton(function_name:str, uops:List[UOp]):
       r[u] = r[vin[0]]
     elif uop == UOps.STORE:
       assert not isinstance(dtype, ImageDType), "unimplemented: image store"
-      kk(f"{'if '+r[vin[3]]+': ' if len(vin)>3 else ''}tl.store({r[vin[0]]} + {r[vin[1]]}, {r[vin[2]].replace('//', '/')}, mask = {render_valid(valid)}) ")
+      kk(f"tl.store({r[vin[0]]} + {r[vin[1]]}, {r[vin[2]].replace('//', '/')}, mask = {render_valid(valid)}) ")
     elif uop == UOps.DEFINE_GLOBAL:
       bufs.append(args)
       signatures.append(signature_dtypes[args[1]])

--- a/tinygrad/renderer/triton.py
+++ b/tinygrad/renderer/triton.py
@@ -95,7 +95,7 @@ def uops_to_triton(function_name:str, uops:List[UOp]):
       r[u] = r[vin[0]]
     elif uop == UOps.STORE:
       assert not isinstance(dtype, ImageDType), "unimplemented: image store"
-      kk(f"tl.store({r[vin[0]]} + {r[vin[1]]}, {r[vin[2]].replace('//', '/')}, mask = {render_valid(valid)}) ")
+      kk(f"{'if '+r[vin[3]]+': ' if len(vin)>3 else ''}tl.store({r[vin[0]]} + {r[vin[1]]}, {r[vin[2]].replace('//', '/')}, mask = {render_valid(valid)}) ")
     elif uop == UOps.DEFINE_GLOBAL:
       bufs.append(args)
       signatures.append(signature_dtypes[args[1]])


### PR DESCRIPTION
<img width="1497" alt="image" src="https://github.com/tinygrad/tinygrad/assets/2525478/11b813f7-ca4f-4f4e-ae94-70eed718113c">
17^3 @ 17^3 now can be optimized, 3 PADTO then handcodeopt, 16s -> 0.6s

checked with fuzzer and both the loop pushing and applying PADTO look good

(1) MAX does not work with padding output shapetracker 0 as it needs -inf as the padding value
(2) if the network has an in-place assign, PADTO would break the assign

we also need a different search strategy, PADTO is good because we can follow up with a LOCAL or GROUP, but BEAM would not pick it because PADTO by itself is slower