### PR TITLE
support vals on WebGPU, run more tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,17 +246,15 @@ jobs:
     #- name: Run webgpu pytest
     #  run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto
     - name: Run selected webgpu tests
-      run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto test/test_ops.py test/test_dtype.py test/test_jit.py
+      run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto test/ --ignore=test/test_dtype_alu.py --ignore=test/test_search.py --ignore=test/imported/ --ignore=test/external --ignore=test/models --durations=20
     - name: Build WEBGPU Efficientnet
       run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m examples.compile_efficientnet
     - name: Install Puppeteer
       run: npm install puppeteer
     - name: Run WEBGPU Efficientnet
       run: node test/web/test_webgpu.js
-    - name: Test LLaMA compile speed
-      run: PYTHONPATH="." METAL=1 python test/external/external_test_speed_llama.py
 
-  testmetalwebgpu:
+  testmetal:
     name: Metal Tests
     runs-on: macos-13
     timeout-minutes: 20
@@ -290,6 +288,8 @@ jobs:
       run: METAL=1 python -m pytest -n=auto test/external/external_test_onnx_backend.py
     - name: Test tensor core ops
       run: METAL=1 TC=2 python test/test_ops.py TestOps.test_big_gemm
+    - name: Test LLaMA compile speed
+      run: PYTHONPATH="." METAL=1 python test/external/external_test_speed_llama.py
 
   testhipcompilation:
     name: HIP Compilation Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,7 +246,12 @@ jobs:
     #- name: Run webgpu pytest
     #  run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto
     - name: Run selected webgpu tests
-      run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto test/ --ignore=test/test_dtype_alu.py --ignore=test/test_search.py --ignore=test/imported/ --ignore=test/external --ignore=test/models --durations=20
+      run: |
+        WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto test/ \
+        --ignore=test/extra/test_lr_scheduler.py --ignore=test/test_randomness.py --ignore=test/test_linearizer.py \
+        --ignore=test/test_speed_v_torch.py --ignore=test/test_net_speed.py --ignore=test/test_dtype_alu.py \
+        --ignore=test/test_search.py --ignore=test/imported/ --ignore=test/external --ignore=test/models \
+        --durations=20
     - name: Build WEBGPU Efficientnet
       run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m examples.compile_efficientnet
     - name: Install Puppeteer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,17 +247,17 @@ jobs:
     #  run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto
     - name: Run selected webgpu tests
       run: |
-        WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto test/ \
-        --ignore=test/extra/test_lr_scheduler.py --ignore=test/test_randomness.py --ignore=test/test_linearizer.py \
-        --ignore=test/test_speed_v_torch.py --ignore=test/test_net_speed.py --ignore=test/test_dtype_alu.py \
-        --ignore=test/test_search.py --ignore=test/imported/ --ignore=test/external --ignore=test/models \
-        --durations=20
+        WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m pytest -n=auto test/test_ops.py test/test_dtype.py \
+        test/test_jit.py test/test_symbolic_ops.py test/test_symbolic_jit.py test/test_linearizer.py \
+        test/test_linearizer_failures.py test/test_nn.py
     - name: Build WEBGPU Efficientnet
       run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python -m examples.compile_efficientnet
     - name: Install Puppeteer
       run: npm install puppeteer
     - name: Run WEBGPU Efficientnet
       run: node test/web/test_webgpu.js
+    - name: Test LLaMA compile speed
+      run: PYTHONPATH="." METAL=1 python test/external/external_test_speed_llama.py
 
   testmetal:
     name: Metal Tests
@@ -293,8 +293,6 @@ jobs:
       run: METAL=1 python -m pytest -n=auto test/external/external_test_onnx_backend.py
     - name: Test tensor core ops
       run: METAL=1 TC=2 python test/test_ops.py TestOps.test_big_gemm
-    - name: Test LLaMA compile speed
-      run: PYTHONPATH="." METAL=1 python test/external/external_test_speed_llama.py
 
   testhipcompilation:
     name: HIP Compilation Tests

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -306,6 +306,7 @@ class TestHandCodedOpts(unittest.TestCase):
     # float4/other hcopt shouldn't upcast last axis, since we already have 7 upcast, and the last axis is not very contiguous
     assert k.upcasted == 1 and k.full_shape[-1] == 7
 
