### PR TITLE
Support sum of bools

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -543,7 +543,8 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3,3,45,65), (3,3,65,45)], lambda x,y: x @ y, Tensor.dot, atol=1e-4)
   def test_sum_simple(self):
     helper_test_op(None, lambda x: x.sum(), Tensor.sum, vals=[[1.,1.]])
-    helper_test_op(None, lambda x: x.sum(), Tensor.sum, vals=[[True,False,True]], forward_only=True)
+    if Device.DEFAULT != "WEBGPU": # WEBGPU does not support boolean global vars
+      helper_test_op(None, lambda x: x.sum(), Tensor.sum, vals=[[True,False,True]], forward_only=True)
   def test_sum_full(self):
     helper_test_op([(16384)], lambda x: x.sum(), lambda x: x.sum())
   def test_sum_small_full(self):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -543,6 +543,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3,3,45,65), (3,3,65,45)], lambda x,y: x @ y, Tensor.dot, atol=1e-4)
   def test_sum_simple(self):
     helper_test_op(None, lambda x: x.sum(), Tensor.sum, vals=[[1.,1.]])
+    helper_test_op(None, lambda x: x.sum(), Tensor.sum, vals=[[True,False,True]], forward_only=True)
   def test_sum_full(self):
     helper_test_op([(16384)], lambda x: x.sum(), lambda x: x.sum())
   def test_sum_small_full(self):

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -150,6 +150,7 @@ class Where(Function):
 class Sum(Function):
   def forward(self, x:LazyBuffer, new_shape:Tuple[int, ...]) -> LazyBuffer:
     self.input_shape = x.shape
+    if x.dtype == dtypes.bool: x = x.cast(dtypes.int64)
     return x.r(ReduceOps.SUM, new_shape)
 
   def backward(self, grad_output:LazyBuffer) -> LazyBuffer:


### PR DESCRIPTION
mirrors torch's `torch.tensor([True, True, False]).sum()` output dtype and results. This unblocks dtypes math.