### PR TITLE
Make torch backend more usable, fix bfloat support in the llvm backend

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -103,14 +103,14 @@ def _test_ops(a_dtype:DType, b_dtype:DType, target_dtype=None):
 
 class TestBFloat16DType(unittest.TestCase):
   def setUp(self):
-    if not is_dtype_supported(dtypes.bfloat16): raise unittest.SkipTest("bfloat16 not supported")
+    if Device.DEFAULT not in ["LLVM"]: raise unittest.SkipTest("bfloat16 not supported")
   def test_bf16_to_float(self):
     with self.assertRaises(AssertionError):
-      _test_cast(Tensor([100000], dtype=dtypes.bfloat16), dtypes.float32, [100000])
+      _test_cast(Tensor([100000], dtype=dtypes.bfloat16), dtypes.float32)
 
   def test_float_to_bf16(self):
     with self.assertRaises(AssertionError):
-      _test_cast(Tensor([100000], dtype=dtypes.float32), dtypes.bfloat16, [100000])
+      _test_cast(Tensor([100000], dtype=dtypes.float32), dtypes.bfloat16)
 
   # torch.tensor([10000, -1, -1000, -10000, 20]).type(torch.bfloat16)
 

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -103,7 +103,7 @@ def _test_ops(a_dtype:DType, b_dtype:DType, target_dtype=None):
 
 class TestBFloat16DType(unittest.TestCase):
   def setUp(self):
-    if Device.DEFAULT not in ["LLVM"]: raise unittest.SkipTest("bfloat16 not supported")
+    if Device.DEFAULT not in ["LLVM", "TORCH"]: raise unittest.SkipTest("bfloat16 not supported")
   def test_bf16_to_float(self):
     with self.assertRaises(AssertionError):
       _test_cast(Tensor([100000], dtype=dtypes.bfloat16), dtypes.float32)

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -125,7 +125,7 @@ class TestBFloat16DType(unittest.TestCase):
     t.to(f"disk:{temp('f32')}").realize()
 
     # hack to "cast" f32 -> bf16
-    dat = open(temp('f32'), "rb").read()
+    with open(temp('f32'), "rb") as f: dat = f.read()
     adat = b''.join([dat[i+2:i+4] for i in range(0, len(dat), 4)])
     with open(temp('bf16'), "wb") as f: f.write(adat)
 

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -38,6 +38,13 @@ def cast(bb, val, input_type, output_type, bitcast=False):
   if input_type == output_type: return val
   if bitcast: return bb[-1].bitcast(val, dtype_to_llvm_dtype[output_type])
 
+  if input_type == dtypes.bfloat16:
+    val = bb[-1].bitcast(bb[-1].shl(bb[-1].sext(val, ir.IntType(32)), ir.Constant(ir.IntType(32), 16)),val, ir.FloatType())
+    input_type = dtypes.float32
+  if output_type == dtypes.bfloat16:
+    val = cast(bb, val, input_type, dtypes.float32)
+    return bb[-1].trunc(bb[-1].lshr(bb[-1].bitcast(val, ir.IntType(32)), ir.Constant(ir.IntType(32), 16)), ir.IntType(16))
+
   if dtypes.is_float(input_type):
     if dtypes.is_float(output_type):
       if output_type.itemsize > input_type.itemsize: return bb[-1].fpext(val, dtype_to_llvm_dtype[output_type])

--- a/tinygrad/runtime/ops_torch.py
+++ b/tinygrad/runtime/ops_torch.py
@@ -9,7 +9,7 @@ from tinygrad.runtime.ops_cpu import einsum_mulacc, shape_to_axis
 device = torch.device("cuda:0" if torch.cuda.is_available() else ("mps" if getenv("MPS", 0) else "cpu"))
 type_map = {torch.float64: dtypes.float64, torch.float16: dtypes.float16, torch.float32: dtypes.float32,
             torch.int8: dtypes.int8, torch.int32: dtypes.int32, torch.int64: dtypes.int64,
-            torch.uint8: dtypes.uint8, torch.bool: dtypes.bool, torch.int16: dtypes.int16}
+            torch.uint8: dtypes.uint8, torch.bool: dtypes.bool, torch.int16: dtypes.int16, torch.bfloat16: dtypes.bfloat16}
 inverse_type_map = {v:k for k,v in type_map.items()}
 
 def output_type(x, y): return x.dtype if type_map[x.dtype].priority > type_map[y.dtype].priority else y.dtype

