### PR TITLE
fuzzer validates outputs + (partially) oob accesses

### DIFF
--- a/test/external/fuzz_linearizer.py
+++ b/test/external/fuzz_linearizer.py
@@ -19,7 +19,7 @@ def get_fuzz_rawbufs(lin):
   rawbufs = bufs_from_lin(lin)
 
   # Reallocate output buffer with additional area to detect out-of-bounds writes.
-  RED_AREA_SIZE = 1024
+  RED_AREA_SIZE = 1024 if isinstance(device, Compiled) else 0
   rawbufs[0] = type(rawbufs[0])(Device.DEFAULT, rawbufs[0].size + RED_AREA_SIZE, rawbufs[0].dtype)
   with Context(DEBUG=0):
     for rawbuf in rawbufs[1:]:

--- a/test/external/fuzz_linearizer.py
+++ b/test/external/fuzz_linearizer.py
@@ -20,15 +20,15 @@ def get_fuzz_rawbufs(lin):
 
   # Reallocate output buffer with additional area to detect out-of-bounds writes.
   RED_AREA_SIZE = 1024 if isinstance(device, Compiled) else 0
-  rawbufs[0] = type(rawbufs[0])(Device.DEFAULT, rawbufs[0].size + RED_AREA_SIZE, rawbufs[0].dtype)
+  rawbufs[0] = get_fuzz_rawbuf_like(rawbufs[0], zero=True, size=rawbufs[0].size+RED_AREA_SIZE)
   with Context(DEBUG=0):
     for rawbuf in rawbufs[1:]:
       t = Tensor.uniform((rawbuf.size,), dtype=rawbuf.dtype)
       rawbuf.copyin(t.realize().lazydata.realized.as_buffer())
   return rawbufs
 
-def get_fuzz_rawbuf_like(rawbuf, zero=False, dev=Device.DEFAULT):
-  rawbuf = type(rawbuf)(dev, rawbuf.size, rawbuf.dtype)
+def get_fuzz_rawbuf_like(rawbuf, zero=False, size=None):
+  rawbuf = type(rawbuf)(Device.DEFAULT, rawbuf.size if size is None else size, rawbuf.dtype)
   if zero:
     with Context(DEBUG=0):
       mv = memoryview(bytearray(rawbuf.size * rawbuf.dtype.itemsize))

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E501
-import unittest
+import unittest, random
 import numpy as np
 from tinygrad.codegen.linearizer import Linearizer
 from tinygrad.features.search import Opt, OptOps

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -3,7 +3,7 @@ import unittest, random
 import numpy as np
 from tinygrad.codegen.linearizer import Linearizer
 from tinygrad.features.search import Opt, OptOps
-from tinygrad import Device, dtypes
+from tinygrad import Device, dtypes, Tensor
 from tinygrad.helpers import OSX, CI
 from test.external.fuzz_linearizer import run_linearizer, get_fuzz_rawbufs, get_fuzz_rawbuf_like
 
@@ -41,6 +41,11 @@ def helper_add_store(op):
 
 @unittest.skipIf(CI and Device.DEFAULT=="CUDA", "failed on CUDA CI")
 class TestLinearizerFailures(unittest.TestCase):
+  def setUp(self):
+    random.seed(42)
+    np.random.seed(42)
+    Tensor.manual_seed(42)
+
   def test_failure_1(self):
     ast = LazyOp(op=BinaryOps.ADD, src=(LazyOp(op=BinaryOps.ADD, src=(LazyOp(op=ReduceOps.SUM, src=(LazyOp(op=BufferOps.LOAD, src=(), arg=MemBuffer(idx=1, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(32, 16, 16), strides=(16, 1, 0), offset=0, mask=None, contiguous=False),)))),), arg=(32, 16, 1)), LazyOp(op=BufferOps.LOAD, src=(), arg=MemBuffer(idx=2, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(32, 16, 1), strides=(0, 1, 0), offset=0, mask=None, contiguous=False),))))), arg=None), LazyOp(op=BufferOps.LOAD, src=(), arg=MemBuffer(idx=1, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(32, 16, 1), strides=(16, 1, 0), offset=0, mask=None, contiguous=True),))))), arg=None)
     ast = helper_add_store(ast)

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -5,7 +5,7 @@ from tinygrad.codegen.linearizer import Linearizer
 from tinygrad.features.search import Opt, OptOps
 from tinygrad import Device, dtypes
 from tinygrad.helpers import OSX, CI
