### PR TITLE
fail on putting bf buffer on CPU

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -132,6 +132,7 @@ class Tensor:
 
   def to(self, device:Optional[str]) -> Tensor:
     if device is None or device == self.device: return self
+    if device == "CPU" and self.lazydata.dtype == dtypes.bfloat16: raise RuntimeError("bfloat buffer is not supported on CPU {}".format(self.lazydata))
     ret = Tensor(self.lazydata, device)
     if self.grad: ret.grad = self.grad.to(device)
     return ret

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -132,7 +132,7 @@ class Tensor:
 
   def to(self, device:Optional[str]) -> Tensor:
     if device is None or device == self.device: return self
-    if device == "CPU" and self.lazydata.dtype == dtypes.bfloat16: raise RuntimeError("bfloat buffer is not supported on CPU {}".format(self.lazydata))
+    if device == "CPU" and self.lazydata.dtype.np is None: raise RuntimeError("{} buffer is not supported on CPU".format(self.lazydata.dtype))
     ret = Tensor(self.lazydata, device)
     if self.grad: ret.grad = self.grad.to(device)
     return ret


### PR DESCRIPTION
add error when attempting to move brainfloat buffer to CPU, e.g.

`RuntimeError: dtypes.bfloat16 buffer is not supported on CPU`

### background

otherwise `CPU=1 python3 examples/coder.py` fails as

```
tinygrad/runtime/ops_cpu.py", line 23, in as_strided
    return np.ndarray(shape, x.dtype, buffer=np.require(x, requirements='C'), offset=offset*x.dtype.itemsize,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: strides is incompatible with shape of requested array and size of buffer
```

due to 
```
# tinygrad/runtime/ops_cpu.py

numpy_fxn_for_op: Dict[Op, Callable] = {
  UnaryOps.CAST: lambda x,y: x.view(y[0].np) if y[1] else x.astype(y[0].np, copy=False),
```

where y[0].np is `None` leading to bf buffer being casted as float64, from 

https://github.com/tinygrad/tinygrad/blob/a280cfe16999c1be20c914ee7442281a01813f94/tinygrad/dtype.py#L62

[numpy.ndarray.view.html](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.view.html)

```
ndarray.view([dtype][, type])
- Passing None for dtype is different from omitting the parameter, since the former invokes dtype(None) which is an alias for dtype('float_').
```