### PR TITLE
add _reduce_ function for Tensor

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -469,24 +469,51 @@ class TestTensorCreationDevice(unittest.TestCase):
     x = y.one_hot(10)
     x.realize()
 
+class TestTensorReduce(unittest.TestCase):
+  def test_reconstruct_scalar(self):
+    y = Tensor(1)
+    x = Tensor(*y.__reduce__()[1])
+
+    np.testing.assert_equal(y.numpy(), x.numpy())
+    assert y.dtype == x.dtype
+    assert y.device == x.device
+    assert y.requires_grad == x.requires_grad
+
+  def test_reconstruct_multi_dim(self):
+    shape: list[int] = []
+    for i in range(1, 3):  # (2,), (2,2), (2,2,2), ...
+      shape.append(2)
+
+      y = Tensor.randn(shape)
+      x = Tensor(*y.__reduce__()[1])
+
+      np.testing.assert_equal(y.numpy(), x.numpy())
+      assert y.dtype == x.dtype
+      assert y.device == x.device
+      assert y.requires_grad == x.requires_grad
+
 class TestTensorPickle(unittest.TestCase):
   def test_pickle_scalar(self):
-    y = Tensor(1).to("CPU")
+    y = Tensor(1)
     x = pickle.loads(pickle.dumps(y))
-    np.testing.assert_equal(y.numpy(), x.numpy())
 
-  def test_pickle_one_dim(self):
-    y = Tensor([1, 2, 3]).to("CPU")
-    x = pickle.loads(pickle.dumps(y))
     np.testing.assert_equal(y.numpy(), x.numpy())
+    assert y.dtype == x.dtype
+    assert y.device == x.device
+    assert y.requires_grad == x.requires_grad
 
   def test_pickle_multi_dim(self):
-    shape = [2]
-    for i in range(1, 10):  # (2,), (2,2), (2,2,2), ...
+    shape: list[int] = []
+    for i in range(1, 3):  # (2,), (2,2), (2,2,2), ...
       shape.append(2)
-      y = Tensor.randn(shape).to("CPU")
+
+      y = Tensor.randn(shape)
       x = pickle.loads(pickle.dumps(y))
+
       np.testing.assert_equal(y.numpy(), x.numpy())
+      assert y.dtype == x.dtype
+      assert y.device == x.device
+      assert y.requires_grad == x.requires_grad
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -470,23 +470,23 @@ class TestTensorCreationDevice(unittest.TestCase):
     x.realize()
 
 class TestTensorPickle(unittest.TestCase):
-    def test_pickle_scalar(self):
-      y = Tensor(1).to("CPU")
+  def test_pickle_scalar(self):
+    y = Tensor(1).to("CPU")
+    x = pickle.loads(pickle.dumps(y))
+    np.testing.assert_equal(y.numpy(), x.numpy())
+
+  def test_pickle_one_dim(self):
+    y = Tensor([1, 2, 3]).to("CPU")
+    x = pickle.loads(pickle.dumps(y))
+    np.testing.assert_equal(y.numpy(), x.numpy())
+
+  def test_pickle_multi_dim(self):
+    shape = [2]
+    for i in range(1, 10):  # (2,), (2,2), (2,2,2), ...
+      shape.append(2)
+      y = Tensor.randn(shape).to("CPU")
       x = pickle.loads(pickle.dumps(y))
       np.testing.assert_equal(y.numpy(), x.numpy())
-
-    def test_pickle_one_dim(self):
-      y = Tensor([1, 2, 3]).to("CPU")
-      x = pickle.loads(pickle.dumps(y))
-      np.testing.assert_equal(y.numpy(), x.numpy())
-
-    def test_pickle_multi_dim(self):
-      shape = [2]
-      for i in range(1, 10):  # (2,), (2,2), (2,2,2), ...
-        shape.append(2)
-        y = Tensor.randn(shape).to("CPU")
-        x = pickle.loads(pickle.dumps(y))
-        np.testing.assert_equal(y.numpy(), x.numpy())
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -470,10 +470,23 @@ class TestTensorCreationDevice(unittest.TestCase):
     x.realize()
 
 class TestTensorPickle(unittest.TestCase):
