### PR TITLE
Add an assert where there should be one

### DIFF
--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -53,6 +53,7 @@ class DiskRunner(JITRunner):
     # TODO: there shouldn't actually be casts here, bitcasts should fold into the load
     if ast.src[0].op == UnaryOps.CAST:
       top_src = ast.src[0].src[0]
+      assert ast.src[0].src[0].arg.dtype.itemsize == ast.src[0].arg[0].itemsize # cannot bitcast between different sizes
       # TODO: assert that this is bitcast
       self.new_dtype = ast.src[0].arg[0]
     else:


### PR DESCRIPTION
This makes #3482 fail cleanly. However, it also makes tests fail in general (IMO they should fail though). Seems related to changes done in #3421 

I'm going to need a bit more guidance on how to continue from here. Would adding supporting casts from disk be the right option?