### PR TITLE
readonly memoryview

### DIFF
--- a/docs/abstractions2.py
+++ b/docs/abstractions2.py
@@ -15,8 +15,8 @@ a = MallocAllocator.alloc(4)
 b = MallocAllocator.alloc(4)
 
 # load in some values (little endian)
-MallocAllocator.copyin(a, bytearray([2,0,0,0]))
-MallocAllocator.copyin(b, bytearray([3,0,0,0]))
+MallocAllocator.copyin(a, memoryview(bytearray([2,0,0,0])))
+MallocAllocator.copyin(b, memoryview(bytearray([3,0,0,0])))
 
 # compile a program to a binary
 lib = compile_clang("void add(int *out, int *a, int *b) { out[0] = a[0] + b[0]; }")

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 from PIL import Image
-from tinygrad.helpers import Context, ContextVar, DType, dtypes, merge_dicts, strip_parens, prod, round_up, fetch
+from tinygrad.helpers import Context, ContextVar, DType, dtypes, from_mv, merge_dicts, strip_parens, prod, round_up, fetch
 from tinygrad.shape.symbolic import Variable, NumNode
 
 VARIABLE = ContextVar("VARIABLE", 0)
@@ -159,6 +159,14 @@ class TestFetch(unittest.TestCase):
     img = fetch("https://media.istockphoto.com/photos/hen-picture-id831791190", allow_caching=False)
     with Image.open(img) as pimg:
       assert pimg.size == (705, 1024)
+
+class TestCtypes(unittest.TestCase):
+  def test_from_mv_readonly(self):
+    buf = bytearray(list(range(5)))
+    mvro = memoryview(buf).toreadonly()
+    assert mvro.readonly
+    ret = from_mv(mvro)
+    assert ret[:5] == buf
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -268,8 +268,7 @@ def cpu_time_execution(cb, enable):
 
 # *** ctypes helpers
 
-# TODO: make this work with read only memoryviews (if possible)
-def from_mv(mv, to_type=ctypes.c_char): return ctypes.cast(ctypes.addressof(to_type.from_buffer(mv)), ctypes.POINTER(to_type))
+def from_mv(mv: memoryview, to_type=ctypes.c_char): return ctypes.cast(ctypes.addressof(to_type.from_buffer(memoryview(mv.obj))), ctypes.POINTER(to_type)) # memoryview(mv.obj) wraps a new memoryview to remove readonly on mv
 def to_char_p_p(options: List[bytes], to_type=ctypes.c_char): return (ctypes.POINTER(to_type) * len(options))(*[ctypes.cast(ctypes.create_string_buffer(o), ctypes.POINTER(to_type)) for o in options])
 @functools.lru_cache(maxsize=None)
 def init_c_struct_t(fields: Tuple[Tuple[str, ctypes._SimpleCData], ...]):


### PR DESCRIPTION
wrapping a memoryview around the readonly memoryview's obj makes a new writeable memoryview. unsure how to test beyond the test suite.

```
>>> buf = bytearray([1,2,3,4,5])
>>> mvro = memoryview(buf).toreadonly()
>>> mvro.readonly
True
>>> mvw = memoryview(mvro.obj)
>>> mvw.readonly
False
>>> mvro.obj == mvw.obj
True
```

NOTE: `memoryview(mv)` on its own doesn't work because cpython [copies](https://github.com/python/cpython/blob/main/Objects/memoryobject.c#L548) the `readonly` bit

i also tried:
- ctypes incantations, didn't get anywhere
- can probably use `ctypes.pythonapi` methods but that felt more hacky than this