### PR TITLE
add local ci scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
-    # TODO: run the pre-commit hook to replace a lot of this
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
@@ -29,42 +28,12 @@ jobs:
       with:
         path: ${{ env.Python3_ROOT_DIR }}/lib/python3.8/site-packages
         key: linting-packages-${{ hashFiles('**/setup.py') }}-3.8
-    - name: Install dependencies
-      run: pip install -e '.[linting,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
-    - name: Lint with pylint
-      run: python -m pylint --disable=all -e W0311 -e C0303 --jobs=0 --indent-string='  ' **/*.py
-    - name: Lint with ruff
-      run: |
-        pip3 install --upgrade --force-reinstall ruff
-        python3 -m ruff . --preview
-    - name: Lint tinygrad with pylint
-      run: python -m pylint tinygrad/
-    - name: Run mypy
-      run: python -m mypy
-    - name: Test Docs
-      run: |
-        python docs/abstractions.py
-        python docs/abstractions2.py
-    - name: Test Quickstart
-      run: awk '/```python/{flag=1;next}/```/{flag=0}flag' docs/quickstart.md > quickstart.py &&  PYTHONPATH=. python quickstart.py
-    - name: Fuzz Test symbolic
-      run: python test/external/fuzz_symbolic.py
-    - name: Fuzz Test shapetracker
-      run: |
-        PYTHONPATH="." python test/external/fuzz_shapetracker.py
-        PYTHONPATH="." python test/external/fuzz_shapetracker_math.py
-    - name: Test shapetracker to_movement_ops
-      run: PYTHONPATH="." python extra/to_movement_ops.py
-    - name: Use as an external package
-      run: |
-        mkdir $HOME/test_external_dir
-        cd $HOME/test_external_dir
-        python -m venv venv
-        source venv/bin/activate
-        pip install $GITHUB_WORKSPACE
-        python -c "from tinygrad.tensor import Tensor; print(Tensor([1,2,3,4,5]))"
-    - name: Repo line count <5000 lines
-      run: MAX_LINE_COUNT=5000 python sz.py
+    - name: Run Lint Script
+      run: bash lint.sh
+      shell: bash
+    - name: Run Fuzz Script
+      run: bash fuzz.sh
+      shell: bash
 
   testcpuimagenet:
     name: CPU and ImageNet to C Tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,23 +7,15 @@ repos:
         language: system
         always_run: true
         pass_filenames: false
-      - id: ruff
-        name: ruff
-        entry: ruff . --preview
+      - id: lint
+        name: lint files
+        entry: ./lint.sh
         language: system
         always_run: true
         pass_filenames: false
-      - id: mypy
-        name: mypy
-        entry: mypy tinygrad/
-        language: system
-        always_run: true
-        pass_filenames: false
-      - id: docs
-        name: docs
-        entry: |
-          python3 docs/abstractions.py
-          python3 docs/abstractions2.py
+      - id: fuzz
+        name: fuzz tests
+        entry: ./fuzz.sh
         language: system
         always_run: true
         pass_filenames: false
@@ -42,12 +34,6 @@ repos:
       - id: example
         name: multi device tests
         entry: python3 test/external/external_test_example.py
-        language: system
-        always_run: true
-        pass_filenames: false
-      - id: pylint
-        name: pylint
-        entry: env PYTHONPATH="." python3 -m pylint tinygrad/
         language: system
         always_run: true
         pass_filenames: false

--- a/fuzz.sh
+++ b/fuzz.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Run fuzz CI locally.
+set -xeuo pipefail
+
+readonly VENV_DIR=/tmp/tiny-env
+rm -rf "${VENV_DIR}"
+python3 -m venv "${VENV_DIR}"
+source "${VENV_DIR}/bin/activate"
+python --version
+
+# Install dependencies.
+pip install --upgrade pip setuptools wheel
+pip install -e '.[testing]'
+
+# Test docs.
+python docs/abstractions.py
+python docs/abstractions2.py
+
+# Test quickstart.
+awk '/```python/{flag=1;next}/```/{flag=0}flag' docs/quickstart.md > quickstart.py
+PYTHONPATH='.' python quickstart.py
+
+# Run fuzz tests.
+PYTHONPATH='.' python test/external/fuzz_symbolic.py
+PYTHONPATH='.' python test/external/fuzz_shapetracker.py
+PYTHONPATH='.' python test/external/fuzz_shapetracker_math.py
+
+# Test ShapeTracker to_movement_ops.
+python extra/to_movement_ops.py
+
+# Use as an external package.
+python -c "from tinygrad.tensor import Tensor; print(Tensor([1,2,3,4,5]))"
+
+# Clean up.
+set +u
+deactivate
+
+echo "Fuzzing passed. Congrats!"

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Run linter CI locally.
+set -xeuo pipefail
+
+readonly VENV_DIR=/tmp/tiny-env
+rm -rf "${VENV_DIR}"
+python3 -m venv "${VENV_DIR}"
+source "${VENV_DIR}/bin/activate"
+python --version
+
+# Install dependencies.
+pip install --upgrade pip setuptools wheel
+pip install -e '.[linting]'
+
+# Lint with pylint.
+PYLINT_ARGS="-efail -wfail -cfail -rfail"
+# Lint modules and tests separately.
+pylint --rcfile=.pylintrc --disable=all --enable=W0311,C0303 --jobs=0 --indent-string='  ' $(find tinygrad -name '*.py' | xargs) || pylint-exit $PYLINT_ARGS $?
+pylint --rcfile=.pylintrc --disable=all --enable=W0311,C0303 --jobs=0 --indent-string='  ' $(find test -name '*.py' | xargs) || pylint-exit $PYLINT_ARGS $?
+
+# Lint with ruff.
+ruff . --preview
+
+# Check types with mypy.
+mypy
+
+# Check line count.
+MAX_LINE_COUNT=5000 python sz.py
+
+# Clean up.
+set +u
+deactivate
+
+echo "Linting passed. Congrats!"

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,13 @@ setup(name='tinygrad',
         'webgpu': ["wgpu>=v0.12.0"],
         'linting': [
             "pylint",
+            "pylint-exit",
             "mypy",
             "typing-extensions",
             "pre-commit",
             "ruff",
             "types-tqdm",
+            "tabulate",
         ],
         'testing': [
             "torch",

--- a/test/imported/test_indexing.py
+++ b/test/imported/test_indexing.py
@@ -1060,10 +1060,10 @@ class TestIndexing(unittest.TestCase):
   '''
 
   def test_int_indices(self):
-      v = Tensor.randn(5, 7, 3)
-      numpy_testing_assert_equal_helper(v[[0, 4, 2]].shape, (3, 7, 3))
-      numpy_testing_assert_equal_helper(v[:, [0, 4, 2]].shape, (5, 3, 3))
-      numpy_testing_assert_equal_helper(v[:, [[0, 1], [4, 3]]].shape, (5, 2, 2, 3))
+    v = Tensor.randn(5, 7, 3)
+    numpy_testing_assert_equal_helper(v[[0, 4, 2]].shape, (3, 7, 3))
+    numpy_testing_assert_equal_helper(v[:, [0, 4, 2]].shape, (5, 3, 3))
+    numpy_testing_assert_equal_helper(v[:, [[0, 1], [4, 3]]].shape, (5, 2, 2, 3))
 
   # TODO setindex
   '''


### PR DESCRIPTION
This change adds two CI scripts, `lint.sh` and `fuzz.sh`. They contain the lint and fuzz steps from the `Unit Test` workflow, making them reproducible across local environments and GitHub Actions.