### PR TITLE
refactor if checks to be more compact

### DIFF
--- a/examples/yolov8.py
+++ b/examples/yolov8.py
@@ -200,7 +200,7 @@ def clip_boxes(boxes, shape):
   return boxes
 
 def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None):
-  gain = ratio_pad if ratio_pad else min(img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1])
+  gain = ratio_pad or min(img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1])
   pad = ((img1_shape[1] - img0_shape[1] * gain) / 2, (img1_shape[0] - img0_shape[0] * gain) / 2)
   boxes_np = boxes.numpy() if isinstance(boxes, Tensor) else boxes
   boxes_np[..., [0, 2]] -= pad[0]

--- a/extra/backends/ptx.py
+++ b/extra/backends/ptx.py
@@ -46,7 +46,7 @@ def uops_to_asm(lang:AssemblyLanguage, function_name:str, uops:List[UOp]) -> str
   r: Dict[UOp, str] = {}
   def ssa(u, prefix="t", dtype=None) -> str:
     nonlocal c, r
-    prefix += f"_{dtype if dtype else lang.types[u.dtype]}_"
+    prefix += f"_{dtype or lang.types[u.dtype]}_"
     c[prefix] += 1
     if u: r[u] = f"%{prefix}{c[prefix]-1}"
     return f"%{prefix}{c[prefix]-1}"

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -174,7 +174,7 @@ def diskcache(func):
 
 def fetch(url:str, name:Optional[Union[pathlib.Path, str]]=None, allow_caching=not getenv("DISABLE_HTTP_CACHE")) -> pathlib.Path:
   if url.startswith(("/", ".")): return pathlib.Path(url)
-  fp = pathlib.Path(name) if name is not None and (isinstance(name, pathlib.Path) or '/' in name) else pathlib.Path(_cache_dir) / "tinygrad" / "downloads" / (name if name else hashlib.md5(url.encode('utf-8')).hexdigest())  # noqa: E501
+  fp = pathlib.Path(name) if name is not None and (isinstance(name, pathlib.Path) or '/' in name) else pathlib.Path(_cache_dir) / "tinygrad" / "downloads" / (name or hashlib.md5(url.encode('utf-8')).hexdigest())  # noqa: E501
   if not fp.is_file() or not allow_caching:
     with urllib.request.urlopen(url, timeout=10) as r:
       assert r.status == 200


### PR DESCRIPTION
This proposes a refactoring, which simplifies and makes more compact `if-else` expression of type `var if var else` to the equivalent `var or`.

Reference one-liner to obtain all `var if var else` occurrences:
```bash
grep -oPrnH '\b(\w+) if \1\b else' .
```

Additionally, some unused imports have been removed.