### PR TITLE
increase stable diffusion validation threshold 1e-4 -> 3e-4

### DIFF
--- a/examples/stable_diffusion.py
+++ b/examples/stable_diffusion.py
@@ -649,5 +649,5 @@ if __name__ == "__main__":
   if args.prompt == default_prompt and args.steps == 5 and args.seed == 0 and args.guidance == 7.5:
     ref_image = Tensor(np.array(Image.open(Path(__file__).parent / "stable_diffusion_seed0.png")))
     distance = (((x - ref_image).cast(dtypes.float) / ref_image.max())**2).mean().item()
-    assert distance < 1e-4, f"validation failed with {distance=}"
+    assert distance < 3e-4, f"validation failed with {distance=}"
     print(colored(f"output validated with {distance=}", "green"))


### PR DESCRIPTION
saw a flaky CI failure with 1.1e-4, and 3e-4 is a good number