### PR TITLE
Implement complete C-style casting for the Python backend

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -161,6 +161,7 @@ class TestHalfDtype(TestDType): DTYPE = dtypes.half
 
 class TestFloatDType(TestDType):
   DTYPE = dtypes.float
+  @unittest.skipIf(getenv("HIP", 0) == 1 or getenv("CUDA", 0) == 1, "doesn't work on CUDA or HIP")
   def test_float_to_uint_negative(self):
     _test_op(lambda: Tensor([-3.5, -2.5, -1.5], dtype=dtypes.float).cast(dtypes.uint), dtypes.uint, [4294967293, 4294967294, 4294967295])
 

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -159,7 +159,10 @@ class TestBFloat16DType(unittest.TestCase):
 
 class TestHalfDtype(TestDType): DTYPE = dtypes.half
 
-class TestFloatDType(TestDType): DTYPE = dtypes.float
+class TestFloatDType(TestDType):
+  DTYPE = dtypes.float
+  def test_float_to_uint_negative(self):
+    _test_op(lambda: Tensor([-3.5, -2.5, -1.5], dtype=dtypes.float).cast(dtypes.uint), dtypes.uint, [4294967293, 4294967294, 4294967295])
 
 class TestDoubleDtype(TestDType):
   DTYPE = dtypes.double
@@ -187,11 +190,17 @@ class TestInt8Dtype(TestDType):
   def test_int8_to_uint8_negative(self):
     _test_op(lambda: Tensor([-1, -2, -3, -4], dtype=dtypes.int8).cast(dtypes.uint8), dtypes.uint8, [255, 254, 253, 252])
 
+  def test_int8_to_uint16_negative(self):
+    _test_op(lambda: Tensor([-1, -2, -3, -4], dtype=dtypes.int8).cast(dtypes.uint16), dtypes.uint16, [65535, 65534, 65533, 65532])
+
 class TestUint8Dtype(TestDType):
   DTYPE = dtypes.uint8
   @unittest.skipIf(getenv("CUDA",0)==1 or getenv("PTX", 0)==1, "cuda saturation works differently")
   def test_uint8_to_int8_overflow(self):
     _test_op(lambda: Tensor([255, 254, 253, 252], dtype=dtypes.uint8).cast(dtypes.int8), dtypes.int8, [-1, -2, -3, -4])
+
+  def test_uint16_to_int8_overflow(self):
+    _test_op(lambda: Tensor([65535, 65534, 65533, 65532], dtype=dtypes.uint16).cast(dtypes.int8), dtypes.int8, [-1, -2, -3, -4])
 
 @unittest.skipIf(Device.DEFAULT == "WEBGL", "No bitcast on WebGL")
 class TestBitCast(unittest.TestCase):

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -161,7 +161,7 @@ class TestHalfDtype(TestDType): DTYPE = dtypes.half
 
 class TestFloatDType(TestDType):
   DTYPE = dtypes.float
-  @unittest.skipIf(getenv("HIP", 0) == 1 or getenv("CUDA", 0) == 1, "doesn't work on CUDA or HIP")
+  @unittest.skipIf(getenv("HIP", 0) == 1 or getenv("CUDA", 0) == 1 or getenv("METAL", 0) == 1, "doesn't work on CUDA, HIP, or METAL")
   def test_float_to_uint_negative(self):
     _test_op(lambda: Tensor([-3.5, -2.5, -1.5], dtype=dtypes.float).cast(dtypes.uint), dtypes.uint, [4294967293, 4294967294, 4294967295])
 

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -189,11 +189,6 @@ class TestDoubleDtype(TestDType):
       a = [2, 3, 4]
       np.testing.assert_allclose(func(Tensor(a, dtype=self.DTYPE)).numpy(), func(torch.tensor(a, dtype=torch.float64)), rtol=1e-12, atol=1e-12)
 
-  def test_float64_to_float32_cast_inf(self):
-    _test_op(lambda: Tensor([3.4e40, 3.4e38, 1, 0], dtype=dtypes.float64).cast(dtypes.float32),
-             dtypes.float32, [float('inf'), 3.4e38, 1, 0])
-
-
 class TestInt8Dtype(TestDType):
   DTYPE = dtypes.int8
   @unittest.skipIf(getenv("CUDA",0)==1 or getenv("PTX", 0)==1, "cuda saturation works differently")
@@ -229,12 +224,7 @@ class TestBitCast(unittest.TestCase):
     assert b.numpy()[0,0] == 1.
 
 class TestInt16Dtype(TestDType): DTYPE = dtypes.int16
-
-class TestUint16Dtype(TestDType):
-  DTYPE = dtypes.uint16
-
-  def test_uint16_to_int8_overflow(self):
-    _test_op(lambda: Tensor([2**16-1, 2**16-2, 1, 0], dtype=dtypes.uint16).cast(dtypes.int8), dtypes.int8, [-1, -2, 1, 0])
+class TestUint16Dtype(TestDType): DTYPE = dtypes.uint16
 
 class TestInt32Dtype(TestDType): DTYPE = dtypes.int32
 class TestUint32Dtype(TestDType): DTYPE = dtypes.uint32

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -49,8 +49,8 @@ def _store(m, i, v):
 def cstyle_cast(value, in_dtype: DType, out_dtype: DType, bitcast: bool):
   def c_bitcast(value, in_dtype: DType, out_dtype: DType):
     # mapping dtype.name to ctypes API names as per https://docs.python.org/3/library/ctypes.html
