### PR TITLE
fix maximum/where Scalar casting

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -399,10 +399,10 @@ class TestAutoCastType(unittest.TestCase):
 
   @given(strat.sampled_from(core_dtypes))
   def test_broadcast_scalar(self, dt):
-    assert(Tensor.rand(4, 4, dtype=dt) + 2.3).dtype == (dt if dtypes.is_float(dt) else dtypes.default_float)
-    assert(Tensor.rand(4, 4, dtype=dt) + 2).dtype == (dt if dtypes.is_float(dt) or dtypes.is_int(dt) else dtypes.default_int)
+    assert (Tensor.rand(4, 4, dtype=dt) + 2.3).dtype == (dt if dtypes.is_float(dt) else dtypes.default_float)
+    assert (Tensor.rand(4, 4, dtype=dt) + 2).dtype == (dt if dtypes.is_float(dt) or dtypes.is_int(dt) else dtypes.default_int)
     if Device.DEFAULT != "WEBGPU" and dt != dtypes.bool:
-      assert(Tensor.rand(4, 4, dtype=dt) + True).dtype == dt
+      assert (Tensor.rand(4, 4, dtype=dt) + True).dtype == dt
 
   def test_sum(self):
     assert (Tensor([0, 1], dtype=dtypes.bool)).sum().dtype == dtypes.int32

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -398,7 +398,7 @@ class TestAutoCastType(unittest.TestCase):
       np.testing.assert_allclose(func(Tensor(a, dtype=dtype)).numpy(), func(torch.tensor(a)), rtol=1e-3, atol=1e-3)
 
   @given(strat.sampled_from(core_dtypes))
-  def test_broadcast(self, dt):
+  def test_broadcast_scalar(self, dt):
     assert(Tensor.rand(4, 4, dtype=dt) + 2.3).dtype == (dt if dt >= dtypes.float16 else dtypes.default_float)
     assert(Tensor.rand(4, 4, dtype=dt) + 2).dtype == (dt if dt >= dtypes.int8 else dtypes.default_int)
     if Device.DEFAULT != "WEBGPU" and dt != dtypes.bool:
@@ -444,11 +444,11 @@ class TestAutoCastType(unittest.TestCase):
     assert (Tensor([True, False]).where(other, input_)).dtype == data_type
 
   @given(strat.sampled_from(core_dtypes), strat.sampled_from(core_dtypes))
-  def test_where(self, dt1, dt2):
+  def test_where_no_scalar(self, dt1, dt2):
     self.check_where_alternate_input_other(Tensor(2, dtype=dt1), Tensor(3, dtype=dt2), least_upper_dtype(dt1, dt2))
 
   @given(strat.sampled_from(core_dtypes))
-  def test_where_scalar(self, dt):
+  def test_where_one_scalar(self, dt):
     t = Tensor(2, dtype=dt)
     self.check_where_alternate_input_other(t, 3.2, (dt if dt >= dtypes.float16 else dtypes.default_float))
     self.check_where_alternate_input_other(t, 3, (dt if dt >= dtypes.int8 else dtypes.default_int))

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -508,7 +508,11 @@ class TestAutoCastType(unittest.TestCase):
     assert (Tensor([True, False]).where(3, True)).dtype == dtypes.default_int
     assert (Tensor([True, False]).where(False, True)).dtype == dtypes.bool
 
-  def test_maximum(self):
+  @given(strat.sampled_from(core_dtypes), strat.sampled_from(core_dtypes))
+  def test_maximum(self, dt1, dt2):
+    Tensor([0, 1, 2], dtype=dt1).maximum(Tensor([2, 0, 5], dtype=dt2)).dtype == least_upper_dtype(dt1, dt2)
+
+  def test_maximum_const(self):
     assert Tensor([1, 2], dtype=dtypes.float16).maximum(3.1).dtype == dtypes.float16
     assert Tensor([1, 2], dtype=dtypes.float64).maximum(3.1).dtype == dtypes.float64
     assert Tensor([1, 2], dtype=dtypes.float16).maximum(3).dtype == dtypes.float16

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -473,7 +473,6 @@ class TestAutoCastType(unittest.TestCase):
   @given(strat.sampled_from(core_dtypes))
   def test_where_one_const(self, dt):
     t = Tensor(2, dtype=dt)
-    # TODO is this right?
     if dtypes.is_float(dt):
       assert (Tensor([True, False]).where(t, 3.2)).dtype == dt
       assert (Tensor([True, False]).where(3.2, t)).dtype == dt

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -492,7 +492,7 @@ class TestAutoCastType(unittest.TestCase):
 
   @given(strat.sampled_from(core_dtypes), strat.sampled_from(core_dtypes))
   def test_maximum(self, dt1, dt2):
-    # TODO bool and bool casts to int
+    # TODO bool maximum with bool casts to int
     if dt1 != dtypes.bool and dt2 != dtypes.bool:
       assert Tensor([0, 1, 2], dtype=dt1).maximum(Tensor([2, 0, 5], dtype=dt2)).dtype == least_upper_dtype(dt1, dt2)
 
