### PR TITLE
one_hot in transformer.py

### DIFF
--- a/extra/models/transformer.py
+++ b/extra/models/transformer.py
@@ -51,7 +51,7 @@ class Transformer:
     maxlen_eye = Tensor.eye(x.shape[1])
     maxlen_eye = maxlen_eye.unsqueeze(0).expand([bs, *maxlen_eye.shape])
 
-    onehot_feat = x[:, :, None] == Tensor.arange(self.syms).reshape((1,1) + (self.syms,))
+    onehot_feat = x.one_hot(self.syms)
 
     onehot = maxlen_eye.cat(onehot_feat, dim=2).flatten(end_dim=1)
 


### PR DESCRIPTION
I replaced it with new one_hot tensor op. The _examples/transformer.py_ trains to 0.999 accuracy and **test_transformer** in _test_train.py_ passes.