### PR TITLE
Add a Nix flake for development and usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ wandb
 model.safetensors
 quickstart.py
 .hypothesis
+*result*

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, setuptools
+, wheel
+, numpy
+, tqdm
+, ...
+}@args:
+
+buildPythonPackage {
+  pname = "tinygrad";
+  version = args.version;
+  pyproject = true;
+
+  src = ./.;
+
+  propagatedBuildInputs = [
+    numpy
+    tqdm
+  ];
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  pythonImportsCheck = [ "tinygrad" ];
+
+  meta = with lib; {
+    description = "You like pytorch? You like micrograd? You love tinygrad";
+    homepage = "https://github.com/tinygrad/tinygrad";
+    license = licenses.mit;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1704152458,
+        "narHash": "sha256-DS+dGw7SKygIWf9w4eNBUZsK+4Ug27NwEWmn2tnbycg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "88a2cd8166694ba0b6cb374700799cec53aef527",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "You like pytorch? You like micrograd? You love tinygrad! ❤️ ";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        packages.default = pkgs.python3Packages.callPackage ./default.nix {
+          version = inputs.self.lastModifiedDate;
+        };
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            self'.packages.default
+            pkgs.ruff
+          ];
+        };
+      };
+    };
+}


### PR DESCRIPTION
Adds a `flake.nix` that you interact with via `nix develop`, `nix shell` or `nix build` to get up and running with Tinygrad with no extra steps on any platform.

I haven't tried it on a GPU yet, but I will later use [Mobile NixOS](https://mobile.nixos.org/) to try it on an SDM845

## macOS (lol)

Since I'm too poor to own a Mac I used [NixThePlanet](https://github.com/MatthewCroughan/NixThePlanet) to run Darwin with a single Nix command to test

### x86_64-darwin
![image](https://github.com/tinygrad/tinygrad/assets/26458780/233a7e2f-0358-4705-be60-21203954091c)

### aarch64-darwin
![image](https://github.com/tinygrad/tinygrad/assets/26458780/9731b699-cb38-481b-a1d6-8943d146e0ed)

# Linux

### x86_64-linux

![image](https://github.com/tinygrad/tinygrad/assets/26458780/28eb9d1a-3612-4e1a-ae53-18d84622ea4e)

### aarch64-linux

![image](https://github.com/tinygrad/tinygrad/assets/26458780/82f37e95-499c-4fa3-ac64-88483cf75f49)
