### PR TITLE
[WIP] Support lazy layers

### DIFF
--- a/examples/beautiful_mnist.py
+++ b/examples/beautiful_mnist.py
@@ -7,13 +7,13 @@ from tqdm import trange
 class Model:
   def __init__(self):
     self.layers: List[Callable[[Tensor], Tensor]] = [
-      nn.Conv2d(1, 32, 5), Tensor.relu,
-      nn.Conv2d(32, 32, 5), Tensor.relu,
+      nn.LazyConv2d(32, 5), Tensor.relu,
+      nn.LazyConv2d(32, 5), Tensor.relu,
       nn.BatchNorm2d(32), Tensor.max_pool2d,
-      nn.Conv2d(32, 64, 3), Tensor.relu,
-      nn.Conv2d(64, 64, 3), Tensor.relu,
+      nn.LazyConv2d(64, 3), Tensor.relu,
+      nn.LazyConv2d(64, 3), Tensor.relu,
       nn.BatchNorm2d(64), Tensor.max_pool2d,
-      lambda x: x.flatten(1), nn.Linear(576, 10)]
+      lambda x: x.flatten(1), nn.LazyLinear(10)]
 
   def __call__(self, x:Tensor) -> Tensor: return x.sequential(self.layers)
 

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -4,6 +4,22 @@ from tinygrad.tensor import Tensor
 from tinygrad.helpers import prod
 from tinygrad.nn import optim, state  # noqa: F401
 
+class LazyLayer:
+  def __init__(self, get_layer_input_size, create_layer):
+    self.get_layer_input_size, self.create_layer = get_layer_input_size, create_layer
+    self.layer_input_size, self.layer = None, None
+
+  def __call__(self, t:Tensor):
+    assert isinstance(t, Tensor), f"expected Tensor, got {type(t)}"
+
+    if self.layer is None:
+      self.layer_input_size = self.get_layer_input_size(t)
+      self.layer = self.create_layer(self.layer_input_size)
+    if self.layer_input_size is not None:
+      assert self.layer_input_size == (sz := self.get_layer_input_size(t)), f"expected input size {self.layer_input_size}, got {sz}"
+
+    return self.layer(t)
+
 class BatchNorm2d:
   def __init__(self, sz:int, eps=1e-5, affine=True, track_running_stats=True, momentum=0.1):
     self.eps, self.track_running_stats, self.momentum = eps, track_running_stats, momentum
@@ -54,6 +70,15 @@ class Conv2d:
   def initialize_weight(self, out_channels, in_channels, groups):
     return Tensor.kaiming_uniform(out_channels, in_channels//groups, *self.kernel_size, a=math.sqrt(5))
 
+class LazyConv2d(LazyLayer):
+  def __init__(self, out_channels, kernel_size, stride=1, padding=0, dilation=1, groups=1, bias=True):
+    def get_layer_input_size(t:Tensor):
+      assert len(t.shape) == 4, f"expected 4D tensor, got {t.shape}"
+      return t.shape[1]
+    def create_layer(in_channels:int): return Conv2d(in_channels, out_channels, kernel_size, stride, padding, dilation, groups, bias)
+
+    super().__init__(get_layer_input_size, create_layer)
+
 def ConvTranspose1d(in_channels, out_channels, kernel_size, stride=1, padding=0, output_padding=0, dilation=1, groups=1, bias=True):
   return ConvTranspose2d(in_channels, out_channels, (kernel_size,), stride, padding, output_padding, dilation, groups, bias)
 
@@ -78,6 +103,15 @@ class Linear:
 
   def __call__(self, x:Tensor):
     return x.linear(self.weight.transpose(), self.bias)
+
+class LazyLinear(LazyLayer):
+  def __init__(self, out_features, bias=True):
+    def get_layer_input_size(t:Tensor):
+      assert len(t.shape) >= 1, f"expected at least 1D tensor, got {t.shape}"
+      return t.shape[-1]
+    def create_layer(in_features:int): return Linear(in_features, out_features, bias)
+
+    super().__init__(get_layer_input_size, create_layer)
 
 class GroupNorm:
   def __init__(self, num_groups:int, num_channels:int, eps:float=1e-5, affine:bool=True):


### PR DESCRIPTION
This is a proposal to support lazy layers in tinygrad.

When building complex models it is harder to manually compute the output of each layer to use it as the input argument for the next layer.

The current code implements the base `LazyLayer` class and the lazy layers for `Linear` and `Conv2d`, and uses them in the `beautiful_mnist.py` example for illustration.

I would happily implement lazy layers for the rest and add tests if the proposal is desired and the approach is good.