### PR TITLE
don't optimize buffers when its not an astrunner

### DIFF
--- a/tinygrad/jit.py
+++ b/tinygrad/jit.py
@@ -88,7 +88,7 @@ class _CacheCollector:
     if self.cache is None: return
     for k,v in var_vals.items(): assert k in self.var_vals and self.var_vals[k] == v, f"var_vals {k} mismatch {v} != {self.var_vals.get(k)}"
     self.placeholders[rawbufs[0]] = PlaceHolder(rawbufs[0])    # NOTE: this is making an assumption that 0 is special
-    self.cache.append((prg, [self.placeholders.get(x, x) if isinstance(x, RawBuffer) else x for x in rawbufs]))
+    self.cache.append((prg, [self.placeholders.get(x, x) if isinstance(prg, ASTRunner) and isinstance(x, RawBuffer) else x for x in rawbufs]))
 
   def finish(self) -> List[JitItem]:
     if self.cache is None: return []


### PR DESCRIPTION
#2288 broke hip multigpu, didn't notice till now, really need tests on hip multigpu but not really sure how to go about it.

This was in the original cachecollector and isn't in the new one, but its kinda needed because stuff that isn't an astrunner like the functions multigpu injects shouldn't have optimized buffers.