### PR TITLE
Ensure shrink arguments are valid

### DIFF
--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -121,7 +121,7 @@ class View:
 
   @functools.lru_cache(maxsize=None)  # pylint: disable=method-cache-max-size-none
   def shrink(self, arg: Tuple[Tuple[sint, sint], ...]) -> View:
-    assert all((b>=0 and e<=s) for s,(b,e) in zip(self.shape,arg)) and len(arg) == len(self.shape)
+    assert all((0<=b<=e<=s) for s,(b,e) in zip(self.shape,arg)) and len(arg) == len(self.shape), f"invalid shrink {arg} for {self.shape}"
     return self.__unsafe_resize(arg)
 
   @functools.lru_cache(maxsize=None)  # pylint: disable=method-cache-max-size-none


### PR DESCRIPTION
Without this the code like 

```
from tinygrad.tensor import Tensor

t = Tensor.arange(2*3).reshape((2,3))

print(t.numpy())

t = t.shrink(((1, 0),(0, 3)))
print(t.numpy())
```

fails with a relatively hard to parse error message
```
[135](https://file+.vscode-resource.vscode-cdn.net/home/gregor/Desktop/programming/tinygrad/docs/~/Desktop/programming/tinygrad/tinygrad/shape/symbolic.py:135) if len(args) == 0: return super().__new__(cls)   # fix pickle
    [136](https://file+.vscode-resource.vscode-cdn.net/home/gregor/Desktop/programming/tinygrad/docs/~/Desktop/programming/tinygrad/tinygrad/shape/symbolic.py:136) expr, nmin, nmax = args
--> [137](https://file+.vscode-resource.vscode-cdn.net/home/gregor/Desktop/programming/tinygrad/docs/~/Desktop/programming/tinygrad/tinygrad/shape/symbolic.py:137) assert nmin >= 0 and nmin <= nmax, f"invalid Variable {expr=} {nmin=} {nmax=}"
    [138](https://file+.vscode-resource.vscode-cdn.net/home/gregor/Desktop/programming/tinygrad/docs/~/Desktop/programming/tinygrad/tinygrad/shape/symbolic.py:138) if nmin == nmax: return NumNode(nmin)
    [139](https://file+.vscode-resource.vscode-cdn.net/home/gregor/Desktop/programming/tinygrad/docs/~/Desktop/programming/tinygrad/tinygrad/shape/symbolic.py:139) return super().__new__(cls)

AssertionError: invalid Variable expr='idx0' nmin=0 nmax=-2
```

Can add a test for it, haven't added it since I don't see such things generally covered in tests. 