### PR TITLE
cache collector optimizations are allowed only for kernel operations

### DIFF
--- a/tinygrad/features/jit.py
+++ b/tinygrad/features/jit.py
@@ -165,10 +165,13 @@ class _CacheCollector:
   def add(self, prg, rawbufs, var_vals):
     if self.cache is None: return
     for k,v in var_vals.items(): assert k in self.var_vals and self.var_vals[k] == v, f"var_vals {k} mismatch {v} != {self.var_vals.get(k)}"
+
+    # Buffer optimization is allowed only for kernel operations. Avoids for copies (prevents parallelism) and syncs (incorrect buffer reuse).
+    allow_buffer_optimization = isinstance(prg, CompiledASTRunner)
+
     # NOTE: this is making an assumption that 0 is special
-    # TODO: this is wrong for sync and wait
     if len(rawbufs): self.placeholders[rawbufs[0]] = PlaceHolder(rawbufs[0])
-    self.cache.append((prg, [self.placeholders.get(x, x) if isinstance(x, Buffer) else x for x in rawbufs]))
+    self.cache.append((prg, [self.placeholders.get(x, x) if isinstance(x, Buffer) and allow_buffer_optimization else x for x in rawbufs]))
 
   def finish(self) -> List[JitItem]:
     if self.cache is None: return []


### PR DESCRIPTION
Forbid optimizations for everything but astrunners. For syncs this is incorrect. For copies (+transfers), optimizing may create a dependency chain that prevents parallel execution.

* SD mem usage is the same
* hlb_cifar 6 GPUs (with ring all reduce) `12.51 GB used` -> `12.55 GB used`

For #3403