### PR TITLE
Improve error message on wrongly set env key

### DIFF
--- a/test/unit/test_device.py
+++ b/test/unit/test_device.py
@@ -1,19 +1,46 @@
 #!/usr/bin/env python
 import unittest
+from unittest.mock import patch
+import os
 from tinygrad.device import Device
+from tinygrad.helpers import getenv
+
 
 class TestDevice(unittest.TestCase):
-  def test_canonicalize(self):
-    assert Device.canonicalize(None) == Device.DEFAULT
-    assert Device.canonicalize("CPU") == "CPU"
-    assert Device.canonicalize("cpu") == "CPU"
-    assert Device.canonicalize("GPU") == "GPU"
-    assert Device.canonicalize("GPU:0") == "GPU"
-    assert Device.canonicalize("gpu:0") == "GPU"
-    assert Device.canonicalize("GPU:1") == "GPU:1"
-    assert Device.canonicalize("gpu:1") == "GPU:1"
-    assert Device.canonicalize("GPU:2") == "GPU:2"
-    assert Device.canonicalize("disk:/dev/shm/test") == "DISK:/dev/shm/test"
+    def test_canonicalize(self):
+        assert Device.canonicalize(None) == Device.DEFAULT
+        assert Device.canonicalize("CPU") == "CPU"
+        assert Device.canonicalize("cpu") == "CPU"
+        assert Device.canonicalize("GPU") == "GPU"
+        assert Device.canonicalize("GPU:0") == "GPU"
+        assert Device.canonicalize("gpu:0") == "GPU"
+        assert Device.canonicalize("GPU:1") == "GPU:1"
+        assert Device.canonicalize("gpu:1") == "GPU:1"
+        assert Device.canonicalize("GPU:2") == "GPU:2"
+        assert Device.canonicalize("disk:/dev/shm/test") == "DISK:/dev/shm/test"
+
+    def test_default_device_from_env(self):
+        def reset_caches():
+            getenv.cache_clear()
+            if "DEFAULT" in Device.__dict__:
+                del Device.__dict__["DEFAULT"]
+
+        with patch.dict(os.environ, {"CUDA": "1"}, clear=True):
+            reset_caches()
+            self.assertEqual(Device.canonicalize(None), "CUDA")
+
+        # this is commonly already set on MacOS
+        with patch.dict(
+            os.environ, {"CLANG": "arm64-apple-darwin20.0.0-clang"}, clear=True
+        ):
+            reset_caches()
+            self.assertRaisesRegex(
+                ValueError,
+                "environment variable 'CLANG' cannot be casted to <class 'int'>. Please check docs/env_vars.md for reference.",
+                Device.canonicalize,
+                None,
+            )
+
 
 if __name__ == "__main__":
-  unittest.main()
+    unittest.main()

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -268,7 +268,7 @@ class Compiler:
   def render(self, name:str, uops) -> str: raise NotImplementedError("need a render function")
   def compile(self, src:str) -> bytes: raise NotImplementedError("need a compile function")
   def compile_cached(self, src:str) -> bytes:
-    if self.cachekey is not None: lib = diskcache_get(self.cachekey, src)
+    lib = diskcache_get(self.cachekey, src) if self.cachekey is not None else None
     if lib is None:
       lib = self.compile(src)
       if self.cachekey is not None: diskcache_put(self.cachekey, src, lib)

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -62,7 +62,11 @@ def get_contraction(old_shape:Tuple[sint, ...], new_shape:Tuple[sint, ...]) -> O
 @functools.lru_cache(maxsize=None)
 def to_function_name(s:str): return ''.join([c if c in (string.ascii_letters+string.digits+'_') else f'{ord(c):02X}' for c in ansistrip(s)])
 @functools.lru_cache(maxsize=None)
-def getenv(key:str, default=0): return type(default)(os.getenv(key, default))
+def getenv(key:str, default=0):
+  try:
+    return type(default)(os.getenv(key, default))
+  except ValueError:
+    raise ValueError(f"environment variable '{key}' cannot be casted to {type(default)}. Please check docs/env_vars.md for reference.") from None
 def temp(x:str) -> str: return (pathlib.Path(tempfile.gettempdir()) / x).as_posix()
 
 class GraphException(Exception): pass


### PR DESCRIPTION
When I tried to run tinygrad locally (M1 Mac), I got `ValueError: invalid literal for int() with base 10: 'arm64-apple-darwin20.0.0-clang'`, it took me a minute to figure out the root cause (CLANG was set by default in my PATH).

This PR improves the error message to help future users figure this out quicker.

I also included a mini bug-fix in `tinygrad/device.py`, it was failing with `local variable 'lib' referenced before assignment` when setting `DISABLE_COMPILER_CACHE=1`.