### PR TITLE
fix dtypes helpers for integers

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -4,6 +4,7 @@ from tinygrad.helpers import CI, DTYPES_DICT, getenv, DType, DEBUG, ImageDType, 
 from tinygrad import Device
 from tinygrad.tensor import Tensor, dtypes
 from typing import Any, List
+from hypothesis import given, strategies as st
 
 def is_dtype_supported(dtype: DType):
   # for GPU, cl_khr_fp16 isn't supported (except now we don't need it!)
@@ -192,10 +193,17 @@ class TestEqStrDType(unittest.TestCase):
 class TestHelpers(unittest.TestCase):
   def test_helpers(self):
     self.assertTrue(dtypes.is_int(dtypes.int8))
-    self.assertFalse(dtypes.is_int(dtypes.float))
-    self.assertTrue(dtypes.is_float(dtypes.float))
     self.assertTrue(dtypes.is_int(dtypes.int.vec(4)))
+    self.assertTrue(dtypes.is_unsigned(dtypes.uint8))
+    self.assertTrue(dtypes.is_unsigned(dtypes.uint32.vec(4)))
+    self.assertTrue(dtypes.is_float(dtypes.float))
     self.assertTrue(dtypes.is_float(dtypes.float.vec(4)))
+    self.assertFalse(dtypes.is_int(dtypes.float))
+    self.assertFalse(dtypes.is_int(dtypes.float.vec(4)))
+
+  @given(st.sampled_from([d for d in DTYPES_DICT.values() if dtypes.is_float(d) or dtypes.is_int(d)]), st.integers(min_value=2, max_value=8))
+  def test_scalar(self, dtype, amt):
+    assert dtype.vec(amt).scalar() == dtype
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -49,7 +49,7 @@ class TestDType(unittest.TestCase):
   DATA: Any = None
   @classmethod
   def setUpClass(cls):
-    if not is_dtype_supported(cls.DTYPE): raise unittest.SkipTest("dtype not supported")
+    if not cls.DTYPE or not is_dtype_supported(cls.DTYPE): raise unittest.SkipTest("dtype not supported")
     cls.DATA = np.random.randint(0, 100, size=10, dtype=cls.DTYPE.np).tolist() if dtypes.is_int(cls.DTYPE) else np.random.choice([True, False], size=10).tolist() if cls.DTYPE == dtypes.bool else np.random.uniform(0, 1, size=10).tolist()
   def setUp(self):
     if self.DTYPE is None: raise unittest.SkipTest("base class")
@@ -188,6 +188,14 @@ class TestEqStrDType(unittest.TestCase):
     if PtrDType is None: raise unittest.SkipTest("no PtrDType support")
     self.assertEqual(str(dtypes.imagef((1,2,4))), "dtypes.imagef((1, 2, 4))")
     self.assertEqual(str(PtrDType(dtypes.float32)), "ptr.dtypes.float")
+
+class TestHelpers(unittest.TestCase):
+  def test_helpers(self):
+    self.assertTrue(dtypes.is_int(dtypes.int8))
+    self.assertFalse(dtypes.is_int(dtypes.float))
+    self.assertTrue(dtypes.is_float(dtypes.float))
+    self.assertTrue(dtypes.is_int(dtypes.int.vec(4)))
+    self.assertTrue(dtypes.is_float(dtypes.float.vec(4)))
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -191,15 +191,28 @@ class TestEqStrDType(unittest.TestCase):
     self.assertEqual(str(PtrDType(dtypes.float32)), "ptr.dtypes.float")
 
 class TestHelpers(unittest.TestCase):
