### PR TITLE
Switch from pyobj to metalcompute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ setup(name='tinygrad',
         "License :: OSI Approved :: MIT License"
       ],
       install_requires=["numpy", "tqdm", "pyopencl",
-                        "pyobjc-framework-Metal; platform_system=='Darwin'",
-                        "pyobjc-framework-libdispatch; platform_system=='Darwin'"],
+                        "metalcompute; platform_system=='Darwin'"],
       python_requires='>=3.8',
       extras_require={
         'llvm': ["llvmlite"],


### PR DESCRIPTION
Fixes the "MTLLibrary is not formatted as a MetalLib file" #2226 on my local computer, but I still want to figure out what exactly is doing the fix.