### PR TITLE
mulacc in lazy

### DIFF
--- a/test/test_lazyop.py
+++ b/test/test_lazyop.py
@@ -1,3 +1,4 @@
+from typing import Any
 import unittest
 from hypothesis import assume, given, strategies as st
 from tinygrad.tensor import Tensor
@@ -30,33 +31,38 @@ class TestLazyOp(unittest.TestCase):
       # sanity check if caching works this should be way faster
       assert time.monotonic() -st < 0.5, f"{i}"
 
+class TestMULACC(unittest.TestCase):
+  floats = [dtype for dtype in DTYPES_DICT.values() if dtypes.is_float(dtype)]
+  @staticmethod
+  def _get_reduce(out): return [op for op in out.lazydata.schedule()[-1].ast.get_lazyops() if op.op == ReduceOps.SUM][0]
+  @staticmethod
+  def _get_cast(out): return [op for op in out.lazydata.schedule()[-1].ast.get_lazyops() if op.op == UnaryOps.CAST][0]
+
   def test_basic_mulacc_fusion(self):
     x = Tensor.rand(1024,1024)
     w = Tensor.rand(1024,1024)
     out = (x*w).sum(-1)
-    reduceop = [op for op in out.lazydata.schedule()[-1].ast.get_lazyops() if op.op == ReduceOps.SUM][0]
+    reduceop = self._get_reduce(out)
     assert reduceop.src[0].op == TernaryOps.MULACC and len(reduceop.src[0].src) == 2
 
-  def test_mulacc_fusion_mid_ops(self):
+  def test_mulacc_fusion_mid_ast(self):
     x = Tensor.rand(1024,1024)
     w = Tensor.rand(1024,1024)
-    x = x.add(4).mul(8)
-    out = (x*w).sum(-1).add(4).mul(8)
-    reduceop = [op for op in out.lazydata.schedule()[-1].ast.get_lazyops() if op.op == ReduceOps.SUM][0]
+    out = ((x.add(4).mul(2))*w).sum(-1).add(4).mul(2)
+    reduceop = self._get_reduce(out)
     assert reduceop.src[0].op == TernaryOps.MULACC and len(reduceop.src[0].src) == 2
 
-  floats = [dtype for dtype in DTYPES_DICT.values() if dtypes.is_float(dtype)]
-  @unittest.skip("TODO support CAST in MULACC fusion")
   @given(st.sampled_from(floats), st.sampled_from(floats))
   def test_mulacc_fusion_midcast(self, d1, d2):
     assume(d1 != d2)
     x = Tensor.rand(1024,1024, dtype=d1)
     w = Tensor.rand(1024,1024, dtype=d1)
     out = (x*w).cast(d2).sum(-1)
-    reduceop = [op for op in out.lazydata.schedule()[-1].ast.get_lazyops() if op.op == ReduceOps.SUM][0]
-    assert reduceop.op == ReduceOps.SUM
-    assert reduceop.src[0].op == UnaryOps.CAST and reduceop.src[0].arg[0] == d2
-    assert reduceop.src[0].src[0].op == TernaryOps.MULACC and len(reduceop.src[0].src[0].src) == 2
+    reduceop = self._get_reduce(out)
+    castop = self._get_cast(out)
+    assert reduceop.src[0].op == TernaryOps.MULACC
+    assert castop.src[0].op == ReduceOps.SUM
+    assert castop.arg[0] == d2
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_lazyop.py
+++ b/test/test_lazyop.py
@@ -1,11 +1,12 @@
 import unittest
+from hypothesis import assume, given, strategies as st
 from tinygrad.tensor import Tensor
 
 # stuff needed to unpack a kernel
 # ruff: noqa: F401
-from tinygrad.ops import LazyOp, TernaryOps, BinaryOps, UnaryOps, ReduceOps, BufferOps, MemBuffer, ConstBuffer
+from tinygrad.ops import LazyOp, TernaryOps, BinaryOps, UnaryOps, ReduceOps, BufferOps, MemBuffer, ConstBuffer, get_lazyop_info
 from tinygrad.lazy import LazyBuffer
