### PR TITLE
Fix hip_matmul device error

### DIFF
--- a/extra/gemm/hip_matmul.py
+++ b/extra/gemm/hip_matmul.py
@@ -2,7 +2,7 @@ import time
 import numpy as np
 from tinygrad import dtypes
 from tinygrad.helpers import getenv, prod, flat_mv
-from tinygrad.runtime.ops_hip import HIPAllocator, HIPProgram, compile_hip
+from tinygrad.runtime.ops_hip import HIPAllocator, HIPDevice, HIPProgram, compile_hip
 
 # AMD_LOG_LEVEL=3 ./MIOpenDriver gemm --iter 1000 --time 1 --a_w 2048 --a_h 2048 --b_w 2048
 # 5.5: Cijk_Ailk_Bljk_HHS_BH_MT128x128x16_MI16x16x16x1_SN_1LDSB0_APM1_ABV0_ACED0_AF0EM1_AF1EM1_AMAS3_ASE_ASGT_ASAE01_ASCE01_ASEM1_AAC0_BL1_BS1_DTL0_DTVA0_DVO0_ETSP_EPS1_FL0_GRVW8_GSU1_GSUASB_GLS0_ISA1100_IU1_K1_KLA_LBSPP128_LPA0_LPB8_LDL1_LRVW16_LWPMn1_LDW0_FMA_MIAV1_MDA2_NTA0_NTB0_NTC0_NTD0_NEPBS0_NLCA1_NLCB1_ONLL1_OPLV0_PK0_PAP0_PGR1_PLR1_RK0_SIA1_SS1_SU32_SUM0_SUS128_SCIUI1_SPO0_SRVW0_SSO0_SVW4_SNLL0_TT4_64_TLDS1_USFGROn1_VAW2_VSn1_VW4_WSGRA1_WSGRB1_WS32_WG32_4_1_WGM4
@@ -25,7 +25,7 @@ FLOPS = N*N*N*2
 BW = N*N*3*4
 
 # Can HIPAllocator initialized as device=0 by default?
-device = 0
+device = HIPDevice()
 hipallocator = HIPAllocator(device)
 a = hipallocator.alloc(N*N*4)
 b = hipallocator.alloc(N*N*2)
@@ -95,7 +95,7 @@ extern "C" __global__ void __launch_bounds__ (128, 1) test(float* c, __half* a, 
   }}
 }}""")
 
-prog = HIPProgram(device, "test", lib)
+prog = HIPProgram(device.device, "test", lib)
 
 def timeit(fxn):
   st = time.perf_counter()


### PR DESCRIPTION
`python3 extra/gemm/hip_matmul.py` produces the following error on current master:

` File "/home/wpmed/tinygrad/extra/gemm/hip_matmul.py", line 30, in <module>
    a = hipallocator.alloc(N*N*4)
  File "/home/wpmed/tinygrad/tinygrad/device.py", line 152, in alloc
    try: return super().alloc(size, options)
  File "/home/wpmed/tinygrad/tinygrad/device.py", line 140, in alloc
    return self._alloc_with_options(size, options) if options is not None else self._alloc(size)
  File "/home/wpmed/tinygrad/tinygrad/runtime/ops_hip.py", line 55, in _alloc
    check(hip.hipSetDevice(self.device.device))
AttributeError: 'int' object has no attribute 'device'`

This is because in this example device is set to `0`, but `HIPAllocator` expects a `HIPDevice`. The `int` value of the device then can be accessed by `device.device` when creating the `HIPProgram`.