### PR TITLE
Replace DType.np with DType.format 

### DIFF
--- a/test/external/external_test_opt.py
+++ b/test/external/external_test_opt.py
@@ -53,21 +53,21 @@ class TestInferenceMinKernels(unittest.TestCase):
   @unittest.skipIf(not PUSH_PERMUTES, "this test requires PUSH_PERMUTES")
   def test_convnext(self):
     model = ConvNeXt()
-    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=p.dtype.np))
+    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=np.dtype(p.dtype.format)))
     img = Tensor.randn(1, 3, 224, 224)
     with CLCache(129):
       model(img).realize()
 
   def test_enet(self):
     model = EfficientNet(getenv("ENET_NUM", 0), has_se=False)
-    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=p.dtype.np))
+    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=np.dtype(p.dtype.format)))
     img = Tensor.randn(1, 3, 224, 224)
     with CLCache(51):
       model.forward(img).realize()
 
   def test_enet_se(self):
     model = EfficientNet(getenv("ENET_NUM", 0), has_se=True)
-    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=p.dtype.np))
+    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=np.dtype(p.dtype.format)))
     img = Tensor.randn(1, 3, 224, 224)
     # TODO: this seems very high
     with CLCache(115):
@@ -75,14 +75,14 @@ class TestInferenceMinKernels(unittest.TestCase):
 
   def test_resnet(self):
     model = ResNet18()
-    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=p.dtype.np))
+    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=np.dtype(p.dtype.format)))
     img = Tensor.randn(1, 3, 224, 224)
     with CLCache(26):
       model.forward(img).realize()
 
   def test_vit(self):
     model = ViT(embed_dim=192, num_heads=3)
-    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=p.dtype.np))
+    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=np.dtype(p.dtype.format)))
     img = Tensor.randn(1, 3, 224, 224)
     with CLCache(222): # NOTE: this is way too high
       out = model.forward(img)
@@ -93,7 +93,7 @@ class TestInferenceMinKernels(unittest.TestCase):
     from examples.llama import Transformer
     args_tiny = {"dim": 512, "hidden_dim": 1024, "n_heads": 8, "n_layers": 4, "norm_eps": 1e-05, "vocab_size": 1000}
     model = Transformer(**args_tiny)
-    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=p.dtype.np))
+    for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=np.dtype(p.dtype.format)))
     inp = Tensor([[1,2,3,4]])
     with CLCache(100):
       model(inp, 0).realize()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -41,8 +41,8 @@ def _assert_eq(tensor:Tensor, target_dtype:DType, target):
     raise AssertionError(f"\ntensor {tensor.numpy()} dtype {tensor.dtype} does not match target {target} with dtype {target_dtype}") from e
 
 def _test_op(fxn, target_dtype:DType, target): _assert_eq(fxn(), target_dtype, target)
-def _test_cast(a:Tensor, target_dtype:DType): _test_op(lambda: a.cast(target_dtype), target_dtype, a.numpy().astype(target_dtype.np).tolist())
-def _test_bitcast(a:Tensor, target_dtype:DType, target=None): _test_op(lambda: a.bitcast(target_dtype), target_dtype, target or a.numpy().view(target_dtype.np).tolist())
+def _test_cast(a:Tensor, target_dtype:DType): _test_op(lambda: a.cast(target_dtype), target_dtype, a.numpy().astype(np.dtype(target_dtype.format)).tolist())
+def _test_bitcast(a:Tensor, target_dtype:DType, target=None): _test_op(lambda: a.bitcast(target_dtype), target_dtype, target or a.numpy().view(np.dtype(target_dtype.format)).tolist())
 
 class TestDType(unittest.TestCase):
   DTYPE: Any = None
