### PR TITLE
Remove as_buffer for TORCH

### DIFF
--- a/tinygrad/runtime/ops_torch.py
+++ b/tinygrad/runtime/ops_torch.py
@@ -3,7 +3,7 @@ import numpy as np
 from typing import Dict, Callable
 from tinygrad.ops import BufferOps, UnaryOps, BinaryOps, MovementOps, TernaryOps, ReduceOps, Op
 from tinygrad.device import Interpreted, Allocator
-from tinygrad.helpers import getenv, dtypes, DType, flat_mv
+from tinygrad.helpers import getenv, dtypes, DType
 from tinygrad.runtime.ops_cpu import einsum_mulacc, shape_to_axis
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else ("mps" if getenv("MPS", 0) else "cpu"))
@@ -43,7 +43,6 @@ torch_fxn_for_op: Dict[Op, Callable] = {
 
 class TorchAllocator(Allocator):
   def _alloc(self, size:int, dtype:DType): return torch.empty([size], device=device, dtype=inverse_type_map[dtype])
-  def as_buffer(self, src:torch.Tensor) -> memoryview: return flat_mv(np.require(src.numpy(), requirements='C').data)
   def copyin(self, dest:torch.Tensor, src:memoryview): dest.copy_(torch.frombuffer(src, dtype=dest.dtype))
   def copyout(self, dest:memoryview, src:torch.Tensor): torch.frombuffer(dest, dtype=src.dtype).copy_(src.flatten())
 


### PR DESCRIPTION
When torch is using cuda, it should not support `as_buffer`, since it is not possible to convert a torch tensor that is on the gpu to a buffer (since torch doesn't use the unified memory api). Right now, this fix just removes `as_buffer` altogether, but if desired, I can change this to conditionally define `as_buffer` only when torch is using cuda tensors.

I can't really think of a good way to implement regression tests in CI for this, since without cuda support in CI it is not possible to instantiate torch cuda tensors. Perhaps a test that requires `as_buffer` to be undefined when `torch.cuda.is_available()` is mocked to return True?