### PR TITLE
WIP: change some linter steps to use pre-commit hooks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
-    # TODO: run the pre-commit hook to replace a lot of this
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
@@ -30,27 +29,31 @@ jobs:
         path: ${{ env.Python3_ROOT_DIR }}/lib/python3.8/site-packages
         key: linting-packages-${{ hashFiles('**/setup.py') }}-3.8
     - name: Install dependencies
-      run: pip install -e '.[linting,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
+      run: |
+        pip install -e '.[linting,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
+        pip3 install --upgrade --force-reinstall ruff
     - name: Repo line count
       run: python sz.py
     - name: Lint with pylint
       run: python -m pylint --disable=all -e W0311 -e C0303 --jobs=0 --indent-string='  ' **/*.py
-    - name: Lint with ruff
-      run: |
-        pip3 install --upgrade --force-reinstall ruff
-        python3 -m ruff . --preview
-    - name: Lint tinygrad with pylint
-      run: python -m pylint tinygrad/
+    - name: Lint with ruff using pre-commit hook
+      uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: ruff
+    - name: Lint tinygrad with pylint using pre-commit hook
+      uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: pylint
     - name: Run mypy
       run: python -m mypy
     - name: Install SLOCCount
       run: sudo apt install sloccount
     - name: Check <5000 lines
       run: sloccount tinygrad test examples extra; if [ $(sloccount tinygrad | sed -n 's/.*Total Physical Source Lines of Code (SLOC)[ ]*= \([^ ]*\).*/\1/p' | tr -d ',') -gt 5000 ]; then exit 1; fi
-    - name: Test Docs
-      run: |
-        python docs/abstractions.py
-        python docs/abstractions2.py
+    - name: Test Docs using pre-commit hook
+      uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: docs
     - name: Test Quickstart
       run: awk '/```python/{flag=1;next}/```/{flag=0}flag' docs/quickstart.md > quickstart.py &&  PYTHONPATH=. python quickstart.py
     - name: Fuzz Test symbolic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e '.[linting,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
-        pip3 install --upgrade --force-reinstall ruff
     - name: Repo line count
       run: python sz.py
     - name: Lint with pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         pass_filenames: false
       - id: ruff
         name: ruff
-        entry: ruff . --preview
+        entry: python3 -m ruff . --preview
         language: system
         always_run: true
         pass_filenames: false


### PR DESCRIPTION
As I'm unsure of a better way to do it, I've done it based on my understanding of the goal, which is to reuse some steps from pre-commit hooks?

Several questions: 
1. The mypy call is different in two places. Several other inconsistencies, for example, as I'm not sure about the two different calls of pylint, so I only replaced the one that is the same command. 
2. Currently I didn't change the steps much in the file, I just kept the order and used the pre-commit action. Do we prefer a single step of call to this action with multiple checks, or it's fine to just leave this as-is?
