### PR TITLE
fix causal mask in Tensor class

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -390,21 +390,5 @@ class TestZeroShapeTensor(unittest.TestCase):
     np.testing.assert_equal(Tensor([]).sum().numpy(), 0)
     np.testing.assert_equal(Tensor([]).mean().numpy(), 0)
 
-  def test_self_attention(self):
-    np.random.seed(1337)
-    sz = (4,2,8,16)
-    q, k, v = [np.random.randn(*sz).astype(np.float32) for _ in range(3)]
-    tinygrad_res = Tensor.scaled_dot_product_attention(Tensor(q), Tensor(k), Tensor(v)).numpy()
-    pytorch_res  = torch.nn.functional.scaled_dot_product_attention(torch.Tensor(q), torch.Tensor(k), torch.Tensor(v)).cpu()
-    np.testing.assert_allclose(tinygrad_res, pytorch_res, atol=1e-5)
-
-  def test_cross_attention(self):
-    np.random.seed(1337)
-    sz = (4,2,8,16)
-    q, k, v = [np.random.randn(*sz).astype(np.float32) for _ in range(3)]
-    tinygrad_res = Tensor.scaled_dot_product_attention(Tensor(q), Tensor(k), Tensor(v), is_causal=True).numpy()
-    pytorch_res  = torch.nn.functional.scaled_dot_product_attention(torch.Tensor(q), torch.Tensor(k), torch.Tensor(v), is_causal=True).cpu()
-    np.testing.assert_allclose(tinygrad_res, pytorch_res, atol=1e-5)
-
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -391,24 +391,20 @@ class TestZeroShapeTensor(unittest.TestCase):
     np.testing.assert_equal(Tensor([]).mean().numpy(), 0)
 
   def test_self_attention(self):
-    def test_tinygrad(q, k, v):
-      return Tensor.scaled_dot_product_attention(Tensor(q), Tensor(k), Tensor(v)).numpy()
-    def test_pytorch(q, k, v):
-      return torch.nn.functional.scaled_dot_product_attention(torch.Tensor(q), torch.Tensor(k), torch.Tensor(v)).cpu()
     np.random.seed(1337)
     sz = (4,2,8,16)
     q, k, v = [np.random.randn(*sz).astype(np.float32) for _ in range(3)]
-    np.testing.assert_allclose(test_tinygrad(q, k, v), test_pytorch(q, k, v), atol=1e-5)
+    tinygrad_res = Tensor.scaled_dot_product_attention(Tensor(q), Tensor(k), Tensor(v)).numpy()
+    pytorch_res  = torch.nn.functional.scaled_dot_product_attention(torch.Tensor(q), torch.Tensor(k), torch.Tensor(v)).cpu()
+    np.testing.assert_allclose(tinygrad_res, pytorch_res, atol=1e-5)
 
   def test_cross_attention(self):
-    def test_tinygrad(q, k, v):
-      return Tensor.scaled_dot_product_attention(Tensor(q), Tensor(k), Tensor(v), is_causal=True).numpy()
-    def test_pytorch(q, k, v):
-      return torch.nn.functional.scaled_dot_product_attention(torch.Tensor(q), torch.Tensor(k), torch.Tensor(v), is_causal=True).cpu()
     np.random.seed(1337)
     sz = (4,2,8,16)
     q, k, v = [np.random.randn(*sz).astype(np.float32) for _ in range(3)]
-    np.testing.assert_allclose(test_tinygrad(q, k, v), test_pytorch(q, k, v), atol=1e-5)
+    tinygrad_res = Tensor.scaled_dot_product_attention(Tensor(q), Tensor(k), Tensor(v), is_causal=True).numpy()
+    pytorch_res  = torch.nn.functional.scaled_dot_product_attention(torch.Tensor(q), torch.Tensor(k), torch.Tensor(v), is_causal=True).cpu()
+    np.testing.assert_allclose(tinygrad_res, pytorch_res, atol=1e-5)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -390,5 +390,25 @@ class TestZeroShapeTensor(unittest.TestCase):
     np.testing.assert_equal(Tensor([]).sum().numpy(), 0)
     np.testing.assert_equal(Tensor([]).mean().numpy(), 0)
 
