### PR TITLE
Fix python cast uint/int overflow

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -159,7 +159,12 @@ class TestBFloat16DType(unittest.TestCase):
 
 class TestHalfDtype(TestDType): DTYPE = dtypes.half
 
-class TestFloatDType(TestDType): DTYPE = dtypes.float
+class TestFloatDType(TestDType):
+  DTYPE = dtypes.float
+
+  def test_float_to_uint_negative(self):
+    _test_op(lambda: Tensor([-3.5, -2.5, -1.5], dtype=dtypes.float).cast(dtypes.uint), dtypes.uint,
+             [4294967293, 4294967294, 4294967295])
 
 class TestDoubleDtype(TestDType):
   DTYPE = dtypes.double

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -162,9 +162,9 @@ class TestHalfDtype(TestDType): DTYPE = dtypes.half
 class TestFloatDType(TestDType):
   DTYPE = dtypes.float
 
-  def test_float_to_uint_negative(self):
-    _test_op(lambda: Tensor([-3.5, -2.5, -1.5], dtype=dtypes.float).cast(dtypes.uint), dtypes.uint,
-             [4294967293, 4294967294, 4294967295])
+  def test_float_to_uint(self):
+    _test_op(lambda: Tensor([-0.9, -0.3, 1.2], dtype=dtypes.float32).cast(dtypes.uint32), dtypes.uint32,
+             [0, 0, 1])
 
 class TestDoubleDtype(TestDType):
   DTYPE = dtypes.double
@@ -226,7 +226,12 @@ class TestUint16Dtype(TestDType):
     _test_op(lambda: Tensor([2**16-1, 2**16-2, 1, 0], dtype=dtypes.uint16).cast(dtypes.int8), dtypes.int8, [-1, -2, 1, 0])
 
 class TestInt32Dtype(TestDType): DTYPE = dtypes.int32
-class TestUint32Dtype(TestDType): DTYPE = dtypes.uint32
+class TestUint32Dtype(TestDType):
+  DTYPE = dtypes.uint32
+
+  @unittest.skipIf(getenv("PYTHON",0)==1, "python memoryview doesn't support float16")
+  def test_uint32_to_float16_inf(self):
+    _test_op(lambda: Tensor([2**20-1, 2**20-2, 1, 0], dtype=dtypes.uint32).cast(dtypes.float16), dtypes.float16, [float('inf'), float('inf'), 1, 0])
 
 class TestInt64Dtype(TestDType): DTYPE = dtypes.int64
 class TestUint64Dtype(TestDType): DTYPE = dtypes.uint64

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -192,6 +192,9 @@ class TestInt8Dtype(TestDType):
   def test_int8_to_uint8_negative(self):
     _test_op(lambda: Tensor([-1, -2, -3, -4], dtype=dtypes.int8).cast(dtypes.uint8), dtypes.uint8, [255, 254, 253, 252])
 
+  def test_int8_to_uint16_negative(self):
+    _test_op(lambda: Tensor([-1, -2, -3, -4], dtype=dtypes.int8).cast(dtypes.uint16), dtypes.uint16, [2**16-1, 2**16-2, 2**16-3, 2**16-4])
+
 class TestUint8Dtype(TestDType):
   DTYPE = dtypes.uint8
   @unittest.skipIf(getenv("CUDA",0)==1 or getenv("PTX", 0)==1, "cuda saturation works differently")
@@ -215,7 +218,12 @@ class TestBitCast(unittest.TestCase):
     assert b.numpy()[0,0] == 1.
 
 class TestInt16Dtype(TestDType): DTYPE = dtypes.int16
-class TestUint16Dtype(TestDType): DTYPE = dtypes.uint16
+
+class TestUint16Dtype(TestDType):
+  DTYPE = dtypes.uint16
+
+  def test_uint16_to_int8_overflow(self):
+    _test_op(lambda: Tensor([2**16-1, 2**16-2, 1, 0], dtype=dtypes.uint16).cast(dtypes.int8), dtypes.int8, [-1, -2, 1, 0])
 
 class TestInt32Dtype(TestDType): DTYPE = dtypes.int32
 class TestUint32Dtype(TestDType): DTYPE = dtypes.uint32

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -186,6 +186,11 @@ class TestDoubleDtype(TestDType):
       a = [2, 3, 4]
       np.testing.assert_allclose(func(Tensor(a, dtype=self.DTYPE)).numpy(), func(torch.tensor(a, dtype=torch.float64)), rtol=1e-12, atol=1e-12)
 
+  def test_float64_to_float32_cast_inf(self):
+    _test_op(lambda: Tensor([3.4e40, 3.4e38, 1, 0], dtype=dtypes.float64).cast(dtypes.float32),
+             dtypes.float32, [float('inf'), 3.4e38, 1, 0])
+
+
 class TestInt8Dtype(TestDType):
   DTYPE = dtypes.int8
   @unittest.skipIf(getenv("CUDA",0)==1 or getenv("PTX", 0)==1, "cuda saturation works differently")
