### PR TITLE
fix: align .split, .chunk and .unsqueeze with torch, add fuzz tests

### DIFF
--- a/test/test_fuzz_shape_ops.py
+++ b/test/test_fuzz_shape_ops.py
@@ -1,0 +1,89 @@
+import unittest
+from math import prod
+
+from hypothesis import assume, given, settings, strategies as st
+from hypothesis.extra import numpy as stn
+
+import numpy as np
+import torch
+import tinygrad
+from tinygrad.helpers import CI
+
+
+settings.register_profile(__file__, settings.default,
+                          max_examples=100 if CI else 250, deadline=None)
+
+
+# torch wraparound for large numbers
+st_int32 = st.integers(-2147483648, 2147483647)
+
+@st.composite
+def st_shape(draw) -> tuple[int, ...]:
+  s = draw(stn.array_shapes(min_dims=0, max_dims=6,
+                            min_side=0, max_side=512))
+  assume(prod(s) <= 1024 ** 2)
+  assume(prod([d for d in s if d]) <= 1024 ** 4)
+  return s
+
+
+def tensors_for_shape(s:tuple[int, ...]) -> tuple[torch.tensor, tinygrad.Tensor]:
+  x = np.arange(prod(s)).reshape(s)
+  return torch.from_numpy(x), tinygrad.Tensor(x)
+
+def apply(tor, ten, tor_fn, ten_fn=None):
+  ok = True
+  try: tor = tor_fn(tor)
+  except: tor, ok = None, not ok  # noqa: E722
+  try: ten = ten_fn(ten) if ten_fn is not None else tor_fn(ten)
+  except: ten, ok = None, not ok  # noqa: E722
+  return tor, ten, ok
+
+
+class TestShapeOps(unittest.TestCase):
+  @settings.get_profile(__file__)
+  @given(st_shape(), st_int32, st.one_of(st_int32, st.lists(st_int32)))
+  def test_split(self, s:tuple[int, ...], dim:int, sizes:int|list[int]):
+    tor, ten = tensors_for_shape(s)
+    tor, ten, ok = apply(tor, ten, lambda t: t.split(sizes, dim))
+    assert ok
+    if tor is None and ten is None: return
+
+    assert len(tor) == len(ten)
+    assert all([np.array_equal(tor.numpy(), ten.numpy()) for (tor, ten) in zip(tor, ten)])
+
+
+  @settings.get_profile(__file__)
+  @given(st_shape(), st_int32, st_int32)
+  def test_chunk(self, s:tuple[int, ...], dim:int, num:int):
+    # chunking on a 0 dim is cloning and leads to OOM if done unbounded.
+    assume((0 <= (actual_dim := len(s)-dim if dim < 0 else dim) < len(s) and s[actual_dim] > 0) or
+           (num < 32))
+
+    tor, ten = tensors_for_shape(s)
+    tor, ten, ok = apply(tor, ten, lambda t: t.chunk(num, dim))
+    assert ok
+    if tor is None and ten is None: return
+
+    assert len(tor) == len(ten)
+    assert all([np.array_equal(tor.numpy(), ten.numpy()) for (tor, ten) in zip(tor, ten)])
+
+  @settings.get_profile(__file__)
+  @given(st_shape(), st_int32)
+  def test_squeeze(self, s:tuple[int, ...], dim:int):
+    tor, ten = tensors_for_shape(s)
+    tor, ten, ok = apply(tor, ten, lambda t: t.squeeze(dim))
+    assert ok
+    if tor is None and ten is None: return
+    assert np.array_equal(tor.numpy(), ten.numpy())
+
+  @settings.get_profile(__file__)
+  @given(st_shape(), st_int32)
+  def test_unsqueeze(self, s:tuple[int, ...], dim:int):
+    tor, ten = tensors_for_shape(s)
+    tor, ten, ok = apply(tor, ten, lambda t: t.unsqueeze(dim))
+    assert ok
+    if tor is None and ten is None: return
+    assert np.array_equal(tor.numpy(), ten.numpy())
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -499,27 +499,31 @@ class Tensor:
     final_shape = [r*s for r,s in zip(repeats, base_shape)]
     return self.reshape(new_shape).expand(expand_shape).reshape(final_shape)
 
