### PR TITLE
MLPerf Resnet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -446,7 +446,7 @@ jobs:
         run: python -m pytest -n=auto test/ -k 'not (half or test_efficientnet_safetensors)' --ignore=test/external --ignore=test/models --durations=20
       - name: Run pytest (hip)
         if: matrix.backend=='hip'
-        run: python -m pytest -n=auto test/test_ops.py test/test_dtype.py test/test_dtype_alu.py --durations=20
+        run: python -m pytest -n=auto test/test_ops.py test/test_dtype.py test/test_dtype_alu.py test/test_linearizer.py test/imported/test_indexing.py --durations=20
 
   #testunicorn:
   #  name: ARM64 unicorn Test

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -28,7 +28,7 @@ else:
   dtypes.default_float = dtypes.float32
   np_dtype = np.float32
 
-class BatchNorm(nn.BatchNorm2d):
+class BatchNorm(nn.UnsyncBatchNorm2d if getenv("SYNCBN", 0) else nn.BatchNorm2d):
   def __init__(self, num_features):
     super().__init__(num_features, track_running_stats=False, eps=1e-12, momentum=0.85, affine=True)
     self.weight.requires_grad = False

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -16,7 +16,7 @@ from tinygrad.features.multi import MultiLazyBuffer
 
 BS, STEPS = getenv("BS", 512), getenv("STEPS", 1000)
 EVAL_BS = getenv("EVAL_BS", BS)
-GPUS = [f'{Device.DEFAULT}:{i}' for i in range(getenv("GPUS", 1))]
+GPUS = tuple([Device.canonicalize(f'{Device.DEFAULT}:{i}') for i in range(getenv("GPUS", 1))])
 assert BS % len(GPUS) == 0, f"{BS=} is not a multiple of {len(GPUS)=}, uneven multi GPU is slow"
 assert EVAL_BS % len(GPUS) == 0, f"{EVAL_BS=} is not a multiple of {len(GPUS)=}, uneven multi GPU is slow"
 for x in GPUS: Device[x]
@@ -30,7 +30,7 @@ else:
 
 class BatchNorm(nn.UnsyncBatchNorm2d if getenv("SYNCBN", 0) else nn.BatchNorm2d):
   def __init__(self, num_features):
-    super().__init__(num_features, track_running_stats=False, eps=1e-12, momentum=0.85, affine=True)
+    super().__init__(GPUS, num_features, track_running_stats=False, eps=1e-12, momentum=0.85, affine=True)
     self.weight.requires_grad = False
     self.bias.requires_grad = True
 

--- a/examples/mlperf/dataloader.py
+++ b/examples/mlperf/dataloader.py
@@ -75,7 +75,7 @@ def batch_load_resnet(batch_size=64, val=False, shuffle=True):
   from extra.datasets.imagenet import get_imagenet_categories
   cir = get_imagenet_categories()
 
