### PR TITLE
Switch to cuda wrapper instead of pycuda

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -322,6 +322,7 @@ jobs:
           sudo apt install -y --no-install-recommends git g++ cmake ninja-build llvm-15-dev zlib1g-dev libglew-dev \
             flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-dev nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
           ls /usr/local/
+          which nvcc
       - name: Cache gpuocelot
         if: matrix.backend == 'cuda' || matrix.backend == 'ptx' || matrix.backend == 'triton'
         id: cache-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -322,6 +322,7 @@ jobs:
           sudo apt install -y --no-install-recommends git g++ cmake ninja-build llvm-15-dev zlib1g-dev libglew-dev \
             flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-dev nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
           ls /usr/local/
+          ls /usr/
           which nvcc
       - name: Cache gpuocelot
         if: matrix.backend == 'cuda' || matrix.backend == 'ptx' || matrix.backend == 'triton'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,7 +349,7 @@ jobs:
         run: pip install -e '.[testing${{matrix.backend=='llvm'&&',llvm'||matrix.backend=='cuda'&&',cuda'||matrix.backend=='ptx'&&',cuda'||matrix.backend=='triton'&&',triton'||''}}]' --extra-index-url https://download.pytorch.org/whl/cpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/
       - name: Check Device.DEFAULT and print some source
         run: |
-          python -c "from tinygrad.ops import Device; assert Device.DEFAULT in ['LLVM','CLANG','CUDA','GPU'], Device.DEFAULT"
+          PYTHONPATH=${{ github.workspace }} python -c "from tinygrad.ops import Device; assert Device.DEFAULT in ['LLVM','CLANG','CUDA','GPU'], Device.DEFAULT"
           DEBUG=5 PYTHONPATH=${{ github.workspace }} FORWARD_ONLY=1 python3 test/test_ops.py TestOps.test_add
       - name: Run pytest (not cuda)
         if: matrix.backend!='cuda' && matrix.backend!='ptx' && matrix.backend!='triton'
@@ -359,7 +359,7 @@ jobs:
         run: python -m pytest -n=auto test/external/external_test_onnx_backend.py --durations=20
       - name: Run pytest (cuda)
         if: matrix.backend=='cuda'||matrix.backend=='ptx'||matrix.backend=='triton'
-        run: python -m pytest -n=auto test/ -k 'not (half or test_efficientnet_safetensors) and not (test_conv2d and test_tensor.py)' -m 'not exclude_cuda' --ignore=test/external --ignore=test/models --durations=20
+        run: PYTHONPATH=${{ github.workspace }} python -m pytest -n=auto test/ -k 'not (half or test_efficientnet_safetensors) and not (test_conv2d and test_tensor.py)' -m 'not exclude_cuda' --ignore=test/external --ignore=test/models --durations=20
 
   #testunicorn:
   #  name: ARM64 unicorn Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -317,14 +317,10 @@ jobs:
       - name: Install packages (cuda)
         if: matrix.backend == 'cuda' || matrix.backend == 'ptx' || matrix.backend == 'triton'
         run: |
