### PR TITLE
[Bounty] SOTA 7B chatbot + proper chatbot format + better sampling + tests

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -224,6 +224,12 @@ MODEL_PARAMS = {
       "args": {"dim": 2048, "n_layers": 22, "n_heads": 32, "n_kv_heads": 4, "multiple_of": 256, "norm_eps": 1e-05, "vocab_size": 32000},
       "files": 1,
     }
+  },
+  "intel": {
+    "7B": {
+      "args": {"dim": 4096, "n_layers": 32, "n_heads": 32, "n_kv_heads": 8, "multiple_of": 14336, "norm_eps": 1e-05, "rope_theta": 1000000, "vocab_size": 32000},
+      "files": "2",
+    }
   }
 }
 
@@ -511,7 +517,7 @@ After you are done speaking, output [EOS]. You are not Chad.
 
   # *** prompt engineers stop here ****
 
-  LLAMA_SUFFIX = {"1": "", "2": "-2", "code": "-code", "tiny": "-tiny"}[args.gen]
+  LLAMA_SUFFIX = {"1": "", "2": "-2", "code": "-code", "tiny": "-tiny", "intel": "-intel"}[args.gen]
   MODEL_PATH = args.model or Path(__file__).parents[1] / f"weights/LLaMA{LLAMA_SUFFIX}/{args.size}"
   TOKENIZER_PATH = (MODEL_PATH if MODEL_PATH.is_dir() else MODEL_PATH.parent) / "tokenizer.model"
   print(f"using LLaMA{LLAMA_SUFFIX}-{args.size} model")

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -514,6 +514,14 @@ After you are done speaking, output [EOS]. You are not Chad.
     resp_delim = "Lexie: "
     end_delim = " [EOS]\n"
     pre_prompt += ''.join(f"{user_delim}{k}\n{resp_delim}{v}{end_delim}" for k,v in examples.items())
+  elif args.personality.lower() == "robert":
+    pre_prompt = f"""
+### System:
+You are a math expert assistant. Your mission is to help users understand and solve various math problems. You should provide step-by-step solutions, explain reasonings and give the correct answer.
+"""
+    user_delim = "\n### User:\n"
+    resp_delim = "### Assistant:\n"
+    end_delim = "\n"
 
   # *** prompt engineers stop here ****
 
@@ -546,7 +554,8 @@ After you are done speaking, output [EOS]. You are not Chad.
   while 1:
     # add tokens from user in chatbot mode
     if chatbot:
-      user_prompt = user_delim + input(user_delim) + "\n"
+      # TODO: clean this up further to ensure compatibility with other models
+      user_prompt = user_delim + input(user_delim) + "\n" + resp_delim
       outputted += user_prompt
 
     new_toks = [llama.tokenizer.bos_id()] + llama.tokenizer.encode(outputted)

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -517,7 +517,7 @@ After you are done speaking, output [EOS]. You are not Chad.
   elif args.personality.lower() == "robert":
     pre_prompt = f"""
 ### System:
-You are a math expert assistant. Your mission is to help users understand and solve various math problems. You should provide step-by-step solutions, explain reasonings and give the correct answer.
+Hi there! My name's Robert. Let's have a conversation. I prefer talking about topics related to technology, math, machine learning, or whatever you're interested to.
 """
     user_delim = "\n### User:\n"
     resp_delim = "### Assistant:\n"


### PR DESCRIPTION
## Overview

This is PR for using the [Intel-7B](https://huggingface.co/Intel/neural-chat-7b-v3-1) model as the SOTA 7B model as mentioned [here](https://discord.com/channels/1068976834382925865/1068976834928193609/1177733163263475843).

Here's a screenshot of loading the **Intel-7B** model in the existing `examples/llama.py`:
<img width="2358" alt="Screenshot 2023-11-24 at 18 44 45" src="https://github.com/tinygrad/tinygrad/assets/51974347/d3a16698-a1c7-44b1-8c33-6e231e1600db">

The command I ran is the following:
```sh
METAL_XCODE=1 DEBUG=1 python3 examples/llama.py --gen intel --size 7B --model path/to/pytorch_model.bin.index.json
```

For now, you'll have to download the [Intel-7B weights](https://huggingface.co/Intel/neural-chat-7b-v3-1/tree/main) + `tokeniser.model` + `pytorch_model.bin.index.json` files and place them in a single folder. Once #2415 is merged later on, I'll add support for downloading the needed models.

**Note:** This is a work in progress and will address the rest of the tasks as I go.

## Tasks
- [x] Load Intel-7B model
- [ ] Add proper chatbot prompting
- [ ] Add better sampling
- [ ] Add tests
- [ ] Add model downloading depending on #2415 