### PR TITLE
[try] Parallel compile

### DIFF
--- a/test/external/external_test_speed_llama.py
+++ b/test/external/external_test_speed_llama.py
@@ -32,7 +32,7 @@ class TestLLaMASpeed(unittest.TestCase):
     print("assigned empty tensors, doing warmup")
 
     def run_llama(st, empty_method_cache=True):
-      if empty_method_cache: Device[Device.DEFAULT].get_runner.cache_clear()
+      if empty_method_cache: Device[Device.DEFAULT].get_compile_ticket.cache_clear()
       tms = [time.perf_counter()]
       for i in range(5):
         model(Tensor([[1,2,3,4]]), i).realize()

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -189,8 +189,7 @@ class InterpretedASTRunner(JITRunner):
 
 # eventually this will be (ast, opts)
 class CompileTicket(NamedTuple):
-  lin: Union[Linearizer, LazyOp]
-
+  ast: LazyOp
 
 # workers should ignore ctrl c
 def _init_worker(): signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -335,7 +334,7 @@ def _compile_linearizer(compiler, k:Linearizer, name:Optional[str]=None):
 class Compiled:
   def __init__(self, device:str, allocator:Allocator, compiler:Compiler, runtime, graph=None):
     self.dname, self.allocator, self.compiler, self.runtime, self.graph = device, allocator, compiler, runtime, graph
-    self.compiler_cache: Dict[Union[LazyOp, Any], Callable] = {}
+    self.compiler_futures: Dict[Union[LazyOp, Any], Callable] = {}
   def synchronize(self): pass  # override this in your device
 
   def to_program(self, k:Linearizer): return self.to_ast_runner(_compile_linearizer(self.compiler, k))
@@ -368,10 +367,10 @@ class Compiled:
 
   # functools.lru_cache ensures each function runs only once per input
   @functools.lru_cache(None)    # pylint: disable=method-cache-max-size-none
-  def start_compile(self, ast: LazyOp, parallel=True):
+  def start_compile(self, ast: LazyOp):
     compile_fn = functools.partial(_compile_linearizer, self.compiler, self.get_linearizer(ast))
-    self.compiler_cache[CompileTicket(ast)] = compile_fn if not parallel or DEBUG >= 4 or get_beam_pool() is None else get_beam_pool().apply_async(compile_fn).get
+    self.compiler_futures[CompileTicket(ast)] = compile_fn if DEBUG >= 4 or get_beam_pool() is None else get_beam_pool().apply_async(compile_fn).get
     return CompileTicket(ast)
 
   @functools.lru_cache(None)    # pylint: disable=method-cache-max-size-none
-  def get_runner(self, ast:LazyOp) -> CompiledASTRunner: return self.to_ast_runner(*self.compiler_cache.pop(self.start_compile(ast))())
+  def get_runner(self, ast:LazyOp) -> CompiledASTRunner: return self.to_ast_runner(*self.compiler_futures.pop(self.start_compile(ast))())

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -370,7 +370,7 @@ class Compiled:
   @functools.lru_cache(None)    # pylint: disable=method-cache-max-size-none
   def start_compile(self, ast: LazyOp):
     compile_fn = functools.partial(self.compiler.compile_linearizer, self.get_linearizer(ast))
-    self.compiler_futures[CompileTicket(ast)] = compile_fn if DEBUG >= 4 or (beam_pool := get_beam_pool(self.dname)) is None else beam_pool.apply_async(compile_fn).get
+    self.compiler_futures[CompileTicket(ast)] = compile_fn if DEBUG >= 3 or (beam_pool := get_beam_pool(self.dname)) is None else beam_pool.apply_async(compile_fn).get
     return CompileTicket(ast)
 
   @functools.lru_cache(None)    # pylint: disable=method-cache-max-size-none

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -206,7 +206,7 @@ class Interpreted:
 
   def get_compile_ticket(self, ast: LazyOp) -> CompileTicket: return CompileTicket(ast,)
 
