### PR TITLE
fix merging condition in merge_dims

### DIFF
--- a/test/unit/test_view.py
+++ b/test/unit/test_view.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import unittest
+from tinygrad.shape.view import View
+
+class TestView(unittest.TestCase):
+  def test_canonicalize_empty_mask(self):
+    v = View.create(shape=(2,2,2), strides=(4,2,1), mask=((0,2),(0,2),(0,2)))
+    assert v.mask is None
+    v = View.create(shape=(4,3,2), strides=(1,4,10), mask=((0,4),(0,3),(0,2)))
+    assert v.mask is None
+
+  def test_minify_zero_strided_dims(self):
+    target = View.create(shape=(2,2), strides=(30,2), offset=7, mask=None)
+    v = View.create(shape=(2,1,2), strides=(30,0,2), offset=7, mask=None)
+    assert v.minify() == target
+    v = View.create(shape=(1,2,2), strides=(0,30,2), offset=7, mask=None)
+    assert v.minify() == target
+    v = View.create(shape=(2,2,1), strides=(30,2,0), offset=7, mask=None)
+    assert v.minify() == target
+    v = View.create(shape=(2,1,1,2), strides=(30,0,0,2), offset=7, mask=None)
+    assert v.minify() == target
+    v = View.create(shape=(1,1,2,2), strides=(0,0,30,2), offset=7, mask=None)
+    assert v.minify() == target
+    v = View.create(shape=(2,2,1,1), strides=(30,2,0,0), offset=7, mask=None)
+    assert v.minify() == target
+    v = View.create(shape=(1,2,2,1), strides=(0,30,2,0), offset=7, mask=None)
+    assert v.minify() == target
+    v = View.create(shape=(1,2,1,2), strides=(0,30,0,2), offset=7, mask=None)
+    assert v.minify() == target
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/unit/test_view.py
+++ b/test/unit/test_view.py
@@ -28,5 +28,13 @@ class TestView(unittest.TestCase):
     v = View.create(shape=(1,2,1,2), strides=(0,30,0,2), offset=7, mask=None)
     assert v.minify() == target
 
+  def test_empty_mask_contiguous(self):
+    v1 = View.create(shape=(2,2,2), strides=(4,2,1), mask=None)
+    v2 = View.create(shape=(2,2,2), strides=(4,2,1), mask=((0,2),(0,2),(0,2)))
+    assert v1.contiguous == v2.contiguous
+    v1 = View.create(shape=(1,1,1,4), strides=(0,0,0,1), offset=0, mask=None)
+    v2 = View.create(shape=(1,1,1,4), strides=(0,0,0,1), offset=0, mask=((0,1),(0,1),(0,1),(0,4)))
+    assert v1.contiguous == v2.contiguous
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -82,7 +82,6 @@ class View:
   @functools.lru_cache(maxsize=None)
   def create(shape:Tuple[sint, ...], strides:Optional[Tuple[sint, ...]]=None, offset:sint=0, mask:Optional[Tuple[Tuple[sint, sint], ...]]=None):
     strides = canonicalize_strides(shape, strides) if strides else strides_for_shape(shape)
-    contiguous = offset == 0 and mask is None and strides == strides_for_shape(shape)
     # if any dimension has size >1, but is masked such that only one index in the dimension is unmasked
     # then its stride can also be set to 0, albeit with a corresponding adjustment required to the offset
     # TODO: assert comparison with LtNode to avoid mis-using symbolic
@@ -93,6 +92,7 @@ class View:
       strides = tuple(0 if e else st for st,e in zip(strides, elim))
     # canonicalize empty mask
     if mask is not None and all(m == (0,s) for m,s in zip(mask, shape)): mask = None
