### PR TITLE
cleaner events for syncing

### DIFF
--- a/tinygrad/features/multi.py
+++ b/tinygrad/features/multi.py
@@ -27,8 +27,7 @@ class MultiLazyBuffer:
   @property
   def size(self): return sum(x.size for x in self.lbs)
 
-  def __repr__(self):
-    return f"<MLB {self.axis=}{chr(10)}{chr(10).join([f'{x.device} {x.st}' for x in self.lbs])}>"
+  def __repr__(self): return f"<MLB {self.axis=}{chr(10)}{chr(10).join([f'{x.device} {x.st}' for x in self.lbs])}>"
 
   @staticmethod
   def from_sharded(lb:LazyBuffer, devices:Tuple[str, ...], axis:Optional[int]=None):

--- a/tinygrad/realize.py
+++ b/tinygrad/realize.py
@@ -18,7 +18,8 @@ def lower_schedule_item(si:ScheduleItem) -> Optional[JITRunner]:
     f"all devices must be the same, {si.out.device} != {[x.device for x in si.inputs]} {print_tree(si.ast) or ''}"
   if si.ast.op is LoadOps.EMPTY: return None
   if si.ast.op is LoadOps.COPY:
-    if hasattr(Device[si.out.device].allocator, 'transfer') and type(Device[si.out.device]) is type(Device[si.inputs[0].device]): return BufferXfer()
+    if hasattr(Device[si.out.device].allocator, 'transfer') and type(Device[si.out.device]) is type(Device[si.inputs[0].device]):
+      return BufferXfer(Device[si.inputs[0].device])
     if si.inputs[0].device.startswith("DISK"): return BufferRead()
     return BufferCopy()
   if si.ast.op is LoadOps.CUSTOM: return CustomOp(si.ast.arg)

--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -26,10 +26,7 @@ class LLVMProgram:
 
 class LLVMDevice(Compiled):
   def __init__(self, device:str):
-    llvm.initialize()
-    llvm.initialize_native_target()
-    llvm.initialize_native_asmprinter()
-    llvm.initialize_native_asmparser()
+    llvm.initialize(); llvm.initialize_native_target(); llvm.initialize_native_asmprinter(); llvm.initialize_native_asmparser()  # noqa: E702
     self.optimizer: llvm.passmanagers.ModulePassManager = llvm.create_module_pass_manager()
     # this opt actually can change things. ex: opt=3 means no FMA, opt=2 means FMA
     self.target_machine: llvm.targets.TargetMachine = llvm.Target.from_triple(llvm.get_process_triple()).create_target_machine(opt=2)


### PR DESCRIPTION
This gets 2 device llama to 66 ms, probably the most low hanging fruit here.

I will experiment with swapping events for spinlocks, and it's easy to add the BufferXfer to the JIT 