### PR TITLE
Update device.py

### DIFF
--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 class _Device:
   def __init__(self) -> None: self._buffers: List[str] = [x.stem[len("ops_"):].upper() for x in (pathlib.Path(__file__).parent/"runtime").iterdir() if x.stem.startswith("ops_")]  # noqa: E501
-  def canonicalize(self, device:Optional[str]) -> str: return (device.split(":", 1)[0].upper() + ((":"+device.split(":", 1)[1]) if ':' in device else '')).replace(":0", "") if device is not None else self.DEFAULT  # noqa: E501
+  def canonicalize(self, device:Optional[str]) -> str: return (device.split(":", 1)[0].upper() + ((":"+device.split(":", 1)[1]) if ':' in device else '')) if device is not None else self.DEFAULT  # noqa: E501
   def __getitem__(self, ix:str) -> Union[Interpreted, Compiled]: return self.__get_canonicalized_item(self.canonicalize(ix))
   @functools.lru_cache(maxsize=None)  # this class is a singleton, pylint: disable=method-cache-max-size-none
   def __get_canonicalized_item(self, ix:str) -> Union[Interpreted, Compiled]:

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -16,7 +16,10 @@ if TYPE_CHECKING:
 
 class _Device:
   def __init__(self) -> None: self._buffers: List[str] = [x.stem[len("ops_"):].upper() for x in (pathlib.Path(__file__).parent/"runtime").iterdir() if x.stem.startswith("ops_")]  # noqa: E501
-  def canonicalize(self, device:Optional[str]) -> str: return (device.split(":", 1)[0].upper() + ((":"+device.split(":", 1)[1]) if ':' in device else '')) if device is not None else self.DEFAULT  # noqa: E501
+  def canonicalize(self, device:Optional[str], multi=False) -> str:
+    if device is None: return self.DEFAULT
+    else: x = device.split(":", 1)[0].upper() + ((":"+device.split(":", 1)[1]) if ':' in device else '')
+    return x.replace(":0", "") if not multi else x
   def __getitem__(self, ix:str) -> Union[Interpreted, Compiled]: return self.__get_canonicalized_item(self.canonicalize(ix))
   @functools.lru_cache(maxsize=None)  # this class is a singleton, pylint: disable=method-cache-max-size-none
   def __get_canonicalized_item(self, ix:str) -> Union[Interpreted, Compiled]:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -53,7 +53,7 @@ class Tensor:
   def __init__(self, data:Union[None, bool, int, float, List, Tuple, LazyBuffer, np.ndarray, bytes, MultiLazyBuffer],
                device:Optional[Union[str, tuple, list]]=None, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None):
     assert dtype is None or isinstance(dtype, DType), f"invalid dtype {dtype}"
-    device = tuple(Device.canonicalize(x) for x in device) if isinstance(device, (tuple, list)) else Device.canonicalize(device)
+    device = tuple(Device.canonicalize(x, multi=True) for x in device) if isinstance(device, (tuple, list)) else Device.canonicalize(device)
     # tensors have gradients, buffers do not
     self.grad: Optional[Tensor] = None
 


### PR DESCRIPTION
Bug fix for error:
```
Traceback (most recent call last):
  File "/cache/home/nr620/tinygrad/examples/testMulti.py", line 71, in <module>
    O = simpFunc(Xs)
  File "/cache/home/nr620/tinygrad/examples/testMulti.py", line 62, in simpFunc
    t = x+1
  File "/cache/home/nr620/tinygrad/tinygrad/tensor.py", line 832, in __add__
    def __add__(self, x) -> Tensor: return self.add(x)
  File "/cache/home/nr620/tinygrad/tinygrad/tensor.py", line 786, in add
    return mlops.Add.apply(*self._broadcasted(x, reverse)) if x.__class__ is Tensor or x else self
  File "/cache/home/nr620/tinygrad/tinygrad/tensor.py", line 33, in apply
    ret = Tensor(ctx.forward(*[t.lazydata for t in x], **kwargs), device=ctx.device, requires_grad=ctx.requires_grad)
  File "/cache/home/nr620/tinygrad/tinygrad/mlops.py", line 97, in forward
    def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer: return x.e(BinaryOps.ADD, y)
  File "/cache/home/nr620/tinygrad/tinygrad/features/multi.py", line 91, in e
    assert all_same([x.device for x in msrcs]), f"all buffers must have the same device {[x.device for x in msrcs]}"
AssertionError: all buffers must have the same device [('GPU:0', 'GPU:1', 'GPU:2', 'GPU:3'), ('GPU', 'GPU:1', 'GPU:2', 'GPU:3')]
```
for code:
```python
X = Tensor.ones(N, N)
Xs = X.shard(('GPU:0','GPU:1','GPU:2','GPU:3'), 0) def simpFunc(x) -> Tensor:
    t = x+1
    t = t.sum(1)
    return t.realize()
O = simpFunc(Xs)
```