-  BATCH_COUNT = 32
+  BATCH_COUNT = min(32, len(files) // batch_size)
   #q_in, q_out = MyQueue(multiple_writers=False), MyQueue(multiple_readers=False)
   q_in, q_out = Queue(), Queue()
 

--- a/examples/mlperf/dataloader.py
+++ b/examples/mlperf/dataloader.py
@@ -54,8 +54,9 @@ def loader_process(q_in, q_out, X:Tensor):
       else:
         from extra.datasets.imagenet import preprocess_train
         # reseed rng for determinism
-        np.random.seed(seed)
-        random.seed(seed)
+        if seed is not None:
+          np.random.seed(seed)
+          random.seed(seed)
         img = preprocess_train(img)
 
       # broken out
@@ -109,7 +110,7 @@ def batch_load_resnet(batch_size=64, val=False, shuffle=True, seed=None):
     for idx in range(num*batch_size, (num+1)*batch_size):
       fidx = next(gen)
       fn = files[fidx]
-      q_in.put((idx, fn, (seed+1) * len(files) + fidx, val))
+      q_in.put((idx, fn, (seed+1) * len(files) + fidx if seed is not None else None, val))
       Y[idx] = cir[fn.split("/")[-2]]
   for bn in range(BATCH_COUNT): enqueue_batch(bn)
 

--- a/examples/mlperf/model_eval.py
+++ b/examples/mlperf/model_eval.py
@@ -30,7 +30,7 @@ def eval_resnet():
       x = x.permute([0,3,1,2]).cast(dtypes.float32) / 255.0
       x -= self.input_mean
       x /= self.input_std
-      return self.mdl(x).argmax(axis=1).realize()
+      return self.mdl(x).log_softmax().argmax(axis=1).realize()
 
   mdl = TinyJit(ResnetRunner(GPUS))
   tlog("loaded models")

--- a/examples/mlperf/model_eval.py
+++ b/examples/mlperf/model_eval.py
@@ -10,8 +10,6 @@ from examples.mlperf import helpers
 def tlog(x): print(f"{x:25s}  @ {time.perf_counter()-start:5.2f}s")
 
 def eval_resnet():
-  FP16 = getenv("FP16", 0)
-  if FP16: dtypes.default_float = dtypes.float16
   Tensor.no_grad = True
   # Resnet50-v1.5
   from extra.models.resnet import ResNet50
@@ -26,13 +24,13 @@ def eval_resnet():
       for x in get_parameters(self.mdl) if device else []: x.to_(device)
       if (fn:=getenv("RESNET_MODEL", "")): load_state_dict(self.mdl, safe_load(fn))
       else: self.mdl.load_from_pretrained()
-      self.input_mean = Tensor([0.485, 0.456, 0.406], device=device, dtype=dtypes.float32).reshape(1, -1, 1, 1)
-      self.input_std = Tensor([0.229, 0.224, 0.225], device=device, dtype=dtypes.float32).reshape(1, -1, 1, 1)
+      self.input_mean = Tensor([0.485, 0.456, 0.406], device=device).reshape(1, -1, 1, 1)
+      self.input_std = Tensor([0.229, 0.224, 0.225], device=device).reshape(1, -1, 1, 1)
     def __call__(self, x:Tensor) -> Tensor:
       x = x.permute([0,3,1,2]).cast(dtypes.float32) / 255.0
       x -= self.input_mean
       x /= self.input_std
-      return self.mdl(x.cast(dtypes.default_float)).argmax(axis=1).realize()
+      return self.mdl(x).argmax(axis=1).realize()
 
   mdl = TinyJit(ResnetRunner(GPUS))
   tlog("loaded models")

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -98,7 +98,7 @@ def train_resnet():
   # ** Optimizer **
   if getenv("LARS", 1):
     skip_list = {v for k, v in get_state_dict(model).items() if 'bn' in k or 'bias' in k}
-    optimizer = optim.LARS(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay, track_gnorm=bool(getenv("TRACK_NORMS", 1)), skip_list=skip_list)
+    optimizer = optim.LARS(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay, track_gnorm=bool(getenv("TRACK_NORMS", 0)), skip_list=skip_list)
   else:
     optimizer = optim.SGD(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay)
 

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -97,7 +97,8 @@ def train_resnet():
 
   # ** Optimizer **
   if getenv("LARS", 1):
-    optimizer = optim.LARS(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay, track_gnorm=bool(getenv("TRACK_NORMS", 1)))
+    skip_list = {v for k, v in get_state_dict(model).items() if 'bn' in k or 'bias' in k}
+    optimizer = optim.LARS(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay, track_gnorm=bool(getenv("TRACK_NORMS", 1)), skip_list=skip_list)
   else:
     optimizer = optim.SGD(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay)
 

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -182,12 +182,9 @@ def train_resnet():
   # ** epoch loop **
   for e in range(start_epoch, epochs):
     Tensor.training = True
-    # reseed rng for every epoch (restore rng state from ckpt)
-    np.random.seed(seed + e)
-    random.seed(seed + e)
     dt = time.perf_counter()
 
-    it = iter(tqdm(t := batch_load_resnet(batch_size=BS, val=False, shuffle=True), total=steps_in_train_epoch))
+    it = iter(tqdm(t := batch_load_resnet(batch_size=BS, val=False, shuffle=True, seed=seed*epochs + e), total=steps_in_train_epoch))
     def data_get(it):
       x, y, cookie = next(it)
       # x must realize here, since the shm diskbuffer in dataloader might disappear?

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -98,7 +98,7 @@ def train_resnet():
 
   # ** Optimizer **
   if getenv("LARS", 1):
-    optimizer = optim.LARS(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay)
+    optimizer = optim.LARS(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay, track_gnorm=True)
   else:
     optimizer = optim.SGD(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay)
 

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -292,7 +292,7 @@ def train_resnet():
       total_fw_time = sum(eval_times) / len(eval_times)
       tqdm.write(f"eval loss: {total_loss:.2f}, eval time: {total_fw_time:.2f}, eval top 1 acc: {total_top_1:.3f}, eval top 5 acc: {total_top_5:.3f}")
 
-      weight_hists = {f"weights/{k}": wandb.Histogram(v.numpy().flatten().tolist()) for k, v in get_state_dict(model).items() if v.requires_grad}
+      weight_hists = {f"weights/{k}": wandb.Hist(v.numpy().flatten().tolist()) for k, v in get_state_dict(model)}
       wandb.log({"eval/loss": total_loss,
                 "eval/top_1_acc": total_top_1,
                 "eval/top_5_acc": total_top_5,

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -290,7 +290,7 @@ def train_resnet():
         print(f" *** WGMI {fn} ***")
         achieved = True
 
-      if (e+1) % getenv("CKPT_EPOCHS", 4) == 0 or e + 1 == epochs:
+      if not getenv("TESTEVAL") and ((e+1) % getenv("CKPT_EPOCHS", 4) == 0 or e + 1 == epochs):
         if not os.path.exists("./ckpts"): os.mkdir("./ckpts")
         if wandb.run is not None:
           fn = f"./ckpts/{time.strftime('%Y%m%d_%H%M%S')}_{wandb.run.id}_e{e}.safe"

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -241,7 +241,7 @@ def train_resnet():
       eval_top_5_acc = []
       #Tensor.training = False  # disable to make kernels as similar as possible
 
-      iterator = iter(tqdm(t := batch_load_resnet(batch_size=EVAL_BS, val=True, shuffle=False), total=steps_in_val_epoch))
+      iterator = iter(tqdm(t := batch_load_resnet(batch_size=EVAL_BS, val=True, shuffle=True), total=steps_in_val_epoch))
 
       proc = data_get()
 

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -321,7 +321,6 @@ def train_maskrcnn():
 
 if __name__ == "__main__":
   with Tensor.train():
-    Tensor.training = True
     for m in getenv("MODEL", "resnet,retinanet,unet3d,rnnt,bert,maskrcnn").split(","):
       nm = f"train_{m}"
       if nm in globals():

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -274,7 +274,7 @@ def train_resnet():
         proc, next_proc = next_proc, None  # drop cookie
 
       total_top_1 = sum(eval_top_1_acc) / len(eval_top_1_acc)
-      tqdm.write(f"eval loss: {sum(eval_loss) / len(eval_loss):.2f}, eval time: {sum(eval_times) / len(eval_times):.2f}, eval top 1 acc: {sum(eval_top_1_acc) / len(eval_top_1_acc):.2f}, eval top 5 acc: {sum(eval_top_5_acc) / len(eval_top_5_acc):.2f}")
+      tqdm.write(f"eval loss: {sum(eval_loss) / len(eval_loss):.2f}, eval time: {sum(eval_times) / len(eval_times):.2f}, eval top 1 acc: {sum(eval_top_1_acc) / len(eval_top_1_acc):.3f}, eval top 5 acc: {sum(eval_top_5_acc) / len(eval_top_5_acc):.3f}")
       wandb.log({"eval/loss": sum(eval_loss) / len(eval_loss),
                 "eval/forward_time": sum(eval_times) / len(eval_times),
                 "eval/top_1_acc": total_top_1,

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -97,12 +97,13 @@ def train_resnet():
   lr_steps = [30, 60, 80]
   lr_warmup_epochs = 5
   base_lr = 0.256 * (BS / 256)  # Linearly scale from BS=256, lr=0.256
-  base_lr = 8.4 * (BS/2048)
+  base_lr = getenv("LR", 8.4 * (BS/2048))
   epochs = getenv("EPOCHS", 45)
+  decay = getenv("DECAY", 2e-4)
   if getenv("LARS", 1):
-    optimizer = optim.LARS(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=2e-4)
+    optimizer = optim.LARS(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay)
   else:
-    optimizer = optim.SGD(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=2e-4)
+    optimizer = optim.SGD(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay)
   steps_in_train_epoch = (len(get_train_files()) // BS)
   steps_in_val_epoch = (len(get_val_files()) // EVAL_BS)
   #scheduler = MultiStepLR(optimizer, [m for m in lr_steps], gamma=lr_gamma, warmup=lr_warmup)
@@ -157,6 +158,7 @@ def train_resnet():
     'base_lr': base_lr,
     'epochs': epochs,
     'classes': num_classes,
+    'decay': decay,
     'train_files': len(get_train_files()),
     'eval_files': len(get_train_files()),
     'steps_in_train_epoch': steps_in_train_epoch,

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -14,7 +14,8 @@ import time
 import os
 
 FP16 = getenv("FP16", 0)
-BS, EVAL_BS, STEPS = getenv("BS", 64), getenv('EVAL_BS', 64), getenv("STEPS", 1000)
+BS = getenv("BS", 64)
+EVAL_BS = getenv('EVAL_BS', BS)
 
 def train_resnet():
   # TODO: Resnet50-v1.5
@@ -208,7 +209,7 @@ def train_resnet():
       new_st = time.perf_counter()
 
       tqdm.write(
-        f"{i:5} {((cl - st)) * 1000.0:7.2f} ms run, {(fwet - st) * 1000.0:7.2f}+{(et - fwet) * 1000.0:7.2f} ms bw python, {(cl - dte) * 1000.0:7.2f} ms CL, {(dte - dt) * 1000.0:6.2f} ms fetch data, {loss_cpu:5.2f} loss, {top_1_acc:3.2f} acc, {optimizer.lr.numpy()[0] * lr_scaler:.6f} LR, {GlobalCounters.mem_used / 1e9:.2f} GB used, {GlobalCounters.global_ops * 1e-9 / (cl - st):9.2f} GFLOPS")
+        f"{i:5} {((cl - st)) * 1000.0:7.2f} ms run, {(fwet - st) * 1000.0:7.2f}+{(et - fwet) * 1000.0:7.2f} ms python, {(cl - dte) * 1000.0:7.2f} ms CL, {(dte - dt) * 1000.0:6.2f} ms fetch data, {loss_cpu:5.2f} loss, {top_1_acc:3.2f} acc, {optimizer.lr.numpy()[0] * lr_scaler:.6f} LR, {GlobalCounters.mem_used / 1e9:.2f} GB used, {GlobalCounters.global_ops * 1e-9 / (cl - st):9.2f} GFLOPS")
       wandb.log({"lr": optimizer.lr.numpy() * lr_scaler,
                  "train/data_time": dte-dt,
                  "train/step_time": cl - st,

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -292,7 +292,7 @@ def train_resnet():
       total_fw_time = sum(eval_times) / len(eval_times)
       tqdm.write(f"eval loss: {total_loss:.2f}, eval time: {total_fw_time:.2f}, eval top 1 acc: {total_top_1:.3f}, eval top 5 acc: {total_top_5:.3f}")
 
-      weight_hists = {f"weights/{k}": wandb.Hist(v.numpy().flatten().tolist()) for k, v in get_state_dict(model)}
+      weight_hists = {f"weights/{k}": wandb.Histogram(v.numpy().flatten().tolist()) for k, v in get_state_dict(model).items() if v.requires_grad}
       wandb.log({"eval/loss": total_loss,
                 "eval/top_1_acc": total_top_1,
                 "eval/top_5_acc": total_top_5,

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -99,7 +99,7 @@ def train_resnet():
   if getenv("LARS", 1):
     optimizer = optim.LARS(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=2e-4)
   else:
-    optimizer = optim.SGD(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=1/2**15)
+    optimizer = optim.SGD(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=2e-4)
   steps_in_train_epoch = (len(get_train_files()) // BS)
   steps_in_val_epoch = (len(get_val_files()) // EVAL_BS)
   #scheduler = MultiStepLR(optimizer, [m for m in lr_steps], gamma=lr_gamma, warmup=lr_warmup)

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -98,9 +98,10 @@ def train_resnet():
 
   # ** Optimizer **
   if getenv("LARS", 1):
-    optimizer = optim.LARS(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay, track_gnorm=True)
+    optimizer = optim.LARS(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay, track_norms=True)
   else:
     optimizer = optim.SGD(parameters, base_lr / lr_scaler, momentum=.9, weight_decay=decay)
+  parameter_keys = [k for k, v in get_state_dict(model).items() if v.requires_grad]
 
   # ** LR scheduler **
   # scheduler = MultiStepLR(optimizer, [m for m in lr_steps], gamma=lr_gamma, warmup=lr_warmup)
@@ -201,7 +202,7 @@ def train_resnet():
       # the backward step should be realized by loss.numpy(), even though it doesn't depend on this.
       # doing this uses 16.38gb vs 15.55gb? why? because the grads get realized in optimizer.step, and the backward buffers are freed?
       fwet = time.perf_counter()
-      gnorm = backward_step(*proc[1], proc[0][0])
+      wnorm, wnorms, gnorm, gnorms = backward_step(*proc[1], proc[0][0])
       # proc = (proc[0], proc[2])  # drop inputs
 
       et = time.perf_counter()
@@ -215,8 +216,10 @@ def train_resnet():
       dte = time.perf_counter()
 
       device_str = proc[0][2].device if isinstance(proc[0][2].device, str) else f"{proc[0][2].device[0]} * {len(proc[0][2].device)}"
-      proc, top_1_acc, gnorm = proc[0][0].numpy(), proc[0][2].numpy().item() / BS, gnorm.numpy()  # return cookie
+      proc, top_1_acc, wnorm, wnorms, gnorm, gnorms = proc[0][0].numpy(), proc[0][2].numpy().item() / BS, wnorm.numpy(), [x.numpy() for x in wnorms], gnorm.numpy(), [x.numpy() for x in gnorms]  # return cookie
       loss_cpu = proc / lr_scaler
+      wnorms = {f"wnorms/{k}": v for k, v in zip(parameter_keys, wnorms)}
+      gnorms = {f"gnorms/{k}": v for k, v in zip(parameter_keys, gnorms)}
       cl = time.perf_counter()
       new_st = time.perf_counter()
 
@@ -229,9 +232,12 @@ def train_resnet():
                  "train/cl_time": cl - dte,
                  "train/loss": loss_cpu,
                  "train/top_1_acc": top_1_acc,
+                 "train/wnorm": wnorm,
                  "train/gnorm": gnorm,
                  "train/GFLOPS": GlobalCounters.global_ops * 1e-9 / (cl - st),
                  "epoch": e + (i + 1) / steps_in_train_epoch,
+                 **wnorms,
+                 **gnorms,
                  })
 
       st = new_st
@@ -285,11 +291,14 @@ def train_resnet():
       total_top_5 = sum(eval_top_5_acc) / len(eval_top_5_acc)
       total_fw_time = sum(eval_times) / len(eval_times)
       tqdm.write(f"eval loss: {total_loss:.2f}, eval time: {total_fw_time:.2f}, eval top 1 acc: {total_top_1:.3f}, eval top 5 acc: {total_top_5:.3f}")
+
+      weight_hists = {f"weights/{k}": wandb.Hist(v.numpy().flatten().tolist()) for k, v in get_state_dict(model)}
       wandb.log({"eval/loss": total_loss,
                 "eval/top_1_acc": total_top_1,
                 "eval/top_5_acc": total_top_5,
-                 "eval/forward_time": total_fw_time,
+                "eval/forward_time": total_fw_time,
                 "epoch": e + 1,
+                 **weight_hists,
       })
 
       if not achieved and total_top_1 >= target:

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -226,6 +226,7 @@ def train_resnet():
                  "train/loss": loss_cpu,
                  "train/top_1_acc": top_1_acc,
                  "train/GFLOPS": GlobalCounters.global_ops * 1e-9 / (cl - st),
+                 "epoch": e + (i + 1) / steps_in_train_epoch,
                  })
 
       st = new_st
@@ -278,6 +279,7 @@ def train_resnet():
                 "eval/forward_time": sum(eval_times) / len(eval_times),
                 "eval/top_1_acc": total_top_1,
                 "eval/top_5_acc": sum(eval_top_5_acc) / len(eval_top_5_acc),
+                "epoch": e + 1,
       })
 
       if not achieved and total_top_1 >= target:

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -19,7 +19,7 @@ EVAL_BS = getenv('EVAL_BS', BS)
 # fp32 GPUS<=6 7900xtx can fit BS=112
 
 def train_resnet():
-  from extra.models.resnet import ResNet50, ResNet18
+  from extra.models.resnet import ResNet50, ResNet18, UnsyncedBatchNorm
   from examples.mlperf.dataloader import batch_load_resnet
   from extra.datasets.imagenet import get_train_files, get_val_files
   from extra.lr_scheduler import PolynomialLR
@@ -40,9 +40,10 @@ def train_resnet():
   if FP16: dtypes.default_float = dtypes.float16
 
   if getenv("MOCKGPUS", 0):
-    GPUS = tuple([f'{Device.DEFAULT}:{0}' for _ in range(getenv("MOCKGPUS", 0))])
+    GPUS = tuple([Device.canonicalize(f'{Device.DEFAULT}:{0}') for _ in range(getenv("MOCKGPUS", 0))])
   else:
-    GPUS = tuple([f'{Device.DEFAULT}:{i}' for i in range(getenv("GPUS", 1))])
+    GPUS = tuple([Device.canonicalize(f'{Device.DEFAULT}:{i}') for i in range(getenv("GPUS", 1))])
+  UnsyncedBatchNorm.devices = GPUS
   print(f"Training on {GPUS}")
   for x in GPUS: Device[x]
 

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -220,13 +220,14 @@ def train_resnet():
 
       dte = time.perf_counter()
 
+      device_str = proc[0][2].device if isinstance(proc[0][2].device, str) else f"{proc[0][2].device[0]} * {len(proc[0][2].device)}"
       proc, top_1_acc = proc[0][0].numpy(), proc[0][2].numpy().item() / BS  # return cookie
       loss_cpu = proc / lr_scaler
       cl = time.perf_counter()
       new_st = time.perf_counter()
 
       tqdm.write(
-        f"{i:5} {((cl - st)) * 1000.0:7.2f} ms run, {(fwet - st) * 1000.0:7.2f}fw {(et - fwet) * 1000.0:7.2f}bw ms python, {(cl - dte) * 1000.0:7.2f} ms CL, {(dte - dt) * 1000.0:6.2f} ms fetch data, {loss_cpu:5.2f} loss, {top_1_acc:3.2f} acc, {optimizer.lr.numpy()[0] * lr_scaler:.6f} LR, {GlobalCounters.mem_used / 1e9:.2f} GB used, {GlobalCounters.global_ops * 1e-9 / (cl - st):9.2f} GFLOPS")
+        f"{i:5} {((cl - st)) * 1000.0:7.2f} ms run, {(fwet - st) * 1000.0:7.2f}fw {(et - fwet) * 1000.0:7.2f}bw ms python, {(cl - dte) * 1000.0:7.2f} ms {device_str}, {(dte - dt) * 1000.0:6.2f} ms fetch data, {loss_cpu:5.2f} loss, {top_1_acc:3.2f} acc, {optimizer.lr.numpy()[0] * lr_scaler:.6f} LR, {GlobalCounters.mem_used / 1e9:.2f} GB used, {GlobalCounters.global_ops * 1e-9 / (cl - st):9.2f} GFLOPS")
       wandb.log({"lr": optimizer.lr.numpy() * lr_scaler,
                  "train/data_time": dte-dt,
                  "train/step_time": cl - st,

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -177,7 +177,7 @@ def train_resnet():
   else:
     wandb.init(config=wandb_config, tags=wandb_tags)
 
-  # ** train loop **
+  # ** epoch loop **
   for e in range(start_epoch, epochs):
     Tensor.training = True
     dt = time.perf_counter()
@@ -188,6 +188,7 @@ def train_resnet():
       # x must realize here, since the shm diskbuffer in dataloader might disappear?
       return x.shard(GPUS, axis=0).realize(), Tensor(y).shard(GPUS, axis=0), cookie
 
+    # ** train loop **
     i, proc = 0, data_get(it)
     st = time.perf_counter()
     while proc is not None:
@@ -239,8 +240,8 @@ def train_resnet():
 
 
 
-    # "eval" loop. Evaluate every 4 epochs, starting with epoch 0
-    if (e+1) % 1 == 0:
+    # ** eval loop **
+    if (e+1) % getenv("EVAL_EPOCHS", 1) == 0:
       eval_loss = []
       eval_times = []
       eval_top_1_acc = []

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -213,7 +213,7 @@ def train_resnet():
       new_st = time.perf_counter()
 
       tqdm.write(
-        f"{i:5} {((cl - st)) * 1000.0:7.2f} ms run, {(fwet - st) * 1000.0:7.2f}+{(et - fwet) * 1000.0:7.2f} ms python, {(cl - dte) * 1000.0:7.2f} ms CL, {(dte - dt) * 1000.0:6.2f} ms fetch data, {loss_cpu:5.2f} loss, {top_1_acc:3.2f} acc, {optimizer.lr.numpy()[0] * lr_scaler:.6f} LR, {GlobalCounters.mem_used / 1e9:.2f} GB used, {GlobalCounters.global_ops * 1e-9 / (cl - st):9.2f} GFLOPS")
+        f"{i:5} {((cl - st)) * 1000.0:7.2f} ms run, {(fwet - st) * 1000.0:7.2f}fw {(et - fwet) * 1000.0:7.2f}bw ms python, {(cl - dte) * 1000.0:7.2f} ms CL, {(dte - dt) * 1000.0:6.2f} ms fetch data, {loss_cpu:5.2f} loss, {top_1_acc:3.2f} acc, {optimizer.lr.numpy()[0] * lr_scaler:.6f} LR, {GlobalCounters.mem_used / 1e9:.2f} GB used, {GlobalCounters.global_ops * 1e-9 / (cl - st):9.2f} GFLOPS")
       wandb.log({"lr": optimizer.lr.numpy() * lr_scaler,
                  "train/data_time": dte-dt,
                  "train/step_time": cl - st,

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -284,12 +284,15 @@ def train_resnet():
 
         proc, next_proc = next_proc, None  # drop cookie
 
+      total_loss = sum(eval_loss) / len(eval_loss)
       total_top_1 = sum(eval_top_1_acc) / len(eval_top_1_acc)
-      tqdm.write(f"eval loss: {sum(eval_loss) / len(eval_loss):.2f}, eval time: {sum(eval_times) / len(eval_times):.2f}, eval top 1 acc: {sum(eval_top_1_acc) / len(eval_top_1_acc):.3f}, eval top 5 acc: {sum(eval_top_5_acc) / len(eval_top_5_acc):.3f}")
-      wandb.log({"eval/loss": sum(eval_loss) / len(eval_loss),
-                "eval/forward_time": sum(eval_times) / len(eval_times),
+      total_top_5 = sum(eval_top_5_acc) / len(eval_top_5_acc)
+      total_fw_time = sum(eval_times) / len(eval_times)
+      tqdm.write(f"eval loss: {total_loss:.2f}, eval time: {total_fw_time:.2f}, eval top 1 acc: {total_top_1:.3f}, eval top 5 acc: {total_top_5:.3f}")
+      wandb.log({"eval/loss": total_loss,
                 "eval/top_1_acc": total_top_1,
-                "eval/top_5_acc": sum(eval_top_5_acc) / len(eval_top_5_acc),
+                "eval/top_5_acc": total_top_5,
+                 "eval/forward_time": total_fw_time,
                 "epoch": e + 1,
       })
 

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -166,9 +166,8 @@ def train_resnet():
     'scheduler': scheduler.__class__.__name__,
   }
   wandb_tags = []
-  if num_classes != 1000:
-    wandb_tags.append('cats')
-    wandb_tags.append(f'cats{num_classes}')
+  wandb_tags.append(f'cats{num_classes}')
+  wandb_tags.append('cats')
   if getenv("WANDB_RESUME", ""):
     wandb.init(id=getenv("WANDB_RESUME", ""), resume="must", config=wandb_config, tags=wandb_tags)
   else:

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -177,8 +177,8 @@ def train_resnet():
   else:
     wandb.init(config=wandb_config, tags=wandb_tags)
 
+  # ** train loop **
   for e in range(start_epoch, epochs):
-    # train loop
     Tensor.training = True
     dt = time.perf_counter()
 

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -165,6 +165,7 @@ def train_resnet():
     'BEAM': getenv('BEAM'),
     'TEST_TRAIN': getenv('TEST_TRAIN'),
     'TEST_EVAL': getenv('TEST_EVAL'),
+    'SYNCBN': getenv('SYNCBN', 0),
     'model': 'resnet50' if not getenv('SMALL') else 'resnet18',
     'optimizer': optimizer.__class__.__name__,
     'scheduler': scheduler.__class__.__name__,

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -134,7 +134,8 @@ def train_resnet():
         dupe_names[v] = k
         assert k in state_dict
       state_dict[k] = state_dict[dupe_names[v]]
-    state.load_state_dict(train_state, state_dict)
+    train_state_ = {'scheduler': scheduler}
+    state.load_state_dict(train_state_, state_dict)
   start_epoch = 0
   if ckpt:=getenv("RESUME", ""):
     print(f"resuming from {ckpt}")

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -202,7 +202,7 @@ def train_resnet():
 
 
     # "eval" loop. Evaluate every 4 epochs, starting with epoch 0
-    if e % 1 == 0:
+    if (e+1) % 1 == 0:
       eval_loss = []
       eval_times = []
       eval_top_1_acc = []
@@ -244,7 +244,7 @@ def train_resnet():
                 "eval/top_5_acc": sum(eval_top_5_acc) / len(eval_top_5_acc),
       })
 
-      if e % getenv("CKPT_EPOCHS", 4) == 0:
+      if (e+1) % getenv("CKPT_EPOCHS", 4) == 0:
         if not os.path.exists("./ckpts"): os.mkdir("./ckpts")
         fn = f"./ckpts/{time.strftime('%Y%m%d_%H%M%S')}_e{e}.safe"
         print(f"saving ckpt to {fn}")

--- a/extra/datasets/imagenet.py
+++ b/extra/datasets/imagenet.py
@@ -81,7 +81,6 @@ def random_resized_crop(img, size, scale=(0.10, 1.0), ratio=(3/4, 4/3)):
         break
 
   if not random_solution_found:
-    print('no random crop found!')
     # Center crop
     rescale = min(img.size) / 256
     crop_left = (img.width - 224 * rescale) / 2.0

--- a/extra/datasets/imagenet.py
+++ b/extra/datasets/imagenet.py
@@ -16,7 +16,7 @@ def get_imagenet_categories():
 def _get_train_files(): return glob.glob(str(BASEDIR / "train/*/*"))
 @functools.lru_cache(None)
 def get_train_files():
-  train_files = _get_train_files
+  train_files = _get_train_files()
   # test train with less categories
   if getenv("TEST_CATS", 1000) != 1000:
     ci = get_imagenet_categories()

--- a/extra/datasets/imagenet.py
+++ b/extra/datasets/imagenet.py
@@ -3,7 +3,7 @@ import glob, random, json, math
 import numpy as np
 from PIL import Image
 import functools, pathlib
-from tinygrad.helpers import DEBUG, diskcache, getenv
+from tinygrad.helpers import diskcache, getenv
 
 BASEDIR = pathlib.Path(__file__).parent / "imagenet"
 
@@ -12,9 +12,11 @@ def get_imagenet_categories():
   ci = json.load(open(BASEDIR / "imagenet_class_index.json"))
   return {v[0]: int(k) for k,v in ci.items()}
 
+@diskcache
+def _get_train_files(): return glob.glob(str(BASEDIR / "train/*/*"))
 @functools.lru_cache(None)
 def get_train_files():
-  train_files = glob.glob(str(BASEDIR / "train/*/*"))
+  train_files = _get_train_files
   # test train with less categories
   if getenv("TEST_CATS", 1000) != 1000:
     ci = get_imagenet_categories()

--- a/extra/datasets/imagenet.py
+++ b/extra/datasets/imagenet.py
@@ -20,7 +20,7 @@ def get_train_files():
     ci = get_imagenet_categories()
     train_files = [fn for fn in train_files if ci[fn.split("/")[-2]] < getenv("TEST_CATS", 1000)]
     print(f"Limiting to {getenv('TEST_CATS')} categories")
-  if getenv("TEST_TRAIN"): train_files=train_files[:getenv("TEST_TRAIN")] * getenv("TEST_TRAIN_REPEAT", 1)
+  if getenv("TEST_TRAIN"): train_files=train_files[:getenv("TEST_TRAIN")]
   print(f"Training on {len(train_files)} images")
   return train_files
 

--- a/extra/datasets/imagenet.py
+++ b/extra/datasets/imagenet.py
@@ -20,7 +20,7 @@ def get_train_files():
     ci = get_imagenet_categories()
     train_files = [fn for fn in train_files if ci[fn.split("/")[-2]] < getenv("TEST_CATS", 1000)]
     print(f"Limiting to {getenv('TEST_CATS')} categories")
-  if getenv("TEST_TRAIN"): train_files=train_files[:getenv("TEST_TRAIN")]
+  if getenv("TEST_TRAIN"): train_files=train_files[:getenv("TEST_TRAIN")] * getenv("TEST_TRAIN_REPEAT", 1)
   print(f"Training on {len(train_files)} images")
   return train_files
 

--- a/extra/datasets/imagenet.py
+++ b/extra/datasets/imagenet.py
@@ -15,13 +15,21 @@ def get_imagenet_categories():
 @functools.lru_cache(None)
 def get_train_files():
   train_files = glob.glob(str(BASEDIR / "train/*/*"))
-  if getenv("TEST_TRAIN"): train_files = train_files[:getenv("TEST_TRAIN")]
+  # test train with less categories
+  if getenv("TEST_CATS", 1000) != 1000:
+    ci = get_imagenet_categories()
+    train_files = [fn for fn in train_files if ci[fn.split("/")[-2]] < getenv("TEST_CATS", 1000)]
+    print(f"Limiting to {getenv('TEST_CATS')} categories")
+  if getenv("TEST_TRAIN"): train_files=train_files[:getenv("TEST_TRAIN")]
   print(f"Training on {len(train_files)} images")
   return train_files
 
 @functools.lru_cache(None)
 def get_val_files():
   val_files = glob.glob(str(BASEDIR / "val/*/*"))
+  if getenv("TEST_CATS"):
+    ci = get_imagenet_categories()
+    val_files = [fn for fn in val_files if ci[fn.split("/")[-2]] < getenv("TEST_CATS")]
   if getenv("TEST_VAL"): val_files=val_files[:getenv("TEST_VAL")]
   return val_files
 

--- a/extra/lr_scheduler.py
+++ b/extra/lr_scheduler.py
@@ -37,6 +37,7 @@ class MultiStepLR(LR_Scheduler):
 class PolynomialLR(LR_Scheduler):
   def __init__(self, optimizer: Optimizer, start_lr, end_lr, epochs, warmup=0, power=2):
     super().__init__(optimizer)
+    assert epochs > warmup
     self.start_lr = start_lr
     self.end_lr = end_lr
     self.epochs = epochs
@@ -44,8 +45,8 @@ class PolynomialLR(LR_Scheduler):
     self.warmup = warmup
 
   def get_lr(self):
-    warmup_lr = (self.epoch_counter * (1.0/self.warmup)) * self.start_lr
-    x= (1- (self.epoch_counter - 1 - self.warmup)/(self.epochs - self.warmup))
+    warmup_lr = ((self.epoch_counter + 1) * (1.0/(self.warmup+1))) * self.start_lr
+    x= (1- (self.epoch_counter - self.warmup)/(self.epochs - self.warmup))
     return (self.epoch_counter < self.warmup).where(warmup_lr, (self.start_lr-self.end_lr)*x*x+self.end_lr)
 
 class ReduceLROnPlateau(LR_Scheduler):

--- a/extra/lr_scheduler.py
+++ b/extra/lr_scheduler.py
@@ -85,7 +85,7 @@ class CosineAnnealingLR(LR_Scheduler):
     self.eta_max = optimizer.lr.numpy()[0]
 
   def get_lr(self) -> Tensor:
-    return Tensor([self.eta_min + 0.5 * (self.eta_max - self.eta_min) * (1 + math.cos((self.epoch_counter.numpy()[0]/self.T_max) * math.pi))])
+    return Tensor([self.eta_min + 0.5 * (self.eta_max - self.eta_min) * (1 + math.cos((self.epoch_counter.numpy()[0] / self.T_max) * math.pi))], device=self.optimizer.device)
 
 class OneCycleLR(LR_Scheduler):
   def __init__(self, optimizer: Optimizer, max_lr: float, div_factor: float, final_div_factor: float, total_steps: int, pct_start: float,

--- a/extra/lr_scheduler.py
+++ b/extra/lr_scheduler.py
@@ -1,5 +1,5 @@
 import math
-from typing import List
+from typing import List, Union
 from tinygrad.nn.optim import Optimizer
 from tinygrad.tensor import Tensor
 from tinygrad.dtype import dtypes
@@ -9,11 +9,11 @@ class LR_Scheduler:
     self.optimizer = optimizer
     self.epoch_counter = Tensor([0], requires_grad=False, device=self.optimizer.device, dtype=dtypes.float32)
 
-  def get_lr(self): pass
+  def get_lr(self) -> Union[Tensor, int]: pass
 
   def step(self) -> None:
     self.epoch_counter.assign(self.epoch_counter + 1).realize()
-    self.optimizer.lr.assign(self.get_lr()).realize()
+    self.optimizer.lr.assign(lr.cast(self.optimizer.lr.dtype) if isinstance(lr := self.get_lr(), Tensor) else lr).realize()
 
 class MultiStepLR(LR_Scheduler):
   def __init__(self, optimizer: Optimizer, milestones: List[int], gamma=0.1):

--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -69,7 +69,7 @@ class BasicBlock:
     self.downsample = []
     self.bn_downsample = None
     if stride != 1 or in_planes != self.expansion*planes:
-      self.bn_downsample = BatchNorm(self.expansion*planes)
+      self.bn_downsample = BatchNorm(self.expansion*planes)  # name this BN so LARS can exclude it
       self.downsample = [
         Conv2dHeNormal(in_planes, self.expansion*planes, kernel_size=1, stride=stride, bias=False),
         self.bn_downsample

--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -67,10 +67,12 @@ class BasicBlock:
     self.conv2 = Conv2dHeNormal(planes, planes, kernel_size=3, padding=1, stride=1, bias=False)
     self.bn2 = BatchNorm(planes)
     self.downsample = []
+    self.bn_downsample = None
     if stride != 1 or in_planes != self.expansion*planes:
+      self.bn_downsample = BatchNorm(self.expansion*planes)
       self.downsample = [
         Conv2dHeNormal(in_planes, self.expansion*planes, kernel_size=1, stride=stride, bias=False),
-        BatchNorm(self.expansion*planes)
+        self.bn_downsample
       ]
 
   def __call__(self, x):

--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -140,7 +140,7 @@ class ResNet:
     if is_feature_only: features.append(out)
     if not is_feature_only:
       out = out.mean([2,3])
-      out = self.fc(out).float().log_softmax()
+      out = self.fc(out).log_softmax()
       return out
     return features
 

--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -36,7 +36,7 @@ BatchNorm = nn.BatchNorm2d if getenv("BNSYNC", 0) else UnsyncedBatchNorm
 
 # rejection sampling truncated randn
 def randn(*shape, dtype=None, truncstds=2, **kwargs) -> Tensor:
-  CNT=20
+  CNT=8
   x = Tensor.randn(*(*shape, CNT), dtype=dtype, **kwargs)
   ctr = Tensor.arange(CNT).reshape((1,) * len(x.shape[:-1]) + (CNT,)).expand(x.shape)
   take = (x.abs() <= truncstds).where(ctr, CNT).min(axis=-1, keepdim=True)  # set to 0 if no good samples

--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -68,7 +68,7 @@ class BasicBlock:
     self.bn2 = BatchNorm(planes)
     self.conv_downsample, self.bn_downsample = None, None
     if stride != 1 or in_planes != self.expansion*planes:
-      self.conv_downsample = Conv2dHeNormal(in_planes, self.expansion * planes, kernel_size=1, stride=stride, bias=False),
+      self.conv_downsample = Conv2dHeNormal(in_planes, self.expansion * planes, kernel_size=1, stride=stride, bias=False)
       self.bn_downsample = BatchNorm(self.expansion * planes)
 
   def __call__(self, x):
@@ -94,7 +94,7 @@ class Bottleneck:
     self.bn3 = BatchNorm(self.expansion*planes)
     self.conv_downsample, self.bn_downsample = None, None
     if stride != 1 or in_planes != self.expansion*planes:
-      self.conv_downsample = Conv2dHeNormal(in_planes, self.expansion * planes, kernel_size=1, stride=stride, bias=False),
+      self.conv_downsample = Conv2dHeNormal(in_planes, self.expansion * planes, kernel_size=1, stride=stride, bias=False)
       self.bn_downsample = BatchNorm(self.expansion * planes)
 
   def __call__(self, x):

--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -50,6 +50,13 @@ class Conv2dHeNormal(nn.Conv2d):
       std = math.sqrt(2.0 / (1 + a ** 2)) / math.sqrt(prod(argfix(*shape)[1:])) / 0.87962566103423978
       return std * randn(*shape, **kwargs)
     return he_normal(out_channels, in_channels//groups, *self.kernel_size, a=0.0)
+
+class Linear(nn.Linear):
+  def initialize_weight(self, in_features, out_features):
+    return Tensor.normal((out_features, in_features), mean=0.0, std=0.01)
+  def initialize_bias(self, in_features, out_features):
+    return Tensor.zeros(out_features)
+
 class BasicBlock:
   expansion = 1
 
@@ -131,7 +138,7 @@ class ResNet:
     self.layer2 = self._make_layer(self.block, 128, self.num_blocks[1], stride=2, stride_in_1x1=stride_in_1x1)
     self.layer3 = self._make_layer(self.block, 256, self.num_blocks[2], stride=2, stride_in_1x1=stride_in_1x1)
     self.layer4 = self._make_layer(self.block, 512, self.num_blocks[3], stride=2, stride_in_1x1=stride_in_1x1)
-    self.fc = nn.Linear(512 * self.block.expansion, num_classes) if num_classes is not None else None
+    self.fc = Linear(512 * self.block.expansion, num_classes) if num_classes is not None else None
 
   def _make_layer(self, block, planes, num_blocks, stride, stride_in_1x1):
     strides = [stride] + [1] * (num_blocks-1)

--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -97,10 +97,12 @@ class Bottleneck:
     self.conv3 = Conv2dHeNormal(width, self.expansion*planes, kernel_size=1, bias=False)
     self.bn3 = BatchNorm(self.expansion*planes)
     self.downsample = []
+    self.bn_downsample = None
     if stride != 1 or in_planes != self.expansion*planes:
+      self.bn_downsample = BatchNorm(self.expansion * planes)
       self.downsample = [
         Conv2dHeNormal(in_planes, self.expansion*planes, kernel_size=1, stride=stride, bias=False),
-        BatchNorm(self.expansion*planes)
+        self.bn_downsample
       ]
 
   def __call__(self, x):

--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -31,7 +31,7 @@ class UnsyncedBatchNorm:
   # todo: hack, this make loading from weights work on 1 gpu...
   def __getattr__(self, item): return getattr(self.bns[0], item)
 
-BatchNorm = nn.BatchNorm2d if getenv("BNSYNC", 0) else UnsyncedBatchNorm
+BatchNorm = nn.BatchNorm2d if getenv("SYNCBN", 0) else UnsyncedBatchNorm
 
 
 # rejection sampling truncated randn

--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -27,7 +27,8 @@ class UnsyncedBatchNorm:
     # TODO: what do we want to do for inference? average weight? pick any one?
     # a good start would be to check each mean/std are similar
     return bn_ts[0].cat(*bn_ts[1:])
-  def __getattr__(self, item): return getattr(self.bns[0], item) # todo: hack, this make eval only work on 1 gpu if you load from weights...
+  # todo: hack, this make loading from weights work on 1 gpu...
+  def __getattr__(self, item): return getattr(self.bns[0], item)
 
 BatchNorm = nn.BatchNorm2d if getenv("BNSYNC", 0) else UnsyncedBatchNorm
 

--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -140,7 +140,7 @@ class ResNet:
     if is_feature_only: features.append(out)
     if not is_feature_only:
       out = out.mean([2,3])
-      out = self.fc(out).log_softmax()
+      out = self.fc(out)
       return out
     return features
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13,11 +13,11 @@ class TestNN(unittest.TestCase):
     # create in tinygrad
     input = Tensor.randn(3, 5)
     target = Tensor.randint((3,), low=0, high=4)
-    loss = input.sparse_categorical_crossentropy(target)
+    loss = input.sparse_categorical_crossentropy(target, label_smoothing=0.1)
 
     torch_input = torch.tensor(input.numpy())
     torch_target = torch.tensor(target.numpy(), dtype=torch.long)
-    torch_loss = torch.nn.CrossEntropyLoss(reduction='mean')(torch_input, torch_target)
+    torch_loss = torch.nn.CrossEntropyLoss(reduction='mean', label_smoothing=0.1)(torch_input, torch_target)
 
     np.testing.assert_allclose(loss.numpy(), torch_loss.detach().numpy(), atol=1e-5, rtol=1e-6)
 

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -285,7 +285,6 @@ class CompiledASTRunner(JITRunner):
     self.lib, self.clprg = lib, self.device.runtime(self.name, lib)
     self.vars: List[Variable] = []
     if ast:
-      self.ast = ast
       info = get_lazyop_info(ast)
       self.op_estimate, self.mem_estimate = info.flops, info.mem_estimate
       self.vars = ast.vars()
@@ -297,10 +296,6 @@ class CompiledASTRunner(JITRunner):
     return global_size, local_size
 
   def __call__(self, rawbufs:List[Buffer], var_vals:Dict[Variable, int], wait=False, jit=False, do_update_stats=True) -> Optional[float]:
-    if GlobalCounters.kernel_count+1 == getenv("DEBUGK", -1):
-      from tinygrad.graph import print_tree
-      print_tree(self.ast)
-      print(self.prg)
     global_size, local_size = self.launch_dims(var_vals)
     if global_size is not None and local_size is None and all_int(self.global_size): # type: ignore[arg-type]
       # TODO: this is copied from get_program

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -351,10 +351,9 @@ class Compiled:
           lins[-1][1].hand_coded_optimizations()
         kb = Linearizer(ast, self.compiler.linearizer_opts)
         kb.required_optimizations()
-        from tinygrad.features.search import beam_search, time_linearizer, bufs_from_lin
-        test_rawbuffers = bufs_from_lin(kb)    # allocate scratch buffers for optimization
-        lins.append((f"beam{BEAM.value}", beam_search(kb, test_rawbuffers, BEAM.value, bool(getenv("BEAM_ESTIMATE", 1)))))
-        timed = sorted([(nm, tk, time_linearizer(tk, test_rawbuffers, allow_test_size=False, clear_l2=True)) for nm, tk in lins], key=lambda x: x[2])
+        from tinygrad.features.search import beam_search, time_linearizer
+        lins.append((f"beam{BEAM.value}", beam_search(kb, None, BEAM.value, bool(getenv("BEAM_ESTIMATE", 1)))))
+        timed = sorted([(nm, tk, time_linearizer(tk, None, allow_test_size=False, clear_l2=True)) for nm, tk in lins], key=lambda x: x[2])
         if DEBUG >= 1: print("  <  ".join(f"{nm:6s} : {lin.colored_shape(30, dense=True)} : {tm*1e6:8.2f} us" for nm, lin, tm in timed))
         k = timed[0][1]
     return k

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -336,10 +336,9 @@ class Compiled:
           lins[-1][1].hand_coded_optimizations()
         kb = Linearizer(ast, self.compiler.linearizer_opts)
         kb.required_optimizations()
-        from tinygrad.features.search import beam_search, time_linearizer, bufs_from_lin
-        test_rawbuffers = bufs_from_lin(kb)    # allocate scratch buffers for optimization
-        lins.append((f"beam{BEAM.value}", beam_search(kb, test_rawbuffers, BEAM.value, bool(getenv("BEAM_ESTIMATE", 1)))))
-        timed = sorted([(nm, tk, time_linearizer(tk, test_rawbuffers, allow_test_size=False, clear_l2=True)) for nm, tk in lins], key=lambda x: x[2])
+        from tinygrad.features.search import beam_search, time_linearizer
+        lins.append((f"beam{BEAM.value}", beam_search(kb, None, BEAM.value, bool(getenv("BEAM_ESTIMATE", 1)))))
+        timed = sorted([(nm, tk, time_linearizer(tk, None, allow_test_size=False, clear_l2=True)) for nm, tk in lins], key=lambda x: x[2])
         if DEBUG >= 1: print("  <  ".join(f"{nm:6s} : {lin.colored_shape(30, dense=True)} : {tm*1e6:8.2f} us" for nm, lin, tm in timed))
         k = timed[0][1]
     return k

--- a/tinygrad/features/multi.py
+++ b/tinygrad/features/multi.py
@@ -103,8 +103,8 @@ class MultiLazyBuffer:
     if self.axis is None: return MultiLazyBuffer([x.reshape(arg) for x in self.lbs], None, self.real)
     arg_acc:List[sint] = list(itertools.accumulate(arg, operator.mul, initial=1))
     # new_axis is the one that preserves prod(prior to new_axis) and prod(post to new_axis)
-    new_axis = [tuple(p) for p in zip(arg_acc, arg_acc[1:])].index((prod(self.shape[:self.axis]), prod(self.shape[:self.axis+1])))
-    return MultiLazyBuffer([x.reshape(tuple(x.shape[self.axis] if a == new_axis else s for a,s in enumerate(arg))) for x in self.lbs],
+    new_axis = len(arg_acc) - arg_acc[::-1].index(prod(self.shape[:self.axis])) - 1
+    return MultiLazyBuffer([x.reshape(tuple(arg[a]//len(self.lbs) if a == new_axis else s for a,s in enumerate(arg))) for x in self.lbs],
                            new_axis, self.real)
 
   def pad(self, arg:Tuple[Tuple[sint, sint], ...]):

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -97,6 +97,7 @@ def beam_search(lin:Linearizer, rawbufs, amt:int, allow_test_size=True) -> Linea
     ret = lin.copy()
     for o in val[len(lin.applied_opts):]: ret.apply_opt(o)
     return ret
+  if rawbufs is None: rawbufs = bufs_from_lin(lin)
 
   beam: List[Tuple[Linearizer, float]] = []
   seen_libs = set()
@@ -151,6 +152,8 @@ def optimize_local_size(clprg:Callable, global_size:List[int], rawbufs:List[Buff
 def time_linearizer(lin:Linearizer, rawbufs:List[Buffer], allow_test_size=True, max_global_size=65536, cnt=3, disable_cache=False, clear_l2=False) -> float:  # noqa: E501
   key = {"ast": str(lin.ast), "opts": str(lin.applied_opts), "allow_test_size": allow_test_size, "max_global_size": max_global_size, "clear_l2": clear_l2, "device": lin.opts.device.split(':')[0]}  # noqa: E501
   if not disable_cache and CACHELEVEL >= 2 and (val:=diskcache_get("time_linearizer", key)) is not None: return min(val)
+
+  if rawbufs is None: rawbufs = bufs_from_lin(lin)
 
   dev = Device[lin.opts.device]
   assert isinstance(dev, Compiled)

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -92,7 +92,7 @@ def get_linearizer_actions(lin:Linearizer, include_0=True) -> Dict[int, Lineariz
 beam_pool = None
 def beam_search(lin:Linearizer, rawbufs, amt:int, allow_test_size=True) -> Linearizer:
   global beam_pool
-  key = {"ast": str(lin.ast), "amt": amt, "allow_test_size": allow_test_size, "device": lin.opts.device}
+  key = {"ast": str(lin.ast), "amt": amt, "allow_test_size": allow_test_size, "device": lin.opts.device.split(':')[0]}
   if (val:=diskcache_get("beam_search", key)) is not None and not getenv("IGNORE_BEAM_CACHE") and CACHELEVEL >= 1:
     ret = lin.copy()
     for o in val[len(lin.applied_opts):]: ret.apply_opt(o)
@@ -149,7 +149,7 @@ def optimize_local_size(clprg:Callable, global_size:List[int], rawbufs:List[Buff
   return ret[1]
 
 def time_linearizer(lin:Linearizer, rawbufs:List[Buffer], allow_test_size=True, max_global_size=65536, cnt=3, disable_cache=False, clear_l2=False) -> float:  # noqa: E501
-  key = {"ast": str(lin.ast), "opts": str(lin.applied_opts), "allow_test_size": allow_test_size, "max_global_size": max_global_size, "clear_l2": clear_l2, "device": lin.opts.device}  # noqa: E501
+  key = {"ast": str(lin.ast), "opts": str(lin.applied_opts), "allow_test_size": allow_test_size, "max_global_size": max_global_size, "clear_l2": clear_l2, "device": lin.opts.device.split(':')[0]}  # noqa: E501
   if not disable_cache and CACHELEVEL >= 2 and (val:=diskcache_get("time_linearizer", key)) is not None: return min(val)
 
   dev = Device[lin.opts.device]

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -83,7 +83,7 @@ def get_linearizer_actions(lin:Linearizer, include_0=True) -> Dict[int, Lineariz
       for s,c in zip(lin2.full_shape, lin2.colors()):
         if c in {"magenta", "yellow"}: up *= s
         if c in {"cyan", "green", "white"}: lcl *= s
-      if up > 256 or lcl > 256 or ("green" in lin2.colors() and up*lcl > 2 ** 15): continue
+      if up > 256 or lcl > 256 or ("green" in lin2.colors() and up*lcl > 2 ** 11): continue
       acted_lins[i+1] = lin2
     except Exception:
       pass

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -70,6 +70,7 @@ class LazyBuffer:
 
   def cast(self, dtype:DType, bitcast:bool=False):
     if self.dtype == dtype: return self
+    if dtype.itemsize <= self.dtype.itemsize and self != self.base: return self.base.cast(dtype, bitcast)._view(self.st)
     return create_lazybuffer(self.device, ShapeTracker.from_shape(self.shape), dtype, UnaryOps.CAST, (dtype, bitcast), (self,))
 
   def is_unrealized_const(self): return not self.base.realized and self.base.op is LoadOps.CONST

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -1,8 +1,9 @@
 import math
 from typing import Optional, Union, Tuple, cast
 from tinygrad.tensor import Tensor
-from tinygrad.helpers import prod
+from tinygrad.helpers import prod, getenv
 from tinygrad.nn import optim, state  # noqa: F401
+from tinygrad.features.multi import MultiLazyBuffer
 
 class BatchNorm2d:
   def __init__(self, sz:int, eps=1e-5, affine=True, track_running_stats=True, momentum=0.1):
@@ -35,6 +36,54 @@ class BatchNorm2d:
       batch_invstd = self.running_var.reshape(1, -1, 1, 1).expand(x.shape).add(self.eps).rsqrt()
 
     return x.batchnorm(self.weight, self.bias, batch_mean, batch_invstd)
+
+class UnsyncBatchNorm2d:
+  def __init__(self, sz:int, eps=1e-5, affine=True, track_running_stats=True, momentum=0.1, gpus=getenv("GPUS", 1)):
+    self.eps, self.track_running_stats, self.momentum = eps, track_running_stats, momentum
+
+    if affine: self.weight, self.bias = Tensor.ones(sz), Tensor.zeros(sz)
+    else: self.weight, self.bias = None, None
+
+    self.running_mean, self.running_var = [Tensor.zeros(sz, requires_grad=False) for _ in range(gpus)], [Tensor.ones(sz, requires_grad=False) for _ in range(gpus)]
+    self.num_batches_tracked = Tensor.zeros(1, requires_grad=False)
+
+  def __call__(self, x:Tensor):
+    bn_ts = []
+    assert isinstance(x.lazydata, MultiLazyBuffer)
+    for i, bound in enumerate(x.lazydata.bounds):
+      # TODO: __getitem__ does not work
+      # xi = x[bound]
+      xi = x.shrink((bound, None, None, None))
+      batch_mean, batch_invstd = self.calc_stats(xi, self.running_mean[i], self.running_var[i])
+      bni = xi.batchnorm(self.weight, self.bias, batch_mean, batch_invstd)
+      bn_ts.append(bni)
+    if Tensor.training:
+      self.num_batches_tracked += 1
+    # TODO: what do we want to do for inference? average weight? pick any one?
+    # a good start would be to check each mean/std are similar
+    ret = bn_ts[0].cat(*bn_ts[1:])
+    return ret
+
+  def calc_stats(self, x:Tensor, running_mean, running_var):
+    if Tensor.training:
+      # This requires two full memory accesses to x
+      # https://github.com/pytorch/pytorch/blob/c618dc13d2aa23625cb0d7ada694137532a4fa33/aten/src/ATen/native/cuda/Normalization.cuh
+      # There's "online" algorithms that fix this, like https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_Online_algorithm
+      batch_mean = x.mean(axis=(0,2,3))
+      y = (x - batch_mean.reshape(shape=[1, -1, 1, 1]))
+      batch_var = (y*y).mean(axis=(0,2,3))
+      batch_invstd = batch_var.add(self.eps).pow(-0.5)
+
+      # NOTE: wow, this is done all throughout training in most PyTorch models
+      if self.track_running_stats:
+        running_mean.assign((1-self.momentum) * running_mean + self.momentum * batch_mean.detach())
+        running_var.assign((1-self.momentum) * running_var + self.momentum * prod(y.shape)/(prod(y.shape)-y.shape[1]) * batch_var.detach())
+    else:
+      batch_mean = running_mean
+      # NOTE: this can be precomputed for static inference. we expand it here so it fuses
+      batch_invstd = running_var.reshape(1, -1, 1, 1).expand(x.shape).add(self.eps).rsqrt()
+    return batch_mean, batch_invstd
+
 
 # TODO: these Conv lines are terrible
 def Conv1d(in_channels, out_channels, kernel_size, stride=1, padding=0, dilation=1, groups=1, bias=True):

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -38,50 +38,47 @@ class BatchNorm2d:
     return x.batchnorm(self.weight, self.bias, batch_mean, batch_invstd)
 
 class UnsyncBatchNorm2d:
-  def __init__(self, sz:int, eps=1e-5, affine=True, track_running_stats=True, momentum=0.1, gpus=getenv("GPUS", 1)):
+  def __init__(self, GPUS, sz:int, eps=1e-5, affine=True, track_running_stats=True, momentum=0.1):
     self.eps, self.track_running_stats, self.momentum = eps, track_running_stats, momentum
 
     if affine: self.weight, self.bias = Tensor.ones(sz), Tensor.zeros(sz)
     else: self.weight, self.bias = None, None
 
-    self.running_mean, self.running_var = [Tensor.zeros(sz, requires_grad=False) for _ in range(gpus)], [Tensor.ones(sz, requires_grad=False) for _ in range(gpus)]
+    self.running_mean, self.running_var = Tensor.zeros(len(GPUS), sz, requires_grad=False).shard(GPUS), Tensor.ones(len(GPUS), sz, requires_grad=False).shard(GPUS)
     self.num_batches_tracked = Tensor.zeros(1, requires_grad=False)
 
   def __call__(self, x:Tensor):
-    bn_ts = []
     assert isinstance(x.lazydata, MultiLazyBuffer)
-    for i, bound in enumerate(x.lazydata.bounds):
-      # TODO: __getitem__ does not work
-      # xi = x[bound]
-      xi = x.shrink((bound, None, None, None))
-      batch_mean, batch_invstd = self.calc_stats(xi, self.running_mean[i], self.running_var[i])
-      bni = xi.batchnorm(self.weight, self.bias, batch_mean, batch_invstd)
-      bn_ts.append(bni)
+
+    gpus = len(x.lazydata.lbs)
+    rshape = x.shape
+    x = x.reshape(gpus, -1, *x.shape[1:])
+    batch_mean, batch_invstd = self.calc_stats(x)
+    ret = x.batchnorm(self.weight.reshape(1, -1).expand((gpus, -1)), self.bias.reshape(1, -1).expand((gpus, -1)), batch_mean, batch_invstd, axis=2)
+    ret = ret.reshape(rshape)
     if Tensor.training:
       self.num_batches_tracked += 1
-    # TODO: what do we want to do for inference? average weight? pick any one?
-    # a good start would be to check each mean/std are similar
-    ret = bn_ts[0].cat(*bn_ts[1:])
+
     return ret
 
-  def calc_stats(self, x:Tensor, running_mean, running_var):
+  def calc_stats(self, x:Tensor):
     if Tensor.training:
       # This requires two full memory accesses to x
       # https://github.com/pytorch/pytorch/blob/c618dc13d2aa23625cb0d7ada694137532a4fa33/aten/src/ATen/native/cuda/Normalization.cuh
       # There's "online" algorithms that fix this, like https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_Online_algorithm
-      batch_mean = x.mean(axis=(0,2,3))
-      y = (x - batch_mean.reshape(shape=[1, -1, 1, 1]))
-      batch_var = (y*y).mean(axis=(0,2,3))
+      batch_mean = x.mean(axis=(1,3,4))
+      y = (x - batch_mean.reshape(shape=[batch_mean.shape[0], 1, -1, 1, 1]))
+      batch_var = (y*y).mean(axis=(1,3,4))
       batch_invstd = batch_var.add(self.eps).pow(-0.5)
 
       # NOTE: wow, this is done all throughout training in most PyTorch models
       if self.track_running_stats:
-        running_mean.assign((1-self.momentum) * running_mean + self.momentum * batch_mean.detach())
-        running_var.assign((1-self.momentum) * running_var + self.momentum * prod(y.shape)/(prod(y.shape)-y.shape[1]) * batch_var.detach())
+        self.running_mean.assign((1-self.momentum) * self.running_mean + self.momentum * batch_mean.detach())
+        self.running_var.assign((1-self.momentum) * self.running_var + self.momentum * prod(y.shape)/(prod(y.shape)-y.shape[2]) * batch_var.detach())
     else:
-      batch_mean = running_mean
+      batch_mean = self.running_mean
       # NOTE: this can be precomputed for static inference. we expand it here so it fuses
-      batch_invstd = running_var.reshape(1, -1, 1, 1).expand(x.shape).add(self.eps).rsqrt()
+      batch_invstd = self.running_var.reshape(self.running_var.shape[0], 1, -1, 1, 1).expand(x.shape).add(self.eps).rsqrt()
     return batch_mean, batch_invstd
 
 

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -1,10 +1,8 @@
 import math
-from typing import Optional, Union, Tuple, cast, List
-from tinygrad.dtype import dtypes
+from typing import Optional, Union, Tuple, cast
 from tinygrad.tensor import Tensor
-from tinygrad.helpers import prod, getenv
+from tinygrad.helpers import prod
 from tinygrad.nn import optim, state  # noqa: F401
-from tinygrad.features.multi import MultiLazyBuffer
 
 class BatchNorm2d:
   def __init__(self, sz:int, eps=1e-5, affine=True, track_running_stats=True, momentum=0.1):
@@ -36,8 +34,7 @@ class BatchNorm2d:
       # NOTE: this can be precomputed for static inference. we expand it here so it fuses
       batch_invstd = self.running_var.reshape(1, -1, 1, 1).expand(x.shape).add(self.eps).rsqrt()
 
-    ret = x.batchnorm(self.weight, self.bias, batch_mean, batch_invstd)
-    return ret
+    return x.batchnorm(self.weight, self.bias, batch_mean, batch_invstd)
 
 # TODO: these Conv lines are terrible
 def Conv1d(in_channels, out_channels, kernel_size, stride=1, padding=0, dilation=1, groups=1, bias=True):

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -72,12 +72,19 @@ class ConvTranspose2d(Conv2d):
 class Linear:
   def __init__(self, in_features, out_features, bias=True):
     # TODO: is this init good? torch inits to uniform(-1/sqrt(in_features), 1/sqrt(in_features))
-    self.weight = Tensor.kaiming_uniform(out_features, in_features, a=math.sqrt(5))
-    bound = 1 / math.sqrt(in_features)
-    self.bias = Tensor.uniform(out_features, low=-bound, high=bound) if bias else None
+    self.weight = self.initialize_weight(in_features, out_features)
+    self.bias = self.initialize_bias(in_features, out_features) if bias else None
 
   def __call__(self, x:Tensor):
     return x.linear(self.weight.transpose(), self.bias)
+
+  def initialize_weight(self, in_features, out_features):
+    return Tensor.kaiming_uniform(out_features, in_features, a=math.sqrt(5))
+
+  def initialize_bias(self, in_features, out_features):
+    bound = 1 / math.sqrt(in_features)
+    return Tensor.uniform(out_features, low=-bound, high=bound)
+
 
 class GroupNorm:
   def __init__(self, num_groups:int, num_channels:int, eps:float=1e-5, affine:bool=True):

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -97,10 +97,12 @@ class LARS(Optimizer):
           ), 1.0
         )
         scaled_lr = self.lr * trust_ratio
+        g = t.grad + self.weight_decay * t.detach()
       else:
         scaled_lr = self.lr
+        g = t.grad
 
-      g = (t.grad + self.weight_decay * t.detach()) * scaled_lr
+      g = g * scaled_lr
       if self.momentum:
         self.b[i].assign(self.momentum * self.b[i] + g)  # NOTE: self.b[i] is zero on the first run, no if required
         g = (g + self.momentum * self.b[i]) if self.nesterov else self.b[i]

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -73,10 +73,11 @@ class LAMB(Optimizer):
 
 # https://github.com/mlcommons/training/blob/master/image_classification/tensorflow2/lars_optimizer.py
 class LARS(Optimizer):
-  def __init__(self, params: List[Tensor], lr, momentum=0.9, weight_decay=1e-4, eta=0.001, eps=0.0, nesterov=False, track_gnorm=False):
+  def __init__(self, params: List[Tensor], lr, momentum=0.9, weight_decay=1e-4, eta=0.001, eps=0.0, skip_list=None, nesterov=False, track_gnorm=False):
     super().__init__(params, lr)
     self.momentum, self.weight_decay, self.eta, self.eps, self.nesterov, self.track_gnorm = momentum, weight_decay, eta, eps, nesterov, track_gnorm
     self.b = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in self.params]
+    self.skip_list = skip_list or set()
 
   def step(self):
     gnorm = 0
@@ -86,15 +87,18 @@ class LARS(Optimizer):
       # TODO: fix this in lazy.py
       t.grad.realize()
       t_ = t.detach()
-      w_norm = (t_ * t_).sum().sqrt()
       g_norm = (t.grad * t.grad).sum().sqrt()
       if self.track_gnorm: gnorm = gnorm + g_norm.to("HIP")
-      trust_ratio = (w_norm > 0).where(
-        (g_norm > 0).where(
-          self.eta * w_norm / (g_norm + self.weight_decay * w_norm + self.eps), 1.0
-        ), 1.0
-      )
-      scaled_lr = self.lr * trust_ratio
+      if t not in self.skip_list:
+        w_norm = (t_ * t_).sum().sqrt()
+        trust_ratio = (w_norm > 0).where(
+          (g_norm > 0).where(
+            self.eta * w_norm / (g_norm + self.weight_decay * w_norm + self.eps), 1.0
+          ), 1.0
+        )
+        scaled_lr = self.lr * trust_ratio
+      else:
+        scaled_lr = self.lr
 
       g = (t.grad + self.weight_decay * t.detach()) * scaled_lr
       if self.momentum:

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -108,6 +108,8 @@ class LARS(Optimizer):
         self.b[i].assign(self.momentum * self.b[i] + g)  # NOTE: self.b[i] is zero on the first run, no if required
         g = (g + self.momentum * self.b[i]) if self.nesterov else self.b[i]
       t.assign(t.detach() - g)
-    self.realize(self.b)
-    if self.track_norms: return wnorm.sqrt().realize(), [x.realize() for x in wnorms], gnorm.sqrt().realize(), [x.realize() for x in gnorms]
+    wnorm = wnorm.sqrt()
+    gnorm = gnorm.sqrt()
+    self.realize(self.b + [wnorm, gnorm] + wnorms + gnorms)
+    if self.track_norms: return wnorm, wnorms, gnorm, gnorms
 

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -39,7 +39,7 @@ class SGD(Optimizer):
       if self.momentum:
         self.b[i].assign(self.momentum * self.b[i] + g)  # NOTE: self.b[i] is zero on the first run, no if required
         g = (g + self.momentum * self.b[i]) if self.nesterov else self.b[i]
-      t.assign(t.detach() - g * self.lr.cast(g.dtype))
+      t.assign(t.detach() - g * self.lr)
     self.realize(self.b)
 
 # LAMB is essentially just the trust ratio part of LARS applied to Adam/W so if we just set the trust ratio to 1.0 its just Adam/W.
@@ -92,11 +92,9 @@ class LARS(Optimizer):
           self.eta * w_norm / (g_norm + self.weight_decay * w_norm + self.eps), 1.0
         ), 1.0
       )
-
       scaled_lr = self.lr * trust_ratio
 
-      g = (t.grad + self.weight_decay * t.detach())
-      g = g * scaled_lr.cast(g.dtype)
+      g = (t.grad + self.weight_decay * t.detach()) * scaled_lr
       if self.momentum:
         self.b[i].assign(self.momentum * self.b[i] + g)  # NOTE: self.b[i] is zero on the first run, no if required
         g = (g + self.momentum * self.b[i]) if self.nesterov else self.b[i]

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -108,8 +108,6 @@ class LARS(Optimizer):
         self.b[i].assign(self.momentum * self.b[i] + g)  # NOTE: self.b[i] is zero on the first run, no if required
         g = (g + self.momentum * self.b[i]) if self.nesterov else self.b[i]
       t.assign(t.detach() - g)
-    wnorm = wnorm.sqrt()
-    gnorm = gnorm.sqrt()
-    self.realize(self.b + [wnorm, gnorm] + wnorms + gnorms)
-    if self.track_norms: return wnorm, wnorms, gnorm, gnorms
+    self.realize(self.b)
+    if self.track_norms: return wnorm.sqrt().realize(), [x.realize() for x in wnorms], gnorm.sqrt().realize(), [x.realize() for x in gnorms]
 

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -102,5 +102,5 @@ class LARS(Optimizer):
         g = (g + self.momentum * self.b[i]) if self.nesterov else self.b[i]
       t.assign(t.detach() - g)
     self.realize(self.b)
-    return gnorm.realize()
+    if self.track_gnorm: return gnorm.realize()
 

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -73,14 +73,13 @@ class LAMB(Optimizer):
 
 # https://github.com/mlcommons/training/blob/master/image_classification/tensorflow2/lars_optimizer.py
 class LARS(Optimizer):
-  def __init__(self, params: List[Tensor], lr, momentum=0.9, weight_decay=1e-4, eta=0.001, eps=0.0, nesterov=False, track_gnorm=False, track_norms=False):
+  def __init__(self, params: List[Tensor], lr, momentum=0.9, weight_decay=1e-4, eta=0.001, eps=0.0, nesterov=False, track_gnorm=False):
     super().__init__(params, lr)
-    self.momentum, self.weight_decay, self.eta, self.eps, self.nesterov, self.track_norms = momentum, weight_decay, eta, eps, nesterov, track_norms
+    self.momentum, self.weight_decay, self.eta, self.eps, self.nesterov, self.track_gnorm = momentum, weight_decay, eta, eps, nesterov, track_gnorm
     self.b = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in self.params]
 
   def step(self):
-    wnorm, gnorm = 0, 0
-    wnorms, gnorms = [], []
+    gnorm = 0
     for i, t in enumerate(self.params):
       assert t.grad is not None
       # this is needed since the grads can form a "diamond"
@@ -88,14 +87,8 @@ class LARS(Optimizer):
       t.grad.realize()
       t_ = t.detach()
       w_norm = (t_ * t_).sum().sqrt()
-      if self.track_norms:
-        wnorms.append(w_norm.to("HIP"))
-        wnorm = wnorm + (w_norm*w_norm).to("HIP")
       g_norm = (t.grad * t.grad).sum().sqrt()
-      if self.track_norms:
-        gnorms.append(g_norm.to("HIP"))
-        gnorm = gnorm + (g_norm*g_norm).to("HIP")
-
+      if self.track_gnorm: gnorm = gnorm + g_norm.to("HIP")
       trust_ratio = (w_norm > 0).where(
         (g_norm > 0).where(
           self.eta * w_norm / (g_norm + self.weight_decay * w_norm + self.eps), 1.0
@@ -109,5 +102,5 @@ class LARS(Optimizer):
         g = (g + self.momentum * self.b[i]) if self.nesterov else self.b[i]
       t.assign(t.detach() - g)
     self.realize(self.b)
-    if self.track_norms: return wnorm.sqrt().realize(), [x.realize() for x in wnorms], gnorm.sqrt().realize(), [x.realize() for x in gnorms]
+    if self.track_gnorm: return gnorm.realize()
 

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -271,7 +271,7 @@ class HIPLanguage(CStyleLanguage):
   __attribute__((device)) __attribute__((pure)) _Float16 __ocml_log2_f16(_Float16);
   __attribute__((device)) _Float16 __ocml_sin_f16(_Float16);
   __attribute__((device)) __attribute__((const)) _Float16 __ocml_sqrt_f16(_Float16);
-  }\n""" + '\n'.join([_make_hip_dtype(*x) for x in [("signed int", "int", 2),
+  }\n""" + '\n'.join([_make_hip_dtype(*x) for x in [("signed int", "int", 2), ("signed int", "int", 4),
                      ("_Float16", "half", 2), ("_Float16", "half", 4), ("_Float16", "half", 8), ("_Float16", "half", 16),
                      ("float", "float", 2), ("float", "float", 4), ("float", "float", 8)]]) + """
   static __attribute__((device)) half8 __hip_wmma_f16_f16(half16 a, half16 b, half8 c) {

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -129,7 +129,8 @@ class Tensor:
     if DEBUG >= 4: print(f"assign {self.lazydata} <- {x.lazydata}")
     if self.dtype == x.dtype and not getenv("DISALLOW_ASSIGN"):
       if isinstance(self.lazydata, MultiLazyBuffer):
-        for d,s in zip(x.lazydata.lbs, self.lazydata.lbs): d.output_buffer = s.base.realized
+        if self.lazydata.axis == x.lazydata.axis:
+          for d,s in zip(x.lazydata.lbs, self.lazydata.lbs): d.output_buffer = s.base.realized
       else:
         if self.lazydata.base.realized is not None: x.lazydata.output_buffer = self.lazydata.base.realized
     self.lazydata = x.lazydata

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -897,11 +897,12 @@ class Tensor:
     y = (self - self.mean(axis, keepdim=True))
     return y.mul((y*y).mean(axis, keepdim=True).add(eps).rsqrt())
 
-  def batchnorm(self, weight:Optional[Tensor], bias:Optional[Tensor], mean:Tensor, invstd:Tensor) -> Tensor:
-    shape = (1, -1) + (1,) * (self.ndim-2)
+  def batchnorm(self, weight:Optional[Tensor], bias:Optional[Tensor], mean:Tensor, invstd:Tensor, axis=1) -> Tensor:
+    shape = self.shape[:axis-1] + tuple(1 if ax != axis else -1 for ax in range(axis-1,self.ndim))
     x = self - mean.reshape(shape)
-    if weight: x = x * weight.reshape(shape)
-    ret = x.mul(invstd.reshape(shape) if len(invstd.shape) == 1 else invstd)
+    if weight:
+      x = x * weight.reshape(shape)
+    ret = x.mul(invstd.reshape(shape) if len(invstd.shape) == axis else invstd)
     return (ret + bias.reshape(shape)) if bias else ret
 
   def dropout(self, p=0.5) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -930,7 +930,7 @@ class Tensor:
     log_probs, loss_mask = self.log_softmax(), (Y != ignore_index)
     y_counter = Tensor.arange(self.shape[-1], requires_grad=False, device=self.device).unsqueeze(0).expand(Y.numel(), self.shape[-1])
     y = ((y_counter == Y.flatten().reshape(-1, 1)).where(-1, 0) * loss_mask.reshape(-1, 1)).reshape(*Y.shape, self.shape[-1])
-    return log_probs.mul(y).sum() / loss_mask.sum() + (-1 * label_smoothing * log_probs.mean())
+    return log_probs.mul(y).sum() / loss_mask.sum() * (1 - label_smoothing) + (-1 * label_smoothing * log_probs.mean())
 
   # ***** cast ops *****
 


### PR DESCRIPTION
~~Trains to 71.86% in 45 epochs (14.2 hrs): https://wandb.ai/chaosagent/tinygrad-examples_mlperf/reports/stoic-silence--Vmlldzo2Nzg0MzIx~~

Trains to 75.9% in 43 epochs (<14 hrs): https://wandb.ai/chaosagent/tinygrad-examples_mlperf/runs/bfn1jsys/workspace?workspace=user-chaosagent

parts of data augmentation and some other stuff taken from @ojaffe https://github.com/tinygrad/tinygrad/pull/1404

Hacks in current implementation:

- [ ] unsyncbatchnorm in resnet.py is ugly
- [ ] maybe LARS should go in extra/ instead of optim.py?
- [ ] checkpointing code is ugly
- [x] eval is done with train = true to use the same jitted forward_step, so the batchnorm normalizer statistics are more noisy. also need to shuffle eval set to get good BN statistics
- [ ] top5 accuracy calculated in numpy (is there a good way in tinygrad?)
- [ ] LR scheduler get_lr() always returns fp32, disregarding default_float. gives default_float to optimizer though
- [x] split forward and backward step jits wastes memory -- with unified, the intermediates are freed inside jit, with split, intermediates are kept around forever

Things that need to be done:
- [x] use HeNormal initialization in Conv2d
- [x] Normal / zeros init for Linear
- [ ] gradient accumulation to help copy hparams
- [ ] pool of JIT-internal buffers, so that multiple jit functions can share the same buffers (get rid of split fw and bw jits and fix tensor.train in eval)
- [ ] make BEAM not allocate buffers when results are already cached
- [ ] FP16
- [ ] automatic nan-detecting LR scaler for FP16
- [ ] hparam sweep
- [ ] limit group buffers even more in beam for HIP, these compiler crashes crash the entire python process, and beam can't continue after that (i think python multiprocessing has a process replacement mechanism we can use though)
- [ ] investigate optimizer backwards passes
- [x] restore rng state after checkpoint
- [ ] pad or fill last batch instead of dropping it
- [ ] sync weights for unsyncbatchnorm
- [ ] wait for HSA to have fast multigpu ;)
- [ ] wait for ring-all-reduce ;)

Things I saw along the way:

- GPUS=2 is basically free, GPUS=6 is fully python-bound, somewhat n^2 scaling
- kernels are queued one gpu at a time, wasting time.
- when restoring from ckpt, beam takes more memory, since on fresh lazy initialization most of the beams run when buffers are not yet realized (maybe we can steal buffers from other places for the read-only ones? lol)
- ##3343 might be a "soft oom" where if you fill gpu memory too much, something internal to hip (or internal to us) doesn't check allocation succeeds and crashes, or something like that. We should consider a `MLIMIT` env var that OOMs inside our own allocator at some soft limit to prevent this, and also prevent OOMs from crashing desktop sessions ;)
- can't change poweroverdrive on tiny9
- tinybox (tiny9) is unstable
  - `HW Exception by GPU node-4 (Agent handle: 0x562a0ae767c0) reason :GPU Hang` after around 12 hours, sporadically
  - RuntimeError: HIP Error 101, invalid device ordinal cf #3440?
  - `Expected integer value from monitor, but got ""`
- conv kernels get only 20TFlops fp32, can be significantly improved with search

 ```
- bs=104
  - gpus=1:
    - 338.52 ms run
    - 5.95fw    4.35bw ms python
    - 321.81 ms CL,   6.40 ms fetch data,  6.99 loss, 0.00 acc, 0.000305 LR, 22.59 GB used,   7628.71 GFLOPS
  - gpus=4:
    - 388.30 ms run
    - 10.49fw  144.14bw ms python
    - 217.95 ms CL,  15.73 ms fetch data,  3.01 loss, 0.05 acc, 0.318207 LR, 91.62 GB used,  26662.02 GFLOPS                 
  - gpus=5:
    - 424.80 ms run
    - 16.23fw  273.14bw ms python
    - 115.39 ms CL,  20.03 ms fetch data,  3.05 loss, 0.05 acc, 0.195437 LR, 114.66 GB used,  30491.95 GFLOPS                
  - gpus=6: (i don't think i picked the best step for this one)
    - 485.21 ms run
    - 22.90fw  431.69bw ms python
    - 3.28 ms CL,  27.33 ms fetch data,  3.04 loss, 0.06 acc, 0.434845 LR, 137.78 GB used,  32062.92 GFLOPS                
```

potential speedup breakdown:
- (1.25, 1.5)x better search (MCTS?)
- 1.5x FP16
- ~1.25x HSA + better multigpu
- ???