### PR TITLE
Use set comprehensions

### DIFF
--- a/examples/stable_diffusion.py
+++ b/examples/stable_diffusion.py
@@ -413,12 +413,9 @@ def get_pairs(word):
   """Return set of symbol pairs in a word.
   Word is represented as tuple of symbols (symbols being variable-length strings).
   """
-  pairs = set()
-  prev_char = word[0]
-  for char in word[1:]:
-    pairs.add((prev_char, char))
-    prev_char = char
-  return pairs
+  if len(word) < 2:
+    return set()
+  return set(zip(word[:-1], word[1:]))
 
 def whitespace_clean(text):
   text = re.sub(r'\s+', ' ', text)

--- a/openpilot/compile2.py
+++ b/openpilot/compile2.py
@@ -34,7 +34,7 @@ def get_schedule(onnx_data) -> Tuple[List[ScheduleItem], List[ScheduleItem]]:
   schedule = ret.lazydata.schedule()
 
   # filter schedule that don't depend on the inputs
-  input_lb = [x.lazydata.base for x in inputs.values()]
+  input_lb = {x.lazydata.base for x in inputs.values()}
   depends = set(input_lb)
   for si in schedule:
     if any(b in depends for b in si.inputs):


### PR DESCRIPTION
Improve readability and performance especially in larger use cases of get_pairs in stable_diffusion.py. Also the assert call on line 49 of compile2.py should be faster when input_lb is a set instead of a list.