### PR TITLE
Threefry random

### DIFF
--- a/docs/abstractions2.py
+++ b/docs/abstractions2.py
@@ -76,10 +76,10 @@ from tinygrad.lazy import LazyBuffer, LoadOps
 from tinygrad.realize import run_schedule, create_schedule
 
 # allocate some values + load in values
-a = LazyBuffer.loadop(LoadOps.EMPTY, (1,), dtypes.int32, "CLANG")
-b = LazyBuffer.loadop(LoadOps.EMPTY, (1,), dtypes.int32, "CLANG")
-a.realized = Buffer("CLANG", 1, dtypes.int32).copyin(memoryview(bytearray(struct.pack("I", 2))))
-b.realized = Buffer("CLANG", 1, dtypes.int32).copyin(memoryview(bytearray(struct.pack("I", 3))))
+a = LazyBuffer.loadop(LoadOps.EMPTY, (1,), dtypes.int32, DEVICE)
+b = LazyBuffer.loadop(LoadOps.EMPTY, (1,), dtypes.int32, DEVICE)
+a.realized = Buffer(DEVICE, 1, dtypes.int32).copyin(memoryview(bytearray(struct.pack("I", 2))))
+b.realized = Buffer(DEVICE, 1, dtypes.int32).copyin(memoryview(bytearray(struct.pack("I", 3))))
 
 # describe the computation
 out = a.e(BinaryOps.ADD, b)


### PR DESCRIPTION
I completed the TODO at the bottom of tensor.py by replacing custom_random with threefry_random. The algorithm is significantly slower than numpy rng.random, but given that my threefry algorithm is written in pure python i think that it does fairly well, and the can always be improved in the future. Maybe we should consider using the Lehmer random number generator (https://en.wikipedia.org/wiki/Lehmer_random_number_generator) instead of threefry in the future as it has a more simple implementation and it is faster. 