### PR TITLE
Improve HIP support on Intel HW, fix few double exceptions and refactor the backend code

### DIFF
--- a/extra/gemm/hip_matmul.py
+++ b/extra/gemm/hip_matmul.py
@@ -2,7 +2,7 @@ import time
 import numpy as np
 from tinygrad import dtypes
 from tinygrad.helpers import getenv, prod, flat_mv
-from tinygrad.runtime.ops_hip import HIPAllocator, HIPProgram, compile_hip
+from tinygrad.runtime.ops_hip import HIPDevice, HIPAllocator, HIPProgram, compile_hip
 
 # AMD_LOG_LEVEL=3 ./MIOpenDriver gemm --iter 1000 --time 1 --a_w 2048 --a_h 2048 --b_w 2048
 # 5.5: Cijk_Ailk_Bljk_HHS_BH_MT128x128x16_MI16x16x16x1_SN_1LDSB0_APM1_ABV0_ACED0_AF0EM1_AF1EM1_AMAS3_ASE_ASGT_ASAE01_ASCE01_ASEM1_AAC0_BL1_BS1_DTL0_DTVA0_DVO0_ETSP_EPS1_FL0_GRVW8_GSU1_GSUASB_GLS0_ISA1100_IU1_K1_KLA_LBSPP128_LPA0_LPB8_LDL1_LRVW16_LWPMn1_LDW0_FMA_MIAV1_MDA2_NTA0_NTB0_NTC0_NTD0_NEPBS0_NLCA1_NLCB1_ONLL1_OPLV0_PK0_PAP0_PGR1_PLR1_RK0_SIA1_SS1_SU32_SUM0_SUS128_SCIUI1_SPO0_SRVW0_SSO0_SVW4_SNLL0_TT4_64_TLDS1_USFGROn1_VAW2_VSn1_VW4_WSGRA1_WSGRB1_WS32_WG32_4_1_WGM4
@@ -25,7 +25,7 @@ FLOPS = N*N*N*2
 BW = N*N*3*4
 
 # Can HIPAllocator initialized as device=0 by default?
-device = 0
+device = HIPDevice()
 hipallocator = HIPAllocator(device)
 a = hipallocator.alloc(N*N*4)
 b = hipallocator.alloc(N*N*2)

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -257,8 +257,10 @@ class CUDALanguage(CStyleLanguage):
   type_map = {dtypes.bfloat16: "nv_bfloat16"}
 CUDARenderer = functools.partial(uops_to_cstyle, CUDALanguage())
 
+def ifndef(n: str, v: str) -> str: return f'#if !defined({n})\n#define {n} {v}\n#endif\n'
+
 class HIPLanguage(CUDALanguage):
-  kernel_prefix = "#include <hip/hip_common.h>\n#define INFINITY (__builtin_inff())\n#define NAN (__builtin_nanf(\"\"))" + """
+  kernel_prefix = "#include <hip/hip_common.h>\n" + ifndef('INFINITY', '(__builtin_inff())') + ifndef('NAN', '(__builtin_nanf(""))') + """
   typedef float float8 __attribute__((ext_vector_type(8)));
   __device__ float8 make_float8(float x, float y, float z, float w, float a, float b, float c, float d) { return {x, y, z, w, a, b, c, d}; }
   extern "C" __global__

--- a/tinygrad/runtime/graph/hip.py
+++ b/tinygrad/runtime/graph/hip.py
@@ -7,8 +7,8 @@ from tinygrad.runtime.graph.cuda import CUDAGraph
 
 class HIPGraph(CUDAGraph):
   def __del__(self):
-    check(hip.hipGraphDestroy(self.graph))
-    check(hip.hipGraphExecDestroy(self.instance))
+    if hasattr(self, 'graph'): check(hip.hipGraphDestroy(self.graph))
+    if hasattr(self, 'instance'): check(hip.hipGraphExecDestroy(self.instance))
 
   def encode_args_info(self): return (hip.hipDeviceptr_t, (1,2,3))
   def graph_create(self): return init_c_var(hip.hipGraph_t(), lambda x: check(hip.hipGraphCreate(ctypes.byref(x), 0)))

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -17,28 +17,28 @@ def check(status):
 # TODO: remove these helpers, they increase complexity
 def hip_time_execution(cb, enable=False): return time_execution_cuda_style(cb, hip.hipEvent_t, hip.hipEventCreate, hip.hipEventRecord, hip.hipEventSynchronize, hip.hipEventDestroy, hip.hipEventElapsedTime, enable=enable)  # noqa: E501
 