+  def test_self_attention(self):
+    def test_tinygrad(q, k, v):
+      return Tensor.scaled_dot_product_attention(Tensor(q), Tensor(k), Tensor(v)).numpy()
+    def test_pytorch(q, k, v):
+      return torch.nn.functional.scaled_dot_product_attention(torch.Tensor(q), torch.Tensor(k), torch.Tensor(v)).cpu()
+    np.random.seed(1337)
+    sz = (4,2,8,16)
+    q, k, v = [np.random.randn(*sz).astype(np.float32) for _ in range(3)]
+    np.testing.assert_allclose(test_tinygrad(q, k, v), test_pytorch(q, k, v), atol=1e-5)
+
+  def test_cross_attention(self):
+    def test_tinygrad(q, k, v):
+      return Tensor.scaled_dot_product_attention(Tensor(q), Tensor(k), Tensor(v), is_causal=True).numpy()
+    def test_pytorch(q, k, v):
+      return torch.nn.functional.scaled_dot_product_attention(torch.Tensor(q), torch.Tensor(k), torch.Tensor(v), is_causal=True).cpu()
+    np.random.seed(1337)
+    sz = (4,2,8,16)
+    q, k, v = [np.random.randn(*sz).astype(np.float32) for _ in range(3)]
+    np.testing.assert_allclose(test_tinygrad(q, k, v), test_pytorch(q, k, v), atol=1e-5)
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -780,7 +780,7 @@ class Tensor:
     # NOTE: it works if key, value have symbolic shape
     assert all_int(self.shape), f"does not support symbolic shape {self.shape}"
     if is_causal: attn_mask = Tensor.ones(self.shape[-2], key.shape[-2], requires_grad=False, device=self.device).tril(0).cast(dtypes.bool)
-    if attn_mask is not None and attn_mask.dtype == dtypes.bool: attn_mask = (attn_mask == 0).where(-float("inf"), attn_mask)
+    if attn_mask is not None and attn_mask.dtype == dtypes.bool: attn_mask = (attn_mask == 0).where(-float("inf"), 0)
     return (self @ key.transpose(-2,-1) / math.sqrt(self.shape[-1]) + attn_mask).softmax(-1).dropout(dropout_p) @ value
 
   def binary_crossentropy(self, y:Tensor) -> Tensor:


### PR DESCRIPTION
The causal mask being generated in the `scaled_dot_product_attention` function in `tensor.py` was slightly wrong.

## What was wrong?

Running the following:
```python
x = Tensor.ones(1,1,4,4)
Tensor.scaled_dot_product_attention(x, x, x, is_causal=True)
```
With this line added after 783 in the function:
```python
   if attn_mask is not None: print(attn_mask.numpy())
```
Would print the following:
```
[[  1. -inf -inf -inf]
 [  1.   1. -inf -inf]
 [  1.   1.   1. -inf]
 [  1.   1.   1.   1.]]
```
Which is not correct, the following is what the mask should look like:
```
[[  0. -inf -inf -inf]
 [  0.   0. -inf -inf]
 [  0.   0.   0. -inf]
 [  0.   0.   0.   0.]]
```

## What was the impact?

Since the mask addition is always following by a softmax, this "off by 1" is not that big of a deal
```python
>>> x = Tensor.randn(4,4)
>>> (x.softmax() - (x + Tensor.ones(*x.shape)).softmax()).numpy()
[[ 0.0000000e+00  2.6424047e-08  1.8747890e-08  3.6758678e-08]
 [ 5.7731411e-09  0.0000000e+00  4.7959841e-09  5.1841909e-10]
 [-5.9604645e-08 -2.8568575e-08 -2.1569139e-08  7.3544797e-09]
 [ 0.0000000e+00 -2.7606262e-10 -3.9446846e-10  1.9015218e-08]]
```
That means this PR is just bringing the framework's built-in causal mask with what is expected.

## How was this tested?

lm_eval was run against Tiny LLaMA with a 250 limit

The `llama.py` had to get modified for this testing to use the library's causal mask, but this change was not carried forward since this only works when you are not using a KV cache.

Before (1s in the mask):
```
{
  "results": {
    "arc_easy": {
      "acc": 0.22,
      "acc_stderr": 0.02625179282460584,
      "acc_norm": 0.28,
      "acc_norm_stderr": 0.02845414827783233
    }
  },
  "versions": {
    "arc_easy": 0
  }
}
```

After (0s in the mask):
```
{
  "results": {
    "arc_easy": {
      "acc": 0.22,
      "acc_stderr": 0.02625179282460584,
      "acc_norm": 0.28,
      "acc_norm_stderr": 0.02845414827783233
    }
  },
  "versions": {
    "arc_easy": 0
  }
}
```

For sanity check, `Tensor.randn(*attn_mask.shape)*1000` was added to attn_mask before being used to verify my change was actually being tested. The following shows the expected degradation in performance.
```
{
  "results": {
    "arc_easy": {
      "acc": 0.208,
      "acc_stderr": 0.02572139890141639,
      "acc_norm": 0.252,
      "acc_norm_stderr": 0.027513851933031352
    }
  },
  "versions": {
    "arc_easy": 0
  }
}
```
