### PR TITLE
reshape/shrink can happen on sharded axis when the paralleled processes are independent

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -202,6 +202,14 @@ class TestMultiTensor(unittest.TestCase):
     y_sharded = Tensor.scaled_dot_product_attention(q_sharded, k_sharded, v_sharded, is_causal=True)
     np.testing.assert_allclose(y.numpy(), y_sharded.numpy(), atol=1e-6, rtol=1e-6)
 
+  def test_reshape_on_sharded_axis(self):
+    n_heads = 32
+    n_devices = 2
+    qx = Tensor.ones(1,1,4096).contiguous().realize()
+    qx_sharded = qx.shard((d0, d1), axis=2).realize()
+    qx = qx.reshape(1,1,n_heads,-1).realize()
+    qx_sharded = qx_sharded.reshape(1,1,n_heads//n_devices,-1).realize()
+    assert qx.shape == qx_sharded.shape
 
   def test_data_parallel_resnet(self):
     import sys, pathlib


### PR DESCRIPTION
For sharding transformer, it can be extremely efficient by splitting through the number of heads since they are all independent. However, it does require to perform `reshape` and `shrink` on the sharded axis for `xq`, `xk`, and `xv` which currently is not correct or supported. But in reality, once the `xq`s, `xk`s, and `xv`s are properly shareded, and the rest of operations are independent, we only need to track their relative order to each other and gather them back w.r.t a specified axis.


![image](https://github.com/tinygrad/tinygrad/assets/17937555/d7c38ff5-94f2-4f2e-b07e-8137fc7f78fc)