-def compile_hip(prg) -> bytes: return compile_cuda_style(prg, [f'--offload-arch={HIPDevice.default_arch_name}', '-I/opt/rocm/include'], hip.hiprtcProgram, hip.hiprtcCreateProgram, hip.hiprtcCompileProgram, hip.hiprtcGetCode, hip.hiprtcGetCodeSize, hip.hiprtcGetProgramLog, hip.hiprtcGetProgramLogSize, check)  # noqa: E501
+def compile_hip(prg) -> bytes: return compile_cuda_style(prg, *HIPDevice._comp_args)
+def alloc_call(f, *args): return init_c_var(f.argtypes[0]._type_(), lambda x: check(f(ctypes.byref(x), *args)))
 
 class HIPProgram:
-  def __init__(self, device:int, name:str, lib:bytes):
-    self.device, self.name, self.lib = device, name, lib
+  def __init__(self, device:HIPDevice, name:str, lib:bytes):
+    self.hip_scall, self.name, self.lib = device.hip_scall, name, lib
 
     if DEBUG >= 6:
       asm = subprocess.check_output(["/opt/rocm/llvm/bin/llvm-objdump", '-d', '-'], input=lib)
       print('\n'.join([x for x in asm.decode('utf-8').split("\n") if 's_code_end' not in x]))
 
     if MOCKHIP: return
-    check(hip.hipSetDevice(self.device))
-    self.module = init_c_var(hip.hipModule_t(), lambda x: check(hip.hipModuleLoadData(ctypes.byref(x), lib)))
-    self.prg = init_c_var(hip.hipFunction_t(), lambda x: check(hip.hipModuleGetFunction(ctypes.byref(x), self.module, name.encode("utf-8"))))
+    self.module = self.hip_scall(alloc_call, hip.hipModuleLoadData, lib, chk=False)
+    self.prg = alloc_call(hip.hipModuleGetFunction, self.module, name.encode("utf-8"))
 
   def __del__(self):
     if hasattr(self, 'module'): check(hip.hipModuleUnload(self.module))
 
   def __call__(self, *args, global_size:Tuple[int,int,int], local_size:Tuple[int,int,int], vals:Tuple[int, ...]=(), wait=False):
     if MOCKHIP: return float("inf")
-    check(hip.hipSetDevice(self.device))
-    return hip_time_execution(lambda: check(hip.hipModuleLaunchKernel(self.prg, *global_size, *local_size, 0, None, None, encode_args_cuda_style(args, vals, hip.hipDeviceptr_t, marks=(1,2,3))[0])), enable=wait)  # noqa: E501
+    self.hip_scall(hip_time_execution, lambda: check(hip.hipModuleLaunchKernel(self.prg, *global_size, *local_size, 0, None, None,
+                  encode_args_cuda_style(args, vals, hip.hipDeviceptr_t, marks=(1,2,3))[0])), wait, chk=False)
 
 T = TypeVar("T")
 CHUNK_SIZE, PAGE_SIZE = 256*1024*1024, 0x1000
@@ -46,11 +46,9 @@ class HIPAllocator(LRUAllocator):
   def __init__(self, device:HIPDevice):
     self.device = device
     super().__init__()
-  def _alloc(self, size:int):
-    check(hip.hipSetDevice(self.device.device))
-    return init_c_var(hip.hipDeviceptr_t(), lambda x: check(hip.hipMalloc(ctypes.byref(x), size)))
+  def _alloc(self, size:int): return self.device.hip_scall(alloc_call, hip.hipMalloc, size, chk=False)
   def _free(self, opaque:T): check(hip.hipFree(opaque))
-  def _hostalloc(self, size:int): return init_c_var(hip.hipDeviceptr_t(), lambda x: check(hip.hipHostMalloc(ctypes.byref(x), size, 0)))
+  def _hostalloc(self, size:int): return alloc_call(hip.hipHostMalloc, size, 0) # <- watchout, this one does not set the device
   def copy_from_fd(self, dest, fd, offset, size):
     check(hip.hipSetDevice(self.device.device))
     if not hasattr(self, 'hb'): self.hb = [self._hostalloc(CHUNK_SIZE) for _ in range(2)]
