### PR TITLE
[RDNA3_EMU][1/n] Add new compile_hip function to generate llvm bitcode + asm

### DIFF
--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -18,6 +18,10 @@ def hip_time_execution(cb, enable=False): return time_execution_cuda_style(cb, h
 @diskcache
 def compile_hip(prg) -> bytes: return compile_cuda_style(prg, [f'--offload-arch={HIPDevice.default_arch_name}'], hip.hiprtcProgram, hip.hiprtcCreateProgram, hip.hiprtcCompileProgram, hip.hiprtcGetCode, hip.hiprtcGetCodeSize, hip.hiprtcGetProgramLog, hip.hiprtcGetProgramLogSize, check)  # noqa: E501
 
+# Compile hip to llvm ir bitcode
+@diskcache
+def compile_hip_bc(prg) -> bytes: return compile_cuda_style(prg, [f'--offload-arch={HIPDevice.default_arch_name}', '-fgpu-rdc'], hip.hiprtcProgram, hip.hiprtcCreateProgram, hip.hiprtcCompileProgram, hip.hiprtcGetBitcode, hip.hiprtcGetBitcodeSize, hip.hiprtcGetProgramLog, hip.hiprtcGetProgramLogSize, check)  # noqa: E501
+
 class HIPProgram:
   def __init__(self, device:int, name:str, lib:bytes):
     self.device, self.name, self.lib = device, name, lib


### PR DESCRIPTION
For testing purposes we want to create asm to ingest into the rdna3 emulator. By using different hiprtc functions and a new flag (hiprtcGetBitcode, hiptrtcGetBitcodeSize, and -fgpu-rpc) we can generate llvm IR bitcode.

We can then use llc -o <ir> to create proper  AMD assembly.

I've modified the test to use this multi-step hip compilation so we can ingest the asm into the emulator.

Next steps include parsing the assembly and obviously emulating the rdna3 ISA.