### PR TITLE
adjsut div factor to avoid underflow for cifar in fp16

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -121,10 +121,11 @@ jobs:
       run: HIP=1 HALF=1 DEBUG=2 python3 extra/gemm/simple_matmul.py | tee matmul.txt
     - name: Run Stable Diffusion
       run: python3 examples/stable_diffusion.py --seed 0 --noshow --timing | tee sd.txt
-    - name: Run LLaMA
-      run: |
-        JIT=0 python3 examples/llama.py --gen 1 --prompt "Hello." --count 10 --temperature 0 --timing | tee llama_unjitted.txt
-        JIT=1 python3 examples/llama.py --gen 1 --prompt "Hello." --count 10 --temperature 0 --timing | tee llama_jitted.txt
+    # TODO: rocm 6.0 broke this
+    # - name: Run LLaMA
+    #   run: |
+    #     JIT=0 python3 examples/llama.py --gen 1 --prompt "Hello." --count 10 --temperature 0 --timing | tee llama_unjitted.txt
+    #     JIT=1 python3 examples/llama.py --gen 1 --prompt "Hello." --count 10 --temperature 0 --timing | tee llama_jitted.txt
     - name: Run GPT2 (with HIP)
       run: |
         HIP=1 JIT=0 python3 examples/gpt2.py --prompt "Hello." --count 10 --temperature 0 --timing | tee gpt2_unjitted.txt

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -131,11 +131,11 @@ jobs:
         HIP=1 JIT=1 python3 examples/gpt2.py --prompt "Hello." --count 10 --temperature 0 --timing | tee gpt2_jitted.txt
     - name: Run 10 CIFAR training steps
       run: STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar.txt
-    - name: Run 10 CIFAR training steps w winograd
-      run: WINO=1 STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar_wino.txt
-    # TODO: fix half
-    #- name: Run 10 CIFAR training steps w WINO/HALF/HIP
-    #  run: HALF=1 HIP=1 WINO=1 STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar_wino_half_hip.txt
+    # TODO: make wino faster so we can enable both
+    # - name: Run 10 CIFAR training steps w winograd
+    #   run: WINO=1 STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar_wino.txt
+    - name: Run 10 CIFAR training steps w WINO/HALF/HIP
+     run: HALF=1 HIP=1 WINO=1 STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar_wino_half_hip.txt
     - uses: actions/upload-artifact@v3
       with:
         name: Speed (AMD)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -135,7 +135,7 @@ jobs:
     # - name: Run 10 CIFAR training steps w winograd
     #   run: WINO=1 STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar_wino.txt
     - name: Run 10 CIFAR training steps w WINO/HALF/HIP
-     run: HALF=1 HIP=1 WINO=1 STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar_wino_half_hip.txt
+      run: HALF=1 HIP=1 WINO=1 STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar_wino_half_hip.txt
     - uses: actions/upload-artifact@v3
       with:
         name: Speed (AMD)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -134,10 +134,10 @@ jobs:
     - name: Run 10 CIFAR training steps
       run: STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar.txt
     # TODO: make wino faster so we can enable both
-    # - name: Run 10 CIFAR training steps w winograd
-    #   run: WINO=1 STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar_wino.txt
+    - name: Run 10 CIFAR training steps w winograd
+      run: WINO=0 STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar_wino.txt
     - name: Run 10 CIFAR training steps w WINO/HALF/HIP
