### PR TITLE
enable symbolic ops tests for hip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -314,7 +314,7 @@ jobs:
     - name: Test HIP compilation on RDNA3 [gfx1100]
       run: |
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/hip/lib
-        MOCKHIP=1 HIP=1 python -m pytest -s test/test_hip_rdna3.py
+        MOCKHIP=1 HIP=1 python -m pytest -s test/test_hip_rdna3.py test/test_symbolic_ops.py
 
 
   tests:

--- a/test/test_symbolic_ops.py
+++ b/test/test_symbolic_ops.py
@@ -5,7 +5,7 @@ from tinygrad.tensor import Tensor, Device
 import numpy as np
 
 @unittest.skipIf(getenv("ARM64") or getenv("PTX"), "ARM64 and PTX are not supported")
-@unittest.skipIf(Device.DEFAULT in ["HIP", "WEBGPU"], f"{Device.DEFAULT} is not supported")
+@unittest.skipIf(Device.DEFAULT in ["WEBGPU"], f"{Device.DEFAULT} is not supported")
 class TestSymbolicOps(unittest.TestCase):
   def test_plus1(self):
     def f(a): return (a+1).realize()


### PR DESCRIPTION
symbolic ops was already supported in HIP (tested with real HIP, and benchmark llama / gpt2 runs). enabled the test in the new ci infra.