@@ -500,7 +500,7 @@ class TestAutoCastType(unittest.TestCase):
   def test_maximum_const(self, dt):
     assert Tensor([1, 2], dtype=dt).maximum(3.1).dtype == (dt if dt >= dtypes.float16 else dtypes.default_float)
     assert Tensor([1, 2], dtype=dt).maximum(3).dtype == (dt if dt >= dtypes.int8 else dtypes.default_int)
-    # TODO bool and bool casts to int
+    # TODO bool maximum with bool casts to int
     if dt != dtypes.bool:
       assert Tensor([1, 2], dtype=dt).maximum(True).dtype == dt
 

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -508,5 +508,15 @@ class TestAutoCastType(unittest.TestCase):
     assert (Tensor([True, False]).where(3, True)).dtype == dtypes.default_int
     assert (Tensor([True, False]).where(False, True)).dtype == dtypes.bool
 
+  def test_maximum(self):
+    assert Tensor([1, 2], dtype=dtypes.float16).maximum(3.1).dtype == dtypes.float16
+    assert Tensor([1, 2], dtype=dtypes.float64).maximum(3.1).dtype == dtypes.float64
+    assert Tensor([1, 2], dtype=dtypes.float16).maximum(3).dtype == dtypes.float16
+    assert Tensor([1, 2], dtype=dtypes.float64).maximum(3).dtype == dtypes.float64
+    assert Tensor([1, 2], dtype=dtypes.int32).maximum(3).dtype == dtypes.int32
+    assert Tensor([1, 2], dtype=dtypes.int16).maximum(3).dtype == dtypes.int16
+    assert Tensor([1, 2], dtype=dtypes.int32).maximum(3.1).dtype == dtypes.default_float
+    assert Tensor([1, 2], dtype=dtypes.int16).maximum(3.1).dtype == dtypes.default_float
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -492,14 +492,17 @@ class TestAutoCastType(unittest.TestCase):
 
   @given(strat.sampled_from(core_dtypes), strat.sampled_from(core_dtypes))
   def test_maximum(self, dt1, dt2):
-    Tensor([0, 1, 2], dtype=dt1).maximum(Tensor([2, 0, 5], dtype=dt2)).dtype == least_upper_dtype(dt1, dt2)
+    # TODO bool and bool casts to int
+    if dt1 != dtypes.bool and dt2 != dtypes.bool:
+      assert Tensor([0, 1, 2], dtype=dt1).maximum(Tensor([2, 0, 5], dtype=dt2)).dtype == least_upper_dtype(dt1, dt2)
 
   @given(strat.sampled_from(core_dtypes))
   def test_maximum_const(self, dt):
     assert Tensor([1, 2], dtype=dt).maximum(3.1).dtype == (dt if dt >= dtypes.float16 else dtypes.default_float)
     assert Tensor([1, 2], dtype=dt).maximum(3).dtype == (dt if dt >= dtypes.int8 else dtypes.default_int)
-    # TODO :D
-    # assert Tensor([1, 2], dtype=dt).maximum(True).dtype == dt
+    # TODO bool and bool casts to int
+    if dt != dtypes.bool:
+      assert Tensor([1, 2], dtype=dt).maximum(True).dtype == dt
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -508,10 +508,10 @@ class TestAutoCastType(unittest.TestCase):
     assert Tensor([1, 2], dtype=dtypes.float64).maximum(3.1).dtype == dtypes.float64
     assert Tensor([1, 2], dtype=dtypes.float16).maximum(3).dtype == dtypes.float16
     assert Tensor([1, 2], dtype=dtypes.float64).maximum(3).dtype == dtypes.float64
-    assert Tensor([1, 2], dtype=dtypes.int64).maximum(3).dtype == dtypes.int64
-    assert Tensor([1, 2], dtype=dtypes.int16).maximum(3).dtype == dtypes.int16
     assert Tensor([1, 2], dtype=dtypes.int64).maximum(3.1).dtype == dtypes.default_float
     assert Tensor([1, 2], dtype=dtypes.int16).maximum(3.1).dtype == dtypes.default_float
+    assert Tensor([1, 2], dtype=dtypes.int64).maximum(3).dtype == dtypes.int64
+    assert Tensor([1, 2], dtype=dtypes.int16).maximum(3).dtype == dtypes.int16
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -397,40 +397,12 @@ class TestAutoCastType(unittest.TestCase):
       # float16 can have larger precision errors
       np.testing.assert_allclose(func(Tensor(a, dtype=dtype)).numpy(), func(torch.tensor(a)), rtol=1e-3, atol=1e-3)
 
