### PR TITLE
simplify fancy index with negative Tensor entries

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -385,7 +385,8 @@ class Tensor:
       for tensor_dim in type_dim[Tensor]:
         dims_collapsed_, dims_injected = sum(1 for d in dims_collapsed if tensor_dim >= d), sum(1 for d in type_dim[None] if tensor_dim >= d)
         tdim.append(td := tensor_dim - dims_collapsed_ + dims_injected)
-        idx.append((t := indices[tensor_dim + dims_injected]).sign().__neg__().relu() * ret.shape[td] + t) # normalize the negative tensor indices
+        # normalize the negative tensor indices
+        idx.append(((t := indices[tensor_dim + dims_injected]) < 0).where(ret.shape[td], 0) + t)
 
       # compute sum_dim, arange, and idx
       max_dim = max(i.ndim for i in idx)


### PR DESCRIPTION
relevant kernel for `Tensor([1,2,3,4,5,6])[Tensor([1,2,3,4,-1,-2,-3], dtype=dtypes.int32)].numpy()`

master:
<img width="1200" alt="image" src="https://github.com/tinygrad/tinygrad/assets/2525478/8914651f-c926-4c39-bc52-2e792f761069">

this pr:
<img width="1109" alt="image" src="https://github.com/tinygrad/tinygrad/assets/2525478/281505c3-f57c-4dc2-8bed-8b6d388c049c">

@geohotstan fyi