### PR TITLE
faster wino compile by catting consts across data expand dim

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -340,7 +340,7 @@ class TestHandCodedOpts(unittest.TestCase):
         k = Linearizer(si.ast)
         k.hand_coded_optimizations()
         if k.reduceop is not None: continue  # not a tile transform kernel (there is a gemm reduce kernel)
-        if len(k.bufs) < 100: continue  # not a tile transform kernel (there's a permute kernel at the end)
+        if len(k.bufs) < 36: continue  # not a tile transform kernel (there's a permute kernel at the end)
         upcasts.append(tuple(k.full_shape[k.shape_len - k.upcasted:k.shape_len]))
       assert len(upcasts) == 3  # 3 transformation matrices
       # TODO: what did this fix?
@@ -353,7 +353,7 @@ class TestHandCodedOpts(unittest.TestCase):
         k.linearize()
         if len(k.bufs) < 20: continue  # not a tile transform kernel
         # heuristic number to make sure that at least some upcasts but not too many upcasts are being done
-        assert 6 <= prod(k.full_shape[k.shape_len - k.upcasted:k.shape_len]) <= 49
+        assert 6 <= prod(k.full_shape[k.shape_len - k.upcasted:k.shape_len]) <= 216
 
   def test_masked_upcast_many(self):
     layer_1 = Tensor.cat(Tensor.rand(3, 4), Tensor.rand(4, 4))

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -332,28 +332,32 @@ class TestHandCodedOpts(unittest.TestCase):
 
   def test_masked_upcast_wino_full(self):
     with Context(WINO=1):
-      x,w = Tensor.rand(1,4,9,9, requires_grad=True).realize(), Tensor.rand(4,4,3,3, requires_grad=True).realize()
+      x,w = Tensor.rand(1,4,8,8, requires_grad=True).realize(), Tensor.rand(4,4,3,3, requires_grad=True).realize()
       out = Tensor.conv2d(x,w, padding=1)
       upcasts = []
+      wino_schedule = out.lazydata.schedule()
       # collect upcasts of tile transform kernels
-      for i, si in enumerate(out.lazydata.schedule()):
+      for i, si in enumerate(wino_schedule):
         k = Linearizer(si.ast)
         k.hand_coded_optimizations()
         if k.reduceop is not None: continue  # not a tile transform kernel (there is a gemm reduce kernel)
         if len(k.bufs) < 36: continue  # not a tile transform kernel (there's a permute kernel at the end)
         upcasts.append(tuple(k.full_shape[k.shape_len - k.upcasted:k.shape_len]))
       assert len(upcasts) == 3  # 3 transformation matrices
-      # TODO: what did this fix?
+      assert len(wino_schedule) <= 4  # 4 kernels
+      # this test case's inputs are too small, so one of the 4-stacks became a local, which is fine i guess
       assert upcasts.count((6, 6)) == 2 #and upcasts.count((4, 4)) == 1
 
       out.mean().backward()
-      for si in x.grad.lazydata.schedule() + w.grad.lazydata.schedule():
+      backward_schedule = x.grad.lazydata.schedule() + w.grad.lazydata.schedule()
+      for si in backward_schedule:
         k = Linearizer(si.ast)
         k.hand_coded_optimizations()
         k.linearize()
         if len(k.bufs) < 20: continue  # not a tile transform kernel
         # heuristic number to make sure that at least some upcasts but not too many upcasts are being done
         assert 6 <= prod(k.full_shape[k.shape_len - k.upcasted:k.shape_len]) <= 216
+      assert len(backward_schedule) <= 13  # just the current number, but it could be better
 
   def test_masked_upcast_many(self):
     layer_1 = Tensor.cat(Tensor.rand(3, 4), Tensor.rand(4, 4))

--- a/test/test_winograd.py
+++ b/test/test_winograd.py
@@ -28,6 +28,7 @@ class TestWinograd(unittest.TestCase):
         l = Linearizer(s.ast)
         l.hand_coded_optimizations()
         l.linearize()
+      assert len(l.sts) <= 256  # just the current value to prevent regression
       if DEBUG >= 2: print(f"{len(l.sts):4d} shapetrackers with max {max(len(x.views) for x in l.sts)} views")
       for st in l.sts:
         assert len(st.views) <= 2, "too many views in winograd"

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -655,8 +655,8 @@ class Tensor:
     # winograd conv 3 kernel f(4x4,3x3) see: http://arxiv.org/abs/1509.09308
     def apply_matrix(mat, t):
       t_ = t.reshape(t.shape[:len(HW)]+(1,)*len(HW)+t.shape[len(HW):]).expand(t.shape[:len(HW)]+(len(mat),)*len(HW)+t.shape[len(HW):])
