### PR TITLE
Division of two integer types to return float result

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -312,7 +312,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(), ()], lambda x,y: x/y)
     helper_test_op(None, lambda x,y: x/y, Tensor.div, forward_only=True, vals=np.array([[5],[1]], dtype=np.int32))
   def test_div_int(self):
-    helper_test_op(None, lambda x: (x/2).to(torch.int), lambda x: x/2, forward_only=True, vals=np.array([[3]], dtype=np.int32))
+    helper_test_op(None, lambda x: x/2, lambda x: x/2, forward_only=True, vals=np.array([[3]], dtype=np.int32))
   def test_div_const(self):
     helper_test_op([(45,65)], lambda x: x/255)
     helper_test_op([(45,65)], lambda x: x/1)

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -1,7 +1,7 @@
 import math
 from typing import Tuple, Optional
 from tinygrad.helpers import argsort
-from tinygrad.dtype import DType
+from tinygrad.dtype import DType, dtypes
 from tinygrad.ops import UnaryOps, BinaryOps, TernaryOps, ReduceOps
 from tinygrad.tensor import Function
 from tinygrad.lazy import LazyBuffer
@@ -121,6 +121,7 @@ class Mul(Function):
 class Div(Function):
   def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer:
     self.x, self.y = x, y
+    if dtypes.is_int(x.dtype) and dtypes.is_int(y.dtype): self.x, self.y = ((x := x.cast(dtypes.float32)), (y := y.cast(dtypes.float32))) # float result for true division of two ints
     return x.e(BinaryOps.DIV, y)
 
   def backward(self, grad_output:LazyBuffer) -> Tuple[Optional[LazyBuffer], Optional[LazyBuffer]]:


### PR DESCRIPTION
The code is aimed at changing the default behaviour of the `__truediv__` operator for tensors when both arguments are integers, so that a float type is returned instead of an integer - resolves #3133.

Before:

`from tinygrad import Tensor`
`(Tensor([1]) / Tensor([2])).numpy()`
`# array([0], dtype=int32)`

`import torch`
`out = torch.tensor([1]) / torch.tensor([2])`
`print(out, out.dtype)`
`# tensor([0.5000]) torch.float32`

After:

`from tinygrad import Tensor`
`(Tensor([1]) / Tensor([2])).numpy()`
`# array([0.5], dtype=float32)`

`import torch`
`out = torch.tensor([1]) / torch.tensor([2])`
`print(out, out.dtype)`
`# tensor([0.5000]) torch.float32`

The new result is more intuitive and more aligned with torch when using normal division. It makes more sense for a additional `__floordiv__` operator to explicitly return an integer type after division when needed. 