### PR TITLE
Fix dot product on buffers with zero strides

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -588,7 +588,7 @@ class TestOps(unittest.TestCase):
       a = Tensor(3.14)
       a.matmul(a)
   def test_dot_with_const_buffer(self):
-    helper_test_op([], lambda: torch.ones((2,3)).matmul(torch.full((3,4), 2.0)), lambda: Tensor.ones((2,3)).dot(Tensor.full((3,4), 2.0)), forward_only=True)
+    helper_test_op([], lambda: torch.ones((2,3)).matmul(torch.full((3,4), 2.0)), lambda: Tensor.ones((2,3)).dot(Tensor.full((3,4), 2.0)), forward_only=True)  # noqa: E501
 
   def test_matmul_simple(self):
     helper_test_op([(4), (4,4)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -587,8 +587,21 @@ class TestOps(unittest.TestCase):
     with self.assertRaises(AssertionError):
       a = Tensor(3.14)
       a.matmul(a)
-  def test_dot_with_const_buffer(self):
-    helper_test_op([], lambda: torch.ones((2,3)).matmul(torch.full((3,4), 2.0)), lambda: Tensor.ones((2,3)).dot(Tensor.full((3,4), 2.0)), forward_only=True)  # noqa: E501
+  def test_mulacc_with_zero_strides(self):
+    helper_test_op(
+      [],
+      lambda: torch.tensor(1.0).reshape((1,1,1)).expand(2,4,3).mul(torch.tensor(1.0).reshape((1,1,1)).expand(2,4,3)).sum(-1),
+      lambda: Tensor(1.0).reshape((1,1,1)).expand(2,4,3).mul(Tensor(1.0).reshape((1,1,1)).expand(2,4,3)).sum(-1),
+      forward_only=True
+    )
+    a = [[1.,1.,1.,1.], [1.,1.,1.,1.]]
+    b = [1.,1.,1.,1.]
+    helper_test_op(
+      [],
+      lambda: torch.tensor(a).reshape((2,4,1)).expand(2,4,3).mul(torch.tensor(b).reshape((1,4,1)).expand(2,4,3)).sum([0,2]),
+      lambda: Tensor(a).reshape((2,4,1)).expand(2,4,3).mul(Tensor(b).reshape((1,4,1)).expand(2,4,3)).sum([0,2]),
+      forward_only=True
+    )
 
   def test_matmul_simple(self):
     helper_test_op([(4), (4,4)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -602,6 +602,11 @@ class TestOps(unittest.TestCase):
       lambda: Tensor(a).reshape((2,4,1)).expand(2,4,3).mul(Tensor(b).reshape((1,4,1)).expand(2,4,3)).sum([0,2]),
       forward_only=True
     )
+    helper_test_op(
+      [],
+      lambda: torch.ones((1,2)).matmul(torch.ones((2,3))), lambda: Tensor.ones((1,2)).dot(Tensor.ones((2,3))),
+      forward_only=True
+    )
 
   def test_matmul_simple(self):
     helper_test_op([(4), (4,4)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -587,6 +587,8 @@ class TestOps(unittest.TestCase):
     with self.assertRaises(AssertionError):
       a = Tensor(3.14)
       a.matmul(a)
+  def test_dot_with_const_buffer(self):
+    helper_test_op([], lambda: torch.ones((2,3)).matmul(torch.full((3,4), 2.0)), lambda: Tensor.ones((2,3)).dot(Tensor.full((3,4), 2.0)), forward_only=True)
 
   def test_matmul_simple(self):
     helper_test_op([(4), (4,4)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -214,7 +214,7 @@ def _get_interpreted_fxn(fxn_for_op:Dict[Op, Callable], ast:LazyOp) -> Interpret
     # TODO: shortcutted store won't work with strides
     if ast.op == BufferOps.STORE: return _interpret_ast(ast.src[0])
     if TernaryOps.MULACC in fxn_for_op and ast.op == ReduceOps.SUM:
-      if ast.src[0].op == BinaryOps.MUL: ast = LazyOp(TernaryOps.MULACC, ast.src[0].src, ast.arg)
+      if ast.src[0].op == BinaryOps.MUL and not all(src.op == BufferOps.CONST for src in ast.src[0].src): ast = LazyOp(TernaryOps.MULACC, ast.src[0].src, ast.arg)  # noqa: E501
       if (castop:=ast.src[0]).op == UnaryOps.CAST and (mulop:=castop.src[0]).op == BinaryOps.MUL:
         # MULACC with acc cast rewrite: MUL -> CAST -> SUM => CAST -> MULACC
         ast = LazyOp(TernaryOps.MULACC, tuple(LazyOp(UnaryOps.CAST, (s, ), castop.arg) for s in mulop.src), ast.arg)

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -214,7 +214,7 @@ def _get_interpreted_fxn(fxn_for_op:Dict[Op, Callable], ast:LazyOp) -> Interpret
     # TODO: shortcutted store won't work with strides
     if ast.op == BufferOps.STORE: return _interpret_ast(ast.src[0])
     if TernaryOps.MULACC in fxn_for_op and ast.op == ReduceOps.SUM:
-      if ast.src[0].op == BinaryOps.MUL and not all(src.op == BufferOps.CONST for src in ast.src[0].src): ast = LazyOp(TernaryOps.MULACC, ast.src[0].src, ast.arg)  # noqa: E501
+      if ast.src[0].op == BinaryOps.MUL: ast = LazyOp(TernaryOps.MULACC, ast.src[0].src, ast.arg)
       if (castop:=ast.src[0]).op == UnaryOps.CAST and (mulop:=castop.src[0]).op == BinaryOps.MUL:
         # MULACC with acc cast rewrite: MUL -> CAST -> SUM => CAST -> MULACC
         ast = LazyOp(TernaryOps.MULACC, tuple(LazyOp(UnaryOps.CAST, (s, ), castop.arg) for s in mulop.src), ast.arg)

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -15,7 +15,7 @@ def einsum_mulacc(einsum, get_strides, expand):
     (a_axes, a_slices), (b_axes, b_slices) = axes_slice(a_strides := get_strides(a)), axes_slice(get_strides(b))
     if not (set(a_axes).issuperset(sum_axes := tuple(i for i,s in enumerate(new_shape) if s == 1)) or set(b_axes).issuperset(sum_axes)):
       a_axes = tuple(sorted(set(a_axes).union(sum_axes)))
-      a_slices = tuple(slice(None) if s != 0 or i in sum_axes else 0 for i, s in enumerate(a_strides))
+      a_slices = tuple(slice(None) if i in a_axes else 0 for i in range(len(a_strides)))
     out = [i for i in range(len(new_shape)) if a.shape[i] == new_shape[i] and (i in a_axes or i in b_axes)]
     ret = einsum(f"{einscripts(a_axes)}, {einscripts(b_axes)} -> {einscripts(out)}", a[a_slices], b[b_slices])
     return expand(ret.reshape(tuple(1 if i not in a_axes and i not in b_axes else s for i,s in enumerate(new_shape))), new_shape)

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -12,7 +12,10 @@ def einsum_mulacc(einsum, get_strides, expand):
   def einscripts(x): return ''.join(["abcdefghijklmnopqrstuvwxyz"[i] for i in x])
   def axes_slice(strides): return tuple(i for i,s in enumerate(strides) if s != 0), tuple(slice(None) if s != 0 else 0 for s in strides)
   def mulacc(a, b, new_shape):
-    (a_axes, a_slices), (b_axes, b_slices) = axes_slice(get_strides(a)), axes_slice(get_strides(b))
+    (a_axes, a_slices), (b_axes, b_slices) = axes_slice(a_strides := get_strides(a)), axes_slice(get_strides(b))
+    if not (set(a_axes).issuperset(sum_axes := tuple(i for i,s in enumerate(new_shape) if s == 1)) or set(b_axes).issuperset(sum_axes)):
+      a_axes = tuple(sorted(set(a_axes).union(sum_axes)))
+      a_slices = tuple(slice(None) if s != 0 or i in sum_axes else 0 for i, s in enumerate(a_strides))
     out = [i for i in range(len(new_shape)) if a.shape[i] == new_shape[i] and (i in a_axes or i in b_axes)]
     ret = einsum(f"{einscripts(a_axes)}, {einscripts(b_axes)} -> {einscripts(out)}", a[a_slices], b[b_slices])
     return expand(ret.reshape(tuple(1 if i not in a_axes and i not in b_axes else s for i,s in enumerate(new_shape))), new_shape)

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -10,12 +10,14 @@ def reduce_axis(in_shape:Tuple[int, ...], out_shape:Tuple[int, ...]) -> Tuple[in
 
 def einsum_mulacc(einsum, get_strides, expand):
   def einscripts(x): return ''.join(["abcdefghijklmnopqrstuvwxyz"[i] for i in x])
-  def axes_slice(strides): return tuple(i for i,s in enumerate(strides) if s != 0), tuple(slice(None) if s != 0 else 0 for s in strides)
+  def sum_and_nonzero_strides_axes_slices(strides, sum_axes):
+    axes = tuple(i for i,s in enumerate(strides) if s != 0 or i in sum_axes)
+    slices = tuple(slice(None) if s != 0 or i in sum_axes else 0 for i,s in enumerate(strides))
+    return axes, slices
   def mulacc(a, b, new_shape):
-    (a_axes, a_slices), (b_axes, b_slices) = axes_slice(a_strides := get_strides(a)), axes_slice(get_strides(b))
-    if not (set(a_axes).issuperset(sum_axes := tuple(i for i,s in enumerate(new_shape) if s == 1)) or set(b_axes).issuperset(sum_axes)):
-      a_axes = tuple(sorted(set(a_axes).union(sum_axes)))
-      a_slices = tuple(slice(None) if i in a_axes else 0 for i in range(len(a_strides)))
+    sum_axes = tuple(i for i,s in enumerate(new_shape) if s == 1)
+    (a_axes, a_slices) = sum_and_nonzero_strides_axes_slices(get_strides(a), sum_axes)
+    (b_axes, b_slices) = sum_and_nonzero_strides_axes_slices(get_strides(b), sum_axes)
     out = [i for i in range(len(new_shape)) if a.shape[i] == new_shape[i] and (i in a_axes or i in b_axes)]
     ret = einsum(f"{einscripts(a_axes)}, {einscripts(b_axes)} -> {einscripts(out)}", a[a_slices], b[b_slices])
     return expand(ret.reshape(tuple(1 if i not in a_axes and i not in b_axes else s for i,s in enumerate(new_shape))), new_shape)


### PR DESCRIPTION
Trying to apply the `.dot` method on tensors that translate directly to buffer ops of type `CONST` will produce incorrect results. Example:

```py
from tinygrad import Tensor

a = Tensor.ones((2, 3))
b = Tensor.full((3, 4), 2.0)
x = a.dot(b)

print(x.numpy()) # should be matrix of 6s, but getting a matrix of 2s
```

This issue only applies to interpreted backends because of an optimization in the `_interpret_ast` function which rewrites ASTs containing `ReduceOps.SUM` followed by a `BinaryOps.MUL` into `TernaryOps.MULACC`.

In order for `MULACC` to execute correctly, it uses strides info of input arrays, which doesn't work on input arrays that came directly from a buffer op of type `CONST` and were broadcasted later, because `np.broadcast_to` keeps the strides info of input arrays for optimization purposes, and when both inputs contain strides info that are all zeros, it confuses the algorithm into producing incorrect results.

The same issue arose for all cases that need to execute `TernaryOps.MULACC` on input arrays that came from broadcasted `BufferOps.CONST`. For example, computing the gradients of the following scalar also produces incorrect results:

```py
from tinygrad import Tensor

a = Tensor.ones(2, 3, requires_grad=True)
b = Tensor.arange(3.0, requires_grad=True)
x = a.dot(b).sum()

x.backward()
b.grad.numpy() # array([1., 1., 1.], dtype=float32), which should be [2., 2., 2.]
```