### PR TITLE
dtypes: delete the float cast in realize.py

### DIFF
--- a/test/test_lazybuffer.py
+++ b/test/test_lazybuffer.py
@@ -2,6 +2,7 @@
 import numpy as np
 import unittest
 from tinygrad import Tensor, Device, dtypes
+from tinygrad.lazy import LazyBuffer
 
 class TestLazyBuffer(unittest.TestCase):
   def test_fromcpu_shape_tracker(self):
@@ -56,6 +57,15 @@ class TestLazyBuffer(unittest.TestCase):
     b = Tensor.zeros(4,1,4)
     c = a.cat(b, dim=1)
     np.testing.assert_allclose(c.numpy(), np.concatenate((a.numpy(), b.numpy()), axis=1))
+
+  def test_const_dtype(self):
+    lb: LazyBuffer = Tensor([1], dtype=dtypes.int).lazydata
+    assert lb.const(1).base.arg == 1
+    assert type(lb.const(1).base.arg) == int
+
+    lb: LazyBuffer = Tensor([1], dtype=dtypes.float).lazydata
+    assert lb.const(1).base.arg == 1.0
+    assert type(lb.const(1).base.arg) == float
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_lazybuffer.py
+++ b/test/test_lazybuffer.py
@@ -61,11 +61,11 @@ class TestLazyBuffer(unittest.TestCase):
   def test_const_dtype(self):
     lb: LazyBuffer = Tensor([1], dtype=dtypes.int).lazydata
     assert lb.const(1).base.arg == 1
-    assert type(lb.const(1).base.arg) == int
+    assert type(lb.const(1).base.arg) is int
 
     lb: LazyBuffer = Tensor([1], dtype=dtypes.float).lazydata
     assert lb.const(1).base.arg == 1.0
-    assert type(lb.const(1).base.arg) == float
+    assert type(lb.const(1).base.arg) is float
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -40,6 +40,19 @@ class TestLinearizer(unittest.TestCase):
     assert num_loads <= 4, "more load uops than needed"
     assert num_loads >= 4, "unexpected number of uops, maybe this test needs updating?"
 
+  def test_load_cache_const_bufs(self):
+    # make sure const buffers are differentiated from local and mem buffers
+    a = Tensor([1,2,3,4])
+    out = a[2] + 2 + a[3] + 3 + 2 + a[0]
+    si = create_schedule([out.lazydata])[-1]
+    lin = Linearizer(si.ast)
+    lin.linearize()
+
+    cache_keys = lin.load_cache.keys()
+    assert len(cache_keys) == 5
+    assert len([k for k in cache_keys if "CONST" in k]) == 2
+    assert len([k for k in cache_keys if "CONST" not in k]) == 3
+
   def test_upcast_cse(self):
     # when upcasting, within a subtree, there may be common expressions.
 

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -90,7 +90,7 @@ class Linearizer(Kernel):
     invalid_value = 0 if dtypes.is_int(buf.dtype) else 0.0
     for idx, valid, rep_idx in zip(e_idxs, e_valids, iter_idxs(expand_vars)):
       this_const, idx, valid = (invalid_value, NumNode(0), NumNode(1)) if valid.max == 0 else (const, idx, valid)
-      key = f"{acc}{localtype}{this_const if this_const is not None and acc is None else (buf.idx if isinstance(buf, MemBuffer) else cast(LocalBuffer, buf).name)}{idx.render()}{valid.render()}"  # noqa: E501
+      key = f"{acc}{localtype}{'CONST'+str(this_const) if this_const is not None and acc is None else (buf.idx if isinstance(buf, MemBuffer) else cast(LocalBuffer, buf).name)}{idx.render()}{valid.render()}"  # noqa: E501
       if key not in self.load_cache:
         if acc is not None:
           self.load_cache[key] = self.uop(UOps.DEFINE_ACC, localtype, (), this_const, cachable=False)

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -38,7 +38,7 @@ class PtrDType(DType):
   def __eq__(self, dt): return self.priority==dt.priority and self.itemsize==dt.itemsize and self.name==dt.name and self.sz==dt.sz
   def __ne__(self, dt): return not (self == dt)
 
