### PR TITLE
Upgraded nn.Embedding

### DIFF
--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -127,5 +127,5 @@ class Embedding:
     self.weight = Tensor.glorot_uniform(vocab_size, embed_size)
 
   def __call__(self, idx:Tensor) -> Tensor:
-    if not hasattr(self, 'vocab_counter'): self.vocab_counter = Tensor.arange(self.vocab_size, requires_grad=False).reshape(1, 1, self.vocab_size)
-    return (self.vocab_counter == idx.unsqueeze(2)).expand(*idx.shape, self.vocab_size) @ self.weight
+    if not hasattr(self, 'vocab_counter'): self.vocab_counter = Tensor.arange(self.vocab_size, requires_grad=False).reshape(1, 1, self.vocab_size, 1)
+    return ((idx.reshape(*idx.shape, 1, 1).expand(*idx.shape, 1, self.weight.shape[-1]) == self.vocab_counter) * self.weight).sum(-2)


### PR DESCRIPTION
The following PR is trying to address the `O(n) nn.Embedding in one kernel without new ops (supporting BS=128)` bounty

# Kernels

The below kernels were generated with vocab_size=512, embed_size=256, batch_size=128, and after a "warmup" run to realize all of the first-time tensors.

## Kernels Before (NOOPT=1)
```c
extern "C" __global__ void E_128_512(float* data0, const int* data1, const int* data2) {
  int gidx0 = blockIdx.y; /* 128 */
  int gidx1 = blockIdx.x; /* 512 */
  int val0 = data1[gidx1];
  int val1 = data2[gidx0];
  data0[(gidx0*512)+gidx1] = (1.0f-(float)(((val0<val1)+(val1<val0))));
}

extern "C" __global__ void r_128_256_512(float* data0, const float* data1, const float* data2) {
  int gidx0 = blockIdx.y; /* 128 */
  int gidx1 = blockIdx.x; /* 256 */
  float acc0 = 0.0f;
  for (int ridx0 = 0; ridx0 < 512; ridx0++) {
    float val0 = data1[(gidx0*512)+ridx0];
    float val1 = data2[gidx1+(ridx0*256)];
    acc0 = ((val0*val1)+acc0);
  }
  data0[(gidx0*256)+gidx1] = acc0;
}
```

## Kernel After (NOOPT=1)
```c
extern "C" __global__ void r_128_256_512(float* data0, const int* data1, const int* data2, const float* data3) {
  int gidx0 = blockIdx.y; /* 128 */
  int gidx1 = blockIdx.x; /* 256 */
  float acc0 = 0.0f;
  int val0 = data1[gidx0];
  for (int ridx0 = 0; ridx0 < 512; ridx0++) {
    int val1 = data2[ridx0];
    float val2 = data3[gidx1+(ridx0*256)];
    acc0 = (((1.0f-(float)(((val0<val1)+(val1<val0))))*val2)+acc0);
  }
  data0[(gidx0*256)+gidx1] = acc0;
}
```

# Performance

The below kernels were generated with vocab_size=512, embed_size=256, batch_size=1280x1280 for 20 times per iteration with inputs pre-realized before timing started.

## Performance Before
```
git checkout master
python3 playground.py
Running 50 iterations (with 10 warmup)
avg: 0.04312, std: 0.00155
global mem used: 10165.27 GB
```

## Performance After
```
git checkout nn-embedding-optim
python3 playground.py
Running 50 iterations (with 10 warmup)
avg: 0.03632, std: 0.00242
global mem used: 2112.20 GB
```

18.7% speedup while using 20.8% the memory

# Future Improvements

With the current set of ops we are required to multiply every idx entry against the entire weights tensor, even though we only need to for a specific row. This causes the framework to perform dead ops, scaling linearly with vocab size.

While tinygrad does support tensor indexing, that is currently being achieved through a method very similar to that in the old and new nn.Embedding class and comes with the same scaling issues.

If an index op would be added to tinygrad this scaling issue could be addressed, but is out of scope for this PR / bounty as adding new ops was explicitly verboten.