### PR TITLE
merge `render_cast` in cstype

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -41,7 +41,7 @@ class CStyleLanguage(NamedTuple):
 
   # returns a str expression of the casted xs with the given type
   def render_cast(self, x:List[str], var_dtype:DType, bitcast=False) -> str:
-    if bitcast: return f"(*(({self.buffer_prefix}{var_dtype.name}*)&{x[0]}))"
+    if bitcast: return f"(*(({var_dtype.name}*)&{x[0]}))"
     if len(x) == 1: return f"({var_dtype.name})({x[0]})"
     assert len(x) == var_dtype.sz, f"cast is wrong size {len(x)} != {var_dtype.sz}"
     assert self.float4 is not None, "vectorized cast is not supported on this platform"


### PR DESCRIPTION
sort of related to #2822 
sadly not that much of line winner.
webgpu only renders casts from its `type_map` but if we use a function like `render_dtype` in #2822, then it can be handled separately.