-  def test_pickle(self):
-    y = Tensor([1, 2, 3]).to("CPU")
-    x = pickle.loads(pickle.dumps(y))
-    np.testing.assert_equal(y.numpy(), x.numpy())
+    def test_pickle_scalar(self):
+      y = Tensor(1).to("CPU")
+      x = pickle.loads(pickle.dumps(y))
+      np.testing.assert_equal(y.numpy(), x.numpy())
+
+    def test_pickle_one_dim(self):
+      y = Tensor([1, 2, 3]).to("CPU")
+      x = pickle.loads(pickle.dumps(y))
+      np.testing.assert_equal(y.numpy(), x.numpy())
+
+    def test_pickle_multi_dim(self):
+      shape = [2]
+      for i in range(1, 10):  # (2,), (2,2), (2,2,2), ...
+        shape.append(2)
+        y = Tensor.randn(shape).to("CPU")
+        x = pickle.loads(pickle.dumps(y))
+        np.testing.assert_equal(y.numpy(), x.numpy())
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -6,6 +6,7 @@ from tinygrad import Tensor, Device, dtypes
 from tinygrad.helpers import temp, CI
 from extra.gradcheck import numerical_jacobian, jacobian, gradcheck
 from hypothesis import given, settings, strategies as strat
+import pickle
 
 settings.register_profile("my_profile", max_examples=200, deadline=None)
 settings.load_profile("my_profile")
@@ -467,6 +468,12 @@ class TestTensorCreationDevice(unittest.TestCase):
     y = Tensor([1, 2, 3]).to("CPU")
     x = y.one_hot(10)
     x.realize()
+
+class TestTensorPickle(unittest.TestCase):
+  def test_pickle(self):
+    y = Tensor([1, 2, 3]).to("CPU")
+    x = pickle.loads(pickle.dumps(y))
+    np.testing.assert_equal(y.numpy(), x.numpy())
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -488,6 +488,11 @@ class TestTensorCreationDevice(unittest.TestCase):
 
 
 class TestTensorPickle(unittest.TestCase):
+  def test_pickle_scalar(self):
+    y = Tensor(1).to("CPU")
+    x = pickle.loads(pickle.dumps(y))
+    np.testing.assert_equal(y.numpy(), x.numpy())
+
   def test_pickle_one_dim(self):
     y = Tensor([1, 2, 3]).to("CPU")
     x = pickle.loads(pickle.dumps(y))

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -11,11 +11,12 @@ import pickle
 settings.register_profile("my_profile", max_examples=200, deadline=None)
 settings.load_profile("my_profile")
 
-x_init = np.random.randn(1,3).astype(np.float32)
-U_init = np.random.randn(3,3).astype(np.float32)
-V_init = np.random.randn(3,3).astype(np.float32)
-W_init = np.random.randn(3,3).astype(np.float32)
-m_init = np.random.randn(1,3).astype(np.float32)
+x_init = np.random.randn(1, 3).astype(np.float32)
+U_init = np.random.randn(3, 3).astype(np.float32)
+V_init = np.random.randn(3, 3).astype(np.float32)
+W_init = np.random.randn(3, 3).astype(np.float32)
+m_init = np.random.randn(1, 3).astype(np.float32)
+
 
 class TestTinygrad(unittest.TestCase):
   def test_zerodim_initialization(self):
@@ -26,8 +27,8 @@ class TestTinygrad(unittest.TestCase):
     self.assertEqual(b.shape, ())
 
   def test_plus_equals(self):
-    a = Tensor.randn(10,10)
-    b = Tensor.randn(10,10)
+    a = Tensor.randn(10, 10)
+    b = Tensor.randn(10, 10)
     c = a + b
     val1 = c.numpy()
     a += b
@@ -55,10 +56,11 @@ class TestTinygrad(unittest.TestCase):
       out.backward()
       return out.detach().numpy(), x.grad, W.grad
 
-    for x,y in zip(test_tinygrad(), test_pytorch()):
+    for x, y in zip(test_tinygrad(), test_pytorch()):
       np.testing.assert_allclose(x, y, atol=1e-5)
 
