### PR TITLE
Make tests in `test/test_dtype.py` pass for Python emulator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,8 @@ jobs:
         DEBUG=2 EMULATE_HIP=1 FORWARD_ONLY=1 PYTHON=1 python3 ./test/test_linearizer.py TestLinearizer.test_tensor_cores
     - name: Test ops with Python emulator
       run: DEBUG=2 PYTHON=1 python3 -m pytest test/test_ops.py -k "not (test_split or test_simple_cumsum or test_cumsum or test_einsum or test_dot_1d or test_big_gemm or test_broadcastdot or test_multidot or test_var_axis or test_std_axis or test_broadcast_full or test_broadcast_partial or test_simple_conv3d or test_dilated_conv_transpose2d or test_simple_conv_transpose3d or test_large_input_conv2d or test_maxpool2d_simple or test_maxpool2d_bigger_stride or test_avgpool2d or test_cat or test_scaled_product_attention or test_scaled_product_attention_causal)"
+    - name: Test test_dtype.py with Python emulator
+      run: DEBUG=2 PYTHON=1 python3 -m pytest test/test_dtype.py
 
   linter:
     name: Linters

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -9,6 +9,7 @@ from tinygrad.device import Compiled, Allocator, Compiler
 from tinygrad.codegen.uops import UOp, UOps
 from tinygrad.ops import UnaryOps, BinaryOps, TernaryOps
 from tinygrad.codegen.kernel import LinearizerOptions
+import numpy as np
 
 def exec_alu(arg, dtype, p):
   # TODO: make this complete and correctly honor the dtypes
@@ -128,13 +129,8 @@ class PythonProgram:
           if dtype.count > 1:
             ul[i] = inp
           else:
-            # TODO: add real cast
-            if dtypes.is_int(dtype):
-              ul[i] = [int(x) for x in inp[0]]
-            elif dtypes.is_float(dtype):
-              ul[i] = [float(x) for x in inp[0]]
-            else:
-              ul[i] = inp[0]
+            np_inp = np.array(inp[0], dtype=dtp[0].np)
+            ul[i] = np_inp.view(dtype.np).tolist() if arg[1] else np_inp.astype(dtype.np).tolist()
         elif uop is UOps.LOAD:
           if isinstance(dtp[0], ImageDType):
             assert dtype.count == 4


### PR DESCRIPTION
This is more of a proposal to solve the casting problem in the Python emulator.

The proposal suggests using Numpy to handle casting.

My case:
- While bit casting can be implemented easily using Python's `struct` module, the real hassle is with type casting.
- Python's type casting can handle simple cases like casting a float to an integer, but it doesn't have support for c-style type casting which can handle richer cases like converting an unsigned integer to an integer.
- Implementing complete c-style type casting in native Python a) requires more undesired extra lines and b) unnecessary.
- Exporting the problem to Numpy makes the code shorter, cleaner, and of course complete.
- I also believe that this implementation has no trade-offs because Numpy won't be required as a dependency, since it will be only necessary to run the code against the Python backend which is used for development, and doesn't interfere with the runtime's purpose to act as the "living specs of uops".