-from test.external.fuzz_linearizer import run_linearizer, get_fuzz_rawbufs
+from test.external.fuzz_linearizer import run_linearizer, get_fuzz_rawbufs, get_fuzz_rawbuf_like
 
 # stuff needed to unpack a kernel
 from tinygrad.ops import LazyOp, BinaryOps, UnaryOps, ReduceOps, BufferOps, MemBuffer, ConstBuffer, get_lazyop_info
@@ -18,7 +18,7 @@ def helper_test_lin(lin: Linearizer, opts, failed_platforms):
   var_vals = {v: random.randint(v.min, v.max) for v in lin.ast.vars()}
 
   assert run_linearizer(lin, rawbufs, var_vals) == "PASS" or Device.DEFAULT in failed_platforms, "Failed running non-optimized ast"
-  ground_truth = rawbufs[0].as_buffer()
+  ground_truth = np.frombuffer(rawbufs[0].as_buffer(), rawbufs[0].dtype.np)
 
   for opt in opts:
     try:
@@ -27,11 +27,13 @@ def helper_test_lin(lin: Linearizer, opts, failed_platforms):
       # it's considered fixed if we invalidated the opts
       assert Device.DEFAULT not in failed_platforms
 
-  rawbufs[0] = type(rawbufs[0])(Device.DEFAULT, rawbufs[0].size, rawbufs[0].dtype)
+  rawbufs[0] = get_fuzz_rawbuf_like(rawbufs[0], zero=True)
+  linearizer_passed = (run_linearizer(lin, rawbufs, var_vals) == "PASS")
+  output_passed = np.allclose(ground_truth, np.frombuffer(rawbufs[0].as_buffer(), rawbufs[0].dtype.np), rtol=1e-2, atol=1e-2)
   if Device.DEFAULT not in failed_platforms:
-    assert run_linearizer(lin, rawbufs, var_vals) == "PASS" and np.allclose(rawbufs[0].as_buffer(), ground_truth, rtol=1e-2, atol=1e-2)
+    assert linearizer_passed and output_passed
   else:
-    assert run_linearizer(lin, rawbufs, var_vals) != "PASS" or not np.allclose(rawbufs[0].as_buffer(), ground_truth, rtol=1e-2, atol=1e-2)
+    assert not linearizer_passed or not output_passed
 
 def helper_add_store(op):
   info = get_lazyop_info(op)

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -30,8 +30,6 @@ def helper_test_lin(lin: Linearizer, opts, failed_platforms):
   rawbufs[0] = get_fuzz_rawbuf_like(rawbufs[0], zero=True)
   linearizer_passed = (run_linearizer(lin, rawbufs, var_vals) == "PASS")
   output_passed = np.allclose(ground_truth, np.frombuffer(rawbufs[0].as_buffer(), rawbufs[0].dtype.np), rtol=1e-2, atol=1e-2)
-  print(ground_truth)
-  print(np.frombuffer(rawbufs[0].as_buffer(), rawbufs[0].dtype.np))
   if Device.DEFAULT not in failed_platforms:
     assert linearizer_passed and output_passed
   else:

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -30,6 +30,8 @@ def helper_test_lin(lin: Linearizer, opts, failed_platforms):
   rawbufs[0] = get_fuzz_rawbuf_like(rawbufs[0], zero=True)
   linearizer_passed = (run_linearizer(lin, rawbufs, var_vals) == "PASS")
   output_passed = np.allclose(ground_truth, np.frombuffer(rawbufs[0].as_buffer(), rawbufs[0].dtype.np), rtol=1e-2, atol=1e-2)
+  print(ground_truth)
+  print(np.frombuffer(rawbufs[0].as_buffer(), rawbufs[0].dtype.np))
   if Device.DEFAULT not in failed_platforms:
     assert linearizer_passed and output_passed
   else:


### PR DESCRIPTION
Fuzzer now generates random inputs to validate that output matches (before all rawbufs were 0s, so no matter what in most of cases output was 0 as well). Add some additional area for output rawbuf to check for oob writes.