### PR TITLE
Move the webgpu CMPLT hack to one place

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -102,8 +102,8 @@ class LazyBuffer:
       else:
         srcs.append(s)
     assert all_same(dts:=[x.dtype.scalar() for x in (srcs if op != TernaryOps.WHERE else srcs[1:])]), f"all dtypes must match {dts} on {op}"
-    assert op != TernaryOps.WHERE or self.device != "WEBGPU" or srcs[0].dtype == dtypes.bool, "TernaryOps.WHERE must have the first arg be bool"
-    output_dtype = srcs[-1].dtype if op != BinaryOps.CMPLT else (dtypes.bool if self.device != "WEBGPU" else dtypes.float32)
+    if op == TernaryOps.WHERE: assert srcs[0].dtype == dtypes.bool, "TernaryOps.WHERE must have the first arg be bool"
+    output_dtype = srcs[-1].dtype if op != BinaryOps.CMPLT else dtypes.bool
     return create_lazybuffer(self.device, ShapeTracker.from_shape(self.shape), output_dtype, op, arg, tuple(srcs))
 
   # *** reduce ops ***

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -88,8 +88,9 @@ class Sigmoid(Function):
 
 class Less(Function):
   def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer:
+    out = x.e(BinaryOps.CMPLT, y)
     # in webgpu bool cannot be used as a storage buffer type
-    return x.e(BinaryOps.CMPLT, y).cast(dtypes.float if self.device == "WEBGPU" else dtypes.bool)
+    return out.cast(dtypes.float) if out.device == "WEBGPU" else out
 
 class Xor(Function):
   def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer:

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -1,6 +1,6 @@
 import math
 from typing import Tuple, Optional, cast
-from tinygrad.helpers import argsort, DType, dtypes
+from tinygrad.helpers import argsort, DType
 from tinygrad.ops import UnaryOps, BinaryOps, TernaryOps, ReduceOps
 from tinygrad.tensor import Function
 from tinygrad.lazy import LazyBuffer

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -88,9 +88,7 @@ class Sigmoid(Function):
 
 class Less(Function):
   def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer:
-    out = x.e(BinaryOps.CMPLT, y)
-    # in webgpu bool cannot be used as a storage buffer type
-    return out.cast(dtypes.float) if out.device == "WEBGPU" else out
+    return x.e(BinaryOps.CMPLT, y)
 
 class Xor(Function):
   def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Union, Type, Tuple, Any, List, Dict, Callable
 import functools
 from enum import Enum, auto
-from tinygrad.helpers import prod, DType, dedup
+from tinygrad.helpers import dtypes, prod, DType, dedup
 from tinygrad.shape.symbolic import Variable
 from dataclasses import dataclass
 
@@ -87,7 +87,7 @@ InterpretedFlopCounter: Dict[Op, Callable] = {
   BufferOps.STORE: lambda self,arg: FlopCounter(arg.st.shape, arg.dtype, self.consume_flops(), {**self.mem, arg.idx: arg.dtype.itemsize*arg.st.size()}),  # noqa: E501
   UnaryOps.CAST: lambda self,arg: FlopCounter(self.shape, arg[0], self.consume_flops(), self.mem),   # cast uses no flops
   **{op:lambda self: FlopCounter(self.shape, self.dtype, self.consume_flops() + prod(self.shape), self.mem) for op in UnaryOps if op != UnaryOps.CAST},  # noqa: E501
-  **{op:lambda self,y: FlopCounter(self.shape, self.dtype, self.consume_flops() + y.consume_flops() + prod(self.shape), {**self.mem, **y.mem}) for op in BinaryOps},  # noqa: E501
+  **{op:lambda self,y,op=op: FlopCounter(self.shape,  dtypes.bool if op == BinaryOps.CMPLT else self.dtype, self.consume_flops() + y.consume_flops() + prod(self.shape), {**self.mem, **y.mem}) for op in BinaryOps},  # noqa: E501
   **{op:lambda self,new_shape: FlopCounter(new_shape, self.dtype, self.consume_flops() + prod(self.shape), self.mem) for op in ReduceOps},
   TernaryOps.WHERE: lambda self,y,z: FlopCounter(self.shape, y.dtype, self.consume_flops() + y.consume_flops() + z.consume_flops() + prod(self.shape), {**self.mem, **y.mem, **z.mem})}  # noqa: E501
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -817,8 +817,13 @@ class Tensor:
   def __imatmul__(self, x) -> Tensor: return self.assign(self.matmul(x))
   def __ixor__(self, x) -> Tensor: return self.assign(self.xor(x))
 
-  def __lt__(self, x) -> Tensor: return mlops.Less.apply(*self._broadcasted(x, False))
-  def __gt__(self, x) -> Tensor: return mlops.Less.apply(*self._broadcasted(x, True))
+  # in webgpu bool cannot be used as a storage buffer type
+  def __lt__(self, x) -> Tensor:
+    out = mlops.Less.apply(*self._broadcasted(x, False))
+    return out.float() if self.device == "WEBGPU" else out
+  def __gt__(self, x) -> Tensor:
+    out = mlops.Less.apply(*self._broadcasted(x, True))
+    return out.float() if self.device == "WEBGPU" else out
   def __ge__(self, x) -> Tensor: return 1.0-(self<x)
   def __le__(self, x) -> Tensor: return 1.0-(self>x)
   def __ne__(self, x) -> Tensor: return (self<x) + (self>x)   # type: ignore[override]


### PR DESCRIPTION
The high-level problem is that we can't define globals with boolean buffers in webgpu. These hacks were first put in both lazy and mlops in #2888 and #2887 to cast the CMPLT output to float. This made it really hard to manage all the issues it caused with the UOps spec PR #2800.

these changes:
- ensure CMPLT is always a bool, we don't need the mlops bool cast
- remove the workaround in lazy asserts for webgpu, CMPLT _is_ still a bool in wgsl.