### PR TITLE
Fix LLVM issue with bitcast+fptrunc vectorization and add type load/downconversion test

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -128,7 +128,6 @@ class TestDType(unittest.TestCase):
     def from_TstoTs(T1, T2): return reduce(lambda x, y: x+y, [tt(t) for t in (T1) for tt in T2])
     broken = {
       'TORCH':from_TstoTs((dt.half, dt.float, dt.double), (from_T2Achar,)) + ((dt.short, dt.float),) + ((dt.short, dt.double),),
-      'LLVM':from_T2Achar(dt.float) + from_T2Ashort(dt.float) + from_T2Achar(dt.half),
       'CPU':from_TstoTs((dt.half, dt.float, dt.double), (from_T2Achar,)) + from_TstoTs((dt.float, dt.double), (from_T2Ashort,)) +
             ((dt.uint, dt.double),),
       'CLANG':from_TstoTs((dt.float, dt.double), (from_T2Achar, from_T2Ashort)) + from_T2Achar(dt.half) + ((dt.uint, dt.double),),

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -26,9 +26,8 @@ class TestTorchLoad(unittest.TestCase):
   def test_load_convnext(self): compare_weights_both('https://dl.fbaipublicfiles.com/convnext/convnext_tiny_1k_224_ema.pth')
 
   # for GPU, cl_khr_fp16 isn't supported
-  # for LLVM, it segfaults because it can't link to the casting function
   # CUDACPU architecture is sm_35 but we need at least sm_70 to run fp16 ALUs
-  @unittest.skipIf(Device.DEFAULT in ["GPU", "LLVM", "CUDA"] and CI, "fp16 broken in some backends")
+  @unittest.skipIf(Device.DEFAULT in ["GPU", "CUDA"] and CI, "fp16 broken in some backends")
   @unittest.skipIf(Device.DEFAULT == "TORCH", "torch doesn't support the way we load bfloat (cast to uint32)")
   def test_load_llama2bfloat(self): compare_weights_both("https://huggingface.co/qazalin/bf16-lightweight/resolve/main/consolidated.00.pth?download=true")
 

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -65,9 +65,7 @@ class Linearizer(Kernel):
   def get_reduce_acc(self, reduceop:LazyOp):
     dtype = get_lazyop_info(reduceop).dtype
     if reduceop.op == ReduceOps.SUM: return 0.0 if dtypes.is_float(dtype) else 0
-    elif reduceop.op == ReduceOps.MAX:
-      if dtypes.is_int(dtype): return 0 if dtypes.is_unsigned(dtype) else -2**(dtype.itemsize*8-1)
-      return -math.inf if dtypes.is_float(dtype) else False
+    elif reduceop.op == ReduceOps.MAX: return dtypes.min_val(dtype)
 
   # NOTE: once images are loaded, we uop them as their base float
   def get_base_dtype(self, dt:DType): return dt.base if isinstance(dt, ImageDType) else dt

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -1,3 +1,4 @@
+from math import inf
 from typing import Final, Optional, ClassVar, Set, Tuple, Dict, Any
 from dataclasses import dataclass, field
 import numpy as np  # TODO: remove numpy
@@ -48,6 +49,10 @@ class dtypes:
   def from_py(x) -> DType: return dtypes.default_float if isinstance(x, float) else dtypes.bool if isinstance(x, bool) else dtypes.default_int
   @staticmethod
   def fields() -> Dict[str, DType]: return DTYPES_DICT
+  @staticmethod
+  def min_val(x: DType): return (False, -inf, -2**(x.itemsize*8-1), 0)[int(dtypes.is_float(x)) + dtypes.is_int(x)*(2 + dtypes.is_unsigned(x))]
+  @staticmethod
+  def max_val(x: DType): return inf if dtypes.is_float(x) else ((2**(x.itemsize*8-int(not dtypes.is_unsigned(x))))-1 if dtypes.is_int(x) else True)
   bool: Final[DType] = DType(0, 1, "bool", np.bool_)
   int8: Final[DType] = DType(1, 1, "char", np.int8)
   uint8: Final[DType] = DType(2, 1, "unsigned char", np.uint8)

--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -21,9 +21,9 @@ class LLVM:
     llvm.initialize_native_target()
     llvm.initialize_native_asmprinter()
     llvm.initialize_native_asmparser()
-    target = llvm.Target.from_triple(llvm.get_process_triple())
-    LLVM.optimizer = llvm.create_module_pass_manager()
-    LLVM.target_machine = target.create_target_machine(opt=2)  # this opt actually can change things. ex: opt=3 means no FMA, opt=2 means FMA
+    target = llvm.Target.from_triple(ptrip:=llvm.get_process_triple())
+    LLVM.optimizer, attrs = llvm.create_module_pass_manager(), '+f16c' if ptrip.startswith('x86_64-') else None # f16c is for FP16 support
+    LLVM.target_machine = target.create_target_machine(opt=2, features=attrs)
     LLVM.target_machine.add_analysis_passes(LLVM.optimizer)
 
     # TODO: this makes compile times so much faster

--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -33,11 +33,8 @@ class LLVM:
       #llvm.set_option(str(), '--debug')
 
       # does this do anything?
-      builder = llvm.create_pass_manager_builder()
-      builder.opt_level = 3
+      builder = llvm.create_pass_manager_builder(opt=3, loop_vectorize=True, slp_vectorize=True)
       builder.size_level = 0
-      builder.loop_vectorize = True
-      builder.slp_vectorize = True
       builder.populate(LLVM.optimizer)
 
     LLVM.target_machine.set_asm_verbosity(True)


### PR DESCRIPTION
This patch is expected to fix Issue #1367 as well as add some tests around various types being downconverted after loading from disk. The test brings to light various inconsistencies that conversion might go with different backends and different type permutations, as well as hopefully help us to clean it over time to make it all more consistent.

The goal over time would be to reduce broken to 0.

The original bug I was after causes crash in the llvm-generated code, and it's only happens when the compiler sees multiple fptrunc operations like so:

```
define void @"E_4194304_4"(half* noalias %".1", i32* noalias %".2") "no-nans-fp-math"="true"
{
[...]
  %".17" = bitcast i32 %".7" to float
  %".18" = bitcast i32 %".10" to float
  %".19" = bitcast i32 %".13" to float
  %".20" = bitcast i32 %".16" to float
  %".21" = fptrunc float %".17" to half
  %".22" = fptrunc float %".18" to half
  %".23" = fptrunc float %".19" to half
  %".24" = fptrunc float %".20" to half
```

The code was crashing so dive into gdb revealed this:

```
Dump of assembler code for function E_4194304_4:
   0x00007ffff7bcd000 <+0>:  push   %rbp
   0x00007ffff7bcd001 <+1>:  push   %r15
   0x00007ffff7bcd003 <+3>:  push   %r14
   0x00007ffff7bcd005 <+5>:  push   %r13
   0x00007ffff7bcd007 <+7>:  push   %r12
   0x00007ffff7bcd009 <+9>:  push   %rbx
   0x00007ffff7bcd00a <+10>: sub    $0x18,%rsp
   0x00007ffff7bcd00e <+14>: mov    %rsi,%rbx
   0x00007ffff7bcd011 <+17>: mov    %rdi,%r14
   0x00007ffff7bcd014 <+20>: add    $0xc,%rbx
   0x00007ffff7bcd018 <+24>: xor    %ebp,%ebp
   0x00007ffff7bcd01a <+26>: movabs $0x0,%r15
   0x00007ffff7bcd024 <+36>: cs nopw 0x0(%rax,%rax,1)
   0x00007ffff7bcd02e <+46>: xchg   %ax,%ax
   0x00007ffff7bcd030 <+48>: movss  -0xc(%rbx),%xmm0
   0x00007ffff7bcd035 <+53>: movss  -0x8(%rbx),%xmm1
   0x00007ffff7bcd03a <+58>: movss  %xmm1,0xc(%rsp)
   0x00007ffff7bcd040 <+64>: movss  -0x4(%rbx),%xmm1
   0x00007ffff7bcd045 <+69>: movss  %xmm1,0x10(%rsp)
   0x00007ffff7bcd04b <+75>: movss  (%rbx),%xmm1
   0x00007ffff7bcd04f <+79>: movss  %xmm1,0x14(%rsp)
=> 0x00007ffff7bcd055 <+85>: call   *%r15
   0x00007ffff7bcd058 <+88>: mov    %ax,0xa(%rsp)
   0x00007ffff7bcd05d <+93>: movss  0xc(%rsp),%xmm0
```

%r15 is very obviously 0 at this point, so trying to compile the IR with the lcc gave me this:

```
        movss   -12(%r15), %xmm0                # xmm0 = mem[0],zero,zero,zero
        movss   -8(%r15), %xmm1                 # xmm1 = mem[0],zero,zero,zero
        movss   %xmm1, 32(%rsp)                 # 4-byte Spill
        movss   -4(%r15), %xmm1                 # xmm1 = mem[0],zero,zero,zero
        movss   %xmm1, 16(%rsp)                 # 4-byte Spill
        movss   (%r15), %xmm1                   # xmm1 = mem[0],zero,zero,zero
        movss   %xmm1, 12(%rsp)                 # 4-byte Spill
        callq   __truncsfhf2@PLT
        movaps  %xmm0, 48(%rsp)                 # 16-byte Spill
        movss   32(%rsp), %xmm0                 # 4-byte Reload
                                        # xmm0 = mem[0],zero,zero,zero
        callq   __truncsfhf2@PLT
```

Which was a bit unexpected but gave me a clue. So after trying few things that did not work, the +f16c' seems to do the trick.

None of the existing dtype tests hit the issue since you'd need multiple conversion operations to trigger the vectorization.

I've fixed the llvm so it passes all checks, as a bonus I've fixed coder to check if bfloat is supported and fallback to do conversion via LLVM backend if not. This makes coder working with GPU and TORCH, however for some reason it produces gibberish on torch (uint support is lacking?)