### PR TITLE
canonicalize empty masks

### DIFF
--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -90,6 +90,8 @@ class View:
         strides, offset, mask = (0,) * len(shape), 0, ((0,0),) * len(shape)
       offset += sum((strides[i] * mask[i][0]) if e else 0 for i, e in enumerate(elim))
       strides = tuple(0 if e else st for st,e in zip(strides, elim))
+    # canonicalize empty mask
+    if mask and all(b==0 and e==s for (b,e),s in zip(mask, shape)): mask = None
     return View(shape, strides, offset, mask, contiguous)
 
   @functools.lru_cache(None)  # pylint: disable=method-cache-max-size-none


### PR DESCRIPTION
Fixes the following trivial cases:
```
same but unequal
ShapeTracker(views=(View(shape=(7, 4, 3, 1, 5), strides=(54, 0, 1, 0, 12), offset=1, mask=((0, 7), (0, 4), (0, 3), (0, 1), (0, 5)), contiguous=False),))
ShapeTracker(views=(View(shape=(7, 4, 3, 1, 5), strides=(54, 0, 1, 0, 12), offset=1, mask=None, contiguous=False),))
same but unequal
ShapeTracker(views=(View(shape=(3,), strides=(-4,), offset=8, mask=((0, 3),), contiguous=False),))
ShapeTracker(views=(View(shape=(3,), strides=(-4,), offset=8, mask=None, contiguous=False),))
same but unequal
ShapeTracker(views=(View(shape=(2, 4, 10, 1), strides=(0, -20, 1, 0), offset=60, mask=((0, 2), (0, 4), (0, 10), (0, 1)), contiguous=False),))
ShapeTracker(views=(View(shape=(2, 4, 10, 1), strides=(0, -20, 1, 0), offset=60, mask=None, contiguous=False),))
```

Tested with fuzzer upto 10k

seed=42
before change:
same but unequal: 6.32%
after change:
same but unequal: 6.20%

seed=420
before change:
same but unequal: 6.38%
after change:
same but unequal: 6.22%

reproduce stats:
``` python
CNT=5000 CHECK_NEQ=1 FUZZ=plus PYTHONPATH="." python3 test/external/fuzz_shapetracker_math.py
```