@@ -226,12 +231,7 @@ class TestUint16Dtype(TestDType):
     _test_op(lambda: Tensor([2**16-1, 2**16-2, 1, 0], dtype=dtypes.uint16).cast(dtypes.int8), dtypes.int8, [-1, -2, 1, 0])
 
 class TestInt32Dtype(TestDType): DTYPE = dtypes.int32
-class TestUint32Dtype(TestDType):
-  DTYPE = dtypes.uint32
-
-  @unittest.skipIf(getenv("PYTHON",0)==1, "python memoryview doesn't support float16")
-  def test_uint32_to_float16_inf(self):
-    _test_op(lambda: Tensor([2**20-1, 2**20-2, 1, 0], dtype=dtypes.uint32).cast(dtypes.float16), dtypes.float16, [float('inf'), float('inf'), 1, 0])
+class TestUint32Dtype(TestDType): DTYPE = dtypes.uint32
 
 class TestInt64Dtype(TestDType): DTYPE = dtypes.int64
 class TestUint64Dtype(TestDType): DTYPE = dtypes.uint64

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -195,7 +195,7 @@ class TestInt8Dtype(TestDType):
   DTYPE = dtypes.int8
   @unittest.skipIf(getenv("CUDA",0)==1 or getenv("PTX", 0)==1, "cuda saturation works differently")
   def test_int8_to_uint8_negative(self):
-    _test_op(lambda: Tensor([-1, -2, -3, -4], dtype=dtypes.int8).cast(dtypes.uint8), dtypes.uint8, [255, 254, 253, 252])
+    _test_op(lambda: Tensor([1, 0, -1, -4], dtype=dtypes.int8).cast(dtypes.uint8), dtypes.uint8, [1, 0, 2**8-1, 2**8-4])
 
   def test_int8_to_uint16_negative(self):
     _test_op(lambda: Tensor([-1, -2, -3, -4], dtype=dtypes.int8).cast(dtypes.uint16), dtypes.uint16, [2**16-1, 2**16-2, 2**16-3, 2**16-4])

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -195,7 +195,7 @@ class TestInt8Dtype(TestDType):
   DTYPE = dtypes.int8
   @unittest.skipIf(getenv("CUDA",0)==1 or getenv("PTX", 0)==1, "cuda saturation works differently")
   def test_int8_to_uint8_negative(self):
-    _test_op(lambda: Tensor([1, 0, -1, -4], dtype=dtypes.int8).cast(dtypes.uint8), dtypes.uint8, [1, 0, 2**8-1, 2**8-4])
+    _test_op(lambda: Tensor([-1, -2, -3, -4], dtype=dtypes.int8).cast(dtypes.uint8), dtypes.uint8, [255, 254, 253, 252])
 
   def test_int8_to_uint16_negative(self):
     _test_op(lambda: Tensor([-1, -2, -3, -4], dtype=dtypes.int8).cast(dtypes.uint16), dtypes.uint16, [2**16-1, 2**16-2, 2**16-3, 2**16-4])

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -134,10 +134,10 @@ class PythonProgram:
               ul[i] = list(struct.unpack(unpack_format, struct.pack(pack_format, *inp[0])))
             else:
               casted = [float(x) if dtypes.is_float(dtype) else int(x) if dtypes.is_int(dtype) else x for x in inp[0]]
-              overflowed = [(x % 2**(dtype.itemsize*8)) - 2**(dtype.itemsize*8-1)*(not dtypes.is_unsigned(dtype))*(x<0) if dtypes.is_int(dtype)
-                            else x for x in casted]
-              packed = struct.pack(pack_format if (dtypes.is_int(dtype) and dtypes.is_int(dtp[0]) and dtype.itemsize == dtp[0].itemsize)
-                                   else unpack_format, *overflowed)
+              overflow_adjustment = 2**(dtype.itemsize*8-1) * (not dtypes.is_unsigned(dtype))
+              overflow_fixed = [((x + overflow_adjustment) % 2**(dtype.itemsize*8) - overflow_adjustment) if dtypes.is_int(dtype)
+                                else x for x in casted]
+              packed = struct.pack(unpack_format, *overflow_fixed)
               ul[i] = list(struct.unpack(unpack_format, packed))
         elif uop is UOps.LOAD:
           if isinstance(dtp[0], ImageDType):

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -134,7 +134,7 @@ class PythonProgram:
               ul[i] = list(struct.unpack(unpack_format, struct.pack(pack_format, *inp[0])))
             else:
               casted = [float(x) if dtypes.is_float(dtype) else int(x) if dtypes.is_int(dtype) else x for x in inp[0]]
-              overflow_adjust = 2**(dtype.itemsize * 8 - 1) if (dtypes.is_int(dtype) and not dtypes.is_unsigned(dtype)) else 0
+              overflow_adjust = 2**(dtype.itemsize*8 - 1) if (dtypes.is_int(dtype) and not dtypes.is_unsigned(dtype)) else 0
               overflow_fixed = [((x + overflow_adjust) % 2**(dtype.itemsize*8) - overflow_adjust) if dtypes.is_int(dtype) else x for x in casted]
               ul[i] = list(struct.unpack(unpack_format, struct.pack(unpack_format, *overflow_fixed)))
         elif uop is UOps.LOAD:

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -134,7 +134,7 @@ class PythonProgram:
               ul[i] = list(struct.unpack(unpack_format, struct.pack(pack_format, *inp[0])))
             else:
               casted = [float(x) if dtypes.is_float(dtype) else int(x) if dtypes.is_int(dtype) else x for x in inp[0]]
