### PR TITLE
failed test case due to cast resets shapetracker

### DIFF
--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -1,10 +1,9 @@
 import pathlib
 import unittest
 import numpy as np
-from tinygrad.tensor import Tensor, Device, dtypes
+from tinygrad import Tensor, Device, dtypes
 from tinygrad.nn.state import safe_load, safe_save, get_state_dict, torch_load
-from tinygrad.helpers import CI, fetch, temp
-from tinygrad.helpers import Timing
+from tinygrad.helpers import Timing, CI, fetch, temp
 
 def compare_weights_both(url):
   import torch


### PR DESCRIPTION
cast implicitly resets shapetracker and makes it contiguous (for disk tensor), which fails for Interpreted backend if inputs contain non-contiguous st.