+  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "Result is incorrect")
   def test_masked_upcast_wino(self):
     monster = Tensor.stack([Tensor.stack([Tensor.rand(16) for _ in range(6)]) for _ in range(6)])
 

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -306,7 +306,7 @@ class TestHandCodedOpts(unittest.TestCase):
     # float4/other hcopt shouldn't upcast last axis, since we already have 7 upcast, and the last axis is not very contiguous
     assert k.upcasted == 1 and k.full_shape[-1] == 7
 
-  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "Result is incorrect")
+  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "Failing because of custom kernel splitting to circumvent the 8 buffer limit")
   def test_masked_upcast_wino(self):
     monster = Tensor.stack([Tensor.stack([Tensor.rand(16) for _ in range(6)]) for _ in range(6)])
 

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -55,7 +55,7 @@ class TestLinearizerFailures(unittest.TestCase):
     # related to OptOps.NOLOCALS
     # IndexError: list index out of range
     ast = helper_add_store(ast)
-    helper_test_lin(Linearizer(ast), opts, failed_platforms=["METAL"])
+    helper_test_lin(Linearizer(ast), opts, failed_platforms=["METAL", "WEBGPU"])
 
   def test_failure_5(self):
     ast = LazyOp(op=ReduceOps.SUM, src=(LazyOp(op=BinaryOps.ADD, src=(LazyOp(op=BinaryOps.MUL, src=(LazyOp(op=BinaryOps.ADD, src=(LazyOp(op=BufferOps.CONST, src=(), arg=ConstBuffer(val=0.1464405059814453, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(2, 1, 4, 1, 3, 1, 4, 1), strides=(0, 0, 0, 0, 0, 0, 0, 0), offset=0, mask=None, contiguous=False),)))), LazyOp(op=BufferOps.CONST, src=(), arg=ConstBuffer(val=1.0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(2, 1, 4, 1, 3, 1, 4, 1), strides=(0, 0, 0, 0, 0, 0, 0, 0), offset=0, mask=None, contiguous=False),))))), arg=None), LazyOp(op=BufferOps.LOAD, src=(), arg=MemBuffer(idx=1, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(2, 1, 4, 1, 3, 1, 4, 1), strides=(0, 0, 0, 0, 0, 0, 0, 0), offset=0, mask=None, contiguous=False),))))), arg=None), LazyOp(op=BinaryOps.MUL, src=(LazyOp(op=BinaryOps.ADD, src=(LazyOp(op=BufferOps.CONST, src=(), arg=ConstBuffer(val=0.1464405059814453, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(2, 1, 4, 1, 3, 1, 4, 1), strides=(0, 0, 0, 0, 0, 0, 0, 0), offset=0, mask=None, contiguous=False),)))), LazyOp(op=BufferOps.CONST, src=(), arg=ConstBuffer(val=1.0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(2, 1, 4, 1, 3, 1, 4, 1), strides=(0, 0, 0, 0, 0, 0, 0, 0), offset=0, mask=None, contiguous=False),))))), arg=None), LazyOp(op=BufferOps.LOAD, src=(), arg=MemBuffer(idx=1, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(2, 1, 4, 1, 3, 1, 4, 1), strides=(0, 0, 0, 0, 0, 0, 0, 0), offset=0, mask=None, contiguous=False),))))), arg=None)), arg=None),), arg=(1, 1, 1, 1, 1, 1, 1, 1))
@@ -86,7 +86,7 @@ class TestLinearizerFailures(unittest.TestCase):
     # fatal error: bracket nesting level exceeded maximum of 256
     # note: use -fbracket-depth=N to increase maximum nesting level
     ast = helper_add_store(ast)
-    helper_test_lin(Linearizer(ast), opts, failed_platforms=["CLANG", "METAL"])
+    helper_test_lin(Linearizer(ast), opts, failed_platforms=["CLANG", "METAL", "WEBGPU"])
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11,6 +11,7 @@ import pytest
 pytestmark = [pytest.mark.exclude_cuda]
 
 class TestNN(unittest.TestCase):
