### PR TITLE
set expandable_segments:True in ops_torch.py to reduce memory fragmentation

### DIFF
--- a/tinygrad/runtime/ops_torch.py
+++ b/tinygrad/runtime/ops_torch.py
@@ -1,3 +1,4 @@
+import os
 import torch
 from typing import Dict, Callable
 from tinygrad.ops import BufferOps, UnaryOps, BinaryOps, TernaryOps, ReduceOps, MovementOps, Op
@@ -6,6 +7,7 @@ from tinygrad.dtype import dtypes
 from tinygrad.helpers import getenv, flatten
 from tinygrad.runtime.ops_cpu import einsum_mulacc, reduce_axis
 
+os.environ['PYTORCH_CUDA_ALLOC_CONF']='expandable_segments:True'
 device = torch.device("cuda:0" if torch.cuda.is_available() else ("mps" if getenv("MPS", 0) else "cpu"))
 type_map = {torch.bool: dtypes.bool,
             torch.int8: dtypes.int8, torch.uint8: dtypes.uint8, torch.int16: dtypes.int16, torch.int32: dtypes.int32, torch.int64: dtypes.int64,


### PR DESCRIPTION
the current ops_torch.py backend ooms because of memory fragmentation on a 4090 on: 
test/models/test_real_world.py::TestRealWorld::test_llama 
test/models/test_whisper.py::TestWhisper::test_transcribe_long 
examples/beautiful_mnist.py

setting the envvar PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True fixes it for now.

setting it in runtime/ops_torch.py because its a torch-runtime specific tweak