### PR TITLE
combine expressions and some cleanup in yolov8 and unet3d

### DIFF
--- a/examples/yolov8.py
+++ b/examples/yolov8.py
@@ -36,8 +36,7 @@ def preprocess(im, imgsz=640, model_stride=32, model_pt=True):
   im = Tensor([compute_transform(x, new_shape=imgsz, auto=auto, stride=model_stride) for x in im])
   im = Tensor.stack(im) if im.shape[0] > 1 else im
   im = im[..., ::-1].permute(0, 3, 1, 2)  # BGR to RGB, BHWC to BCHW, (n, 3, h, w)
-  im /= 255  # 0 - 255 to 0.0 - 1.0
-  return im
+  return im/255 # 0 - 255 to 0.0 - 1.0
 
 # Post Processing functions
 def box_area(box):
@@ -50,8 +49,7 @@ def box_iou(box1, box2):
   inter = wh[:, :, 0] * wh[:, :, 1]
   area1 = box_area(box1)[:, None]
   area2 = box_area(box2)[None, :]
-  iou = inter / (area1 + area2 - inter)
-  return iou
+  return inter / (area1 + area2 - inter) #return iou
 
 def compute_nms(boxes, scores, iou_threshold):
   order, keep = scores.argsort()[::-1], []
@@ -315,11 +313,9 @@ class Darknet:
     return [*self.b1, *self.b2, *self.b3, *self.b4, *self.b5]
 
   def __call__(self, x):
-    x1 = x.sequential(self.b1)
-    x2 = x1.sequential(self.b2)
+    x2 = x.sequential(self.b1, self.b2)
     x3 = x2.sequential(self.b3)
-    x4 = x3.sequential(self.b4)
-    x5 = x4.sequential(self.b5)
+    x5 = x4.sequential(self.b4, self.b5)
     return (x2, x3, x5)
 
 #yolo fpn (neck)

--- a/extra/models/unet3d.py
+++ b/extra/models/unet3d.py
@@ -10,7 +10,7 @@ class DownsampleBlock:
     self.conv2 = [nn.Conv2d(c1, c1, kernel_size=(3,3,3), padding=(1,1,1,1,1,1), bias=False), nn.InstanceNorm(c1), Tensor.relu]
 
   def __call__(self, x):
-    return x.sequential(self.conv1).sequential(self.conv2)
+    return x.sequential(self.conv1, self.conv2)
 
 class UpsampleBlock:
   def __init__(self, c0, c1):
@@ -21,7 +21,7 @@ class UpsampleBlock:
   def __call__(self, x, skip):
     x = x.sequential(self.upsample_conv)
     x = Tensor.cat(x, skip, dim=1)
-    return x.sequential(self.conv1).sequential(self.conv2)
+    return x.sequential(self.conv1, self.conv2)
 
 class UNet3D:
   def __init__(self, in_channels=1, n_class=3):
@@ -31,7 +31,7 @@ class UNet3D:
     self.downsample = [DownsampleBlock(i, o) for i, o in zip(inp, out)]
     self.bottleneck = DownsampleBlock(filters[-1], filters[-1])
     self.upsample = [UpsampleBlock(filters[-1], filters[-1])] + [UpsampleBlock(i, o) for i, o in zip(out[::-1], inp[::-1])]
-    self.output = {"conv": nn.Conv2d(filters[0], n_class, kernel_size=(1, 1, 1))}
+    self.final_conv = nn.Conv2d(filters[0], n_class, kernel_size=(1, 1, 1))
 
   def __call__(self, x):
     x = self.input_block(x)
@@ -42,8 +42,7 @@ class UNet3D:
     x = self.bottleneck(x)
     for upsample, skip in zip(self.upsample, outputs[::-1]):
       x = upsample(x, skip)
-    x = self.output["conv"](x)
-    return x
+    return self.final_conv(x)
 
   def load_from_pretrained(self):
     fn = Path(__file__).parents[1] / "weights" / "unet-3d.ckpt"


### PR DESCRIPTION
Combined some lines to eliminate unnecessary variable assignment (bad for total inference time), I believe these changes do not reduce readability.

Concatenate some op. calls (remove occurrences of calling .sequential twice in a row in same line).

I didn't understand why 3d UNet's final conv layer was created as a dictionary. Maybe it's a personal preference, but I believe having it just as a layer improves readability. 