### PR TITLE
Cast final result in `.pow` hlop to be the least upper dtype from input dtypes

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -472,5 +472,12 @@ class TestAutoCastType(unittest.TestCase):
     b = (Tensor.rand((100,)) * 20 - 10).cast(dt2)
     self.assertEqual((a ** b).dtype, least_upper_dtype(dt1, dt2))
 
+  @given(strat.sampled_from(core_dtypes))
+  def test_pow_scalar(self, tensor_dt):
+    a = (Tensor.rand((100,)) * 20 - 10).cast(tensor_dt)
+    scalers = [(5, dtypes.from_py(5)), (5.546, dtypes.from_py(5.546))]
+    for scalar, scalar_dt in scalers:
+      self.assertEqual((a ** scalar).dtype, least_upper_dtype(tensor_dt, scalar_dt))
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -466,5 +466,11 @@ class TestAutoCastType(unittest.TestCase):
   def test_matmul(self, dt1, dt2):
     assert (Tensor([0, 1], dtype=dt1) @ Tensor([0, 1], dtype=dt2)).dtype == least_upper_dtype(dt1, dt2)
 
+  @given(strat.sampled_from(core_dtypes), strat.sampled_from(core_dtypes))
+  def test_pow(self, dt1, dt2):
+    a = (Tensor.rand((100,)) * 20 - 10).cast(dt1)
+    b = (Tensor.rand((100,)) * 20 - 10).cast(dt2)
+    self.assertEqual((a ** b).dtype, least_upper_dtype(dt1, dt2))
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -471,6 +471,7 @@ class TestAutoCastType(unittest.TestCase):
     a = (Tensor.rand((100,)) * 20 - 10).cast(dt1)
     b = (Tensor.rand((100,)) * 20 - 10).cast(dt2)
     self.assertEqual((a ** b).dtype, least_upper_dtype(dt1, dt2))
+    self.assertEqual(a.pow(b, reverse=True).dtype, least_upper_dtype(dt1, dt2))
 
   @given(strat.sampled_from(core_dtypes))
   def test_pow_scalar(self, tensor_dt):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -364,18 +364,6 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], lambda x: 2.0**x, lambda x: 2.0**x)
     helper_test_op([()], lambda x: x**2.0, lambda x: x**2.0)
     helper_test_op([()], lambda x: 2.0**x, lambda x: 2.0**x)
-  def test_pow_dtype_cast(self):
-    x = Tensor.arange(-10, 10)
-    y = Tensor.randint((20,))
-    int_x = x.cast(dtypes.default_int)
-    float_x = x.cast(dtypes.default_float)
-    int_y = y.cast(dtypes.default_int)
-    float_y = y.cast(dtypes.default_float)
-
-    self.assertEqual((int_x ** int_y).dtype, dtypes.default_int)
-    self.assertEqual((int_x ** float_y).dtype, dtypes.default_float)
-    self.assertEqual((float_x ** int_y).dtype, dtypes.default_float)
-    self.assertEqual((float_x ** float_y).dtype, dtypes.default_float)
 
   def test_sqrt(self):
     helper_test_op([(45,65)], lambda x: x.sqrt(), a=0)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -364,6 +364,18 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], lambda x: 2.0**x, lambda x: 2.0**x)
     helper_test_op([()], lambda x: x**2.0, lambda x: x**2.0)
     helper_test_op([()], lambda x: 2.0**x, lambda x: 2.0**x)
