### PR TITLE
dtypes math in ops instead of linearizer

### DIFF
--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -463,12 +463,6 @@ class Linearizer(Kernel):
   def uop(self, uop:UOps, dtype:Optional[DType]=None, vin:Tuple[UOp, ...]=tuple(), arg:Any=None, cachable=True, insert_before=None, simplify=True) -> UOp:
     key = (uop, dtype, vin, arg)
     if uop == UOps.PHI and vin[1].dtype != dtype: vin = (vin[0], self.cast(vin[1], dtype)) + vin[1:]
-     # TODO drop this - dtypes should be correct
-    if uop == UOps.ALU: # upcast vins to the same dtype TODO get rid of this
-      if isinstance(dtype, ImageDType): dtype = dtypes.float # TODO image dtype hack same with localtype def
-      if arg == TernaryOps.WHERE: vin = (vin[0],) + tuple(self.cast(x, dtype) for x in vin[1:]) # the first arg is always bool
-      elif arg == BinaryOps.CMPLT: vin = tuple(self.cast(x, max([cast(DType,v.dtype) for v in vin])) for x in vin); dtype = dtypes.bool # HACK - see ops.py L104
-      else: vin = tuple(self.cast(x, dtype) for x in vin)
     if simplify:
       if uop == UOps.PHI and len(vin) == 2: return vin[1]   # a phi without loops is a noop
       if uop == UOps.GEP and vin[0].uop == UOps.CONST: return self.const(vin[0].arg, dtype, insert_before)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -101,8 +101,9 @@ InterpretedFlopCounter: Dict[Op, Callable] = {
   BufferOps.STORE: lambda self,arg: FlopCounter(arg.st.shape, arg.dtype, self.consume_flops(), {**self.mem, arg.idx: arg.dtype.itemsize*arg.st.size()}), UnaryOps.CAST: lambda self,arg: FlopCounter(self.shape, arg[0], self.consume_flops(), self.mem),   # cast uses no flops
   **{op:lambda self: FlopCounter(self.shape, self.dtype, self.consume_flops() + prod(self.shape), self.mem) for op in UnaryOps if op != UnaryOps.CAST},
   **{op:lambda self,y: FlopCounter(self.shape, max(self.dtype, y.dtype), self.consume_flops() + y.consume_flops() + prod(self.shape), {**self.mem, **y.mem}) for op in BinaryOps},
+  # BinaryOps.CMPLT: lambda self,y: FlopCounter(self.shape, dtypes.bool, self.consume_flops() + y.consume_flops() + prod(self.shape), {**self.mem, **y.mem}), TODO why does tinygrad expect self.dtype here? HACK in linearizer L470
   **{op:lambda self,new_shape: FlopCounter(new_shape, self.dtype, self.consume_flops() + prod(self.shape), self.mem) for op in ReduceOps},
-  TernaryOps.WHERE: lambda self,y,z: FlopCounter(self.shape, max(y.dtype, z.dtype), self.consume_flops() + y.consume_flops() + z.consume_flops() + prod(self.shape), {**self.mem, **y.mem, **z.mem})}
+  TernaryOps.WHERE: lambda self,y,z: FlopCounter(self.shape, max(y.dtype, z.dtype), self.consume_flops() + y.consume_flops() + z.consume_flops() + prod(self.shape), {**self.mem, **y.mem, **z.mem}), TernaryOps.MULACC: lambda self,y,arg: FlopCounter(self.shape, max(self.dtype, y.dtype), self.consume_flops() + y.consume_flops() + prod(self.shape), {**self.mem, **y.mem})}
 
 @functools.lru_cache(None)
 def get_lazyop_info(ast:LazyOp) -> FlopCounter:


### PR DESCRIPTION
lifts up promotions from the linearizer to ops
unblocks autocast https://github.com/tinygrad/tinygrad/pull/2710#issuecomment-1850656084 and truediv

pending:
- [ ] defined behavior for FlopCounter on a LocalBuffer, this optimization breaks promotion https://github.com/tinygrad/tinygrad/blob/master/tinygrad/codegen/linearizer.py#L191
- [ ] LazyOp src promotion
- [ ] shouldn't cmplt expect a bool in return?
- [ ] linearizer should fallback to float for image ops