### PR TITLE
remove cstyle hip functions that deals with different types of input

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -303,20 +303,6 @@ __device__ half sin(half x) { return hsin(x); }
 __device__ half sqrt(half x) { return hsqrt(x); }
 __device__ half hmax(half a, half b) { return __hgt(a, b) ? a : b; }
 __device__ half operator%(const half &a, const half &b) { return __hsub(a, __hmul(b, __float2half(floorf(__half2float(a) / __half2float(b))))); }
-__device__ bool operator!=(const half &a, const int &b) { return (float)a != b; }
-
-// HACKS for ALU ops on half and result of half2 GEP
-__device__ half operator+(const half &a, const unsigned short &b) { return __hadd(a, (half)(b)); }
-__device__ half operator-(const half &a, const unsigned short &b) { return __hsub(a, (half)(b)); }
-__device__ half operator*(const half &a, const unsigned short &b) { return __hmul(a, (half)(b)); }
-__device__ half operator/(const half &a, const unsigned short &b) { return __hdiv(a, (half)(b)); }
-__device__ bool operator<(const half &a, const unsigned short &b) { return __hlt(a, (half)(b)); }
-// now the other way
-__device__ half operator+(const unsigned short &a, const half &b) { return __hadd((half)(a), b); }
-__device__ half operator-(const unsigned short &a, const half &b) { return __hsub((half)(a), b); }
-__device__ half operator*(const unsigned short &a, const half &b) { return __hmul((half)(a), b); }
-__device__ half operator/(const unsigned short &a, const half &b) { return __hdiv((half)(a), b); }
-__device__ bool operator<(const unsigned short &a, const half &b) { return __hlt((half)(a), b); }
   """
   gid = [f'blockIdx.{chr(120+i)}' for i in range(3)]
   lid = [f'threadIdx.{chr(120+i)}' for i in range(3)]


### PR DESCRIPTION
input dtypes are aligned before uop level so we don't need functions that handle different input types