### PR TITLE
remove obsolete TODO in beautiful_mnist

### DIFF
--- a/examples/beautiful_mnist.py
+++ b/examples/beautiful_mnist.py
@@ -23,7 +23,6 @@ if __name__ == "__main__":
   model = Model()
   opt = nn.optim.Adam(nn.state.get_parameters(model))
 
-  # TODO: there's a compiler error if you comment out TinyJit since randint isn't being realized and there's something weird with int
   @TinyJit
   def train_step(samples:Tensor) -> Tensor:
     with Tensor.train():


### PR DESCRIPTION
the compiler error was due to `error: call to 'max' is ambiguous` when we have max(int, float) in kernel. it was first fixed in 4380ccb1 the non fp32 math PR, and further solidified with dtype refactor