### PR TITLE
search: add BEAM UPCAST/LOCAL params and loosen TC criteria during BEAM

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -4,7 +4,7 @@ from typing import NamedTuple, Optional, List, Tuple, cast, Dict, Union
 from tinygrad.ops import LazyOp, FlopCounter, get_lazyop_info, UnaryOps, BinaryOps, ReduceOps, MemBuffer, ConstBuffer, BufferOps
 from tinygrad.device import Device, Compiled
 from tinygrad.dtype import dtypes, ImageDType, DType
-from tinygrad.helpers import dedup, colored, ansilen, getenv, prod, DEBUG, round_up, all_int, get_contraction
+from tinygrad.helpers import dedup, colored, ansilen, getenv, prod, DEBUG, round_up, all_int, get_contraction, BEAM
 from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.shape.symbolic import sint
 from tinygrad.shape.view import View, strides_for_shape
@@ -350,14 +350,18 @@ class Kernel:
         mul_op = self.reduceop.src[0].src[0] if has_cast else self.reduceop.src[0]
         if mul_op.op != BinaryOps.MUL: continue
 
-        if not (mul_op.src[0].op == BufferOps.LOAD and mul_op.src[0].arg.dtype == tc.dtype_in): continue
-        if not (mul_op.src[1].op == BufferOps.LOAD and mul_op.src[1].arg.dtype == tc.dtype_in): continue
+        LOOSE_TC = getenv("BEAM_LOOSE_TC", 0)
+        def buf_index(src: LazyOp) -> Optional[int]:
+          if src.op == BufferOps.LOAD and src.arg.dtype == tc.dtype_in: return self.bufs.index(cast(MemBuffer, src.arg))
+          if BEAM and LOOSE_TC and src.op == UnaryOps.CAST and src.arg[0] == tc.dtype_in: return self.bufs.index(cast(MemBuffer, src.src[0].arg))
+          return None
+        if (buf0:=buf_index(mul_op.src[0])) is None or (buf1:=buf_index(mul_op.src[1])) is None: continue
 
-        buf0, buf1 = self.bufs.index(cast(MemBuffer, mul_op.src[0].arg)), self.bufs.index(cast(MemBuffer, mul_op.src[1].arg))
-        buf0_strides, buf1_strides = self.sts[buf0].real_strides(), self.sts[buf1].real_strides()
+        buf0_strides, buf1_strides, reduce_sz = self.sts[buf0].real_strides(), self.sts[buf1].real_strides(), self.full_shape[self.first_reduce]
         axis_buf0 = [(i,self.full_shape[i],buf1_strides[i]) for i,s in enumerate(buf0_strides[:self.first_reduce]) if s == 0 and self.full_shape[i]%tc.dims[0] == 0]  # noqa: E501
         axis_buf1 = [(i,self.full_shape[i],buf0_strides[i]) for i,s in enumerate(buf1_strides[:self.first_reduce]) if s == 0 and self.full_shape[i]%tc.dims[1] == 0]  # noqa: E501
-        if not(axis_buf0 and axis_buf1 and self.full_shape[self.first_reduce]%tc.dims[2] == 0 and self.full_shape[self.first_reduce] >= tc.dims[2] and (self.shape_len-self.first_reduce) == 1): continue  # noqa: E501
+        if not(axis_buf0 and axis_buf1 and reduce_sz%tc.dims[2] == 0 and reduce_sz >= tc.dims[2]): continue
+        if not((self.shape_len-self.first_reduce) == 1 or (BEAM and LOOSE_TC)): continue
 
         axis_choices = list(itertools.product(axis_buf0, axis_buf1))
         if not(axis < len(axis_choices)): continue

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -76,7 +76,7 @@ def bufs_from_lin(lin:Linearizer) -> List[Buffer]:
 
 # get dictionary of all possible actions
 def get_linearizer_actions(lin:Linearizer, include_0=True) -> Dict[int, Linearizer]:
-  acted_lins = {0:lin} if include_0 else {}
+  acted_lins, max_up, max_lcl = {0:lin} if include_0 else {}, getenv("BEAM_UPCAST_MAX", 256), getenv("BEAM_LOCAL_MAX", 256)
   for i,a in enumerate(actions):
     if a.axis is not None and a.axis >= lin.shape_len: continue
     if a.axis is not None and lin.full_shape[a.axis] == a.amt and Opt(a.op, a.axis, 0) in actions: continue
