### PR TITLE
Add backward for Less MLOps

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -425,5 +425,23 @@ class TestZeroShapeTensor(unittest.TestCase):
     np.testing.assert_equal(Tensor([]).sum().numpy(), 0)
     np.testing.assert_equal(Tensor([]).mean().numpy(), 0)
 
+class TestMLOps(unittest.TestCase):
+  def test_less_backward(self):
+    from tinygrad.nn.optim import SGD
+    from tinygrad.nn.state import get_parameters
+    def relu_(t): return t * (t > 0)
+    class Net:
+      def __init__(self): self.w = Tensor.randn(10, 10)
+      def __call__(self, x: Tensor): return self.w.dot(x)
+    net = Net()
+    optim = SGD(get_parameters(net))
+    rd = Tensor.randn(10)
+    relu_(net(rd)).mean().backward()
+    grad = net.w.grad.numpy()
+    optim.zero_grad()
+    net(rd).relu().mean().backward()
+    np.testing.assert_equal(grad, net.w.grad.numpy())
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -78,8 +78,8 @@ class Sqrt(Function):
 # TODO: have the backend automatically find this
 class Sigmoid(Function):
   def forward(self, x:LazyBuffer) -> LazyBuffer:
-    x = x.cast(least_upper_float(x.dtype))
-    self.ret = x.const(1).e(BinaryOps.DIV, x.const(1).e(BinaryOps.ADD, x.e(BinaryOps.MUL, x.const(-1/math.log(2))).e(UnaryOps.EXP2)))
+    self.ret = x.cast(ftype:=least_upper_float(x.dtype)).const(1).e(
+      BinaryOps.DIV, x.cast(ftype).const(1).e(BinaryOps.ADD, x.e(BinaryOps.MUL, x.cast(ftype).const(-1/math.log(2))).e(UnaryOps.EXP2)))
     return self.ret
 
   def backward(self, grad_output:LazyBuffer) -> LazyBuffer:
@@ -89,13 +89,15 @@ class Sigmoid(Function):
 
 class Less(Function):
   def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer:
-    output_dtype = least_upper_dtype(x.dtype, y.dtype)
-    return x.cast(output_dtype).e(BinaryOps.CMPLT, y.cast(output_dtype))
+    self.ret = x.e(BinaryOps.CMPLT, y)
+    return self.ret
+
+  def backward(self, grad_output:LazyBuffer) -> Tuple[Optional[LazyBuffer], Optional[LazyBuffer]]:
+    return None, None
 
 class Xor(Function):
   def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer:
-    output_dtype = least_upper_dtype(x.dtype, y.dtype)
-    return x.cast(output_dtype).e(BinaryOps.XOR, y.cast(output_dtype))
+    return x.e(BinaryOps.XOR, y)
 
 class Add(Function):
   def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer:

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -80,6 +80,7 @@ class Sigmoid(Function):
   def forward(self, x:LazyBuffer) -> LazyBuffer:
     x = x.cast(least_upper_float(x.dtype))
     self.ret = x.const(1).e(BinaryOps.DIV, x.const(1).e(BinaryOps.ADD, x.e(BinaryOps.MUL, x.const(-1/math.log(2))).e(UnaryOps.EXP2)))
+    return self.ret
 
   def backward(self, grad_output:LazyBuffer) -> LazyBuffer:
     return self.ret.e(BinaryOps.MUL, self.ret.const(1).e(BinaryOps.SUB, self.ret)).e(BinaryOps.MUL, grad_output)
@@ -88,8 +89,8 @@ class Sigmoid(Function):
 
 class Less(Function):
   def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer:
-    self.ret = x.e(BinaryOps.CMPLT, y)
-    return self.ret
+    output_dtype = least_upper_dtype(x.dtype, y.dtype)
+    return x.cast(output_dtype).e(BinaryOps.CMPLT, y.cast(output_dtype))
 
   def backward(self, grad_output:LazyBuffer) -> Tuple[Optional[LazyBuffer], Optional[LazyBuffer]]:
     return None, None

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -78,9 +78,8 @@ class Sqrt(Function):
 # TODO: have the backend automatically find this
 class Sigmoid(Function):
   def forward(self, x:LazyBuffer) -> LazyBuffer:
-    self.ret = x.cast(ftype:=least_upper_float(x.dtype)).const(1).e(
-      BinaryOps.DIV, x.cast(ftype).const(1).e(BinaryOps.ADD, x.e(BinaryOps.MUL, x.cast(ftype).const(-1/math.log(2))).e(UnaryOps.EXP2)))
-    return self.ret
+    x = x.cast(least_upper_float(x.dtype))
+    self.ret = x.const(1).e(BinaryOps.DIV, x.const(1).e(BinaryOps.ADD, x.e(BinaryOps.MUL, x.const(-1/math.log(2))).e(UnaryOps.EXP2)))
 
   def backward(self, grad_output:LazyBuffer) -> LazyBuffer:
     return self.ret.e(BinaryOps.MUL, self.ret.const(1).e(BinaryOps.SUB, self.ret)).e(BinaryOps.MUL, grad_output)
@@ -97,7 +96,8 @@ class Less(Function):
 
 class Xor(Function):
   def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer:
-    return x.e(BinaryOps.XOR, y)
+    output_dtype = least_upper_dtype(x.dtype, y.dtype)
+    return x.cast(output_dtype).e(BinaryOps.XOR, y.cast(output_dtype))
 
 class Add(Function):
   def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer:


### PR DESCRIPTION
Using `Less` (`<`) in the computation graph during backprop would previously result in the following error: `E   RuntimeError: backward not implemented for <class 'tinygrad.mlops.Less'>`.

For example, this would happen if you implemented your own custom loss that used `<`.

I added `None` gradients to `Less`'s backward pass. Maybe this should better be fixed by modifying the base class `Function` and always returning `None` grads if not overriden.

I added the corresponding test to `test_tensor.py`, happy to move them elsewhere if there is a better spot.