### PR TITLE
Implement einsum

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -456,6 +456,14 @@ class TestOps(unittest.TestCase):
     helper_test_op([(10,20)], lambda x: x.argmin(1, False), lambda x: x.argmin(1, False), forward_only=True)
     helper_test_op([(10,20)], lambda x: x.argmin(1, True), lambda x: x.argmin(1, True), forward_only=True)
 
+  def test_einsum(self):
+    # dot product
+    helper_test_op([(30),(30)], lambda a,b: torch.einsum('i,i->i', [a,b]), lambda a,b: Tensor.einsum('i,i->i', [a,b]))
+    # batch matrix multiplication
+    helper_test_op([(10,20,30),(10,30,40)], lambda a,b: torch.einsum('ijk,ikl->ijl', [a, b]), lambda a,b: Tensor.einsum('ijk,ikl->ijl', [a, b]))
+    # bilinear transformation
+    helper_test_op([(2,3),(5,3,7),(2,7)], lambda a,b,c: torch.einsum('ik,jkl,il->ij', [a,b,c]), lambda a,b,c: Tensor.einsum('ik,jkl,il->ij', [a,b,c]))
+
   def test_matmul_simple(self):
     helper_test_op([(4), (4,4)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
   def test_matmul(self):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -457,10 +457,28 @@ class TestOps(unittest.TestCase):
     helper_test_op([(10,20)], lambda x: x.argmin(1, True), lambda x: x.argmin(1, True), forward_only=True)
 
   def test_einsum(self):
+    # matrix transpose
+    helper_test_op([(150,150)], lambda a: torch.einsum('ij->ji', a), lambda a: Tensor.einsum('ij->ji', a))
+    # sum all elements
+    helper_test_op([(20,30,40)], lambda a: torch.einsum('ijk->', a), lambda a: Tensor.einsum('ijk->', a))
+    # column sum
+    helper_test_op([(50,50)], lambda a: torch.einsum('ij->j', a), lambda a: Tensor.einsum('ij->j', a))
+    # row sum
+    helper_test_op([(15,15)], lambda a: torch.einsum('ij->i', a), lambda a: Tensor.einsum('ij->i', a))
+    # matrix-vector multiplication
+    helper_test_op([(15,20), (20,)], lambda a,b: torch.einsum('ik,k->i', a,b), lambda a,b: Tensor.einsum('ik,k->i', a, b))
+    # matrix-matrix multiplication
+    helper_test_op([(15,20), (20,30)], lambda a,b: torch.einsum('ik,kj->ij', a,b), lambda a,b: Tensor.einsum('ik,kj->ij', a, b))
     # dot product
     helper_test_op([(30),(30)], lambda a,b: torch.einsum('i,i->i', [a,b]), lambda a,b: Tensor.einsum('i,i->i', [a,b]))
+    # hadamard product
+    helper_test_op([(30,40),(30,40)], lambda a,b: torch.einsum('ij,ij->ij', a,b), lambda a,b: Tensor.einsum('ij,ij->ij', a,b))
+    # outer product
+    helper_test_op([(15,), (15,)], lambda a,b: torch.einsum('i,j->ij', a,b), lambda a,b: Tensor.einsum('i,j->ij',a,b))
     # batch matrix multiplication
     helper_test_op([(10,20,30),(10,30,40)], lambda a,b: torch.einsum('ijk,ikl->ijl', [a, b]), lambda a,b: Tensor.einsum('ijk,ikl->ijl', [a, b]))
+    # tensor contraction
+    helper_test_op([(3,5,8,10),(11,13,5,16,8)], lambda a,b: torch.einsum('pqrs,tuqvr->pstuv', a,b), lambda a,b: Tensor.einsum('pqrs,tuqvr->pstuv', a,b))
     # bilinear transformation
     helper_test_op([(2,3),(5,3,7),(2,7)], lambda a,b,c: torch.einsum('ik,jkl,il->ij', [a,b,c]), lambda a,b,c: Tensor.einsum('ik,jkl,il->ij', [a,b,c]))
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -477,8 +477,14 @@ class TestOps(unittest.TestCase):
     helper_test_op([(15,), (15,)], lambda a,b: torch.einsum('i,j->ij', a,b), lambda a,b: Tensor.einsum('i,j->ij',a,b))
     # batch matrix multiplication
     helper_test_op([(10,20,30),(10,30,40)], lambda a,b: torch.einsum('ijk,ikl->ijl', [a, b]), lambda a,b: Tensor.einsum('ijk,ikl->ijl', [a, b]))
+    # batch matrix multiplication, result permuted
+    helper_test_op([(10,20,25),(10,25,32)], lambda a,b: torch.einsum('ijk,ikl->jil', [a, b]), lambda a,b: Tensor.einsum('ijk,ikl->jil', [a, b]))
+    # batch matrix multiplication, result & input permuted
+    helper_test_op([(20,10,25),(10,25,32)], lambda a,b: torch.einsum('jik,ikl->jil', [a, b]), lambda a,b: Tensor.einsum('jik,ikl->jil', [a, b]))
     # tensor contraction
     helper_test_op([(3,5,8,10),(11,13,5,16,8)], lambda a,b: torch.einsum('pqrs,tuqvr->pstuv', a,b), lambda a,b: Tensor.einsum('pqrs,tuqvr->pstuv', a,b))
+    # tensor contraction, input permuted
+    helper_test_op([(3,8,10,5),(11,5,13,16,8)], lambda a,b: torch.einsum('prsq,tquvr->pstuv', a,b), lambda a,b: Tensor.einsum('prsq,tquvr->pstuv', a,b))
     # bilinear transformation
     helper_test_op([(2,3),(5,3,7),(2,7)], lambda a,b,c: torch.einsum('ik,jkl,il->ij', [a,b,c]), lambda a,b,c: Tensor.einsum('ik,jkl,il->ij', [a,b,c]))
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -482,9 +482,9 @@ class TestOps(unittest.TestCase):
     # batch matrix multiplication, result & input permuted
     helper_test_op([(20,10,25),(10,25,32)], lambda a,b: torch.einsum('jik,ikl->jil', [a, b]), lambda a,b: Tensor.einsum('jik,ikl->jil', [a, b]))
     # tensor contraction
-    helper_test_op([(3,5,8,10),(11,13,5,16,8)], lambda a,b: torch.einsum('pqrs,tuqvr->pstuv', a,b), lambda a,b: Tensor.einsum('pqrs,tuqvr->pstuv', a,b))
+    helper_test_op([(3,5,8,10),(11,13,5,16,8)], lambda a,b: torch.einsum('pqrs,tuqvr->pstuv', a,b), lambda a,b: Tensor.einsum('pqrs,tuqvr->pstuv', a,b), atol=1e-5)
     # tensor contraction, input permuted
-    helper_test_op([(3,8,10,5),(11,5,13,16,8)], lambda a,b: torch.einsum('prsq,tquvr->pstuv', a,b), lambda a,b: Tensor.einsum('prsq,tquvr->pstuv', a,b))
+    helper_test_op([(3,8,10,5),(11,5,13,16,8)], lambda a,b: torch.einsum('prsq,tquvr->pstuv', a,b), lambda a,b: Tensor.einsum('prsq,tquvr->pstuv', a,b), atol=1e-5)
     # bilinear transformation
     helper_test_op([(2,3),(5,3,7),(2,7)], lambda a,b,c: torch.einsum('ik,jkl,il->ij', [a,b,c]), lambda a,b,c: Tensor.einsum('ik,jkl,il->ij', [a,b,c]))
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -488,6 +488,24 @@ class TestOps(unittest.TestCase):
     # bilinear transformation
     helper_test_op([(2,3),(5,3,7),(2,7)], lambda a,b,c: torch.einsum('ik,jkl,il->ij', [a,b,c]), lambda a,b,c: Tensor.einsum('ik,jkl,il->ij', [a,b,c]))
 
+  @unittest.expectedFailure
+  def test_einsum_shape_check(self):
+    a = Tensor.zeros(3,8,10,5)
+    b = Tensor.zeros(11,5,13,16,8)
+    Tensor.einsum('pqrs,tuqvr->pstuv',a,b)
+
+  @unittest.expectedFailure
+  def test_einsum_arity_check1(self):
+    a = Tensor.zeros(10,15)
+    b = Tensor.zeros(15,20)
+    c = Tensor.zeros(20,10)
+    Tensor.einsum('ij,jk->ij', a,b,c)
+
+  @unittest.expectedFailure
+  def test_einsum_arity_check2(self):
+    a = Tensor.zeros(10,10)
+    Tensor.einsum('ij,jk->ij', a)
+
   def test_matmul_simple(self):
     helper_test_op([(4), (4,4)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
   def test_matmul(self):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -517,14 +517,14 @@ class Tensor:
     lhs = [sorted(enumerate(s), key=lambda e:e[1]) for s in lhs.split(',')]
     rhs = sorted(enumerate(rhs), key=lambda e:e[1])
 
-    assert len(xs) == len(lhs), f"number of args doesn't match number of operands in formula, expected {len(lhs)}, got {len(xs)}"
+    assert len(xs) == len(lhs), f"number of inputs doesn't match number of operands in formula, expected {len(lhs)}, got {len(xs)}"
 
     lhs, rhs = [[list(zip(*l)) for l in lhs], list(zip(*rhs)) or [[], []]]
     dims = {}
     for i, l in enumerate(lhs):
       for order, letter in enumerate(l[1]):
         if letter not in dims: dims[letter] = xs[i].shape[l[0][order]]
-        else: assert dims[letter] == xs[i].shape[l[0][order]]
+        else: assert dims[letter] == xs[i].shape[l[0][order]], f"dims of the same index should all be equal in the inputs. expected {dims[letter]} for input #{i+1}, got {xs[i].shape[l[0][order]]}"
     xs_ = [None]*len(xs)
     for i,x in enumerate(xs):
       xs_[i] = x.permute(lhs[i][0]) \

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -512,7 +512,7 @@ class Tensor:
 
   @staticmethod
   def einsum(formula, *xs) -> Tensor:
-    if isinstance(xs[0], list): xs = tuple(xs[0])
+    xs = argfix(*xs)
     lhs, rhs = formula.split("->")
     lhs = [sorted(enumerate(s), key=lambda e:e[1]) for s in lhs.split(',')]
     rhs = sorted(enumerate(rhs), key=lambda e:e[1])

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -510,6 +510,31 @@ class Tensor:
     return self.shape[axis]-idx.max(axis=axis, keepdim=keepdim)-1
   def argmin(self, axis=None, keepdim=False): return (-self).argmax(axis=axis, keepdim=keepdim)
 
+  @staticmethod
+  def einsum(formula: str, *xs:Union[Tensor, List[Tensor]]) -> Tensor:
+    if isinstance(xs[0], list): xs = xs[0]
+    lhs, rhs = formula.split("->")
+    lhs = [sorted(enumerate(s), key=lambda e:e[1]) for s in lhs.split(',')]
+    rhs = sorted(enumerate(rhs), key=lambda e:e[1])
+
+    assert len(xs) == len(lhs), f"number of args doesn't match number of operands in formula, expected {len(lhs)}, got {len(xs)}"
+
+    lhs, rhs = [[list(zip(*l)) for l in lhs], list(zip(*rhs)) or [[], []]]
+    dims = {}
+    for i, l in enumerate(lhs):
+      for order, letter in enumerate(l[1]):
+        if letter not in dims: dims[letter] = xs[i].shape[l[0][order]]
+        else: assert dims[letter] == xs[i].shape[l[0][order]]
+    xs_ = [None]*len(xs)
+    for i,x in enumerate(xs):
+      xs_[i] = x.permute(lhs[i][0]) \
+        .reshape([dims[letter] if letter in lhs[i][1] else 1 for letter in sorted(dims.keys())]) \
+        .expand([e[1] for e in sorted(dims.items(), key=lambda e: e[0])])
+
+    return reduce(lambda a,b:a*b, xs_) \
+      .sum(axis=[axis for axis,letter in enumerate(sorted(dims.keys())) if letter not in rhs[1]]) \
+      .permute(rhs[0])
+
   # ***** processing ops *****
 
   def _pool(self, k_:Tuple[sint, ...], stride:Union[Tuple[int, ...], int]=1, dilation:Union[Tuple[int, ...], int]=1) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -511,8 +511,8 @@ class Tensor:
   def argmin(self, axis=None, keepdim=False): return (-self).argmax(axis=axis, keepdim=keepdim)
 
   @staticmethod
-  def einsum(formula: str, *xs:Union[Tensor, List[Tensor]]) -> Tensor:
-    if isinstance(xs[0], list): xs = xs[0]
+  def einsum(formula, *xs) -> Tensor:
+    if isinstance(xs[0], list): xs = tuple(xs[0])
     lhs, rhs = formula.split("->")
     lhs = [sorted(enumerate(s), key=lambda e:e[1]) for s in lhs.split(',')]
     rhs = sorted(enumerate(rhs), key=lambda e:e[1])


### PR DESCRIPTION
Closes #2665. Is this desired in core? Seems appropriate to me, but it doesn't take self, so if LOC is a problem, could be in extra.

- [x] untested einsum impl
- [x] add a few simple tests
- [x] cover every case [here](https://rockt.github.io/2018/04/30/einsum)
- [x] make sure transpose shenanigans are indeed covered by tests
- [x] add mustfails for bad syntax, mismatched shapes
- [x] check if it works in einops
- [x] add more helpful error msg on dim mismatch
- [x] perf comparisons