@@ -67,31 +65,30 @@ class HIPAllocator(LRUAllocator):
       self.hb = self.hb[1:] + [self.hb[0]]
       minor_offset = 0 # only on the first
   def copyin(self, dest:T, src: memoryview):
-    check(hip.hipSetDevice(self.device.device))
-    host_mem = self._hostalloc(len(src))
+    host_mem = self.device.hip_scall(self._hostalloc, len(src), chk=False)
     self.device.pending_copyin.append(host_mem)
     ctypes.memmove(host_mem, from_mv(src), len(src))
     check(hip.hipMemcpyAsync(dest, host_mem, len(src), hip.hipMemcpyHostToDevice, None))
-  def copyout(self, dest:memoryview, src:T):
-    check(hip.hipSetDevice(self.device.device))
-    check(hip.hipMemcpy(from_mv(dest), src, len(dest), hip.hipMemcpyDeviceToHost))
-  def transfer(self, dest:T, src:T, sz:int):
-    check(hip.hipSetDevice(self.device.device))
-    # TODO: hipMemcpyAsync, but you have to track the "src" buffer to not free it
-    check(hip.hipMemcpy(dest, src, sz, hip.hipMemcpyDeviceToDevice))
+  def copyout(self, dest:memoryview, src:T): self.device.hip_scall(hip.hipMemcpy, from_mv(dest), src, len(dest), hip.hipMemcpyDeviceToHost)
+  # TODO: hipMemcpyAsync, but you have to track the "src" buffer to not free it
+  def transfer(self, dest:T, src:T, sz:int): self.device.hip_scall(hip.hipMemcpy, dest, src, sz, hip.hipMemcpyDeviceToDevice)
 
 class HIPDevice(Compiled):
   default_arch_name = "gfx1100"
+  _comp_args = ([], hip.hiprtcProgram, hip.hiprtcCreateProgram, hip.hiprtcCompileProgram, hip.hiprtcGetCode,
+           hip.hiprtcGetCodeSize, hip.hiprtcGetProgramLog, hip.hiprtcGetProgramLogSize, check) # type: ignore[var-annotated]
   def __init__(self, device:str=""):
-    self.device = int(device.split(":")[1]) if ":" in device else 0
+    self.device, bas = int(device.split(":")[1]) if ":" in device else 0, (None, '', 'unavailable',)
     self.pending_copyin: List[hip.hipDeviceptr_t] = []
-    if self.device == 0 and not MOCKHIP: HIPDevice.default_arch_name = init_c_var(hip.hipDeviceProp_t(), lambda x: check(hip.hipGetDeviceProperties(x, self.device))).gcnArchName.decode()  # noqa: E501
+
+    if self.device == 0 and not MOCKHIP: HIPDevice.default_arch_name = alloc_call(hip.hipGetDeviceProperties, self.device).gcnArchName.decode()
+    if not (o:=HIPDevice._comp_args[0]) and (a:=HIPDevice.default_arch_name) not in bas: o.extend(('-I/opt/rocm/include', f'--offload-arch={a}'))
 
     from tinygrad.runtime.graph.hip import HIPGraph
     super().__init__(MallocAllocator if MOCKHIP else HIPAllocator(self), LinearizerOptions("HIP"), HIPRenderer,
-                     compile_hip, functools.partial(HIPProgram, self.device), HIPGraph)
+                     compile_hip, functools.partial(HIPProgram, self), HIPGraph)
   def synchronize(self):
-    check(hip.hipSetDevice(self.device))
-    check(hip.hipDeviceSynchronize())
+    self.hip_scall(hip.hipDeviceSynchronize)
     for opaque in self.pending_copyin: check(hip.hipFree(opaque))
     self.pending_copyin.clear()
+  def hip_scall(self, f, *args, chk=True): return (check(hip.hipSetDevice(self.device)), check(f(*args)) if chk else f(*args))[1]


### PR DESCRIPTION
This patch gets rid of the following warning when running HIP backend on Intel HW using chipStar project as well as reorganizes the HIP backend code to reduce duplication and boilerplate (as well as gets rid of the most of the noqa: E501). It also fixes few double exceptions here and there.

```
CHIP warning [TID 177892] [1704330852.929269646] : hiprtc: ignored option: '--offload-arch=unavailable'
CHIP warning [TID 177892] [1704330852.929358833] : hiprtc: ignored option: '-I/opt/rocm/include'
