### PR TITLE
Disk shm refactor

### DIFF
--- a/test/test_copy_speed.py
+++ b/test/test_copy_speed.py
@@ -1,7 +1,7 @@
 import unittest
 from tinygrad import Tensor
 from tinygrad import Device
-from tinygrad.helpers import Timing, CI, OSX
+from tinygrad.helpers import Timing, CI
 import multiprocessing.shared_memory as shared_memory
 
 N = 4096 if CI else 16384

--- a/test/test_copy_speed.py
+++ b/test/test_copy_speed.py
@@ -9,7 +9,6 @@ class TestCopySpeed(unittest.TestCase):
   @classmethod
   def setUpClass(cls): Device[Device.DEFAULT].synchronize()
 
-  @unittest.skipIf(OSX, "no shm on OSX")
   def testCopySHMtoDefault(self):
     s = shared_memory.SharedMemory(name="test_X", create=True, size=N*N*4)
     s.close()

--- a/test/test_copy_speed.py
+++ b/test/test_copy_speed.py
@@ -1,7 +1,7 @@
 import unittest
 from tinygrad import Tensor
 from tinygrad import Device
-from tinygrad.helpers import Timing, CI
+from tinygrad.helpers import Timing, CI, OSX
 import multiprocessing.shared_memory as shared_memory
 
 N = 4096 if CI else 16384
@@ -12,7 +12,7 @@ class TestCopySpeed(unittest.TestCase):
   def testCopySHMtoDefault(self):
     s = shared_memory.SharedMemory(name="test_X", create=True, size=N*N*4)
     s.close()
-    if CI:
+    if CI and not OSX:
       t = Tensor.empty(N, N, device="disk:/dev/shm/test_X").realize()
     else:
       t = Tensor.empty(N, N, device="disk:shm:test_X").realize()

--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -1,6 +1,4 @@
-import os, mmap
-try: import _posixshmem
-except Exception: pass
+import os, mmap, _posixshmem
 from typing import Callable, Dict, Tuple
 from tinygrad.helpers import prod, DType, OSX, dtypes
 from tinygrad.device import Interpreted, Allocator
@@ -27,21 +25,15 @@ class DiskBuffer:
 
 disk_fxn_for_op: Dict[Op, Callable] = { UnaryOps.CAST: DiskBuffer.cast, MovementOps.AS_STRIDED: DiskBuffer.as_strided }
 
-MAP_LOCKED, MAP_POPULATE = 0x2000, 0x008000
+MAP_LOCKED, MAP_POPULATE, MADV_HUGEPAGE = 0 if OSX else 0x2000, getattr(mmap, "MAP_POPULATE", 0 if OSX else 0x008000), getattr(mmap, "MADV_HUGEPAGE", None)
 class DiskAllocator(Allocator):
   def __init__(self, device): self.device = device
   def _alloc(self, size):
     if str(self.device).startswith("shm:"):
-      if OSX:
-        with open(f"/tmp/shm_{self.device[4:]}", "w+b") as f:
-          f.truncate(size)
-          shm = mmap.mmap(f.fileno(), size, flags=mmap.MAP_SHARED)
-      else:
-        fd = _posixshmem.shm_open(self.device[4:], os.O_RDWR, 0o600)
-        # TODO: these flags are somewhat platform specific, but python doesn't expose the ones we need
-        shm = mmap.mmap(fd, size, flags=mmap.MAP_SHARED | MAP_LOCKED | MAP_POPULATE)
-        shm.madvise(mmap.MADV_HUGEPAGE)     # type: ignore   # not on OSX
-        os.close(fd)
+      fd = _posixshmem.shm_open("/"+self.device[4:], os.O_RDWR, 0o600)
+      shm = mmap.mmap(fd, size, flags=mmap.MAP_SHARED | MAP_POPULATE | MAP_LOCKED)
+      if MADV_HUGEPAGE is not None: shm.madvise(MADV_HUGEPAGE) # type: ignore
+      os.close(fd)
       buf = UnderlyingDiskBuffer(None, shm)
     else:
       f = open(self.device, "a+b")

--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -30,7 +30,7 @@ class DiskAllocator(Allocator):
   def __init__(self, device): self.device = device
   def _alloc(self, size):
     if str(self.device).startswith("shm:"):
-      fd = _posixshmem.shm_open("/"+self.device[4:], os.O_RDWR, 0o600)
+      fd = _posixshmem.shm_open("/"+self.device[4:].lstrip("/"), os.O_RDWR, 0o600)
       shm = mmap.mmap(fd, size, flags=mmap.MAP_SHARED | MAP_POPULATE | MAP_LOCKED)
       if (hp := getattr(mmap, "MADV_HUGEPAGE", None)) is not None: shm.madvise(hp) # type: ignore
       os.close(fd)


### PR DESCRIPTION
1. We don't need `try: import _posixshmem` because tinygrad dropped support for windows in [v0.7.0](https://github.com/tinygrad/tinygrad/releases/tag/v0.7.0)
2. python >=3.10 mmap module exposes MAP_POPULATE [issue](https://github.com/python/cpython/issues/84791). After tinygrad switches its minimum version to 3.10 we can remove platform dependant check `0 if OSX else 0x008000`
3. MAP_LOCKED is still not exposed
4. MADV_HUGEPAGE is actually exposed in python >=3.8, so we can just check that attribute from mmap module
5. Leading slash is always prepended [shared_memory.py](https://github.com/python/cpython/blob/main/Lib/multiprocessing/shared_memory.py#L73)