### PR TITLE
Cuda Tensor Cores 

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -43,6 +43,10 @@ tensor_cores: Dict[str, List[TensorCore]] = {
   "HIP": [
     TensorCore(device="HIP", dims=[16,16,16], dtype_in=dtypes.half, dtype_out=dtypes.float, upcast_dim=1, threads=[(0,16),(1,2)], thread_local_sizes=[16,16,8], thread_local_aliases=[ [[0],[0],[-1],[1]], [[0],[1],[-1],[0]], [[0],[1],[0],[2,-1]] ]),
     TensorCore(device="HIP", dims=[16,16,16], dtype_in=dtypes.half, dtype_out=dtypes.half,  upcast_dim=1, threads=[(0,16),(1,2)], thread_local_sizes=[16,16,8], thread_local_aliases=[ [[0],[0],[-1],[1]], [[0],[1],[-1],[0]], [[0],[1],[0],[2,-1]] ]),
+  ],
+   "CUDA": [
+    TensorCore(device="CUDA", dims=[16,16,16], dtype_in=dtypes.half, dtype_out=dtypes.float, upcast_dim=1, threads=[(0,16),(1,2)], thread_local_sizes=[16,16,8], thread_local_aliases=[ [[0],[0],[-1],[1]], [[0],[1],[-1],[0]], [[0],[1],[0],[2,-1]] ]),
+    TensorCore(device="CUDA", dims=[16,16,16], dtype_in=dtypes.half, dtype_out=dtypes.half,  upcast_dim=1, threads=[(0,16),(1,2)], thread_local_sizes=[16,16,8], thread_local_aliases=[ [[0],[0],[-1],[1]], [[0],[1],[-1],[0]], [[0],[1],[0],[2,-1]] ]),
   ]
 }
 

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -157,9 +157,9 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp]) -> Tu
         kk("nvcuda::wmma::fragment<nvcuda::wmma::matrix_b, 16, 16, 16, half, nvcuda::wmma::row_major> b_frag;")
         kk("nvcuda::wmma::fragment<nvcuda::wmma::accumulator, 16, 16, 16, float> c_frag;")
         kk("nvcuda::wmma::fill_fragment(c_frag, 0.0f);")
-        kk(f"__shared__ half a[16*16];")
-        kk(f"__shared__ half b[16*16];")
-        kk(f"__shared__ float c[16*16];")
+        kk("__shared__ half a[16*16];")
+        kk("__shared__ half b[16*16];")
+        kk("__shared__ float c[16*16];")
         for i in range(16*16):
           kk(f"a[lidx1*16+{i%16}] = {r[vin[(i%16)]]};")
         for i in range(16*16):

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -152,6 +152,8 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp]) -> Tu
         assert dtype == dtypes.float.vec(8), "output dtype of HIP TC is _float8"
         kk(f"{lang.generic_var_prefix if lang.generic_var_prefix else dtype.name} {ssa(u, 'wmma')} = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32({r[vin[0]]}, {r[vin[1]]}, {r[vin[2]]});")
       elif args[0] == "CUDA":
+        output = ssa(u, "wmma")
+        kk("float wmma0[8];")
         kk("{")
         kk("nvcuda::wmma::fragment<nvcuda::wmma::matrix_a, 16, 16, 16, half, nvcuda::wmma::row_major> a_frag;")
         kk("nvcuda::wmma::fragment<nvcuda::wmma::matrix_b, 16, 16, 16, half, nvcuda::wmma::row_major> b_frag;")
@@ -170,7 +172,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp]) -> Tu
         kk("nvcuda::wmma::mma_sync(c_frag, a_frag, b_frag, c_frag);")
         kk("nvcuda::wmma::store_matrix_sync(c, c_frag, 16, wmma::mem_row_major);")
         for i in range(8):
-          kk(f"{r[vin[32+i]]} = c[lidx1+(lidx0*16)+{i*32}];")
+          kk(f"{output}[{i}] = c[lidx1+(lidx0*16)+{i*32}];")
         kk("__syncthreads();")
         kk("}")
       else:

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -153,8 +153,6 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp]) -> Tu
         kk(f"{lang.generic_var_prefix if lang.generic_var_prefix else dtype.name} {ssa(u, 'wmma')} = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32({r[vin[0]]}, {r[vin[1]]}, {r[vin[2]]});")
       elif args[0] == "CUDA":
         kk("{")
-        kk("int warpM = (blockIdx.x * blockDim.x + threadIdx.x) / warpSize;")
-        kk("int warpN = (blockIdx.y * blockDim.y + threadIdx.y);")
         kk("nvcuda::wmma::fragment<nvcuda::wmma::matrix_a, 16, 16, 16, half, nvcuda::wmma::row_major> a_frag;")
         kk("nvcuda::wmma::fragment<nvcuda::wmma::matrix_b, 16, 16, 16, half, nvcuda::wmma::row_major> b_frag;")
         kk("nvcuda::wmma::fragment<nvcuda::wmma::accumulator, 16, 16, 16, float> c_frag;")

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -159,21 +159,13 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp]) -> Tu
         kk("nvcuda::wmma::fragment<nvcuda::wmma::matrix_b, 16, 16, 16, half, nvcuda::wmma::row_major> b_frag;")
         kk("nvcuda::wmma::fragment<nvcuda::wmma::accumulator, 16, 16, 16, float> c_frag;")
         kk("nvcuda::wmma::fill_fragment(c_frag, 0.0f);")
