### PR TITLE
Fix RetinaNet model evaluation script

### DIFF
--- a/examples/mlperf/model_eval.py
+++ b/examples/mlperf/model_eval.py
@@ -122,7 +122,7 @@ def eval_retinanet():
     n += len(targets)
     print(f"[{n}/{len(coco.imgs)}] == {(mt-st)*1000:.2f} ms loading data, {(et-mt)*1000:.2f} ms to run model, {(ext-et)*1000:.2f} ms for postprocessing")
     img_ids = [t["image_id"] for t in targets]
-    coco_results  = [{"image_id": targets[i]["image_id"], "category_id": label, "bbox": box, "score": score}
+    coco_results  = [{"image_id": targets[i]["image_id"], "category_id": label, "bbox": box.tolist(), "score": score}
       for i, prediction in enumerate(predictions) for box, score, label in zip(*prediction.values())]
     with redirect_stdout(None):
       coco_eval.cocoDt = coco.loadRes(coco_results)


### PR DESCRIPTION
# Description
This PR fixes an issue regarding `bbox` being passed in as an `ndarray` to `loadRes` function of `pycocotools` after running `MODEL=retinanet python3 examples/mlperf/model_eval.py`:

<img width="708" alt="Screenshot 2024-01-27 at 8 23 47 PM" src="https://github.com/tinygrad/tinygrad/assets/51974347/30252c2f-f59d-4428-b973-e74900e306dd">

To fix the issue, each `bbox` is converted to a list using `tolist()`. With this fix and letting the evaluation script run, it completes it with the target metric:

<img width="506" alt="Screenshot 2024-01-27 at 8 20 40 PM" src="https://github.com/tinygrad/tinygrad/assets/51974347/49db5a9b-d077-4699-8b23-ca426a5af857">