-  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "this test uses more than 8 bufs which breaks webgpu") #TODO: remove after #1461
+  @unittest.skipIf(Device.DEFAULT == "WEBGPU",
+                   "this test uses more than 8 bufs which breaks webgpu")  # TODO: remove after #1461
   def test_backward_pass_diamond_model(self):
     def test_tinygrad():
       u = Tensor(U_init, requires_grad=True)
@@ -84,7 +86,7 @@ class TestTinygrad(unittest.TestCase):
       out.backward()
       return out.detach().numpy(), u.grad, v.grad, w.grad
 
-    for x,y in zip(test_tinygrad(), test_pytorch()):
+    for x, y in zip(test_tinygrad(), test_pytorch()):
       np.testing.assert_allclose(x, y, atol=1e-5)
 
   def test_nograd(self):
@@ -116,17 +118,21 @@ class TestTinygrad(unittest.TestCase):
 
     torch_x = torch.tensor(x, requires_grad=True)
     torch_W = torch.tensor(W, requires_grad=True)
+
     def torch_func(x): return torch.nn.functional.log_softmax(x.matmul(torch_W).relu(), dim=1)
+
     PJ = torch.autograd.functional.jacobian(torch_func, torch_x).squeeze().numpy()
 
     tiny_x = Tensor(x, requires_grad=True)
     tiny_W = Tensor(W, requires_grad=True)
+
     def tiny_func(x): return x.dot(tiny_W).relu().log_softmax()
+
     J = jacobian(tiny_func, tiny_x)
     NJ = numerical_jacobian(tiny_func, tiny_x)
 
-    np.testing.assert_allclose(PJ, J, atol = 1e-5)
-    np.testing.assert_allclose(PJ, NJ, atol = 1e-3)
+    np.testing.assert_allclose(PJ, J, atol=1e-5)
+    np.testing.assert_allclose(PJ, NJ, atol=1e-3)
 
   def test_gradcheck(self):
     W = np.random.RandomState(1337).random((10, 5)).astype(np.float32)
@@ -134,28 +140,33 @@ class TestTinygrad(unittest.TestCase):
 
     tiny_x = Tensor(x, requires_grad=True)
     tiny_W = Tensor(W, requires_grad=True)
+
     def tiny_func(x): return x.dot(tiny_W).relu().log_softmax()
 
-    self.assertTrue(gradcheck(tiny_func, tiny_x, eps = 1e-3))
+    self.assertTrue(gradcheck(tiny_func, tiny_x, eps=1e-3))
 
     # coarse approx. since a "big" eps and the non-linearities of the model
-    self.assertFalse(gradcheck(tiny_func, tiny_x, eps = 1e-5))
+    self.assertFalse(gradcheck(tiny_func, tiny_x, eps=1e-5))
 
   def test_random_fns_are_deterministic_with_seed(self):
-    for random_fn in [Tensor.randn, Tensor.normal, Tensor.uniform, Tensor.scaled_uniform, Tensor.glorot_uniform, Tensor.kaiming_normal]:
+    for random_fn in [Tensor.randn, Tensor.normal, Tensor.uniform, Tensor.scaled_uniform, Tensor.glorot_uniform,
+                      Tensor.kaiming_normal]:
       with self.subTest(msg=f"Tensor.{random_fn.__name__}"):
         Tensor.manual_seed(1337)
-        a = random_fn(10,10).realize()
+        a = random_fn(10, 10).realize()
         Tensor.manual_seed(1337)
-        b = random_fn(10,10).realize()
+        b = random_fn(10, 10).realize()
         np.testing.assert_allclose(a.numpy(), b.numpy())
 
   def test_randn_isnt_inf_on_zero(self):
     # simulate failure case of rand handing a zero to randn
     original_rand, Tensor.rand = Tensor.rand, Tensor.zeros
-    try: self.assertNotIn(np.inf, Tensor.randn(16).numpy())
-    except: raise
-    finally: Tensor.rand = original_rand
+    try:
+      self.assertNotIn(np.inf, Tensor.randn(16).numpy())
+    except:
+      raise
+    finally:
+      Tensor.rand = original_rand
 
   def test_zeros_like_has_same_dtype_and_shape(self):
     for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
