### PR TITLE
Use new_dtype.itemsize in disk tensor offset

### DIFF
--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -68,8 +68,7 @@ class DiskRunner(JITRunner):
   def __call__(self, rawbufs:List[Buffer], var_vals:Dict[Any, int], wait=False, jit=False):
     assert len(rawbufs) == 2
     src = rawbufs[1]._buf
-    # TODO: src.dtype.itemsize or self.new_dtype.itemsize?
-    rawbufs[0]._buf = DiskBuffer(src.ud, self.new_size, self.new_dtype, offset=src.offset+self.new_offset*src.dtype.itemsize)
+    rawbufs[0]._buf = DiskBuffer(src.ud, self.new_size, self.new_dtype, offset=src.offset+self.new_offset*self.new_dtype.itemsize)
 
 class DiskDevice(Compiled):
   def __init__(self, device:str): super().__init__(device, DiskAllocator(device[len("disk:"):]), None, None)


### PR DESCRIPTION
This fixed hlb_cifar disk tensor dataset construction when there are multiple files with a different dtype (/tmp/cifar_train_y).