### PR TITLE
failed test case for disk tensor assign into dtype int64

### DIFF
--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -205,5 +205,17 @@ class TestDiskTensor(unittest.TestCase):
     helper_test_disk_tensor("dt5", [1,2,3,4,5], lambda x: x.reshape((1,5)))
     helper_test_disk_tensor("dt6", [1,2,3,4], lambda x: x.reshape((2,2)))
 
+  @unittest.expectedFailure
+  def test_assign_to_different_dtype(self):
+    # NOTE: this is similar to Y_train in fetch_cifar
+    t = Tensor.empty(10, device=f'disk:{temp("dt7")}', dtype=dtypes.int64)
+
+    for i in range(5):
+      data = np.array([3, 3])
+      idx = 2 * i
+      t[idx:idx+2].assign(data)
+
+    np.testing.assert_array_equal(t.numpy(), np.array([3] * 10))
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
failed case for #3510, mark as expectedFailure for now