### PR TITLE
remove the all_int(shape) check in Tensor._loadop

### DIFF
--- a/test/test_symbolic_ops.py
+++ b/test/test_symbolic_ops.py
@@ -46,6 +46,7 @@ class TestSymbolicOps(unittest.TestCase):
       expected = f(q, k, v).numpy()
       np.testing.assert_allclose(symbolic, expected, atol=1e-6, rtol=1e-6)
 
+  @unittest.skipIf(getenv("MOCKHIP"), "MOCKHIP only compiles and does not run")
   def test_attention_training(self):
     with Tensor.train():
       self.test_attention(dropout_p=0.0)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -150,20 +150,17 @@ class Tensor:
 
   @staticmethod
   def _loadop(op, shape, device:Optional[str]=None, dtype:Optional[DType]=None, arg=None, **kwargs):
-    assert all_int(shape), f"cannot create with symbolic shape {shape}"
     return Tensor(LazyBuffer.loadop(op, shape, dtype or dtypes.default_float, Device.canonicalize(device), arg), dtype=dtype, device=device, **kwargs)
 
   @staticmethod
-  def empty(*shape, **kwargs):
-    return Tensor._loadop(LoadOps.EMPTY, argfix(*shape), **kwargs)
+  def empty(*shape, **kwargs): return Tensor._loadop(LoadOps.EMPTY, argfix(*shape), **kwargs)
 
   _seed: int = int(time.time())
   @staticmethod
   def manual_seed(seed=0): Tensor._seed = seed
 
   @staticmethod
-  def rand(*shape, **kwargs):
-    return Tensor._loadop(LoadOps.CUSTOM, argfix(*shape), arg=custom_random, **kwargs)
+  def rand(*shape, **kwargs): return Tensor._loadop(LoadOps.CUSTOM, argfix(*shape), arg=custom_random, **kwargs)
 
   # ***** creation helper functions *****
 


### PR DESCRIPTION
we can support jittable symbolic shape random with custom rand now, and we can formalize it in the test after threefry is ready