### PR TITLE
Removing ~10 lines (No functionality change)

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -408,7 +408,7 @@ class Kernel:
     if opt.op in [OptOps.LOCAL, OptOps.LASTLOCAL]:   # cyan
       assert self.opts.has_local, "target does not support local"
       assert axis < self.first_reduce, "can't local a reduce"
-      assert not self.tensor_core, "can't local with tensor cores"
+      if opt.op == OptOps.LOCAL: assert not(self.tensor_core), "can't local with tensor cores"
       insert_before = self.first_reduce if opt.op == OptOps.LOCAL else self.first_reduce - self.local_dims
       self.shift_to(axis, amt, insert_before=insert_before)
       self.local_dims += 1


### PR DESCRIPTION
Change the `axis` and `amt` if else statements to more condensed versions. the `amt` keeps part of its if statement. 

condensed  `OptOps.LOCAL` and `OptOps.LASTLOCAL` into one if statement. (only difference between them is the `self.shift_to()` function and `assert not(self.tensor_core), "can't local with tensor cores"` and both differences are accounted for ) 
