### PR TITLE
Python ALU Ops Dtypes

### DIFF
--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -44,13 +44,10 @@ def exec_alu(arg, dtype, p):
 
   def check_types(arg, p, dtype):
     types = [dtype] if arg not in {BinaryOps.CMPEQ, BinaryOps.CMPLT} else []
-    p = p if arg is not TernaryOps.WHERE else p[1:]
-    types.extend(dtypes.from_py(x) for x in p)
-    if all(dtypes.is_bool(t) for t in types):
-        if arg is BinaryOps.MUL: return
-        raise TypeError(f"Invalid operation {arg} for bools")
+    for i in range(int(arg is TernaryOps.WHERE), len(p)): types.append(dtypes.from_py(p[i]))
+    if arg is BinaryOps.MUL and all(dtypes.is_bool(t) for t in types): return
     if not (all(dtypes.is_float(t) for t in types) or all(dtypes.is_int(t) for t in types)):
-        raise TypeError(f"All elements in p must be of the same basic type, got {types} for {arg} {dtype} {p}")
+      raise TypeError(f"All elements in p must be of the same basic type, got {types} for {arg} {dtype} {p}")
 
   check_types(arg, p, dtype)
 

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -42,14 +42,9 @@ def exec_alu(arg, dtype, p):
   if len(p) != exp_arg_len:
     raise ValueError(f"Invalid number of operands for operation {arg}: {p}")
 
-  def check_types(arg, p, dtype):
-    types = [dtype] if arg not in {BinaryOps.CMPEQ, BinaryOps.CMPLT} else []
-    for i in range(int(arg is TernaryOps.WHERE), len(p)): types.append(dtypes.from_py(p[i]))
-    if arg is BinaryOps.MUL and all(dtypes.is_bool(t) for t in types): return
-    if not (all(dtypes.is_float(t) for t in types) or all(dtypes.is_int(t) for t in types)):
-      raise TypeError(f"All elements in p must be of the same basic type, got {types} for {arg} {dtype} {p}")
-
-  check_types(arg, p, dtype)
+  types = [dtype] + [dtypes.from_py(x) for x in p]
+  if not (all(dtypes.is_float(t) or dtypes.is_bool(t) for t in types) or all(dtypes.is_int(t) or dtypes.is_bool(t) for t in types)):
+    raise TypeError(f"All elements in p must be of the same basic type, got {types} for {arg} {dtype} {p}")
 
   result = operations[arg]()
   if result is None:

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -20,7 +20,7 @@ def exec_alu(arg, dtype, p):
     TernaryOps.WHERE: lambda: None if not dtypes.is_bool(dtypes.from_py(p[0])) else p[1] if p[0] else p[2],
     UnaryOps.LOG2: lambda: math.nan if p[0] < 0 else -math.inf if p[0] == 0 else math.log2(p[0]),
     UnaryOps.EXP2: lambda: safe_exp2(p[0]),
-    UnaryOps.SQRT: lambda: math.nan if p[0] <= 0 else math.sqrt(p[0]),
+    UnaryOps.SQRT: lambda: math.nan if p[0] < 0 else math.sqrt(p[0]),
     UnaryOps.SIN: lambda: math.sin(p[0]),
     UnaryOps.NEG: lambda: -p[0],
     # Multiplication hijacked for and operation


### PR DESCRIPTION
Adds:
- Consideration of dtypes when performing alu ops in ops_python emu.
- Necessary helper functions for this and modified exec_alu.
- Consideration of vectorized operands/result was not made but maintains old behaviors.
- Rounding of floats in limited scenarios (can be disabled) which assumes IEEE standard precision.
- Overflow checking on non-floats.