@@ -184,8 +195,8 @@ class TestTinygrad(unittest.TestCase):
   def test_ndim(self):
     assert Tensor(1).ndim == 0
     assert Tensor.randn(1).ndim == 1
-    assert Tensor.randn(2,2,2).ndim == 3
-    assert Tensor.randn(1,1,1,1,1,1).ndim == 6
+    assert Tensor.randn(2, 2, 2).ndim == 3
+    assert Tensor.randn(1, 1, 1, 1, 1, 1).ndim == 6
 
   def test_argfix(self):
     self.assertEqual(Tensor.zeros().shape, ())
@@ -200,31 +211,32 @@ class TestTinygrad(unittest.TestCase):
     self.assertEqual(Tensor.zeros(1).shape, (1,))
     self.assertEqual(Tensor.ones(1).shape, (1,))
 
-    self.assertEqual(Tensor.zeros(1,10,20).shape, (1,10,20))
-    self.assertEqual(Tensor.ones(1,10,20).shape, (1,10,20))
+    self.assertEqual(Tensor.zeros(1, 10, 20).shape, (1, 10, 20))
+    self.assertEqual(Tensor.ones(1, 10, 20).shape, (1, 10, 20))
 
     self.assertEqual(Tensor.zeros([1]).shape, (1,))
     self.assertEqual(Tensor.ones([1]).shape, (1,))
 
-    self.assertEqual(Tensor.zeros([10,20,40]).shape, (10,20,40))
-    self.assertEqual(Tensor.ones([10,20,40]).shape, (10,20,40))
+    self.assertEqual(Tensor.zeros([10, 20, 40]).shape, (10, 20, 40))
+    self.assertEqual(Tensor.ones([10, 20, 40]).shape, (10, 20, 40))
 
-    self.assertEqual(Tensor.rand(1,10,20).shape, (1,10,20))
-    self.assertEqual(Tensor.rand((10,20,40)).shape, (10,20,40))
+    self.assertEqual(Tensor.rand(1, 10, 20).shape, (1, 10, 20))
+    self.assertEqual(Tensor.rand((10, 20, 40)).shape, (10, 20, 40))
 
-    self.assertEqual(Tensor.empty(1,10,20).shape, (1,10,20))
-    self.assertEqual(Tensor.empty((10,20,40)).shape, (10,20,40))
+    self.assertEqual(Tensor.empty(1, 10, 20).shape, (1, 10, 20))
+    self.assertEqual(Tensor.empty((10, 20, 40)).shape, (10, 20, 40))
 
   def test_numel(self):
     assert Tensor.randn(10, 10).numel() == 100
-    assert Tensor.randn(1,2,5).numel() == 10
-    assert Tensor.randn(1,1,1,1,1,1).numel() == 1
+    assert Tensor.randn(1, 2, 5).numel() == 10
+    assert Tensor.randn(1, 1, 1, 1, 1, 1).numel() == 1
     assert Tensor([]).numel() == 0
-    assert Tensor.randn(1,0,2,5).numel() == 0
+    assert Tensor.randn(1, 0, 2, 5).numel() == 0
 
   def test_element_size(self):
     for _, dtype in dtypes.fields().items():
-      assert dtype.itemsize == Tensor.randn(3, dtype=dtype).element_size(), f"Tensor.element_size() not matching Tensor.dtype.itemsize for {dtype}"
+      assert dtype.itemsize == Tensor.randn(3,
+                                            dtype=dtype).element_size(), f"Tensor.element_size() not matching Tensor.dtype.itemsize for {dtype}"
 
   def test_deepwalk_ctx_check(self):
     layer = Tensor.uniform(1, 1, requires_grad=True)
@@ -238,56 +250,57 @@ class TestTinygrad(unittest.TestCase):
     np.testing.assert_equal(Tensor(None).numpy(), np.array([]))
 
   def test_tensor_ndarray_dtype(self):
