### PR TITLE
PoC UnaryOps before expand

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -70,6 +70,7 @@ class LazyBuffer:
 
   def cast(self, dtype:DType, bitcast:bool=False):
     if self.dtype == dtype: return self
+    if dtype.itemsize <= self.dtype.itemsize and self != self.base: return self.base.cast(dtype, bitcast)._view(self.st)
     return create_lazybuffer(self.device, ShapeTracker.from_shape(self.shape), dtype, UnaryOps.CAST, (dtype, bitcast), (self,))
 
   def is_unrealized_const(self): return not self.base.realized and self.base.op is LoadOps.CONST

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -104,6 +104,7 @@ class LazyBuffer:
 
   def e(self, op:Union[LoadOps, UnaryOps, BinaryOps, TernaryOps], *in_srcs:LazyBuffer, arg:Optional[Any]=None) -> LazyBuffer:
     srcs: List[LazyBuffer] = []
+    if isinstance(op, UnaryOps) and self != self.base: return self.base.e(op, *in_srcs, arg=arg)._view(self.st)
     for s in (self,)+in_srcs:
       if s == s.base and s.base.contiguous_child and (root:=s.base.contiguous_child[0]()) is not None:
         srcs.append(root._view(s.base.contiguous_child[1]))

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -104,7 +104,6 @@ class LazyBuffer:
 
   def e(self, op:Union[LoadOps, UnaryOps, BinaryOps, TernaryOps], *in_srcs:LazyBuffer, arg:Optional[Any]=None) -> LazyBuffer:
     srcs: List[LazyBuffer] = []
-    if isinstance(op, UnaryOps) and self != self.base: return self.base.e(op, *in_srcs, arg=arg)._view(self.st)
     for s in (self,)+in_srcs:
       if s == s.base and s.base.contiguous_child and (root:=s.base.contiguous_child[0]()) is not None:
         srcs.append(root._view(s.base.contiguous_child[1]))


### PR DESCRIPTION
** this is a PoC, and probably not how this should eventually be implemented ** (i will need to read the rest of lazy.py...)

the matmul forwards is: `half(sum(float(mul(a,b))))`, so the backwards is `mul(half(expand(float(grad))),b)`. Expands always realize in the lazy graph, but half(expand(float)) is just expand, so the casts can be simplified out by swapping the half and expand. this saves membw, and also allows half/half tc to trigger.

this change just applies casts to smaller dtypes before any movementops, just to check perf, and it's quite good (7950x):

```
993   14.06 ms run,    0.86 ms python,   13.21 ms HIP,  496.00 loss, 0.000112 LR, 2.08 GB used, 250407.02 GFLOPS,   3521.88 GOPS
994   14.05 ms run,    0.85 ms python,   13.20 ms HIP,  493.25 loss, 0.000107 LR, 2.08 GB used, 250617.10 GFLOPS,   3521.88 GOPS
995   14.07 ms run,    0.84 ms python,   13.23 ms HIP,  494.75 loss, 0.000102 LR, 2.08 GB used, 250300.24 GFLOPS,   3521.88 GOPS

```