### PR TITLE
add METAL_FAST_MATH env var to disable metal fast math

### DIFF
--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -172,6 +172,10 @@ if Device.DEFAULT == "METAL" or (OSX and Device.DEFAULT == "GPU"):
   backend_test.exclude('test_mish_cpu')
   backend_test.exclude('test_mish_expanded_cpu')
 
+if Device.DEFAULT == 'METAL':
+  # with default fast math enabled, padding -inf does not work
+  backend_test.exclude('test_MaxPool3d_stride_padding_cpu')
+
 # TODO: llvm has problems with inf
 if Device.DEFAULT in ['LLVM']:
   backend_test.exclude('test_isinf_cpu')

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -20,6 +20,7 @@ class MetalCompiler(Compiler):
       return subprocess.check_output(['xcrun', '-sdk', 'macosx', 'metallib', '-', '-o', '-'], input=air)
     else:
       options = Metal.MTLCompileOptions.new()
+      options.setFastMathEnabled_(getenv("METAL_FAST_MATH", 1))
       library = unwrap2(self.device.device.newLibraryWithSource_options_error_(src, options, None))
       return library.libraryDataContents().bytes().tobytes()
 


### PR DESCRIPTION
disable test_MaxPool3d_stride_padding_cpu onnx test that would fail with fast math enabled. the test failed with `NOOPT=1 python -m pytest test/external/external_test_onnx_backend.py -k test_MaxPool3d_stride_padding_cpu` and passed with
`METAL_FAST_MATH=0 DISABLE_COMPILER_CACHE=1 NOOPT=1 python -m pytest test/external/external_test_onnx_backend.py -k test_MaxPool3d_stride_padding_cpu`