### PR TITLE
PoC/RFC: UnLazify errors

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -3,7 +3,7 @@ import sys, math
 from collections import defaultdict
 from typing import Union, Optional, Any, Tuple, List, Set, Dict, DefaultDict, cast
 from tinygrad.dtype import dtypes, DType, ImageDType, Scalar
-from tinygrad.helpers import prod, flatten, getenv, dedup, DEBUG, all_int, all_same, GRAPH
+from tinygrad.helpers import prod, flatten, getenv, dedup, DEBUG, all_int, all_same, GRAPH, LazyError
 from tinygrad.ops import LoadOps, UnaryOps, BinaryOps, TernaryOps, ReduceOps, BufferOps, Op, LazyOp, ConstBuffer, MemBuffer, ScheduleItem
 from tinygrad.shape.symbolic import sint, Variable
 from tinygrad.shape.shapetracker import ShapeTracker
@@ -24,6 +24,7 @@ def create_lazybuffer(device:str, st:ShapeTracker, dtype:DType, op:Optional[Op]=
 
   return LazyBuffer(device, st, dtype, op, arg, srcs, base=base, cache_key=cache_key if enable_cache else None)
 
+@LazyError()
 class LazyBuffer:
   def __init__(self, device:str, st:ShapeTracker, dtype:DType,
                op:Optional[Op]=None, arg:Any=None, srcs:Tuple[LazyBuffer, ...]=(),

--- a/tinygrad/realize.py
+++ b/tinygrad/realize.py
@@ -2,7 +2,7 @@ from typing import List, Dict, Optional, cast
 from tinygrad.ops import LoadOps, ScheduleItem, BufferOps, GlobalCounters
 from tinygrad.device import Device, Buffer, BufferCopy, BufferXfer, BufferRead, JITRunner, update_stats, InterpretedASTRunner, Compiled, BufferOptions
 from tinygrad.graph import print_tree, realized_lazybuffer
-from tinygrad.helpers import colored, getenv, GRAPH, cpu_time_execution, DEBUG
+from tinygrad.helpers import colored, getenv, GRAPH, cpu_time_execution, DEBUG, LazyRealizer
 from tinygrad.shape.symbolic import Variable
 
 # *** schedule running ***
@@ -21,6 +21,7 @@ class SyncOp(JITRunner):
     et = cpu_time_execution(self.device.synchronize, enable=wait or DEBUG >= 1)
     update_stats(colored("synchronize", "RED"), 0, 0, {}, et, 1, device=self.dname)
 
+@LazyRealizer("si.out")
 def lower_schedule_item(si:ScheduleItem) -> Optional[JITRunner]:
   assert all(si.out.device == x.device for x in si.inputs) or si.ast.op in {LoadOps.COPY, LoadOps.WAIT}, \
     f"all devices must be the same, {si.out.device} != {[x.device for x in si.inputs]} {print_tree(si.ast) or ''}"


### PR DESCRIPTION
I'm experimenting with unlazifying errors in tinygrad to make stacktrace point to where the error was made instead of just some assertion inside realize and good luck finding what actually caused it. This would've made debugging mysterious stuff like [this](https://github.com/tinygrad/tinygrad/pull/3000#issuecomment-1919026930) waaay easier.

This is just a simple quick PoC to show the idea and not waste time if you're not interested in having something like this.

Example:
```python
from tinygrad import *

a = Tensor.rand((4,), device="CPU:1")
b = Tensor.rand((4,), device="CPU:2")
c = a + b
print(c.numpy())
```

Before:
```
  0 ━┳ STORE MemBuffer(idx=0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(4,), strides=(1,), offset=0, mask=None, contiguous=True),)))
  1  ┗━┳ ADD 
  2    ┣━━ LOAD MemBuffer(idx=1, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(4,), strides=(1,), offset=0, mask=None, contiguous=True),)))
  3    ┗━━ LOAD MemBuffer(idx=2, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(4,), strides=(1,), offset=0, mask=None, contiguous=True),)))
Traceback (most recent call last):
  File "/Users/user/src/tinygrad/fun1.py", line 6, in <module>
    print(c.numpy())
          ^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/tensor.py", line 155, in numpy
    return np.frombuffer(self._data(), dtype=self.dtype.np).reshape(self.shape)
                         ^^^^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/tensor.py", line 142, in _data
    return cast(Buffer, t.cast(t.dtype.scalar()).contiguous().realize().lazydata.base.realized).as_buffer()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/tensor.py", line 116, in realize
    run_schedule(self.lazydata.schedule())
  File "/Users/user/src/tinygrad/tinygrad/realize.py", line 48, in run_schedule
    prg = lower_schedule_item(si)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/realize.py", line 25, in lower_schedule_item
    assert all(si.out.device == x.device for x in si.inputs) or si.ast.op in {LoadOps.COPY, LoadOps.WAIT}, \
                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: all devices must be the same, CPU:1 != ['CPU:1', 'CPU:2']
```

After (w/DEBUG=1):
```
  0 ━┳ STORE MemBuffer(idx=0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(4,), strides=(1,), offset=0, mask=None, contiguous=True),)))
  1  ┗━┳ ADD 
  2    ┣━━ LOAD MemBuffer(idx=1, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(4,), strides=(1,), offset=0, mask=None, contiguous=True),)))
  3    ┗━━ LOAD MemBuffer(idx=2, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(4,), strides=(1,), offset=0, mask=None, contiguous=True),)))
Traceback (most recent call last):
  File "/Users/user/src/tinygrad/fun1.py", line 6, in <module>
    print(c.numpy())
          ^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/tensor.py", line 155, in numpy
    return np.frombuffer(self._data(), dtype=self.dtype.np).reshape(self.shape)
                         ^^^^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/tensor.py", line 142, in _data
    return cast(Buffer, t.cast(t.dtype.scalar()).contiguous().realize().lazydata.base.realized).as_buffer()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/tensor.py", line 116, in realize
    run_schedule(self.lazydata.schedule())
  File "/Users/user/src/tinygrad/tinygrad/realize.py", line 49, in run_schedule
    prg = lower_schedule_item(si)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/helpers.py", line 132, in wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/realize.py", line 26, in lower_schedule_item
    assert all(si.out.device == x.device for x in si.inputs) or si.ast.op in {LoadOps.COPY, LoadOps.WAIT}, \
                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: all devices must be the same, CPU:1 != ['CPU:1', 'CPU:2'] 

This might've been caused by:
  File "/Users/user/src/tinygrad/fun1.py", line 5, in <module>
    c = a + b
  File "/Users/user/src/tinygrad/tinygrad/tensor.py", line 857, in __add__
    def __add__(self, x) -> Tensor: return self.add(x)
  File "/Users/user/src/tinygrad/tinygrad/tensor.py", line 809, in add
    return mlops.Add.apply(*self._broadcasted(x, reverse)) if x.__class__ is Tensor or x else self
  File "/Users/user/src/tinygrad/tinygrad/tensor.py", line 34, in apply
    ret.lazydata, ret.requires_grad, ret.grad = ctx.forward(*[t.lazydata for t in x], **kwargs), ctx.requires_grad, None
  File "/Users/user/src/tinygrad/tinygrad/mlops.py", line 99, in forward
    def forward(self, x:LazyBuffer, y:LazyBuffer) -> LazyBuffer: return x.e(BinaryOps.ADD, y)
  File "/Users/user/src/tinygrad/tinygrad/lazy.py", line 118, in e
    return create_lazybuffer(self.device, ShapeTracker.from_shape(self.shape), out_dtype, op, arg, tuple(srcs))
  File "/Users/user/src/tinygrad/tinygrad/lazy.py", line 26, in create_lazybuffer
    return LazyBuffer(device, st, dtype, op, arg, srcs, base=base, cache_key=cache_key if enable_cache else None)
  File "/Users/user/src/tinygrad/tinygrad/lazy.py", line 34, in __init__
    self.stacktrace = traceback.extract_stack()
 ```