### PR TITLE
Fix Tensor.mean to compute the mean correctly when 0-length axes are selected

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -683,6 +683,8 @@ class TestOps(unittest.TestCase):
     helper_test_op([()], lambda x: x.mean())
   def test_mean_axis(self):
     helper_test_op([(3,4,5,6)], lambda x: x.mean(axis=(1,2)))
+  def test_mean_zero_axis(self):
+    helper_test_op([], lambda: torch.ones((1,0,3,0,5)).mean(axis=(1,3)), lambda: Tensor.ones((1,0,3,0,5)).mean(axis=(1,3)), forward_only=True)
 
   def test_var(self):
     helper_test_op([(15, 25, 35)], lambda x: x.var())

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -459,7 +459,7 @@ class TestZeroShapeTensor(unittest.TestCase):
     np.testing.assert_equal(Tensor([]).max().numpy(), -float("inf"))
     np.testing.assert_equal(Tensor([]).min().numpy(), float("inf"))
     np.testing.assert_equal(Tensor([]).sum().numpy(), 0)
-    np.testing.assert_equal(Tensor([]).mean().numpy(), 0)
+    np.testing.assert_equal(Tensor([]).mean().numpy(), float("nan"))
 
 class TestTensorCreationDevice(unittest.TestCase):
   # test auxiliary tensors are created on the same device

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -541,8 +541,9 @@ class Tensor:
 
   def mean(self, axis=None, keepdim=False):
     assert all_int(self.shape), "does not support symbolic shape"
-    out = self.sum(axis=axis, keepdim=keepdim)
-    return out.mul(prod(out.shape)/prod(self.shape)) if 0 not in self.shape else out
+    sum = self.sum(axis=axis, keepdim=keepdim)
+    x_shape_prod, sum_shape_prod = prod(self.shape), prod(sum.shape)
+    return sum if sum_shape_prod == 0 else sum.div(x_shape_prod / sum_shape_prod)
   def var(self, axis=None, keepdim=False, correction=1):
     assert all_int(self.shape), "does not support symbolic shape"
     square_sum = ((self - self.mean(axis=axis, keepdim=True)).square()).sum(axis=axis, keepdim=keepdim)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -541,9 +541,9 @@ class Tensor:
 
   def mean(self, axis=None, keepdim=False):
     assert all_int(self.shape), "does not support symbolic shape"
-    sum = self.sum(axis=axis, keepdim=keepdim)
-    x_shape_prod, sum_shape_prod = prod(self.shape), prod(sum.shape)
-    return sum if sum_shape_prod == 0 else sum.div(x_shape_prod / sum_shape_prod)
+    sum_t = self.sum(axis=axis, keepdim=keepdim)
+    x_shape_prod, sum_shape_prod = prod(self.shape), prod(sum_t.shape)
+    return sum_t if sum_shape_prod == 0 else sum_t.div(x_shape_prod / sum_shape_prod)
   def var(self, axis=None, keepdim=False, correction=1):
     assert all_int(self.shape), "does not support symbolic shape"
     square_sum = ((self - self.mean(axis=axis, keepdim=True)).square()).sum(axis=axis, keepdim=keepdim)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -541,9 +541,8 @@ class Tensor:
 
   def mean(self, axis=None, keepdim=False):
     assert all_int(self.shape), "does not support symbolic shape"
-    sum_t = self.sum(axis=axis, keepdim=keepdim)
-    x_shape_prod, sum_shape_prod = prod(self.shape), prod(sum_t.shape)
-    return sum_t if sum_shape_prod == 0 else sum_t.div(x_shape_prod / sum_shape_prod)
+    out = self.sum(axis=axis, keepdim=keepdim)
+    return out.div(prod(self.shape) / prod(out.shape)) if 0 not in out.shape else out
   def var(self, axis=None, keepdim=False, correction=1):
     assert all_int(self.shape), "does not support symbolic shape"
     square_sum = ((self - self.mean(axis=axis, keepdim=True)).square()).sum(axis=axis, keepdim=keepdim)


### PR DESCRIPTION
Using `Tensor.mean` to compute the mean for tensors with 0(s) in their shape should output `nan`s when selecting those zeros in `axis`. This complies with Pytorch's behavior and actually makes sense.