-  @given(strat.sampled_from([dtypes.float16,dtypes.float32,dtypes.float64]))
-  def test_broadcast_float(self, default_float):
-    dtypes.default_float = default_float
-    assert (Tensor.rand(4, 4, dtype=dtypes.bool) + 2.3).dtype == dtypes.default_float
-    assert (Tensor.rand(4, 4, dtype=dtypes.int) + 2.3).dtype == dtypes.default_float
-    assert (Tensor.rand(4, 4, dtype=dtypes.int8) + 2.3).dtype == dtypes.default_float
-    assert (Tensor.rand(4, 4, dtype=dtypes.uint64) + 2.3).dtype == dtypes.default_float
-    assert (Tensor.rand(4, 4, dtype=dtypes.float16) + 2.3).dtype == dtypes.float16
-    assert (Tensor.rand(4, 4, dtype=dtypes.bfloat16) + 2.3).dtype == dtypes.bfloat16
-    assert (Tensor.rand(4, 4, dtype=dtypes.float32) + 2.3).dtype == dtypes.float32
-    assert (Tensor.rand(4, 4, dtype=dtypes.float64) + 2.3).dtype == dtypes.float64
-
-  @given(strat.sampled_from([dtypes.int8,dtypes.int16,dtypes.int32,dtypes.int64]))
-  def test_broadcast_int(self, default_int):
-    dtypes.default_int = default_int
-    assert (Tensor.rand(4, 4, dtype=dtypes.bool) + 2).dtype == dtypes.default_int
-    assert (Tensor.rand(4, 4, dtype=dtypes.int) + 2).dtype == dtypes.int
-    assert (Tensor.rand(4, 4, dtype=dtypes.int8) + 2).dtype == dtypes.int8
-    assert (Tensor.rand(4, 4, dtype=dtypes.uint64) + 2).dtype == dtypes.uint64
-    assert (Tensor.rand(4, 4, dtype=dtypes.float16) + 2).dtype == dtypes.float16
-    assert (Tensor.rand(4, 4, dtype=dtypes.bfloat16) + 2).dtype == dtypes.bfloat16
-    assert (Tensor.rand(4, 4, dtype=dtypes.float32) + 2).dtype == dtypes.float32
-    assert (Tensor.rand(4, 4, dtype=dtypes.float64) + 2).dtype == dtypes.float64
-
-  def test_broadcast_bool(self):
-    if Device.DEFAULT != "WEBGPU":
-      assert (Tensor([0, 1], dtype=dtypes.bool) + True).dtype == dtypes.bool
-    assert (Tensor([0, 1], dtype=dtypes.int) + True).dtype == dtypes.int32
-    assert (Tensor([0, 1], dtype=dtypes.int8) + True).dtype == dtypes.int8
-    assert (Tensor([0, 1], dtype=dtypes.uint64) + True).dtype == dtypes.uint64
-    assert (Tensor([0, 1], dtype=dtypes.float16) + True).dtype == dtypes.float16
-    assert (Tensor([0, 1], dtype=dtypes.bfloat16) + True).dtype == dtypes.bfloat16
-    assert (Tensor([0, 1], dtype=dtypes.float32) + True).dtype == dtypes.float32
-    assert (Tensor([0, 1], dtype=dtypes.float64) + True).dtype == dtypes.float64
+  @given(strat.sampled_from(core_dtypes))
+  def test_broadcast(self, dt):
+    assert(Tensor.rand(4, 4, dtype=dt) + 2.3).dtype == (dt if dt >= dtypes.float16 else dtypes.default_float)
+    assert(Tensor.rand(4, 4, dtype=dt) + 2).dtype == (dt if dt >= dtypes.int8 else dtypes.default_int)
+    if Device.DEFAULT != "WEBGPU" and dt != dtypes.bool:
+      assert(Tensor.rand(4, 4, dtype=dt) + True).dtype == dt
 
   def test_sum(self):
     assert (Tensor([0, 1], dtype=dtypes.bool)).sum().dtype == dtypes.int32

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -54,6 +54,10 @@ def _test_cast(a:Tensor, target_dtype:DType):
 def _test_bitcast(a:Tensor, target_dtype:DType, target=None):
   _test_op(lambda: a.bitcast(target_dtype), target_dtype, target or a.numpy().view(target_dtype.np).tolist())
 
+def where_alternate_input_other(input_, other, data_type):
+  assert (Tensor([True, False]).where(input_, other)).dtype == data_type
+  assert (Tensor([True, False]).where(other, input_)).dtype == data_type
+
 class TestDType(unittest.TestCase):
   DTYPE: Any = None
   DATA: Any = None
@@ -471,40 +475,29 @@ class TestAutoCastType(unittest.TestCase):
     assert (Tensor([True, False]).where(Tensor(2, dtype=dt1), Tensor(3, dtype=dt2))).dtype == least_upper_dtype(dt1, dt2)
 
   @given(strat.sampled_from(core_dtypes))
-  def test_where_one_const(self, dt):
+  def test_where_scalar(self, dt):
     t = Tensor(2, dtype=dt)
     if dtypes.is_float(dt):
