### PR TITLE
use one kvcache tensor in gpt2 instead of two separate caches

### DIFF
--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -133,6 +133,13 @@ class TestSymbolicReshape(unittest.TestCase):
         t = t.reshape(vj, vi)
         assert t.shape == (vj, vi)
 
+  def test_symbolic_mask(self):
+    # taken from gpt2 single kvcache
+    view = View(shape=(1, (NumNode(1)+Variable('start_pos', 1, 128).bind(3)), 16, 64), strides=(0, 1024, 64, 1), offset=131072, mask=((0, 1), (0, Variable('start_pos', 1, 128).bind(3)), (0, 16), (0, 64)), contiguous=False)
+    new_shape = (1, 1, (NumNode(1)+Variable('start_pos', 1, 128).bind(3)), 16, 64)
+    # this is mergeable, but need more tests to make sure the correctness
+    assert view.reshape(new_shape) == None
+
 class TestSymbolicExpand(unittest.TestCase):
   def test_expand_into_symbols(self):
     vi = Variable("i", 1, 5).bind(3)

--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -138,7 +138,7 @@ class TestSymbolicReshape(unittest.TestCase):
     view = View(shape=(1, (NumNode(1)+Variable('start_pos', 1, 128).bind(3)), 16, 64), strides=(0, 1024, 64, 1), offset=131072, mask=((0, 1), (0, Variable('start_pos', 1, 128).bind(3)), (0, 16), (0, 64)), contiguous=False)
     new_shape = (1, 1, (NumNode(1)+Variable('start_pos', 1, 128).bind(3)), 16, 64)
     # this is mergeable, but need more tests to make sure the correctness
-    assert view.reshape(new_shape) == None
+    assert view.reshape(new_shape) is None
 
 class TestSymbolicExpand(unittest.TestCase):
   def test_expand_into_symbols(self):

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -4,7 +4,7 @@ import functools, itertools, operator
 from dataclasses import dataclass
 from typing import Tuple, List, Optional, Dict, Set, cast, Union, Iterable
 from tinygrad.ops import MovementOps
-from tinygrad.helpers import prod, DEBUG, merge_dicts
+from tinygrad.helpers import prod, DEBUG, merge_dicts, getenv
 from tinygrad.shape.symbolic import Variable, MulNode, Node, SumNode, NumNode, sint
 from tinygrad.shape.view import View, _merge_dims
 
@@ -154,7 +154,7 @@ class ShapeTracker:
   def stride(self, mul: Tuple[int, ...]) -> ShapeTracker: return ShapeTracker(self.views[0:-1] + (self.views[-1].stride(mul), ))
 
   def reshape(self, new_shape: Tuple[sint, ...]) -> ShapeTracker:
-    if (new_view := self.views[-1].reshape(new_shape)) is not None: return ShapeTracker(self.views[0:-1] + (new_view,))
+    if getenv("MERGE_VIEW", 1) and (new_view := self.views[-1].reshape(new_shape)) is not None: return ShapeTracker(self.views[0:-1] + (new_view,))
     return ShapeTracker(self.views + (View.create(new_shape), ))
 
 # returns the axes to create new_shape if new_shape can be created by combining axis from old_shape

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -35,6 +35,7 @@ def _merge_dims(shape:Tuple[int, ...], strides:Tuple[int, ...], mask:Optional[Tu
 @functools.lru_cache(maxsize=None)
 def _reshape_mask(view: View, new_shape:Tuple[sint, ...]) -> Tuple[Optional[Tuple[Tuple[sint, sint], ...]], Optional[Tuple[sint, ...]], bool]:
   if view.mask is None: return view.mask, None, False
+  if any(not isinstance(m[0], int) or not isinstance(m[1], int) for m in view.mask): return view.mask, None, True
   new_mask: List[Tuple[int, int]] = []
 
   r_masks, r_shape, r_new_shape = reversed(view.mask), reversed(view.shape), reversed(new_shape)


### PR DESCRIPTION
2.86ms -> 2.65ms (on 3080). 518 kernels -> 470 kernels

found an issue with reshaping with a symbolic mask, will merge this once i have a regression test for it