### PR TITLE
remove some `type: ignore` comments

### DIFF
--- a/examples/beautiful_cartpole.py
+++ b/examples/beautiful_cartpole.py
@@ -33,7 +33,7 @@ def evaluate(model:ActorCritic, test_env:gym.Env) -> float:
 if __name__ == "__main__":
   env = gym.make('CartPole-v1')
 
-  model = ActorCritic(env.observation_space.shape[0], int(env.action_space.n))    # type: ignore
+  model = ActorCritic(env.observation_space.shape[0], int(env.action_space.n))
   opt = nn.optim.Adam(nn.state.get_parameters(model), lr=1e-2)
 
   @TinyJit

--- a/extra/gemm/amx.py
+++ b/extra/gemm/amx.py
@@ -5,7 +5,7 @@ import sys
 np.set_printoptions(linewidth=160)
 np.set_printoptions(linewidth=1000, threshold=10000000000, suppress=False)
 from tinygrad.runtime.ops_llvm import LLVM, LLVMBuffer, int_const
-from llvmlite import ir  # type: ignore
+from llvmlite import ir
 
 
 # https://github.com/corsix/amx/blob/main/Instructions.md

--- a/extra/triton/triton.py
+++ b/extra/triton/triton.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Final, Callable, DefaultDict
+from typing import Dict, List, Final, Callable, DefaultDict, Any
 from collections import defaultdict
 from tinygrad.ops import UnaryOps, BinaryOps, TernaryOps, Op
 from tinygrad.helpers import DType, dtypes, ImageDType, DEBUG, getenv
@@ -42,7 +42,11 @@ def define_scalar(local_size, dtype, args):
 def uops_to_triton(function_name:str, uops:List[UOp]):
   local_size: List[int] = []
   depth = 1
-  signatures, dims, bufs, kernel, valid = [], [], [], [], [] #type: ignore
+  dims: List[Any] = []
+  bufs: List[Any] = []
+  valid: List[str] = []
+  signatures: List[str] = []
+  kernel: List[str] = []
 
   c: DefaultDict[str, int] = defaultdict(int)
   r: Dict[UOp, str] = {}

--- a/extra/triton/triton.py
+++ b/extra/triton/triton.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Final, Callable, DefaultDict, Any
+from typing import Dict, List, Final, Callable, DefaultDict
 from collections import defaultdict
 from tinygrad.ops import UnaryOps, BinaryOps, TernaryOps, Op
 from tinygrad.helpers import DType, dtypes, ImageDType, DEBUG, getenv
@@ -42,11 +42,7 @@ def define_scalar(local_size, dtype, args):
 def uops_to_triton(function_name:str, uops:List[UOp]):
   local_size: List[int] = []
   depth = 1
-  dims: List[Any] = []
-  bufs: List[Any] = []
-  valid: List[str] = []
-  signatures: List[str] = []
-  kernel: List[str] = []
+  signatures, dims, bufs, kernel, valid = [], [], [], [], [] #type: ignore
 
   c: DefaultDict[str, int] = defaultdict(int)
   r: Dict[UOp, str] = {}

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -49,7 +49,7 @@ def time_linearizer(lin:Linearizer, rawbufs:List[RawBuffer], allow_test_size=Tru
     # TODO: this is copied from prg.__call__
     global_size, local_size = prg.launch_dims(var_vals)
     prg.global_size = real_global_size
-    if global_size is not None and local_size is None and all_int(tuple(prg.global_size)): # type: ignore[arg-type]
+    if global_size is not None and prg.global_size is not None and local_size is None and all_int(tuple(prg.global_size)):
       local_size = optimize_local_size(prg.clprg, global_size, rawbufs)
       global_size = [g//l if g%l == 0 else g/l for g,l in zip(global_size, local_size)]
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Union, Type, Tuple, Any, List, Dict, Callable, Mapping, get_args
+from typing import TYPE_CHECKING, Union, Type, Tuple, Any, List, Dict, Callable, Mapping
 import functools
 from enum import Enum, auto
 from tinygrad.helpers import prod, DType, dedup

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Union, Type, Tuple, Any, List, Dict, Callable, Mapping
+from typing import TYPE_CHECKING, Union, Type, Tuple, Any, List, Dict, Callable, Mapping, get_args
 import functools
 from enum import Enum, auto
 from tinygrad.helpers import prod, DType, dedup
@@ -61,9 +61,9 @@ class LazyOp:
   def get_lazyops(self) -> List[LazyOp]: return [self] + [item for x in self.src for item in x.get_lazyops()]
 
   def replace_with_movement_ops(self:LazyOp, ops:List[Tuple[MovementOps, Tuple[Any, ...]]]) -> 'LazyBuffer':
-    assert self.op in BinaryOps or self.op in UnaryOps or self.op in TernaryOps
+    assert isinstance(self.op, (UnaryOps, BinaryOps, TernaryOps))
     srcs = [z.replace_with_movement_ops(ops) for z in self.src]
-    return srcs[0].e(self.op, *srcs[1:], arg=self.arg)   # type: ignore
+    return srcs[0].e(self.op, *srcs[1:], arg=self.arg)
 
   @property
   def st(self): raise NotImplementedError


### PR DESCRIPTION
removes some `type: ignore` comments and fixes resulting errors as part of https://github.com/tinygrad/tinygrad/issues/2240