### PR TITLE
parallel beam support for GPU (CLDevice)

### DIFF
--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -48,8 +48,9 @@ def _compile_linearizer(compiler:Compiler, lin:Linearizer, name:Optional[str]=No
   src = compiler.render(name if name is not None else to_function_name(lin.name), lin.uops)   # NOTE: these all have the same name for deduping
   return compiler.compile(src), lin.global_size, lin.local_size
 
-def _try_compile_linearized_w_idx(x, compiler:Compiler):
-  try: return (x[0], _compile_linearizer(compiler, x[1], "test"))
+def _try_compile_linearized_w_idx(x):
+  device = Device[x[1].opts.device]
+  try: return (x[0], _compile_linearizer(device.compiler, x[1], "test"))
   except Exception:
     if DEBUG >= 4: traceback.print_exc()
     return (x[0], None)
@@ -101,7 +102,7 @@ def beam_search(lin:Linearizer, rawbufs, amt:int, allow_test_size=True) -> Linea
   beam: List[Tuple[Linearizer, float]] = []
   seen_libs = set()
 
-  default_parallel = 1 if lin.opts.device in {"CUDA", "HIP"} else 0
+  default_parallel = 1 if lin.opts.device in {"CUDA", "HIP", "GPU"} else 0
   if beam_pool is None and getenv("PARALLEL", default_parallel): beam_pool = multiprocessing.Pool(multiprocessing.cpu_count(), _init_worker)
 
   try:
@@ -112,8 +113,7 @@ def beam_search(lin:Linearizer, rawbufs, amt:int, allow_test_size=True) -> Linea
     while not exiting:
       acted_lins = flatten([get_linearizer_actions(lin, include_0=False).values() for lin,_ in beam]) if len(beam) else [lin]
       timed_lins: List[Tuple[Linearizer, float]] = []
-      _compile_fn = functools.partial(_try_compile_linearized_w_idx, compiler=Device[lin.opts.device].compiler)
-      for i,proc in (map(_compile_fn, enumerate(acted_lins)) if beam_pool is None else beam_pool.imap_unordered(_compile_fn, enumerate(acted_lins))):
+      for i,proc in (map(_try_compile_linearized_w_idx, enumerate(acted_lins)) if beam_pool is None else beam_pool.imap_unordered(_try_compile_linearized_w_idx, enumerate(acted_lins))):
         if proc is None: continue
         lib, global_size, local_size = proc
         if lib in seen_libs: continue


### PR DESCRIPTION
When using parallel beam for GPU (OpenCL) kernels, you get pickling error in the current implementation. It has to do with the CLDevice object not being picklable it seems, specifically because it deals with ctypes objects containing pointers, and these aren't picklable. So, instead of creating the device object within the beam search function and passing it to the compile function, I created the device object within the compile function itself. This got rid of the pickling error. I ran "handcode_resnet50_opt.py" with BEAM=1 after making these changes, and got 2x speed improvement as compared to using non-parallel beam (i.e. PARALLEL=0) -- parallel beam worked basically. I tried it multiple times, and it seems to work fine. Maybe the current implementation was intended, but I can't seem to figure out why. Creating the object within each process shouldn't affect things significantly, no? 