### PR TITLE
make DType a dataclass

### DIFF
--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -8,9 +8,9 @@ class DType:
   priority: int  # this determines when things get upcasted
   itemsize: int
   name: str
-  np: Optional[type] = field(default=None, compare=False)
+  np: Optional[type] = field(default=None, compare=False)  # TODO: someday this will be removed with the "remove numpy" project
   sz: int = 1
-  def __repr__(self): return f"dtypes.{'_'*(c:=self.sz!=1)}{INVERSE_DTYPES_DICT[self.name if not c else self.scalar().name]}{str(self.sz)*(c)}"
+  def __repr__(self): return f"dtypes.{'_'*(c:=self.sz!=1)}{INVERSE_DTYPES_DICT[self.name if not c else self.scalar().name]}{str(self.sz)*c}"
   def vec(self, sz:int):
     assert sz > 1 and self.sz == 1, f"can't vectorize {self} with size {sz}"
     return DType(self.priority, self.itemsize*sz, f"{INVERSE_DTYPES_DICT[self.name]}{sz}", None, sz)
@@ -22,7 +22,7 @@ class ImageDType(DType):
   shape: Tuple[int, ...] = (0,)  # arbitrary arg for the dtype, used in image for the shape
   base: Any = field(default=None, hash=False)
   def __post_init__(self):
-    if self.base is None: raise ValueError("base cannot be None")
+    if not isinstance(self.base, DType): raise ValueError("base is not a valid dtype")
   def scalar(self): return self.base
   def vec(self, sz:int): return self.base.vec(sz)
   def __repr__(self): return f"dtypes.{self.name}({self.shape})"

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -1,5 +1,5 @@
 from typing import Final, Optional, ClassVar, Set, Tuple, Dict, Any
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import numpy as np  # TODO: remove numpy
 import functools
 
@@ -22,16 +22,12 @@ class DType:
 @dataclass(frozen=True)
 class ImageDType(DType):
   shape: Tuple[int, ...] = (0,)  # arbitrary arg for the dtype, used in image for the shape
-  base: Any = None
+  base: Any = field(default=None, hash=False)
   def __post_init__(self):
     if self.base is None: raise ValueError("base cannot be None!")
   def scalar(self): return self.base
   def vec(self, sz:int): return self.base.vec(sz)
   def __repr__(self): return f"dtypes.{self.name}({self.shape})"
-  # TODO: fix this to not need these
-  def __hash__(self): return hash((super().__hash__(), self.shape))
-  def __eq__(self, x): return super().__eq__(x) and self.shape == x.shape
-  def __ne__(self, x): return super().__ne__(x) or self.shape != x.shape
 
 class PtrDType(DType):
   def __init__(self, dt:DType): super().__init__(dt.priority, dt.itemsize, dt.name, dt.sz)

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -7,19 +7,21 @@ class DType(NamedTuple):
   priority: int  # this determines when things get upcasted
   itemsize: int
   name: str
-  np: Optional[type]  # TODO: someday this will be removed with the "remove numpy" project
   sz: int = 1
-  def __repr__(self): return f"dtypes.{INVERSE_DTYPES_DICT[self]}" if self.sz == 1 else f"dtypes._{INVERSE_DTYPES_DICT[self.scalar()]}{self.sz}"
+  def __repr__(self):
+    return f"dtypes.{INVERSE_DTYPES_DICT[self.name]}" if self.sz == 1 else f"dtypes._{INVERSE_DTYPES_DICT[self.scalar().name]}{self.sz}"
   def vec(self, sz:int):
     assert sz > 1 and self.sz == 1, f"can't vectorize {self} with size {sz}"
-    return DType(self.priority, self.itemsize*sz, f"{INVERSE_DTYPES_DICT[self]}{sz}", None, sz)
+    return DType(self.priority, self.itemsize*sz, f"{INVERSE_DTYPES_DICT[self.name]}{sz}", sz)
   def scalar(self): return DTYPES_DICT[self.name[:-len(str(self.sz))]] if self.sz > 1 else self
+  @property
+  def np(self) -> Optional[type]: return DTYPES_TO_NP_MAP[self.name if self.sz == 1 else self.scalar().name]
 
 # dependent typing?
 class ImageDType(DType):