-from tinygrad.helpers import dtypes
+from tinygrad.helpers import DTYPES_DICT, dtypes
 from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.shape.view import View
 from tinygrad.shape.symbolic import Variable
@@ -28,6 +29,26 @@ class TestLazyOp(unittest.TestCase):
       for _ in range(i): p = p.e(BinaryOps.ADD, p)
       # sanity check if caching works this should be way faster
       assert time.monotonic() -st < 0.5, f"{i}"
+
+  def test_basic_mulacc_fusion(self):
+    x = Tensor.rand(1024,1024)
+    w = Tensor.rand(1024,1024)
+    out = (x*w).sum(-1)
+    reduceop = [op for op in out.lazydata.schedule()[-1].ast.get_lazyops() if op.op == ReduceOps.SUM][0]
+    assert reduceop.src[0].op == TernaryOps.MULACC and len(reduceop.src[0].src) == 2
+
+  floats = [dtype for dtype in DTYPES_DICT.values() if dtypes.is_float(dtype)]
+  @unittest.skip("TODO support CAST in MULACC fusion")
+  @given(st.sampled_from(floats), st.sampled_from(floats))
+  def test_mulacc_fusion_midcast(self, d1, d2):
+    assume(d1 != d2)
+    x = Tensor.rand(1024,1024, dtype=d1)
+    w = Tensor.rand(1024,1024, dtype=d1)
+    out = (x*w).cast(d2).sum(-1)
+    reduceop = [op for op in out.lazydata.schedule()[-1].ast.get_lazyops() if op.op == ReduceOps.SUM][0]
+    assert reduceop.op == ReduceOps.SUM
+    assert reduceop.src[0].op == UnaryOps.CAST and reduceop.src[0].arg[0] == d2
+    assert reduceop.src[0].src[0].op == TernaryOps.MULACC and len(reduceop.src[0].src[0].src) == 2
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_lazyop.py
+++ b/test/test_lazyop.py
@@ -37,6 +37,14 @@ class TestLazyOp(unittest.TestCase):
     reduceop = [op for op in out.lazydata.schedule()[-1].ast.get_lazyops() if op.op == ReduceOps.SUM][0]
     assert reduceop.src[0].op == TernaryOps.MULACC and len(reduceop.src[0].src) == 2
 
+  def test_mulacc_fusion_mid_ops(self):
+    x = Tensor.rand(1024,1024)
+    w = Tensor.rand(1024,1024)
+    x = x.add(4).mul(8)
+    out = (x*w).sum(-1).add(4).mul(8)
+    reduceop = [op for op in out.lazydata.schedule()[-1].ast.get_lazyops() if op.op == ReduceOps.SUM][0]
+    assert reduceop.src[0].op == TernaryOps.MULACC and len(reduceop.src[0].src) == 2
+
   floats = [dtype for dtype in DTYPES_DICT.values() if dtypes.is_float(dtype)]
   @unittest.skip("TODO support CAST in MULACC fusion")
   @given(st.sampled_from(floats), st.sampled_from(floats))

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -577,6 +577,10 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x), lambda x: Tensor.std(x))
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=None, correction=0), lambda x: Tensor.std(x, correction=0))
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=None, correction=5), lambda x: Tensor.std(x, correction=5))
+
+  def test_mulacc_downcast(self):
+    helper_test_op([(1024, 1024), (1024, 1024)], lambda x,w: (x*w).to(torch.half).sum(-1).to(torch.float), lambda x,w: (x*w).cast(dtypes.half).sum(-1).cast(dtypes.float), atol=1e-2, rtol=1e-1)
+
   def test_std_axis(self):
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=0), lambda x: Tensor.std(x, axis=0))
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=2), lambda x: Tensor.std(x, axis=2))

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -578,6 +578,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=None, correction=0), lambda x: Tensor.std(x, correction=0))
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=None, correction=5), lambda x: Tensor.std(x, correction=5))
 
