### PR TITLE
Fixed Tensor.randint() not accepting tuple shapes

### DIFF
--- a/test/test_randomness.py
+++ b/test/test_randomness.py
@@ -47,10 +47,11 @@ def equal_distribution(tiny_func, torch_func=None, numpy_func=None, shape=(20, 2
   torch.manual_seed(1337)
   np.random.seed(1337)
   assert not (torch_func is None and numpy_func is None), "no function to compare with"
-  x = tiny_func(*shape).numpy().flatten()
+  x1 = tiny_func(*shape).numpy().flatten()
+  x2 = tiny_func(shape).numpy().flatten()
   if numpy_func is not None: y = numpy_func(shape).flatten()
   if torch_func is not None: z = torch_func(shape).numpy().flatten()
-  return (numpy_func is None or kstest(x, y) >= alpha) and (torch_func is None or kstest(x, z) >= alpha)
+  return (numpy_func is None or (kstest(x1, y) >= alpha and kstest(x2, y) >= alpha)) and (torch_func is None or (kstest(x1, z) >= alpha and kstest(x2, z) >= alpha))
 
 def normal_test(func, shape=(20, 23), alpha=0.05): return equal_distribution(func, numpy_func=lambda x: np.random.randn(*x), shape=shape, alpha=alpha)
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -190,7 +190,7 @@ class Tensor:
   @staticmethod
   def randn(*shape, dtype:Optional[DType]=None, **kwargs) -> Tensor:
     # https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
-    src = Tensor.rand(2, *shape, **kwargs)
+    src = Tensor.rand((2, *argfix(*shape)), **kwargs)
     return src[0].mul(2*math.pi).cos().mul((1 - src[1]).log().mul(-2).sqrt()).cast(dtype or dtypes.default_float)
 
   @staticmethod
@@ -205,22 +205,22 @@ class Tensor:
     return ((high-low) * Tensor.rand(*shape, **kwargs)).cast(dtype) + low
 
   @staticmethod
-  def scaled_uniform(*shape, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs).mul(prod(shape)**-0.5)
+  def scaled_uniform(*shape, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs).mul(prod(argfix(*shape))**-0.5)
 
   # https://www.tensorflow.org/api_docs/python/tf/keras/initializers/GlorotUniform
   @staticmethod
-  def glorot_uniform(*shape, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs).mul((6/(shape[0]+prod(shape[1:])))**0.5)
+  def glorot_uniform(*shape, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs).mul((6/(argfix(*shape)[0]+prod(argfix(*shape)[1:])))**0.5)
 
   # https://pytorch.org/docs/stable/_modules/torch/nn/init.html#kaiming_uniform_
   @staticmethod
   def kaiming_uniform(*shape, a:float = 0.01, **kwargs) -> Tensor:
-    bound = math.sqrt(3.0) * math.sqrt(2.0 / (1 + a ** 2)) / math.sqrt(prod(shape[1:]))
+    bound = math.sqrt(3.0) * math.sqrt(2.0 / (1 + a ** 2)) / math.sqrt(prod(argfix(*shape)[1:]))
     return Tensor.uniform(*shape, low=-bound, high=bound, **kwargs)
 
   # https://pytorch.org/docs/stable/_modules/torch/nn/init.html#kaiming_normal_
   @staticmethod
   def kaiming_normal(*shape, a:float = 0.01, **kwargs) -> Tensor:
-    std = math.sqrt(2.0 / (1 + a ** 2)) / math.sqrt(prod(shape[1:]))
+    std = math.sqrt(2.0 / (1 + a ** 2)) / math.sqrt(prod(argfix(*shape)[1:]))
     return Tensor.normal(*shape, mean=0.0, std=std, **kwargs)
 
   def multinomial(self:Tensor, num_samples:int = 1, replacement:bool = False) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -209,7 +209,7 @@ class Tensor:
 
   # https://www.tensorflow.org/api_docs/python/tf/keras/initializers/GlorotUniform
   @staticmethod
-  def glorot_uniform(*shape, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs).mul((6/(argfix(*shape)[0]+prod(argfix(*shape)[1:])))**0.5)
+  def glorot_uniform(*shape, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs).mul((6/(argfix(*shape)[0]+prod(argfix(*shape)[1:])))**0.5) # noqa: E501
 
   # https://pytorch.org/docs/stable/_modules/torch/nn/init.html#kaiming_uniform_
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -209,7 +209,7 @@ class Tensor:
 
   # https://www.tensorflow.org/api_docs/python/tf/keras/initializers/GlorotUniform
   @staticmethod
-  def glorot_uniform(*shape, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs).mul((6/(argfix(*shape)[0]+prod(argfix(*shape)[1:])))**0.5) # noqa: E501
+  def glorot_uniform(*shape, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs)*((6/(argfix(*shape)[0]+prod(argfix(*shape)[1:])))**0.5)
 
   # https://pytorch.org/docs/stable/_modules/torch/nn/init.html#kaiming_uniform_
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -209,7 +209,8 @@ class Tensor:
 
   # https://www.tensorflow.org/api_docs/python/tf/keras/initializers/GlorotUniform
   @staticmethod
-  def glorot_uniform(*shape, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs)*((6/(argfix(*shape)[0]+prod(argfix(*shape)[1:])))**0.5)
+  def glorot_uniform(*shape, **kwargs) -> Tensor:
+    return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs)*((6/(argfix(*shape)[0]+prod(argfix(*shape)[1:])))**0.5)
 
   # https://pytorch.org/docs/stable/_modules/torch/nn/init.html#kaiming_uniform_
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -194,7 +194,7 @@ class Tensor:
     return src[0].mul(2*math.pi).cos().mul((1 - src[1]).log().mul(-2).sqrt()).cast(dtype or dtypes.default_float)
 
   @staticmethod
-  def randint(*shape, low=0, high=10, **kwargs) -> Tensor: return Tensor.uniform(shape, low=low, high=high, dtype=dtypes.int32)
+  def randint(*shape, low=0, high=10, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=low, high=high, dtype=dtypes.int32)
 
   @staticmethod
   def normal(*shape, mean=0.0, std=1.0, **kwargs) -> Tensor: return (std * Tensor.randn(*shape, **kwargs)) + mean

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -210,7 +210,7 @@ class Tensor:
   # https://www.tensorflow.org/api_docs/python/tf/keras/initializers/GlorotUniform
   @staticmethod
   def glorot_uniform(*shape, **kwargs) -> Tensor:
-    return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs)*((6/(argfix(*shape)[0]+prod(argfix(*shape)[1:])))**0.5)
+    return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs).mul((6/(argfix(*shape)[0]+prod(argfix(*shape)[1:])))**0.5)
 
   # https://pytorch.org/docs/stable/_modules/torch/nn/init.html#kaiming_uniform_
   @staticmethod