-  @functools.lru_cache(None)  # pylint: disable=method-cache-max-size-none
+  @functools.lru_cache(None)   # pylint: disable=method-cache-max-size-none
   def get_runner(self, ast:LazyOp) -> InterpretedASTRunner: return _get_interpreted_fxn(self.fxn_for_op, ast)
 
 def _get_interpreted_fxn(fxn_for_op:Dict[Op, Callable], ast:LazyOp) -> InterpretedASTRunner:

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -1,7 +1,4 @@
 from __future__ import annotations
-import multiprocessing
-from multiprocessing.pool import AsyncResult
-import signal
 from collections import defaultdict
 from typing import TYPE_CHECKING, Union, Any, List, Optional, Dict, Callable, Tuple, cast, ClassVar, NamedTuple
 import importlib, inspect, functools, pathlib, time, re, ctypes
@@ -192,10 +189,13 @@ class CompileTicket(NamedTuple):
   ast: LazyOp
 
 # workers should ignore ctrl c
-def _init_worker(): signal.signal(signal.SIGINT, signal.SIG_IGN)
+def _init_worker():
+  import signal
+  signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 @functools.lru_cache
 def get_beam_pool():
+  import multiprocessing
   default_parallel = 1 if Device.DEFAULT in {"CUDA", "HIP"} else 0
   return multiprocessing.Pool(multiprocessing.cpu_count(), _init_worker) if getenv("PARALLEL", default_parallel) else None
 

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -332,7 +332,6 @@ class CompiledASTRunner(JITRunner):
     self.first_run = False
     return et
 
-
 class Compiled:
   def __init__(self, device:str, allocator:Allocator, compiler:Compiler, runtime, graph=None):
     self.dname, self.allocator, self.compiler, self.runtime, self.graph = device, allocator, compiler, runtime, graph

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -206,7 +206,7 @@ class Interpreted:
 
   def get_compile_ticket(self, ast: LazyOp) -> CompileTicket: return CompileTicket(ast,)
 
-  @functools.lru_cache(None)   # pylint: disable=method-cache-max-size-none
+  @functools.lru_cache(None) # pylint: disable=method-cache-max-size-none
   def get_runner(self, ast:LazyOp) -> InterpretedASTRunner: return _get_interpreted_fxn(self.fxn_for_op, ast)
 
 def _get_interpreted_fxn(fxn_for_op:Dict[Op, Callable], ast:LazyOp) -> InterpretedASTRunner:

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -206,7 +206,7 @@ class Interpreted:
 
   def get_compile_ticket(self, ast: LazyOp) -> CompileTicket: return CompileTicket(ast,)
 
-  @functools.lru_cache(None) # pylint: disable=method-cache-max-size-none
+  @functools.lru_cache(None)    # pylint: disable=method-cache-max-size-none
   def get_runner(self, ast:LazyOp) -> InterpretedASTRunner: return _get_interpreted_fxn(self.fxn_for_op, ast)
 
 def _get_interpreted_fxn(fxn_for_op:Dict[Op, Callable], ast:LazyOp) -> InterpretedASTRunner:

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, cast, DefaultDict, Optional, Tuple, Callable
-import itertools, functools, random, math, time, multiprocessing, traceback, signal
+import itertools, functools, random, math, time, traceback
 from tinygrad.device import Device, Compiled, Buffer, CompiledASTRunner, Compiler, get_beam_pool
 from tinygrad.ops import MemBuffer, LazyOp
 from tinygrad.helpers import prod, flatten, DEBUG, CACHELEVEL, diskcache_get, diskcache_put, getenv, Context, colored, to_function_name
@@ -91,7 +91,7 @@ def beam_search(lin:Linearizer, rawbufs, amt:int, allow_test_size=True) -> Linea
   beam: List[Tuple[Linearizer, float]] = []
   seen_libs = set()
 