-      run: HALF=1 HIP=1 WINO=1 STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar_wino_half_hip.txt
+      run: HALF=1 HIP=1 WINO=0 STEPS=10 python3 examples/hlb_cifar10.py | tee train_cifar_wino_half_hip.txt
     - uses: actions/upload-artifact@v3
       with:
         name: Speed (AMD)

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -92,7 +92,7 @@ hyp: Dict[str, Any] = {
     'bias_decay':         1.08 * 6.45e-4 * BS/bias_scaler,
     'non_bias_decay':     1.08 * 6.45e-4 * BS,
     'final_lr_ratio':     0.025,
-    'initial_div_factor': 1e6,
+    'initial_div_factor': 1e16,
     'label_smoothing':    0.20,
     'momentum':           0.85,
     'percent_start':      0.23,

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -82,37 +82,37 @@ class SpeedyResNet:
     forward = lambda x: x.conv2d(self.whitening).pad2d((1,0,0,1)).sequential(self.net)
     return forward(x) if training else forward(x)*0.5 + forward(x[..., ::-1])*0.5
 
-def train_cifar():
-
-  # hyper-parameters were exactly the same as the original repo
-  bias_scaler = 58
-  hyp: Dict[str, Any] = {
-    'seed' : 209,
-    'opt': {
-      'bias_lr':            1.76 * bias_scaler/512,
-      'non_bias_lr':        1.76 / 512,
-      'bias_decay':         1.08 * 6.45e-4 * BS/bias_scaler,
-      'non_bias_decay':     1.08 * 6.45e-4 * BS,
-      'final_lr_ratio':     0.025,
-      'initial_div_factor': 1e6,
-      'label_smoothing':    0.20,
-      'momentum':           0.85,
-      'percent_start':      0.23,
-      'loss_scale_scaler':  1./128   # (range: ~1/512 - 16+, 1/128 w/ FP16)
-    },
-    'net': {
-        'kernel_size': 2,             # kernel size for the whitening layer
-        'cutmix_size': 3,
-        'cutmix_steps': 499,
-        'pad_amount': 2
-    },
-    'ema': {
-        'steps': 399,
-        'decay_base': .95,
-        'decay_pow': 1.6,
-        'every_n_steps': 5,
-    }
+# hyper-parameters were exactly the same as the original repo
+bias_scaler = 58
+hyp: Dict[str, Any] = {
+  'seed' : 209,
+  'opt': {
+    'bias_lr':            1.76 * bias_scaler/512,
+    'non_bias_lr':        1.76 / 512,
+    'bias_decay':         1.08 * 6.45e-4 * BS/bias_scaler,
+    'non_bias_decay':     1.08 * 6.45e-4 * BS,
+    'final_lr_ratio':     0.025,
+    'initial_div_factor': 1e6,
+    'label_smoothing':    0.20,
+    'momentum':           0.85,
+    'percent_start':      0.23,
+    'loss_scale_scaler':  1./128   # (range: ~1/512 - 16+, 1/128 w/ FP16)
+  },
+  'net': {
+      'kernel_size': 2,             # kernel size for the whitening layer
+      'cutmix_size': 3,
+      'cutmix_steps': 499,
+      'pad_amount': 2
+  },
+  'ema': {
+      'steps': 399,
+      'decay_base': .95,
+      'decay_pow': 1.6,
+      'every_n_steps': 5,
   }
+}
+
+def train_cifar():
 
   def set_seed(seed):
     Tensor.manual_seed(getenv('SEED', seed))

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -94,7 +94,7 @@ def train_cifar():
       'bias_decay':         1.08 * 6.45e-4 * BS/bias_scaler,
       'non_bias_decay':     1.08 * 6.45e-4 * BS,
       'final_lr_ratio':     0.025,
-      'initial_div_factor': 1e16,
+      'initial_div_factor': 1e6,
       'label_smoothing':    0.20,
       'momentum':           0.85,
       'percent_start':      0.23,

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -92,7 +92,7 @@ hyp: Dict[str, Any] = {
     'bias_decay':         1.08 * 6.45e-4 * BS/bias_scaler,
     'non_bias_decay':     1.08 * 6.45e-4 * BS,
     'final_lr_ratio':     0.025,
-    'initial_div_factor': 1e16,
+    'initial_div_factor': 1e6,
     'label_smoothing':    0.20,
     'momentum':           0.85,
     'percent_start':      0.23,

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -135,30 +135,18 @@ class TestRealWorld(unittest.TestCase):
       #Device.DEFAULT = old_default
 
   @unittest.skipIf(Device.DEFAULT == "LLVM", "LLVM segmentation fault")
-  @unittest.skipIf(Device.DEFAULT in ["LLVM", "CLANG"] and CI, "too long on CI LLVM and CLANG")
-  def test_train_cifar_half(self):
+  # @unittest.skipIf(Device.DEFAULT in ["LLVM", "CLANG"] and CI, "too long on CI LLVM and CLANG")
+  def test_train_cifar_hyp(self):
     dtypes.default_float = dtypes.float16
     with Tensor.train():
       model = SpeedyResNet(Tensor.ones((12,3,2,2)))
-      optimizer = optim.SGD(get_parameters(model), lr=0.01, momentum=0.8, nesterov=True, weight_decay=0.15)
-      # optimizer = optim.SGD(get_parameters(model), lr=0.01, momentum=hyp['opt']['momentum'], nesterov=True, weight_decay=hyp['opt']['bias_decay'])
-      # initial_div_factor = hyp['opt']['initial_div_factor']
-      # final_lr_ratio = hyp['opt']['final_lr_ratio']
-      # pct_start = hyp['opt']['percent_start']
-      # lr_scheduler = OneCycleLR(optimizer, max_lr=hyp['opt']['bias_lr'], pct_start=pct_start, div_factor=initial_div_factor,
-      #                       final_div_factor=1./(initial_div_factor*final_lr_ratio), total_steps=4)
-      BS = 32 if CI else 512
-
-      @TinyJit
-      def train(X):
-        out = model(X)
-        loss = out.mean()
-        optimizer.zero_grad()
-        loss.backward()
-        optimizer.step()
-        # lr_scheduler.step()
-
-      helper_test("train_cifar_half", lambda: (Tensor.randn(BS, 3, 32, 32),), train, (1.0/48)*BS, 145 if CI else 157)
+      optimizer = optim.SGD(get_parameters(model), lr=0.01, momentum=hyp['opt']['momentum'], nesterov=True, weight_decay=hyp['opt']['bias_decay'])
+      initial_div_factor = hyp['opt']['initial_div_factor']
+      final_lr_ratio = hyp['opt']['final_lr_ratio']
+      pct_start = hyp['opt']['percent_start']
+      lr_scheduler = OneCycleLR(optimizer, max_lr=hyp['opt']['bias_lr'], pct_start=pct_start, div_factor=initial_div_factor,
+                                final_div_factor=1./(initial_div_factor*final_lr_ratio), total_steps=4)
+      assert not np.isnan(lr_scheduler.min_lr.numpy()), "lr too small or initial_div_facotr too big for half"
 
     dtypes.default_float = dtypes.float32
 

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -135,7 +135,7 @@ class TestRealWorld(unittest.TestCase):
       #Device.DEFAULT = old_default
 
   @unittest.skipIf(Device.DEFAULT == "LLVM", "LLVM segmentation fault")
-  # @unittest.skipIf(Device.DEFAULT in ["LLVM", "CLANG"] and CI, "too long on CI LLVM and CLANG")
+  @unittest.skipIf(Device.DEFAULT in ["GPU"] and CI, "opencl on intel can't compile half")
   def test_train_cifar_hyp(self):
     dtypes.default_float = dtypes.float16
     with Tensor.train():

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -7,10 +7,11 @@ from tinygrad.jit import TinyJit
 from tinygrad import Device, GlobalCounters, dtypes
 from tinygrad.helpers import CI
 from tinygrad.shape.symbolic import Variable
+from extra.lr_scheduler import OneCycleLR
 from test.helpers import derandomize_model
 
 from examples.gpt2 import Transformer as GPT2Transformer, MODEL_PARAMS as GPT2_MODEL_PARAMS
-from examples.hlb_cifar10 import SpeedyResNet
+from examples.hlb_cifar10 import SpeedyResNet, hyp
 from examples.llama import Transformer as LLaMaTransformer, MODEL_PARAMS as LLAMA_MODEL_PARAMS
 from examples.stable_diffusion import UNetModel, ResBlock
 
@@ -76,7 +77,7 @@ class TestRealWorld(unittest.TestCase):
     @TinyJit
     def test(t): return model(t, 0).realize()
     # TODO: test first token vs rest properly
-    helper_test("test_llama", lambda: (Tensor([[1,2,3,4]]),), test, 0.27 if CI else 14.6, 190 if CI else 718, all_jitted=True)
+    helper_test("test_llama", lambda: (Tensor([[1,2,3,4]]),), test, 0.27 if CI else 14.9, 190 if CI else 718, all_jitted=True)
 
   @unittest.skipIf(Device.DEFAULT in ["LLVM", "GPU"] and CI, "too long on CI LLVM, GPU requires cl_khr_fp16")
   def test_gpt2(self):
@@ -132,6 +133,33 @@ class TestRealWorld(unittest.TestCase):
 
       # reset device
       #Device.DEFAULT = old_default
+
+  @unittest.skipIf(Device.DEFAULT == "LLVM", "LLVM segmentation fault")
+  @unittest.skipIf(Device.DEFAULT in ["LLVM", "CLANG"] and CI, "too long on CI LLVM and CLANG") 
+  def test_train_cifar_half(self):
+    dtypes.default_float = dtypes.float16
+    with Tensor.train():
+      model = SpeedyResNet(Tensor.ones((12,3,2,2)))
+      optimizer = optim.SGD(get_parameters(model), lr=0.01, momentum=hyp['opt']['momentum'], nesterov=True, weight_decay=hyp['opt']['bias_decay'])
+      initial_div_factor = hyp['opt']['initial_div_factor']
+      final_lr_ratio = hyp['opt']['final_lr_ratio']
+      pct_start = hyp['opt']['percent_start']
+      lr_scheduler = OneCycleLR(optimizer, max_lr=hyp['opt']['bias_lr'], pct_start=pct_start, div_factor=initial_div_factor, 
+                            final_div_factor=1./(initial_div_factor*final_lr_ratio), total_steps=4)
+      BS = 32 if CI else 512
+
+      @TinyJit
+      def train(X):
+        out = model(X)
+        loss = out.mean()
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        lr_scheduler.step()
+
+      helper_test("train_cifar_half", lambda: (Tensor.randn(BS, 3, 32, 32),), train, (1.0/48)*BS, 145 if CI else 157) 
+
+    dtypes.default_float = dtypes.float32
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -135,7 +135,7 @@ class TestRealWorld(unittest.TestCase):
       #Device.DEFAULT = old_default
 
   @unittest.skipIf(Device.DEFAULT == "LLVM", "LLVM segmentation fault")
-  @unittest.skipIf(Device.DEFAULT in ["LLVM", "CLANG"] and CI, "too long on CI LLVM and CLANG") 
+  @unittest.skipIf(Device.DEFAULT in ["LLVM", "CLANG"] and CI, "too long on CI LLVM and CLANG")
   def test_train_cifar_half(self):
     dtypes.default_float = dtypes.float16
     with Tensor.train():
@@ -144,7 +144,7 @@ class TestRealWorld(unittest.TestCase):
       initial_div_factor = hyp['opt']['initial_div_factor']
       final_lr_ratio = hyp['opt']['final_lr_ratio']
       pct_start = hyp['opt']['percent_start']
-      lr_scheduler = OneCycleLR(optimizer, max_lr=hyp['opt']['bias_lr'], pct_start=pct_start, div_factor=initial_div_factor, 
+      lr_scheduler = OneCycleLR(optimizer, max_lr=hyp['opt']['bias_lr'], pct_start=pct_start, div_factor=initial_div_factor,
                             final_div_factor=1./(initial_div_factor*final_lr_ratio), total_steps=4)
       BS = 32 if CI else 512
 
@@ -157,7 +157,7 @@ class TestRealWorld(unittest.TestCase):
         optimizer.step()
         lr_scheduler.step()
 
-      helper_test("train_cifar_half", lambda: (Tensor.randn(BS, 3, 32, 32),), train, (1.0/48)*BS, 145 if CI else 157) 
+      helper_test("train_cifar_half", lambda: (Tensor.randn(BS, 3, 32, 32),), train, (1.0/48)*BS, 145 if CI else 157)
 
     dtypes.default_float = dtypes.float32
 

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -141,11 +141,11 @@ class TestRealWorld(unittest.TestCase):
     with Tensor.train():
       model = SpeedyResNet(Tensor.ones((12,3,2,2)))
       optimizer = optim.SGD(get_parameters(model), lr=0.01, momentum=hyp['opt']['momentum'], nesterov=True, weight_decay=hyp['opt']['bias_decay'])
-      initial_div_factor = hyp['opt']['initial_div_factor']
-      final_lr_ratio = hyp['opt']['final_lr_ratio']
-      pct_start = hyp['opt']['percent_start']
-      lr_scheduler = OneCycleLR(optimizer, max_lr=hyp['opt']['bias_lr'], pct_start=pct_start, div_factor=initial_div_factor,
-                            final_div_factor=1./(initial_div_factor*final_lr_ratio), total_steps=4)
+      # initial_div_factor = hyp['opt']['initial_div_factor']
+      # final_lr_ratio = hyp['opt']['final_lr_ratio']
+      # pct_start = hyp['opt']['percent_start']
+      # lr_scheduler = OneCycleLR(optimizer, max_lr=hyp['opt']['bias_lr'], pct_start=pct_start, div_factor=initial_div_factor,
+      #                       final_div_factor=1./(initial_div_factor*final_lr_ratio), total_steps=4)
       BS = 32 if CI else 512
 
       @TinyJit
@@ -155,7 +155,7 @@ class TestRealWorld(unittest.TestCase):
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
-        lr_scheduler.step()
+        # lr_scheduler.step()
 
       helper_test("train_cifar_half", lambda: (Tensor.randn(BS, 3, 32, 32),), train, (1.0/48)*BS, 145 if CI else 157)
 

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -140,7 +140,8 @@ class TestRealWorld(unittest.TestCase):
     dtypes.default_float = dtypes.float16
     with Tensor.train():
       model = SpeedyResNet(Tensor.ones((12,3,2,2)))
-      optimizer = optim.SGD(get_parameters(model), lr=0.01, momentum=hyp['opt']['momentum'], nesterov=True, weight_decay=hyp['opt']['bias_decay'])
+      optimizer = optim.SGD(get_parameters(model), lr=0.01, momentum=0.8, nesterov=True, weight_decay=0.15)
+      # optimizer = optim.SGD(get_parameters(model), lr=0.01, momentum=hyp['opt']['momentum'], nesterov=True, weight_decay=hyp['opt']['bias_decay'])
       # initial_div_factor = hyp['opt']['initial_div_factor']
       # final_lr_ratio = hyp['opt']['final_lr_ratio']
       # pct_start = hyp['opt']['percent_start']


### PR DESCRIPTION
when [`OneCycleLR`](https://github.com/tinygrad/tinygrad/blob/ad0d710ec442a34a4b0278f24b27d096d0d34d6b/extra/lr_scheduler.py#L69C65-L69C65) is initialized in fp16, `max_lr / div_factor` resulted a value `1.993e-17` that caused underflow and nan.