-  def __new__(cls, priority, itemsize, name, np, shape, base):
-    return super().__new__(cls, priority, itemsize, name, np)
-  def __init__(self, priority, itemsize, name, np, shape, base):
+  def __new__(cls, priority, itemsize, name, shape, base):
+    return super().__new__(cls, priority, itemsize, name)
+  def __init__(self, priority, itemsize, name, shape, base):
     self.shape: Tuple[int, ...] = shape  # arbitrary arg for the dtype, used in image for the shape
     self.base: DType = base
     super().__init__()
@@ -32,7 +34,7 @@ class ImageDType(DType):
   def __ne__(self, x): return super().__ne__(x) or self.shape != x.shape
 
 class PtrDType(DType):
-  def __new__(cls, dt:DType): return super().__new__(cls, dt.priority, dt.itemsize, dt.name, dt.np, dt.sz)
+  def __new__(cls, dt:DType): return super().__new__(cls, dt.priority, dt.itemsize, dt.name, dt.sz)
   def __repr__(self): return f"ptr.{super().__repr__()}"
 
 class dtypes:
@@ -48,20 +50,20 @@ class dtypes:
   def from_py(x) -> DType: return dtypes.default_float if isinstance(x, float) else dtypes.bool if isinstance(x, bool) else dtypes.default_int
   @staticmethod
   def fields() -> Dict[str, DType]: return DTYPES_DICT
-  bool: Final[DType] = DType(0, 1, "bool", np.bool_)
-  int8: Final[DType] = DType(1, 1, "char", np.int8)
-  uint8: Final[DType] = DType(2, 1, "unsigned char", np.uint8)
-  int16: Final[DType] = DType(3, 2, "short", np.int16)
-  uint16: Final[DType] = DType(4, 2, "unsigned short", np.uint16)
-  int32: Final[DType] = DType(5, 4, "int", np.int32)
-  uint32: Final[DType] = DType(6, 4, "unsigned int", np.uint32)
-  int64: Final[DType] = DType(7, 8, "long", np.int64)
-  uint64: Final[DType] = DType(8, 8, "unsigned long", np.uint64)
-  float16: Final[DType] = DType(9, 2, "half", np.float16)
+  bool: Final[DType] = DType(0, 1, "bool")
+  int8: Final[DType] = DType(1, 1, "char")
+  uint8: Final[DType] = DType(2, 1, "unsigned char")
+  int16: Final[DType] = DType(3, 2, "short")
+  uint16: Final[DType] = DType(4, 2, "unsigned short")
+  int32: Final[DType] = DType(5, 4, "int")
+  uint32: Final[DType] = DType(6, 4, "unsigned int")
+  int64: Final[DType] = DType(7, 8, "long")
+  uint64: Final[DType] = DType(8, 8, "unsigned long")
+  float16: Final[DType] = DType(9, 2, "half")
   # bfloat16 has higher priority than float16, so least_upper_dtype(dtypes.int64, dtypes.uint64) = dtypes.float16
-  bfloat16: Final[DType] = DType(10, 2, "__bf16", None)
-  float32: Final[DType] = DType(11, 4, "float", np.float32)
-  float64: Final[DType] = DType(12, 8, "double", np.float64)
+  bfloat16: Final[DType] = DType(10, 2, "__bf16")
+  float32: Final[DType] = DType(11, 4, "float")
+  float64: Final[DType] = DType(12, 8, "double")
 
   # dtype aliases
   half = float16; float = float32; double = float64 # noqa: E702
@@ -70,9 +72,9 @@ class dtypes:
 
   # NOTE: these are image dtypes
   @staticmethod
-  def imageh(shp): return ImageDType(100, 2, "imageh", np.float16, shp, dtypes.float32)
+  def imageh(shp): return ImageDType(100, 2, "imageh", shp, dtypes.float32)
   @staticmethod
-  def imagef(shp): return ImageDType(100, 4, "imagef", np.float32, shp, dtypes.float32)
+  def imagef(shp): return ImageDType(100, 4, "imagef", shp, dtypes.float32)
 
   default_float: ClassVar[DType] = float32
   default_int: ClassVar[DType] = int32
@@ -94,4 +96,8 @@ def least_upper_float(dt:DType) -> DType: return dt if dtypes.is_float(dt) else 
 
 # HACK: staticmethods are not callable in 3.8 so we have to compare the class
 DTYPES_DICT = {k: v for k, v in dtypes.__dict__.items() if not (k.startswith(('__', 'default')) or v.__class__ is staticmethod)}