+  def _resolve_dim(self, dim:int, *, outer:bool=False) -> int:
+    if not -max(1, self.ndim+outer) <= dim < max(1, self.ndim+outer):
+      raise IndexError(f"{dim=} out of range {[-max(1, self.ndim+outer), max(1, self.ndim+outer)-1]}")
+    return dim + self.ndim+outer if dim < 0 else dim
+
   def split(self, sizes:Union[int, List[int]], dim:int=0) -> Tuple[Tensor, ...]:
     assert all_int(self.shape), f"does not support symbolic shape {self.shape}"
-    dim = dim + self.ndim if dim < 0 else dim
-    if isinstance(sizes, int): return tuple(self.chunk(math.ceil(self.shape[dim]/sizes), dim=dim))
+    dim = self._resolve_dim(dim)
+    if isinstance(sizes, int): sizes = [min(sizes, self.shape[dim]-i) for i in range(0, max(1, self.shape[dim]), max(1, sizes))]
+    assert sum(sizes) == self.shape[dim], f"expect sizes to sum exactly to {self.shape[dim]}, but got {sum(sizes)}"
     return tuple(self[sl] for sl in [tuple([slice(None)]*dim + [slice(sum(sizes[:i]), sum(sizes[:i + 1]))]) for i in range(len(sizes))])
 
   def chunk(self, num:int, dim:int=0) -> List[Tensor]:
     assert all_int(self.shape), f"does not support symbolic shape {self.shape}"
-    dim, step = dim + self.ndim if dim < 0 else dim, math.ceil(self.shape[dim]/num)
-    slice_params = [[slice(None)]*dim + [slice(k, k + step)] for k in range(0, self.shape[dim], step)]
-    return [self[tuple(sl)] for sl in slice_params]
+    dim = self._resolve_dim(dim)
+    assert num > 0, f"expect num to be greater than 0, got: {num}"
+    return list(self.split(math.ceil(self.shape[dim]/num) if self.shape[dim] else [0]*num, dim=dim))
 
   def squeeze(self, dim:Optional[int]=None) -> Tensor:
     if dim is None: return self.reshape(tuple(dim for dim in self.shape if dim != 1))
-    if self.ndim == 0 and dim in [-1, 0]: return self  # this is to match torch behavior
-    if not -self.ndim <= dim <= self.ndim-1: raise IndexError(f"{dim=} out of range {[-self.ndim, self.ndim-1] if self.ndim else [-1, 0]}")
-    if dim < 0: dim += self.ndim
-    return self if self.shape[dim] != 1 else self.reshape(self.shape[:dim] + self.shape[dim+1:])
+    dim = self._resolve_dim(dim)
+    return self if not self.ndim or self.shape[dim] != 1 else self.reshape(self.shape[:dim] + self.shape[dim+1:])
 
   def unsqueeze(self, dim:int) -> Tensor:
-    if dim < 0: dim = self.ndim + dim + 1
+    dim = self._resolve_dim(dim, outer=True)
     return self.reshape(self.shape[:dim] + (1,) + self.shape[dim:])
 
   # (padding_left, padding_right, padding_top, padding_bottom)


### PR DESCRIPTION
This fixes `.split` where `self.shape[dim]` is not perfectly divisible by `sizes` - `.chunk` is always the wrong choice here:

`tensor((5,)).split(4)` should result in `(tensor((4,)), tensor((1,)))`, was `(tensor((3,)), tensor((2,)))`

This also fixes issues in `.split` and `.chunk` where tensors with `shape[dim] == 0` lead to empty tuples/lists when the tensor itself should have been returned instead.

All included tests are hypothesis fuzz-tests and written with the idea in mind that if torch rises an error then so should tinygrad - otherwise all outputs must match. Because of this tinygrad will now be strict regarding `sizes` having to sum up to passed dimension in `.split`, `num` having to be non-null for `.chunk` and only allowing valid dims in `.unsqueeze`.

---

I am not sure if the testcases are in the right directory and file, or if any existing helper functions should have been used instead. Please tell me should anything be moved or rewritten to use other functions.

I am also not sure on the name or location of `_resolve_dim`. I think adding the function allows for nicer errors to be returned and the four modified functions are by far not the only ones able to use it.