### PR TITLE
fix LtNode simplification when lhs and rhs contain same variables

### DIFF
--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -413,9 +413,11 @@ class TestSymbolicSymbolicOps(unittest.TestCase):
     c = Variable("c", 1, 10)
     d = Variable("d", 5, 10)
     # if the value is always the same, it folds to num
-    assert (a < b) == 1
-    assert (b < a) == 0
-    assert (d < a) == 0
+    assert (a < b) == NumNode(1)
+    assert (b < a) == NumNode(0)
+    assert (d < a) == NumNode(0)
+    assert (a < a) == NumNode(0)
+    assert (a > a) == NumNode(0)
     # if it remains as a LtNode, bool is always true and (min, max) == (0, 1)
     assert isinstance((a < c), LtNode) and (a < c).min == 0 and (a < c).max == 1
     assert a < c

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -168,9 +168,9 @@ class OpNode(Node):
 
 class LtNode(OpNode):
   def get_bounds(self) -> Tuple[int, int]:
-    if (diff := self.a - self.b).min >= 0: return 0, 0
-    if diff.max < 0: return 1, 1
-    return 0, 1
+    if self.a == self.b: return (0, 0)
+    if isinstance(self.b, int): return (1, 1) if self.a.max < self.b else (0, 0) if self.a.min >= self.b else (0, 1)
+    return (1, 1) if self.a.max < self.b.min else (0, 0) if self.a.min >= self.b.max else (0, 1)
   def substitute(self, var_vals: Mapping[Variable, Union[NumNode, Variable]]) -> Node:
     return self.a.substitute(var_vals) < (self.b if isinstance(self.b, int) else self.b.substitute(var_vals))
 

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -168,8 +168,9 @@ class OpNode(Node):
 
 class LtNode(OpNode):
   def get_bounds(self) -> Tuple[int, int]:
-    if isinstance(self.b, int): return (1, 1) if self.a.max < self.b else (0, 0) if self.a.min >= self.b else (0, 1)
-    return (1, 1) if self.a.max < self.b.min else (0, 0) if self.a.min >= self.b.max else (0, 1)
+    if (diff := self.a - self.b).min >= 0: return 0, 0
+    if diff.max < 0: return 1, 1
+    return 0, 1
   def substitute(self, var_vals: Mapping[Variable, Union[NumNode, Variable]]) -> Node:
     return self.a.substitute(var_vals) < (self.b if isinstance(self.b, int) else self.b.substitute(var_vals))
 


### PR DESCRIPTION
`(Variable("a", 1, 5) < Variable("a", 1, 5))` should eval to `NumNode(0)`