-      assert (Tensor([True, False]).where(t, 3.2)).dtype == dt
-      assert (Tensor([True, False]).where(3.2, t)).dtype == dt
-      assert (Tensor([True, False]).where(t, 3)).dtype == dt
-      assert (Tensor([True, False]).where(3, t)).dtype == dt
-      assert (Tensor([True, False]).where(t, True)).dtype == dt
-      assert (Tensor([True, False]).where(True, t)).dtype == dt
+      where_alternate_input_other(t, 3.2, dt)
+      where_alternate_input_other(t, 3, dt)
+      where_alternate_input_other(t, True, dt)
     elif dtypes.is_int(dt):
-      assert (Tensor([True, False]).where(t, 3.2)).dtype == dtypes.default_float
-      assert (Tensor([True, False]).where(3.2, t)).dtype == dtypes.default_float
-      assert (Tensor([True, False]).where(t, 3)).dtype == dt
-      assert (Tensor([True, False]).where(3, t)).dtype == dt
-      assert (Tensor([True, False]).where(t, True)).dtype == dt
-      assert (Tensor([True, False]).where(True, t)).dtype == dt
+      where_alternate_input_other(t, 3.2, dtypes.default_float)
+      where_alternate_input_other(t, 3, dt)
+      where_alternate_input_other(t, True, dt)
     else:
-      assert (Tensor([True, False]).where(t, 3.2)).dtype == dtypes.default_float
-      assert (Tensor([True, False]).where(3.2, t)).dtype == dtypes.default_float
-      assert (Tensor([True, False]).where(t, 3)).dtype == dtypes.default_int
-      assert (Tensor([True, False]).where(3, t)).dtype == dtypes.default_int
-      assert (Tensor([True, False]).where(t, True)).dtype == dt
-      assert (Tensor([True, False]).where(True, t)).dtype == dt
+      where_alternate_input_other(t, 3.2, dtypes.default_float)
+      where_alternate_input_other(t, 3, dtypes.default_int)
+      where_alternate_input_other(t, True, dt)
 
-  def test_where_two_consts(self):
-    assert (Tensor([True, False]).where(3.1, 3.2)).dtype == dtypes.default_float
-    assert (Tensor([True, False]).where(3, 3.2)).dtype == dtypes.default_float
-    assert (Tensor([True, False]).where(3.2, 3)).dtype == dtypes.default_float
-    assert (Tensor([True, False]).where(True, 3.2)).dtype == dtypes.default_float
-    assert (Tensor([True, False]).where(3.2, True)).dtype == dtypes.default_float
-    assert (Tensor([True, False]).where(2, 3)).dtype == dtypes.default_int
-    assert (Tensor([True, False]).where(True, 3)).dtype == dtypes.default_int
-    assert (Tensor([True, False]).where(3, True)).dtype == dtypes.default_int
-    assert (Tensor([True, False]).where(False, True)).dtype == dtypes.bool
+
+  def where_where_two_consts(self):
+    where_alternate_input_other(3.1, 3.2, dtypes.default_float)
+    where_alternate_input_other(3.1, 3, dtypes.default_float)
+    where_alternate_input_other(3.1, True, dtypes.default_float)
+    where_alternate_input_other(3, 2, dtypes.default_int)
+    where_alternate_input_other(3, True, dtypes.default_int)
+    where_alternate_input_other(False, True, dtypes.bool)
 
   @given(strat.sampled_from(core_dtypes), strat.sampled_from(core_dtypes))
   def test_maximum(self, dt1, dt2):

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -399,8 +399,8 @@ class TestAutoCastType(unittest.TestCase):
 
   @given(strat.sampled_from(core_dtypes))
   def test_broadcast_scalar(self, dt):
-    assert(Tensor.rand(4, 4, dtype=dt) + 2.3).dtype == (dt if dt >= dtypes.float16 else dtypes.default_float)
-    assert(Tensor.rand(4, 4, dtype=dt) + 2).dtype == (dt if dt >= dtypes.int8 else dtypes.default_int)
+    assert(Tensor.rand(4, 4, dtype=dt) + 2.3).dtype == (dt if dtypes.is_float(dt) else dtypes.default_float)
+    assert(Tensor.rand(4, 4, dtype=dt) + 2).dtype == (dt if dtypes.is_float(dt) or dtypes.is_int(dt) else dtypes.default_int)
     if Device.DEFAULT != "WEBGPU" and dt != dtypes.bool:
       assert(Tensor.rand(4, 4, dtype=dt) + True).dtype == dt
 
@@ -450,8 +450,8 @@ class TestAutoCastType(unittest.TestCase):
   @given(strat.sampled_from(core_dtypes))
   def test_where_one_scalar(self, dt):
     t = Tensor(2, dtype=dt)
