### PR TITLE
Remove deepwalk's nested func

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -241,15 +241,14 @@ class Tensor:
 
   # ***** toposort and backward pass *****
 
-  def deepwalk(self):
-    def _deepwalk(node, visited, nodes):
-      visited.add(node)
-      if getattr(node, "_ctx", None):
-        for i in node._ctx.parents:
-          if i not in visited: _deepwalk(i, visited, nodes)
-        nodes.append(node)
-      return nodes
-    return _deepwalk(self, set(), [])
+  def deepwalk(self, visited=None, nodes=None) -> List[Tensor]:
+    if visited is None: visited, nodes = set(), []
+    visited.add(self)
+    if getattr(self, "_ctx", None):
+      for i in self._ctx.parents:
+        if i not in visited: i.deepwalk(visited, nodes)
+      nodes.append(self)
+    return nodes
 
   def backward(self) -> Tensor:
     assert self.shape == tuple(), f"backward can only be called for scalar tensors, but it has shape {self.shape})"


### PR DESCRIPTION
Instead of creating a second function (_deepwalk) every time deepwalk is called, deepwalk now handles the combined functionality of deepwalk and _deepwalk. Also specifies the return type. This passes all the tests except for an overzealous linter. 1 line is removed and code is slightly less indented/complex.