-    arr = np.array([1]) # where dtype is implicitly int64
+    arr = np.array([1])  # where dtype is implicitly int64
     assert Tensor(arr).dtype == dtypes.int64
-    assert Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32 # check if ndarray correctly casts to Tensor dtype
-    assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64 # check that it works for something else
+    assert Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32  # check if ndarray correctly casts to Tensor dtype
+    assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64  # check that it works for something else
 
   def test_tensor_list_dtype(self):
-    for arr in ([1], [[[1]]], [[1,1],[1,1]], [[[1,1],[1,1]],[[1,1],[1,1]]]):
+    for arr in ([1], [[[1]]], [[1, 1], [1, 1]], [[[1, 1], [1, 1]], [[1, 1], [1, 1]]]):
       assert Tensor(arr).dtype == dtypes.default_int
       assert Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32
       assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64
 
-    for arr in ([True], [[[False]]], [[True,False],[True,False]], [[[False,True],[False,False]],[[True,True],[False,True]]]):
+    for arr in ([True], [[[False]]], [[True, False], [True, False]],
+                [[[False, True], [False, False]], [[True, True], [False, True]]]):
       assert Tensor(arr).dtype == dtypes.bool
       assert Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32
       assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64
 
     # empty tensor defaults
-    for arr in ([], [[[]]], [[],[]]):
+    for arr in ([], [[[]]], [[], []]):
       t = Tensor(arr)
       assert t.dtype == dtypes.default_float
       np.testing.assert_allclose(t.numpy(), np.array(arr))
 
     # mixture of bool and int
-    for arr in ([True, 3], [[True],[3]], [[[True]], [[3]]], [[True, 3], [3, True]]):
+    for arr in ([True, 3], [[True], [3]], [[[True]], [[3]]], [[True, 3], [3, True]]):
       t = Tensor(arr)
       assert t.dtype == dtypes.default_int
       np.testing.assert_allclose(t.numpy(), np.array(arr))
 
     # mixture of bool, int and float
-    for arr in ([[True,True],[3.,True]], [[0,1],[3.,4]], [[[0],[1]],[[3.],[4]]], [[[True],[1]],[[3.],[4]]]):
+    for arr in ([[True, True], [3., True]], [[0, 1], [3., 4]], [[[0], [1]], [[3.], [4]]], [[[True], [1]], [[3.], [4]]]):
       t = Tensor(arr)
       assert t.dtype == dtypes.default_float
       np.testing.assert_allclose(t.numpy(), np.array(arr))
 
   def test_tensor_list_shapes(self):
-    self.assertEqual(Tensor([[[]]]).shape, (1,1,0))
-    self.assertEqual(Tensor([[],[]]).shape, (2,0))
-    self.assertEqual(Tensor([[[[]],[[]]], [[[]],[[]]], [[[]],[[]]]]).shape, (3,2,1,0))
+    self.assertEqual(Tensor([[[]]]).shape, (1, 1, 0))
+    self.assertEqual(Tensor([[], []]).shape, (2, 0))
+    self.assertEqual(Tensor([[[[]], [[]]], [[[]], [[]]], [[[]], [[]]]]).shape, (3, 2, 1, 0))
 
   def test_tensor_list_errors(self):
     # inhomogeneous shape
-    with self.assertRaises(ValueError): Tensor([[],[[]]])
-    with self.assertRaises(ValueError): Tensor([[1],[]])
-    with self.assertRaises(ValueError): Tensor([[1],[1],1])
-    with self.assertRaises(ValueError): Tensor([[[1,1,1],[1,1]]])
-    with self.assertRaises(ValueError): Tensor([[1,1,1],[[1,1,1]]])
+    with self.assertRaises(ValueError): Tensor([[], [[]]])
+    with self.assertRaises(ValueError): Tensor([[1], []])
+    with self.assertRaises(ValueError): Tensor([[1], [1], 1])
+    with self.assertRaises(ValueError): Tensor([[[1, 1, 1], [1, 1]]])
+    with self.assertRaises(ValueError): Tensor([[1, 1, 1], [[1, 1, 1]]])
 
   def test_tensor_copy(self):
