### PR TITLE
Add isinstance check before gcd call in SumNode.__lt__

### DIFF
--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -394,6 +394,14 @@ class TestSymbolicSymbolicOps(unittest.TestCase):
     assert a < 3 and (a < 3).min == 0 and (a < 3).max == 1
     assert a > 3 and (a > 3).min == 0 and (a > 3).max == 1
 
+  def test_sumnode_mulnode_lt(self):
+    a = Variable("a", 1, 2)
+    b = Variable("b", 1, 2)
+    c = Variable("c", 1, 2)
+    x = SumNode([MulNode(a, b), c])
+    assert isinstance((x < 3), Node) and (x < 3) == 0 
+    assert isinstance((x < 4), LtNode) and (x < 4).min == 0 and (x < 4).max == 1
+
   def test_num_node_mul_node(self):
     a = Variable("a", 1, 5)
     b = NumNode(2) * a
@@ -447,6 +455,7 @@ class TestSymbolicSymbolicOps(unittest.TestCase):
     b = a + 1
     c = b.substitute({a: NumNode(1)})
     assert c == NumNode(2)
+
 
 
 if __name__ == '__main__':

--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -399,7 +399,7 @@ class TestSymbolicSymbolicOps(unittest.TestCase):
     b = Variable("b", 1, 2)
     c = Variable("c", 1, 2)
     x = SumNode([MulNode(a, b), c])
-    assert isinstance((x < 3), Node) and (x < 3).min == 0 and (x < 4).max == 1
+    assert isinstance((x < 3), Node) and (x < 3) == 0
     assert isinstance((x < 4), LtNode) and (x < 4).min == 0 and (x < 4).max == 1
 
   def test_num_node_mul_node(self):
@@ -455,6 +455,8 @@ class TestSymbolicSymbolicOps(unittest.TestCase):
     b = a + 1
     c = b.substitute({a: NumNode(1)})
     assert c == NumNode(2)
+
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -399,7 +399,7 @@ class TestSymbolicSymbolicOps(unittest.TestCase):
     b = Variable("b", 1, 2)
     c = Variable("c", 1, 2)
     x = SumNode([MulNode(a, b), c])
-    assert isinstance((x < 3), Node) and (x < 3) == 0 
+    assert isinstance((x < 3), Node) and (x < 3).min == 0 and (x < 4).max == 1
     assert isinstance((x < 4), LtNode) and (x < 4).min == 0 and (x < 4).max == 1
 
   def test_num_node_mul_node(self):
@@ -455,8 +455,6 @@ class TestSymbolicSymbolicOps(unittest.TestCase):
     b = a + 1
     c = b.substitute({a: NumNode(1)})
     assert c == NumNode(2)
-
-
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -456,7 +456,5 @@ class TestSymbolicSymbolicOps(unittest.TestCase):
     c = b.substitute({a: NumNode(1)})
     assert c == NumNode(2)
 
-
-
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -290,7 +290,7 @@ class SumNode(RedNode):
       if muls:
         # NOTE: gcd in python 3.8 takes exactly 2 args
         mul_gcd = b
-        for x in muls: mul_gcd = gcd(mul_gcd, x.b)  # type: ignore  # mypy cannot tell x.b is int here
+        for x in muls: mul_gcd = gcd(mul_gcd, x.b) if isinstance(x.b, int) else 1
         all_others = Variable.sum(others)
         if all_others.min >= 0 and all_others.max < mul_gcd:
           lhs, b = Variable.sum([mul//mul_gcd for mul in muls]), b//mul_gcd


### PR DESCRIPTION
SumNode.\_\_lt\_\_ currently has an ill-typed call to math.gcd, sending a (Node | int) to the function which requires an int.   This PR fixes this by checking to see if the argument is an int.  If it is an int, the behavior is the same.  If it is not an int, the gcd is set to 1, so which results in the code not performing an optional reduction of both sides of the inequality.  It also includes a test case which reproduces the error in the old code.

It might also be worth writing a gcd function in the Node class so that more reductions are possible.  This would also affect similar code in SumNode.\_\_floor\_div\_\_