### PR TITLE
Lean for mergeability of views

### DIFF
--- a/docs/proofs/Merge.lean
+++ b/docs/proofs/Merge.lean
@@ -21,9 +21,8 @@ def proj {n : Nat} (v : View n) (i : Fin n)  (j : Nat) : Nat :=
 def valid {n : Nat} (v : View n) (i : Fin n) (j : Nat) : Prop :=
   let p : i.val < List.length v.min.val := by rw [v.min.property]; exact i.isLt
   let q : i.val < List.length v.max.val := by rw [v.max.property]; exact i.isLt
-
   (proj v i j) >= List.get v.min.val (Fin.mk i p)
-  ∧ (proj v i j) <= List.get v.max.val (Fin.mk i p)
+  ∧ (proj v i j) <= List.get v.max.val (Fin.mk i q)
 
 
 def idxs {n : Nat} (v : View n) : Type :=

--- a/docs/proofs/Merge.lean
+++ b/docs/proofs/Merge.lean
@@ -14,12 +14,16 @@ def size {n : Nat} (v : View n) : Nat :=
 
 
 def proj {n : Nat} (v : View n) (i : Fin n)  (j : Nat) : Nat :=
-  (j - v.offset) % (List.get v.stride.val (Fin.mk i sorry))
+  let p : i.val < List.length v.stride.val := by rw [v.stride.property]; exact i.isLt
+  (j - v.offset) % (List.get v.stride.val (Fin.mk i p))
 
 
 def valid {n : Nat} (v : View n) (i : Fin n) (j : Nat) : Prop :=
-  (proj v i j) >= List.get v.min.val (Fin.mk i sorry)
-  ∧ (proj v i j) <= List.get v.max.val (Fin.mk i sorry)
+  let p : i.val < List.length v.min.val := by rw [v.min.property]; exact i.isLt
+  let q : i.val < List.length v.max.val := by rw [v.max.property]; exact i.isLt
+
+  (proj v i j) >= List.get v.min.val (Fin.mk i p)
+  ∧ (proj v i j) <= List.get v.max.val (Fin.mk i p)
 
 
 def idxs {n : Nat} (v : View n) : Type :=
@@ -46,6 +50,6 @@ def wrap (x : Nat) : Tuple Nat 1 := Subtype.mk [x] rfl
 def v2 : View 1 :=
   View.mk 0 (wrap 4) (wrap 0) (wrap 3) (wrap 1)
 
-theorem thm1 (f : idxs v1 → idxs v2) (g : idxs v2 → idxs v1) :
+theorem cx (f : idxs v1 → idxs v2) (g : idxs v2 → idxs v1) :
   ¬ reshapeable v1 v2 f g :=
   sorry

--- a/docs/proofs/Merge.lean
+++ b/docs/proofs/Merge.lean
@@ -31,3 +31,21 @@ def idxs {n : Nat} (v : View n) : Type :=
 def reshapeable {n m : Nat} (v : View n) (w: View m)
   (f : idxs v → idxs w) (g : idxs w → idxs v) : Prop :=
   (f ∘ g = id) ∧ (g ∘ f = id)
+
+def tt : Tuple Nat 2 :=
+  Subtype.mk [2,2] rfl
+
+def zz : Tuple Nat 2 :=
+  Subtype.mk [0,0] rfl
+
+def v1 : View 2 :=
+  View.mk 0 tt zz tt (Subtype.mk [2,1] rfl)
+
+def wrap (x : Nat) : Tuple Nat 1 := Subtype.mk [x] rfl
+
+def v2 : View 1 :=
+  View.mk 0 (wrap 4) (wrap 0) (wrap 3) (wrap 1)
+
+theorem thm1 (f : idxs v1 → idxs v2) (g : idxs v2 → idxs v1) :
+  ¬ reshapeable v1 v2 f g :=
+  sorry

--- a/docs/proofs/Merge.lean
+++ b/docs/proofs/Merge.lean
@@ -1,20 +1,33 @@
 def Tuple (α : Type) (n : Nat) :=
   { as : List α // as.length = n }
 
-
 structure View (n : Nat) where
-  shape : Tuple Nat n
---  strides : Tuple Nat n
---  mask : Tuple Nat n
   offset : Nat
+  shape : Tuple Nat n
+  min : Tuple Nat n
+  max : Tuple Nat n
+  stride : Tuple Nat n
+
 
 def size {n : Nat} (v : View n) : Nat :=
   List.foldl (λ x y ↦ x * y) 1 v.shape.val
 
-def idxs {n : Nat} (v : View n) : Type :=
-  { n : Nat // n >= v.offset ∧ n < v.offset + size v }
 
+def proj {n : Nat} (v : View n) (i : Fin n)  (j : Nat) : Nat :=
+  (j - v.offset) % (List.get v.stride.val (Fin.mk i sorry))
+
+
+def valid {n : Nat} (v : View n) (i : Fin n) (j : Nat) : Prop :=
+  (proj v i j) >= List.get v.min.val (Fin.mk i sorry)
+  ∧ (proj v i j) <= List.get v.max.val (Fin.mk i sorry)
+
+
+def idxs {n : Nat} (v : View n) : Type :=
+  { j : Nat
+    // j >= v.offset
+    ∧  j < v.offset + size v
+    ∧  forall i : Fin n, valid v i j}
 
 def reshapeable {n m : Nat} (v : View n) (w: View m)
   (f : idxs v → idxs w) (g : idxs w → idxs v) : Prop :=
-  (size v = size w) → (f ∘ g = id) ∧ (g ∘ f = id)
+  (f ∘ g = id) ∧ (g ∘ f = id)

--- a/docs/proofs/Merge.lean
+++ b/docs/proofs/Merge.lean
@@ -1,0 +1,20 @@
+def Tuple (α : Type) (n : Nat) :=
+  { as : List α // as.length = n }
+
+
+structure View (n : Nat) where
+  shape : Tuple Nat n
+--  strides : Tuple Nat n
+--  mask : Tuple Nat n
+  offset : Nat
+
+def size {n : Nat} (v : View n) : Nat :=
+  List.foldl (λ x y ↦ x * y) 1 v.shape.val
+
+def idxs {n : Nat} (v : View n) : Type :=
+  { n : Nat // n >= v.offset ∧ n < v.offset + size v }
+
+
+def reshapeable {n m : Nat} (v : View n) (w: View m)
+  (f : idxs v → idxs w) (g : idxs w → idxs v) : Prop :=
+  (size v = size w) → (f ∘ g = id) ∧ (g ∘ f = id)


### PR DESCRIPTION
Just starting with some basic definitions to prove the easiest case.  Also would be good to get a better idea of the right definition of "mergeability of shapetrackers." Currently working under the assumption that it just means there is a order-preserving bijection of underlying indices that preserves the masks.  In this case, it's clear that there needs to be a condition on the masks for the shapetrackers to be mergeable -- example: View(shape=(6), mask=(0,4)) can't be reshaped into a single mask on View(shape=(2,3))