-    x = copy.deepcopy(Tensor.ones((3,3,3)))
-    np.testing.assert_allclose(x.numpy(), np.ones((3,3,3)))
+    x = copy.deepcopy(Tensor.ones((3, 3, 3)))
+    np.testing.assert_allclose(x.numpy(), np.ones((3, 3, 3)))
 
   def test_copy_from_disk(self):
     t = Tensor.randn(30, device="CPU").to(f"disk:{temp('test_copy_from_disk')}")
@@ -298,7 +311,7 @@ class TestTinygrad(unittest.TestCase):
   # Regression test for https://github.com/tinygrad/tinygrad/issues/1751
   def test_copy_from_numpy_unaligned(self):
     # 2**15 is the minimum for repro
-    arr = np.random.randn(2**15).astype(dtypes.float.np)
+    arr = np.random.randn(2 ** 15).astype(dtypes.float.np)
     fn = temp('test_copy_from_numpy_unaligned')
     with open(fn, 'wb') as f: f.write(b't' + arr.tobytes())
     with open(fn, "a+b") as f: memview = memoryview(mmap.mmap(f.fileno(), arr.nbytes + 1))
@@ -306,7 +319,7 @@ class TestTinygrad(unittest.TestCase):
     np.testing.assert_allclose(arr, ua_arr)
     assert not ua_arr.flags.aligned
     # force device copy - to() is opt'd away - Tensor(dev)/1 is ignored
-    np.testing.assert_allclose(ua_arr, (Tensor(ua_arr)/Tensor(1)).numpy())
+    np.testing.assert_allclose(ua_arr, (Tensor(ua_arr) / Tensor(1)).numpy())
 
   def test_item_to_tensor_to_item(self):
     for a in [0, 1, 2, 3, -1, -100, 100, -101.1, 2.345, 100.1, True, False]:
@@ -320,9 +333,11 @@ class TestTinygrad(unittest.TestCase):
       assert type(reshaped_item) == type(a), a
       np.testing.assert_allclose(reshaped_item, a), a
 
+
 @unittest.skipIf(CI and Device.DEFAULT in {"GPU", "CUDA", "METAL"}, "no GPU CI")
 class TestMoveTensor(unittest.TestCase):
   d0, d1 = f"{Device.DEFAULT}:0", f"{Device.DEFAULT}:1"
+
   @given(strat.sampled_from([d0, d1]), strat.sampled_from([d0, d1]),
          strat.sampled_from([dtypes.float16, dtypes.float32]), strat.sampled_from([True, False, None]))
   def test_to_preserves(self, src, dest, dtype, requires_grad):
@@ -339,6 +354,7 @@ class TestMoveTensor(unittest.TestCase):
     np.testing.assert_equal(s.numpy(), t.numpy())
     assert s.dtype == t.dtype
     assert s.requires_grad == t.requires_grad
+
 
 class TestZeroShapeTensor(unittest.TestCase):
   def test_shape_stride(self):
@@ -462,6 +478,7 @@ class TestZeroShapeTensor(unittest.TestCase):
     np.testing.assert_equal(Tensor([]).sum().numpy(), 0)
     np.testing.assert_equal(Tensor([]).mean().numpy(), 0)
 
+
 class TestTensorCreationDevice(unittest.TestCase):
   # test auxiliary tensors are created on the same device
   def test_one_hot(self):
@@ -469,11 +486,21 @@ class TestTensorCreationDevice(unittest.TestCase):
     x = y.one_hot(10)
     x.realize()
 
+
 class TestTensorPickle(unittest.TestCase):
-  def test_pickle(self):
+  def test_pickle_one_dim(self):
     y = Tensor([1, 2, 3]).to("CPU")
     x = pickle.loads(pickle.dumps(y))
     np.testing.assert_equal(y.numpy(), x.numpy())
+
+  def test_pickle_multi_dim(self):
+    shape = [2]
+    for i in range(1, 10):  # (2,), (2,2), (2,2,2), ...
+      shape.append(2)
+      y = Tensor.randn(shape).to("CPU")
+      x = pickle.loads(pickle.dumps(y))
+      np.testing.assert_equal(y.numpy(), x.numpy())
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -99,6 +99,8 @@ class Tensor:
   # Python has a non moving GC, so this should be okay
   def __hash__(self): return id(self)
 
