### PR TITLE
Fix argmax and argmin dtypes

### DIFF
--- a/docs/DESIGNv2.md
+++ b/docs/DESIGNv2.md
@@ -3,7 +3,7 @@ tinygrad is a bit bloated now, and there's several places where concerns should 
 tensor.py and mlops.py are great code. The interface going backward here is:
 
 LazyBuffer.const (this creates a matching size buffer)
-LazyBuffer.contiguous (tbis is not exactly elementwise)
+LazyBuffer.contiguous (this is not exactly elementwise)
 LazyBuffer.e (elementwise)
 LazyBuffer.r (reduce)
 reshape/permute/expand/stride/shrink/pad (movement)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -448,12 +448,18 @@ class TestOps(unittest.TestCase):
 
   def test_argmax(self):
     self.assertEqual(torch.Tensor([2,2]).argmax().numpy(), Tensor([2,2]).argmax().numpy()) # check if returns first index for same max
+    self.assertEqual(torch.Tensor([2,2]).argmax().numpy().dtype, Tensor([2,2]).argmax().numpy().dtype)
+    self.assertEqual(torch.Tensor([2,2]).argmax(axis=0).numpy(), Tensor([2,2]).argmax(axis=0).numpy())
+    self.assertEqual(torch.Tensor([2,2]).argmax(axis=0).numpy().dtype, Tensor([2,2]).argmax(axis=0).numpy().dtype)
     helper_test_op([(10,20)], lambda x: x.argmax(), lambda x: x.argmax(), forward_only=True)
     helper_test_op([(10,20)], lambda x: x.argmax(0, False), lambda x: x.argmax(0, False), forward_only=True)
     helper_test_op([(10,20)], lambda x: x.argmax(1, False), lambda x: x.argmax(1, False), forward_only=True)
     helper_test_op([(10,20)], lambda x: x.argmax(1, True), lambda x: x.argmax(1, True), forward_only=True)
   def test_argmin(self):
     self.assertEqual(torch.Tensor([2, 2]).argmin().numpy(), Tensor([2, 2]).argmin().numpy())
+    self.assertEqual(torch.Tensor([2, 2]).argmin().numpy().dtype, Tensor([2, 2]).argmin().numpy().dtype)
+    self.assertEqual(torch.Tensor([2, 2]).argmin(axis=0).numpy(), Tensor([2, 2]).argmin(axis=0).numpy())
+    self.assertEqual(torch.Tensor([2, 2]).argmin(axis=0).numpy().dtype, Tensor([2, 2]).argmin(axis=0).numpy().dtype)
     helper_test_op([(10,20)], lambda x: x.argmin(), lambda x: x.argmin(), forward_only=True)
     helper_test_op([(10,20)], lambda x: x.argmin(0, False), lambda x: x.argmin(0, False), forward_only=True)
     helper_test_op([(10,20)], lambda x: x.argmin(1, False), lambda x: x.argmin(1, False), forward_only=True)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -519,11 +519,11 @@ class Tensor:
   def argmax(self, axis=None, keepdim=False):
     if axis is None:
       idx = (self == self.max(axis)) * Tensor.arange(prod(self.shape)-1,-1,-1, requires_grad=False, device=self.device).reshape(self.shape)
-      return prod(self.shape) - idx.max() - 1
+      return (prod(self.shape) - idx.max() - 1).cast(dtypes.int64)
     axis = axis + len(self.shape) if axis < 0 else axis
-    m = self == self.max(axis=axis, keepdim=True)
+    m = (self == self.max(axis=axis, keepdim=True))
     idx = m * Tensor.arange(self.shape[axis]-1,-1,-1, requires_grad=False, device=self.device).reshape(self.shape[axis], *[1]*(self.ndim-axis-1))
-    return self.shape[axis]-idx.max(axis=axis, keepdim=keepdim)-1
+    return (self.shape[axis]-idx.max(axis=axis, keepdim=keepdim)-1).cast(dtypes.int64)
   def argmin(self, axis=None, keepdim=False): return (-self).argmax(axis=axis, keepdim=keepdim)
 
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -521,7 +521,7 @@ class Tensor:
       idx = (self == self.max(axis)) * Tensor.arange(prod(self.shape)-1,-1,-1, requires_grad=False, device=self.device).reshape(self.shape)
       return (prod(self.shape) - idx.max() - 1).cast(dtypes.int64)
     axis = axis + len(self.shape) if axis < 0 else axis
-    m = (self == self.max(axis=axis, keepdim=True))
+    m = self == self.max(axis=axis, keepdim=True)
     idx = m * Tensor.arange(self.shape[axis]-1,-1,-1, requires_grad=False, device=self.device).reshape(self.shape[axis], *[1]*(self.ndim-axis-1))
     return (self.shape[axis]-idx.max(axis=axis, keepdim=keepdim)-1).cast(dtypes.int64)
   def argmin(self, axis=None, keepdim=False): return (-self).argmax(axis=axis, keepdim=keepdim)


### PR DESCRIPTION
Argmax and argmin returned tensors of type `float32` instead of `int64`. Numpy returns `int64`. This also allows to directly use argmin/max to index another Tensor.