### PR TITLE
O(n) nn.Embedding in one kernel without new ops.

### DIFF
--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -126,8 +126,8 @@ class Embedding:
     self.weight = Tensor.glorot_uniform(vocab_size, embed_size)
 
   def __call__(self, idx:Tensor) -> Tensor:
-    if not hasattr(self, 'vocab_counter'):
-      self.vocab_counter = Tensor.arange(self.vocab_size, requires_grad=False, device=self.weight.device).reshape(1, 1, self.vocab_size)
     batch_size, seqlen = idx.shape
     if seqlen == 0: return Tensor.empty(batch_size, 0, self.embed_size, device=self.weight.device)
-    return (self.vocab_counter == idx.unsqueeze(2)).expand(*idx.shape, self.vocab_size) @ self.weight
+    increments = Tensor.arange(self.embed_size, requires_grad=False, device=self.weight.device).reshape(1, 1, self.embed_size)
+    idx = idx.reshape((batch_size, seqlen, 1)).expand((batch_size, seqlen, self.embed_size)) * self.embed_size + increments
+    return self.weight.reshape(-1)[idx].reshape((batch_size, seqlen, self.embed_size))


### PR DESCRIPTION
Submission for the `O(n) nn.Embedding in one kernel without new ops (supporting BS=128)` bounty.

The idea is to generate all the indices in the right shape first and then to rely on tensor indexing. This gets rid of matrix multiplications and reduces runtime.

The generated kernels can be seen with this command
```
DEBUG=9 python > /tmp/tmp.txt <<EOF
from tinygrad.tensor import Tensor
from tinygrad import nn
import numpy as np
batch_size, seqlen, vocab_size, embedding_size = 128, 64, 32, 16
I = Tensor(np.random.randint(0, vocab_size, size=(batch_size, seqlen)))
print(nn.Embedding(vocab_size, embedding_size)(I).numpy())
EOF
```

Tested: All unit tests pass