-    self.check_where_alternate_input_other(t, 3.2, (dt if dt >= dtypes.float16 else dtypes.default_float))
-    self.check_where_alternate_input_other(t, 3, (dt if dt >= dtypes.int8 else dtypes.default_int))
+    self.check_where_alternate_input_other(t, 3.2, (dt if dtypes.is_float(dt) else dtypes.default_float))
+    self.check_where_alternate_input_other(t, 3, (dt if dtypes.is_float(dt) or dtypes.is_int(dt) else dtypes.default_int))
     self.check_where_alternate_input_other(t, True, dt)
 
   def test_where_two_scalars(self):
@@ -464,17 +464,13 @@ class TestAutoCastType(unittest.TestCase):
 
   @given(strat.sampled_from(core_dtypes), strat.sampled_from(core_dtypes))
   def test_maximum(self, dt1, dt2):
-    # TODO bool maximum with bool casts to int
-    if dt1 != dtypes.bool and dt2 != dtypes.bool:
-      assert Tensor([0, 1, 2], dtype=dt1).maximum(Tensor([2, 0, 5], dtype=dt2)).dtype == least_upper_dtype(dt1, dt2)
+    assert Tensor([0, 1, 2], dtype=dt1).maximum(Tensor([2, 0, 5], dtype=dt2)).dtype == least_upper_dtype(dt1, dt2)
 
   @given(strat.sampled_from(core_dtypes))
   def test_maximum_const(self, dt):
-    assert Tensor([1, 2], dtype=dt).maximum(3.1).dtype == (dt if dt >= dtypes.float16 else dtypes.default_float)
-    assert Tensor([1, 2], dtype=dt).maximum(3).dtype == (dt if dt >= dtypes.int8 else dtypes.default_int)
-    # TODO bool maximum with bool casts to int
-    if dt != dtypes.bool:
-      assert Tensor([1, 2], dtype=dt).maximum(True).dtype == dt
+    assert Tensor([1, 2], dtype=dt).maximum(3.1).dtype == (dt if dtypes.is_float(dt) else dtypes.default_float)
+    assert Tensor([1, 2], dtype=dt).maximum(3).dtype == (dt if dtypes.is_float(dt) or dtypes.is_int(dt) else dtypes.default_int)
+    assert Tensor([1, 2], dtype=dt).maximum(True).dtype == dt
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -516,9 +516,9 @@ class TestAutoCastType(unittest.TestCase):
     assert Tensor([1, 2], dtype=dtypes.float64).maximum(3.1).dtype == dtypes.float64
     assert Tensor([1, 2], dtype=dtypes.float16).maximum(3).dtype == dtypes.float16
     assert Tensor([1, 2], dtype=dtypes.float64).maximum(3).dtype == dtypes.float64
-    assert Tensor([1, 2], dtype=dtypes.int32).maximum(3).dtype == dtypes.int32
+    assert Tensor([1, 2], dtype=dtypes.int64).maximum(3).dtype == dtypes.int64
     assert Tensor([1, 2], dtype=dtypes.int16).maximum(3).dtype == dtypes.int16
-    assert Tensor([1, 2], dtype=dtypes.int32).maximum(3.1).dtype == dtypes.default_float
+    assert Tensor([1, 2], dtype=dtypes.int64).maximum(3.1).dtype == dtypes.default_float
     assert Tensor([1, 2], dtype=dtypes.int16).maximum(3.1).dtype == dtypes.default_float
 
 if __name__ == '__main__':

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -14,7 +14,6 @@ settings.load_profile("my_profile")
 
 core_dtypes = list(DTYPES_DICT.values())
 floats = [dt for dt in core_dtypes if dtypes.is_float(dt)]
-non_floats = [dt for dt in core_dtypes if not dtypes.is_float(dt)]
 def is_dtype_supported(dtype: DType, device: str = Device.DEFAULT):
   if dtype == dtypes.bfloat16: return False # numpy doesn't support bf16, tested separately in TestBFloat16DType
   if device in ["WEBGPU", "WEBGL"]: return dtype in [dtypes.float, dtypes.int32, dtypes.uint32]

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -260,14 +260,16 @@ class TestOps(unittest.TestCase):
   def test_maximum(self):
     helper_test_op([(45,65), (45,65)], torch.maximum, Tensor.maximum)
     helper_test_op([(), ()], torch.maximum, Tensor.maximum)
-    helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[1., 0., 3., 4.], [1., 2., 3., 0.]])
-    helper_test_op(None, torch.maximum, Tensor.maximum, vals=np.array([[1, 0, 3, 4], [1, 2, 3, 0]], dtype=np.int32), forward_only=True)
+    helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[1., 0., 3., -4.], 3.])
+    helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[1., 0., 3., -4.], [-1., -2., 3., 0.]])
+    helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[True, False, False], True], forward_only=True)
     helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[True, False, False], [True, True, False]], forward_only=True)
   def test_minimum(self):
     helper_test_op([(45,65), (45,65)], torch.minimum, Tensor.minimum)
     helper_test_op([(), ()], torch.minimum, Tensor.minimum)
