### PR TITLE
make disk simpler

### DIFF
--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -1,4 +1,4 @@
-import os, mmap, _posixshmem
+import os, mmap, _posixshmem, io
 from typing import Callable, Dict, Tuple
 from tinygrad.dtype import DType, dtypes
 from tinygrad.helpers import prod, OSX
@@ -8,8 +8,7 @@ from tinygrad.shape.view import strides_for_shape
 
 class UnderlyingDiskBuffer:
   def __init__(self, fd, mem): self.fd, self.mem = fd, mem
-  def __del__(self):
-    if self.fd: self.fd.close()
+  def __del__(self): os.close(self.fd)
 
 class DiskBuffer:
   def __init__(self, ud:UnderlyingDiskBuffer, size:int, dtype:DType=dtypes.uint8, offset=0):
@@ -32,21 +31,22 @@ class DiskAllocator(Allocator):
   def _alloc(self, size):
     if str(self.device).startswith("shm:"):
       fd = _posixshmem.shm_open("/"+self.device[4:].lstrip("/"), os.O_RDWR, 0o600)
-      shm = mmap.mmap(fd, size, flags=mmap.MAP_SHARED | MAP_POPULATE | MAP_LOCKED)
-      if (hp := getattr(mmap, "MADV_HUGEPAGE", None)) is not None: shm.madvise(hp) # type: ignore
-      os.close(fd)
-      buf = UnderlyingDiskBuffer(None, shm)
+      mmap_flags = mmap.MAP_SHARED | MAP_POPULATE | MAP_LOCKED
     else:
-      f = open(self.device, "a+b")
-      if os.path.getsize(self.device) < size: os.ftruncate(f.fileno(), size)
-      buf = UnderlyingDiskBuffer(f, mmap.mmap(f.fileno(), size))
-    return DiskBuffer(buf, size)
+      fd = os.open(self.device, os.O_RDWR|os.O_CREAT|(0 if OSX else os.O_DIRECT))
+      if os.fstat(fd).st_size < size: os.ftruncate(fd, size)
+      mmap_flags = mmap.MAP_SHARED
+    mem = mmap.mmap(fd, size, flags=mmap_flags)
+    if (hp := getattr(mmap, "MADV_HUGEPAGE", None)) is not None: mem.madvise(hp) # type: ignore
+    return DiskBuffer(UnderlyingDiskBuffer(fd, mem), size)
   def as_buffer(self, src:DiskBuffer): return src._buf()
   def copyin(self, dest:DiskBuffer, src:memoryview): dest._buf()[:] = src
   def copyout(self, dest:memoryview, src:DiskBuffer):
-    if src.ud.fd is not None:
-      src.ud.fd.seek(src.offset)
-      src.ud.fd.readinto(dest)
+    if OSX:
+      # OSX doesn't seem great at mmap, this is faster
+      with io.FileIO(src.ud.fd, "a+b", closefd=False) as fo:
+        fo.seek(src.offset)
+        fo.readinto(dest)
     else:
       dest[:] = src._buf()
 

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -50,9 +50,12 @@ class HIPAllocator(LRUAllocator):
   def _free(self, opaque:T): check(hip.hipFree(opaque))
   def copyin(self, dest:T, src: memoryview):
     check(hip.hipSetDevice(self.device.device))
-    host_mem = init_c_var(hip.hipDeviceptr_t(), lambda x: check(hip.hipHostMalloc(ctypes.byref(x), len(src), 0)))
-    self.device.pending_copyin.append(host_mem)
-    ctypes.memmove(host_mem, from_mv(src), len(src))
+    from tinygrad.helpers import Timing
+    with Timing("alloc: ", lambda x: f", {len(src)/x:.2f} GB/s"):
+      host_mem = init_c_var(hip.hipDeviceptr_t(), lambda x: check(hip.hipHostMalloc(ctypes.byref(x), len(src), 0)))
+      self.device.pending_copyin.append(host_mem)
+    with Timing("copy: ", lambda x: f", {len(src)/x:.2f} GB/s"):
+      ctypes.memmove(host_mem, from_mv(src), len(src))
     check(hip.hipMemcpyAsync(dest, host_mem, len(src), hip.hipMemcpyHostToDevice, None))
   def copyout(self, dest:memoryview, src:T):
     check(hip.hipSetDevice(self.device.device))


### PR DESCRIPTION
Faster on M3 too!

```
diane@blak:~/tinygrad$ sudo purge; python3 examples/llama.py --prompt "Hello." --count 10 --temperature 0 --timing --gen 1
using METAL backend
using LLaMA-7B model
ram used: 13.48 GB, freqs_cis                                         : 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 292/292 [00:02<00:00, 134.56it/s]
loaded weights in 2177.77 ms, 13.48 GB loaded at 6.19 GB/s
```