-    def to_cname(dtype_name: str): return dtype_name.replace("char", "int8").replace("unsigned ", "u")
-    in_cvalue, out_ctype = getattr(ctypes, f"c_{to_cname(in_dtype.name)}")(value), getattr(ctypes, f"c_{to_cname(out_dtype.name)}")
+    def to_cname(dtype_name: str): return f"c_{dtype_name.replace('char', 'int8').replace('unsigned ', 'u')}"
+    in_cvalue, out_ctype = getattr(ctypes, f"{to_cname(in_dtype.name)}")(value), getattr(ctypes, f"{to_cname(out_dtype.name)}")
     return ctypes.cast(ctypes.pointer(in_cvalue), ctypes.POINTER(out_ctype)).contents.value
 
   if bitcast: return c_bitcast(value, in_dtype, out_dtype)

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -1,7 +1,7 @@
 # a python uops emulator
 # works to test the tensor cores, and all the uops in general
 # this is the (living) definition of uops
-from typing import Tuple, List, Optional, Any, Dict
+from typing import Tuple, List, Optional, Any, Dict, Type
 import pickle, base64, itertools, time, math, ctypes
 from tinygrad.dtype import DType, dtypes, ImageDType
 from tinygrad.helpers import all_same, getenv, flatten
@@ -48,7 +48,7 @@ def _store(m, i, v):
 
 def cstyle_cast(value, in_dtype: DType, out_dtype: DType, bitcast: bool):
   def c_bitcast(value, in_dtype: DType, out_dtype: DType):
-    to_ctype = {dtypes.bool: ctypes.c_bool, dtypes.int8: ctypes.c_int8, dtypes.uint8: ctypes.c_uint8,
+    to_ctype: Dict[DType, Type[ctypes._SimpleCData]] = {dtypes.bool: ctypes.c_bool, dtypes.int8: ctypes.c_int8, dtypes.uint8: ctypes.c_uint8,
                 dtypes.int16: ctypes.c_int16, dtypes.uint16: ctypes.c_uint16, dtypes.int32: ctypes.c_int32,
                 dtypes.uint32: ctypes.c_uint32, dtypes.int64: ctypes.c_int64, dtypes.uint64: ctypes.c_uint64,
                 dtypes.float32: ctypes.c_float, dtypes.float64: ctypes.c_double}

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -49,7 +49,7 @@ def _store(m, i, v):
 def cstyle_cast(value, in_dtype: DType, out_dtype: DType, bitcast: bool):
   def c_bitcast(value, in_dtype: DType, out_dtype: DType):
     # mapping dtype.name to ctypes API names as per https://docs.python.org/3/library/ctypes.html
-    def to_cname(dtype_name: str): return dtype_name.replace("char", "int8").replace("unsigned", "u").replace(" ", "")
+    def to_cname(dtype_name: str): return dtype_name.replace("char", "int8").replace("unsigned ", "u")
     in_cvalue, out_ctype = getattr(ctypes, f"c_{to_cname(in_dtype.name)}")(value), getattr(ctypes, f"c_{to_cname(out_dtype.name)}")
     return ctypes.cast(ctypes.pointer(in_cvalue), ctypes.POINTER(out_ctype)).contents.value
 

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -55,12 +55,11 @@ def cstyle_cast(value, in_dtype: DType, out_dtype: DType, bitcast: bool):
 
   if bitcast: return c_bitcast(value, in_dtype, out_dtype)
 
-  # perform Python type casting
+  # perform Python type casting for Python-supported types
   out = int(value) if dtypes.is_int(out_dtype) else float(value) if dtypes.is_float(out_dtype) else bool(value)
-  # return the output if the involved types are Python-supported
-  if not (dtypes.is_unsigned(in_dtype) or dtypes.is_unsigned(out_dtype)): return out
-  # otherwise, bitcast the output to mimic C-style type casting for operands involving unsigned types
-  return c_bitcast(out, out_dtype, out_dtype)
+  # bitcast the output to mimic C-style type casting for operands involving unsigned types
+  if dtypes.is_unsigned(in_dtype) or dtypes.is_unsigned(out_dtype): out = c_bitcast(out, out_dtype, out_dtype)
+  return out
 
 class PythonProgram:
   def __init__(self, name:str, lib:bytes):


### PR DESCRIPTION
I understand that the bounty have been claimed, but I have been working on C-style casting for the Python backend and I noticed that the merged PR isn't complete.

Here are some cases that the current implementation misses (run twice with `CLANG=1` and `PYTHON=1` to compare the results):

```python
a = Tensor([-2.5, -1, 1, 2.5], dtype=dtypes.float)
b = a.cast(dtypes.uint) # or dtypes.uint8, dtypes.uint16, dtypes.uint64
print(a.numpy(), b.numpy())

a = Tensor([0, 1, 255], dtype=dtypes.int8)
b = a.cast(dtypes.uint16) # or dtypes.uint32, dtypes.uint64
print(a.numpy(), b.numpy())

a = Tensor([-1, -2], dtype=dtypes.int16)
b = a.cast(dtypes.uint32) # or dtypes.uint8, dtypes.uint64
print(a.numpy(), b.numpy())
```