### PR TITLE
Fix backward for `matmul` with 0 in input shapes

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -557,14 +557,13 @@ class TestOps(unittest.TestCase):
     helper_test_op([(256,256), (256,256)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-3)
   @unittest.skipIf(IMAGE>0, "no 0 in shape matmul on images")
   def test_gemm_with_zeros_shape(self):
-    # TODO: support backward for this
-    helper_test_op([(8,8), (8,0)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7, forward_only=True)
-    helper_test_op([(0,8), (8,8)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7, forward_only=True)
-    helper_test_op([(0,8), (8,0)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7, forward_only=True)
-    helper_test_op([(8,0), (0,8)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7, forward_only=True)
-    helper_test_op([(0,0), (0,0)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7, forward_only=True)
-    helper_test_op([(0), (0,8)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7, forward_only=True)
-    helper_test_op([(0), (0)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7, forward_only=True)
+    helper_test_op([(8,8), (8,0)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7)
+    helper_test_op([(0,8), (8,8)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7)
+    helper_test_op([(0,8), (8,0)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7)
+    helper_test_op([(8,0), (0,8)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7)
+    helper_test_op([(0,0), (0,0)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7)
+    helper_test_op([(0), (0,8)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7)
+    helper_test_op([(0), (0)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-7)
   def test_broadcastdot(self):
     helper_test_op([(10,45,65), (65,45)], lambda x,y: x @ y, Tensor.dot, atol=1e-4)
     with self.assertRaises(AssertionError):
@@ -591,10 +590,9 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3,4,5,6)], lambda x: x.sum(axis=1), lambda x: Tensor.sum(x, axis=1))
     helper_test_op([()], lambda x: x.sum(), Tensor.sum)
   def test_sum_with_zeros_shape(self):
-    # TODO: support backward for this
-    helper_test_op([(4, 0)], lambda x: x.sum(axis=(0,)), lambda x: Tensor.sum(x, axis=(0,)), forward_only=True)
-    helper_test_op([(4, 0)], lambda x: x.sum(axis=(1,)), lambda x: Tensor.sum(x, axis=(1,)), forward_only=True)
-    helper_test_op([(4, 0)], lambda x: x.sum(axis=(0,1)), lambda x: Tensor.sum(x, axis=(0,1)), forward_only=True)
+    helper_test_op([(4, 0)], lambda x: x.sum(axis=(0,)), lambda x: Tensor.sum(x, axis=(0,)))
+    helper_test_op([(4, 0)], lambda x: x.sum(axis=(1,)), lambda x: Tensor.sum(x, axis=(1,)))
+    helper_test_op([(4, 0)], lambda x: x.sum(axis=(0,1)), lambda x: Tensor.sum(x, axis=(0,1)))
   def test_min(self):
     helper_test_op([(3,3)], lambda x: x.min(), Tensor.min)
     helper_test_op([(45,3)], lambda x: x.min(), Tensor.min)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -517,8 +517,8 @@ class Tensor:
     axis_: List[int] = list(range(len(self.shape))) if axis is None else ([axis] if isinstance(axis, int) else list(axis))
     axis_ = [x if x >= 0 else x+len(self.shape) for x in axis_]
     shape = tuple(s for i,s in enumerate(self.shape) if i not in axis_)
-    if 0 in self.shape and 0 not in shape:
-      return Tensor.full(tuple(1 if s == 0 else s for s in self.shape) if keepdim else shape, {mlops.Sum: 0.0, mlops.Max: -float("inf")}[fxn])
+    if 0 in self.shape and 0 not in shape and fxn is mlops.Max:
+      return Tensor.full(tuple(1 if s == 0 else s for s in self.shape) if keepdim else shape, -float("inf"))
     ret = fxn.apply(self, new_shape=tuple([1 if i in axis_ else s for i,s in enumerate(self.shape)]))
     return ret if keepdim else ret.reshape(shape=shape)
 


### PR DESCRIPTION
The reason `.backward()` wasn't working for loss outputs with input tensors that came from a `matmul` operation with 0 in its input shapes is because the `_reduce` in tensor.py generate entirely new tensors for reduce operations that their original tensor has a 0 in its shape and the requested output shape doesn't have a zero in it, resulting in losing the history in `_ctx` and thus being unable to do backpropagation. After testing, it turned out that this is necessary for reduce operations that use the `mlops.Max` op, but not for ones using `mlops.Sum` op, as the forward logic for the operation can produce the desired result.

I ran the tests and they worked (I stop `test_real_world.py` & `test_whisper.py` after 30 mins as they take forever on my device), and the below dev test compares the new results with pytorch's.

Dev test:
```python
import torch

torch.manual_seed(42)

a = torch.rand((3, 4), requires_grad=True)
b = torch.rand((4, 0), requires_grad=True)

c = a @ b

loss = (c+1).square().mean()

loss.backward()

from tinygrad import Tensor

t_a = Tensor(a.detach().numpy(), requires_grad=True)
t_b = Tensor(b.detach().numpy(), requires_grad=True)

t_c = t_a @ t_b

t_loss = (t_c+1)\
    .square()\
    .mean()

t_loss.backward()

print(b.grad.numpy(), b.grad)
print(t_b.grad.numpy(), t_b.grad)
```

Output:
```
[] tensor([], size=(4, 0))
[] <Tensor <LB CPU (4, 0) contig:True (<LoadOps.CONST: 2>, None)> on CPU with grad None>
```