-          find /* | grep cuda.h
           echo 'Acquire::http::Pipeline-Depth "5";' | sudo tee -a /etc/apt/apt.conf.d/99parallel
           sudo apt update -y
           sudo apt install -y --no-install-recommends git g++ cmake ninja-build llvm-15-dev zlib1g-dev libglew-dev \
-            flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-dev nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
-          ls /usr/local/
-          ls /usr/
-          which nvcc
+            flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-toolkit-gcc
       - name: Cache gpuocelot
         if: matrix.backend == 'cuda' || matrix.backend == 'ptx' || matrix.backend == 'triton'
         id: cache-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -320,7 +320,8 @@ jobs:
           echo 'Acquire::http::Pipeline-Depth "5";' | sudo tee -a /etc/apt/apt.conf.d/99parallel
           sudo apt update -y
           sudo apt install -y --no-install-recommends git g++ cmake ninja-build llvm-15-dev zlib1g-dev libglew-dev \
-            flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-toolkit-gcc
+            flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-dev nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
+          ls /usr/local/
       - name: Cache gpuocelot
         if: matrix.backend == 'cuda' || matrix.backend == 'ptx' || matrix.backend == 'triton'
         id: cache-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -317,6 +317,7 @@ jobs:
       - name: Install packages (cuda)
         if: matrix.backend == 'cuda' || matrix.backend == 'ptx' || matrix.backend == 'triton'
         run: |
+          find /* | grep cuda.h
           echo 'Acquire::http::Pipeline-Depth "5";' | sudo tee -a /etc/apt/apt.conf.d/99parallel
           sudo apt update -y
           sudo apt install -y --no-install-recommends git g++ cmake ninja-build llvm-15-dev zlib1g-dev libglew-dev \

--- a/extra/cuda_wrapper.py
+++ b/extra/cuda_wrapper.py
@@ -33,6 +33,7 @@ try:
     ptr = ctypes.c_char_p()
     status = _libcuda.cuGetErrorString(status, ctypes.byref(ptr))
     if status != 0: raise RuntimeError("CUDA error: cuGetErrorString failed")
+    assert ptr.value is not None
     return ptr.value.decode("utf-8")
 
   def cuCheckStatus(status):

--- a/extra/cuda_wrapper.py
+++ b/extra/cuda_wrapper.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 try:
   def cu_get_include_paths(compiler):
     result = subprocess.check_output([compiler, "-E", "-x", "c", "-", "-v"], input="", stderr=subprocess.STDOUT, universal_newlines=True)
+    print("nvcc", result)
     lines = result.splitlines()
 
     includes = []

--- a/extra/cuda_wrapper.py
+++ b/extra/cuda_wrapper.py
@@ -39,11 +39,11 @@ try:
     status = _libcuda.cuInit(flags)
     cuCheckStatus(status)
 
-  _libcuda.cuCtxCreate.restype = int
-  _libcuda.cuCtxCreate.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_void_p]
+  _libcuda.cuCtxCreate_v2.restype = int
+  _libcuda.cuCtxCreate_v2.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_void_p]
   def cuCtxCreate(flags, device):
     ptr = ctypes.c_void_p()
-    status = _libcuda.cuCtxCreate(ctypes.byref(ptr), flags, device)
+    status = _libcuda.cuCtxCreate_v2(ctypes.byref(ptr), flags, device)
     cuCheckStatus(status)
     return ptr
 
@@ -60,10 +60,10 @@ try:
     cuCheckStatus(status)
 
   _libcuda.cuEventCreate.restype = int
-  _libcuda.cuEventCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
-  def cuEventCreate():
+  _libcuda.cuEventCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_uint]
+  def cuEventCreate(flags=0):
     ptr = ctypes.c_void_p()
-    status = _libcuda.cuEventCreate(ctypes.byref(ptr))
+    status = _libcuda.cuEventCreate(ctypes.byref(ptr), flags)
     cuCheckStatus(status)
     return ptr
 
@@ -208,38 +208,38 @@ try:
     status = _libcuda.cuGraphExecKernelNodeSetParams(gexec, node, ctypes.byref(params.c_struct))
     cuCheckStatus(status)
 
-  _libcuda.cuMemAlloc.restype = int
-  _libcuda.cuMemAlloc.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
+  _libcuda.cuMemAlloc_v2.restype = int
+  _libcuda.cuMemAlloc_v2.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
   def cuMemAlloc(count):
     ptr = ctypes.c_void_p()
-    status = _libcuda.cuMemAlloc(ctypes.byref(ptr), count)
+    status = _libcuda.cuMemAlloc_v2(ctypes.byref(ptr), count)
     cuCheckStatus(status)
     return ptr.value
 
-  _libcuda.cuMemFree.restype = int
-  _libcuda.cuMemFree.argtypes = [ctypes.c_void_p]
+  _libcuda.cuMemFree_v2.restype = int
+  _libcuda.cuMemFree_v2.argtypes = [ctypes.c_void_p]
   def cuMemFree(ptr):
-    status = _libcuda.cuMemFree(ptr)
+    status = _libcuda.cuMemFree_v2(ptr)
     cuCheckStatus(status)
 
-  _libcuda.cuMemcpyAsync.restype = int
-  _libcuda.cuMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p]
+  _libcuda.cuMemcpyHtoDAsync_v2.restype = int
+  _libcuda.cuMemcpyHtoDAsync_v2.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p]
   def cuMemcpyHtoDAsync(dst, src, count, stream):
-    status = _libcuda.cuMemcpyHtoDAsync(dst, src, ctypes.c_size_t(count), stream)
+    status = _libcuda.cuMemcpyHtoDAsync_v2(dst, src, ctypes.c_size_t(count), stream)
     cuCheckStatus(status)
 
-  _libcuda.cuMemcpyAsync.restype = int
-  _libcuda.cuMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t]
+  _libcuda.cuMemcpyDtoH_v2.restype = int
+  _libcuda.cuMemcpyDtoH_v2.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t]
   def cuMemcpyDtoH(dst, src, count):
-    status = _libcuda.cuMemcpyDtoH(dst, src, ctypes.c_size_t(count))
+    status = _libcuda.cuMemcpyDtoH_v2(dst, src, ctypes.c_size_t(count))
     cuCheckStatus(status)
 
-  _libcuda.cuMemGetInfo.restype = int
-  _libcuda.cuMemGetInfo.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+  _libcuda.cuMemGetInfo_v2.restype = int
+  _libcuda.cuMemGetInfo_v2.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
   def cuMemGetInfo():
     free = ctypes.c_size_t()
     total = ctypes.c_size_t()
-    status = _libcuda.cuMemGetInfo(ctypes.byref(free), ctypes.byref(total))
+    status = _libcuda.cuMemGetInfo_v2(ctypes.byref(free), ctypes.byref(total))
     cuCheckStatus(status)
     return free.value, total.value
 

--- a/extra/cuda_wrapper.py
+++ b/extra/cuda_wrapper.py
@@ -1,9 +1,13 @@
 import subprocess
-from cuda import nvrtc, cuda, cudart
+import ctypes
+from tinygrad.helpers import DEBUG
+import sys
+import numpy as np
+from typing import Any, Dict, List, Tuple
+from dataclasses import dataclass
 
-def cu_get_include_paths(compiler):
-  try:
-    # Run the compiler command to get the include paths
+try:
+  def cu_get_include_paths(compiler):
     result = subprocess.check_output([compiler, "-E", "-x", "c", "-", "-v"], input="", stderr=subprocess.STDOUT, universal_newlines=True)
     lines = result.splitlines()
 
@@ -14,705 +18,354 @@ def cu_get_include_paths(compiler):
         includes = line.split()
     return includes
 
-  except Exception as e:
-    print(f"An error occurred, CUDA might be unavailable: {e}")
-    return []
-
-cuda_includes = cu_get_include_paths(compiler="nvcc")
-
-import ctypes
-from tinygrad.helpers import DEBUG
-import sys
-import numpy as np
-from typing import Any, Dict, List, Tuple
-from dataclasses import dataclass
-
-# try:
-_libcuda = ctypes.cdll.LoadLibrary("libcuda.so.1")
-# print(_libcuda)
-# _libcudart = ctypes.cdll.LoadLibrary("libcudart.so")
-_libcudartrtc = ctypes.cdll.LoadLibrary("libnvrtc.so")
-
-_libcuda.cuGetErrorString.restype = ctypes.c_int
-_libcuda.cuGetErrorString.argtypes = [ctypes.c_int, ctypes.c_void_p]
-def cuGetErrorString(status):
-  ptr = ctypes.c_char_p()
-  status = _libcuda.cuGetErrorString(status, ctypes.byref(ptr))
-  if status != 0: raise RuntimeError("CUDA error: cuGetErrorString failed")
-  return ptr.value.decode("utf-8")
-
-def cuCheckStatus(status):
-  if status != 0: raise RuntimeError("CUDA error %s: %s" % (status, cuGetErrorString(status)))
-
-_libcuda.cuInit.restype = int
-_libcuda.cuInit.argtypes = [ctypes.c_uint]
-def cuInit(flags):
-  status = _libcuda.cuInit(flags)
-  cuCheckStatus(status)
-
-_libcuda.cuCtxCreate.restype = int
-_libcuda.cuCtxCreate.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_void_p]
-def cuCtxCreate(flags, device):
-  ptr = ctypes.c_void_p()
-  status = _libcuda.cuCtxCreate(ctypes.byref(ptr), flags, device)
-  cuCheckStatus(status)
-  return ptr
-
-_libcuda.cuCtxSynchronize.restype = int
-_libcuda.cuCtxSynchronize.argtypes = []
-def cuCtxSynchronize():
-  status = _libcuda.cuCtxSynchronize()
-  cuCheckStatus(status)
-
-_libcuda.cuStreamSynchronize.restype = int
-_libcuda.cuStreamSynchronize.argtypes = [ctypes.c_void_p]
-def cuStreamSynchronize(stream):
-  status = _libcuda.cuStreamSynchronize(stream)
-  cuCheckStatus(status)
-
-_libcuda.cuEventCreate.restype = int
-_libcuda.cuEventCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
-def cuEventCreate():
-  ptr = ctypes.c_void_p()
-  status = _libcuda.cuEventCreate(ctypes.byref(ptr))
-  cuCheckStatus(status)
-  return ptr
-
-_libcuda.cuEventRecord.restype = int
-_libcuda.cuEventRecord.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-def cuEventRecord(event, stream=None):
-  status = _libcuda.cuEventRecord(event, stream)
-  cuCheckStatus(status)
-
-_libcuda.cuEventDestroy.restype = int
-_libcuda.cuEventDestroy.argtypes = [ctypes.c_void_p]
-def cuEventDestroy(event):
-  status = _libcuda.cuEventDestroy(event)
-  cuCheckStatus(status)
-
-_libcuda.cuEventSynchronize.restype = int
-_libcuda.cuEventSynchronize.argtypes = [ctypes.c_void_p]
-def cuEventSynchronize(event):
-  status = _libcuda.cuEventSynchronize(event)
-  cuCheckStatus(status)
-
-_libcuda.cuEventElapsedTime.restype = int
-_libcuda.cuEventElapsedTime.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.c_void_p, ctypes.c_void_p]
-def cuEventElapsedTime(start, stop):
-  t = ctypes.c_float()
-  status = _libcuda.cuEventElapsedTime(ctypes.byref(t), start, stop)
-  cuCheckStatus(status)
-  return t.value
-
-## Stream Management
-
-# Stream capture modes:
-hipStreamCaptureModeGlobal = 0
-hipStreamCaptureModeThreadLocal = 1
-hipStreamCaptureModeRelaxed = 2
-
-_libcuda.cuStreamCreate.restype = int
-_libcuda.cuStreamCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
-def cuStreamCreate():
-  ptr = ctypes.c_void_p()
-  status = _libcuda.cuStreamCreate(ctypes.byref(ptr))
-  cuCheckStatus(status)
-  return ptr
-
-_libcuda.cuStreamDestroy.restype = int
-_libcuda.cuStreamDestroy.argtypes = [ctypes.c_void_p]
-def cuStreamDestroy(stream):
-  status = _libcuda.cuStreamDestroy(stream)
-  cuCheckStatus(status)
-
-_libcuda.cuStreamBeginCapture.restype = int
-_libcuda.cuStreamBeginCapture.argtypes = [ctypes.c_void_p, ctypes.c_int]
-def cuStreamBeginCapture(stream, mode=hipStreamCaptureModeGlobal):
-  t = ctypes.c_float()
-  status = _libcuda.cuStreamBeginCapture(stream, mode)
-  cuCheckStatus(status)
-
-_libcuda.cuStreamEndCapture.restype = int
-_libcuda.cuStreamEndCapture.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-def cuStreamEndCapture(stream):
-  ptr = ctypes.c_void_p()
-  status = _libcuda.cuStreamEndCapture(stream, ctypes.byref(ptr))
-  cuCheckStatus(status)
-  return ptr
-
-_libcuda.cuStreamGetCaptureInfo_v2.restype = int
-_libcuda.cuStreamGetCaptureInfo_v2.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
-def cuStreamGetCaptureInfo_v2(stream):
-  status_out = ctypes.c_void_p()
-  id_out = ctypes.c_ulonglong()
-  graph_out = ctypes.c_void_p()
-  deps_out = ctypes.POINTER(ctypes.c_void_p)()
-  num_deps = ctypes.c_size_t()
-  status = _libcuda.cuStreamGetCaptureInfo_v2(stream, ctypes.byref(status_out), ctypes.byref(id_out), ctypes.byref(graph_out), ctypes.byref(deps_out), ctypes.byref(num_deps))
-  cuCheckStatus(status)
-  deps = [ctypes.cast(deps_out[i], ctypes.c_void_p) for i in range(num_deps.value)]
-  return status_out, id_out.value, graph_out, deps
-
-hipStreamAddCaptureDependencies = 0
-hipStreamSetCaptureDependencies = 1
-
-_libcuda.cuStreamUpdateCaptureDependencies.restype = int
-_libcuda.cuStreamUpdateCaptureDependencies.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint]
-def cuStreamUpdateCaptureDependencies(stream, deps, flags=hipStreamAddCaptureDependencies):
-  deps_in = (ctypes.c_void_p * len(deps))()
-  deps_in[:] = deps
-  num_deps = ctypes.c_size_t()
-  num_deps.value = len(deps)
-  flags_in = ctypes.c_uint()
-  flags_in.value = flags
-  status = _libcuda.cuStreamUpdateCaptureDependencies(stream, deps_in, num_deps, flags_in)
-  cuCheckStatus(status)
-
-
-## Graph Management
-
-_libcuda.cuGraphCreate.restype = int
-_libcuda.cuGraphCreate.argtypes = [ctypes.c_void_p, ctypes.c_uint]
-def cuGraphCreate():
-  ptr = ctypes.c_void_p()
-  status = _libcuda.cuGraphCreate(ctypes.byref(ptr), 0)
-  cuCheckStatus(status)
-  return ptr
-
-_libcuda.cuGraphInstantiate.restype = int
-_libcuda.cuGraphInstantiate.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
-def cuGraphInstantiate(graph):
-  ptr = ctypes.c_void_p()
-  status = _libcuda.cuGraphInstantiate(ctypes.byref(ptr), graph, 0, 0, 0)
-  cuCheckStatus(status)
-  return ptr
-
-_libcuda.cuGraphDestroy.restype = int
-_libcuda.cuGraphDestroy.argtypes = [ctypes.c_void_p]
-def cuGraphDestroy(graph):
-  status = _libcuda.cuGraphDestroy(graph)
-  cuCheckStatus(status)
-
-_libcuda.cuGraphExecDestroy.restype = int
-_libcuda.cuGraphExecDestroy.argtypes = [ctypes.c_void_p]
-def cuGraphExecDestroy(gexec):
-  status = _libcuda.cuGraphExecDestroy(gexec)
-  cuCheckStatus(status)
-
-_libcuda.cuGraphLaunch.restype = int
-_libcuda.cuGraphLaunch.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-def cuGraphLaunch(graph_exec, stream=0):
-  status = _libcuda.cuGraphLaunch(graph_exec, stream)
-  cuCheckStatus(status)
-
-class hipKernelNodeParams(ctypes.Structure):
-  _fields_ = [("blockDimX", ctypes.c_uint32), ("blockDimY", ctypes.c_uint32), ("blockDimZ", ctypes.c_uint32),
-              ("extra", ctypes.POINTER(ctypes.c_void_p)),
-              ("func", ctypes.c_void_p),
-              ("gridDimX", ctypes.c_uint32), ("gridDimY", ctypes.c_uint32), ("gridDimZ", ctypes.c_uint32),
-              ("kernelParams", ctypes.POINTER(ctypes.c_void_p)),
-              ("sharedMemBytes", ctypes.c_uint32)]
-
-@dataclass
-class kernelNodeParamsWrapper():
-  c_struct: Any
-  context: Any = None
-
-def getCStructForType(argtypes):
-  fields = []
-  for j,typ in enumerate(argtypes):
-    fields.append((f'field{j}', typ))
-
-  class CStructure(ctypes.Structure):
-    _pack_ = 1
-    _fields_ = fields
-  return CStructure
-
-def setKernelNodeLaunchDims(npwrapper:kernelNodeParamsWrapper, grid, block):
-  npwrapper.c_struct.blockDimX = block[0]
-  npwrapper.c_struct.blockDimY = block[1]
-  npwrapper.c_struct.blockDimZ = block[2]
-  npwrapper.c_struct.gridDimX = grid[0]
-  npwrapper.c_struct.gridDimY = grid[1]
-  npwrapper.c_struct.gridDimZ = grid[2]
-
-def setKernelNodeParams(npwrapper:kernelNodeParamsWrapper, args, ids):
-  for j,i in enumerate(ids):
-    setattr(npwrapper.context[1], f'field{i}', args[j])
-
-def buildKernelNodeParams(args, argtypes, func, grid, block, sharedMemBytes=0):
-  c_struct_t = getCStructForType(argtypes)
-  struct = c_struct_t(*args)
-  size = ctypes.c_size_t(ctypes.sizeof(struct))
-  p_size = ctypes.c_void_p(ctypes.addressof(size))
-  p_struct = ctypes.c_void_p(ctypes.addressof(struct))
-  config = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), p_struct,
-                                ctypes.c_void_p(2), p_size, ctypes.c_void_p(3))
-  params = hipKernelNodeParams(block[0], block[1], block[2], config, func, grid[0], grid[1], grid[2], None, sharedMemBytes)
-  return kernelNodeParamsWrapper(c_struct=params, context=(size, struct, config))
-
-_libcuda.cuGraphAddKernelNode.restype = int
-_libcuda.cuGraphAddKernelNode.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p]
-def cuGraphAddKernelNode(graph, deps, params:kernelNodeParamsWrapper):
-  graph_node = ctypes.c_void_p()
-  deps_in = (ctypes.c_void_p * len(deps))()
-  deps_in[:] = deps
-  num_deps = ctypes.c_size_t(len(deps))
-  status = _libcuda.cuGraphAddKernelNode(ctypes.byref(graph_node), graph, deps_in, num_deps, ctypes.byref(params.c_struct))
-  cuCheckStatus(status)
-  return graph_node
-
-_libcuda.cuGraphExecKernelNodeSetParams.restype = int
-_libcuda.cuGraphExecKernelNodeSetParams.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
-def cuGraphExecKernelNodeSetParams(gexec, node, params:kernelNodeParamsWrapper):
-  status = _libcuda.cuGraphExecKernelNodeSetParams(gexec, node, ctypes.byref(params.c_struct))
-  cuCheckStatus(status)
-
-_libcuda.cuMemAlloc.restype = int
-_libcuda.cuMemAlloc.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
-def cuMemAlloc(count):
-  ptr = ctypes.c_void_p()
-  status = _libcuda.cuMemAlloc(ctypes.byref(ptr), count)
-  cuCheckStatus(status)
-  return ptr.value
-
-_libcuda.cuMemFree.restype = int
-_libcuda.cuMemFree.argtypes = [ctypes.c_void_p]
-def cuMemFree(ptr):
-  status = _libcuda.cuMemFree(ptr)
-  cuCheckStatus(status)
-
-# memory copy modes
-hipMemcpyHostToHost = 0
-hipMemcpyHostToDevice = 1
-hipMemcpyDeviceToHost = 2
-hipMemcpyDeviceToDevice = 3
-hipMemcpyDefault = 4
-
-_libcuda.cuMemcpy.restype = int
-_libcuda.cuMemcpy.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]
-def cuMemcpy(dst, src, count, direction):
-  status = _libcuda.cuMemcpy(dst, src, ctypes.c_size_t(count), direction)
-  cuCheckStatus(status)
-
-_libcuda.cuMemcpyAsync.restype = int
-_libcuda.cuMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_void_p]
-def cuMemcpyAsync(dst, src, count, direction, stream):
-  status = _libcuda.cuMemcpyAsync(dst, src, ctypes.c_size_t(count), direction, stream)
-  cuCheckStatus(status)
-
-_libcuda.cuMemcpyAsync.restype = int
-_libcuda.cuMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p]
-def cuMemcpyHtoDAsync(dst, src, count, stream):
-  status = _libcuda.cuMemcpyHtoDAsync(dst, src, ctypes.c_size_t(count), stream)
-  cuCheckStatus(status)
-
-_libcuda.cuMemcpyAsync.restype = int
-_libcuda.cuMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t]
-def cuMemcpyDtoH(dst, src, count):
-  status = _libcuda.cuMemcpyDtoH(dst, src, ctypes.c_size_t(count))
-  cuCheckStatus(status)
-
-_libcuda.cuMemGetInfo.restype = int
-_libcuda.cuMemGetInfo.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-def cuMemGetInfo():
-  free = ctypes.c_size_t()
-  total = ctypes.c_size_t()
-  status = _libcuda.cuMemGetInfo(ctypes.byref(free), ctypes.byref(total))
-  cuCheckStatus(status)
-  return free.value, total.value
-
-class hipIpcMemHandle_t(ctypes.Structure):
-  _fields_ = [("reserved", ctypes.c_char * 64)]
-
-_libcuda.cuIpcGetMemHandle.restype = int
-_libcuda.cuIpcGetMemHandle.argtypes = [ctypes.POINTER(hipIpcMemHandle_t), ctypes.c_void_p]
-def cuIpcGetMemHandle(ptr):
-  handle = hipIpcMemHandle_t()
-  status = _libcuda.cuIpcGetMemHandle(ctypes.byref(handle), ptr)
-  cuCheckStatus(status)
-  return handle
-
-_libcuda.cuIpcOpenMemHandle.restype = int
-_libcuda.cuIpcOpenMemHandle.argtypes = [ctypes.POINTER(ctypes.c_void_p), hipIpcMemHandle_t, ctypes.c_uint]
-def cuIpcOpenMemHandle(handle, flags):
-  ptr = ctypes.c_void_p()
-  status = _libcuda.cuIpcOpenMemHandle(ctypes.byref(ptr), handle, flags)
-  cuCheckStatus(status)
-  return ptr.value
-
-_libcuda.cuIpcCloseMemHandle.restype = int
-_libcuda.cuIpcCloseMemHandle.argtypes = [ctypes.c_void_p]
-def cuIpcCloseMemHandle(ptr):
-  status = _libcuda.cuIpcCloseMemHandle(ptr)
-  cuCheckStatus(status)
-
-_libcuda.cuDeviceGet.restype = int
-_libcuda.cuDeviceGet.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.c_int]
-def cuDeviceGet(id):
-  dev = ctypes.c_int()
-  status = _libcuda.cuDeviceGet(ctypes.byref(dev), id)
-  cuCheckStatus(status)
-  return dev.value
-
-_libcuda.cuDeviceGetCount.restype = int
-_libcuda.cuDeviceGetCount.argtypes = [ctypes.POINTER(ctypes.c_int)]
-def cuDeviceGetCount():
-  count = ctypes.c_int()
-  status = _libcuda.cuDeviceGetCount(ctypes.byref(count))
-  cuCheckStatus(status)
-  return count.value
-
-class hipDeviceArch(ctypes.Structure):
-  _fields_ = [
-    # *32-bit Atomics*
-    # 32-bit integer atomics for global memory.
-    ("hasGlobalInt32Atomics", ctypes.c_uint, 1),
-
-    # 32-bit float atomic exch for global memory.
-    ("hasGlobalFloatAtomicExch", ctypes.c_uint, 1),
-
-    # 32-bit integer atomics for shared memory.
-    ("hasSharedInt32Atomics", ctypes.c_uint, 1),
-
-    # 32-bit float atomic exch for shared memory.
-    ("hasSharedFloatAtomicExch", ctypes.c_uint, 1),
-
-    # 32-bit float atomic add in global and shared memory.
-    ("hasFloatAtomicAdd", ctypes.c_uint, 1),
-
-    # *64-bit Atomics*
-    # 64-bit integer atomics for global memory.
-    ("hasGlobalInt64Atomics", ctypes.c_uint, 1),
-
-    # 64-bit integer atomics for shared memory.
-    ("hasSharedInt64Atomics", ctypes.c_uint, 1),
-
-    # *Doubles*
-    # Double-precision floating point.
-    ("hasDoubles", ctypes.c_uint, 1),
-
-    # *Warp cross-lane operations*
-    # Warp vote instructions (__any, __all).
-    ("hasWarpVote", ctypes.c_uint, 1),
-
-    # Warp ballot instructions (__ballot).
-    ("hasWarpBallot", ctypes.c_uint, 1),
-
-    # Warp shuffle operations. (__shfl_*).
-    ("hasWarpShuffle", ctypes.c_uint, 1),
-
-    # Funnel two words into one with shift&mask caps.
-    ("hasFunnelShift", ctypes.c_uint, 1),
-
-    # *Sync*
-    # __threadfence_system.
-    ("hasThreadFenceSystem", ctypes.c_uint, 1),
-
-    # __syncthreads_count, syncthreads_and, syncthreads_or.
-    ("hasSyncThreadsExt", ctypes.c_uint, 1),
-
-    # *Misc*
-    # Surface functions.
-    ("hasSurfaceFuncs", ctypes.c_uint, 1),
-
-    # Grid and group dims are 3D (rather than 2D).
-    ("has3dGrid", ctypes.c_uint, 1),
-
-    # Dynamic parallelism.
-    ("hasDynamicParallelism", ctypes.c_uint, 1),
-  ]
-
-class hipDeviceProperties(ctypes.Structure):
-  _fields_ = [
-    # Device name
-    ("_name", ctypes.c_char * 256),
-
-    # Size of global memory region (in bytes)
-    ("totalGlobalMem", ctypes.c_size_t),
-
-    # Size of shared memory region (in bytes).
-    ("sharedMemPerBlock", ctypes.c_size_t),
-
-    # Registers per block.
-    ("regsPerBlock", ctypes.c_int),
-
-    # Warp size.
-    ("warpSize", ctypes.c_int),
-
-    # Max work items per work group or workgroup max size.
-    ("maxThreadsPerBlock", ctypes.c_int),
-
-    # Max number of threads in each dimension (XYZ) of a block.
-    ("maxThreadsDim", ctypes.c_int * 3),
-
-    # Max grid dimensions (XYZ).
-    ("maxGridSize", ctypes.c_int * 3),
-
-    # Max clock frequency of the multiProcessors in khz.
-    ("clockRate", ctypes.c_int),
-
-    # Max global memory clock frequency in khz.
-    ("memoryClockRate", ctypes.c_int),
-
-    # Global memory bus width in bits.
-    ("memoryBusWidth", ctypes.c_int),
-
-    # Size of shared memory region (in bytes).
-    ("totalConstMem", ctypes.c_size_t),
-
-    # Major compute capability.  On HCC, this is an approximation and features may
-    # differ from CUDA CC.  See the arch feature flags for portable ways to query
-    # feature caps.
-    ("major", ctypes.c_int),
-
-    # Minor compute capability.  On HCC, this is an approximation and features may
-    # differ from CUDA CC.  See the arch feature flags for portable ways to query
-    # feature caps.
-    ("minor", ctypes.c_int),
-
-    # Number of multi-processors (compute units).
-    ("multiProcessorCount", ctypes.c_int),
-
-    # L2 cache size.
-    ("l2CacheSize", ctypes.c_int),
-
-    # Maximum resident threads per multi-processor.
-    ("maxThreadsPerMultiProcessor", ctypes.c_int),
-
-    # Compute mode.
-    ("computeMode", ctypes.c_int),
-
-    # Frequency in khz of the timer used by the device-side "clock*"
-    # instructions.  New for HIP.
-    ("clockInstructionRate", ctypes.c_int),
-
-    # Architectural feature flags.  New for HIP.
-    ("arch", hipDeviceArch),
-
-    # Device can possibly execute multiple kernels concurrently.
-    ("concurrentKernels", ctypes.c_int),
-
-    # PCI Domain ID
-    ("pciDomainID", ctypes.c_int),
-
-    # PCI Bus ID.
-    ("pciBusID", ctypes.c_int),
-
-    # PCI Device ID.
-    ("pciDeviceID", ctypes.c_int),
-
-    # Maximum Shared Memory Per Multiprocessor.
-    ("maxSharedMemoryPerMultiProcessor", ctypes.c_size_t),
-
-    # 1 if device is on a multi-GPU board, 0 if not.
-    ("isMultiGpuBoard", ctypes.c_int),
-
-    # Check whether HIP can map host memory
-    ("canMapHostMemory", ctypes.c_int),
-
-    # DEPRECATED: use gcnArchName instead
-    ("gcnArch", ctypes.c_int),
-
-    # AMD GCN Arch Name.
-    ("_gcnArchName", ctypes.c_char * 256),
-
-    # APU vs dGPU
-    ("integrated", ctypes.c_int),
-
-    # HIP device supports cooperative launch
-    ("cooperativeLaunch", ctypes.c_int),
-
-    # HIP device supports cooperative launch on multiple devices
-    ("cooperativeMultiDeviceLaunch", ctypes.c_int),
-
-    # Maximum size for 1D textures bound to linear memory
-    ("maxTexture1DLinear", ctypes.c_int),
-
-    # Maximum number of elements in 1D images
-    ("maxTexture1D", ctypes.c_int),
-
-    # Maximum dimensions (width, height) of 2D images, in image elements
-    ("maxTexture2D", ctypes.c_int * 2),
-
-    # Maximum dimensions (width, height, depth) of 3D images, in image elements
-    ("maxTexture3D", ctypes.c_int * 3),
-
-    # Addres of HDP_MEM_COHERENCY_FLUSH_CNTL register
-    ("hdpMemFlushCntl", ctypes.POINTER(ctypes.c_uint)),
-
-    # Addres of HDP_REG_COHERENCY_FLUSH_CNTL register
-    ("hdpRegFlushCntl", ctypes.POINTER(ctypes.c_uint)),
-
-    # Maximum pitch in bytes allowed by memory copies
-    ("memPitch", ctypes.c_size_t),
-
-    # Alignment requirement for textures
-    ("textureAlignment", ctypes.c_size_t),
-
-    # Pitch alignment requirement for texture references bound to pitched memory
-    ("texturePitchAlignment", ctypes.c_size_t),
-
-    # Run time limit for kernels executed on the device
-    ("kernelExecTimeoutEnabled", ctypes.c_int),
-
-    # Device has ECC support enabled
-    ("ECCEnabled", ctypes.c_int),
-
-    # 1:If device is Tesla device using TCC driver, else 0
-    ("tccDriver", ctypes.c_int),
-
-    # HIP device supports cooperative launch on multiple
-    # devices with unmatched functions
-    ("cooperativeMultiDeviceUnmatchedFunc", ctypes.c_int),
-
-    # HIP device supports cooperative launch on multiple
-    # devices with unmatched grid dimensions
-    ("cooperativeMultiDeviceUnmatchedGridDim", ctypes.c_int),
-
-    # HIP device supports cooperative launch on multiple
-    # devices with unmatched block dimensions
-    ("cooperativeMultiDeviceUnmatchedBlockDim", ctypes.c_int),
-
-    # HIP device supports cooperative launch on multiple
-    # devices with unmatched shared memories
-    ("cooperativeMultiDeviceUnmatchedSharedMem", ctypes.c_int),
-
-    # 1: if it is a large PCI bar device, else 0
-    ("isLargeBar", ctypes.c_int),
-
-    # Revision of the GPU in this device
-    ("asicRevision", ctypes.c_int),
-
-    # Device supports allocating managed memory on this system
-    ("managedMemory", ctypes.c_int),
-
-    # Host can directly access managed memory on the device without migration
-    ("directManagedMemAccessFromHost", ctypes.c_int),
-
-    # Device can coherently access managed memory concurrently with the CPU
-    ("concurrentManagedAccess", ctypes.c_int),
-
-    # Device supports coherently accessing pageable memory
-    # without calling hipHostRegister on it
-    ("pageableMemoryAccess", ctypes.c_int),
-
-    # Device accesses pageable memory via the host"s page tables
-    ("pageableMemoryAccessUsesHostPageTables", ctypes.c_int),
-  ]
-
-  @property
-  def name(self):
-    return self._name.decode("utf-8")
-
-  @property
-  def gcnArchName(self):
-    return self._gcnArchName.decode("utf-8")
-
-# TODO: Fix this
-_libcuda.cuDeviceGetProperties.restype = int
-_libcuda.cuDeviceGetProperties.argtypes = [ctypes.POINTER(hipDeviceProperties), ctypes.c_int]
-def cuDeviceGetProperties(deviceId: int):
-  device_properties = hipDeviceProperties()
-  status = _libcuda.cuDeviceGetProperties(ctypes.pointer(device_properties), deviceId)
-  cuCheckStatus(status)
-  return device_properties
-
-_libcuda.cuModuleLoadData.restype = int
-_libcuda.cuModuleLoadData.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_void_p]
-def cuModuleLoadData(data):
-  module = ctypes.c_void_p()
-  data_ptr = np.char.array(data).ctypes.data
-  status = _libcuda.cuModuleLoadData(ctypes.byref(module), data_ptr)
-  cuCheckStatus(status)
-  return module
-
-_libcuda.cuModuleGetFunction.restype = int
-_libcuda.cuModuleGetFunction.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_void_p, ctypes.POINTER(ctypes.c_char)]
-def cuModuleGetFunction(module, func_name):
-  kernel = ctypes.c_void_p()
-  status = _libcuda.cuModuleGetFunction(ctypes.byref(kernel), module, func_name.encode("utf-8"))
-  cuCheckStatus(status)
-  return kernel
-
-_libcuda.cuModuleUnload.restype = int
-_libcuda.cuModuleUnload.argtypes = [ctypes.c_void_p]
-def cuModuleUnload(module):
-  status = _libcuda.cuModuleUnload(module)
-  cuCheckStatus(status)
-
-_libcuda.cuLaunchKernel.restype = int
-_libcuda.cuLaunchKernel.argtypes = [ctypes.c_void_p,
-                                          ctypes.c_uint, ctypes.c_uint, ctypes.c_uint, # block dim
-                                          ctypes.c_uint, ctypes.c_uint, ctypes.c_uint, # thread dim
-                                          ctypes.c_uint, ctypes.c_void_p,
-                                          ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_void_p)]
-def cuLaunchKernel(kernel, bx, by, bz, tx, ty, tz, shared, stream, struct):
-  c_bx, c_by, c_bz = ctypes.c_uint(bx), ctypes.c_uint(by), ctypes.c_uint(bz)
-  c_tx, c_ty, c_tz = ctypes.c_uint(tx), ctypes.c_uint(ty), ctypes.c_uint(tz)
-  c_shared = ctypes.c_uint(shared)
-
-  param_buffer_ptr, param_buffer_size, param_buffer_end = ctypes.c_void_p(1), ctypes.c_void_p(2), ctypes.c_void_p(0)
-  size = ctypes.c_size_t(ctypes.sizeof(struct))
-  p_size, p_struct = ctypes.c_void_p(ctypes.addressof(size)), ctypes.c_void_p(ctypes.addressof(struct))
-  config = (ctypes.c_void_p * 5)(param_buffer_ptr, p_struct, param_buffer_size, p_size, param_buffer_end)
-
-  status = _libcuda.cuLaunchKernel(kernel, c_bx, c_by, c_bz, c_tx, c_ty, c_tz, c_shared, stream, None, config)
-  cuCheckStatus(status)
-
-_libcudartrtc.nvrtcCreateProgram.restype = int
-_libcudartrtc.nvrtcCreateProgram.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_char),
-                                            ctypes.c_int, ctypes.POINTER(ctypes.c_char_p), ctypes.POINTER(ctypes.c_char_p)]
-def curtcCreateProgram(source, name, header_names, header_sources):
-  c_header_names, c_header_sources = (ctypes.c_char_p * len(header_names))(), (ctypes.c_char_p * len(header_sources))()
-  c_header_names[:], c_header_sources[:] = [h.encode("utf-8") for h in header_names], [h.encode("utf-8") for h in header_sources]
-
-  prog = ctypes.c_void_p()
-  status = _libcudartrtc.nvrtcCreateProgram(ctypes.byref(prog), source.encode("utf-8"), name.encode("utf-8"), len(header_names), c_header_sources, c_header_names)
-  cuCheckStatus(status)
-  return prog
-
-_libcudartrtc.nvrtcDestroyProgram.restype = int
-_libcudartrtc.nvrtcDestroyProgram.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
-def curtcDestroyProgram(prog):
-  status = _libcudartrtc.nvrtcDestroyProgram(ctypes.byref(prog))
-  cuCheckStatus(status)
-
-
-_libcudartrtc.nvrtcGetProgramLogSize.restype = int
-_libcudartrtc.nvrtcGetProgramLogSize.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
-_libcudartrtc.nvrtcGetProgramLog.restype = int
-_libcudartrtc.nvrtcGetProgramLog.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
-def curtcGetProgramLog(prog):
-  logsz = ctypes.c_size_t()
-  status = _libcudartrtc.nvrtcGetProgramLogSize(prog, logsz)
-  cuCheckStatus(status)
-  logstr = ctypes.create_string_buffer(logsz.value)
-  status = _libcudartrtc.nvrtcGetProgramLog(prog, logstr)
-  cuCheckStatus(status)
-  return logstr.value.decode()
-
-_libcudartrtc.nvrtcCompileProgram.restype = int
-_libcudartrtc.nvrtcCompileProgram.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)]
-def curtcCompileProgram(prog, options):
-  c_options = (ctypes.c_char_p * len(options))()
-  c_options[:] = [o.encode("utf-8") for o in options]
-
-  status = _libcudartrtc.nvrtcCompileProgram(prog, len(options), c_options)
-  if status == 6: print(hiprtcGetProgramLog(prog))
-  cuCheckStatus(status)
-
-_libcudartrtc.nvrtcGetPTXSize.restype = int
-_libcudartrtc.nvrtcGetPTXSize.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
-_libcudartrtc.nvrtcGetPTXSize.restype = int
-_libcudartrtc.nvrtcGetPTXSize.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_char)]
-def curtcGetCode(prog):
-  code_size = ctypes.c_size_t()
-  status = _libcudartrtc.nvrtcGetPTXSize(prog, ctypes.byref(code_size))
-  cuCheckStatus(status)
-  e_code = ("0" * code_size.value).encode("utf-8")
-  status = _libcudartrtc.nvrtcGetPTXSize(prog, e_code)
-  cuCheckStatus(status)
-  return e_code
-# except:
-#   if DEBUG >= 1: print("WARNING: libcuda.so or libnvrtc.so not found. CUDA support will not work.")
+  _libcuda = ctypes.cdll.LoadLibrary("libcuda.so.1")
+  _libnvrtc = ctypes.cdll.LoadLibrary("libnvrtc.so")
+  _nvrtc_includes = cu_get_include_paths(compiler="nvcc")
+
+  _libcuda.cuGetErrorString.restype = ctypes.c_int
+  _libcuda.cuGetErrorString.argtypes = [ctypes.c_int, ctypes.c_void_p]
+  def cuGetErrorString(status):
+    ptr = ctypes.c_char_p()
+    status = _libcuda.cuGetErrorString(status, ctypes.byref(ptr))
+    if status != 0: raise RuntimeError("CUDA error: cuGetErrorString failed")
+    return ptr.value.decode("utf-8")
+
+  def cuCheckStatus(status):
+    if status != 0: raise RuntimeError("CUDA error %s: %s" % (status, cuGetErrorString(status)))
+
+  _libcuda.cuInit.restype = int
+  _libcuda.cuInit.argtypes = [ctypes.c_uint]
+  def cuInit(flags):
+    status = _libcuda.cuInit(flags)
+    cuCheckStatus(status)
+
+  _libcuda.cuCtxCreate.restype = int
+  _libcuda.cuCtxCreate.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_void_p]
+  def cuCtxCreate(flags, device):
+    ptr = ctypes.c_void_p()
+    status = _libcuda.cuCtxCreate(ctypes.byref(ptr), flags, device)
+    cuCheckStatus(status)
+    return ptr
+
+  _libcuda.cuCtxSynchronize.restype = int
+  _libcuda.cuCtxSynchronize.argtypes = []
+  def cuCtxSynchronize():
+    status = _libcuda.cuCtxSynchronize()
+    cuCheckStatus(status)
+
+  _libcuda.cuStreamSynchronize.restype = int
+  _libcuda.cuStreamSynchronize.argtypes = [ctypes.c_void_p]
+  def cuStreamSynchronize(stream):
+    status = _libcuda.cuStreamSynchronize(stream)
+    cuCheckStatus(status)
+
+  _libcuda.cuEventCreate.restype = int
+  _libcuda.cuEventCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+  def cuEventCreate():
+    ptr = ctypes.c_void_p()
+    status = _libcuda.cuEventCreate(ctypes.byref(ptr))
+    cuCheckStatus(status)
+    return ptr
+
+  _libcuda.cuEventRecord.restype = int
+  _libcuda.cuEventRecord.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+  def cuEventRecord(event, stream=None):
+    status = _libcuda.cuEventRecord(event, stream)
+    cuCheckStatus(status)
+
+  _libcuda.cuEventDestroy.restype = int
+  _libcuda.cuEventDestroy.argtypes = [ctypes.c_void_p]
+  def cuEventDestroy(event):
+    status = _libcuda.cuEventDestroy(event)
+    cuCheckStatus(status)
+
+  _libcuda.cuEventSynchronize.restype = int
+  _libcuda.cuEventSynchronize.argtypes = [ctypes.c_void_p]
+  def cuEventSynchronize(event):
+    status = _libcuda.cuEventSynchronize(event)
+    cuCheckStatus(status)
+
+  _libcuda.cuEventElapsedTime.restype = int
+  _libcuda.cuEventElapsedTime.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.c_void_p, ctypes.c_void_p]
+  def cuEventElapsedTime(start, stop):
+    t = ctypes.c_float()
+    status = _libcuda.cuEventElapsedTime(ctypes.byref(t), start, stop)
+    cuCheckStatus(status)
+    return t.value
+
+  ## Stream Management
+
+  _libcuda.cuStreamCreate.restype = int
+  _libcuda.cuStreamCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+  def cuStreamCreate():
+    ptr = ctypes.c_void_p()
+    status = _libcuda.cuStreamCreate(ctypes.byref(ptr))
+    cuCheckStatus(status)
+    return ptr
+
+  _libcuda.cuStreamDestroy.restype = int
+  _libcuda.cuStreamDestroy.argtypes = [ctypes.c_void_p]
+  def cuStreamDestroy(stream):
+    status = _libcuda.cuStreamDestroy(stream)
+    cuCheckStatus(status)
+
+  ## Graph Management
+
+  _libcuda.cuGraphCreate.restype = int
+  _libcuda.cuGraphCreate.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+  def cuGraphCreate():
+    ptr = ctypes.c_void_p()
+    status = _libcuda.cuGraphCreate(ctypes.byref(ptr), 0)
+    cuCheckStatus(status)
+    return ptr
+
+  _libcuda.cuGraphInstantiate.restype = int
+  _libcuda.cuGraphInstantiate.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+  def cuGraphInstantiate(graph):
+    ptr = ctypes.c_void_p()
+    status = _libcuda.cuGraphInstantiate(ctypes.byref(ptr), graph, 0, 0, 0)
+    cuCheckStatus(status)
+    return ptr
+
+  _libcuda.cuGraphDestroy.restype = int
+  _libcuda.cuGraphDestroy.argtypes = [ctypes.c_void_p]
+  def cuGraphDestroy(graph):
+    status = _libcuda.cuGraphDestroy(graph)
+    cuCheckStatus(status)
+
+  _libcuda.cuGraphExecDestroy.restype = int
+  _libcuda.cuGraphExecDestroy.argtypes = [ctypes.c_void_p]
+  def cuGraphExecDestroy(gexec):
+    status = _libcuda.cuGraphExecDestroy(gexec)
+    cuCheckStatus(status)
+
+  _libcuda.cuGraphLaunch.restype = int
+  _libcuda.cuGraphLaunch.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+  def cuGraphLaunch(graph_exec, stream=0):
+    status = _libcuda.cuGraphLaunch(graph_exec, stream)
+    cuCheckStatus(status)
+
+  class hipKernelNodeParams(ctypes.Structure):
+    _fields_ = [("blockDimX", ctypes.c_uint32), ("blockDimY", ctypes.c_uint32), ("blockDimZ", ctypes.c_uint32),
+                ("extra", ctypes.POINTER(ctypes.c_void_p)),
+                ("func", ctypes.c_void_p),
+                ("gridDimX", ctypes.c_uint32), ("gridDimY", ctypes.c_uint32), ("gridDimZ", ctypes.c_uint32),
+                ("kernelParams", ctypes.POINTER(ctypes.c_void_p)),
+                ("sharedMemBytes", ctypes.c_uint32)]
+
+  @dataclass
+  class kernelNodeParamsWrapper():
+    c_struct: Any
+    context: Any = None
+
+  def getCStructForType(argtypes):
+    fields = []
+    for j,typ in enumerate(argtypes):
+      fields.append((f'field{j}', typ))
+
+    class CStructure(ctypes.Structure):
+      _pack_ = 1
+      _fields_ = fields
+    return CStructure
+
+  def setKernelNodeLaunchDims(npwrapper:kernelNodeParamsWrapper, grid, block):
+    npwrapper.c_struct.blockDimX = block[0]
+    npwrapper.c_struct.blockDimY = block[1]
+    npwrapper.c_struct.blockDimZ = block[2]
+    npwrapper.c_struct.gridDimX = grid[0]
+    npwrapper.c_struct.gridDimY = grid[1]
+    npwrapper.c_struct.gridDimZ = grid[2]
+
+  def setKernelNodeParams(npwrapper:kernelNodeParamsWrapper, args, ids):
+    for j,i in enumerate(ids):
+      setattr(npwrapper.context[1], f'field{i}', args[j])
+
+  def buildKernelNodeParams(args, argtypes, func, grid, block, sharedMemBytes=0):
+    c_struct_t = getCStructForType(argtypes)
+    struct = c_struct_t(*args)
+    size = ctypes.c_size_t(ctypes.sizeof(struct))
+    p_size = ctypes.c_void_p(ctypes.addressof(size))
+    p_struct = ctypes.c_void_p(ctypes.addressof(struct))
+    config = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), p_struct,
+                                  ctypes.c_void_p(2), p_size, ctypes.c_void_p(3))
+    params = hipKernelNodeParams(block[0], block[1], block[2], config, func, grid[0], grid[1], grid[2], None, sharedMemBytes)
+    return kernelNodeParamsWrapper(c_struct=params, context=(size, struct, config))
+
+  _libcuda.cuGraphAddKernelNode.restype = int
+  _libcuda.cuGraphAddKernelNode.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p]
+  def cuGraphAddKernelNode(graph, deps, params:kernelNodeParamsWrapper):
+    graph_node = ctypes.c_void_p()
+    deps_in = (ctypes.c_void_p * len(deps))()
+    deps_in[:] = deps
+    num_deps = ctypes.c_size_t(len(deps))
+    status = _libcuda.cuGraphAddKernelNode(ctypes.byref(graph_node), graph, deps_in, num_deps, ctypes.byref(params.c_struct))
+    cuCheckStatus(status)
+    return graph_node
+
+  _libcuda.cuGraphExecKernelNodeSetParams.restype = int
+  _libcuda.cuGraphExecKernelNodeSetParams.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+  def cuGraphExecKernelNodeSetParams(gexec, node, params:kernelNodeParamsWrapper):
+    status = _libcuda.cuGraphExecKernelNodeSetParams(gexec, node, ctypes.byref(params.c_struct))
+    cuCheckStatus(status)
+
+  _libcuda.cuMemAlloc.restype = int
+  _libcuda.cuMemAlloc.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
+  def cuMemAlloc(count):
+    ptr = ctypes.c_void_p()
+    status = _libcuda.cuMemAlloc(ctypes.byref(ptr), count)
+    cuCheckStatus(status)
+    return ptr.value
+
+  _libcuda.cuMemFree.restype = int
+  _libcuda.cuMemFree.argtypes = [ctypes.c_void_p]
+  def cuMemFree(ptr):
+    status = _libcuda.cuMemFree(ptr)
+    cuCheckStatus(status)
+
+  _libcuda.cuMemcpyAsync.restype = int
+  _libcuda.cuMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p]
+  def cuMemcpyHtoDAsync(dst, src, count, stream):
+    status = _libcuda.cuMemcpyHtoDAsync(dst, src, ctypes.c_size_t(count), stream)
+    cuCheckStatus(status)
+
+  _libcuda.cuMemcpyAsync.restype = int
+  _libcuda.cuMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t]
+  def cuMemcpyDtoH(dst, src, count):
+    status = _libcuda.cuMemcpyDtoH(dst, src, ctypes.c_size_t(count))
+    cuCheckStatus(status)
+
+  _libcuda.cuMemGetInfo.restype = int
+  _libcuda.cuMemGetInfo.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+  def cuMemGetInfo():
+    free = ctypes.c_size_t()
+    total = ctypes.c_size_t()
+    status = _libcuda.cuMemGetInfo(ctypes.byref(free), ctypes.byref(total))
+    cuCheckStatus(status)
+    return free.value, total.value
+
+
+  ## Device Management
+
+  _libcuda.cuDeviceGet.restype = int
+  _libcuda.cuDeviceGet.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.c_int]
+  def cuDeviceGet(id):
+    dev = ctypes.c_int()
+    status = _libcuda.cuDeviceGet(ctypes.byref(dev), id)
+    cuCheckStatus(status)
+    return dev.value
+
+  _libcuda.cuDeviceGetCount.restype = int
+  _libcuda.cuDeviceGetCount.argtypes = [ctypes.POINTER(ctypes.c_int)]
+  def cuDeviceGetCount():
+    count = ctypes.c_int()
+    status = _libcuda.cuDeviceGetCount(ctypes.byref(count))
+    cuCheckStatus(status)
+    return count.value
+
+  _libcuda.cuDeviceComputeCapability.restype = int
+  _libcuda.cuDeviceComputeCapability.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
+  def cuDeviceComputeCapability(device_id):
+    major = ctypes.c_int()
+    minor = ctypes.c_int()
+    status = _libcuda.cuDeviceComputeCapability(ctypes.byref(major), ctypes.byref(minor), device_id)
+    cuCheckStatus(status)
+    return (major.value, minor.value)
+
+  _libcuda.cuModuleLoadData.restype = int
+  _libcuda.cuModuleLoadData.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_void_p]
+  def cuModuleLoadData(data):
+    module = ctypes.c_void_p()
+    data_ptr = np.char.array(data).ctypes.data
+    status = _libcuda.cuModuleLoadData(ctypes.byref(module), data_ptr)
+    cuCheckStatus(status)
+    return module
+
+  _libcuda.cuModuleGetFunction.restype = int
+  _libcuda.cuModuleGetFunction.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_void_p, ctypes.POINTER(ctypes.c_char)]
+  def cuModuleGetFunction(module, func_name):
+    kernel = ctypes.c_void_p()
+    status = _libcuda.cuModuleGetFunction(ctypes.byref(kernel), module, func_name.encode("utf-8"))
+    cuCheckStatus(status)
+    return kernel
+
+  _libcuda.cuModuleUnload.restype = int
+  _libcuda.cuModuleUnload.argtypes = [ctypes.c_void_p]
+  def cuModuleUnload(module):
+    status = _libcuda.cuModuleUnload(module)
+    cuCheckStatus(status)
+
+  _libcuda.cuLaunchKernel.restype = int
+  _libcuda.cuLaunchKernel.argtypes = [ctypes.c_void_p,
+                                            ctypes.c_uint, ctypes.c_uint, ctypes.c_uint, # block dim
+                                            ctypes.c_uint, ctypes.c_uint, ctypes.c_uint, # thread dim
+                                            ctypes.c_uint, ctypes.c_void_p,
+                                            ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_void_p)]
+  def cuLaunchKernel(kernel, bx, by, bz, tx, ty, tz, shared, stream, struct):
+    c_bx, c_by, c_bz = ctypes.c_uint(bx), ctypes.c_uint(by), ctypes.c_uint(bz)
+    c_tx, c_ty, c_tz = ctypes.c_uint(tx), ctypes.c_uint(ty), ctypes.c_uint(tz)
+    c_shared = ctypes.c_uint(shared)
+
+    param_buffer_ptr, param_buffer_size, param_buffer_end = ctypes.c_void_p(1), ctypes.c_void_p(2), ctypes.c_void_p(0)
+    size = ctypes.c_size_t(ctypes.sizeof(struct))
+    p_size, p_struct = ctypes.c_void_p(ctypes.addressof(size)), ctypes.c_void_p(ctypes.addressof(struct))
+    config = (ctypes.c_void_p * 5)(param_buffer_ptr, p_struct, param_buffer_size, p_size, param_buffer_end)
+
+    status = _libcuda.cuLaunchKernel(kernel, c_bx, c_by, c_bz, c_tx, c_ty, c_tz, c_shared, stream, None, config)
+    cuCheckStatus(status)
+
+  _libnvrtc.nvrtcCreateProgram.restype = int
+  _libnvrtc.nvrtcCreateProgram.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_char),
+                                              ctypes.c_int, ctypes.POINTER(ctypes.c_char_p), ctypes.POINTER(ctypes.c_char_p)]
+  def nvrtcCreateProgram(source, name, header_names, header_sources):
+    c_header_names, c_header_sources = (ctypes.c_char_p * len(header_names))(), (ctypes.c_char_p * len(header_sources))()
+    c_header_names[:], c_header_sources[:] = [h.encode("utf-8") for h in header_names], [h.encode("utf-8") for h in header_sources]
+
+    prog = ctypes.c_void_p()
+    status = _libnvrtc.nvrtcCreateProgram(ctypes.byref(prog), source.encode("utf-8"), name.encode("utf-8"), len(header_names), c_header_sources, c_header_names)
+    cuCheckStatus(status)
+    return prog
+
+  _libnvrtc.nvrtcDestroyProgram.restype = int
+  _libnvrtc.nvrtcDestroyProgram.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+  def nvrtcDestroyProgram(prog):
+    status = _libnvrtc.nvrtcDestroyProgram(ctypes.byref(prog))
+    cuCheckStatus(status)
+
+  _libnvrtc.nvrtcGetProgramLogSize.restype = int
+  _libnvrtc.nvrtcGetProgramLogSize.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+  _libnvrtc.nvrtcGetProgramLog.restype = int
+  _libnvrtc.nvrtcGetProgramLog.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+  def nvrtcGetProgramLog(prog):
+    logsz = ctypes.c_size_t()
+    status = _libnvrtc.nvrtcGetProgramLogSize(prog, logsz)
+    cuCheckStatus(status)
+    logstr = ctypes.create_string_buffer(logsz.value)
+    status = _libnvrtc.nvrtcGetProgramLog(prog, logstr)
+    cuCheckStatus(status)
+    return logstr.value.decode()
+
+  _libnvrtc.nvrtcCompileProgram.restype = int
+  _libnvrtc.nvrtcCompileProgram.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)]
+  def nvrtcCompileProgram(prog, options):
+    options += _nvrtc_includes
+    c_options = (ctypes.c_char_p * len(options))()
+    c_options[:] = [o.encode("utf-8") for o in options]
+
+    status = _libnvrtc.nvrtcCompileProgram(prog, len(options), c_options)
+    if status == 6: print(nvrtcGetProgramLog(prog))
+    cuCheckStatus(status)
+
+  _libnvrtc.nvrtcGetPTXSize.restype = int
+  _libnvrtc.nvrtcGetPTXSize.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+  _libnvrtc.nvrtcGetPTX.restype = int
+  _libnvrtc.nvrtcGetPTX.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_char)]
+  def nvrtcGetPTX(prog):
+    code_size = ctypes.c_size_t()
+    status = _libnvrtc.nvrtcGetPTXSize(prog, ctypes.byref(code_size))
+    cuCheckStatus(status)
+    e_code = ("0" * code_size.value).encode("utf-8")
+    status = _libnvrtc.nvrtcGetPTX(prog, e_code)
+    cuCheckStatus(status)
+    return e_code
+except:
+  if DEBUG >= 1: print("WARNING: libcuda.so or libnvrtc.so not found. CUDA support will not work.")

--- a/extra/cuda_wrapper.py
+++ b/extra/cuda_wrapper.py
@@ -1,0 +1,718 @@
+import subprocess
+from cuda import nvrtc, cuda, cudart
+
+def cu_get_include_paths(compiler):
+  try:
+    # Run the compiler command to get the include paths
+    result = subprocess.check_output([compiler, "-E", "-x", "c", "-", "-v"], input="", stderr=subprocess.STDOUT, universal_newlines=True)
+    lines = result.splitlines()
+
+    includes = []
+    for line in lines:
+      if line.startswith("#$ INCLUDES="):
+        line = line.strip().rstrip()[len("#$ INCLUDES=\""):-1]
+        includes = line.split()
+    return includes
+
+  except Exception as e:
+    print(f"An error occurred, CUDA might be unavailable: {e}")
+    return []
+
+cuda_includes = cu_get_include_paths(compiler="nvcc")
+
+import ctypes
+from tinygrad.helpers import DEBUG
+import sys
+import numpy as np
+from typing import Any, Dict, List, Tuple
+from dataclasses import dataclass
+
+# try:
+_libcuda = ctypes.cdll.LoadLibrary("libcuda.so.1")
+# print(_libcuda)
+# _libcudart = ctypes.cdll.LoadLibrary("libcudart.so")
+_libcudartrtc = ctypes.cdll.LoadLibrary("libnvrtc.so")
+
+_libcuda.cuGetErrorString.restype = ctypes.c_int
+_libcuda.cuGetErrorString.argtypes = [ctypes.c_int, ctypes.c_void_p]
+def cuGetErrorString(status):
+  ptr = ctypes.c_char_p()
+  status = _libcuda.cuGetErrorString(status, ctypes.byref(ptr))
+  if status != 0: raise RuntimeError("CUDA error: cuGetErrorString failed")
+  return ptr.value.decode("utf-8")
+
+def cuCheckStatus(status):
+  if status != 0: raise RuntimeError("CUDA error %s: %s" % (status, cuGetErrorString(status)))
+
+_libcuda.cuInit.restype = int
+_libcuda.cuInit.argtypes = [ctypes.c_uint]
+def cuInit(flags):
+  status = _libcuda.cuInit(flags)
+  cuCheckStatus(status)
+
+_libcuda.cuCtxCreate.restype = int
+_libcuda.cuCtxCreate.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_void_p]
+def cuCtxCreate(flags, device):
+  ptr = ctypes.c_void_p()
+  status = _libcuda.cuCtxCreate(ctypes.byref(ptr), flags, device)
+  cuCheckStatus(status)
+  return ptr
+
+_libcuda.cuCtxSynchronize.restype = int
+_libcuda.cuCtxSynchronize.argtypes = []
+def cuCtxSynchronize():
+  status = _libcuda.cuCtxSynchronize()
+  cuCheckStatus(status)
+
+_libcuda.cuStreamSynchronize.restype = int
+_libcuda.cuStreamSynchronize.argtypes = [ctypes.c_void_p]
+def cuStreamSynchronize(stream):
+  status = _libcuda.cuStreamSynchronize(stream)
+  cuCheckStatus(status)
+
+_libcuda.cuEventCreate.restype = int
+_libcuda.cuEventCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+def cuEventCreate():
+  ptr = ctypes.c_void_p()
+  status = _libcuda.cuEventCreate(ctypes.byref(ptr))
+  cuCheckStatus(status)
+  return ptr
+
+_libcuda.cuEventRecord.restype = int
+_libcuda.cuEventRecord.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+def cuEventRecord(event, stream=None):
+  status = _libcuda.cuEventRecord(event, stream)
+  cuCheckStatus(status)
+
+_libcuda.cuEventDestroy.restype = int
+_libcuda.cuEventDestroy.argtypes = [ctypes.c_void_p]
+def cuEventDestroy(event):
+  status = _libcuda.cuEventDestroy(event)
+  cuCheckStatus(status)
+
+_libcuda.cuEventSynchronize.restype = int
+_libcuda.cuEventSynchronize.argtypes = [ctypes.c_void_p]
+def cuEventSynchronize(event):
+  status = _libcuda.cuEventSynchronize(event)
+  cuCheckStatus(status)
+
+_libcuda.cuEventElapsedTime.restype = int
+_libcuda.cuEventElapsedTime.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.c_void_p, ctypes.c_void_p]
+def cuEventElapsedTime(start, stop):
+  t = ctypes.c_float()
+  status = _libcuda.cuEventElapsedTime(ctypes.byref(t), start, stop)
+  cuCheckStatus(status)
+  return t.value
+
+## Stream Management
+
+# Stream capture modes:
+hipStreamCaptureModeGlobal = 0
+hipStreamCaptureModeThreadLocal = 1
+hipStreamCaptureModeRelaxed = 2
+
+_libcuda.cuStreamCreate.restype = int
+_libcuda.cuStreamCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+def cuStreamCreate():
+  ptr = ctypes.c_void_p()
+  status = _libcuda.cuStreamCreate(ctypes.byref(ptr))
+  cuCheckStatus(status)
+  return ptr
+
+_libcuda.cuStreamDestroy.restype = int
+_libcuda.cuStreamDestroy.argtypes = [ctypes.c_void_p]
+def cuStreamDestroy(stream):
+  status = _libcuda.cuStreamDestroy(stream)
+  cuCheckStatus(status)
+
+_libcuda.cuStreamBeginCapture.restype = int
+_libcuda.cuStreamBeginCapture.argtypes = [ctypes.c_void_p, ctypes.c_int]
+def cuStreamBeginCapture(stream, mode=hipStreamCaptureModeGlobal):
+  t = ctypes.c_float()
+  status = _libcuda.cuStreamBeginCapture(stream, mode)
+  cuCheckStatus(status)
+
+_libcuda.cuStreamEndCapture.restype = int
+_libcuda.cuStreamEndCapture.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+def cuStreamEndCapture(stream):
+  ptr = ctypes.c_void_p()
+  status = _libcuda.cuStreamEndCapture(stream, ctypes.byref(ptr))
+  cuCheckStatus(status)
+  return ptr
+
+_libcuda.cuStreamGetCaptureInfo_v2.restype = int
+_libcuda.cuStreamGetCaptureInfo_v2.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+def cuStreamGetCaptureInfo_v2(stream):
+  status_out = ctypes.c_void_p()
+  id_out = ctypes.c_ulonglong()
+  graph_out = ctypes.c_void_p()
+  deps_out = ctypes.POINTER(ctypes.c_void_p)()
+  num_deps = ctypes.c_size_t()
+  status = _libcuda.cuStreamGetCaptureInfo_v2(stream, ctypes.byref(status_out), ctypes.byref(id_out), ctypes.byref(graph_out), ctypes.byref(deps_out), ctypes.byref(num_deps))
+  cuCheckStatus(status)
+  deps = [ctypes.cast(deps_out[i], ctypes.c_void_p) for i in range(num_deps.value)]
+  return status_out, id_out.value, graph_out, deps
+
+hipStreamAddCaptureDependencies = 0
+hipStreamSetCaptureDependencies = 1
+
+_libcuda.cuStreamUpdateCaptureDependencies.restype = int
+_libcuda.cuStreamUpdateCaptureDependencies.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint]
+def cuStreamUpdateCaptureDependencies(stream, deps, flags=hipStreamAddCaptureDependencies):
+  deps_in = (ctypes.c_void_p * len(deps))()
+  deps_in[:] = deps
+  num_deps = ctypes.c_size_t()
+  num_deps.value = len(deps)
+  flags_in = ctypes.c_uint()
+  flags_in.value = flags
+  status = _libcuda.cuStreamUpdateCaptureDependencies(stream, deps_in, num_deps, flags_in)
+  cuCheckStatus(status)
+
+
+## Graph Management
+
+_libcuda.cuGraphCreate.restype = int
+_libcuda.cuGraphCreate.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+def cuGraphCreate():
+  ptr = ctypes.c_void_p()
+  status = _libcuda.cuGraphCreate(ctypes.byref(ptr), 0)
+  cuCheckStatus(status)
+  return ptr
+
+_libcuda.cuGraphInstantiate.restype = int
+_libcuda.cuGraphInstantiate.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+def cuGraphInstantiate(graph):
+  ptr = ctypes.c_void_p()
+  status = _libcuda.cuGraphInstantiate(ctypes.byref(ptr), graph, 0, 0, 0)
+  cuCheckStatus(status)
+  return ptr
+
+_libcuda.cuGraphDestroy.restype = int
+_libcuda.cuGraphDestroy.argtypes = [ctypes.c_void_p]
+def cuGraphDestroy(graph):
+  status = _libcuda.cuGraphDestroy(graph)
+  cuCheckStatus(status)
+
+_libcuda.cuGraphExecDestroy.restype = int
+_libcuda.cuGraphExecDestroy.argtypes = [ctypes.c_void_p]
+def cuGraphExecDestroy(gexec):
+  status = _libcuda.cuGraphExecDestroy(gexec)
+  cuCheckStatus(status)
+
+_libcuda.cuGraphLaunch.restype = int
+_libcuda.cuGraphLaunch.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+def cuGraphLaunch(graph_exec, stream=0):
+  status = _libcuda.cuGraphLaunch(graph_exec, stream)
+  cuCheckStatus(status)
+
+class hipKernelNodeParams(ctypes.Structure):
+  _fields_ = [("blockDimX", ctypes.c_uint32), ("blockDimY", ctypes.c_uint32), ("blockDimZ", ctypes.c_uint32),
+              ("extra", ctypes.POINTER(ctypes.c_void_p)),
+              ("func", ctypes.c_void_p),
+              ("gridDimX", ctypes.c_uint32), ("gridDimY", ctypes.c_uint32), ("gridDimZ", ctypes.c_uint32),
+              ("kernelParams", ctypes.POINTER(ctypes.c_void_p)),
+              ("sharedMemBytes", ctypes.c_uint32)]
+
+@dataclass
+class kernelNodeParamsWrapper():
+  c_struct: Any
+  context: Any = None
+
+def getCStructForType(argtypes):
+  fields = []
+  for j,typ in enumerate(argtypes):
+    fields.append((f'field{j}', typ))
+
+  class CStructure(ctypes.Structure):
+    _pack_ = 1
+    _fields_ = fields
+  return CStructure
+
+def setKernelNodeLaunchDims(npwrapper:kernelNodeParamsWrapper, grid, block):
+  npwrapper.c_struct.blockDimX = block[0]
+  npwrapper.c_struct.blockDimY = block[1]
+  npwrapper.c_struct.blockDimZ = block[2]
+  npwrapper.c_struct.gridDimX = grid[0]
+  npwrapper.c_struct.gridDimY = grid[1]
+  npwrapper.c_struct.gridDimZ = grid[2]
+
+def setKernelNodeParams(npwrapper:kernelNodeParamsWrapper, args, ids):
+  for j,i in enumerate(ids):
+    setattr(npwrapper.context[1], f'field{i}', args[j])
+
+def buildKernelNodeParams(args, argtypes, func, grid, block, sharedMemBytes=0):
+  c_struct_t = getCStructForType(argtypes)
+  struct = c_struct_t(*args)
+  size = ctypes.c_size_t(ctypes.sizeof(struct))
+  p_size = ctypes.c_void_p(ctypes.addressof(size))
+  p_struct = ctypes.c_void_p(ctypes.addressof(struct))
+  config = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), p_struct,
+                                ctypes.c_void_p(2), p_size, ctypes.c_void_p(3))
+  params = hipKernelNodeParams(block[0], block[1], block[2], config, func, grid[0], grid[1], grid[2], None, sharedMemBytes)
+  return kernelNodeParamsWrapper(c_struct=params, context=(size, struct, config))
+
+_libcuda.cuGraphAddKernelNode.restype = int
+_libcuda.cuGraphAddKernelNode.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p]
+def cuGraphAddKernelNode(graph, deps, params:kernelNodeParamsWrapper):
+  graph_node = ctypes.c_void_p()
+  deps_in = (ctypes.c_void_p * len(deps))()
+  deps_in[:] = deps
+  num_deps = ctypes.c_size_t(len(deps))
+  status = _libcuda.cuGraphAddKernelNode(ctypes.byref(graph_node), graph, deps_in, num_deps, ctypes.byref(params.c_struct))
+  cuCheckStatus(status)
+  return graph_node
+
+_libcuda.cuGraphExecKernelNodeSetParams.restype = int
+_libcuda.cuGraphExecKernelNodeSetParams.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+def cuGraphExecKernelNodeSetParams(gexec, node, params:kernelNodeParamsWrapper):
+  status = _libcuda.cuGraphExecKernelNodeSetParams(gexec, node, ctypes.byref(params.c_struct))
+  cuCheckStatus(status)
+
+_libcuda.cuMemAlloc.restype = int
+_libcuda.cuMemAlloc.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
+def cuMemAlloc(count):
+  ptr = ctypes.c_void_p()
+  status = _libcuda.cuMemAlloc(ctypes.byref(ptr), count)
+  cuCheckStatus(status)
+  return ptr.value
+
+_libcuda.cuMemFree.restype = int
+_libcuda.cuMemFree.argtypes = [ctypes.c_void_p]
+def cuMemFree(ptr):
+  status = _libcuda.cuMemFree(ptr)
+  cuCheckStatus(status)
+
+# memory copy modes
+hipMemcpyHostToHost = 0
+hipMemcpyHostToDevice = 1
+hipMemcpyDeviceToHost = 2
+hipMemcpyDeviceToDevice = 3
+hipMemcpyDefault = 4
+
+_libcuda.cuMemcpy.restype = int
+_libcuda.cuMemcpy.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]
+def cuMemcpy(dst, src, count, direction):
+  status = _libcuda.cuMemcpy(dst, src, ctypes.c_size_t(count), direction)
+  cuCheckStatus(status)
+
+_libcuda.cuMemcpyAsync.restype = int
+_libcuda.cuMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_void_p]
+def cuMemcpyAsync(dst, src, count, direction, stream):
+  status = _libcuda.cuMemcpyAsync(dst, src, ctypes.c_size_t(count), direction, stream)
+  cuCheckStatus(status)
+
+_libcuda.cuMemcpyAsync.restype = int
+_libcuda.cuMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p]
+def cuMemcpyHtoDAsync(dst, src, count, stream):
+  status = _libcuda.cuMemcpyHtoDAsync(dst, src, ctypes.c_size_t(count), stream)
+  cuCheckStatus(status)
+
+_libcuda.cuMemcpyAsync.restype = int
+_libcuda.cuMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t]
+def cuMemcpyDtoH(dst, src, count):
+  status = _libcuda.cuMemcpyDtoH(dst, src, ctypes.c_size_t(count))
+  cuCheckStatus(status)
+
+_libcuda.cuMemGetInfo.restype = int
+_libcuda.cuMemGetInfo.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+def cuMemGetInfo():
+  free = ctypes.c_size_t()
+  total = ctypes.c_size_t()
+  status = _libcuda.cuMemGetInfo(ctypes.byref(free), ctypes.byref(total))
+  cuCheckStatus(status)
+  return free.value, total.value
+
+class hipIpcMemHandle_t(ctypes.Structure):
+  _fields_ = [("reserved", ctypes.c_char * 64)]
+
+_libcuda.cuIpcGetMemHandle.restype = int
+_libcuda.cuIpcGetMemHandle.argtypes = [ctypes.POINTER(hipIpcMemHandle_t), ctypes.c_void_p]
+def cuIpcGetMemHandle(ptr):
+  handle = hipIpcMemHandle_t()
+  status = _libcuda.cuIpcGetMemHandle(ctypes.byref(handle), ptr)
+  cuCheckStatus(status)
+  return handle
+
+_libcuda.cuIpcOpenMemHandle.restype = int
+_libcuda.cuIpcOpenMemHandle.argtypes = [ctypes.POINTER(ctypes.c_void_p), hipIpcMemHandle_t, ctypes.c_uint]
+def cuIpcOpenMemHandle(handle, flags):
+  ptr = ctypes.c_void_p()
+  status = _libcuda.cuIpcOpenMemHandle(ctypes.byref(ptr), handle, flags)
+  cuCheckStatus(status)
+  return ptr.value
+
+_libcuda.cuIpcCloseMemHandle.restype = int
+_libcuda.cuIpcCloseMemHandle.argtypes = [ctypes.c_void_p]
+def cuIpcCloseMemHandle(ptr):
+  status = _libcuda.cuIpcCloseMemHandle(ptr)
+  cuCheckStatus(status)
+
+_libcuda.cuDeviceGet.restype = int
+_libcuda.cuDeviceGet.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.c_int]
+def cuDeviceGet(id):
+  dev = ctypes.c_int()
+  status = _libcuda.cuDeviceGet(ctypes.byref(dev), id)
+  cuCheckStatus(status)
+  return dev.value
+
+_libcuda.cuDeviceGetCount.restype = int
+_libcuda.cuDeviceGetCount.argtypes = [ctypes.POINTER(ctypes.c_int)]
+def cuDeviceGetCount():
+  count = ctypes.c_int()
+  status = _libcuda.cuDeviceGetCount(ctypes.byref(count))
+  cuCheckStatus(status)
+  return count.value
+
+class hipDeviceArch(ctypes.Structure):
+  _fields_ = [
+    # *32-bit Atomics*
+    # 32-bit integer atomics for global memory.
+    ("hasGlobalInt32Atomics", ctypes.c_uint, 1),
+
+    # 32-bit float atomic exch for global memory.
+    ("hasGlobalFloatAtomicExch", ctypes.c_uint, 1),
+
+    # 32-bit integer atomics for shared memory.
+    ("hasSharedInt32Atomics", ctypes.c_uint, 1),
+
+    # 32-bit float atomic exch for shared memory.
+    ("hasSharedFloatAtomicExch", ctypes.c_uint, 1),
+
+    # 32-bit float atomic add in global and shared memory.
+    ("hasFloatAtomicAdd", ctypes.c_uint, 1),
+
+    # *64-bit Atomics*
+    # 64-bit integer atomics for global memory.
+    ("hasGlobalInt64Atomics", ctypes.c_uint, 1),
+
+    # 64-bit integer atomics for shared memory.
+    ("hasSharedInt64Atomics", ctypes.c_uint, 1),
+
+    # *Doubles*
+    # Double-precision floating point.
+    ("hasDoubles", ctypes.c_uint, 1),
+
+    # *Warp cross-lane operations*
+    # Warp vote instructions (__any, __all).
+    ("hasWarpVote", ctypes.c_uint, 1),
+
+    # Warp ballot instructions (__ballot).
+    ("hasWarpBallot", ctypes.c_uint, 1),
+
+    # Warp shuffle operations. (__shfl_*).
+    ("hasWarpShuffle", ctypes.c_uint, 1),
+
+    # Funnel two words into one with shift&mask caps.
+    ("hasFunnelShift", ctypes.c_uint, 1),
+
+    # *Sync*
+    # __threadfence_system.
+    ("hasThreadFenceSystem", ctypes.c_uint, 1),
+
+    # __syncthreads_count, syncthreads_and, syncthreads_or.
+    ("hasSyncThreadsExt", ctypes.c_uint, 1),
+
+    # *Misc*
+    # Surface functions.
+    ("hasSurfaceFuncs", ctypes.c_uint, 1),
+
+    # Grid and group dims are 3D (rather than 2D).
+    ("has3dGrid", ctypes.c_uint, 1),
+
+    # Dynamic parallelism.
+    ("hasDynamicParallelism", ctypes.c_uint, 1),
+  ]
+
+class hipDeviceProperties(ctypes.Structure):
+  _fields_ = [
+    # Device name
+    ("_name", ctypes.c_char * 256),
+
+    # Size of global memory region (in bytes)
+    ("totalGlobalMem", ctypes.c_size_t),
+
+    # Size of shared memory region (in bytes).
+    ("sharedMemPerBlock", ctypes.c_size_t),
+
+    # Registers per block.
+    ("regsPerBlock", ctypes.c_int),
+
+    # Warp size.
+    ("warpSize", ctypes.c_int),
+
+    # Max work items per work group or workgroup max size.
+    ("maxThreadsPerBlock", ctypes.c_int),
+
+    # Max number of threads in each dimension (XYZ) of a block.
+    ("maxThreadsDim", ctypes.c_int * 3),
+
+    # Max grid dimensions (XYZ).
+    ("maxGridSize", ctypes.c_int * 3),
+
+    # Max clock frequency of the multiProcessors in khz.
+    ("clockRate", ctypes.c_int),
+
+    # Max global memory clock frequency in khz.
+    ("memoryClockRate", ctypes.c_int),
+
+    # Global memory bus width in bits.
+    ("memoryBusWidth", ctypes.c_int),
+
+    # Size of shared memory region (in bytes).
+    ("totalConstMem", ctypes.c_size_t),
+
+    # Major compute capability.  On HCC, this is an approximation and features may
+    # differ from CUDA CC.  See the arch feature flags for portable ways to query
+    # feature caps.
+    ("major", ctypes.c_int),
+
+    # Minor compute capability.  On HCC, this is an approximation and features may
+    # differ from CUDA CC.  See the arch feature flags for portable ways to query
+    # feature caps.
+    ("minor", ctypes.c_int),
+
+    # Number of multi-processors (compute units).
+    ("multiProcessorCount", ctypes.c_int),
+
+    # L2 cache size.
+    ("l2CacheSize", ctypes.c_int),
+
+    # Maximum resident threads per multi-processor.
+    ("maxThreadsPerMultiProcessor", ctypes.c_int),
+
+    # Compute mode.
+    ("computeMode", ctypes.c_int),
+
+    # Frequency in khz of the timer used by the device-side "clock*"
+    # instructions.  New for HIP.
+    ("clockInstructionRate", ctypes.c_int),
+
+    # Architectural feature flags.  New for HIP.
+    ("arch", hipDeviceArch),
+
+    # Device can possibly execute multiple kernels concurrently.
+    ("concurrentKernels", ctypes.c_int),
+
+    # PCI Domain ID
+    ("pciDomainID", ctypes.c_int),
+
+    # PCI Bus ID.
+    ("pciBusID", ctypes.c_int),
+
+    # PCI Device ID.
+    ("pciDeviceID", ctypes.c_int),
+
+    # Maximum Shared Memory Per Multiprocessor.
+    ("maxSharedMemoryPerMultiProcessor", ctypes.c_size_t),
+
+    # 1 if device is on a multi-GPU board, 0 if not.
+    ("isMultiGpuBoard", ctypes.c_int),
+
+    # Check whether HIP can map host memory
+    ("canMapHostMemory", ctypes.c_int),
+
+    # DEPRECATED: use gcnArchName instead
+    ("gcnArch", ctypes.c_int),
+
+    # AMD GCN Arch Name.
+    ("_gcnArchName", ctypes.c_char * 256),
+
+    # APU vs dGPU
+    ("integrated", ctypes.c_int),
+
+    # HIP device supports cooperative launch
+    ("cooperativeLaunch", ctypes.c_int),
+
+    # HIP device supports cooperative launch on multiple devices
+    ("cooperativeMultiDeviceLaunch", ctypes.c_int),
+
+    # Maximum size for 1D textures bound to linear memory
+    ("maxTexture1DLinear", ctypes.c_int),
+
+    # Maximum number of elements in 1D images
+    ("maxTexture1D", ctypes.c_int),
+
+    # Maximum dimensions (width, height) of 2D images, in image elements
+    ("maxTexture2D", ctypes.c_int * 2),
+
+    # Maximum dimensions (width, height, depth) of 3D images, in image elements
+    ("maxTexture3D", ctypes.c_int * 3),
+
+    # Addres of HDP_MEM_COHERENCY_FLUSH_CNTL register
+    ("hdpMemFlushCntl", ctypes.POINTER(ctypes.c_uint)),
+
+    # Addres of HDP_REG_COHERENCY_FLUSH_CNTL register
+    ("hdpRegFlushCntl", ctypes.POINTER(ctypes.c_uint)),
+
+    # Maximum pitch in bytes allowed by memory copies
+    ("memPitch", ctypes.c_size_t),
+
+    # Alignment requirement for textures
+    ("textureAlignment", ctypes.c_size_t),
+
+    # Pitch alignment requirement for texture references bound to pitched memory
+    ("texturePitchAlignment", ctypes.c_size_t),
+
+    # Run time limit for kernels executed on the device
+    ("kernelExecTimeoutEnabled", ctypes.c_int),
+
+    # Device has ECC support enabled
+    ("ECCEnabled", ctypes.c_int),
+
+    # 1:If device is Tesla device using TCC driver, else 0
+    ("tccDriver", ctypes.c_int),
+
+    # HIP device supports cooperative launch on multiple
+    # devices with unmatched functions
+    ("cooperativeMultiDeviceUnmatchedFunc", ctypes.c_int),
+
+    # HIP device supports cooperative launch on multiple
+    # devices with unmatched grid dimensions
+    ("cooperativeMultiDeviceUnmatchedGridDim", ctypes.c_int),
+
+    # HIP device supports cooperative launch on multiple
+    # devices with unmatched block dimensions
+    ("cooperativeMultiDeviceUnmatchedBlockDim", ctypes.c_int),
+
+    # HIP device supports cooperative launch on multiple
+    # devices with unmatched shared memories
+    ("cooperativeMultiDeviceUnmatchedSharedMem", ctypes.c_int),
+
+    # 1: if it is a large PCI bar device, else 0
+    ("isLargeBar", ctypes.c_int),
+
+    # Revision of the GPU in this device
+    ("asicRevision", ctypes.c_int),
+
+    # Device supports allocating managed memory on this system
+    ("managedMemory", ctypes.c_int),
+
+    # Host can directly access managed memory on the device without migration
+    ("directManagedMemAccessFromHost", ctypes.c_int),
+
+    # Device can coherently access managed memory concurrently with the CPU
+    ("concurrentManagedAccess", ctypes.c_int),
+
+    # Device supports coherently accessing pageable memory
+    # without calling hipHostRegister on it
+    ("pageableMemoryAccess", ctypes.c_int),
+
+    # Device accesses pageable memory via the host"s page tables
+    ("pageableMemoryAccessUsesHostPageTables", ctypes.c_int),
+  ]
+
+  @property
+  def name(self):
+    return self._name.decode("utf-8")
+
+  @property
+  def gcnArchName(self):
+    return self._gcnArchName.decode("utf-8")
+
+# TODO: Fix this
+_libcuda.cuDeviceGetProperties.restype = int
+_libcuda.cuDeviceGetProperties.argtypes = [ctypes.POINTER(hipDeviceProperties), ctypes.c_int]
+def cuDeviceGetProperties(deviceId: int):
+  device_properties = hipDeviceProperties()
+  status = _libcuda.cuDeviceGetProperties(ctypes.pointer(device_properties), deviceId)
+  cuCheckStatus(status)
+  return device_properties
+
+_libcuda.cuModuleLoadData.restype = int
+_libcuda.cuModuleLoadData.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_void_p]
+def cuModuleLoadData(data):
+  module = ctypes.c_void_p()
+  data_ptr = np.char.array(data).ctypes.data
+  status = _libcuda.cuModuleLoadData(ctypes.byref(module), data_ptr)
+  cuCheckStatus(status)
+  return module
+
+_libcuda.cuModuleGetFunction.restype = int
+_libcuda.cuModuleGetFunction.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_void_p, ctypes.POINTER(ctypes.c_char)]
+def cuModuleGetFunction(module, func_name):
+  kernel = ctypes.c_void_p()
+  status = _libcuda.cuModuleGetFunction(ctypes.byref(kernel), module, func_name.encode("utf-8"))
+  cuCheckStatus(status)
+  return kernel
+
+_libcuda.cuModuleUnload.restype = int
+_libcuda.cuModuleUnload.argtypes = [ctypes.c_void_p]
+def cuModuleUnload(module):
+  status = _libcuda.cuModuleUnload(module)
+  cuCheckStatus(status)
+
+_libcuda.cuLaunchKernel.restype = int
+_libcuda.cuLaunchKernel.argtypes = [ctypes.c_void_p,
+                                          ctypes.c_uint, ctypes.c_uint, ctypes.c_uint, # block dim
+                                          ctypes.c_uint, ctypes.c_uint, ctypes.c_uint, # thread dim
+                                          ctypes.c_uint, ctypes.c_void_p,
+                                          ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_void_p)]
+def cuLaunchKernel(kernel, bx, by, bz, tx, ty, tz, shared, stream, struct):
+  c_bx, c_by, c_bz = ctypes.c_uint(bx), ctypes.c_uint(by), ctypes.c_uint(bz)
+  c_tx, c_ty, c_tz = ctypes.c_uint(tx), ctypes.c_uint(ty), ctypes.c_uint(tz)
+  c_shared = ctypes.c_uint(shared)
+
+  param_buffer_ptr, param_buffer_size, param_buffer_end = ctypes.c_void_p(1), ctypes.c_void_p(2), ctypes.c_void_p(0)
+  size = ctypes.c_size_t(ctypes.sizeof(struct))
+  p_size, p_struct = ctypes.c_void_p(ctypes.addressof(size)), ctypes.c_void_p(ctypes.addressof(struct))
+  config = (ctypes.c_void_p * 5)(param_buffer_ptr, p_struct, param_buffer_size, p_size, param_buffer_end)
+
+  status = _libcuda.cuLaunchKernel(kernel, c_bx, c_by, c_bz, c_tx, c_ty, c_tz, c_shared, stream, None, config)
+  cuCheckStatus(status)
+
+_libcudartrtc.nvrtcCreateProgram.restype = int
+_libcudartrtc.nvrtcCreateProgram.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_char),
+                                            ctypes.c_int, ctypes.POINTER(ctypes.c_char_p), ctypes.POINTER(ctypes.c_char_p)]
+def curtcCreateProgram(source, name, header_names, header_sources):
+  c_header_names, c_header_sources = (ctypes.c_char_p * len(header_names))(), (ctypes.c_char_p * len(header_sources))()
+  c_header_names[:], c_header_sources[:] = [h.encode("utf-8") for h in header_names], [h.encode("utf-8") for h in header_sources]
+
+  prog = ctypes.c_void_p()
+  status = _libcudartrtc.nvrtcCreateProgram(ctypes.byref(prog), source.encode("utf-8"), name.encode("utf-8"), len(header_names), c_header_sources, c_header_names)
+  cuCheckStatus(status)
+  return prog
+
+_libcudartrtc.nvrtcDestroyProgram.restype = int
+_libcudartrtc.nvrtcDestroyProgram.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+def curtcDestroyProgram(prog):
+  status = _libcudartrtc.nvrtcDestroyProgram(ctypes.byref(prog))
+  cuCheckStatus(status)
+
+
+_libcudartrtc.nvrtcGetProgramLogSize.restype = int
+_libcudartrtc.nvrtcGetProgramLogSize.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+_libcudartrtc.nvrtcGetProgramLog.restype = int
+_libcudartrtc.nvrtcGetProgramLog.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+def curtcGetProgramLog(prog):
+  logsz = ctypes.c_size_t()
+  status = _libcudartrtc.nvrtcGetProgramLogSize(prog, logsz)
+  cuCheckStatus(status)
+  logstr = ctypes.create_string_buffer(logsz.value)
+  status = _libcudartrtc.nvrtcGetProgramLog(prog, logstr)
+  cuCheckStatus(status)
+  return logstr.value.decode()
+
+_libcudartrtc.nvrtcCompileProgram.restype = int
+_libcudartrtc.nvrtcCompileProgram.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)]
+def curtcCompileProgram(prog, options):
+  c_options = (ctypes.c_char_p * len(options))()
+  c_options[:] = [o.encode("utf-8") for o in options]
+
+  status = _libcudartrtc.nvrtcCompileProgram(prog, len(options), c_options)
+  if status == 6: print(hiprtcGetProgramLog(prog))
+  cuCheckStatus(status)
+
+_libcudartrtc.nvrtcGetPTXSize.restype = int
+_libcudartrtc.nvrtcGetPTXSize.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+_libcudartrtc.nvrtcGetPTXSize.restype = int
+_libcudartrtc.nvrtcGetPTXSize.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_char)]
+def curtcGetCode(prog):
+  code_size = ctypes.c_size_t()
+  status = _libcudartrtc.nvrtcGetPTXSize(prog, ctypes.byref(code_size))
+  cuCheckStatus(status)
+  e_code = ("0" * code_size.value).encode("utf-8")
+  status = _libcudartrtc.nvrtcGetPTXSize(prog, e_code)
+  cuCheckStatus(status)
+  return e_code
+# except:
+#   if DEBUG >= 1: print("WARNING: libcuda.so or libnvrtc.so not found. CUDA support will not work.")

--- a/extra/cuda_wrapper.py
+++ b/extra/cuda_wrapper.py
@@ -10,7 +10,7 @@ try:
   _nvrtc_includes = None
   def _get_include_paths():
     global _nvrtc_includes
-    if _nvrtc_includes is not None: return _nvrtc_includes
+    if _nvrtc_includes is not None: return _nvrtc_includes # type: ignore
 
     compiler = "nvcc"
     result = subprocess.check_output([compiler, "-E", "-x", "c", "-", "-v"], input="", stderr=subprocess.STDOUT, universal_newlines=True)

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,8 @@ setup(name='tinygrad',
       python_requires='>=3.8',
       extras_require={
         'llvm': ["llvmlite"],
-        'cuda': ["pycuda"],
         'arm': ["unicorn"],
-        'triton': ["triton-nightly>=2.1.0.dev20231014192330", "pycuda"],
+        'triton': ["triton-nightly>=2.1.0.dev20231014192330"],
         'webgpu': ["wgpu>=v0.12.0"],
         'linting': [
             "flake8",

--- a/tinygrad/renderer/cuda.py
+++ b/tinygrad/renderer/cuda.py
@@ -2,7 +2,7 @@ import functools
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 
 class CUDALanguage(CStyleLanguage):
-  kernel_prefix = "#include <math_constants.h>\n#define INFINITY (CUDART_INF_F)\n#define NAN (CUDART_NAN_F)\n__global__ "
+  kernel_prefix = "#include <math_constants.h>\n#define INFINITY (CUDART_INF_F)\n#define NAN (CUDART_NAN_F)\nextern \"C\" __global__ "
   smem_prefix = "__shared__ "
   smem_prefix_for_cast = False
   arg_int_prefix = "const int"

--- a/tinygrad/renderer/cuda.py
+++ b/tinygrad/renderer/cuda.py
@@ -2,7 +2,7 @@ import functools
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 
 class CUDALanguage(CStyleLanguage):
-  kernel_prefix = "#include <math_constants.h>\n#define INFINITY (CUDART_INF_F)\n#define NAN (CUDART_NAN_F)\nextern \"C\" __global__ "
+  kernel_prefix = "#define INFINITY (__int_as_float(0x7f800000))\n#define NAN (__int_as_float(0x7fffffff))\nextern \"C\" __global__ "
   smem_prefix = "__shared__ "
   smem_prefix_for_cast = False
   arg_int_prefix = "const int"

--- a/tinygrad/renderer/cuda.py
+++ b/tinygrad/renderer/cuda.py
@@ -2,7 +2,7 @@ import functools
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 
 class CUDALanguage(CStyleLanguage):
-  kernel_prefix = "__global__ "
+  kernel_prefix = "#include <math_constants.h>\n#define INFINITY (CUDART_INF_F)\n#define NAN (CUDART_NAN_F)\n__global__ "
   smem_prefix = "__shared__ "
   smem_prefix_for_cast = False
   arg_int_prefix = "const int"

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -24,18 +24,17 @@ if getenv("CUDACPU", 0) == 1:
   lib = ctypes.CDLL(ctypes.util.find_library("gpuocelot"))
   lib.ptx_run.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.POINTER(ctypes.c_void_p), ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
   class cuda_class:
-    cuDeviceComputeCapability = _ = lambda x: (3,5)
-    cuEventRecord = cuEventDestroy = cuModuleLoadData = cuModuleUnload = lambda x: x
-    cuModuleGetFunction = _ = lambda x, y: x
-    cuLaunchKernel = _ = lambda src, gx, gy, gz, lx, ly, lz, shared, stream, args: lib.ptx_run(src, len(args), (ctypes.c_void_p * len(args))(*[ctypes.cast(x, ctypes.c_void_p) for x in args]), lx, ly, lz, gx, gy, gz, shared)
-    cuEventCreate = _ = lambda: time.perf_counter()
-    cuEventElapsedTime = _ = lambda x, y: y - x
+    cuDeviceComputeCapability = lambda x: (3,5) # noqa: E731
+    cuEventRecord = cuEventDestroy = cuModuleLoadData = cuModuleUnload = lambda x: x # noqa: E731
+    cuModuleGetFunction = lambda x, y: x # noqa: E731
+    cuLaunchKernel = lambda src, gx, gy, gz, lx, ly, lz, shared, stream, args: lib.ptx_run(src, len(args), (ctypes.c_void_p * len(args))(*[ctypes.cast(x, ctypes.c_void_p) for x in args]), lx, ly, lz, gx, gy, gz, shared)  # noqa: E731
+    cuEventCreate = lambda: time.perf_counter() # noqa: E731
+    cuEventElapsedTime = lambda x, y: y - x # noqa: E731
+    cuCtxSynchronize = lambda: None # noqa: E731
 
     nvrtcCreateProgram = cuda.nvrtcCreateProgram
     nvrtcCompileProgram = cuda.nvrtcCompileProgram
     nvrtcGetPTX = cuda.nvrtcGetPTX
-
-    cuCtxSynchronize = _ = lambda: None
 
   cuda: Any = cuda_class # type: ignore
   RawCUDABuffer = RawMallocBuffer

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -47,7 +47,7 @@ else:
     def _do_alloc(self, size, dtype, device, **kwargs): return cuda.cuMemAlloc(size * dtype.itemsize)
     def _do_free(self, buf): cuda.cuMemFree(buf)
     def _cached_bufkey(self, size, dtype, device): return (device, size*dtype.itemsize) # Buffers of the same length could be reused, no matter what dtype.
-    def _get_cur_free_space(self, device): return cuda.cuMemGetInfo()[0] # type: ignore
+    def _get_cur_free_space(self, device): return cuda.cuMemGetInfo()[0]
   CUDAAlloc = CUDAAllocator()
   class RawCUDABuffer(RawBufferCopyInOut): # type: ignore
     def __init__(self, size, dtype): super().__init__(size, dtype, allocator=CUDAAlloc)

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -1,7 +1,8 @@
-import subprocess, time, re, hashlib, tempfile
+import subprocess, time, re, hashlib, tempfile, ctypes
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, cast, Callable
 import numpy as np
+import extra.cuda_wrapper as cuda
 from pycuda.compiler import compile as cuda_compile
 from tinygrad.helpers import DEBUG, getenv, colored, diskcache
 from tinygrad.ops import Compiled
@@ -20,71 +21,92 @@ def pretty_ptx(s):
   return s
 def arch(): return "sm_" + "".join([str(x) for x in pycuda.driver.Context.get_device().compute_capability()])
 
-if getenv("CUDACPU", 0) == 1:
-  import ctypes, ctypes.util
-  lib = ctypes.CDLL(ctypes.util.find_library("gpuocelot"))
-  lib.ptx_run.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.POINTER(ctypes.c_void_p), ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
-  class cuda:
-    class module:
-      def __init__(self, src): self.src = src
-      def get_function(self, _): return self
-      def __call__(self, *args, block, grid, shared): lib.ptx_run(self.src, len(args), (ctypes.c_void_p * len(args))(*[ctypes.cast(x, ctypes.c_void_p) for x in args]), *block, *grid, shared)
-    module_from_buffer = lambda src: cuda.module(src) # pylint: disable=unnecessary-lambda # noqa: E731
-    class Event:
-      def __init__(self): pass
-      def record(self): self.start = time.perf_counter()
-      def time_till(self, other): return other.start - self.start
-      def synchronize(self): pass
-    class Context:
-      synchronize = lambda:0 # noqa: E731
-    CompileError = Exception
-  class context:
-    class device:
-      compute_capability = lambda: (3,5) # pylint: disable=unnecessary-lambda # noqa: E731
-    get_device = lambda: context.device # pylint: disable=unnecessary-lambda # noqa: E731
-  import pycuda.driver
-  pycuda.driver.Context = context
-  RawCUDABuffer = RawMallocBuffer
-else:
-  import pycuda.autoprimaryctx # pylint: disable=unused-import # noqa: F401
-  import pycuda.driver as cuda # type: ignore
-  class CUDAAllocator(LRUAllocator):
-    def __init__(self): super().__init__(self._get_cur_free_space(None))
-    def _do_alloc(self, size, dtype, device, **kwargs): return cuda.mem_alloc(size * dtype.itemsize) # type: ignore
-    def _cached_bufkey(self, size, dtype, device): return (device, size*dtype.itemsize) # Buffers of the same length could be reused, no matter what dtype.
-    def _get_cur_free_space(self, device): return cuda.mem_get_info()[0] # type: ignore
-  CUDAAlloc = CUDAAllocator()
-  class RawCUDABuffer(RawBufferCopyInOut): # type: ignore
-    def __init__(self, size, dtype): super().__init__(size, dtype, allocator=CUDAAlloc)
-    def _copyin(self, x:np.ndarray, stream:Optional[cuda.Stream]=None): cuda.memcpy_htod_async(self._buf, x.ravel(), stream) # type: ignore
-    def _copyout(self, x:np.ndarray): cuda.memcpy_dtoh(x, self._buf) # type: ignore
+cuda.cuInit(0)
+device = cuda.cuDeviceGet(0)
+cuda.cuCtxCreate(0, device)
 
+# if getenv("CUDACPU", 0) == 1:
+#   import ctypes, ctypes.util
+#   lib = ctypes.CDLL(ctypes.util.find_library("gpuocelot"))
+#   lib.ptx_run.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.POINTER(ctypes.c_void_p), ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+#   class cuda:
+#     class module:
+#       def __init__(self, src): self.src = src
+#       def get_function(self, _): return self
+#       def __call__(self, *args, block, grid, shared): lib.ptx_run(self.src, len(args), (ctypes.c_void_p * len(args))(*[ctypes.cast(x, ctypes.c_void_p) for x in args]), *block, *grid, shared)
+#     module_from_buffer = lambda src: cuda.module(src) # pylint: disable=unnecessary-lambda # noqa: E731
+#     class Event:
+#       def __init__(self): pass
+#       def record(self): self.start = time.perf_counter()
+#       def time_till(self, other): return other.start - self.start
+#       def synchronize(self): pass
+#     class Context:
+#       synchronize = lambda:0 # noqa: E731
+#     CompileError = Exception
+#   class context:
+#     class device:
+#       compute_capability = lambda: (3,5) # pylint: disable=unnecessary-lambda # noqa: E731
+#     get_device = lambda: context.device # pylint: disable=unnecessary-lambda # noqa: E731
+#   import pycuda.driver
+#   pycuda.driver.Context = context
+#   RawCUDABuffer = RawMallocBuffer
+# else:
+class CUDAAllocator(LRUAllocator):
+  def _do_alloc(self, size, dtype, device, **kwargs): return cuda.cuMemAlloc(size * dtype.itemsize)
+  def _do_free(self, buf): cuda.cuMemFree(buf)
+  def _cached_bufkey(self, size, dtype, device): return (device, size*dtype.itemsize) # Buffers of the same length could be reused, no matter what dtype.
+  #TODO: missing size on device.
+
+CUDAAlloc = CUDAAllocator()
+
+class RawCUDABuffer(RawBufferCopyInOut): # type: ignore
+  def __init__(self, size, dtype): super().__init__(size, dtype, allocator=CUDAAlloc)
+  def _copyin(self, x:np.ndarray): cuda.cuMemcpyHtoDAsync(self._buf, np.require(x, requirements='C').ctypes.data_as(ctypes.c_void_p), self.size * self.dtype.itemsize, 0)
+  def _copyout(self, x:np.ndarray): cuda.cuMemcpyDtoH(np.require(x, requirements='C').ctypes.data_as(ctypes.c_void_p), self._buf, self.size * self.dtype.itemsize)
+
+# TODO: reimplement as cuda compiler.
 @diskcache
 def compile_cuda(prg) -> bytes: return cuda_compile(prg, target="ptx", no_extern_c=True, options=['-Wno-deprecated-gpu-targets'])
+
+def time_execution(cb, enable=False):
+  # if enable:
+  #   start, end = hip.hipEventCreate(), hip.hipEventCreate()
+  #   hip.hipEventRecord(start)
+  cb()
+  # if enable:
+  #   hip.hipEventRecord(end)
+  #   hip.hipEventSynchronize(end)
+  #   ret = hip.hipEventElapsedTime(start, end)*1e-3
+  #   hip.hipEventDestroy(start)
+  #   hip.hipEventDestroy(end)
+  #   return ret
 
 class CUDAProgram:
   def __init__(self, name:str, _prg:bytes):
     prg = _prg.decode('utf-8')
-    if DEBUG >= 5: print(pretty_ptx(prg))
-    if DEBUG >= 6:
-      try:
-        fn = (Path(tempfile.gettempdir()) / f"tinycuda_{hashlib.md5(prg.encode('utf-8')).hexdigest()}").as_posix()
-        with open(fn + ".ptx", "wb") as f: f.write(prg.encode('utf-8'))
-        subprocess.run(["ptxas", f"-arch={arch()}", "-o", fn, fn+".ptx"], check=True)
-        print(subprocess.check_output(['nvdisasm', fn]).decode('utf-8'))
-      except Exception as e: print("failed to generate SASS", str(e))
+    # if DEBUG >= 5: print(pretty_ptx(prg))
+    # if DEBUG >= 6:
+    #   try:
+    #     fn = (Path(tempfile.gettempdir()) / f"tinycuda_{hashlib.md5(prg.encode('utf-8')).hexdigest()}").as_posix()
+    #     with open(fn + ".ptx", "wb") as f: f.write(prg.encode('utf-8'))
+    #     subprocess.run(["ptxas", f"-arch={arch()}", "-o", fn, fn+".ptx"], check=True)
+    #     print(subprocess.check_output(['nvdisasm', fn]).decode('utf-8'))
+    #   except Exception as e: print("failed to generate SASS", str(e))
+    # # TODO: name is wrong, so we get it from the ptx using hacks
+    # self.prg = cuda.module_from_buffer(prg.encode('utf-8')).get_function(prg.split(".visible .entry ")[1].split("(")[0])
+    
+    # print("Here")
+
     # TODO: name is wrong, so we get it from the ptx using hacks
-    self.prg = cuda.module_from_buffer(prg.encode('utf-8')).get_function(prg.split(".visible .entry ")[1].split("(")[0])
+    name = prg.split(".visible .entry ")[1].split("(")[0]
+    self.c_struct_t = None
+    self.module = cuda.cuModuleLoadData(prg.encode('utf-8'))
+    self.prg = cuda.cuModuleGetFunction(self.module, name)
 
   def __call__(self, *args, global_size:Tuple[int,int,int], local_size:Tuple[int,int,int], shared:int=0, wait=False):
-    if wait:
-      start, end = cuda.Event(), cuda.Event()
-      start.record()
-    self.prg(*[x._buf if isinstance(x, RawCUDABuffer) else np.int32(x) if (isinstance(x, int) and not getenv("CUDACPU")) else x for x in args], block=tuple(local_size), grid=tuple(global_size), shared=shared)
-    if wait:
-      end.record()
-      end.synchronize()
-      return start.time_till(end)*1e-3
+    if self.c_struct_t is None: self.c_struct_t = cuda.getCStructForType([(ctypes.c_void_p if not isinstance(x, int) else ctypes.c_int) for x in args])
+    c_params = cast(Callable, self.c_struct_t)(*[x._buf if not isinstance(x, int) else x for x in args])
+    return time_execution(lambda: cuda.cuLaunchKernel(self.prg, *global_size, *local_size, 0, 0, c_params), enable=wait)
 
 CUDABuffer = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=False if getenv("PTX") else True, supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024]),
-                      CUDARenderer, compile_cuda, CUDAProgram, cuda.Context.synchronize)
+                      CUDARenderer, compile_cuda, CUDAProgram, cuda.cuCtxSynchronize)

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -24,18 +24,18 @@ if getenv("CUDACPU", 0) == 1:
   lib = ctypes.CDLL(ctypes.util.find_library("gpuocelot"))
   lib.ptx_run.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.POINTER(ctypes.c_void_p), ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
   class cuda_class:
-    cuDeviceComputeCapability = lambda x: (3,5)
+    cuDeviceComputeCapability = _ = lambda x: (3,5)
     cuEventRecord = cuEventDestroy = cuModuleLoadData = cuModuleUnload = lambda x: x
-    cuModuleGetFunction = lambda x, y: x
-    cuLaunchKernel = lambda src, gx, gy, gz, lx, ly, lz, shared, stream, args: lib.ptx_run(src, len(args), (ctypes.c_void_p * len(args))(*[ctypes.cast(x, ctypes.c_void_p) for x in args]), lx, ly, lz, gx, gy, gz, shared)
-    cuEventCreate = lambda: time.perf_counter()
-    cuEventElapsedTime = lambda x, y: y - x
+    cuModuleGetFunction = _ = lambda x, y: x
+    cuLaunchKernel = _ = lambda src, gx, gy, gz, lx, ly, lz, shared, stream, args: lib.ptx_run(src, len(args), (ctypes.c_void_p * len(args))(*[ctypes.cast(x, ctypes.c_void_p) for x in args]), lx, ly, lz, gx, gy, gz, shared)
+    cuEventCreate = _ = lambda: time.perf_counter()
+    cuEventElapsedTime = _ = lambda x, y: y - x
 
     nvrtcCreateProgram = cuda.nvrtcCreateProgram
     nvrtcCompileProgram = cuda.nvrtcCompileProgram
     nvrtcGetPTX = cuda.nvrtcGetPTX
 
-    cuCtxSynchronize = lambda: None
+    cuCtxSynchronize = _ = lambda: None
 
   cuda: Any = cuda_class # type: ignore
   RawCUDABuffer = RawMallocBuffer

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -20,7 +20,6 @@ def pretty_ptx(s):
   return s
 
 if getenv("CUDACPU", 0) == 1:
-  
   lib = ctypes.CDLL(ctypes.util.find_library("gpuocelot"))
   lib.ptx_run.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.POINTER(ctypes.c_void_p), ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
   class cuda_class:

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -25,7 +25,7 @@ if getenv("CUDACPU", 0) == 1:
   lib.ptx_run.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.POINTER(ctypes.c_void_p), ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
   class cuda_class:
     cuDeviceComputeCapability = lambda x: (3,5) # noqa: E731
-    cuEventRecord = cuEventDestroy = cuModuleLoadData = cuModuleUnload = lambda x: x # noqa: E731
+    cuEventRecord = cuEventSynchronize = cuEventDestroy = cuModuleLoadData = cuModuleUnload = lambda x: x # noqa: E731
     cuModuleGetFunction = lambda x, y: x # noqa: E731
     cuLaunchKernel = lambda src, gx, gy, gz, lx, ly, lz, shared, stream, args: lib.ptx_run(src, len(args), (ctypes.c_void_p * len(args))(*[ctypes.cast(x, ctypes.c_void_p) for x in args]), lx, ly, lz, gx, gy, gz, shared)  # noqa: E731
     cuEventCreate = lambda: time.perf_counter() # noqa: E731


### PR DESCRIPTION
Decided to move to our own wrapper instead of pycuda & python-cuda. Also switches `nvcc` to `nvrtc`.

As of python-cuda I find it a bit strange when it comes to managing versions: if you have cuda11, you have to install python-cuda=11.x.x (the same for cuda12). Also there are no pip package of cuda11 for python3.11 and no cuda12 for python3.8.