+  @unittest.skipIf(Device.DEFAULT in ["GPU", "LLVM", "WEBGPU"] or getenv("CUDACPU") == 1, "fp16 broken in some backends")
   def test_mulacc_downcast(self):
     helper_test_op([(1024, 1024), (1024, 1024)], lambda x,w: (x*w).to(torch.half).sum(-1).to(torch.float), lambda x,w: (x*w).cast(dtypes.half).sum(-1).cast(dtypes.float), atol=1e-2, rtol=1e-1)
 

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -340,7 +340,7 @@ class Kernel:
         if has_cast and not(isinstance(self.reduceop.src[0], LazyOp) and self.reduceop.src[0].op == UnaryOps.CAST and self.reduceop.src[0].arg[0] == tc.dtype_out): continue  # noqa: E501
         mul_op = self.reduceop.src[0].src[0] if has_cast else self.reduceop.src[0]
 
-        if not(isinstance(mul_op, LazyOp) and mul_op.op == BinaryOps.MUL): continue
+        if not(isinstance(mul_op, LazyOp) and mul_op.op == TernaryOps.MULACC): continue
         if not(isinstance(mul_op.src[0], LazyOp) and mul_op.src[0].op == BufferOps.LOAD and mul_op.src[0].arg.dtype == tc.dtype_in): continue
         if not(isinstance(mul_op.src[1], LazyOp) and mul_op.src[1].op == BufferOps.LOAD and mul_op.src[1].arg.dtype == tc.dtype_in): continue
         buf0, buf1 = self.bufs.index(cast(MemBuffer, mul_op.src[0].arg)), self.bufs.index(cast(MemBuffer, mul_op.src[1].arg))

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import os, math, itertools
 from typing import NamedTuple, Optional, List, Tuple, cast, Dict, Union
-from tinygrad.ops import LazyOp, FlopCounter, TernaryOps, get_lazyop_info, UnaryOps, BinaryOps, ReduceOps, MemBuffer, ConstBuffer, BufferOps, vars_from_ast
+from tinygrad.ops import LazyOp, FlopCounter, TernaryOps, get_lazyop_info, UnaryOps, BinaryOps, ReduceOps, MemBuffer, ConstBuffer, BufferOps, vars_from_ast # noqa: E501
 from tinygrad.device import Device, Compiled
 from tinygrad.helpers import dedup, dtypes, colored, ImageDType, DType, ansilen, getenv, prod, DEBUG, round_up
 from tinygrad.shape.shapetracker import ShapeTracker, get_contraction

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import os, math, itertools
 from typing import NamedTuple, Optional, List, Tuple, cast, Dict, Union
-from tinygrad.ops import LazyOp, FlopCounter, TernaryOps, get_lazyop_info, UnaryOps, BinaryOps, ReduceOps, MemBuffer, ConstBuffer, BufferOps, vars_from_ast # noqa: E501
+from tinygrad.ops import LazyOp, FlopCounter, TernaryOps, get_lazyop_info, UnaryOps, ReduceOps, MemBuffer, ConstBuffer, BufferOps, vars_from_ast
 from tinygrad.device import Device, Compiled
 from tinygrad.helpers import dedup, dtypes, colored, ImageDType, DType, ansilen, getenv, prod, DEBUG, round_up
 from tinygrad.shape.shapetracker import ShapeTracker, get_contraction

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import os, math, itertools
 from typing import NamedTuple, Optional, List, Tuple, cast, Dict, Union
-from tinygrad.ops import LazyOp, FlopCounter, get_lazyop_info, UnaryOps, BinaryOps, ReduceOps, MemBuffer, ConstBuffer, BufferOps, vars_from_ast
+from tinygrad.ops import LazyOp, FlopCounter, TernaryOps, get_lazyop_info, UnaryOps, BinaryOps, ReduceOps, MemBuffer, ConstBuffer, BufferOps, vars_from_ast
 from tinygrad.device import Device, Compiled
 from tinygrad.helpers import dedup, dtypes, colored, ImageDType, DType, ansilen, getenv, prod, DEBUG, round_up
 from tinygrad.shape.shapetracker import ShapeTracker, get_contraction
