### PR TITLE
clean up ast_parse

### DIFF
--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -496,9 +496,10 @@ class Linearizer(Kernel):
       input_acc = acc[:]
       for val, off in zip(zip(*values), cast(List[int], offs)):
         acc[off] = self.uop(UOps.ALU, dtypes.float32, val+(acc[off],), ops[x.op])
+        ret.append(acc[off])
+      for off in range(len(acc)):
         if input_acc[off] != acc[off]:
           acc[off] = self.uop(UOps.PHI, dtypes.float32, (input_acc[off], acc[off]) + tuple(loop_ctx))
-        ret.append(acc[off])
     else:
       ret = [self.uop(UOps.ALU, dtypes.float32, val, x.op) for val in zip(*values)]
     return ret

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -492,20 +492,13 @@ class Linearizer(Kernel):
     values = [self.ast_parse(cast(LazyOp, v), acc, offs, loaded_buffers, loop_ctx=loop_ctx) for v in x.src]
     ops = {ReduceOps.SUM:BinaryOps.ADD, ReduceOps.MAX:BinaryOps.MAX, TernaryOps.MULACC:TernaryOps.MULACC}
     if x.op in ops:
-      ret = []
+      ret: List[UOp] = []
       input_acc = acc[:]
-      for idx, val, off in zip([[i] for i in range(len(values[0]))], zip(*values), cast(List[int], offs)):
+      for val, off in zip(zip(*values), cast(List[int], offs)):
         acc[off] = self.uop(UOps.ALU, dtypes.float32, val+(acc[off],), ops[x.op])
-        ret.append((idx, acc[off]))
-      for off in range(len(acc)):
         if input_acc[off] != acc[off]:
           acc[off] = self.uop(UOps.PHI, dtypes.float32, (input_acc[off], acc[off]) + tuple(loop_ctx))
+        ret.append(acc[off])
     else:
-      ret = [(idx, self.uop(UOps.ALU, dtypes.float32, val, x.op)) for idx, val in zip([[i] for i in range(len(values[0]))], zip(*values))]
-    ordered_ret: List[Optional[UOp]] = [None]*len(values[0])
-    # scatter
-    for i,j in ret:
-      for k in i:
-        ordered_ret[k] = j
-    assert all(isinstance(x, UOp) for x in ordered_ret), "some tokens didn't get scattered?"
-    return cast(List[UOp], ordered_ret)
+      ret = [self.uop(UOps.ALU, dtypes.float32, val, x.op) for val in zip(*values)]
+    return ret


### PR DESCRIPTION
i think there was a scatter when the Tokens were around. with UOps it's just a linear pass so we can remove the index scatter and just build the ret list directly