### PR TITLE
Getitem round3 ....

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -359,7 +359,7 @@ class Tensor:
       indices_filtered[dim] = ((0, 0) if (st > 0 and e < s) or (st <= 0 and e > s) else (s, e) if st > 0 else (e+1, s+1), st)
     for dim in type_dim[Tensor]: indices_filtered[dim] = ((0, self.shape[dim]), 1)
 
-    new_slice, strides = ((),()) if not indices_filtered else zip(*tuple(i for i in indices_filtered))
+    new_slice, strides = ((),()) if not indices_filtered else zip(*indices_filtered)
     ret = self.shrink(new_slice).flip(axis=[i for i, s in enumerate(strides) if s < 0])
     # add strides by pad -> reshape -> shrink
     if any(abs(s) != 1 for s in strides):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -337,8 +337,8 @@ class Tensor:
 
     # record None for dimension injection later and filter None and record rest of indices
     type_dim[None] = [dim for dim, i in enumerate(indices) if i is None]
-    indices_filtered = [v for v in indices if v is not None]
-    for dim,i in enumerate(indices_filtered): type_dim[type(i)].append(dim)
+    indices = [v for v in indices if v is not None]
+    for dim,i in enumerate(indices): type_dim[type(i)].append(dim)
 
     # validation! raise Errors
     if slice in type_dim and self.ndim == 0: raise IndexError("slice cannot be applied to a 0-dim tensor.")
@@ -349,17 +349,17 @@ class Tensor:
 
     # 2. basic indexing (no copy)
     if indexed := type_dim[int] or type_dim[slice]:
-      # turn indices in indices_filtered to Tuple[shrink_arg, strides]
+      # turn indices in indices to Tuple[shrink_arg, strides]
       for dim in type_dim[int]:
-        if (i := indices_filtered[dim]) >= self.shape[dim] or i < -self.shape[dim]:
+        if (i := indices[dim]) >= self.shape[dim] or i < -self.shape[dim]:
           raise IndexError(f"index {i} is out of bounds for dimension {dim} with size {self.shape[dim]}")
-        indices_filtered[dim] = ((i,i+1),1) if i >= 0 else ((self.shape[dim]+i, self.shape[dim]+i+1), 1)
+        indices[dim] = ((i,i+1),1) if i >= 0 else ((self.shape[dim]+i, self.shape[dim]+i+1), 1)
       for dim in type_dim[slice]:
-        s, e, st = indices_filtered[dim].indices(self.shape[dim])
-        indices_filtered[dim] = (((0, 0) if e < s else (s, e)) if st > 0 else ((0, 0) if e > s else (e+1, s+1)), st)
-      for dim in type_dim[Tensor]: indices_filtered[dim] = ((0,self.shape[dim]), 1)
+        s, e, st = indices[dim].indices(self.shape[dim])
+        indices[dim] = (((0, 0) if e < s else (s, e)) if st > 0 else ((0, 0) if e > s else (e+1, s+1)), st)
+      for dim in type_dim[Tensor]: indices[dim] = ((0,self.shape[dim]), 1)
 
-      new_slice, strides = zip(*tuple(i for i in indices_filtered))
+      new_slice, strides = zip(*tuple(i for i in indices))
       ret = self.shrink(new_slice).flip(axis=[i for i, s in enumerate(strides) if s < 0])
       # add strides by pad -> reshape -> shrink
       if any(abs(s) != 1 for s in strides):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -348,6 +348,7 @@ class Tensor:
     if num_slices > len(self.shape): raise IndexError(f"too many indices for tensor of dimension {len(self.shape)}")
 
     # 2. basic indexing (no copy)
+    # currently indices_filtered: Tuple[Union[slice, int, Tensor], ...]
     # turn indices in indices_filtered to Tuple[shrink_arg, strides]
     for dim in type_dim[int]:
       if (i := indices_filtered[dim]) >= self.shape[dim] or i < -self.shape[dim]:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -368,7 +368,7 @@ class Tensor:
         ret = ret.reshape(flatten([sh // s, s] for s, sh in zip(strides, ret.shape)))
         ret = ret.shrink(tuple(flatten(((0, sh), (0, 1)) for sh in ret.shape[::2]))).reshape(ret.shape[::2])
 
-    # inject dim=1 for None and collapse dim for int
+    # inject 1 for dim where it's None and collapse dim for int
     new_shape = list(ret.shape) if indexed else list(self.shape)
     for dim in type_dim[None]: new_shape.insert(dim, 1)
     for dim in (dims_collapsed := [dim + sum(1 for d in type_dim[None] if dim >= d) for dim in reversed(type_dim[int])]): new_shape.pop(dim)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -390,7 +390,7 @@ class Tensor:
       # compute sum_dim, arange, and idx
       max_dim = max(i.ndim for i in idx)
       sum_dim = [d if n==0 else d+max_dim-n for n,d in enumerate(tdim)]
-      arange = [Tensor.arange(ret.shape[d], dtype=dtypes.int32, requires_grad=False, device=ret.device).reshape(*[1]*sd, ret.shape[d], *[1]*(ret.ndim + max_dim - n - sd - 1)) for n,(sd,d) in enumerate(zip(sum_dim, tdim))]   # noqa: E501
+      arange = [Tensor.arange(ret.shape[d], dtype=dtypes.int32, requires_grad=False, device=self.device).reshape(*[1]*sd, ret.shape[d], *[1]*(ret.ndim + max_dim - n - sd - 1)) for n,(sd,d) in enumerate(zip(sum_dim, tdim))]   # noqa: E501
       first_idx = [idx[0].reshape(*[1]*tdim[0], *[1]*(1 + max_dim - idx[0].ndim), *idx[0].shape, *[1]*(ret.ndim - tdim[0] - 1))]
       rest_idx = [i.reshape(*[1]*tdim[0], *[1]*(max_dim - i.ndim), *i.shape, *[1]*(ret.ndim - tdim[0] - n)) for n,i in enumerate(idx[1:], 1)]
       idx = first_idx + rest_idx

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -364,7 +364,7 @@ class Tensor:
     # add strides by pad -> reshape -> shrink
     if any(abs(s) != 1 for s in strides):
       strides = tuple(abs(s) for s in strides)
-      ret = ret.pad(tuple((0, s-(sh % s) if sh % s != 0 else 0) for s, sh in zip(strides, ret.shape)))
+      ret = ret.pad(tuple((0, round_up(sh,s) - sh) for s, sh in zip(strides, ret.shape)))
       ret = ret.reshape(flatten([sh // s, s] for s, sh in zip(strides, ret.shape)))
       ret = ret.shrink(tuple(flatten(((0, sh), (0, 1)) for sh in ret.shape[::2]))).reshape(ret.shape[::2])
 


### PR DESCRIPTION
by fixing the `TODO: totally unreadable line`
I decided to make more refactors....
- fully use type_dim to do eeevverything, avoid `[<code> if isinstance(i, type) else <code> ... for i in indices]`
- ~~move `2. basic indexing (no copy)` inside an if conditional, so we don't call shrink, flip, etc unless necessary~~
- got rid of crazy 1 liner :D

let's see how many lines I added