@@ -479,7 +479,7 @@ class Kernel:
     MV_BLOCKSIZE, MV_THREADS_PER_ROW, MV_ROWS_PER_THREAD = getenv("MV_BLOCKSIZE", 4), getenv("MV_THREADS_PER_ROW", 8), getenv("MV_ROWS_PER_THREAD", 4)
     if self.opts.has_local and getenv("MV",1) != 0 and (MV_BLOCKSIZE > 1 or MV_THREADS_PER_ROW > 1 or MV_ROWS_PER_THREAD > 1) and  \
         self.reduceop and self.reduceop.op == ReduceOps.SUM and len(self.full_shape) >= 2 and self.opts.has_shared and \
-        isinstance(self.reduceop.src[0], LazyOp) and self.reduceop.src[0].op == BinaryOps.MUL and \
+        isinstance(self.reduceop.src[0], LazyOp) and self.reduceop.src[0].op == TernaryOps.MULACC and \
         self.reduceop.src[0].src[0].op == BufferOps.LOAD and self.reduceop.src[0].src[1].op == BufferOps.LOAD:
       buf0 = self.bufs.index(self.reduceop.src[0].src[0].arg)
       buf1 = self.bufs.index(self.reduceop.src[0].src[1].arg)

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -516,7 +516,7 @@ class Linearizer(Kernel):
       ret: List[UOp] = []
       input_acc = acc[:]
       for val, off in zip(zip(*values), cast(List[int], offs)):
-        if x.src[0].op != TernaryOps.MULACC and not (x.src[0].op == UnaryOps.CAST and x.src[0].src[0].op == TernaryOps.MULACC): acc[off] = self.uop(UOps.ALU, vin=val+(acc[off],), arg=ops[x.op])
+        if x.src[0].op != TernaryOps.MULACC and not (x.src[0].op == UnaryOps.CAST and x.src[0].src[0].op == TernaryOps.MULACC): acc[off] = self.uop(UOps.ALU, vin=val+(acc[off],), arg=ops[x.op]) # noqa: E501
         ret.append(acc[off])
       for off in range(len(acc)):
         if input_acc[off] != acc[off]:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -513,7 +513,7 @@ class Linearizer(Kernel):
       ret: List[UOp] = []
       input_acc = acc[:]
       for val, off in zip(zip(*values), cast(List[int], offs)):
-        if x.src[0].op != TernaryOps.MULACC and not (x.src[0].op == UnaryOps.CAST and x.src[0].src[0].op == TernaryOps.MULACC): acc[off] = self.uop(UOps.ALU, vin=val+(acc[off],), arg=ops[x.op]) # noqa: E501
+        if x.src[0].op != TernaryOps.MULACC: acc[off] = self.uop(UOps.ALU, vin=val+(acc[off],), arg=ops[x.op])
         ret.append(acc[off])
       for off in range(len(acc)):
         if input_acc[off] != acc[off]:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -469,7 +469,7 @@ class Linearizer(Kernel):
     key = (uop, dtype, vin, arg)
     if uop == UOps.PHI and vin[1].dtype != dtype: vin = (vin[0], self.cast(vin[1], dtype)) + vin[1:]
     if uop == UOps.ALU: # upcast vins to the same dtype
-      upcast_dtype = max(cast(DType, x.dtype) for x in vin)
+      upcast_dtype = dtypes.float if arg == TernaryOps.MULACC else max(cast(DType, x.dtype) for x in vin) # MULACC is only supported in float
       if arg == TernaryOps.WHERE: vin = (vin[0],) + tuple(self.cast(x, upcast_dtype) for x in vin[1:]) # the first arg is always bool
       else: vin = tuple(self.cast(x, upcast_dtype) for x in vin)
       dtype = dtype or upcast_dtype # some ops like BinaryOps.CMPLT return bool

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -6,7 +6,7 @@ import importlib, inspect, functools, pathlib, time, re, ctypes
 from tinygrad.helpers import DType, dtypes, ImageDType
 from tinygrad.helpers import ansilen, DEBUG, getenv, GlobalCounters, colored, BEAM, NOOPT, all_int, to_function_name, from_mv, flat_mv
 from tinygrad.shape.symbolic import Variable, sym_infer, sint
