### PR TITLE
Fix metal tests broken by 3f56d1a

### DIFF
--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -17,6 +17,12 @@ dtypes_float = (dtypes.float32, dtypes.float16)
 dtypes_int = (dtypes.int8, dtypes.int16, dtypes.int32, dtypes.int64, dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
 dtypes_bool = (dtypes.bool,)
 binary_operations = [operator.add, operator.sub, operator.mul, operator.lt, operator.eq]
+
+# TODO: LLVM comparing with nan is incorrect
+if Device.DEFAULT == "LLVM":
+  binary_operations.remove(operator.lt)
+  binary_operations.remove(operator.eq)
+
 integer_binary_operations = binary_operations + [(Tensor.xor, np.bitwise_xor)]
 unary_operations = [(Tensor.exp, np.exp), (Tensor.log, np.log), operator.neg, (Tensor.sin, np.sin),
                     (Tensor.sqrt, np.sqrt), (Tensor.reciprocal, np.reciprocal)]
@@ -29,11 +35,6 @@ unary_operations = [(Tensor.exp, np.exp), (Tensor.log, np.log), operator.neg, (T
 
 # TODO: (a+b)/2 in tensor.py's maximum can overflow. This requires a new implementation of maximum that can be backpropagated
 #binary_operations += [(Tensor.maximum, np.maximum)]
-
-# TODO: LLVM comparing with nan is incorrect
-if Device.DEFAULT == "LLVM":
-  binary_operations.remove(operator.lt)
-  binary_operations.remove(operator.eq)
 
 # TODO: CUDACPU segfaults on sin
 if getenv("CUDACPU"): unary_operations.remove((Tensor.sin, np.sin))

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -18,8 +18,8 @@ dtypes_int = (dtypes.int8, dtypes.int16, dtypes.int32, dtypes.int64, dtypes.uint
 dtypes_bool = (dtypes.bool,)
 binary_operations = [operator.add, operator.sub, operator.mul, operator.lt, operator.eq]
 
-# TODO: LLVM comparing with nan is incorrect
-if Device.DEFAULT == "LLVM":
+# TODO: LLVM and METAL comparing with nan is incorrect
+if Device.DEFAULT in {"LLVM", "METAL"}:
   binary_operations.remove(operator.lt)
   binary_operations.remove(operator.eq)
 


### PR DESCRIPTION
3f56d1a5e8385b12526899abd120e811033bb313 added `operators.lt` and `operators.eq` to `binary_operations` in test_dtype_alu.py, except for llvm. This broke `METAL=1 python -m pytest -n=auto test/ --ignore=test/external --ignore=test/models --durations=20` on my machine, but for some reason not on CI. Maybe it has somehting to do with the fact that metal in CI is software-emulated.

This PR moves exclusion check earlier (before `integer_binary_operations = binary_operations + [(Tensor.xor, np.bitwise_xor)]`) and adds METAL to exclusion list.