-    helper_test_op(None, torch.minimum, Tensor.minimum, vals=[[1., 0., 3., 4.], [1., 2., 3., 0.]])
-    helper_test_op(None, torch.minimum, Tensor.minimum, vals=np.array([[1, 0, 3, 4], [1, 2, 3, 0]], dtype=np.int32), forward_only=True)
+    helper_test_op(None, torch.minimum, Tensor.minimum, vals=[[1., 0., 3., -4.], 3.])
+    helper_test_op(None, torch.minimum, Tensor.minimum, vals=[[1., 0., 3., -4.], [-1., -2., 3., 0.]])
+    helper_test_op(None, torch.minimum, Tensor.minimum, vals=[[True, False, False], True], forward_only=True)
     helper_test_op(None, torch.minimum, Tensor.minimum, vals=[[True, False, False], [True, True, False]], forward_only=True)
 
   def test_add(self):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -262,6 +262,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(), ()], torch.maximum, Tensor.maximum)
     helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[1., 0., 3., 4.], [1., 2., 3., 0.]])
     helper_test_op(None, torch.maximum, Tensor.maximum, vals=np.array([[1, 0, 3, 4], [1, 2, 3, 0]], dtype=np.int32), forward_only=True)
+    helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[True, False, False], [True, True, False]], forward_only=True)
   def test_minimum(self):
     helper_test_op([(45,65), (45,65)], torch.minimum, Tensor.minimum)
     helper_test_op([(), ()], torch.minimum, Tensor.minimum)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -266,6 +266,9 @@ class TestOps(unittest.TestCase):
   def test_minimum(self):
     helper_test_op([(45,65), (45,65)], torch.minimum, Tensor.minimum)
     helper_test_op([(), ()], torch.minimum, Tensor.minimum)
+    helper_test_op(None, torch.minimum, Tensor.minimum, vals=[[1., 0., 3., 4.], [1., 2., 3., 0.]])
+    helper_test_op(None, torch.minimum, Tensor.minimum, vals=np.array([[1, 0, 3, 4], [1, 2, 3, 0]], dtype=np.int32), forward_only=True)
+    helper_test_op(None, torch.minimum, Tensor.minimum, vals=[[True, False, False], [True, True, False]], forward_only=True)
 
   def test_add(self):
     helper_test_op([(45,68), (45,68)], lambda x,y: x+y)

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -105,6 +105,7 @@ class LazyBuffer:
         srcs.append(s)
     assert all_same(dts:=[x.dtype.scalar() for x in (srcs[1:] if op is TernaryOps.WHERE else srcs)]), f"all dtypes must match {dts} on {op}"
     assert all_same([x.shape for x in srcs]), f"all shapes must be the same {[x.shape for x in srcs]}"
+    if op is TernaryOps.WHERE: assert srcs[0].dtype == dtypes.bool, "TernaryOps.WHERE must have the first arg be bool"
     out_dtype = dtypes.bool if op in (BinaryOps.CMPLT, BinaryOps.CMPEQ) else srcs[-1].dtype
     return create_lazybuffer(self.device, ShapeTracker.from_shape(self.shape), out_dtype, op, arg, tuple(srcs))
 

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -105,7 +105,6 @@ class LazyBuffer:
         srcs.append(s)
     assert all_same(dts:=[x.dtype.scalar() for x in (srcs[1:] if op is TernaryOps.WHERE else srcs)]), f"all dtypes must match {dts} on {op}"
     assert all_same([x.shape for x in srcs]), f"all shapes must be the same {[x.shape for x in srcs]}"
-    if op is TernaryOps.WHERE: assert srcs[0].dtype == dtypes.bool, "TernaryOps.WHERE must have the first arg be bool"
     out_dtype = dtypes.bool if op in (BinaryOps.CMPLT, BinaryOps.CMPEQ) else srcs[-1].dtype
     return create_lazybuffer(self.device, ShapeTracker.from_shape(self.shape), out_dtype, op, arg, tuple(srcs))
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -835,8 +835,7 @@ class Tensor:
     return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan)
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
-  # TODO: this implicitly changes dtype with /2
-  def maximum(self, x:Union[Tensor, Scalar]) -> Tensor: return (self<x).detach().where(x, (self>x).detach().where(self, (self+x)/2))
+  def maximum(self, x:Union[Tensor, Scalar]) -> Tensor: return (self<x).detach().where(x, (self>x).detach().where(self, ((self+x)*0.5).cast(self.dtype))) # noqa: E501
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return -((-self).maximum(-x))
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -836,9 +836,9 @@ class Tensor:
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
   def maximum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self<x).detach().where(x, (self>x).detach().where(self, (self+x)*0.5) if self.requires_grad and dtypes.is_float(self.dtype) else self)
