### PR TITLE
[Refactor][Kernel] use deepcopy, save LoC, increase readibility

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -114,7 +114,7 @@ class Kernel:
   def copy(self):
     ret = deepcopy(self)
     # uncached since linearize didn't run
-    ret.applied_opts_cache, ret.local_alias = None, self.local_alias.copy()
+    ret.applied_opts_cache = None
     return ret
 
   @property
@@ -198,8 +198,10 @@ class Kernel:
   def reshape_and_permute(self, new_shape_fxn, axis):
     new_sts = []
     for st in self.sts:
-      if new_shape_fxn is not None: st = st.reshape(tuple(new_shape_fxn(st.shape)))
-      if axis is not None: st = st.permute(tuple(axis))
+      if new_shape_fxn is not None: 
+        st = st.reshape(tuple(new_shape_fxn(st.shape)))
+      if axis is not None: 
+        st = st.permute(tuple(axis))
       new_sts.append(st)
     self.sts = new_sts
 

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -9,6 +9,7 @@ from tinygrad.shape.symbolic import sint
 from tinygrad.shape.view import View, strides_for_shape
 from dataclasses import dataclass
 from enum import Enum, auto
+from copy import deepcopy
 
 class OptOps(Enum):
   UPCAST = auto(); UPCASTMID = auto(); UNROLL = auto(); LOCAL = auto(); LASTLOCAL = auto() # noqa: E702
@@ -111,23 +112,9 @@ class Kernel:
     self.applied_opts_cache: Optional[List[Opt]] = None
 
   def copy(self):
-    ret = type(self).__new__(type(self))
-
-    # base linearizer params
-    ret.opts, ret.ast = self.opts, self.ast
-
-    # things downstream of the AST
-    # NOTE: we copy bufs for local buffers and sts for optimizations
-    ret.info, ret.reduceop, ret.bufs, ret.earlybufs, ret.full_buf_index, ret.sts = \
-      self.info, self.reduceop, self.bufs[:], self.earlybufs, self.full_buf_index, self.sts[:]
-
-    # parameters for optimizations
-    ret.applied_opts, ret.group_for_reduce, ret.upcasted, ret.local_dims, ret.local_alias, ret.tensor_core, ret.dont_use_locals = \
-      self.applied_opts[:], self.group_for_reduce[:], self.upcasted, self.local_dims, self.local_alias.copy(), self.tensor_core, self.dont_use_locals
-
+    ret = deepcopy(self)
     # uncached since linearize didn't run
     ret.applied_opts_cache = None
-
     return ret
 
   @property

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -114,7 +114,7 @@ class Kernel:
   def copy(self):
     ret = deepcopy(self)
     # uncached since linearize didn't run
-    ret.applied_opts_cache = None
+    ret.applied_opts_cache, ret.local_alias = None, self.local_alias.copy()
     return ret
 
   @property

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -198,10 +198,8 @@ class Kernel:
   def reshape_and_permute(self, new_shape_fxn, axis):
     new_sts = []
     for st in self.sts:
-      if new_shape_fxn is not None: 
-        st = st.reshape(tuple(new_shape_fxn(st.shape)))
-      if axis is not None: 
-        st = st.permute(tuple(axis))
+      if new_shape_fxn is not None: st = st.reshape(tuple(new_shape_fxn(st.shape)))
+      if axis is not None: st = st.permute(tuple(axis))
       new_sts.append(st)
     self.sts = new_sts
 


### PR DESCRIPTION
Removed most lines from the `copy()` function of `Kernel` by moving the logic to Python's deepcopy  


## Test Results
[success] python3 -m pip install -e '.[testing]'
[success] python3 test/test_ops.py
[fail] python3 -m pytest test/   