### PR TITLE
rsqrt is self.reciprocal().sqrt()

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -312,14 +312,14 @@ class TestAutoCastType(unittest.TestCase):
   def test_int_to_float_unary_func(self, dtype):
     for func in [
       lambda t: t.exp(),
-      # lambda t: t.exp2(),  # requires MUL
+      lambda t: t.exp2(),
       lambda t: t.log(),
       lambda t: t.log2(),
       lambda t: t.sqrt(),
-      # lambda t: t.rsqrt(),  # requires DIV
+      lambda t: t.rsqrt(),
       lambda t: t.sin(),
-      # lambda t: t.cos(),  # requires SUB
-      # lambda t: t.tan(),  # requires .cos() to work
+      lambda t: t.cos(),
+      lambda t: t.tan(),
       lambda t: t.sigmoid(),
     ]:
       a = [2, 3, 4]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -684,7 +684,7 @@ class Tensor:
   def sigmoid(self): return mlops.Sigmoid.apply(self)
   def sin(self): return mlops.Sin.apply(self)
   def sqrt(self): return mlops.Sqrt.apply(self)
-  def rsqrt(self): return (1/self).sqrt()
+  def rsqrt(self): return self.reciprocal().sqrt()
   def cos(self): return ((math.pi/2)-self).sin()
   def tan(self): return self.sin() / self.cos()
 


### PR DESCRIPTION
(1/self) is incorrect for int tensor