-def cast_scalar(scalar: Scalar, dtype:DType): return int(scalar) if dtypes.is_int(dtype) else float(scalar)
+def cast_scalar(scalar: Scalar, dtype:DType): return int(scalar) if dtypes.is_int(dtype) else float(scalar) if dtypes.is_float(dtype) else bool(scalar)
 
 class dtypes:
   @staticmethod

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -38,7 +38,8 @@ class PtrDType(DType):
   def __eq__(self, dt): return self.priority==dt.priority and self.itemsize==dt.itemsize and self.name==dt.name and self.sz==dt.sz
   def __ne__(self, dt): return not (self == dt)
 
-def cast_scalar(scalar: Scalar, dtype:DType): return int(scalar) if dtypes.is_int(dtype) else float(scalar) if dtypes.is_float(dtype) else bool(scalar)
+def cast_scalar(scalar: Scalar, dtype:DType):
+  return int(scalar) if dtypes.is_int(dtype) else float(scalar) if dtypes.is_float(dtype) else bool(scalar)
 
 class dtypes:
   @staticmethod

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -38,6 +38,8 @@ class PtrDType(DType):
   def __eq__(self, dt): return self.priority==dt.priority and self.itemsize==dt.itemsize and self.name==dt.name and self.sz==dt.sz
   def __ne__(self, dt): return not (self == dt)
 
+def cast_scalar(scalar: Scalar, dtype:DType): return int(scalar) if dtypes.is_int(dtype) else float(scalar)
+
 class dtypes:
   @staticmethod
   def is_float(x: DType) -> bool: return x.scalar() in (dtypes.float16, dtypes.bfloat16, dtypes.float32, dtypes.float64)

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import math
 from typing import Union, Optional, Any, Tuple, List, Dict, cast
-from tinygrad.dtype import dtypes, DType, Scalar
+from tinygrad.dtype import cast_scalar, dtypes, DType, Scalar
 from tinygrad.helpers import prod, getenv, all_int, all_same
 from tinygrad.ops import LoadOps, UnaryOps, BinaryOps, TernaryOps, ReduceOps, Op
 from tinygrad.shape.symbolic import sint
@@ -53,7 +53,7 @@ class LazyBuffer:
 
   def const(self, val:Scalar, shape:Optional[Tuple[sint,...]]=None) -> LazyBuffer:
     shape = self.shape if shape is None else shape
-    return LazyBuffer.loadop(LoadOps.CONST, tuple(), self.dtype, self.device, arg=val).reshape((1,)*len(shape)).expand(shape)
+    return LazyBuffer.loadop(LoadOps.CONST, tuple(), self.dtype, self.device, arg=cast_scalar(val, self.dtype)).reshape((1,)*len(shape)).expand(shape)
 
   def contiguous(self):
     if not self.st.contiguous or self.size != self.base.size or self.is_unrealized_const():

