### PR TITLE
canonicalized shapetracker

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -344,17 +344,17 @@ class TestZeroShapeTensor(unittest.TestCase):
     t = Tensor.rand(3, 2, 0)
     assert t.shape == (3, 2, 0)
     # numpy has stride 0, 0, 0; torch has stride 2, 1, 1
-    assert t.lazydata.st.real_strides() == (0, 0, 1)
+    assert t.lazydata.st.real_strides() == (0, 0, 0)
 
     t = Tensor.rand(3, 0, 2)
     assert t.shape == (3, 0, 2)
     # numpy has stride 0, 0, 0; torch has stride 2, 2, 1
-    assert t.lazydata.st.real_strides() == (0, 2, 1)
+    assert t.lazydata.st.real_strides() == (0, 0, 0)
 
     t = Tensor.rand(0, 0, 0)
     assert t.shape == (0, 0, 0)
     # numpy has stride 0, 0, 0; torch has stride 1, 1, 1
-    assert t.lazydata.st.real_strides() == (0, 0, 1)
+    assert t.lazydata.st.real_strides() == (0, 0, 0)
 
   def test_rand(self):
     t = Tensor.rand(3, 2, 0)

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -7,6 +7,7 @@ from tinygrad.shape.symbolic import Node, NumNode, Variable, sint
 
 @functools.lru_cache(maxsize=None)
 def canonicalize_strides(shape:Tuple[int, ...], strides:Tuple[int, ...]) -> Tuple[int, ...]:
+  if any(s == 0 for s in shape): return (0,) * len(strides)
   return tuple(0 if s == 1 else st for s, st in zip(shape, strides))
 
 @functools.lru_cache(maxsize=None)


### PR DESCRIPTION
this is a proof of concept. this works (100% match as far as I checked) without using `st.real_strides()` (the fuzzer result is identical with the part using real_strides in merge_views commented out!)

```python
DEBUG=2 CHECK_NEQ=1 FUZZ=plus PYTHONPATH="." python3 test/external/fuzz_shapetracker_math.py
```