+    contiguous = offset == 0 and mask is None and strides == strides_for_shape(shape)
     return View(shape, strides, offset, mask, contiguous)
 
   @functools.lru_cache(None)  # pylint: disable=method-cache-max-size-none

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -22,14 +22,14 @@ def _merge_dims(shape:Tuple[int, ...], strides:Tuple[int, ...], mask:Optional[Tu
   assert len(shape) == len(strides)
   ret = [(shape[0], strides[0], shape[0] if strides[0] else 0)]
   # wrt merging zero strided dimensions
-  merging = (mask and strides[0] == 0 and shape[0] != 1 and mask[0][1] - mask[0][0] == 1)
+  merging = strides[0] == 0 and (mask[0][1] - mask[0][0] == 1 if mask else shape[0] == 1)
   for i, (sh, st) in enumerate(zip(shape[1:], strides[1:]), start=1):
     if sh == 1: continue
     if merging or ret[-1][1] == sh * st: # mergeable
       ret[-1] = (ret[-1][0] * sh, st, (sh if merging else ret[-1][2] * sh) if st else 0)
     else: ret.append((sh, st, sh if st else 0)) # begin new
     # merging ends with either non-zero strided dim or zero strided dim with mask range > 1
-    merging = (st == 0 and mask and mask[i][1] - mask[i][0] == 1)
+    merging = st == 0 and (mask[i][1] - mask[i][0] == 1 if mask else sh == 1)
   return tuple(ret)
 
 @functools.lru_cache(maxsize=None)

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -82,6 +82,9 @@ class View:
   @functools.lru_cache(maxsize=None)
   def create(shape:Tuple[sint, ...], strides:Optional[Tuple[sint, ...]]=None, offset:sint=0, mask:Optional[Tuple[Tuple[sint, sint], ...]]=None):
     strides = canonicalize_strides(shape, strides) if strides else strides_for_shape(shape)
+    # canonicalize empty mask
+    if mask is not None and all(m == (0,s) for m,s in zip(mask, shape)): mask = None
+    contiguous = offset == 0 and mask is None and strides == strides_for_shape(shape)
     # if any dimension has size >1, but is masked such that only one index in the dimension is unmasked
     # then its stride can also be set to 0, albeit with a corresponding adjustment required to the offset
     # TODO: assert comparison with LtNode to avoid mis-using symbolic
@@ -90,9 +93,6 @@ class View:
         strides, offset, mask = (0,) * len(shape), 0, ((0,0),) * len(shape)
       offset += sum((strides[i] * mask[i][0]) if e else 0 for i, e in enumerate(elim))
       strides = tuple(0 if e else st for st,e in zip(strides, elim))
-    # canonicalize empty mask
-    if mask is not None and all(m == (0,s) for m,s in zip(mask, shape)): mask = None
-    contiguous = offset == 0 and mask is None and strides == strides_for_shape(shape)
     return View(shape, strides, offset, mask, contiguous)
 
   @functools.lru_cache(None)  # pylint: disable=method-cache-max-size-none


### PR DESCRIPTION
repro:
```python
from tinygrad.shape.view import View

a = View.create(shape=(2, 1, 2), strides=(30, 0, 2), offset=7, mask=None)
print(a)
print(a.minify())
b = View.create(shape=(1, 2, 2), strides=(0, 30, 2), offset=7, mask=None)
print(b)
print(b.minify())
```

before:
```
View(shape=(2, 1, 2), strides=(30, 0, 2), offset=7, mask=None, contiguous=False)
View(shape=(2, 2), strides=(30, 2), offset=7, mask=None, contiguous=False)
View(shape=(1, 2, 2), strides=(0, 30, 2), offset=7, mask=None, contiguous=False)
View(shape=(1, 2, 2), strides=(0, 30, 2), offset=7, mask=None, contiguous=False)
```

after:
```
View(shape=(2, 1, 2), strides=(30, 0, 2), offset=7, mask=None, contiguous=False)
View(shape=(2, 2), strides=(30, 2), offset=7, mask=None, contiguous=False)
View(shape=(1, 2, 2), strides=(0, 30, 2), offset=7, mask=None, contiguous=False)
View(shape=(2, 2), strides=(30, 2), offset=7, mask=None, contiguous=False)
```

merge_dims now merges preceding 1s in shape. this change makes reshapes slightly faster for such cases. 

found another bug!

repro:
```python
v = View.create(shape=(1,1,1,4), strides=(0,0,0,1), offset=0, mask=None)
print(v)
v = View.create(shape=(1,1,1,4), strides=(0,0,0,1), offset=0, mask=((0,1),(0,1),(0,1),(0,4)))
print(v)
```

before:
```
View(shape=(1, 1, 1, 4), strides=(0, 0, 0, 1), offset=0, mask=None, contiguous=True)
View(shape=(1, 1, 1, 4), strides=(0, 0, 0, 1), offset=0, mask=None, contiguous=False)
```

after:
```
View(shape=(1, 1, 1, 4), strides=(0, 0, 0, 1), offset=0, mask=None, contiguous=True)
View(shape=(1, 1, 1, 4), strides=(0, 0, 0, 1), offset=0, mask=None, contiguous=True)
```