### PR TITLE
Unintended result of tolist() (from PTX)

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -42,7 +42,7 @@ def _assert_eq(tensor:Tensor, target_dtype:DType, target):
     raise AssertionError(f"\ntensor {tensor.numpy()} dtype {tensor.dtype} does not match target {target} with dtype {target_dtype}") from e
 
 def _test_op(fxn, target_dtype:DType, target): _assert_eq(fxn(), target_dtype, target)
-def _test_cast(a:Tensor, target_dtype:DType): _test_op(lambda: a.cast(target_dtype), target_dtype, a.numpy().astype(target_dtype.np).tolist())
+def _test_cast(a:Tensor, target_dtype:DType): _test_op(lambda: a.cast(target_dtype), target_dtype, list(a.numpy().astype(target_dtype.np)))
 def _test_bitcast(a:Tensor, target_dtype:DType, target=None): _test_op(lambda: a.bitcast(target_dtype), target_dtype, target or a.numpy().view(target_dtype.np).tolist())
 
 class TestDType(unittest.TestCase):


### PR DESCRIPTION
Using `tolist()` instead of `list()` doesn't work as intended if the array has been casted from `float32` to `float16`. This probably has to do something with the fact that `.astype(np.float16)` doesn't seem to make a copy. This is reproducible with the following code:

```py
import numpy as np
arr = np.random.rand(8)
print(arr.astype(np.float16).tolist())
print(list(arr.astype(np.float16)))
```