### PR TITLE
Extend available types for `safe_save`

### DIFF
--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -108,6 +108,14 @@ class TestSafetensors(unittest.TestCase):
     import json
     assert json.loads(dat[8:8+sz])['__metadata__']['hello'] == 'world'
 
+  def test_save_all_dtypes(self):
+    for dtype in dtypes.fields().values(): 
+      if dtype in [dtypes.bfloat16, dtypes._arg_int32]: continue # not supported in numpy
+      path = temp("ones.safetensors")
+      ones = Tensor.rand((10,10), dtype=dtype)
+      safe_save(get_state_dict(ones), path)
+      assert ones == list(safe_load(path).values())[0]
+
 def helper_test_disk_tensor(fn, data, np_fxn, tinygrad_fxn=None):
   if tinygrad_fxn is None: tinygrad_fxn = np_fxn
   pathlib.Path(temp(fn)).unlink(missing_ok=True)

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -109,7 +109,7 @@ class TestSafetensors(unittest.TestCase):
     assert json.loads(dat[8:8+sz])['__metadata__']['hello'] == 'world'
 
   def test_save_all_dtypes(self):
-    for dtype in dtypes.fields().values(): 
+    for dtype in dtypes.fields().values():
       if dtype in [dtypes.bfloat16, dtypes._arg_int32]: continue # not supported in numpy
       path = temp("ones.safetensors")
       ones = Tensor.rand((10,10), dtype=dtype)

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -5,7 +5,7 @@ from tinygrad.tensor import Tensor
 from tinygrad.helpers import dtypes, prod, argsort, DEBUG, Timing, GlobalCounters, CI, unwrap
 from tinygrad.shape.view import strides_for_shape
 
-safe_dtypes = {"F16": dtypes.float16, "F32": dtypes.float32, "U8": dtypes.uint8, "I8": dtypes.int8, "I32": dtypes.int32, "I64": dtypes.int64}
+safe_dtypes = {"F16": dtypes.float16, "F32": dtypes.float32, "U8": dtypes.uint8, "I8": dtypes.int8, "I32": dtypes.int32, "I64": dtypes.int64, "F64": dtypes.double, "B": dtypes.bool, "I16": dtypes.short, "U16": dtypes.ushort, "UI": dtypes.uint, "UL": dtypes.ulong}
 inverse_safe_dtypes = {v:k for k,v in safe_dtypes.items()}
 
 def safe_load_metadata(fn:Union[Tensor,str]) -> Tuple[Tensor, int, Any]:


### PR DESCRIPTION
Saving tensors of certain types (e.g. doubles, bools, shorts) currently fails. I have added a unit test to show that they fail. Adding the missing dtypes to `safe_dtypes` enables the unit test to run successfully. 

Please note that there may be a very good reason that `safe_dtypes` did not already include the dtypes that I added. Please let me know if that is so. The unit test does assert that the saved and loaded tensors are the same, but maybe I am missing something else.

Please feel free to suggest any modifications.