### PR TITLE
add no_grad_mode context manager with decorator support

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -468,5 +468,50 @@ class TestTensorCreationDevice(unittest.TestCase):
     x = y.one_hot(10)
     x.realize()
 
+class TestTrainMode(unittest.TestCase):
+  def test_train_mode(self):
+    assert not Tensor.training
+    @Tensor.train()
+    def f():
+      assert Tensor.training
+    f()
+    assert not Tensor.training
+
+class TestNoGradMode(unittest.TestCase):
+  def test_no_grad_mode(self):
+    x = Tensor(x_init, requires_grad=True)
+    m = Tensor(m_init, requires_grad=True)
+    W = Tensor(W_init, requires_grad=True)
+    with Tensor.no_grad_mode():
+      tmp = x.mul(m)
+      mm = tmp.matmul(W)
+      out = mm.relu()
+      out = out.sum()
+      out.backward()
+    assert x.grad is None
+    assert m.grad is None
+    assert tmp.grad is None
+    assert mm.grad is None
+    assert W.grad is None
+    assert W.requires_grad
+
+  def test_no_grad_mode_context_manager(self):
+    x = Tensor(x_init, requires_grad=True)
+    m = Tensor(m_init, requires_grad=True)
+    W = Tensor(W_init, requires_grad=True)
+    @Tensor.no_grad_mode()
+    def f(x, m, W):
+      tmp = x.mul(m)
+      mm = tmp.matmul(W)
+      out = mm.relu()
+      out = out.sum()
+      out.backward()
+      assert x.grad is None
+      assert m.grad is None
+      assert tmp.grad is None
+      assert mm.grad is None
+      assert W.grad is None
+    f(x, m, W)
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1,6 +1,7 @@
 # inspired by https://github.com/karpathy/micrograd/blob/master/micrograd/engine.py
 from __future__ import annotations
 import time, math, itertools
+from contextlib import ContextDecorator
 from typing import List, Tuple, Callable, Optional, ClassVar, Type, Union, Sequence, Iterable, Dict, DefaultDict, cast, get_args
 from collections import defaultdict
 from functools import partialmethod, reduce
@@ -50,12 +51,16 @@ class Tensor:
   __slots__ = "lazydata", "requires_grad", "grad", "_ctx"
   __deletable__ = ('_ctx',)
   training: ClassVar[bool] = False
-  class train:
+  class train(ContextDecorator):
     def __init__(self, val=True): self.val = val
     def __enter__(self): self.prev, Tensor.training = Tensor.training, self.val
     def __exit__(self, exc_type, exc_value, traceback): Tensor.training = self.prev
 
   no_grad: ClassVar[bool] = False
+  class no_grad_mode(ContextDecorator):
+    def __init__(self, val=True): self.val = val
+    def __enter__(self): self.prev, Tensor.no_grad = Tensor.no_grad, self.val
+    def __exit__(self, exc_type, exc_value, traceback): Tensor.no_grad = self.prev
   def __init__(self, data:Union[None, Scalar, List, Tuple, LazyBuffer, np.ndarray, bytes, MultiLazyBuffer],
                device:Optional[Union[str, tuple, list]]=None, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None):
     assert dtype is None or isinstance(dtype, DType), f"invalid dtype {dtype}"


### PR DESCRIPTION
Introduces `no_grad_mode` context manager which can be called like `torch.no_grad`:
```python
with Tensor.no_grad_mode(): ...
# OR
@Tensor.no_grad_mode()
def f(): ...
```
Also adds ability to use `Tensor.train()` as a decorator:
```python
@Tensor.train():
def f(): ...
```