+  def __reduce__(self) -> Tuple[Type[Tensor], Tuple[List[int]]]: return self.__class__, (self.data().tolist(),)
+
   @property
   def device(self) -> Union[str, Tuple[str, ...]]: return self.lazydata.device
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -99,7 +99,8 @@ class Tensor:
   # Python has a non moving GC, so this should be okay
   def __hash__(self): return id(self)
 
-  def __reduce__(self) -> Tuple[Type, Tuple[List, Optional[Union[str, tuple, list]], Optional[DType], Optional[bool]]]: return self.__class__, (self.data().tolist(), self.device, self.dtype, self.requires_grad)
+  def __reduce__(self) -> Tuple[Type, Tuple[List, Optional[Union[str, tuple, list]], Optional[DType], Optional[bool]]]:
+    return self.__class__, (self.data().tolist(), self.device, self.dtype, self.requires_grad)
 
   @property
   def device(self) -> Union[str, Tuple[str, ...]]: return self.lazydata.device

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -99,7 +99,7 @@ class Tensor:
   # Python has a non moving GC, so this should be okay
   def __hash__(self): return id(self)
 
-  def __reduce__(self) -> Tuple[Type, Tuple[List]]: return self.__class__, (self.data().tolist(),)
+  def __reduce__(self) -> Tuple[Type, Tuple[List, Optional[Union[str, tuple, list]], Optional[DType], Optional[bool]]]: return self.__class__, (self.data().tolist(), self.device, self.dtype, self.requires_grad)
 
   @property
   def device(self) -> Union[str, Tuple[str, ...]]: return self.lazydata.device

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -99,8 +99,7 @@ class Tensor:
   # Python has a non moving GC, so this should be okay
   def __hash__(self): return id(self)
 
-  def __reduce__(self) -> Tuple[Type, Tuple[List, Optional[Union[str, tuple, list]], Optional[DType], Optional[bool]]]:
-    return self.__class__, (self.data().tolist(), self.device, self.dtype, self.requires_grad)
+  def __reduce__(self): return self.__class__, (self.data().tolist(), self.device, self.dtype, self.requires_grad)
 
   @property
   def device(self) -> Union[str, Tuple[str, ...]]: return self.lazydata.device

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -99,7 +99,7 @@ class Tensor:
   # Python has a non moving GC, so this should be okay
   def __hash__(self): return id(self)
 
-  def __reduce__(self) -> Tuple[Type[Tensor], Tuple[List[int]]]: return self.__class__, (self.data().tolist(),)
+  def __reduce__(self) -> Tuple[Type, Tuple[List]]: return self.__class__, (self.data().tolist(),)
 
   @property
   def device(self) -> Union[str, Tuple[str, ...]]: return self.lazydata.device


### PR DESCRIPTION
## Purpose

Enables pickle serialisation for tools like [ray](https://ray.io/).

## What it changes

### Code

```py
@ray.remote
def add(x: tiny.Tensor, y: tiny.Tensor) -> tiny.Tensor: return x + y

ref = add.remote(
    tiny.Tensor([0, 1, 2, 3, 4]),
    tiny.Tensor([1, 1, 1, 1, 1])
)

print(ray.get(ref)) # get the tensor
```

### Previously

Previously, ray was not able to serialise Tensor objects from tinygrad:

```
TypeError: cannot pickle 'weakref.ReferenceType' object

During handling of the above exception, another exception occurred:

IndexError                                Traceback (most recent call last)
Cell In[10], line 1
----> 1 ref = add.remote(
      2     tiny.Tensor([0, 1, 2, 3, 4]),
      3     tiny.Tensor([1, 1, 1, 1, 1])
      4 )
      6 ray.get(ref)
```

### Now

This pull request fixes this issue by implementing the `_reduce_` function in the `Tensor` class:

```py
print(ray.get(ref)) # get the tensor

<Tensor <LB CUDA (5,) contig:True (<LoadOps.COPY: 3>, None)> on CUDA with grad None>
```