### PR TITLE
test/external/fuzz_linearizer: add a FUZZ_MAX_SIZE option

### DIFF
--- a/test/external/fuzz_linearizer.py
+++ b/test/external/fuzz_linearizer.py
@@ -71,13 +71,13 @@ def fuzz_linearizer(lin: Linearizer):
   print_tree(lin.ast)
   print(lin.colored_shape())
   rawbufs = get_fuzz_rawbufs(lin)
-  FUZZ_BEAM=getenv("FUZZ_BEAM", 0)
   seen_uops = {}
   last_lins = [lin]
   failures = defaultdict(list)
 
-  FUZZ_MAX_SIZE=getenv("FUZZ_MAX_SIZE", 0)
-  if FUZZ_MAX_SIZE > 0 and prod(lin.full_shape)>FUZZ_MAX_SIZE:
+  FUZZ_BEAM = getenv("FUZZ_BEAM", 0)
+  FUZZ_MAX_SIZE = getenv("FUZZ_MAX_SIZE", 0)
+  if FUZZ_MAX_SIZE > 0 and prod(lin.full_shape) > FUZZ_MAX_SIZE:
     print("skipping large kernel")
     return failures
 

--- a/test/external/fuzz_linearizer.py
+++ b/test/external/fuzz_linearizer.py
@@ -7,7 +7,7 @@ from tinygrad.codegen.linearizer import Linearizer
 from tinygrad.features.search import get_linearizer_actions, bufs_from_lin
 from tinygrad.tensor import Tensor
 from tinygrad.features.graph import print_tree
-from tinygrad.helpers import getenv, from_mv, Context
+from tinygrad.helpers import getenv, from_mv, prod, Context
 from tinygrad.device import Device, Compiled
 from tinygrad.codegen.linearizer import UOp
 
@@ -75,6 +75,11 @@ def fuzz_linearizer(lin: Linearizer):
   seen_uops = {}
   last_lins = [lin]
   failures = defaultdict(list)
+
+  FUZZ_MAX_SIZE=getenv("FUZZ_MAX_SIZE", 0)
+  if FUZZ_MAX_SIZE > 0 and prod(lin.full_shape)>FUZZ_MAX_SIZE:
+    print("skipping large kernel")
+    return failures
 
   # get baseline unoptimized output
   unoptimized = Linearizer(lin.ast)


### PR DESCRIPTION
this allows us to limit the size of the kernel and reduce running times by avoiding ones that take a long time