--- a/tinygrad/realize.py
+++ b/tinygrad/realize.py
@@ -93,7 +93,7 @@ def _recursive_lazyop(buf:LazyBuffer, inputs:List[LazyBuffer], var_vals:Dict[Var
   if buf.op is LoadOps.CONST:
     unbound_st, st_var_vals = st.simplify().unbind()
     var_vals.update(st_var_vals)
-    return LazyOp(BufferOps.CONST, (), ConstBuffer(float(buf.arg), buf.dtype, unbound_st))
+    return LazyOp(BufferOps.CONST, (), ConstBuffer(buf.arg, buf.dtype, unbound_st))
 
   # if we aren't fusing it, it's a load and we add it to the inputs
   if buf.realized or (buf in realizes and not first):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -800,7 +800,7 @@ class Tensor:
       assert isinstance(y, (float, int, bool)), f"{type(y)=}, {y=}"
       if isinstance(self.dtype, ImageDType) or dtypes.is_float(x.dtype) or (dtypes.is_int(x.dtype) and isinstance(y, int)): y_dtype = x.dtype
       else: y_dtype = dtypes.from_py(y)
-      y = Tensor(y, self.device, y_dtype, requires_grad=False)
+      y = Tensor(cast_scalar(y, self.dtype), self.device, y_dtype, requires_grad=False)
 
     if match_dtype:
       output_dtype = least_upper_dtype(x.dtype, y.dtype)
@@ -818,7 +818,7 @@ class Tensor:
   def _to_const_val(self, x:Union[Tensor, Scalar]) -> Union[Tensor, Scalar]:
     # TODO: update with multi
     return x.lazydata.base.arg if isinstance(x, Tensor) and isinstance(x.lazydata, LazyBuffer) and x.lazydata.is_unrealized_contiguous_const() \
-      and not x.requires_grad and self._broadcasted(x)[0].shape == self.shape else x if isinstance(x, Tensor) else cast_scalar(x, self.dtype)
+      and not x.requires_grad and self._broadcasted(x)[0].shape == self.shape else x
 
   def add(self, x:Union[Tensor, Scalar], reverse=False) -> Tensor:
     x = self._to_const_val(x)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from functools import partialmethod, reduce
 import numpy as np
 
-from tinygrad.dtype import DType, dtypes, ImageDType, Scalar, least_upper_float, least_upper_dtype
+from tinygrad.dtype import DType, dtypes, ImageDType, Scalar, least_upper_float, least_upper_dtype, cast_scalar
 from tinygrad.helpers import argfix, make_pair, getenv, IMAGE, DEBUG, WINO, flatten, prod, all_int, round_up, merge_dicts, fully_flatten, flat_mv
 from tinygrad.lazy import LazyBuffer
 from tinygrad.features.multi import MultiLazyBuffer

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from functools import partialmethod, reduce
 import numpy as np
 
-from tinygrad.dtype import DType, dtypes, ImageDType, Scalar, least_upper_float, least_upper_dtype
+from tinygrad.dtype import DType, cast_scalar, dtypes, ImageDType, Scalar, least_upper_float, least_upper_dtype
 from tinygrad.helpers import argfix, make_pair, getenv, IMAGE, DEBUG, WINO, flatten, prod, all_int, round_up, merge_dicts, fully_flatten
 from tinygrad.lazy import LazyBuffer
 from tinygrad.features.multi import MultiLazyBuffer
@@ -818,7 +818,7 @@ class Tensor:
   def _to_const_val(self, x:Union[Tensor, Scalar]) -> Union[Tensor, Scalar]:
     # TODO: update with multi
     return x.lazydata.base.arg if isinstance(x, Tensor) and isinstance(x.lazydata, LazyBuffer) and x.lazydata.is_unrealized_contiguous_const() \
-      and not x.requires_grad and self._broadcasted(x)[0].shape == self.shape else x
+      and not x.requires_grad and self._broadcasted(x)[0].shape == self.shape else x if isinstance(x, Tensor) else cast_scalar(x, self.dtype)
 
   def add(self, x:Union[Tensor, Scalar], reverse=False) -> Tensor:
     x = self._to_const_val(x)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -800,7 +800,7 @@ class Tensor:
       assert isinstance(y, (float, int, bool)), f"{type(y)=}, {y=}"
       if isinstance(self.dtype, ImageDType) or dtypes.is_float(x.dtype) or (dtypes.is_int(x.dtype) and isinstance(y, int)): y_dtype = x.dtype
       else: y_dtype = dtypes.from_py(y)
-      y = Tensor(cast_scalar(y, self.dtype), self.device, y_dtype, requires_grad=False)
+      y = Tensor(cast_scalar(y, y_dtype), self.device, y_dtype, requires_grad=False)
 
     if match_dtype:
       output_dtype = least_upper_dtype(x.dtype, y.dtype)


### PR DESCRIPTION
in realize.py we force the ConstBuffer's arg to be float. I think this is wrong, it has lead to ASTs like this:

`Tensor([1,2,3]) + 2`
```
  0 ━┳ STORE MemBuffer(idx=0, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(3,), strides=(1,), offset=0, mask=None, contiguous=True),)))
  1  ┗━┳ ADD 
  2    ┣━━ LOAD MemBuffer(idx=1, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(3,), strides=(1,), offset=0, mask=None, contiguous=True),)))
  3    ┗━━ CONST ConstBuffer(val=2.0, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(3,), strides=(0,), offset=0, mask=None, contiguous=False),)))
  ```
  
when I removed that float cast, it uncovered issues upstream where we create these const buffers, eg. tensor.py's _broadcast and lazy.py's const could return bufs like this:

`ConstBuffer(val=1, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(), strides=(), offset=0, mask=None, contiguous=True),)))`

now the AST is correct:
```
  0 ━┳ STORE MemBuffer(idx=0, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(3,), strides=(1,), offset=0, mask=None, contiguous=True),)))
  1  ┗━┳ ADD 
  2    ┣━━ LOAD MemBuffer(idx=1, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(3,), strides=(1,), offset=0, mask=None, contiguous=True),)))
  3    ┗━━ CONST ConstBuffer(val=2, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(3,), strides=(0,), offset=0, mask=None, contiguous=False),)))
 ```