### PR TITLE
WIP copy_with_st for partial tensor inplace update

### DIFF
--- a/examples/gpt2.py
+++ b/examples/gpt2.py
@@ -40,9 +40,12 @@ class Attention:
 
     if isinstance(Device[Device.DEFAULT], Compiled):
       # update the cache
+      # # the dream. we cannot getitem a Variable index yet...
+      # self.cache_kv[:, :, start_pos:start_pos+seqlen, :, :] = Tensor.stack([xk, xv])
       st = self.cache_kv.lazydata.st
       st = st.shrink(((0, st.shape[0]), (0, st.shape[1]), (start_pos, start_pos+seqlen), (0, st.shape[3]), (0, st.shape[4])))
-      self.cache_kv.copy_with_st(Tensor.stack([xk, xv]), st).realize()
+      self.cache_kv.lazydata.copy_with_st(Tensor.stack([xk, xv]).lazydata, st)
+      self.cache_kv.realize()
 
       keys = self.cache_kv[0].shrink((None, (0, start_pos+seqlen), None, None))
       values = self.cache_kv[1].shrink((None, (0, start_pos+seqlen), None, None))

--- a/extra/setitem.py
+++ b/extra/setitem.py
@@ -1,0 +1,39 @@
+from tinygrad import Tensor
+# import torch
+# t = torch.arange(42).reshape(6, 7)
+# # # a = torch.rand(12).reshape(6, 2)  # somehow this does not work in torch
+# a = torch.arange(12).reshape(6, 2)
+# # t[:, 2:4] = a
+# t.as_strided((6, 2), (7, 1), 2)[:] = a
+# print(t)
+
+# # materialize a buffer
+# import torch
+# a = torch.zeros(10, 10)
+# b = a.permute(1, 0)
+# b[3] = 1
+
+a = Tensor.zeros(10, 10)
+b = a.permute(1, 0)
+# b is not contiguous
+assert not b.lazydata.st.contiguous
+assert b[3].lazydata.base is a.lazydata.base
+# TODO: before updating the base, go through the views and make sure it's okay?
+base = b[3].lazydata.base
+print(b.lazydata.realized)
+b.realize()
+print(b.lazydata.realized)
+
+# correct behavior is to continguous a, which becomes the view of b
+
+# t = Tensor.arange(42).reshape(6, 7).realize()
+# a = Tensor.rand(6, 2).realize()
+
+# assert t[:].lazydata is t.lazydata
+# assert t[:, 2:4].lazydata.base is t.lazydata.base
+
+# t[:, 2:4] = a
+
+# t.realize()
+
+# print(t.numpy())

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -223,7 +223,10 @@ class LazyBuffer:
     return LazyBuffer.loadop(LoadOps.CONTIGUOUS, self.shape, self.dtype, self.device, src=self)
 
   def copy_with_st(self:LazyBuffer, other:LazyBuffer, st:ShapeTracker):
+    assert self.dtype == other.dtype
+    # if not, need to materialize the buffer before partial update
     assert self.st.contiguous and self.realized, "can only copy to contiguous and realized buffer"
+    # updating the base
     self.output_buffer = self.realized
     self.realized = None
     self.op = LazyOp(BufferOps.STORE, (other,), st)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -118,6 +118,12 @@ class Tensor:
     if self.dtype == x.dtype and self.lazydata.realized is not None and not getenv("DISALLOW_ASSIGN"): x.lazydata.output_buffer = self.lazydata.realized
     self.lazydata = x.lazydata
     return self
+
+  def copy_with_st(self, other:Tensor, st) -> Tensor:
+    # TODO: do we call a contiguous().realize() on self implicitly?
+    self.lazydata.copy_with_st(other.lazydata, st)
+    return self
+
   def detach(self) -> Tensor: return Tensor(self.lazydata, device=self.device, requires_grad=False)
 
   # TODO: these are good places to start removing numpy


### PR DESCRIPTION
with this, gpt-2 kvcache can update only one column per token, not the full cache. on M1 Max with BEAM=12 per token time 13ms -> 11.7ms

does not work with interpreted backend, also need a cleaner op than abusing the BufferOps.STORE

given that this eventually would be part of setitem, we can have a slice <-> shapetracker helpers and an op to call tensor[slice] = other for interpreted.