### PR TITLE
fix Tensor.randint ignoring kwargs

### DIFF
--- a/test/test_randomness.py
+++ b/test/test_randomness.py
@@ -65,6 +65,7 @@ class TestRandomness(unittest.TestCase):
   def test_randint(self):
     self.assertFalse(normal_test(Tensor.randint))
     self.assertTrue(equal_distribution(partial(Tensor.randint, low=-2, high=5), numpy_func=lambda x: np.random.randint(low=-2, high=5, size=x)))
+    self.assertTrue(Tensor.randint(1,device="CLANG").device=="CLANG")
 
   def test_normal(self):
     self.assertTrue(normal_test(Tensor.normal))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -229,7 +229,7 @@ class Tensor:
     return src[0].mul(2*math.pi).cos().mul((1 - src[1]).log().mul(-2).sqrt()).cast(dtype or dtypes.default_float)
 
   @staticmethod
-  def randint(*shape, low=0, high=10, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=low, high=high, dtype=dtypes.int32)
+  def randint(*shape, low=0, high=10, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=low, high=high, **{**kwargs, **{'dtype':dtypes.int32}})
 
   @staticmethod
   def normal(*shape, mean=0.0, std=1.0, **kwargs) -> Tensor: return (std * Tensor.randn(*shape, **kwargs)) + mean

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -229,7 +229,7 @@ class Tensor:
     return src[0].mul(2*math.pi).cos().mul((1 - src[1]).log().mul(-2).sqrt()).cast(dtype or dtypes.default_float)
 
   @staticmethod
-  def randint(*shape, low=0, high=10, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=low, high=high, **{**kwargs, **{'dtype':dtypes.int32}})
+  def randint(*shape, low=0, high=10, **kwargs) -> Tensor: return Tensor.uniform(*shape, low=low, high=high, dtype=dtypes.int32, **kwargs)
 
   @staticmethod
   def normal(*shape, mean=0.0, std=1.0, **kwargs) -> Tensor: return (std * Tensor.randn(*shape, **kwargs)) + mean


### PR DESCRIPTION
I tried to create a Tensor.randint on another device:
```python
from tinygrad import Tensor

x = Tensor.randint([3,3],device="CLANG")
print(x)
```
Output shows it is created on "GPU" instead:
```python
<Tensor <LB GPU (3, 3) contig:True (<UnaryOps.CAST: 3>, None)> on GPU with grad None>
```
This PR fixes it by making Tensor.randint pass the kwargs on, only updating the dtype to int32. Also added a test that would fail without this PR.