+  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "no int64 on WebGPU")
   def test_sparse_cat_cross_entropy(self):
     input = torch.randn(3, 5)
     target = torch.empty(3, dtype=torch.long).random_(5)

--- a/test/test_symbolic_ops.py
+++ b/test/test_symbolic_ops.py
@@ -1,11 +1,10 @@
 import unittest
 from tinygrad.shape.symbolic import Variable
 from tinygrad.helpers import getenv
-from tinygrad.tensor import Tensor, Device
+from tinygrad.tensor import Tensor
 import numpy as np
 
 @unittest.skipIf(getenv("ARM64") or getenv("PTX"), "ARM64 and PTX are not supported")
-@unittest.skipIf(Device.DEFAULT in ["WEBGPU"], f"{Device.DEFAULT} is not supported")
 class TestSymbolicOps(unittest.TestCase):
   def test_plus1(self):
     def f(a): return (a+1).realize()

--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -94,6 +94,7 @@ class TestNonFloatUOps(TestUOps):
   def test_div_int32(self): self._test_bop_fxn(BinaryOps.DIV, lambda a,b: int(a/b), dtypes.int32, no_b_zero=True)
   def test_mod_int32(self): self._test_bop_fxn(BinaryOps.MOD, lambda a,b: abs(int(a))%abs(int(b))*(1,-1)[a<0], dtypes.int32, no_b_zero=True)
   def test_cmplt_int32(self): self._test_bop_fxn(BinaryOps.CMPLT, lambda a,b: float(a<b), dtypes.int32)
+  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "no bool storage buffer on webgpu")
   def test_mul_bool(self): self._test_bop_fxn(BinaryOps.MUL, lambda a,b: bool(a) and bool(b), dtypes.bool)
 
 if __name__ == '__main__':

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -5,13 +5,17 @@ from tinygrad.renderer.cstyle import WGSLRenderer
 import wgpu
 
 wgpu_device = get_default_device()
+def create_uniform(val: int) -> wgpu.GPUBuffer:
+  buf = wgpu_device.create_buffer(size=4, usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST)
+  wgpu_device.queue.write_buffer(buf, 0, val.to_bytes(4, "little"))
+  return buf
 
 class WebGPUProgram:
   def __init__(self, name:str, lib:bytes): self.name, self.lib, self.prg = name, lib, wgpu_device.create_shader_module(code=lib)   # NOTE: this is the compiler
   def __call__(self, *bufs, global_size, local_size, vals=(), wait=False):
     assert len(bufs) <= 8, "WEBGPU only supports 8 buffers"
-    binding_layouts = [{"binding": i, "visibility": wgpu.ShaderStage.COMPUTE, "buffer": {"type": wgpu.BufferBindingType.storage}} for i in range(len(bufs))]
-    bindings = [{"binding": i, "resource": {"buffer": x, "offset": 0, "size": x.size}} for i, x in enumerate(bufs)]
+    binding_layouts = [{"binding": i, "visibility": wgpu.ShaderStage.COMPUTE, "buffer": {"type": wgpu.BufferBindingType.uniform if i >= len(bufs) else wgpu.BufferBindingType.storage }} for i in range(len(bufs)+len(vals))]
+    bindings = [{"binding": i, "resource": {"buffer": create_uniform(x) if i >= len(bufs) else x, "offset": 0, "size": 4 if i >= len(bufs) else x.size}} for i,x in enumerate(bufs+vals)]
     bind_group_layout = wgpu_device.create_bind_group_layout(entries=binding_layouts)
     pipeline_layout = wgpu_device.create_pipeline_layout(bind_group_layouts=[bind_group_layout])
     bind_group = wgpu_device.create_bind_group(layout=bind_group_layout, entries=bindings)


### PR DESCRIPTION
- support `vals` using uniforms, test_symbolic passes
- brought back `render_store` because the explicit cast is needed in some cases (example: assigning a cmplt bool result to a i32 output buffer)