-  def test_helpers(self):
-    self.assertTrue(dtypes.is_int(dtypes.int8))
-    self.assertTrue(dtypes.is_int(dtypes.int.vec(4)))
-    self.assertTrue(dtypes.is_unsigned(dtypes.uint8))
-    self.assertTrue(dtypes.is_unsigned(dtypes.uint32.vec(4)))
-    self.assertTrue(dtypes.is_float(dtypes.float))
-    self.assertTrue(dtypes.is_float(dtypes.float.vec(4)))
-    self.assertFalse(dtypes.is_int(dtypes.float))
-    self.assertFalse(dtypes.is_int(dtypes.float.vec(4)))
+  signed_ints = (dtypes.int8, dtypes.int16, dtypes.int32, dtypes.int64)
+  uints = (dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
+  floats = (dtypes.float16, dtypes.float32, dtypes.float64)
+
+  @given(st.sampled_from(signed_ints+uints), st.integers(min_value=1, max_value=8))
+  def test_is_int(self, dtype, amt):
+    assert dtypes.is_int(dtype.vec(amt) if amt > 1 else dtype)
+    assert not dtypes.is_float(dtype.vec(amt) if amt > 1 else dtype)
+
+  @given(st.sampled_from(uints), st.integers(min_value=1, max_value=8))
+  def test_is_unsigned_uints(self, dtype, amt):
+    assert dtypes.is_unsigned(dtype.vec(amt) if amt > 1 else dtype)
+
+  @given(st.sampled_from(signed_ints), st.integers(min_value=1, max_value=8))
+  def test_is_unsigned_signed_ints(self, dtype, amt):
+    assert not dtypes.is_unsigned(dtype.vec(amt) if amt > 1 else dtype)
+
+  @given(st.sampled_from(floats), st.integers(min_value=1, max_value=8))
+  def test_is_float(self, dtype, amt):
+    assert dtypes.is_float(dtype.vec(amt) if amt > 1 else dtype)
+    assert not dtypes.is_int(dtype.vec(amt) if amt > 1 else dtype)
+    assert not dtypes.is_unsigned(dtype.vec(amt) if amt > 1 else dtype)
 
   @given(st.sampled_from([d for d in DTYPES_DICT.values() if dtypes.is_float(d) or dtypes.is_int(d)]), st.integers(min_value=2, max_value=8))
   def test_scalar(self, dtype, amt):

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -137,7 +137,7 @@ class PtrDType(DType):
 
 class dtypes:
   @staticmethod # static methds on top, or bool in the type info will refer to dtypes.bool
-  def is_int(x: DType)-> bool: return x in (dtypes.int8, dtypes.int16, dtypes.int32, dtypes.int64, dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
+  def is_int(x: DType)-> bool: return x.scalar() in (dtypes.int8, dtypes.int16, dtypes.int32, dtypes.int64, dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
   @staticmethod
   def is_float(x: DType) -> bool: return x.scalar() in (dtypes.float16, dtypes.float32, dtypes.float64)
   @staticmethod

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -139,9 +139,9 @@ class dtypes:
   @staticmethod # static methds on top, or bool in the type info will refer to dtypes.bool
   def is_int(x: DType)-> bool: return x in (dtypes.int8, dtypes.int16, dtypes.int32, dtypes.int64, dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
   @staticmethod
-  def is_float(x: DType) -> bool: return x in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes.half.vec(4), dtypes.float.vec(2), dtypes.float.vec(4))
+  def is_float(x: DType) -> bool: return x.scalar() in (dtypes.float16, dtypes.float32, dtypes.float64)
   @staticmethod
-  def is_unsigned(x: DType) -> bool: return x in (dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
+  def is_unsigned(x: DType) -> bool: return x.scalar() in (dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
   @staticmethod
   def from_np(x) -> DType: return DTYPES_DICT[np.dtype(x).name]
   @staticmethod

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -112,7 +112,7 @@ class DType(NamedTuple):
   def __repr__(self): return f"dtypes.{INVERSE_DTYPES_DICT[self]}" if self.sz == 1 else f"dtypes._{INVERSE_DTYPES_DICT[self.scalar()]}{self.sz}"
   def vec(self, sz:int):
     assert sz > 1 and self.sz == 1, f"can't vectorize {self} with size {sz}"
-    return DType(self.priority, self.itemsize*sz, self.name+str(sz), None, sz)
+    return DType(self.priority, self.itemsize*sz, f"{INVERSE_DTYPES_DICT[self]}{str(sz)}", None, sz)
   def scalar(self): return DTYPES_DICT[self.name[:-len(str(self.sz))]] if self.sz > 1 else self
 
 # dependent typing?
@@ -154,14 +154,21 @@ class dtypes:
   float64: Final[DType] = DType(11, 8, "double", np.float64)
   double = float64
   int8: Final[DType] = DType(1, 1, "char", np.int8)
+  char = int8
   int16: Final[DType] = DType(3, 2, "short", np.int16)
+  short = int16
   int32: Final[DType] = DType(5, 4, "int", np.int32)
   int = int32
   int64: Final[DType] = DType(7, 8, "long", np.int64)
+  long = int64
   uint8: Final[DType] = DType(2, 1, "unsigned char", np.uint8)
+  uchar = uint8
   uint16: Final[DType] = DType(4, 2, "unsigned short", np.uint16)
+  ushort = uint16
   uint32: Final[DType] = DType(6, 4, "unsigned int", np.uint32)
+  uint = uint32
   uint64: Final[DType] = DType(8, 8, "unsigned long", np.uint64)
+  ulong = uint64
 
   # NOTE: bfloat16 isn't supported in numpy
   bfloat16: Final[DType] = DType(9, 2, "__bf16", None)

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -51,7 +51,7 @@ class CStyleLanguage(NamedTuple):
   def render_const(self, x:Union[float,int,bool], var_dtype) -> str:
     if math.isnan(x): val = "NAN"
     elif math.isinf(x): val = ("-" if x < 0 else "") + "INFINITY"
-    else: val = f"{float(x)}f" if dtypes.is_float(var_dtype.scalar()) else f"{int(x)}" if dtypes.is_int(var_dtype.scalar()) else f"{bool(x)}".lower()
+    else: val = f"{float(x)}f" if dtypes.is_float(var_dtype) else f"{int(x)}" if dtypes.is_int(var_dtype) else f"{bool(x)}".lower()
     return self.render_cast([val]*var_dtype.sz, var_dtype) if var_dtype.sz > 1 or var_dtype not in [dtypes.float, dtypes.int, dtypes.bool] else val
 
   # returns a str expression of the loaded value with the output type

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -51,7 +51,7 @@ class CStyleLanguage(NamedTuple):
   def render_const(self, x:Union[float,int,bool], var_dtype) -> str:
     if math.isnan(x): val = "NAN"
     elif math.isinf(x): val = ("-" if x < 0 else "") + "INFINITY"
-    else: val = f"{float(x)}f" if dtypes.is_float(var_dtype) else f"{int(x)}" if dtypes.is_int(var_dtype) else f"{bool(x)}".lower()
+    else: val = f"{float(x)}f" if dtypes.is_float(var_dtype.scalar()) else f"{int(x)}" if dtypes.is_int(var_dtype.scalar()) else f"{bool(x)}".lower()
     return self.render_cast([val]*var_dtype.sz, var_dtype) if var_dtype.sz > 1 or var_dtype not in [dtypes.float, dtypes.int, dtypes.bool] else val
 
   # returns a str expression of the loaded value with the output type


### PR DESCRIPTION
1. dtypes.is_dtype should always check the scalar version

this caused a regression in rendering vectorized int constants. we should figure out why CI was green.

example kernel diff for `TestOps.test_simple_padding_conv2d`
```diff
__kernel void r_4_4_4_3(write_only image2d_t data0, read_only image2d_t data1, read_only image2d_t data2) {
const sampler_t smp = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
  int lidx0 = get_local_id(0); /* 4 */
  float4 acc0 = (float4)(0.0f,0.0f,0.0f,0.0f);
  float4 acc1 = (float4)(0.0f,0.0f,0.0f,0.0f);
  float4 acc2 = (float4)(0.0f,0.0f,0.0f,0.0f);
  float4 val0 = read_imagef(data1, smp, (int2)((lidx0+(-1)),0));
-   float4 val1 = read_imagef(data2, smp, (int2)(false,false));
+   float4 val1 = read_imagef(data2, smp, (int2)(0,0));
    float4 val2 = read_imagef(data2, smp, (int2)(1,0));
  // ...
}
```

2. non-32bit ints and unsigned int vector types were broken because aliases didn't exist for them. 


adds unit tests at the dtypes level to fuzz these