### PR TITLE
Add linespace

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -138,6 +138,16 @@ class TestOps(unittest.TestCase):
   def test_arange_big(self):
     helper_test_op([], lambda: torch.arange(256), lambda: Tensor.arange(256), forward_only=True)
 
+  def test_linspace(self):
+    helper_test_op([], lambda: torch.linspace(5, 10, 0), lambda: Tensor.linspace(5, 10, 0), forward_only=True)
+    helper_test_op([], lambda: torch.linspace(5, 10, 1), lambda: Tensor.linspace(5, 10, 1), forward_only=True)
+    helper_test_op([], lambda: torch.linspace(5, 10, 5), lambda: Tensor.linspace(5, 10, 5), forward_only=True)
+    helper_test_op([], lambda: torch.linspace(5.1, 10.1, 5), lambda: Tensor.linspace(5.1, 10.1, 5), forward_only=True)
+    helper_test_op([], lambda: torch.linspace(10, 5, 5), lambda: Tensor.linspace(10, 5, 5), forward_only=True)
+    helper_test_op([], lambda: torch.linspace(-math.pi, math.pi, 2000), lambda: Tensor.linspace(-math.pi, math.pi, 2000), forward_only=True)
+    with self.assertRaises(AssertionError):
+      Tensor.linspace(10, 5, -1)
+
   def test_sum_fake(self):
     helper_test_op([(256, 1)], lambda x: x.sum(axis=1))
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -181,6 +181,11 @@ class Tensor:
     return Tensor.full((math.ceil((stop-start)/step),), step, **kwargs).cumsum() + (start - step)
 
   @staticmethod
+  def linspace(start: Union[int, float], stop: Union[int, float], steps: int, **kwargs):
+    assert steps > -1, "number of steps must be non-negative"
+    return Tensor([], **kwargs) if steps == 0 else Tensor.full((1,), start, **kwargs) if steps == 1 else Tensor.full((steps,), start, **kwargs) + Tensor.arange(steps, **kwargs) * ((stop-start) / (steps-1))
+
+  @staticmethod
   def eye(dim:int, **kwargs): return Tensor.full((dim,1),1,**kwargs).pad(((0,0),(0,dim))).reshape(dim*(dim+1)).shrink(((0,dim*dim),)).reshape(dim, dim)
 
   def full_like(self, fill_value, **kwargs): return Tensor.full(self.shape, fill_value=fill_value, dtype=kwargs.pop("dtype", self.dtype), device=kwargs.pop("device", self.device), **kwargs)


### PR DESCRIPTION
In order to follow the simplest examples available on the [pytorch site](https://pytorch.org/tutorials/beginner/pytorch_with_examples.html) let's implement `linespace` method.

Pros:
- easier way or creating test data,
- improved usability (no need to use `np`),
- easier entry for non technical users, which may result in a better framework adoption.

Cons:
- +6 lines to the `tensor.py`