-INVERSE_DTYPES_DICT = {v:k for k,v in DTYPES_DICT.items()}
+INVERSE_DTYPES_DICT = {v.name:k for k,v in DTYPES_DICT.items()}
+def dtype_to_np(x: DType) -> Optional[type]:
+  s="u"*dtypes.is_unsigned(x)+f"int{x.itemsize*8}" if dtypes.is_int(x) else f"float{x.itemsize*8}" if dtypes.is_float(x) else "bool"
+  return np.dtype(s).type if x is not dtypes.bfloat16 else None
+DTYPES_TO_NP_MAP = {d.name: dtype_to_np(d) for d in set(DTYPES_DICT.values())}

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -19,7 +19,7 @@ class DType:
   def np(self) -> Optional[type]: return DTYPES_TO_NP_MAP[self.name if self.sz == 1 else self.scalar().name]
 
 # dependent typing?
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class ImageDType(DType):
   shape: Tuple[int, ...] = (0,)  # arbitrary arg for the dtype, used in image for the shape
   base: Any = field(default=None, hash=False)
@@ -29,6 +29,7 @@ class ImageDType(DType):
   def vec(self, sz:int): return self.base.vec(sz)
   def __repr__(self): return f"dtypes.{self.name}({self.shape})"
 
+# @dataclass(frozen=True, init=False, repr=False, eq=False)
 class PtrDType(DType):
   def __init__(self, dt:DType): super().__init__(dt.priority, dt.itemsize, dt.name, dt.sz)
   def __repr__(self): return f"ptr.{super().__repr__()}"

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -28,6 +28,8 @@ class ImageDType(DType):
   def scalar(self): return self.base
   def vec(self, sz:int): return self.base.vec(sz)
   def __repr__(self): return f"dtypes.{self.name}({self.shape})"
+  @property
+  def np(self) -> Optional[type]: return DTYPES_TO_NP_MAP[self.base.name if self.sz == 1 else self.base.scalar().name]
 
 # @dataclass(frozen=True, init=False, repr=False, eq=False)
 class PtrDType(DType):

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -8,14 +8,13 @@ class DType:
   priority: int  # this determines when things get upcasted
   itemsize: int
   name: str
+  np: Optional[type] = field(default=None, compare=False)
   sz: int = 1
   def __repr__(self): return f"dtypes.{'_'*(c:=self.sz!=1)}{INVERSE_DTYPES_DICT[self.name if not c else self.scalar().name]}{str(self.sz)*(c)}"
   def vec(self, sz:int):
     assert sz > 1 and self.sz == 1, f"can't vectorize {self} with size {sz}"
-    return DType(self.priority, self.itemsize*sz, f"{INVERSE_DTYPES_DICT[self.name]}{sz}", sz)
+    return DType(self.priority, self.itemsize*sz, f"{INVERSE_DTYPES_DICT[self.name]}{sz}", None, sz)
   def scalar(self): return DTYPES_DICT[self.name[:-len(str(self.sz))]] if self.sz > 1 else self
-  @property
-  def np(self) -> Optional[type]: return DTYPES_TO_NP_MAP[self.name if self.sz == 1 else self.scalar().name]
 
 # dependent typing?
 @dataclass(frozen=True, repr=False)
@@ -27,12 +26,10 @@ class ImageDType(DType):
   def scalar(self): return self.base
   def vec(self, sz:int): return self.base.vec(sz)
   def __repr__(self): return f"dtypes.{self.name}({self.shape})"
-  @property
-  def np(self) -> Optional[type]: return self.base.np
 
 # @dataclass(frozen=True, init=False, repr=False, eq=False)
 class PtrDType(DType):
-  def __init__(self, dt:DType): super().__init__(dt.priority, dt.itemsize, dt.name, dt.sz)
+  def __init__(self, dt:DType): super().__init__(dt.priority, dt.itemsize, dt.name, dt.np, dt.sz)
   def __repr__(self): return f"ptr.{super().__repr__()}"
   def __hash__(self): return super().__hash__()
   def __eq__(self, dt): return self.priority==dt.priority and self.itemsize==dt.itemsize and self.name==dt.name and self.sz==dt.sz
