### PR TITLE
Change enum syntax

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import os, math, itertools
-from typing import NamedTuple, Optional, List, Tuple, cast, Dict, Union
+from typing import NamedTuple, Optional, List, Tuple, cast, Dict, Union, Callable
 from tinygrad.ops import LazyOp, FlopCounter, get_lazyop_info, UnaryOps, BinaryOps, ReduceOps, MemBuffer, ConstBuffer, BufferOps, vars_from_ast
 from tinygrad.device import Device, Compiled
 from tinygrad.helpers import dedup, dtypes, colored, ImageDType, DType, ansilen, getenv, prod, DEBUG, round_up
@@ -8,12 +8,10 @@ from tinygrad.shape.shapetracker import ShapeTracker, get_contraction
 from tinygrad.shape.symbolic import sint
 from tinygrad.shape.view import View, strides_for_shape
 from dataclasses import dataclass
-from enum import Enum, auto
+from enum import Enum
 
-class OptOps(Enum):
-  UPCAST = auto(); UPCASTMID = auto(); UNROLL = auto(); LOCAL = auto(); LASTLOCAL = auto() # noqa: E702
-  GROUP = auto(); GROUPTOP = auto(); NOLOCALS = auto(); PADTO = auto() # noqa: E702
-  def __lt__(self, x:OptOps): return self.value < x.value
+OptOps = Enum('OptOps', ['UPCAST', 'UPCASTMID', 'UNROLL', 'LOCAL', 'LASTLOCAL', 'GROUP', 'GROUPTOP', 'NOLOCALS', 'PADTO'])
+OptOps.__lt__: Callable[[OptOps, OptOps], bool] = lambda self, other: self.value < other.value #type: ignore
 
 @dataclass(frozen=True, order=True)
 class Opt:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import List, Tuple, Any, Optional, cast, DefaultDict, Dict, Union, Sequence, Final, Set
 import itertools, math, functools
 from collections import defaultdict
-from enum import Enum, auto
+from enum import Enum
 from dataclasses import dataclass
 
 from tinygrad.helpers import colored, ImageDType, DEBUG, dtypes, DType, prod, PtrDType, getenv, all_same, to_function_name, flatten
@@ -13,11 +13,7 @@ from tinygrad.codegen.kernel import LocalBuffer, Kernel
 from tinygrad.features.image import to_image_idx
 
 # bottom ones are asm only
-class UOps(Enum):
-  LOOP = auto(); IF = auto(); END = auto(); SPECIAL = auto() # loops can be global, local, or other # noqa: E702
-  DEFINE_GLOBAL = auto(); DEFINE_LOCAL = auto(); DEFINE_ACC = auto() # this defines buffers # noqa: E702
-  LOAD = auto(); STORE = auto(); CONST = auto(); BARRIER = auto(); PHI = auto() # noqa: E702
-  ALU = auto(); WMMA = auto(); CAST = auto(); GEP = auto() # noqa: E702
+UOps = Enum("UOps", ['LOOP', 'IF', 'END', 'SPECIAL', 'DEFINE_GLOBAL', 'DEFINE_LOCAL', 'DEFINE_ACC', 'LOAD', 'STORE', 'CONST', 'BARRIER', 'PHI', 'ALU', 'WMMA', 'CAST', 'GEP']) #noqa: E501
 
 @dataclass(eq=False)
 class UOp:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Union, Type, Tuple, Any, List, Dict, Callable
 import functools
-from enum import Enum, auto
+from enum import Enum
 from tinygrad.helpers import dtypes, prod, DType, dedup
 from tinygrad.shape.symbolic import Variable
 from dataclasses import dataclass
@@ -10,14 +10,14 @@ from dataclasses import dataclass
 # the Enum class doesn't work with mypy, this is static. sorry it's ugly
 # NOTE: MOD, CMPLT don't have to be implemented on vectors, just scalars
 # NOTE: rdna3 only has RECIP and not DIV. DIV is on the chopping block
-class UnaryOps(Enum): EXP2 = auto(); LOG2 = auto(); CAST = auto(); SIN = auto(); SQRT = auto(); RECIP = auto(); NEG = auto() # noqa: E702
-class BinaryOps(Enum): ADD = auto(); SUB = auto(); MUL = auto(); DIV = auto(); MAX = auto(); MOD = auto(); CMPLT = auto(); XOR = auto() # noqa: E702
-class TernaryOps(Enum): MULACC = auto(); WHERE = auto() # noqa: E702
-class ReduceOps(Enum): SUM = auto(); MAX = auto() # noqa: E702
-class BufferOps(Enum): LOAD = auto(); CONST = auto(); STORE = auto() # noqa: E702
+UnaryOps = Enum("UnaryOps", ['EXP2', 'LOG2', 'CAST', 'SIN', 'SQRT', 'RECIP', 'NEG'])
+BinaryOps = Enum("BinaryOps", ['ADD', 'SUB', 'MUL', 'DIV', 'MAX', 'MOD', 'CMPLT', 'XOR'])
+TernaryOps = Enum("TernaryOps", ['MULACC', 'WHERE'])
+ReduceOps = Enum("ReduceOps", ['SUM', 'MAX'])
+BufferOps = Enum("BufferOps", ['LOAD', 'CONST', 'STORE'])
 # Ops below this line are not allowed in ASTs
-class MovementOps(Enum): RESHAPE = auto(); PERMUTE = auto(); EXPAND = auto(); PAD = auto(); SHRINK = auto(); STRIDE = auto(); AS_STRIDED = auto() # noqa: E702
-class LoadOps(Enum): EMPTY = auto(); CONST = auto(); COPY = auto(); CONTIGUOUS = auto(); CUSTOM = auto() # noqa: E702
+MovementOps = Enum('MovementOps', ['RESHAPE', 'PERMUTE', 'EXPAND', 'PAD', 'SHRINK', 'STRIDE', 'AS_STRIDED'])
+LoadOps = Enum('LoadOps', ['EMPTY', 'CONST', 'COPY', 'CONTIGUOUS', 'CUSTOM'])
 
 Op = Union[UnaryOps, BinaryOps, ReduceOps, MovementOps, LoadOps, TernaryOps, BufferOps]
 OpType = Union[Type[UnaryOps], Type[BinaryOps], Type[ReduceOps], Type[MovementOps], Type[LoadOps], Type[TernaryOps], Type[BufferOps]]


### PR DESCRIPTION
Instead of using auto() all the time, how about we change to the functional syntax?