### PR DESCRIPTION
Fixed an issue where Tensor.randint((4,4)) was causing errors due to a missing asterisk (*) in the static method, a bug introduced a week ago. Additionally, updated several other tensor methods related to randomness to align more closely with PyTorch standards and other Tinygrad methods. Tests have been revised to include checks for both 2,3 and *(2,3) shape inputs.

- Added asterisk 
- Updated Randomness tests

Old Version 
```python
In [1]: from tinygrad.tensor import Tensor

In [2]: a = Tensor.randint((4,4))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 a = Tensor.randint((4,4))

File ~/tinygrad/tinygrad/tensor.py:197, in Tensor.randint(low, high, *shape, **kwargs)
    196 @staticmethod
--> 197 def randint(*shape, low=0, high=10, **kwargs) -> Tensor: return Tensor.uniform(shape, low=low, high=high, dtype=dtypes.int32)

File ~/tinygrad/tinygrad/tensor.py:205, in Tensor.uniform(low, high, *shape, **kwargs)
    202 @staticmethod
    203 def uniform(*shape, low=0.0, high=1.0, **kwargs) -> Tensor:
    204   dtype = kwargs.pop("dtype", dtypes.default_float)
--> 205   return ((high-low) * Tensor.rand(*shape, **kwargs)).cast(dtype) + low

File ~/tinygrad/tinygrad/tensor.py:805, in Tensor.__rmul__(self, x)
--> 805 def __rmul__(self, x) -> Tensor: return self.mul(x, True)

File ~/tinygrad/tinygrad/tensor.py:757, in Tensor.mul(self, x, reverse)
    755 if x.__class__ is not Tensor and x == 0.0: return mlops.Zero.apply(self)
    756 if x.__class__ is not Tensor and x == -1.0: return -self
--> 757 return mlops.Mul.apply(*self._broadcasted(x, reverse)) if x.__class__ is Tensor or x != 1.0 else self

File ~/tinygrad/tinygrad/tensor.py:740, in Tensor._broadcasted(self, y, reverse, match_dtype)
    737 if len(y.shape) < len(x.shape): y = y.reshape((1,) * (len(x.shape) - len(y.shape)) + y.shape)
    738 elif len(x.shape) < len(y.shape): x = x.reshape((1,) * (len(y.shape) - len(x.shape)) + x.shape)
--> 740 broadcasted_shape = tuple(max(xi, yi) for xi, yi in zip(x.shape, y.shape))
    741 return x.expand(broadcasted_shape), y.expand(broadcasted_shape)

File ~/tinygrad/tinygrad/tensor.py:740, in <genexpr>(.0)
    737 if len(y.shape) < len(x.shape): y = y.reshape((1,) * (len(x.shape) - len(y.shape)) + y.shape)
    738 elif len(x.shape) < len(y.shape): x = x.reshape((1,) * (len(y.shape) - len(x.shape)) + x.shape)
--> 740 broadcasted_shape = tuple(max(xi, yi) for xi, yi in zip(x.shape, y.shape))
    741 return x.expand(broadcasted_shape), y.expand(broadcasted_shape)

TypeError: '>' not supported between instances of 'tuple' and 'int'
```

New Version
```python
In [1]: from tinygrad.tensor import Tensor

In [2]: a = Tensor.randint((4,4))

In [3]: a.numpy()
Out[3]:
array([[4, 4, 2, 2],
       [2, 2, 5, 8],
       [2, 5, 4, 9],
       [1, 0, 3, 7]], dtype=int32)

In [4]:
```