### PR TITLE
[Refactor] Potential speed-up in `get_linearizer_actions()` + 3 LoC saves

### DIFF
--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -47,7 +47,7 @@ def bufs_from_lin(lin:Linearizer) -> List[Buffer]:
 # get dictionary of all possible actions
 def get_linearizer_actions(lin:Linearizer, include_0=True) -> Dict[int, Linearizer]:
   acted_lins = {0:lin} if include_0 else {}
-  is_valid = lambda a: (a.axis is None) or (a.axis<lin.shape_len) or (lin.full_shape[a.axis] == a.amt and Opt(a.op, a.axis, 0) not in actions)
+  def is_valid(a): return (a.axis is None) or (a.axis<lin.shape_len) or (lin.full_shape[a.axis] == a.amt and Opt(a.op, a.axis, 0) not in actions)
   for i,a in enumerate(filter(is_valid, actions)):
     try:
       (lin2:=lin.copy()).apply_opt(a)


### PR DESCRIPTION
Potential performance improvements in this PR:

1) moved `if` logic inside of for-loop to a `filter`, which makes the code faster. Additionally, it arguably make the code more readable, and saves 1 LoC. It is possible to save one more LoC's, trading off readibility, by moving `is_valid` variable inside of the filter. 

2) Moved zip+for+if logic into a numpy array selection logic. It is much faster, but also have some overhead from list -> np.array conversion. Overall, it is probably faster. Need to do benchmarking


Ask: Please show me how to do performance benchmarking. Couldn't understand it from the code yet.