@@ -87,7 +87,7 @@ def get_linearizer_actions(lin:Linearizer, include_0=True) -> Dict[int, Lineariz
       for s,c in zip(lin2.full_shape, lin2.colors()):
         if c in {"magenta", "yellow"}: up *= s
         if c in {"cyan", "green", "white"}: lcl *= s
-      if up > 256 or lcl > 256 or ("green" in lin2.colors() and up*lcl > 2 ** 15): continue
+      if up > max_up or lcl > max_lcl or ("green" in lin2.colors() and up*lcl > 2 ** 15): continue
       acted_lins[i+1] = lin2
     except Exception:
       pass
@@ -105,7 +105,7 @@ def beam_search(lin:Linearizer, rawbufs, amt:int, allow_test_size=True) -> Linea
   beam: List[Tuple[Linearizer, float]] = []
   seen_libs = set()
 
-  default_parallel = 1 if lin.opts.device in {"CUDA", "HIP"} else 0
+  default_parallel, min_progress_micros = 1 if lin.opts.device in {"CUDA", "HIP"} else 0, getenv("BEAM_MIN_PROGRESS",0)
   if beam_pool is None and getenv("PARALLEL", default_parallel): beam_pool = multiprocessing.Pool(multiprocessing.cpu_count(), _init_worker)
 
   try:
@@ -128,8 +128,9 @@ def beam_search(lin:Linearizer, rawbufs, amt:int, allow_test_size=True) -> Linea
 
       # done
       opts = sorted(timed_lins, key=lambda x: x[1])
-      exiting = len(opts) == 0 or (len(beam) > 0 and beam[0][1] <= opts[0][1])
+      exiting = len(opts) == 0 or (len(beam) > 0 and ((beam[0][1]-opts[0][1])*1e6 < min_progress_micros))
       if not exiting: beam = opts[:amt]
+      elif len(opts) > 0 and opts[0][1] < beam[0][1]: beam = opts[:1]
       assert len(beam) > 0, "no BEAM items succeeded?!?"
       if DEBUG >= 2: print(f"\r{time.perf_counter() - st:7.2f}s:", colored(f"{beam[0][1]*1e6:12.2f} us", "green" if exiting else None), f"from {len(acted_lins):3d} -> {len(opts):3d} actions\033[K", beam[0][0].colored_shape())  # noqa: E501
   except KeyboardInterrupt as e:


### PR DESCRIPTION
For `LATEWINO=1`, this patch Increases the number of tensor core-eligible kernels in hlb_cifar from 13 to 18 and reduces single GPU step time from 15.3ms down to 13.7ms with `time HIP=1 HALF=1 STEPS=1000 LATEWINO=1 LATEBEAM=16 BEAM_LOOSE_TC=1 BEAM_UPCAST_MAX=4096 BEAM_LOCAL_MAX=512 BEAM_MIN_PROGRESS=25 TARGET_EVAL_ACC_PCT=93 python3 examples/hlb_cifar10.py`:

```
995   13.64 ms run,    1.76 ms python,   11.88 ms HIP,  494.75 loss, 0.000102 LR, 2.08 GB used,  14496.43 GFLOPS,    197.78 GOPS
996   13.56 ms run,    1.76 ms python,   11.80 ms HIP,  499.75 loss, 0.000099 LR, 2.08 GB used,  14590.15 GFLOPS,    197.78 GOPS
997   13.55 ms run,    1.75 ms python,   11.80 ms HIP,  492.00 loss, 0.000094 LR, 2.08 GB used,  14593.94 GFLOPS,    197.78 GOPS
998   13.67 ms run,    1.77 ms python,   11.90 ms HIP,  494.25 loss, 0.000089 LR, 2.08 GB used,  14468.05 GFLOPS,    197.78 GOPS
999   13.53 ms run,    1.75 ms python,   11.78 ms HIP,  493.00 loss, 0.000086 LR, 2.08 GB used,  14618.84 GFLOPS,    197.78 GOPS
shuffling test dataset in 51.91 ms (epoch=0)
eval     9610/10240 93.85%,    0.40 val_loss STEP=1000 (in 2887.89 ms)
eval_acc_pct=93.84765625 >= 93.0

real	1m14.793s
user	0m56.854s
sys	0m23.821s
```

for `LATEWINO=0`, tensor core-eligible kernels go from 7 to 18 and reduces single GPU step time from 48ms to 34ms with `time HIP=1 HALF=1 STEPS=1000 LATEWINO=0 LATEBEAM=16 BEAM_LOOSE_TC=1 BEAM_UPCAST_MAX=4096 BEAM_LOCAL_MAX=512 BEAM_MIN_PROGRESS=25 TARGET_EVAL_ACC_PCT=93 python3 examples/hlb_cifar10.py`:

```
995   33.54 ms run,    1.89 ms python,   31.64 ms HIP,  496.00 loss, 0.000102 LR, 2.38 GB used,  20128.66 GFLOPS,    675.01 GOPS
996   33.64 ms run,    1.88 ms python,   31.77 ms HIP,  494.50 loss, 0.000099 LR, 2.38 GB used,  20064.42 GFLOPS,    675.01 GOPS
997   33.20 ms run,    1.57 ms python,   31.63 ms HIP,  496.25 loss, 0.000094 LR, 2.38 GB used,  20333.03 GFLOPS,    675.01 GOPS
998   33.32 ms run,    1.56 ms python,   31.76 ms HIP,  494.75 loss, 0.000089 LR, 2.38 GB used,  20259.64 GFLOPS,    675.01 GOPS
999   33.03 ms run,    1.58 ms python,   31.45 ms HIP,  491.50 loss, 0.000086 LR, 2.38 GB used,  20435.47 GFLOPS,    675.01 GOPS
shuffling test dataset in 60.42 ms (epoch=0)
eval     9611/10240 93.86%,    0.40 val_loss STEP=1000 (in 716.13 ms)
eval_acc_pct=93.857421875 >= 93.0

real	0m56.127s
user	0m24.191s
sys	0m37.729s
```
