### PR TITLE
Reproducible model benchmark output

### DIFF
--- a/test/external/external_model_benchmark.py
+++ b/test/external/external_model_benchmark.py
@@ -31,7 +31,6 @@ MODELS = {
 
 CSV = {}
 open_csv = None
-torch.manual_seed(1)
 
 def benchmark(mnm, nm, fxn):
   tms = []
@@ -46,6 +45,7 @@ def benchmark(mnm, nm, fxn):
 #BASE = pathlib.Path(__file__).parents[2] / "weights" / "onnx"
 BASE = pathlib.Path("/tmp/onnx")
 def benchmark_model(m, validate_outs=False):
+  torch.manual_seed(1)
   global open_csv, CSV
   CSV = {"model": m}
 


### PR DESCRIPTION
If you run `python3 test/external/external_model_benchmark.py` vs `MODEL="openpilot" python3 test/external/external_model_benchmark.py` and print out what the `np_inputs` dict's data is, it's different because of how torch.randn behaves when it's called more than once.

I think it's better to have this be a reproducible output no matter how we run the benchmark test.