### PR TITLE
correct (dtype, device) in test_dtype.is_dtype_supported

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -12,19 +12,14 @@ from hypothesis import given, settings, strategies as st
 core_dtypes = list(DTYPES_DICT.values())
 floats = [dt for dt in core_dtypes if dtypes.is_float(dt)]
 def is_dtype_supported(dtype: DType, device: str = Device.DEFAULT):
-  # for GPU, cl_khr_fp16 isn't supported
-  # for LLVM, it segfaults because it can't link to the casting function
-  # CUDA in CI uses CUDACPU that does not support half
-  if dtype == dtypes.half: return not (CI and device in ["GPU", "LLVM", "CUDA"]) and device != "WEBGPU"
   if dtype == dtypes.bfloat16: return False # numpy doesn't support bf16, tested separately in TestBFloat16DType
-  # TODO: is this correct? it reduces to only GPU on non-OSX
-  if dtype == dtypes.float64: return device not in ["WEBGPU", "METAL"] and (not OSX and device == "GPU")
-  if dtype in [dtypes.int8, dtypes.uint8]: return device not in ["WEBGPU"]
-  if dtype in [dtypes.int16, dtypes.uint16]: return device not in ["WEBGPU", "TORCH"]
-  if dtype == dtypes.uint32: return device not in ["TORCH"]
-  if dtype in [dtypes.int64, dtypes.uint64]: return device not in ["WEBGPU", "TORCH"]
-  # for WEBGPU, host-shareablity is a requirement for storage buffers, but 'bool' type is not host-shareable
-  if dtype == dtypes.bool: return device != "WEBGPU"
+  if device == "WEBGPU": return dtype in [dtypes.float, dtypes.int32, dtypes.uint32]
+  if device == "TORCH": return dtype not in [dtypes.uint16, dtypes.uint32, dtypes.uint64]
+  # for CI GPU, cl_khr_fp16 isn't supported
+  # for CI LLVM, it segfaults because it can't link to the casting function
+  # CUDA in CI uses CUDACPU that does not support half
+  if dtype == dtypes.half: return not (CI and device in ["GPU", "LLVM", "CUDA"])
+  if dtype == dtypes.float64: return device != "METAL" and not (OSX and device == "GPU")
   return True
 
 def get_available_cast_dtypes(dtype: DType) -> List[DType]:


### PR DESCRIPTION
corrected dtypes for TORCH and float64 support