-              overflow_adjust = 0 if dtypes.is_unsigned(dtype) else 2 ** (dtype.itemsize * 8 - 1)
+              overflow_adjust = 2**(dtype.itemsize * 8 - 1) if (dtypes.is_int(dtype) and not dtypes.is_unsigned(dtype)) else 0
               overflow_fixed = [((x + overflow_adjust) % 2**(dtype.itemsize*8) - overflow_adjust) if dtypes.is_int(dtype) else x for x in casted]
               ul[i] = list(struct.unpack(unpack_format, struct.pack(unpack_format, *overflow_fixed)))
         elif uop is UOps.LOAD:

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -136,8 +136,7 @@ class PythonProgram:
               casted = [float(x) if dtypes.is_float(dtype) else int(x) if dtypes.is_int(dtype) else x for x in inp[0]]
               overflow_adjust = 0 if dtypes.is_unsigned(dtype) else 2 ** (dtype.itemsize * 8 - 1)
               overflow_fixed = [((x + overflow_adjust) % 2**(dtype.itemsize*8) - overflow_adjust) if dtypes.is_int(dtype) else x for x in casted]
-              packed = struct.pack(unpack_format, *overflow_fixed)
-              ul[i] = list(struct.unpack(unpack_format, packed))
+              ul[i] = list(struct.unpack(unpack_format, struct.pack(unpack_format, *overflow_fixed)))
         elif uop is UOps.LOAD:
           if isinstance(dtp[0], ImageDType):
             assert dtype.count == 4

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -134,8 +134,10 @@ class PythonProgram:
               ul[i] = list(struct.unpack(unpack_format, struct.pack(pack_format, *inp[0])))
             else:
               casted = [float(x) if dtypes.is_float(dtype) else int(x) if dtypes.is_int(dtype) else x for x in inp[0]]
+              overflowed = [(x % 2**(dtype.itemsize*8)) - (dtype.itemsize*8-1)*dtypes.is_unsigned(dtype) if dtypes.is_int(dtype)
+                            else x for x in casted]
               packed = struct.pack(pack_format if (dtypes.is_int(dtype) and dtypes.is_int(dtp[0]) and dtype.itemsize == dtp[0].itemsize)
-                                   else unpack_format, *casted)
+                                   else unpack_format, *overflowed)
               ul[i] = list(struct.unpack(unpack_format, packed))
         elif uop is UOps.LOAD:
           if isinstance(dtp[0], ImageDType):

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -134,7 +134,7 @@ class PythonProgram:
               ul[i] = list(struct.unpack(unpack_format, struct.pack(pack_format, *inp[0])))
             else:
               casted = [float(x) if dtypes.is_float(dtype) else int(x) if dtypes.is_int(dtype) else x for x in inp[0]]
-              overflowed = [(x % 2**(dtype.itemsize*8)) - (dtype.itemsize*8-1)*dtypes.is_unsigned(dtype) if dtypes.is_int(dtype)
+              overflowed = [(x % 2**(dtype.itemsize*8)) - 2**(dtype.itemsize*8-1)*(not dtypes.is_unsigned(dtype))*(x<0) if dtypes.is_int(dtype)
                             else x for x in casted]
               packed = struct.pack(pack_format if (dtypes.is_int(dtype) and dtypes.is_int(dtp[0]) and dtype.itemsize == dtp[0].itemsize)
                                    else unpack_format, *overflowed)

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -134,9 +134,8 @@ class PythonProgram:
               ul[i] = list(struct.unpack(unpack_format, struct.pack(pack_format, *inp[0])))
             else:
               casted = [float(x) if dtypes.is_float(dtype) else int(x) if dtypes.is_int(dtype) else x for x in inp[0]]
-              overflow_adjustment = 2**(dtype.itemsize*8-1) * (not dtypes.is_unsigned(dtype))
-              overflow_fixed = [((x + overflow_adjustment) % 2**(dtype.itemsize*8) - overflow_adjustment) if dtypes.is_int(dtype)
-                                else x for x in casted]
+              overflow_adjust = 0 if dtypes.is_unsigned(dtype) else 2 ** (dtype.itemsize * 8 - 1)
+              overflow_fixed = [((x + overflow_adjust) % 2**(dtype.itemsize*8) - overflow_adjust) if dtypes.is_int(dtype) else x for x in casted]
               packed = struct.pack(unpack_format, *overflow_fixed)
               ul[i] = list(struct.unpack(unpack_format, packed))
         elif uop is UOps.LOAD:


### PR DESCRIPTION
Followup to #3446. #3447 brought up some good test edge cases around uint/int out-of-bounds conversions differing from numpy. Roll our own overflow wraparound handling, which simplifies struct packing afterwards