### PR TITLE
bump db version to 11

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -125,7 +125,7 @@ _cache_dir: str = getenv("XDG_CACHE_HOME", os.path.expanduser("~/Library/Caches"
 CACHEDB: str = getenv("CACHEDB", os.path.abspath(os.path.join(_cache_dir, "tinygrad", "cache.db")))
 CACHELEVEL = getenv("CACHELEVEL", 2)
 
-VERSION = 10
+VERSION = 11
 _db_connection = None
 def db_connection():
   global _db_connection


### PR DESCRIPTION
followup after #3370 disabled fast math on metal. This ensured that the benchmark does not used old compiled cache.