### PR TITLE
Add [override] error code to type: ignore in tensor.py

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -750,8 +750,8 @@ class Tensor:
   def __gt__(self, x) -> Tensor: return mlops.Less.apply(*self._broadcasted(x, True))
   def __ge__(self, x) -> Tensor: return 1.0-(self<x)
   def __le__(self, x) -> Tensor: return 1.0-(self>x)
-  def __ne__(self, x) -> Tensor: return (self<x) + (self>x)   # type: ignore
-  def __eq__(self, x) -> Tensor: return 1.0-(self != x)       # type: ignore
+  def __ne__(self, x) -> Tensor: return (self<x) + (self>x)   # type: ignore[override]
+  def __eq__(self, x) -> Tensor: return 1.0-(self != x)       # type: ignore[override]
 
   # ***** functional nn ops *****
 


### PR DESCRIPTION
Adds the '[override]' error code to the type ignores for '=' and '!='.  This means that mypy will only ignore that specific error code, so it can catch other type errors involving these operators.  

This also seems to be the best practice regarding overriding the return type for equality operators according to this thread: https://github.com/python/mypy/issues/2783