-from tinygrad.ops import LazyOp, TernaryOps, get_lazyop_info, ReduceOps, BufferOps, BinaryOps, UnaryOps, Op, vars_from_ast
+from tinygrad.ops import LazyOp, get_lazyop_info, BufferOps, UnaryOps, Op, vars_from_ast
 
 if TYPE_CHECKING:
   from tinygrad.codegen.linearizer import Linearizer

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -212,9 +212,6 @@ def _get_interpreted_fxn(fxn_for_op:Dict[Op, Callable], ast:LazyOp) -> Interpret
   def _interpret_ast(ast:LazyOp) -> str:
     # TODO: shortcutted store won't work with strides
     if ast.op == BufferOps.STORE: return _interpret_ast(ast.src[0])
-    if TernaryOps.MULACC in fxn_for_op and ast.op == ReduceOps.SUM and isinstance(ast.src[0], LazyOp) and ast.src[0].op == BinaryOps.MUL:
-      ast = LazyOp(TernaryOps.MULACC, ast.src[0].src, ast.arg)
-
     if ast.op in BufferOps:
       if ast.op == ast.op == BufferOps.CONST: tmp = f"{gstr(fxn_for_op[ast.op], ast.op)}({gstr(ast.arg.val)}, {gstr(ast.arg.dtype)})"
       else: tmp = f"{gstr(fxn_for_op[UnaryOps.CAST], UnaryOps.CAST)}(inputs[{ast.arg.idx}], ({gstr(ast.arg.dtype)}, True))"

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -76,8 +76,11 @@ def _replace_bufferops(op:LazyOp) -> Tuple[LazyOp, List[LazyBuffer]]:
 
 def _fuse_mulacc(op) -> LazyOp:
   if op.op == ReduceOps.SUM:
-    mul_op = op.src[0].src[0] if op.src[0].op == UnaryOps.CAST and op.src[0].src[0].op == BinaryOps.MUL else op.src[0] if op.src[0].op == BinaryOps.MUL else None
-    if mul_op: op = LazyOp(ReduceOps.SUM, (LazyOp(TernaryOps.MULACC, mul_op.src, op.arg),), op.arg)
+    cast_op = op.src[0] if op.src[0].op == UnaryOps.CAST else None
+    mul_op = op.src[0].src[0] if cast_op and op.src[0].src[0].op == BinaryOps.MUL else op.src[0] if op.src[0].op == BinaryOps.MUL else None
+    if mul_op:
+      op = LazyOp(ReduceOps.SUM, (LazyOp(TernaryOps.MULACC, mul_op.src, op.arg),), op.arg)
+      if cast_op: op = LazyOp(UnaryOps.CAST, (op,), cast_op.arg)
   return op.map_buffers({x: _fuse_mulacc(x) for x in op.src})
 
 # **** lazy operations ****

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -78,9 +78,9 @@ def _fuse_mulacc(op) -> LazyOp:
   if op.op == ReduceOps.SUM:
     cast_op = op.src[0] if op.src[0].op == UnaryOps.CAST else None
     mul_op = op.src[0].src[0] if cast_op and op.src[0].src[0].op == BinaryOps.MUL else op.src[0] if op.src[0].op == BinaryOps.MUL else None
-    if mul_op:
+    if mul_op is not None:
       op = LazyOp(ReduceOps.SUM, (LazyOp(TernaryOps.MULACC, mul_op.src, op.arg),), op.arg)
