### PR TITLE
Support Tensor creation from lists and nested lists without numpy

### DIFF
--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 from PIL import Image
-from tinygrad.helpers import Context, ContextVar, DType, dtypes, merge_dicts, strip_parens, prod, round_up, fetch
+from tinygrad.helpers import Context, ContextVar, DType, dtypes, merge_dicts, strip_parens, prod, round_up, fetch, flat_list
 from tinygrad.shape.symbolic import Variable, NumNode
 
 VARIABLE = ContextVar("VARIABLE", 0)
@@ -159,6 +159,35 @@ class TestFetch(unittest.TestCase):
     img = fetch("https://media.istockphoto.com/photos/hen-picture-id831791190", allow_caching=False)
     with Image.open(img) as pimg:
       assert pimg.size == (705, 1024)
+
+class TestFlattenLIst(unittest.TestCase):
+  def test_empty(self):
+    flattened, shape = flat_list([])
+    self.assertEqual(shape, (0,))
+    self.assertEqual(flattened, [])
+
+  def test_scalars(self):
+    flattened, shape = flat_list(1)
+    self.assertEqual(shape, ())
+    self.assertEqual(flattened, [1])
+
+  def test_simple(self):
+    flattened, shape = flat_list([1, 2, 3])
+    self.assertEqual(shape, (3,))
+    self.assertEqual(flattened, [1, 2, 3])
+
+  def test_nested(self):
+    flattened, shape = flat_list([[[[1, 2, 3], [3, 4, 5]], [[5, 6, 7], [7, 8, 9]]]])
+    self.assertEqual(shape, (1, 2, 2, 3))
+    self.assertEqual(flattened, [1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9])
+
+  def test_inhomogenous(self):
+    with self.assertRaises(ValueError):
+      flat_list([[1, 2], [3, 4, 5]])
+
+    with self.assertRaises(ValueError):
+      flat_list([[[1, 2], [3, 4]], [[5, 6], [7]]])
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -1,7 +1,9 @@
 import unittest
 import numpy as np
+import pytest
 from PIL import Image
-from tinygrad.helpers import Context, ContextVar, DType, dtypes, merge_dicts, strip_parens, prod, round_up, fetch, flat_list
+import tinygrad.helpers
+from tinygrad.helpers import Context, ContextVar, DType, dtypes, merge_dicts, strip_parens, prod, round_up, fetch, flat_list, pack_list
 from tinygrad.shape.symbolic import Variable, NumNode
 
 VARIABLE = ContextVar("VARIABLE", 0)
@@ -187,6 +189,16 @@ class TestFlattenLIst(unittest.TestCase):
 
     with self.assertRaises(ValueError):
       flat_list([[[1, 2], [3, 4]], [[5, 6], [7]]])
+
+
+class TestPackList:
+    @pytest.mark.parametrize("dtype", tinygrad.helpers.DTYPE_TYPECODE.keys())  # List all dtypes
+    def test_pack_unpack(self, dtype):
+        for data in (1, [], [0, 1, 2], [[0], [1], [2]]):
+            buffer, shape = pack_list(data, dtype=dtype)
+            reference = np.array(data, dtype=dtype.np)
+            assert buffer.tobytes() == reference.tobytes()
+            assert shape == reference.shape
 
 
 if __name__ == '__main__':

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -304,6 +304,20 @@ def flat_mv(mv:memoryview):
   if len(mv) == 0: return mv
   return mv.cast("B", shape=(mv.nbytes,))
 
+# *** Hepers for handling native lists.
+def flat_list(data: Union[None, int, float, list]) -> Tuple[list, Tuple[int, ...]]:
+  result = []
+  def flatten(data: Union[None, int, float, list]) -> Tuple[int, ...]:
+    if not isinstance(data, list):
+      result.append(data)
+      return ()
+    if not data: return (0,)
+    shape = flatten(data=data[0])
+    for item in data[1:]:
+      if flatten(data=item) != shape: raise ValueError("The data has an inhomogenous shape.")
+    return (len(data), *shape)
+  return result, flatten(data=data)
+
 # *** Helpers for CUDA-like APIs.
 
 def pretty_ptx(s):

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -333,7 +333,7 @@ DTYPE_TYPECODE = {
   dtypes.uint64: "Q"
 }
 
-def pack_list(data: list, dtype: DType) -> Tuple[memoryview, Tuple[int, ...]]:
+def pack_list(data: Union[None, int, float, list], dtype: DType) -> Tuple[memoryview, Tuple[int, ...]]:
   assert dtype in DTYPE_TYPECODE, f"{dtype} is not supported."
   flat_data, shape = flat_list(data=data)
   buffer = memoryview(bytearray(len(flat_data) * dtype.itemsize))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -62,8 +62,7 @@ class Tensor:
     elif isinstance(data, (int, float)):
       data = LazyBuffer.loadop(LoadOps.CONST, tuple(), dtype or Tensor.default_type, device, data)
     elif data is None or data.__class__ is list:
-      assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"
-      data = LazyBuffer.fromCPU(np.array([] if data is None else data, dtype=(dtype or Tensor.default_type).np))
+      data = LazyBuffer.fromNative(data or [], dtype=dtype or Tensor.default_type)
     elif isinstance(data, bytes):
       data = LazyBuffer.fromCPU(np.frombuffer(data, np.uint8))
     elif isinstance(data, np.ndarray):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -62,7 +62,7 @@ class Tensor:
     elif isinstance(data, (int, float)):
       data = LazyBuffer.loadop(LoadOps.CONST, tuple(), dtype or Tensor.default_type, device, data)
     elif data is None or data.__class__ is list:
-      data = LazyBuffer.fromNative(data or [], dtype=dtype or Tensor.default_type)
+      data = LazyBuffer.fromNative(list(data or []), dtype=dtype or Tensor.default_type)
     elif isinstance(data, bytes):
       data = LazyBuffer.fromCPU(np.frombuffer(data, np.uint8))
     elif isinstance(data, np.ndarray):


### PR DESCRIPTION
This is a draft for the second task #2649.
I'm trying to understand the code base; my apologies if this is completely missing the mark.
I'm not trying to lock a bounty, but rather understand by contribute.
This can be extended, but would get some input whether this goes into the correct direction.

This goes via a Python native route when creating tensors from lists. It doesn't remove any support for the creation from np arrays.

Approach:
We can create the pack the data via struct.pack and create a flat, (mutable) memory view on it (mutability required by https://github.com/tinygrad/tinygrad/blob/26f49869f47841817f066aa3357fd9d6aed4f32c/tinygrad/helpers.py#L294)
There's currently no support for bfloat16 (as not exposed in struct.pack), but this could maybe be implemented manually or using a library (as only serialization / deserialization is needed).

The way it is currently implemented is that it walks down the (potentially) nested input and gathers all elements in a flat list (and check that the shape is homogeneous). This is then serialized with struct.pack_into a bytesarray.
One could pack and walk at the same time, but this would assume that we know the dtype beforehand. This is currently the case, but you might want to support inferring the dtype (as numpy does) as well in case no dtype is specified.
Inferring requires looking at all data beforehand. So we could do a second walk there instead of collecting it in a flat list.
Are there any preferences?

The NumpyAllocator (used in the CPU device) assumes an np.ndarray as the buffer, so there's a np.frombuffer view around it in `fromNative` in lazy.py to avoid a copy.

Considered alternatives:
* Use array.array. But that doesn't support float16 and bfloat16.