### PR TITLE
Change `nn.Embedding` from matmul to lookup

### DIFF
--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -123,9 +123,7 @@ class LayerNorm2d(LayerNorm):
 
 class Embedding:
   def __init__(self, vocab_size:int, embed_size:int):
-    self.vocab_size = vocab_size
     self.weight = Tensor.glorot_uniform(vocab_size, embed_size)
 
   def __call__(self, idx:Tensor) -> Tensor:
-    if not hasattr(self, 'vocab_counter'): self.vocab_counter = Tensor.arange(self.vocab_size, requires_grad=False).reshape(1, 1, self.vocab_size)
-    return (self.vocab_counter == idx.unsqueeze(2)).expand(*idx.shape, self.vocab_size) @ self.weight
+    return self.weight[idx]


### PR DESCRIPTION
This simplifies `nn.Embedding`, which previously constructed a `(B, S, V)` one-hot matrix and performed a multiply against the embedding table weights. Now, we just look up the corresponding rows in the embedding table for each token.

This results in a slight reduction in lines, as well as a small speedup for large embedding matrices/batch sizes/sequence lengths.

A very simple benchmark is given below (on a NVIDIA GeForce RTX 3070) with some different batch sizes/sequence lengths and the gpt2 embedding configuration:

```
Old Time (64, 32): 4761.07 ms
New Time (64, 32): 2479.79 ms
Old Time (128, 64): 21437.84 ms
New Time (128, 64): 13881.80 ms
Old Time (32, 512): 43910.92 ms
New Time (32, 512): 28393.64 ms
Old Time (JIT) (16, 128): 5334.19 ms
New Time (JIT) (16, 128): 2365.25 ms
```
__________________________________________________

Below is the benchmark code. I am not yet familiar enough with tinygrad to know the standard benchmarking techniques, so advice is appreciated.

```python
from tinygrad import Tensor, nn
from tinygrad.jit import TinyJit
from tinygrad.helpers import Timing

class NewEmbedding:
  def __init__(self, v, e):
    self.weight = Tensor.glorot_uniform(v, e)
  def _copy(self, e):
    self.weight = e.weight[:]
  def __call__(self, i):
    return self.weight[i]

if __name__ == '__main__':
    # taken from gpt2
    V, E = 50257, 768
    TRIALS = 50

    for (B, S) in [(64, 32), (128, 64), (32, 512)]:

        old = nn.Embedding(V, E)
        new = NewEmbedding(V, E)

        with Timing(f"Old Time {B, S}: "):
            for _ in range(TRIALS):
                i = Tensor.randint((B, S), 0, V)
                old(i).realize()

        with Timing(f"New Time {B, S}: "):
            for _ in range(TRIALS):
                i = Tensor.randint((B, S), 0, V)
                new(i).realize()

    B, S = (16, 256)
    @TinyJit
    def new_jit(x):
        return new(x).realize()

    @TinyJit
    def old_jit(x):
        return old(x).realize()

    i = Tensor.randint((B, S), 0, V)
    for _ in range(5):
       new_jit(i)
       old_jit(i)

    with Timing(f"Old Time (JIT) {B, S}: "):
        for _ in range(TRIALS):
            i = Tensor.randint((B, S), 0, V)
            old_jit(i)

    with Timing(f"New Time (JIT) {B, S}: "):
        for _ in range(TRIALS):
            i = Tensor.randint((B, S), 0, V)
            new_jit(i)
```