### PR TITLE
patch merge_views to handle missing case

### DIFF
--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -18,8 +18,9 @@ def un1d(shape:Tuple[sint, ...], offs:sint) -> List[sint]:
 
 @functools.lru_cache(maxsize=None)
 def merge_views(vm2:View, vm1:View) -> Optional[View]:
-  if vm1.contiguous and vm1.shape == vm2.shape: return vm2
   if vm2.contiguous: return vm1
+  if vm1.contiguous and vm1.shape == vm2.shape: return vm2
+  if vm1.contiguous and vm1.size() == vm2.size() and (ret := vm2.reshape(vm1.shape)) is not None: return ret
   if not vm2.mask and vm1.offset == 0 and None not in (rstrides := ShapeTracker((vm2, vm1)).real_strides()):
     return View.create(vm1.shape, cast(Tuple[sint, ...], rstrides), vm2.offset, vm1.mask)
   if vm1.mask:


### PR DESCRIPTION
When `vm1` is contiguous and size of `vm1` and `vm2` match, then `merge_views(vm2, vm1)` must be `vm2` reshaped to `vm1` , if the reshape is possible.

benchmarks:
```python
SEED=6961 CNT=10000 CHECK_NEQ=1 FUZZ=plus PYTHONPATH="." python3 test/external/fuzz_shapetracker_math.py
```
with `SEED=6961`,
master:
same but unequal 5.54%
branch:
same but unequal 5.42%

with `SEED=5115`,
master:
same but unequal 6.05%
branch:
same but unequal 5.90%