@@ -50,11 +50,11 @@ class TestDType(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
     if not is_dtype_supported(cls.DTYPE): raise unittest.SkipTest("dtype not supported")
-    cls.DATA = np.random.randint(0, 100, size=10, dtype=cls.DTYPE.np).tolist() if dtypes.is_int(cls.DTYPE) else np.random.choice([True, False], size=10).tolist() if cls.DTYPE == dtypes.bool else np.random.uniform(0, 1, size=10).tolist()
+    cls.DATA = np.random.randint(0, 100, size=10, dtype=np.dtype(cls.DTYPE.format)).tolist() if dtypes.is_int(cls.DTYPE) else np.random.choice([True, False], size=10).tolist() if cls.DTYPE == dtypes.bool else np.random.uniform(0, 1, size=10).tolist()
   def setUp(self):
     if self.DTYPE is None: raise unittest.SkipTest("base class")
 
-  def test_to_np(self): _test_to_np(Tensor(self.DATA, dtype=self.DTYPE), self.DTYPE.np, np.array(self.DATA, dtype=self.DTYPE.np))
+  def test_to_np(self): _test_to_np(Tensor(self.DATA, dtype=self.DTYPE), np.dtype(self.DTYPE.format), np.array(self.DATA, dtype=np.dtype(self.DTYPE.format)))
 
   def test_casts_to(self): list(map(
     lambda dtype: _test_cast(Tensor(self.DATA, dtype=dtype), self.DTYPE),

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -49,29 +49,29 @@ class ht:
 def universal_test(a, b, dtype, op):
   if not isinstance(op, tuple): op = (op, op)
   tensor_value = (op[0](Tensor([a], dtype=dtype), Tensor([b], dtype=dtype))).numpy()
-  numpy_value = op[1](np.array([a]).astype(dtype.np), np.array([b]).astype(dtype.np))
+  numpy_value = op[1](np.array([a]).astype(np.dtype(dtype.format)), np.array([b]).astype(np.dtype(dtype.format)))
   if dtype in dtypes_float: np.testing.assert_allclose(tensor_value, numpy_value, atol=1e-10)
   else: np.testing.assert_equal(tensor_value, numpy_value)
 
 def universal_test_unary(a, dtype, op):
   if not isinstance(op, tuple): op = (op, op)
   tensor_value = op[0](Tensor([a], dtype=dtype)).numpy()
-  numpy_value = op[1](np.array([a]).astype(dtype.np))
+  numpy_value = op[1](np.array([a]).astype(np.dtype(dtype.format)))
   if dtype in dtypes_float: np.testing.assert_allclose(tensor_value, numpy_value, atol=5 if Device.DEFAULT == "METAL" and op[0] == Tensor.sin else 1e-3, rtol=2 if Device.DEFAULT == "METAL" and op[0] == Tensor.sin else 1e-4 if dtype == dtypes.float32 else 1e-2)  # exp and log and sin are approximations (in METAL, the default fast-math versions are less precise)
   else: np.testing.assert_equal(tensor_value, numpy_value)
 
 def universal_test_cast(a, in_dtype, dtype):
   tensor_value = Tensor([a], dtype=in_dtype).cast(dtype)
-  numpy_value = np.array([a]).astype(dtype.np)
+  numpy_value = np.array([a]).astype(np.dtype(dtype.format))
   np.testing.assert_equal(tensor_value, numpy_value)
 
 def universal_test_midcast(a, b, c, op1, op2, d1:DType, d2:DType):
   if not isinstance(op1, tuple): op1 = (op1, op1)
   if not isinstance(op2, tuple): op2 = (op2, op2)
   at, bt, ct = Tensor([a], dtype=d1), Tensor([b], dtype=d1), Tensor([c], dtype=d2)
-  an, bn, cn = np.array([a]).astype(d1.np), np.array([b]).astype(d1.np), np.array([c]).astype(d2.np)
+  an, bn, cn = np.array([a]).astype(np.dtype(d1.format)), np.array([b]).astype(np.dtype(d1.format)), np.array([c]).astype(np.dtype(d2.format))
   tensor_value = op2[0](op1[0](at, bt).cast(d2), ct).numpy()
-  numpy_value = op2[1](op1[1](an, bn).astype(d2.np), cn)
+  numpy_value = op2[1](op1[1](an, bn).astype(np.dtype(d2.format)), cn)
   np.testing.assert_almost_equal(tensor_value, numpy_value)
 
 class TestDTypeALU(unittest.TestCase):

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -368,7 +368,7 @@ def helper_linearizer_opt(r:Tensor, opts=[], apply_tc=False):
       for opt in opts:
         k.apply_opt(opt)
     prg = to_prg(k)
-    real_bufs[0].copyin(np.zeros((real_bufs[0].size, ), dtype=real_bufs[0].dtype.np).data) # Zero to check that all values are filled
+    real_bufs[0].copyin(np.zeros((real_bufs[0].size, ), dtype=np.dtype(real_bufs[0].dtype.format)).data) # Zero to check that all values are filled
     prg.exec(real_bufs)
     np.testing.assert_allclose(wanna_output, real_bufs[0].toCPU(), atol=1e-4, rtol=1e-4)
 
@@ -382,7 +382,7 @@ def helper_linearizer_opt(r:Tensor, opts=[], apply_tc=False):
   k = Linearizer(realized_ast)
   k.hand_coded_optimizations()
   prg = Device[Device.DEFAULT].to_program(k)
-  real_bufs[0].copyin(np.zeros((real_bufs[0].size, ), dtype=real_bufs[0].dtype.np).data) # Zero to check that all values are filled
+  real_bufs[0].copyin(np.zeros((real_bufs[0].size, ), dtype=np.dtype(real_bufs[0].dtype.format)).data) # Zero to check that all values are filled
   prg.exec(real_bufs)
   np.testing.assert_allclose(wanna_output, real_bufs[0].toCPU(), atol=1e-4, rtol=1e-4)
   for x in opts: # Check custom transformations if any.

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -257,7 +257,7 @@ class TestTinygrad(unittest.TestCase):
   # Regression test for https://github.com/tinygrad/tinygrad/issues/1751
   def test_copy_from_numpy_unaligned(self):
     # 2**15 is the minimum for repro
-    arr = np.random.randn(2**15).astype(dtypes.float.np)
+    arr = np.random.randn(2**15).astype(np.dtype(dtypes.float.format))
     fn = temp('test_copy_from_numpy_unaligned')
     with open(fn, 'wb') as f: f.write(b't' + arr.tobytes())
     with open(fn, "a+b") as f: memview = memoryview(mmap.mmap(f.fileno(), arr.nbytes + 1))

--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -25,7 +25,7 @@ def _test_single_value(vals, op, dtype):
   alu = uop(uops, UOps.ALU, dtype, loads, op)
   uop(uops, UOps.STORE, None, (buf_store, uop(uops, UOps.CONST, dtypes.int32, (), 0), alu))
   buf = Buffer(Device.DEFAULT, 1, dtype)
-  buf2 = [Buffer.fromCPU(Device.DEFAULT, np.array([a], dtype=dtype.np)) for a in vals]
+  buf2 = [Buffer.fromCPU(Device.DEFAULT, np.array([a], dtype=np.dtype(dtype.format))) for a in vals]
   prg = _uops_to_prg(uops)
   prg.exec([buf]+buf2)
   return buf.toCPU()[0]

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -126,7 +126,7 @@ class TestDtypes(unittest.TestCase):
   def test_dtypes_fields(self):
     fields = dtypes.fields()
     self.assertTrue(all(isinstance(value, DType) for value in fields.values()))
-    self.assertTrue(all(issubclass(np.dtype(value.format).type , np.generic) for value in fields.values() if value.format is not None))
+    self.assertTrue(all(issubclass(np.dtype(value.format).type, np.generic) for value in fields.values() if value.format is not None))
     self.assertTrue(all(struct.calcsize(value.format) == value.itemsize and np.dtype(value.format).itemsize == value.itemsize for value in fields.values() if value.format is not None))
 
 class TestStripParens(unittest.TestCase):

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -125,7 +125,7 @@ class TestDtypes(unittest.TestCase):
   def test_dtypes_fields(self):
     fields = dtypes.fields()
     self.assertTrue(all(isinstance(value, DType) for value in fields.values()))
-    self.assertTrue(all(issubclass(np.dtypes(value.format), np.generic) for value in fields.values() if value.np is not None))
+    self.assertTrue(all(issubclass(np.dtypes(value.format), np.generic) for value in fields.values() if value.format is not None))
 
 class TestStripParens(unittest.TestCase):
   def test_simple(self): self.assertEqual("1+2", strip_parens("(1+2)"))

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -3,6 +3,7 @@ import numpy as np
 from PIL import Image
 from tinygrad.helpers import Context, ContextVar, DType, dtypes, merge_dicts, strip_parens, prod, round_up, fetch
 from tinygrad.shape.symbolic import Variable, NumNode
+import struct
 
 VARIABLE = ContextVar("VARIABLE", 0)
 
@@ -125,7 +126,8 @@ class TestDtypes(unittest.TestCase):
   def test_dtypes_fields(self):
     fields = dtypes.fields()
     self.assertTrue(all(isinstance(value, DType) for value in fields.values()))
-    self.assertTrue(all(issubclass(np.dtypes(value.format), np.generic) for value in fields.values() if value.format is not None))
+    self.assertTrue(all(issubclass(np.dtype(value.format).type , np.generic) for value in fields.values() if value.format is not None))
+    self.assertTrue(all(struct.calcsize(value.format) == value.itemsize and np.dtype(value.format).itemsize == value.itemsize for value in fields.values() if value.format is not None))
 
 class TestStripParens(unittest.TestCase):
   def test_simple(self): self.assertEqual("1+2", strip_parens("(1+2)"))

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -125,7 +125,7 @@ class TestDtypes(unittest.TestCase):
   def test_dtypes_fields(self):
     fields = dtypes.fields()
     self.assertTrue(all(isinstance(value, DType) for value in fields.values()))
-    self.assertTrue(all(issubclass(value.np, np.generic) for value in fields.values() if value.np is not None))
+    self.assertTrue(all(issubclass(np.dtypes(value.format), np.generic) for value in fields.values() if value.np is not None))
 
 class TestStripParens(unittest.TestCase):
   def test_simple(self): self.assertEqual("1+2", strip_parens("(1+2)"))

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -128,6 +128,7 @@ class TestDtypes(unittest.TestCase):
     self.assertTrue(all(isinstance(value, DType) for value in fields.values()))
     self.assertTrue(all(issubclass(np.dtype(value.format).type, np.generic) for value in fields.values() if value.format is not None))
     self.assertTrue(all(struct.calcsize(value.format) == value.itemsize and np.dtype(value.format).itemsize == value.itemsize for value in fields.values() if value.format is not None))
+    self.assertTrue(all(np.dtype(value.format).char == value.format for value in fields.values() if value.format is not None))
 
 class TestStripParens(unittest.TestCase):
   def test_simple(self): self.assertEqual("1+2", strip_parens("(1+2)"))

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -84,8 +84,8 @@ class Buffer:
   def fromCPU(device:str, x:np.ndarray): return Buffer(device, x.size, dtypes.from_np(x.dtype)).copyin(x.data)
   def toCPU(self) -> np.ndarray:
     # zero copy with as_buffer
-    if hasattr(self.allocator, 'as_buffer'): return np.frombuffer(self.allocator.as_buffer(self._buf), dtype=np.dtype(self.dtype.np, metadata={"backing": self._buf}))  # type: ignore
-    ret = np.empty(self.size, self.dtype.np)
+    if hasattr(self.allocator, 'as_buffer'): return np.frombuffer(self.allocator.as_buffer(self._buf), dtype=np.dtype(self.dtype.format, metadata={"backing": self._buf}))  # type: ignore
+    ret = np.empty(self.size, np.dtype(self.dtype.format))
     if self.size > 0: self.allocator.copyout(flat_mv(ret.data), self._buf)
     return ret
 

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -6,6 +6,7 @@ from tqdm import tqdm
 from typing import Dict, Tuple, Union, List, NamedTuple, Final, ClassVar, Optional, Iterable, Any, TypeVar, TYPE_CHECKING, Callable
 if TYPE_CHECKING:  # TODO: remove this and import TypeGuard from typing once minimum python supported version is 3.10
   from typing_extensions import TypeGuard
+  import numpy as np
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -143,7 +144,7 @@ class dtypes:
   @staticmethod
   def is_unsigned(x: DType) -> bool: return x in (dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
   @staticmethod
-  def from_np(x) -> DType: return DTYPES_DICT[np.dtype(x).name]
+  def from_np(x: np.dtype) -> DType: return DTYPES_DICT[x.name]
   @staticmethod
   def fields() -> Dict[str, DType]: return DTYPES_DICT
   bool: Final[DType] = DType(0, 1, "bool", '?')

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -117,8 +117,8 @@ class DType(NamedTuple):
 
 # dependent typing?
 class ImageDType(DType):
-  def __new__(cls, priority, itemsize, name, format, shape, base):
-    return super().__new__(cls, priority, itemsize, name, format)
+  def __new__(cls, priority, itemsize, name, format_str, shape, base):
+    return super().__new__(cls, priority, itemsize, name, format_str)
   def __init__(self, priority, itemsize, name, format, shape, base):
     self.shape: Tuple[int, ...] = shape  # arbitrary arg for the dtype, used in image for the shape
     self.base: DType = base

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -119,7 +119,7 @@ class DType(NamedTuple):
 class ImageDType(DType):
   def __new__(cls, priority, itemsize, name, format_str, shape, base):
     return super().__new__(cls, priority, itemsize, name, format_str)
-  def __init__(self, priority, itemsize, name, format, shape, base):
+  def __init__(self, priority, itemsize, name, format_str, shape, base):
     self.shape: Tuple[int, ...] = shape  # arbitrary arg for the dtype, used in image for the shape
     self.base: DType = base
     super().__init__()

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -178,9 +178,6 @@ class dtypes:
 # HACK: staticmethods are not callable in 3.8 so we have to compare the class
 DTYPES_DICT = {k: v for k, v in dtypes.__dict__.items() if not k.startswith('__') and not callable(v) and v.__class__ is not staticmethod}
 INVERSE_DTYPES_DICT = {v:k for k,v in DTYPES_DICT.items()}
-import struct
-for dtype in DTYPES_DICT.values():
-  if dtype.format: assert struct.calcsize(dtype.format) == dtype.itemsize
 
 class GlobalCounters:
   global_ops: ClassVar[int] = 0

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -107,7 +107,7 @@ class DType(NamedTuple):
   priority: int  # this determines when things get upcasted
   itemsize: int
   name: str
-  np: Optional[type]  # TODO: someday this will be removed with the "remove numpy" project
+  format: Optional[str] = None
   sz: int = 1
   def __repr__(self): return f"dtypes.{INVERSE_DTYPES_DICT[self]}" if self.sz == 1 else f"dtypes._{INVERSE_DTYPES_DICT[self.scalar()]}{self.sz}"
   def vec(self, sz:int):
@@ -117,9 +117,9 @@ class DType(NamedTuple):
 
 # dependent typing?
 class ImageDType(DType):
-  def __new__(cls, priority, itemsize, name, np, shape, base):
-    return super().__new__(cls, priority, itemsize, name, np)
-  def __init__(self, priority, itemsize, name, np, shape, base):
+  def __new__(cls, priority, itemsize, name, format, shape, base):
+    return super().__new__(cls, priority, itemsize, name, format)
+  def __init__(self, priority, itemsize, name, format, shape, base):
     self.shape: Tuple[int, ...] = shape  # arbitrary arg for the dtype, used in image for the shape
     self.base: DType = base
     super().__init__()
@@ -132,7 +132,7 @@ class ImageDType(DType):
   def __ne__(self, x): return super().__ne__(x) or self.shape != x.shape
 
 class PtrDType(DType):
-  def __new__(cls, dt:DType): return super().__new__(cls, dt.priority, dt.itemsize, dt.name, dt.np, dt.sz)
+  def __new__(cls, dt:DType): return super().__new__(cls, dt.priority, dt.itemsize, dt.name, dt.format, dt.sz)
   def __repr__(self): return f"ptr.{super().__repr__()}"
 
 class dtypes:
@@ -146,24 +146,24 @@ class dtypes:
   def from_np(x) -> DType: return DTYPES_DICT[np.dtype(x).name]
   @staticmethod
   def fields() -> Dict[str, DType]: return DTYPES_DICT
-  bool: Final[DType] = DType(0, 1, "bool", np.bool_)
-  float16: Final[DType] = DType(9, 2, "half", np.float16)
+  bool: Final[DType] = DType(0, 1, "bool", '?')
+  float16: Final[DType] = DType(9, 2, "half", 'e')
   half = float16
-  float32: Final[DType] = DType(10, 4, "float", np.float32)
+  float32: Final[DType] = DType(10, 4, "float", 'f')
   float = float32
-  float64: Final[DType] = DType(11, 8, "double", np.float64)
+  float64: Final[DType] = DType(11, 8, "double", 'd')
   double = float64
-  int8: Final[DType] = DType(1, 1, "char", np.int8)
-  int16: Final[DType] = DType(3, 2, "short", np.int16)
-  int32: Final[DType] = DType(5, 4, "int", np.int32)
+  int8: Final[DType] = DType(1, 1, "char", 'b')
+  int16: Final[DType] = DType(3, 2, "short", 'h')
+  int32: Final[DType] = DType(5, 4, "int", 'i')
   int = int32
-  int64: Final[DType] = DType(7, 8, "long", np.int64)
-  uint8: Final[DType] = DType(2, 1, "unsigned char", np.uint8)
-  uint16: Final[DType] = DType(4, 2, "unsigned short", np.uint16)
-  uint32: Final[DType] = DType(6, 4, "unsigned int", np.uint32)
-  uint64: Final[DType] = DType(8, 8, "unsigned long", np.uint64)
+  int64: Final[DType] = DType(7, 8, "long", 'q')
+  uint8: Final[DType] = DType(2, 1, "unsigned char", 'B')
+  uint16: Final[DType] = DType(4, 2, "unsigned short", 'H')
+  uint32: Final[DType] = DType(6, 4, "unsigned int", 'I')
+  uint64: Final[DType] = DType(8, 8, "unsigned long", 'Q')
 
-  # NOTE: bfloat16 isn't supported in numpy
+  # NOTE: bfloat16 doesn't have a format
   bfloat16: Final[DType] = DType(9, 2, "__bf16", None)
 
   # NOTE: these are internal dtypes, should probably check for that
@@ -171,13 +171,16 @@ class dtypes:
 
   # NOTE: these are image dtypes
   @staticmethod
-  def imageh(shp): return ImageDType(100, 2, "imageh", np.float16, shp, dtypes.float32)
+  def imageh(shp): return ImageDType(100, 2, "imageh", dtypes.float16.format, shp, dtypes.float32)
   @staticmethod
-  def imagef(shp): return ImageDType(100, 4, "imagef", np.float32, shp, dtypes.float32)
+  def imagef(shp): return ImageDType(100, 4, "imagef", dtypes.float32.format, shp, dtypes.float32)
 
 # HACK: staticmethods are not callable in 3.8 so we have to compare the class
 DTYPES_DICT = {k: v for k, v in dtypes.__dict__.items() if not k.startswith('__') and not callable(v) and v.__class__ is not staticmethod}
 INVERSE_DTYPES_DICT = {v:k for k,v in DTYPES_DICT.items()}
+import struct
+for dtype in DTYPES_DICT.values():
+  if dtype.format: assert struct.calcsize(dtype.format) == dtype.itemsize
 
 class GlobalCounters:
   global_ops: ClassVar[int] = 0

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import os, functools, platform, time, re, contextlib, operator, hashlib, pickle, sqlite3, cProfile, pstats, tempfile, pathlib, string, ctypes
-import numpy as np
 from urllib import request
 from tqdm import tqdm
 from typing import Dict, Tuple, Union, List, NamedTuple, Final, ClassVar, Optional, Iterable, Any, TypeVar, TYPE_CHECKING, Callable

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -203,7 +203,7 @@ class LazyBuffer:
   # create a constant with the shape and dtype of self
   def const(self, val:Union[float, int]) -> LazyBuffer:
     # NOTE: dtypes.from_np(self.dtype.np) to deal with image types
-    return LazyBuffer.loadop(LoadOps.CONST, tuple(), dtypes.from_np(self.dtype.np), self.device, arg=val).reshape((1,)*len(self.shape)).expand(self.shape)
+    return LazyBuffer.loadop(LoadOps.CONST, tuple(), self.dtype, self.device, arg=val).reshape((1,)*len(self.shape)).expand(self.shape)
 
   def copy_to_device(self, device:str) -> LazyBuffer:
     # back off a COPY if it's a double COPY

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -24,8 +24,6 @@ def einsum_mulacc(einsum, get_strides, expand):
     return expand(ret.reshape([(1 if i not in a_axes and i not in b_axes else s) for i,s in enumerate(new_shape)]), new_shape)
   return mulacc
 
-
-
 numpy_fxn_for_op: Dict[Op, Callable] = {
   BufferOps.CONST: lambda val, dtype: np.array(val, dtype=np.dtype(dtype.format)),
   UnaryOps.EXP2: np.exp2, UnaryOps.LOG2: np.log2, UnaryOps.SIN: np.sin,

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -24,10 +24,16 @@ def einsum_mulacc(einsum, get_strides, expand):
     return expand(ret.reshape([(1 if i not in a_axes and i not in b_axes else s) for i,s in enumerate(new_shape)]), new_shape)
   return mulacc
 
+
+def np_cast(x,y):
+  print(y[0].format, np.dtype(y[0].format))
+  return x.view(np.dtype(y[0].format)) if y[1] else x.astype(np.dtype(y[0].format), copy=False)
+
+
 numpy_fxn_for_op: Dict[Op, Callable] = {
-  BufferOps.CONST: lambda val, dtype: np.array(val, dtype=dtype.np),
+  BufferOps.CONST: lambda val, dtype: np.array(val, dtype=np.dtype(dtype.format)),
   UnaryOps.EXP2: np.exp2, UnaryOps.LOG2: np.log2, UnaryOps.SIN: np.sin,
-  UnaryOps.CAST: lambda x,y: x.view(y[0].np) if y[1] else x.astype(y[0].np, copy=False), UnaryOps.NEG: lambda x: np.logical_not(x) if x.dtype == np.bool_ else np.negative(x),
+  UnaryOps.CAST: lambda x,y: np_cast(x, y), UnaryOps.NEG: lambda x: np.logical_not(x) if x.dtype == np.bool_ else np.negative(x),
   BinaryOps.MAX: np.maximum, BinaryOps.CMPLT: lambda x,y: (x<y).astype(output_type(x,y)), BinaryOps.ADD: lambda x, y: np.add(*match_types(x, y)),
   BinaryOps.SUB: lambda x, y: np.subtract(*match_types(x, y)), BinaryOps.MUL: lambda x, y: np.multiply(*match_types(x, y)),
   BinaryOps.DIV: lambda x, y: np.divide(*match_types(x, y)).astype(output_type(x, y), copy=False), BinaryOps.XOR: lambda x, y: np.bitwise_xor(*match_types(x, y)), UnaryOps.SQRT: np.sqrt,

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -25,15 +25,11 @@ def einsum_mulacc(einsum, get_strides, expand):
   return mulacc
 
 
-def np_cast(x,y):
-  print(y[0].format, np.dtype(y[0].format))
-  return x.view(np.dtype(y[0].format)) if y[1] else x.astype(np.dtype(y[0].format), copy=False)
-
 
 numpy_fxn_for_op: Dict[Op, Callable] = {
   BufferOps.CONST: lambda val, dtype: np.array(val, dtype=np.dtype(dtype.format)),
   UnaryOps.EXP2: np.exp2, UnaryOps.LOG2: np.log2, UnaryOps.SIN: np.sin,
-  UnaryOps.CAST: lambda x,y: np_cast(x, y), UnaryOps.NEG: lambda x: np.logical_not(x) if x.dtype == np.bool_ else np.negative(x),
+  UnaryOps.CAST: lambda x,y: x.view(np.dtype(y[0].format)) if y[1] else x.astype(np.dtype(y[0].format), copy=False), UnaryOps.NEG: lambda x: np.logical_not(x) if x.dtype == np.bool_ else np.negative(x),
   BinaryOps.MAX: np.maximum, BinaryOps.CMPLT: lambda x,y: (x<y).astype(output_type(x,y)), BinaryOps.ADD: lambda x, y: np.add(*match_types(x, y)),
   BinaryOps.SUB: lambda x, y: np.subtract(*match_types(x, y)), BinaryOps.MUL: lambda x, y: np.multiply(*match_types(x, y)),
   BinaryOps.DIV: lambda x, y: np.divide(*match_types(x, y)).astype(output_type(x, y), copy=False), BinaryOps.XOR: lambda x, y: np.bitwise_xor(*match_types(x, y)), UnaryOps.SQRT: np.sqrt,

--- a/tinygrad/runtime/ops_torch.py
+++ b/tinygrad/runtime/ops_torch.py
@@ -25,7 +25,7 @@ def as_strided(x, arg):
 torch_fxn_for_op: Dict[Op, Callable] = {
   # TODO: torch.tensor should work here. it doesn't due to "overflow" in uint8
   #BufferOps.CONST: lambda val, dtype: torch.tensor(val, device=device, dtype=inverse_type_map[dtype]),
-  BufferOps.CONST: lambda val, dtype: torch.from_numpy(np.array(val, dtype=dtype.np)).to(device),
+  BufferOps.CONST: lambda val, dtype: torch.from_numpy(np.array(val, dtype=np.dtype(dtype.format))).to(device),
   UnaryOps.SQRT: lambda x: x.sqrt(), UnaryOps.EXP2: lambda x: x.exp2(), UnaryOps.LOG2: lambda x: x.log2(), UnaryOps.SIN: torch.sin,
   UnaryOps.CAST: lambda x,y: (x.view if y[1] else x.type)(next(k for k,v in type_map.items() if v==y[0])), UnaryOps.NEG: lambda x: torch.logical_not(x) if x.dtype is torch.bool else torch.neg(x),
   BinaryOps.MAX: torch.maximum, BinaryOps.CMPLT: lambda x,y: (x<y).type(torch.promote_types(x.dtype, y.dtype)),


### PR DESCRIPTION
 - DType.format is the same format used by struct and memoryview, and it is valid in np.dtype()
 - Replace all uses of dtype.np with np.dtype(dtype.format)
 - test dtype.itemsize against np.dtype(dtype.format).itemsize and struct.calcsize(dtype.format) in test_helpers.py

first task in #2649