### PR TITLE
Run RDNA3 tensor core tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -484,7 +484,7 @@ jobs:
         run: python -m pytest -n=auto test/ -k 'not (half or test_efficientnet_safetensors)' --ignore=test/external --ignore=test/models --durations=20
       - name: Run pytest (hip)
         if: matrix.backend=='hip'
-        run: python -m pytest -n=auto test/test_ops.py test/test_dtype.py test/test_dtype_alu.py --durations=20
+        run: python -m pytest -n=auto test/test_ops.py test/test_dtype.py test/test_dtype_alu.py test/test_linearizer.py --durations=20
 
   #testunicorn:
   #  name: ARM64 unicorn Test


### PR DESCRIPTION
remu supports emulating `v_wmma_f32_16x16x16_f16` and `v_wmma_f16_16x16x16_f16`.
In RDNA3 threads in a warp load the matrices collaboratively by [sharing vector registeres](https://gpuopen.com/learn/wmma_on_rdna3/), remu needed a big rewrite to build the infra for emulating TC instructions end-to-end.