### PR TITLE
Fix mv-command in kits19.py

### DIFF
--- a/extra/datasets/kits19.py
+++ b/extra/datasets/kits19.py
@@ -19,7 +19,7 @@ cd kits19
 pip3 install -r requirements.txt
 python3 -m starter_code.get_imaging
 cd ..
-mv kits extra/datasets
+mv kits19 extra/datasets
 ```
 """
 


### PR DESCRIPTION
Hello,
I was looking at #1637 and #2696 today and tried running the training process. For downloading the kits19 dataset, I followed the comment from `kits19.py` but ran into an error with the `mv` command, I think it's missing the "19"-suffix.