@@ -51,20 +48,20 @@ class dtypes:
   def from_py(x) -> DType: return dtypes.default_float if isinstance(x, float) else dtypes.bool if isinstance(x, bool) else dtypes.default_int
   @staticmethod
   def fields() -> Dict[str, DType]: return DTYPES_DICT
-  bool: Final[DType] = DType(0, 1, "bool")
-  int8: Final[DType] = DType(1, 1, "char")
-  uint8: Final[DType] = DType(2, 1, "unsigned char")
-  int16: Final[DType] = DType(3, 2, "short")
-  uint16: Final[DType] = DType(4, 2, "unsigned short")
-  int32: Final[DType] = DType(5, 4, "int")
-  uint32: Final[DType] = DType(6, 4, "unsigned int")
-  int64: Final[DType] = DType(7, 8, "long")
-  uint64: Final[DType] = DType(8, 8, "unsigned long")
-  float16: Final[DType] = DType(9, 2, "half")
+  bool: Final[DType] = DType(0, 1, "bool", np.bool_)
+  int8: Final[DType] = DType(1, 1, "char", np.int8)
+  uint8: Final[DType] = DType(2, 1, "unsigned char", np.uint8)
+  int16: Final[DType] = DType(3, 2, "short", np.int16)
+  uint16: Final[DType] = DType(4, 2, "unsigned short", np.uint16)
+  int32: Final[DType] = DType(5, 4, "int", np.int32)
+  uint32: Final[DType] = DType(6, 4, "unsigned int", np.uint32)
+  int64: Final[DType] = DType(7, 8, "long", np.int64)
+  uint64: Final[DType] = DType(8, 8, "unsigned long", np.uint64)
+  float16: Final[DType] = DType(9, 2, "half", np.float16)
   # bfloat16 has higher priority than float16, so least_upper_dtype(dtypes.int64, dtypes.uint64) = dtypes.float16
-  bfloat16: Final[DType] = DType(10, 2, "__bf16")
-  float32: Final[DType] = DType(11, 4, "float")
-  float64: Final[DType] = DType(12, 8, "double")
+  bfloat16: Final[DType] = DType(10, 2, "__bf16", None)
+  float32: Final[DType] = DType(11, 4, "float", np.float32)
+  float64: Final[DType] = DType(12, 8, "double", np.float64)
 
   # dtype aliases
   half = float16; float = float32; double = float64 # noqa: E702
@@ -73,9 +70,9 @@ class dtypes:
 
   # NOTE: these are image dtypes
   @staticmethod
-  def imageh(shp): return ImageDType(100, 2, "imageh", shape=shp, base=dtypes.float32)
+  def imageh(shp): return ImageDType(100, 2, "imageh", np.float16, shape=shp, base=dtypes.float32)
   @staticmethod
-  def imagef(shp): return ImageDType(100, 4, "imagef", shape=shp, base=dtypes.float32)
+  def imagef(shp): return ImageDType(100, 4, "imagef", np.float32, shape=shp, base=dtypes.float32)
 
   default_float: ClassVar[DType] = float32
   default_int: ClassVar[DType] = int32
@@ -97,5 +94,4 @@ def least_upper_float(dt:DType) -> DType: return dt if dtypes.is_float(dt) else 
 
 # HACK: staticmethods are not callable in 3.8 so we have to compare the class
 DTYPES_DICT = {k: v for k, v in dtypes.__dict__.items() if not (k.startswith(('__', 'default')) or v.__class__ is staticmethod)}
-def dtype_to_np(x: DType) -> Optional[type]: return np.dtype("u"*dtypes.is_unsigned(x)+f"int{x.itemsize*8}" if dtypes.is_int(x) else f"float{x.itemsize*8}" if dtypes.is_float(x) else "bool").type if x is not dtypes.bfloat16 else None  # noqa: E501
-INVERSE_DTYPES_DICT, DTYPES_TO_NP_MAP = {v.name:k for k,v in DTYPES_DICT.items()}, {d.name: dtype_to_np(d) for d in set(DTYPES_DICT.values())}
+INVERSE_DTYPES_DICT = {v.name:k for k,v in DTYPES_DICT.items()}


### PR DESCRIPTION
- [x] Make `DType` a dataclass

* directly using `DType` object as keys creates issues while subclassing the dataclass, so used the `name` attribute as key instead.
* added support for `PtrDType` to `DType` comparison. (this was not needed for `NamedTuple`).