+    return (self<x).detach().where(x, (self>x).detach().where(self, (self+x)/2) if self.requires_grad and dtypes.is_float(self.dtype) else self)
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self>x).detach().where(x, (self<x).detach().where(self, (self+x)*0.5) if self.requires_grad and dtypes.is_float(self.dtype) else self)
+    return (self>x).detach().where(x, (self<x).detach().where(self, (self+x)/2) if self.requires_grad and dtypes.is_float(self.dtype) else self)
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):
     if isinstance(input_, Tensor): input_, other = input_._broadcasted(other)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -835,7 +835,6 @@ class Tensor:
     return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan)
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
-  # TODO: this implicitly changes dtype with /2
   def maximum(self, x:Union[Tensor, Scalar]) -> Tensor: return (self<x).detach().where(x, (self>x).detach().where(self, (self+x)/2))
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return -((-self).maximum(-x))
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -835,8 +835,10 @@ class Tensor:
     return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan)
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
-  def maximum(self, x:Union[Tensor, Scalar]) -> Tensor: return (self<x).detach().where(x, (self>x).detach().where(self, ((self+x)*0.5).cast(self.dtype))) # noqa: E501
-  def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return (self>x).detach().where(x, (self<x).detach().where(self, ((self+x)*0.5).cast(self.dtype))) # noqa: E501
+  def maximum(self, x:Union[Tensor, Scalar]) -> Tensor:
+    return (self<x).detach().where(x, self if self.dtype == dtypes.bool else (self>x).detach().where(self, (self+x)/2))
+  def minimum(self, x:Union[Tensor, Scalar]) -> Tensor:
+    return (self>x).detach().where(x, self if self.dtype == dtypes.bool else (self<x).detach().where(self, (self+x)/2))
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):
     if isinstance(input_, Tensor): input_, other = input_._broadcasted(other)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -842,9 +842,12 @@ class Tensor:
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return -((-self).maximum(-x))
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):
+    if isinstance(input_, Tensor): input_,other = input_._broadcasted(other)
+    elif isinstance(other, Tensor): other,input_ = other._broadcasted(input_)
+    else: input_,other = Tensor(input_, self.device, dtypes.from_py(input_), False)._broadcasted(other)
     x_,y = self._broadcasted(input_, match_dtype=False)
     x,z = x_._broadcasted(other, match_dtype=False)
-    return mlops.Where.apply(x.cast(dtypes.bool), *y._broadcasted(z))
+    return mlops.Where.apply(x.cast(dtypes.bool), y, z)
 
   # ***** op wrappers (wasted lines to make the typechecker happy) *****
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -835,10 +835,8 @@ class Tensor:
     return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan)
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
-  def maximum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self<x).detach().where(x, (self>x).detach().where(self, (self+x)/2) if self.requires_grad and self.is_floating_point() else self)
-  def minimum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self>x).detach().where(x, (self<x).detach().where(self, (self+x)/2) if self.requires_grad and self.is_floating_point() else self)
+  def maximum(self, x:Union[Tensor, Scalar]) -> Tensor: return (self<x).detach().where(x, (self>x).detach().where(self, ((self+x)/2).cast(self.dtype)))
+  def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return -((-self).maximum(-x))
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):
     if isinstance(input_, Tensor): input_, other = input_._broadcasted(other)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -836,9 +836,9 @@ class Tensor:
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
   def maximum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self<x).detach().where(x, self if not dtypes.is_float(self.dtype) else (self>x).detach().where(self, (self+x)/2))
+    return (self<x).detach().where(x, self if not (self.requires_grad and dtypes.is_float(self.dtype)) else (self>x).detach().where(self, (self+x)/2))
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self>x).detach().where(x, self if not dtypes.is_float(self.dtype) else (self<x).detach().where(self, (self+x)/2))
+    return (self>x).detach().where(x, self if not (self.requires_grad and dtypes.is_float(self.dtype)) else (self<x).detach().where(self, (self+x)/2))
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):
     if isinstance(input_, Tensor): input_, other = input_._broadcasted(other)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -837,7 +837,7 @@ class Tensor:
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
   def maximum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self<x).detach().where(x, (self>x).detach().where(self, ((self * 0.5 + x * 0.5).cast(self.dtype))))
+    return (self<x).detach().where(x, (self==x).detach().where(((self * 0.5 + x * 0.5).cast(self.dtype)), self))
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return -((-self).maximum(-x))
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -836,7 +836,7 @@ class Tensor:
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
   def maximum(self, x:Union[Tensor, Scalar]) -> Tensor: return (self<x).detach().where(x, (self>x).detach().where(self, ((self+x)*0.5).cast(self.dtype))) # noqa: E501
