### PR TITLE
Fix UnicodeDecodeError when debugging on Intel APU

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -350,7 +350,7 @@ jobs:
       - name: Check Device.DEFAULT and print some source
         run: |
           python -c "from tinygrad.ops import Device; assert Device.DEFAULT in ['LLVM','CLANG','CUDA','GPU'], Device.DEFAULT"
-          DEBUG=4 FORWARD_ONLY=1 python3 test/test_ops.py TestOps.test_add
+          DEBUG=5 PYTHONPATH=${{ github.workspace }} FORWARD_ONLY=1 python3 test/test_ops.py TestOps.test_add
       - name: Run pytest (not cuda)
         if: matrix.backend!='cuda' && matrix.backend!='ptx' && matrix.backend!='triton'
         run: python -m pytest -n=auto test/ -k '${{matrix.backend=='llvm'&&'not (test_nn.py and test_conv_transpose2d)'||'test'}}' -m 'not exclude_${{matrix.backend}}' --durations=20

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -81,8 +81,8 @@ class CLProgram:
       elif CL.cl_ctxs[0].devices[0].name.startswith('gfx'):
         asm = early_exec(([ROCM_LLVM_PATH / "llvm-objdump", '-d', '-'], prg))
         print('\n'.join([x for x in asm.decode('utf-8').split("\n") if 's_code_end' not in x]))
-      else:
-        # print the PTX for NVIDIA. TODO: probably broken for everything else
+      elif "NVIDIA" in CL.cl_ctxs[0].devices[0].name:
+        # print the PTX for NVIDIA.
         print(prg.decode('utf-8'))
     if argdtypes is not None: self.set_argdtypes(argdtypes)
 


### PR DESCRIPTION
My laptop has an Intel APU and during debugging with the "GPU" backend when I use `DEBUG >=5` I get the error

```python
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 17: invalid start byte
```

This is caused in ops_gpu.py in `CLProgram` by `print(prg.decode('utf-8'))`.

I added a basic test that causes this error on the CI. As a suggested fix this PR prints it only if the device name contains "NVIDIA".