### PR TITLE
reflect changes to shapetracker in example printouts

### DIFF
--- a/docs/abstractions.py
+++ b/docs/abstractions.py
@@ -306,23 +306,23 @@ from tinygrad.shape.shapetracker import ShapeTracker
 # create a virtual (10, 10) Tensor. this is just a shape, there's no actual tensor
 a = ShapeTracker.from_shape((10, 10))
 
-# you'll see it has one view. the (10, 1 are the strides)
-print(a) # ShapeTracker(shape=(10, 10), views=[View((10, 10), (10, 1), 0)])
+# you'll see it has one view
+print(a) # ShapeTracker(views=(View(shape=(10, 10), strides=(10, 1))))
 
 # we can permute it, and the strides change
 a = a.permute((1,0))
-print(a) # ShapeTracker(shape=(10, 10), views=[View((10, 10), (1, 10), 0)])
+print(a) # ShapeTracker(views=(View(shape=(10, 10), strides=(1, 10))))
 
 # we can then reshape it, and the strides change again
 # note how the permute stays applied
 a = a.reshape((5,2,5,2))
-print(a) # ShapeTracker(shape=(5, 2, 5, 2), views=[View((5, 2, 5, 2), (2, 1, 20, 10), 0)])
+print(a) # ShapeTracker(views=(View(shape=(5, 2, 5, 2), strides=(2, 1, 20, 10))))
 
 # now, if we were to reshape it to a (100,) shape tensor, we have to create a second view
 a = a.reshape((100,))
-print(a) # ShapeTracker(shape=(100,), views=[
-         #   View((5, 2, 5, 2), (2, 1, 20, 10), 0),
-         #   View((100,), (1,), 0)])
+print(a) # ShapeTracker(views=(
+         #   View(shape=(5, 2, 5, 2), strides=(2, 1, 20, 10)),
+         #   View(shape=(100,), strides=(1,))))
 
 # Views stack on top of each other, to allow zero copy for any number of MovementOps
 # we can render a Python expression for the index at any time
@@ -335,17 +335,17 @@ idx, _ = a.expr_idxs()
 print(idx.render())  # ((idx1*10)+idx0)
 
 # the ShapeTracker still has two views though...
-print(a) # ShapeTracker(shape=(10, 10), views=[
-         #   View((5, 2, 5, 2), (2, 1, 20, 10), 0),
-         #   View((10, 10), (10, 1), 0)])
+print(a) # ShapeTracker(views=(
+         #   View(shape=(5, 2, 5, 2), strides=(2, 1, 20, 10),
+         #   View(shape=(10, 10), strides=(10, 1))))
 
 # ...until we simplify it!
 a = a.simplify()
-print(a) # ShapeTracker(shape=(10, 10), views=[View((10, 10), (1, 10), 0)])
+print(a) # ShapeTracker(views=(View(shape=(10, 10), strides=(1, 10), offset=0)))
 
 # and now we permute it back
 a = a.permute((1,0))
-print(a) # ShapeTracker(shape=(10, 10), views=[View((10, 10), (10, 1), 0)])
+print(a) # ShapeTracker(views=(View(shape=(10, 10), strides=(10, 1), offset=0)))
 
 # and it's even contiguous
 assert a.contiguous == True


### PR DESCRIPTION
Back in September [ShapeTracker](https://github.com/tinygrad/tinygrad/blob/d8ad9e5660a50b516a37de7f0e56c0259a911c08/tinygrad/shape/shapetracker.py#L96) was modified to return a tuple of views instead of a list in this PR: #1909 like so:
```python3
class ShapeTracker:
  views: Tuple[View, ...]
```

And `shape` was moved within View as opposed to ShapeTracker itself which now uses the `@property` decorator to access shape thereby hiding it in printouts in this PR: #1844
```python3
@property
  def shape(self) -> Tuple[sint, ...]: return self.views[-1].shape
```

These changes weren't reflected in the [docs/abstractions.py](https://github.com/tinygrad/tinygrad/blob/d8ad9e5660a50b516a37de7f0e56c0259a911c08/docs/abstractions.py#L310) example printouts. 

I am aware this violates the _do not touch_ the docs rule in [CONTRIBUTING.md](https://github.com/tinygrad/tinygrad?tab=readme-ov-file#contributing), however I think this is a valid exception as it keeps the walkthrough docs up to date even if in a small way. That being said, I totally understand if the PR must be closed to adhere to that rule.