### PR TITLE
no exceptions in __del__ when module creation is failed in hip/cuda

### DIFF
--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -50,7 +50,7 @@ class CUDAProgram:
     self.prg = prg if not CUDACPU else lib
 
   def __del__(self):
-    if not CUDACPU: check(cuda.cuModuleUnload(self.module))
+    if hasattr(self, 'module'): check(cuda.cuModuleUnload(self.module))
 
   def __call__(self, *bufs, global_size:Tuple[int,int,int], local_size:Tuple[int,int,int], vals:Tuple[int, ...]=(), wait=False):
     if not CUDACPU: check(cuda.cuCtxSetCurrent(self.device.context))

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -33,7 +33,7 @@ class HIPProgram:
     self.prg = init_c_var(hip.hipFunction_t(), lambda x: check(hip.hipModuleGetFunction(ctypes.byref(x), self.module, name.encode("utf-8"))))
 
   def __del__(self):
-    if not MOCKHIP: check(hip.hipModuleUnload(self.module))
+    if hasattr(self, 'module'): check(hip.hipModuleUnload(self.module))
 
   def __call__(self, *args, global_size:Tuple[int,int,int], local_size:Tuple[int,int,int], vals:Tuple[int, ...]=(), wait=False):
     if MOCKHIP: return float("inf")


### PR DESCRIPTION
No exceptions in __del__ when module creation is failed in hip/cuda like in #3016
```
Exception ignored in: <function CUDAProgram.__del__ at 0x7fe3737caaf0>
Traceback (most recent call last):
  File "/cache/home/nr620/tinygrad/tinygrad/runtime/ops_cuda.py", line 53, in __del__
    if not CUDACPU: check(cuda.cuModuleUnload(self.module))
AttributeError: 'CUDAProgram' object has no attribute 'module'
```