-        kk("__shared__ half a[16*16];")
-        kk("__shared__ half b[16*16];")
         kk("__shared__ float c[16*16];")
-        for i in range(16*16):
-          kk(f"a[lidx1*16+{i%16}] = {r[vin[(i%16)]]};")
-        for i in range(16*16):
-          kk(f"b[lidx1+{i%16*16}] = {r[vin[(i%16)+16]]};")
-        kk("__syncthreads();")
-        kk("nvcuda::wmma::load_matrix_sync(a_frag, a, 16);")
-        kk("nvcuda::wmma::load_matrix_sync(b_frag, b, 16);")
+        kk("nvcuda::wmma::load_matrix_sync(a_frag, data1, 16);")
+        kk("nvcuda::wmma::load_matrix_sync(b_frag, data2, 16);")
         kk("nvcuda::wmma::mma_sync(c_frag, a_frag, b_frag, c_frag);")
         kk("nvcuda::wmma::store_matrix_sync(c, c_frag, 16, wmma::mem_row_major);")
         for i in range(8):
           kk(f"{output}[{i}] = c[lidx1+(lidx0*16)+{i*32}];")
-        kk("__syncthreads();")
         kk("}")
       else:
         raise NotImplementedError(f"WMMA not implemented for {args}")

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -151,6 +151,30 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:List[UOp]) -> Tu
       elif args[0] == "HIP":
         assert dtype == dtypes.float.vec(8), "output dtype of HIP TC is _float8"
         kk(f"{lang.generic_var_prefix if lang.generic_var_prefix else dtype.name} {ssa(u, 'wmma')} = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32({r[vin[0]]}, {r[vin[1]]}, {r[vin[2]]});")
+      elif args[0] == "CUDA":
+        kk("{")
+        kk("int warpM = (blockIdx.x * blockDim.x + threadIdx.x) / warpSize;")
+        kk("int warpN = (blockIdx.y * blockDim.y + threadIdx.y);")
+        kk("nvcuda::wmma::fragment<nvcuda::wmma::matrix_a, 16, 16, 16, half, nvcuda::wmma::row_major> a_frag;")
+        kk("nvcuda::wmma::fragment<nvcuda::wmma::matrix_b, 16, 16, 16, half, nvcuda::wmma::row_major> b_frag;")
+        kk("nvcuda::wmma::fragment<nvcuda::wmma::accumulator, 16, 16, 16, float> c_frag;")
+        kk("nvcuda::wmma::fill_fragment(c_frag, 0.0f);")
+        kk(f"__shared__ half a[16*16];")
+        kk(f"__shared__ half b[16*16];")
+        kk(f"__shared__ float c[16*16];")
+        for i in range(16*16):
+          kk(f"a[lidx1*16+{i%16}] = {r[vin[(i%16)]]};")
+        for i in range(16*16):
+          kk(f"b[lidx1+{i%16*16}] = {r[vin[(i%16)+16]]};")
+        kk("__syncthreads();")
+        kk("nvcuda::wmma::load_matrix_sync(a_frag, a, 16);")
+        kk("nvcuda::wmma::load_matrix_sync(b_frag, b, 16);")
+        kk("nvcuda::wmma::mma_sync(c_frag, a_frag, b_frag, c_frag);")
+        kk("nvcuda::wmma::store_matrix_sync(c, c_frag, 16, wmma::mem_row_major);")
+        for i in range(8):
+          kk(f"{r[vin[32+i]]} = c[lidx1+(lidx0*16)+{i*32}];")
+        kk("__syncthreads();")
+        kk("}")
       else:
         raise NotImplementedError(f"WMMA not implemented for {args}")
     elif uop == UOps.ALU:

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -86,5 +86,5 @@ class CUDAProgram:
       end.synchronize()
       return start.time_till(end)*1e-3
 
-CUDADevice = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=False if getenv("PTX") else True, supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024]),
+CUDADevice = Compiled(RawCUDABuffer, LinearizerOptions(supports_float4=False if getenv("PTX") else True, device="CUDA", supports_float4_alu=False, global_max = [65535, 65535, 2147483647], local_max = [64, 1024, 1024]),
                       CUDARenderer, compile_cuda, CUDAProgram, cuda.Context.synchronize)


### PR DESCRIPTION
- [ ] pass test_tensor_cores (not triggering tc cores)
- [ ] remove memory copy
- [ ] match ` 51982.08 GFLOPS matmul, 76.15 GB/s` from cuda_matmul on 3080ti.

with TC=1:

`gemm  1024x 1024   15.14 ms (  141.80 GFLOPS     0.28 GB/s) in torch,    0.28 ms ( 7745.43 GFLOPS    15.13 GB/s) in tinygrad,    0.02x faster    2147.48 MOPS     4.19 MB`

with TC=0:

`
gemm   1024x 1024   15.28 ms (  140.55 GFLOPS     0.27 GB/s) in torch,    0.29 ms ( 7409.77 GFLOPS    14.47 GB/s) in tinygrad,    0.02x faster    2147.48 MOPS     4.19 MB
`