### PR TITLE
Fix double exception in __del__() when __init__() raises exception.

### DIFF
--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -73,6 +73,7 @@ class Buffer:
     # TODO: mem_used for all devices
     if not self.device.startswith("DISK"): GlobalCounters.mem_used += self.size * self.dtype.itemsize
   def __del__(self):
+    if not hasattr(self, '_buf'): return # happens when __init__ has raised exception
     if not self.device.startswith("DISK"): GlobalCounters.mem_used -= self.size * self.dtype.itemsize
     if isinstance(self.dtype, ImageDType): self.allocator.free(self._buf, self.dtype)
     else: self.allocator.free(self._buf, self.size * self.dtype.itemsize)


### PR DESCRIPTION
This fixes annoying double exception on allocation failure or even sometimes on ^C:

```
[...]

  File "/home/sobomax/projects/tinygrad/tinygrad/device.py", line 70, in __init__
    self._buf = opaque if opaque is not None else self.allocator.alloc(dtype if isinstance(dtype, ImageDType) else size * dtype.itemsize)
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[...]

  File "/home/sobomax/projects/tinygrad/tinygrad/runtime/ops_cuda.py", line 18, in check
    if status != 0: raise RuntimeError(f"CUDA Error {status}, {ctypes.string_at(init_c_var(ctypes.POINTER(ctypes.c_char)(), lambda x: cuda.cuGetErrorString(status, ctypes.byref(x)))).decode()}")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: CUDA Error 2, out of memory
avg:   245.48 GFLOPS     5.02 GB/s           total:    36 kernels   108.06 GOPS     2.21 GB   440.19 ms
Exception ignored in: <function Buffer.__del__ at 0x7f525844d3a0>
Traceback (most recent call last):
  File "/home/sobomax/projects/tinygrad/tinygrad/device.py", line 76, in __del__
    else: self.allocator.free(self._buf, self.size * self.dtype.itemsize)
                              ^^^^^^^^^
AttributeError: 'Buffer' object has no attribute '_buf'
