### PR TITLE
Fix testCopyCPUto6GPUs()

### DIFF
--- a/test/test_copy_speed.py
+++ b/test/test_copy_speed.py
@@ -63,6 +63,5 @@ class TestCopySpeed(unittest.TestCase):
             t.to(f"{Device.DEFAULT}:{g}").realize()
         Device[Device.DEFAULT].synchronize()
 
-
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_copy_speed.py
+++ b/test/test_copy_speed.py
@@ -51,7 +51,6 @@ class TestCopySpeed(unittest.TestCase):
         t.to('cpu').realize()
 
   def testCopyCPUto6GPUs(self):
-    from tinygrad.device import Device
     if not hasattr(Device[Device.DEFAULT], "device_ids"): raise unittest.SkipTest("computer doesn't have multiple devices of the same type")
     if len(Device[Device.DEFAULT].device_ids) != 6: raise unittest.SkipTest("computer doesn't have 6 GPUs")
     t = Tensor.rand(N, N, device="cpu").realize()


### PR DESCRIPTION
should now run on Master's CI tinybox runner.

It also kept failing locally which was annoying.