-      if cast_op: op = LazyOp(UnaryOps.CAST, (op,), cast_op.arg)
+      if cast_op is not None: op = LazyOp(UnaryOps.CAST, (op,), cast_op.arg)
   return op.map_buffers({x: _fuse_mulacc(x) for x in op.src})
 
 # **** lazy operations ****

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -106,8 +106,7 @@ InterpretedFlopCounter: Dict[Op, Callable] = {
   **{op:lambda self: FlopCounter(self.shape, self.dtype, self.consume_flops() + prod(self.shape), self.mem) for op in UnaryOps if op != UnaryOps.CAST},  # noqa: E501
   **{op:lambda self,y: FlopCounter(self.shape, max(self.dtype, y.dtype), self.consume_flops() + y.consume_flops() + prod(self.shape), {**self.mem, **y.mem}) for op in BinaryOps},  # noqa: E501
   **{op:lambda self,new_shape: FlopCounter(new_shape, self.dtype, self.consume_flops() + prod(self.shape), self.mem) for op in ReduceOps},
-  TernaryOps.WHERE: lambda self,y,z: FlopCounter(self.shape, max(y.dtype, z.dtype), self.consume_flops() + y.consume_flops() + z.consume_flops() + prod(self.shape), {**self.mem, **y.mem, **z.mem}),
-  TernaryOps.MULACC: lambda self,y,new_shape: FlopCounter(new_shape, max(self.dtype, y.dtype), self.consume_flops() + y.consume_flops() + prod(self.shape), {**self.mem, **y.mem})} # noqa: E501
+  TernaryOps.WHERE: lambda self,y,z: FlopCounter(self.shape, max(y.dtype, z.dtype), self.consume_flops() + y.consume_flops() + z.consume_flops() + prod(self.shape), {**self.mem, **y.mem, **z.mem}), TernaryOps.MULACC: lambda self,y,new_shape: FlopCounter(new_shape, max(self.dtype, y.dtype), self.consume_flops() + y.consume_flops() + prod(self.shape), {**self.mem, **y.mem})} # noqa: E501
 
 @functools.lru_cache(None)
 def get_lazyop_info(ast:LazyOp) -> FlopCounter:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -106,7 +106,8 @@ InterpretedFlopCounter: Dict[Op, Callable] = {
   **{op:lambda self: FlopCounter(self.shape, self.dtype, self.consume_flops() + prod(self.shape), self.mem) for op in UnaryOps if op != UnaryOps.CAST},  # noqa: E501
   **{op:lambda self,y: FlopCounter(self.shape, max(self.dtype, y.dtype), self.consume_flops() + y.consume_flops() + prod(self.shape), {**self.mem, **y.mem}) for op in BinaryOps},  # noqa: E501
   **{op:lambda self,new_shape: FlopCounter(new_shape, self.dtype, self.consume_flops() + prod(self.shape), self.mem) for op in ReduceOps},
-  TernaryOps.WHERE: lambda self,y,z: FlopCounter(self.shape, max(y.dtype, z.dtype), self.consume_flops() + y.consume_flops() + z.consume_flops() + prod(self.shape), {**self.mem, **y.mem, **z.mem})}  # noqa: E501
+  TernaryOps.WHERE: lambda self,y,z: FlopCounter(self.shape, max(y.dtype, z.dtype), self.consume_flops() + y.consume_flops() + z.consume_flops() + prod(self.shape), {**self.mem, **y.mem, **z.mem}),
+  TernaryOps.MULACC: lambda self,y,new_shape: FlopCounter(new_shape, max(self.dtype, y.dtype), self.consume_flops() + y.consume_flops() + prod(self.shape), {**self.mem, **y.mem})} # noqa: E501
 
 @functools.lru_cache(None)
 def get_lazyop_info(ast:LazyOp) -> FlopCounter:


### PR DESCRIPTION
I think to do #2625 right mulacc should lift up from device and linearizer to lazy.
The ast will look like:
```
  0 ━┳ STORE MemBuffer(idx=0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(1024, 1), strides=(1, 0), offset=0, mask=None, contiguous=True),)))
  1  ┗━┳ SUM (1024, 1)
  2    ┗━┳ MULACC (1024, 1)
  3      ┣━━ LOAD MemBuffer(idx=1, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(1024, 1024), strides=(1024, 1), offset=0, mask=None, contiguous=True),)))
  4      ┗━━ LOAD MemBuffer(idx=2, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(1024, 1024), strides=(1024, 1), offset=0, mask=None, contiguous=True),)))
```