-  beam_pool = get_beam_pool()
+  beam_pool = get_beam_pool(Device[lin.opts.device])
 
   try:
     var_vals = {k:(k.max+k.min)//2 for k in lin.ast.vars()}

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -91,7 +91,7 @@ def beam_search(lin:Linearizer, rawbufs, amt:int, allow_test_size=True) -> Linea
   beam: List[Tuple[Linearizer, float]] = []
   seen_libs = set()
 
-  beam_pool = get_beam_pool(Device[lin.opts.device])
+  beam_pool = get_beam_pool(lin.opts.device)
 
   try:
     var_vals = {k:(k.max+k.min)//2 for k in lin.ast.vars()}

--- a/tinygrad/realize.py
+++ b/tinygrad/realize.py
@@ -36,7 +36,7 @@ def lower_schedule_item(si:ScheduleItem) -> Optional[JITRunner]:
   if si.ast.op is LoadOps.CUSTOM: return CustomOp(si.ast.arg)
   if si.ast.op is LoadOps.SYNC: return SyncOp(si.out.device) if isinstance(Device[si.out.device], Compiled) else None
   if si.ast.op is LoadOps.WAIT: return None
-  return Device[si.out.device].get_compile_ticket(si.ast)
+  return Device[si.out.device].start_compile(si.ast)
 
 logops = open(getenv("LOGOPS", ""), "a") if getenv("LOGOPS", "") else None
 def run_schedule(schedule:List[ScheduleItem]):
@@ -45,7 +45,7 @@ def run_schedule(schedule:List[ScheduleItem]):
     si, prg = schedule.pop(0), prgs.pop(0)
     if logops and si.ast.op not in LoadOps: logops.write(str(si.ast)+"\n")
 
-    if isinstance(prg, CompileTicket): prg = Device[si.out.device].get_compiled(prg)
+    if isinstance(prg, CompileTicket): prg = Device[si.out.device].get_runner(prg.lin)
 
     # invalidate the output buffer if there's a non contig usage of it in inputs
     if si.out.output_buffer is not None:

--- a/tinygrad/realize.py
+++ b/tinygrad/realize.py
@@ -45,7 +45,7 @@ def run_schedule(schedule:List[ScheduleItem]):
     si, prg = schedule.pop(0), prgs.pop(0)
     if logops and si.ast.op not in LoadOps: logops.write(str(si.ast)+"\n")
 
-    if isinstance(prg, CompileTicket): prg = Device[si.out.device].get_runner(prg.lin)
+    if isinstance(prg, CompileTicket): prg = Device[si.out.device].get_runner(*prg)
 
     # invalidate the output buffer if there's a non contig usage of it in inputs
     if si.out.output_buffer is not None:

--- a/tinygrad/realize.py
+++ b/tinygrad/realize.py
@@ -45,6 +45,7 @@ def run_schedule(schedule:List[ScheduleItem]):
     si, prg = schedule.pop(0), prgs.pop(0)
     if logops and si.ast.op not in LoadOps: logops.write(str(si.ast)+"\n")
 
+    # get compiled program if deferred (parallel)
     if isinstance(prg, CompileTicket): prg = Device[si.out.device].get_runner(*prg)
 
     # invalidate the output buffer if there's a non contig usage of it in inputs

--- a/tinygrad/realize.py
+++ b/tinygrad/realize.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Optional, cast
+from typing import List, Dict, Optional, cast, Union
 from tinygrad.ops import LoadOps, ScheduleItem, BufferOps, GlobalCounters
-from tinygrad.device import Device, Buffer, BufferCopy, BufferXfer, BufferRead, JITRunner, update_stats, InterpretedASTRunner, Compiled, BufferOptions, CompileTicket
+from tinygrad.device import Device, Buffer, BufferCopy, BufferXfer, BufferRead, JITRunner, update_stats, InterpretedASTRunner, Compiled, BufferOptions, CompileTicket  # noqa: E501
 from tinygrad.graph import print_tree, realized_lazybuffer
 from tinygrad.helpers import colored, getenv, GRAPH, cpu_time_execution, DEBUG
 from tinygrad.shape.symbolic import Variable
@@ -21,7 +21,7 @@ class SyncOp(JITRunner):
     et = cpu_time_execution(self.device.synchronize, enable=wait or DEBUG >= 1)
     update_stats(colored("synchronize", "RED"), 0, 0, {}, et, 1, device=self.dname)
 
-def lower_schedule_item(si:ScheduleItem) -> Optional[JITRunner]:
+def lower_schedule_item(si:ScheduleItem) -> Optional[Union[JITRunner, CompileTicket]]:
   assert all(si.out.device == x.device for x in si.inputs) or si.ast.op in {LoadOps.COPY, LoadOps.WAIT}, \
     f"all devices must be the same, {si.out.device} != {[x.device for x in si.inputs]} {print_tree(si.ast) or ''}"
   if si.ast.op is LoadOps.EMPTY: return None


### PR DESCRIPTION
Just trying... Would appreciate feedback/suggestions on how to make it beautiful ;)

AFAICT, no visible behavior changes other than beam running for all kernels before any are executed for real.

After:
```
(venv) chaos@tiny4:~/tinygrad$ time LATEWINO=1 LATEBEAM=2 HALF=1 HIP_VISIBLE_DEVICES=3 BS=512 DEBUG=0 python3 examples/hlb_cifar10.py 
shuffling training dataset in 1199.50 ms (epoch=0)
  0 15307.16 ms run, 15304.89 ms python,    2.27 ms HIP, 1200.00 loss, 0.000015 LR, 0.42 GB used,    230.20 GFLOPS,   3523.74 GOPS
  1  967.79 ms run,  967.16 ms python,    0.63 ms HIP, 1202.00 loss, 0.000030 LR, 2.84 GB used,   3639.10 GFLOPS,   3521.88 GOPS
  2   19.47 ms run,    2.27 ms python,   17.19 ms HIP, 1190.00 loss, 0.000045 LR, 2.85 GB used, 180923.39 GFLOPS,   3521.88 GOPS
  3   18.30 ms run,    1.66 ms python,   16.64 ms HIP, 1175.00 loss, 0.000060 LR, 2.85 GB used, 192486.75 GFLOPS,   3521.88 GOPS
  4   18.48 ms run,    1.62 ms python,   16.86 ms HIP, 1160.00 loss, 0.000075 LR, 2.85 GB used, 190574.21 GFLOPS,   3521.88 GOPS
  5   18.59 ms run,    1.62 ms python,   16.97 ms HIP, 1160.00 loss, 0.000090 LR, 2.85 GB used, 189441.68 GFLOPS,   3521.88 GOPS
  6   18.50 ms run,    1.60 ms python,   16.90 ms HIP, 1152.00 loss, 0.000105 LR, 2.85 GB used, 190358.31 GFLOPS,   3521.88 GOPS


...

994   18.36 ms run,    1.57 ms python,   16.79 ms HIP,  499.00 loss, 0.000107 LR, 2.85 GB used, 191810.78 GFLOPS,   3521.88 GOPS
995   18.60 ms run,    1.57 ms python,   17.02 ms HIP,  493.75 loss, 0.000102 LR, 2.85 GB used, 189374.96 GFLOPS,   3521.88 GOPS
996   18.84 ms run,    1.56 ms python,   17.28 ms HIP,  495.75 loss, 0.000099 LR, 2.85 GB used, 186896.82 GFLOPS,   3521.88 GOPS
997   18.49 ms run,    1.61 ms python,   16.88 ms HIP,  496.00 loss, 0.000094 LR, 2.85 GB used, 190516.99 GFLOPS,   3521.88 GOPS
998   18.59 ms run,    1.69 ms python,   16.91 ms HIP,  496.00 loss, 0.000089 LR, 2.85 GB used, 189415.70 GFLOPS,   3521.88 GOPS
999   18.63 ms run,    1.60 ms python,   17.03 ms HIP,  495.25 loss, 0.000086 LR, 2.85 GB used, 189058.18 GFLOPS,   3521.88 GOPS
shuffling test dataset in 108.64 ms (epoch=0)
eval     9611/10240 93.86%,    0.40 val_loss STEP=1000 (in 1212.77 ms)

real    0m51.440s
user    1m15.361s
sys     0m14.884s


```

time_linearizer cache doesn't fill until the third run. seems like just making linearizers and applying opts is taking a lot of time