+  def test_pow_dtype_cast(self):
+    x = Tensor.arange(-10, 10)
+    y = Tensor.randint((20,))
+    int_x = x.cast(dtypes.default_int)
+    float_x = x.cast(dtypes.default_float)
+    int_y = y.cast(dtypes.default_int)
+    float_y = y.cast(dtypes.default_float)
+
+    self.assertEqual((int_x ** int_y).dtype, dtypes.default_int)
+    self.assertEqual((int_x ** float_y).dtype, dtypes.default_float)
+    self.assertEqual((float_x ** int_y).dtype, dtypes.default_float)
+    self.assertEqual((float_x ** float_y).dtype, dtypes.default_float)
 
   def test_sqrt(self):
     helper_test_op([(45,65)], lambda x: x.sqrt(), a=0)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -832,7 +832,7 @@ class Tensor:
     # inject nan if the base is negative and the power is not an integer
     to_nan = (((x - x.trunc()) * 1e10).abs().clip(0, 1) if isinstance(x, Tensor) else int(bool(x - int(x))) if not reverse else ((self - self.trunc()) * 1e10).abs().clip(0, 1)) * base_sign  # noqa: E501
     inject_nan = ((((-to_nan) * 2) + 1)).log().add(1) if isinstance(to_nan, Tensor) else 1 if not to_nan else float("nan")
-    return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan).cast(least_upper_dtype(self.dtype, x.dtype) if isinstance(x, Tensor) else self.dtype)
+    return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan).cast(least_upper_dtype(self.dtype, x.dtype) if isinstance(x, Tensor) else self.dtype)  # noqa: E501
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
   # TODO: this implicitly changes dtype with /2

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -832,7 +832,7 @@ class Tensor:
     # inject nan if the base is negative and the power is not an integer
     to_nan = (((x - x.trunc()) * 1e10).abs().clip(0, 1) if isinstance(x, Tensor) else int(bool(x - int(x))) if not reverse else ((self - self.trunc()) * 1e10).abs().clip(0, 1)) * base_sign  # noqa: E501
     inject_nan = ((((-to_nan) * 2) + 1)).log().add(1) if isinstance(to_nan, Tensor) else 1 if not to_nan else float("nan")
-    return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan).cast(least_upper_dtype(self.dtype, x.dtype))
+    return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan).cast(least_upper_dtype(self.dtype, x.dtype) if isinstance(x, Tensor) else self.dtype)
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
   # TODO: this implicitly changes dtype with /2

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -832,7 +832,7 @@ class Tensor:
     # inject nan if the base is negative and the power is not an integer
     to_nan = (((x - x.trunc()) * 1e10).abs().clip(0, 1) if isinstance(x, Tensor) else int(bool(x - int(x))) if not reverse else ((self - self.trunc()) * 1e10).abs().clip(0, 1)) * base_sign  # noqa: E501
     inject_nan = ((((-to_nan) * 2) + 1)).log().add(1) if isinstance(to_nan, Tensor) else 1 if not to_nan else float("nan")
-    return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan)
+    return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan).cast(least_upper_dtype(self.dtype, x.dtype))
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
   # TODO: this implicitly changes dtype with /2

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -832,7 +832,7 @@ class Tensor:
     # inject nan if the base is negative and the power is not an integer
     to_nan = (((x - x.trunc()) * 1e10).abs().clip(0, 1) if isinstance(x, Tensor) else int(bool(x - int(x))) if not reverse else ((self - self.trunc()) * 1e10).abs().clip(0, 1)) * base_sign  # noqa: E501
     inject_nan = ((((-to_nan) * 2) + 1)).log().add(1) if isinstance(to_nan, Tensor) else 1 if not to_nan else float("nan")
-    return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan).cast(least_upper_dtype(self.dtype, x.dtype) if isinstance(x, Tensor) else self.dtype)  # noqa: E501
+    return ar.mul(sign * base_sign + (1 - base_sign)).mul(inject_nan).cast(least_upper_dtype(self.dtype, x.dtype if isinstance(x, Tensor) else dtypes.from_py(x)))  # noqa: E501
   def xor(self, x:Tensor, reverse=False) -> Tensor: return mlops.Xor.apply(*self._broadcasted(x, reverse))
 
   # TODO: this implicitly changes dtype with /2


### PR DESCRIPTION
While comparing pytorch's `torch.pow` hlop to tinygrad's, I noticed the result `dtype` of tinygrad is always float. This is due to the series of operations used to implement tinygrad's `Tensor.pow` method which contains intermediary results of type float. To solve this and match pytorch's behavior, I added a casting operation to the least upper bound data type of the inputs' data types.