-      matcols = [[Tensor.cat(*[Tensor(float(m[k])).reshape((1,) * len(t.shape)).expand(tuple(1 if k == dim else len(mat) for k in range(len(HW))) + t.shape[len(HW):]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(len(HW))]
-      return sum(prod([matcols[dim][mat_is[dim]] for dim in range(len(HW))]) * t_[mat_is] for mat_is in itertools.product(*[range(len(mat[0])) for _ in range(len(HW))]))
+      matcols = [[Tensor.cat(*[Tensor(float(m[k])).reshape((1,) * len(t.shape)).expand(tuple(1 if k == dim else len(mat) for k in range(len(HW))) + t.shape[len(HW):]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(len(HW))]  # noqa: E501
+      return sum(prod([matcols[dim][mat_is[dim]] for dim in range(len(HW))]) * t_[mat_is] for mat_is in itertools.product(*[range(len(mat[0])) for _ in range(len(HW))]))  # noqa: E501
     HWI, HWO = (6,) * len(HW), (4,) * len(HW)  # F(4x4,3x3) winograd tiles
     winograd_Bt = [[4, 0, -5, 0, 1, 0], [0, -4, -4, 1, 1, 0], [0, 4, -4, -1, 1, 0], [0, -2, -1, 2, 1, 0], [0, 2, -1, -2, 1, 0], [0, 4, 0, -5, 0, 1]]
     winograd_G = [[1/4, 0, 0], [-1/6, -1/6, -1/6], [-1/6, 1/6, -1/6], [1/24, 1/12, 1/6], [1/24, -1/12, 1/6], [0, 0, 1]]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -654,8 +654,9 @@ class Tensor:
 
     # winograd conv 3 kernel f(4x4,3x3) see: http://arxiv.org/abs/1509.09308
     def apply_matrix(mat, t):
+      t_ = t.reshape(t.shape[:len(HW)]+(1,)*len(HW)+t.shape[len(HW):]).expand(t.shape[:len(HW)]+(len(mat),)*len(HW)+t.shape[len(HW):])
       matcols = [[Tensor.cat(*[Tensor(float(m[k])).reshape((1,) * len(t.shape)).expand(tuple(1 if k == dim else len(mat) for k in range(len(HW))) + t.shape[len(HW):]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(len(HW))]  # noqa: E501
-      return sum(prod([matcols[dim][mat_is[dim]] for dim in range(len(HW))]) * t[mat_is] for mat_is in itertools.product(*[range(len(mat[0])) for _ in range(len(HW))]))  # noqa: E501
+      return sum(prod([matcols[dim][mat_is[dim]] for dim in range(len(HW))]) * t_[mat_is] for mat_is in itertools.product(*[range(len(mat[0])) for _ in range(len(HW))]))  # noqa: E501
     HWI, HWO = (6,) * len(HW), (4,) * len(HW)  # F(4x4,3x3) winograd tiles
     winograd_Bt = [[4, 0, -5, 0, 1, 0], [0, -4, -4, 1, 1, 0], [0, 4, -4, -1, 1, 0], [0, -2, -1, 2, 1, 0], [0, 2, -1, -2, 1, 0], [0, 4, 0, -5, 0, 1]]
     winograd_G = [[1/4, 0, 0], [-1/6, -1/6, -1/6], [-1/6, 1/6, -1/6], [1/24, 1/12, 1/6], [1/24, -1/12, 1/6], [0, 0, 1]]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -655,7 +655,7 @@ class Tensor:
     # winograd conv 3 kernel f(4x4,3x3) see: http://arxiv.org/abs/1509.09308
     def apply_matrix(mat, t, dims=len(HW)):
       t_ = t.reshape(t.shape[:dims]+(1,)*dims+t.shape[dims:]).expand(t.shape[:dims]+(len(mat),)*dims+t.shape[dims:])
-      matcols = [[Tensor.cat(*[Tensor(float(m[k])).reshape((1,) * len(t.shape)).expand(t.shape[dims:dims+dim]+(1,)+t.shape[dims+dim+1:]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(dims)]  # noqa: E501
+      matcols = [[Tensor.cat(*[Tensor(float(m[k])).reshape((1,) * len(t.shape)).expand(t_.shape[dims:dims+dim]+(1,)+t_.shape[dims+dim+1:]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(dims)]  # noqa: E501
       return sum(prod([matcols[dim][mat_is[dim]] for dim in range(dims)]) * t_[mat_is] for mat_is in itertools.product(*[range(len(mat[0])) for _ in range(dims)]))  # noqa: E501
     HWI, HWO = (6,) * len(HW), (4,) * len(HW)  # F(4x4,3x3) winograd tiles
     winograd_Bt = [[4, 0, -5, 0, 1, 0], [0, -4, -4, 1, 1, 0], [0, 4, -4, -1, 1, 0], [0, -2, -1, 2, 1, 0], [0, 2, -1, -2, 1, 0], [0, 4, 0, -5, 0, 1]]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -655,7 +655,7 @@ class Tensor:
     # winograd conv 3 kernel f(4x4,3x3) see: http://arxiv.org/abs/1509.09308
     def apply_matrix(mat, t):
       t_ = t.reshape(t.shape[:len(HW)]+(1,)*len(HW)+t.shape[len(HW):]).expand(t.shape[:len(HW)]+(len(mat),)*len(HW)+t.shape[len(HW):])
-      matcols = [[Tensor.cat(*[Tensor(float(m[k])).reshape((1,) * len(t.shape)).expand(tuple(1 if k == dim else len(mat) for k in range(len(HW))) + t.shape[len(HW):]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(len(HW))]  # noqa: E501
+      matcols = [[Tensor.cat(*[Tensor(float(m[k])).reshape((1,) * len(t.shape)).expand(t.shape[len(HW):len(HW)+dim]+(1,)+t.shape[len(HW)+dim+1:]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(len(HW))]  # noqa: E501
       return sum(prod([matcols[dim][mat_is[dim]] for dim in range(len(HW))]) * t_[mat_is] for mat_is in itertools.product(*[range(len(mat[0])) for _ in range(len(HW))]))  # noqa: E501
     HWI, HWO = (6,) * len(HW), (4,) * len(HW)  # F(4x4,3x3) winograd tiles
     winograd_Bt = [[4, 0, -5, 0, 1, 0], [0, -4, -4, 1, 1, 0], [0, 4, -4, -1, 1, 0], [0, -2, -1, 2, 1, 0], [0, 2, -1, -2, 1, 0], [0, 4, 0, -5, 0, 1]]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -653,10 +653,10 @@ class Tensor:
       return ret if bias is None else ret.add(bias.reshape(1, -1, *[1] * len(HW)))
 
     # winograd conv 3 kernel f(4x4,3x3) see: http://arxiv.org/abs/1509.09308
-    def apply_matrix(mat, t):
-      t_ = t.reshape(t.shape[:len(HW)]+(1,)*len(HW)+t.shape[len(HW):]).expand(t.shape[:len(HW)]+(len(mat),)*len(HW)+t.shape[len(HW):])
-      matcols = [[Tensor.cat(*[Tensor(float(m[k])).reshape((1,) * len(t.shape)).expand(t.shape[len(HW):len(HW)+dim]+(1,)+t.shape[len(HW)+dim+1:]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(len(HW))]  # noqa: E501
-      return sum(prod([matcols[dim][mat_is[dim]] for dim in range(len(HW))]) * t_[mat_is] for mat_is in itertools.product(*[range(len(mat[0])) for _ in range(len(HW))]))  # noqa: E501
+    def apply_matrix(mat, t, dims=len(HW)):
+      t_ = t.reshape(t.shape[:dims]+(1,)*dims+t.shape[dims:]).expand(t.shape[:dims]+(len(mat),)*dims+t.shape[dims:])
+      matcols = [[Tensor.cat(*[Tensor(float(m[k])).reshape((1,) * len(t.shape)).expand(t.shape[dims:dims+dim]+(1,)+t.shape[dims+dim+1:]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(dims)]  # noqa: E501
+      return sum(prod([matcols[dim][mat_is[dim]] for dim in range(dims)]) * t_[mat_is] for mat_is in itertools.product(*[range(len(mat[0])) for _ in range(dims)]))  # noqa: E501
     HWI, HWO = (6,) * len(HW), (4,) * len(HW)  # F(4x4,3x3) winograd tiles
     winograd_Bt = [[4, 0, -5, 0, 1, 0], [0, -4, -4, 1, 1, 0], [0, 4, -4, -1, 1, 0], [0, -2, -1, 2, 1, 0], [0, 2, -1, -2, 1, 0], [0, 4, 0, -5, 0, 1]]
     winograd_G = [[1/4, 0, 0], [-1/6, -1/6, -1/6], [-1/6, 1/6, -1/6], [1/24, 1/12, 1/6], [1/24, -1/12, 1/6], [0, 0, 1]]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -655,7 +655,7 @@ class Tensor:
     # winograd conv 3 kernel f(4x4,3x3) see: http://arxiv.org/abs/1509.09308
     def apply_matrix(mat, t, dims=len(HW)):
       t_ = t.reshape(t.shape[:dims]+(1,)*dims+t.shape[dims:]).expand(t.shape[:dims]+(len(mat),)*dims+t.shape[dims:])
-      matcols = [[Tensor.cat(*[Tensor(float(m[k])).reshape((1,) * len(t.shape)).expand(t_.shape[dims:dims+dim]+(1,)+t_.shape[dims+dim+1:]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(dims)]  # noqa: E501
+      matcols = [[Tensor.cat(*[Tensor(float(m[k]), device=t.device).reshape((1,) * len(t.shape)).expand(t_.shape[dims:dims+dim]+(1,)+t_.shape[dims+dim+1:]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(dims)]  # noqa: E501
       return sum(prod([matcols[dim][mat_is[dim]] for dim in range(dims)]) * t_[mat_is] for mat_is in itertools.product(*[range(len(mat[0])) for _ in range(dims)]))  # noqa: E501
     HWI, HWO = (6,) * len(HW), (4,) * len(HW)  # F(4x4,3x3) winograd tiles
     winograd_Bt = [[4, 0, -5, 0, 1, 0], [0, -4, -4, 1, 1, 0], [0, 4, -4, -1, 1, 0], [0, -2, -1, 2, 1, 0], [0, 2, -1, -2, 1, 0], [0, 4, 0, -5, 0, 1]]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -654,9 +654,8 @@ class Tensor:
 
     # winograd conv 3 kernel f(4x4,3x3) see: http://arxiv.org/abs/1509.09308
     def apply_matrix(mat, t):
-      t_ = t.reshape(t.shape[:len(HW)]+(1,)*len(HW)+t.shape[len(HW):]).expand(t.shape[:len(HW)]+(len(mat),)*len(HW)+t.shape[len(HW):])
       matcols = [[Tensor.cat(*[Tensor(float(m[k])).reshape((1,) * len(t.shape)).expand(tuple(1 if k == dim else len(mat) for k in range(len(HW))) + t.shape[len(HW):]) for m in mat], dim=dim) for k in range(len(mat[0]))] for dim in range(len(HW))]  # noqa: E501
-      return sum(prod([matcols[dim][mat_is[dim]] for dim in range(len(HW))]) * t_[mat_is] for mat_is in itertools.product(*[range(len(mat[0])) for _ in range(len(HW))]))  # noqa: E501
+      return sum(prod([matcols[dim][mat_is[dim]] for dim in range(len(HW))]) * t[mat_is] for mat_is in itertools.product(*[range(len(mat[0])) for _ in range(len(HW))]))  # noqa: E501
     HWI, HWO = (6,) * len(HW), (4,) * len(HW)  # F(4x4,3x3) winograd tiles
     winograd_Bt = [[4, 0, -5, 0, 1, 0], [0, -4, -4, 1, 1, 0], [0, 4, -4, -1, 1, 0], [0, -2, -1, 2, 1, 0], [0, 2, -1, -2, 1, 0], [0, 4, 0, -5, 0, 1]]
     winograd_G = [[1/4, 0, 0], [-1/6, -1/6, -1/6], [-1/6, 1/6, -1/6], [1/24, 1/12, 1/6], [1/24, -1/12, 1/6], [0, 0, 1]]


### PR DESCRIPTION
Significantly reduces the number of shapetrackers. for now, there is a bug where the gfactors get unfused into 2 kernels instead of 1. but it's way faster.

the idea is as follows:

```
each column of wino transform matrix mat is multiplied by only one element of the input data vector v

before, we have:
Tensor.stack([sum([mat[i][j] * v[i]] for j in range(len(mat[0]))]) for i in range(len(mat))])

this accesses v[i] once for each element of mat, times the size of the output stack, due the pad and add implementation of stack. However, if we first stacked the consts:

sum( [Tensor.stack(mat[i][j] for i in range(len(mat[i]))) * v[j] for j in range(len(mat))])

we can save a factor of len(mat[0]) for each wino dim.

the core idea is: Tensor.stack(mat[i][j] * v[i] for j in range(...)) is slower than Tensor.stack(mat[i][j] for j in range(...)) * v[i]

```

Before:
```
running conv:  45.63 ms
scheduling:  99.59 ms
linearize 1 with  752 ops: 150.95 ms
 297 shapetrackers with max 1 views
linearize 3 with 1495 ops: 445.40 ms
 592 shapetrackers with max 1 views
linearize 4 with    5 ops:   1.67 ms
   3 shapetrackers with max 1 views
linearize 5 with  859 ops: 370.84 ms
 360 shapetrackers with max 2 views

```
After:
```
test_speed (__main__.TestWinograd) ... running conv:  23.79 ms
scheduling:   6.55 ms
linearize 1 with   90 ops:  23.58 ms
  36 shapetrackers with max 1 views
linearize 3 with  256 ops:  84.64 ms
  89 shapetrackers with max 1 views
linearize 4 with    5 ops:   1.61 ms
   3 shapetrackers with max 1 views
linearize 5 with  210 ops: 113.04 ms
  67 shapetrackers with max 2 views
ok
```