-  def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return -((-self).maximum(-x))
+  def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return (self>x).detach().where(x, (self<x).detach().where(self, ((self+x)*0.5).cast(self.dtype))) # noqa: E501
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):
     if isinstance(input_, Tensor): input_, other = input_._broadcasted(other)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -836,7 +836,8 @@ class Tensor:
     return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan)
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
-  def maximum(self, x:Union[Tensor, Scalar]) -> Tensor: return (self<x).detach().where(x, (self>x).detach().where(self, ((self+x)/2).cast(self.dtype)))
+  def maximum(self, x:Union[Tensor, Scalar]) -> Tensor:
+    return (self<x).detach().where(x, (self>x).detach().where(self, ((self * 0.5 + x * 0.5).cast(self.dtype))))
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return -((-self).maximum(-x))
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -835,7 +835,7 @@ class Tensor:
     return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan)
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
-  # # TODO: this implicitly changes dtype with /2
+  # TODO: this implicitly changes dtype with /2
   def maximum(self, x:Union[Tensor, Scalar]) -> Tensor: return (self<x).detach().where(x, (self>x).detach().where(self, (self+x)/2))
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return -((-self).maximum(-x))
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -836,9 +836,9 @@ class Tensor:
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
   def maximum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self<x).detach().where(x, self if not (self.requires_grad and dtypes.is_float(self.dtype)) else (self>x).detach().where(self, (self+x)/2))
+    return (self<x).detach().where(x, (self>x).detach().where(self, (self+x)*0.5) if self.requires_grad and dtypes.is_float(self.dtype) else self)
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self>x).detach().where(x, self if not (self.requires_grad and dtypes.is_float(self.dtype)) else (self<x).detach().where(self, (self+x)/2))
+    return (self>x).detach().where(x, (self<x).detach().where(self, (self+x)*0.5) if self.requires_grad and dtypes.is_float(self.dtype) else self)
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):
     if isinstance(input_, Tensor): input_, other = input_._broadcasted(other)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -835,6 +835,7 @@ class Tensor:
     return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan)
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
+  # # TODO: this implicitly changes dtype with /2
   def maximum(self, x:Union[Tensor, Scalar]) -> Tensor: return (self<x).detach().where(x, (self>x).detach().where(self, (self+x)/2))
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return -((-self).maximum(-x))
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -836,9 +836,9 @@ class Tensor:
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
   def maximum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self<x).detach().where(x, (self>x).detach().where(self, (self+x)/2) if self.requires_grad and dtypes.is_float(self.dtype) else self)
+    return (self<x).detach().where(x, (self>x).detach().where(self, (self+x)/2) if self.requires_grad and self.is_floating_point() else self)
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self>x).detach().where(x, (self<x).detach().where(self, (self+x)/2) if self.requires_grad and dtypes.is_float(self.dtype) else self)
+    return (self>x).detach().where(x, (self<x).detach().where(self, (self+x)/2) if self.requires_grad and self.is_floating_point() else self)
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):
     if isinstance(input_, Tensor): input_, other = input_._broadcasted(other)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -842,12 +842,11 @@ class Tensor:
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor: return -((-self).maximum(-x))
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):
-    if isinstance(input_, Tensor): input_,other = input_._broadcasted(other)
-    elif isinstance(other, Tensor): other,input_ = other._broadcasted(input_)
-    else: input_,other = Tensor(input_, self.device, dtypes.from_py(input_), False)._broadcasted(other)
+    if isinstance(input_, Tensor): input_, other = input_._broadcasted(other)
+    elif isinstance(other, Tensor): other, input_ = other._broadcasted(input_)
     x_,y = self._broadcasted(input_, match_dtype=False)
     x,z = x_._broadcasted(other, match_dtype=False)
-    return mlops.Where.apply(x.cast(dtypes.bool), y, z)
+    return mlops.Where.apply(x.cast(dtypes.bool), *y._broadcasted(z))
 
   # ***** op wrappers (wasted lines to make the typechecker happy) *****
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -836,9 +836,9 @@ class Tensor:
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
   def maximum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self<x).detach().where(x, self if self.dtype == dtypes.bool else (self>x).detach().where(self, (self+x)/2))
+    return (self<x).detach().where(x, self if not dtypes.is_float(self.dtype) else (self>x).detach().where(self, (self+x)/2))
   def minimum(self, x:Union[Tensor, Scalar]) -> Tensor:
-    return (self>x).detach().where(x, self if self.dtype == dtypes.bool else (self<x).detach().where(self, (self+x)/2))
+    return (self>x).detach().where(x, self if not dtypes.is_float(self.dtype) else (self<x).detach().where(self, (self+x)/2))
 
   def where(self:Tensor, input_:Union[Tensor, Scalar], other:Union[Tensor, Scalar]):
     if isinstance(input_, Tensor): input_, other = input_._broadcasted(other)


### PR DESCRIPTION
resolves #3186 

the problem for #3186 is a `where` scalar casting problem it appears

I cross checked jax's casting behavior for `where` and `maximum` with the tests I wrote in `test_dtype` and they do match.

but the changes in `tensor.py` to fix `where` is really ugly :s   

is there a better way to do it? :s  
I played with a few other ways like changing `_broadcast` to something like `_broadcastall(multiple_tensors)` but it just added even more unneeded complexity