--- a/tinygrad/runtime/ops_torch.py
+++ b/tinygrad/runtime/ops_torch.py
@@ -10,7 +10,7 @@ device = torch.device("cuda:0" if torch.cuda.is_available() else ("mps" if geten
 type_map = {torch.float64: dtypes.float64, torch.float16: dtypes.float16, torch.float32: dtypes.float32,
             torch.int8: dtypes.int8, torch.int32: dtypes.int32, torch.int64: dtypes.int64,
             torch.uint8: dtypes.uint8, torch.bool: dtypes.bool, torch.int16: dtypes.int16, torch.bfloat16: dtypes.bfloat16}
-inverse_type_map = {v:k for k,v in type_map.items()}
+inverse_type_map = dict([(v, k) for k,v in type_map.items()] + [(dtypes.ushort, torch.int16), (dtypes.uint, torch.int32)])
 
 def output_type(x, y): return x.dtype if type_map[x.dtype].priority > type_map[y.dtype].priority else y.dtype
 def match_types(x, y, disallow_bool=False):
@@ -29,7 +29,7 @@ torch_fxn_for_op: Dict[Op, Callable] = {
   #BufferOps.CONST: lambda val, dtype: torch.tensor(val, device=device, dtype=inverse_type_map[dtype]),
   BufferOps.CONST: lambda val, dtype: torch.from_numpy(np.array(val, dtype=dtype.np)).to(device),
   UnaryOps.SQRT: lambda x: x.sqrt(), UnaryOps.EXP2: lambda x: x.exp2(), UnaryOps.LOG2: lambda x: x.log2(), UnaryOps.SIN: torch.sin,
-  UnaryOps.CAST: lambda x,y: (x.view if y[1] else x.type)(next(k for k,v in type_map.items() if v==y[0])),
+  UnaryOps.CAST: lambda x,y: (x.view if y[1] else x.type)(inverse_type_map[y[0]]),
   UnaryOps.NEG: lambda x: torch.logical_not(x) if x.dtype is torch.bool else torch.neg(x),
   BinaryOps.MAX: torch.maximum, BinaryOps.CMPLT: lambda x,y: (x<y).type(torch.promote_types(x.dtype, y.dtype)),
   BinaryOps.ADD: lambda x,y: torch.add(*match_types(x, y)).type(output_type(x,y)),


### PR DESCRIPTION
This change add few missing bits and pieces into torch backend type conversion code:

o dtypes.bfloat16 <-> torch.bfloat16
o dtypes.ushort -> torch.int16
o dtypes.uint -> torch.int32
o np.uint32 -> np.int32

This makes coder and hlb_cifar10 working with TORCH=1 OOB.

```
WARNING: not loading freqs_cis
ram used: 14.58 GB, freqs_cis                                         : 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 292/292 [00:02<00:00, 128.03it/s]
loaded weights in 2281.31 ms, 4.54 GB loaded at 1.99 GB/s
weights -> model: 9970.24 ms
<|im_start|> system
You are Quentin. Quentin is a useful assistant who writes Python code to answer questions. He keeps the code as short as possible and doesn't read from user input<|im_end|>
Q: what is the origin of the word "wednesday"?
<|im_start|> user
what is the origin of the word "wednesday"?<|im_end|>
<|im_start|> assistant
The originJIT captured 713 kernels with 1 inputs
 of the word "Wednesday" can be traced back to Old English "Wodnesdæg", which means "day of Woden". Woden was the Germanic god of war, poetry, and wisdom. The Old English name evolved into "Wednesday" in Middle English.<|im_end|>
Q: ^CTraceback (most recent call last):
  File "/home/sobomax/projects/tinygrad/examples/coder.py", line 68, in <module>
    toks += encode_prompt("user", input("Q: ")) + start_prompt("assistant")
                                  ^^^^^^^^^^^