### PR TITLE
use in_features directly in nn.Linear.__init__ bound check

### DIFF
--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -71,10 +71,9 @@ class ConvTranspose2d(Conv2d):
 
 class Linear:
   def __init__(self, in_features, out_features, bias=True):
+    # TODO: is this init good? torch inits to uniform(-1/sqrt(in_features), 1/sqrt(in_features))
     self.weight = Tensor.kaiming_uniform(out_features, in_features, a=math.sqrt(5))
-    # TODO: remove this once we can represent Tensor with int shape in typing
-    assert isinstance(self.weight.shape[1], int), "does not support symbolic shape"
-    bound = 1 / math.sqrt(self.weight.shape[1])
+    bound = 1 / math.sqrt(in_features)
     self.bias = Tensor.uniform(out_features, low=-bound, high=bound) if bias else None
 
   def __call__(self, x:Tensor):

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -26,8 +26,8 @@ class BatchNorm2d:
 
       # NOTE: wow, this is done all throughout training in most PyTorch models
       if self.track_running_stats:
-        self.running_mean.assign((1 - self.momentum) * self.running_mean + self.momentum * batch_mean.detach())
-        self.running_var.assign((1 - self.momentum) * self.running_var + self.momentum * prod(y.shape)/(prod(y.shape) - y.shape[1]) * batch_var.detach() )  # noqa: E501
+        self.running_mean.assign((1-self.momentum) * self.running_mean + self.momentum * batch_mean.detach())
+        self.running_var.assign((1-self.momentum) * self.running_var + self.momentum * prod(y.shape)/(prod(y.shape)-y.shape[1]) * batch_var.detach())
         self.num_batches_tracked += 1
     else:
       batch_mean = self.running_mean
@@ -63,7 +63,8 @@ class ConvTranspose2d(Conv2d):
     self.output_padding = output_padding
 
   def __call__(self, x:Tensor):
-    return x.conv_transpose2d(self.weight, self.bias, padding=self.padding, output_padding=self.output_padding, stride=self.stride, dilation=self.dilation, groups=self.groups)  # noqa: E501
+    return x.conv_transpose2d(self.weight, self.bias, padding=self.padding, output_padding=self.output_padding, stride=self.stride,
+                              dilation=self.dilation, groups=self.groups)
 
   def initialize_weight(self, out_channels, in_channels, groups):
     return Tensor.kaiming_uniform(in_channels, out_channels//groups, *self.kernel_size, a=math.sqrt(5))

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -1,7 +1,7 @@
 import math
-from typing import Optional, Union, Tuple
+from typing import Optional, Union, Tuple, cast
 from tinygrad.tensor import Tensor
-from tinygrad.helpers import prod, all_int
+from tinygrad.helpers import prod
 from tinygrad.nn import optim, state  # noqa: F401
 
 class BatchNorm2d:
@@ -45,8 +45,7 @@ class Conv2d:
     self.kernel_size = (kernel_size, kernel_size) if isinstance(kernel_size, int) else tuple(kernel_size)
     self.stride, self.padding, self.dilation, self.groups = stride, padding, dilation, groups
     self.weight = self.initialize_weight(out_channels, in_channels, groups)
-    assert all_int(self.weight.shape), "does not support symbolic shape"
-    bound = 1 / math.sqrt(prod(self.weight.shape[1:]))
+    bound = 1 / math.sqrt(cast(int, prod(self.weight.shape[1:])))  # weight shape is always ints but mypy cannot tell
     self.bias = Tensor.uniform(out_channels, low=-bound, high=bound) if bias else None
 
   def __call__(self, x:Tensor):


### PR DESCRIPTION
get rid of the unnecessary check of isinstance int