### PR TITLE
Directly store float4 nodes

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -766,10 +766,13 @@ class TestLinearizerUOptimize(unittest.TestCase):
     k.linearize()
 
     # check that the float4 cast collapses
+    #print(Device[Device.DEFAULT].compiler.render(k.name, k.uops))
     store_vals = [u.vin[-1] for u in k.uops if u.uop is UOps.STORE]
     for val in store_vals:
       assert val.dtype == dtypes.float.vec(4) and val.uop != UOps.CAST
 
+
+  @unittest.skip("TODO: support locals replacement across the uop graph")
   def test_grouped_store_locals_and_globals(self):
     if not Device[Device.DEFAULT].compiler.linearizer_opts.has_local or not Device[Device.DEFAULT].compiler.linearizer_opts.has_shared:
       self.skipTest("Only Compiled uses linearizer with locals and shared")
@@ -792,6 +795,7 @@ class TestLinearizerUOptimize(unittest.TestCase):
       assert store.vin[-1].dtype == dtypes.float.vec(2) and store.vin[-1].uop != UOps.CAST
     assert barrier.vin == tuple(local_stores)
 
+  @unittest.skip("TODO: support locals replacement across the uop graph")
   def test_grouped_store_vals(self):
     x = Tensor.randn((4,3,6,6)).realize()
     out = x.flip((0,1)).contiguous()

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -756,5 +756,52 @@ class TestLinearizerHelper(unittest.TestCase):
     idxs = (uidx0 // 5, uidx0 * 5, uidx1)
     assert expand_idxs(idxs) == (uidx0, NumNode(0), uidx1)
 
+class TestLinearizerUOptimize(unittest.TestCase):
+  def test_grouped_store_phis(self):
+    x, y = Tensor.randn(64,64), Tensor.randn(64,64)
+    out = x.matmul(y)
+
+    k = Linearizer(create_schedule([out.lazydata])[-1].ast)
+    k.hand_coded_optimizations()
+    k.linearize()
+
+    # check that the float4 cast collapses
+    store_vals = [u.vin[-1] for u in k.uops if u.uop is UOps.STORE]
+    for val in store_vals:
+      assert val.dtype == dtypes.float.vec(4) and val.uop != UOps.CAST
+
+  def test_grouped_store_locals_and_globals(self):
+    if not Device[Device.DEFAULT].compiler.linearizer_opts.has_local or not Device[Device.DEFAULT].compiler.linearizer_opts.has_shared:
+      self.skipTest("Only Compiled uses linearizer with locals and shared")
+
+    x, y = Tensor.rand(128, 128), Tensor.rand(128, 128)
+    out = x@y
+
+    opts = [Opt(OptOps.LOCAL, 0, 4), Opt(OptOps.GROUPTOP, 0, 8),
+            Opt(OptOps.UNROLL, 0, 4), Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.UPCAST, 1, 2)] # upcast accs in both reduces
+    k = Linearizer(create_schedule([out.lazydata])[-1].ast)
+    for opt in opts: k.apply_opt(opt)
+    k.linearize()
+
+    local_stores = [u for u in k.uops if u.uop is UOps.STORE and u.vin[0].uop is UOps.DEFINE_LOCAL]
+    barrier = [u for u in k.uops if u.uop is UOps.BARRIER][0]
+    global_stores = [u for u in k.uops if u.uop is UOps.STORE and u.vin[0].uop is UOps.DEFINE_GLOBAL]
+
+    # check that the float4 cast collapses for all stores
+    for store in local_stores+global_stores:
+      assert store.vin[-1].dtype == dtypes.float.vec(2) and store.vin[-1].uop != UOps.CAST
+    assert barrier.vin == tuple(local_stores)
+
+  def test_grouped_store_vals(self):
+    x = Tensor.randn((4,3,6,6)).realize()
+    out = x.flip((0,1)).contiguous()
+
+    k = Linearizer(create_schedule([out.lazydata])[-1].ast)
+    k.hand_coded_optimizations()
+    k.linearize()
+
+    store_val = [u.vin[-1] for u in k.uops if u.uop is UOps.STORE][0]
+    assert store_val.dtype == dtypes.float.vec(4) and store_val.uop != UOps.CAST
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import functools, math
-from typing import List, Set, Optional, Tuple, Any, Dict, DefaultDict
+from typing import List, Set, Optional, Tuple, Any, Dict, DefaultDict, cast
 from collections import defaultdict
 from tinygrad.helpers import DEBUG, flatten, all_same
 from tinygrad.dtype import dtypes, DType
@@ -58,6 +58,10 @@ def uop_alu_resolve(u:UOp) -> sint:
     return uop_alu_resolve(u.vin[0]) + uop_alu_resolve(u.vin[1])
   else:
     raise RuntimeError(f"ALU resolve fail @ {u.uop}")
+
+def phi_resolve_acc(u:UOp) -> UOp:
+  if u.uop == UOps.DEFINE_ACC: return u
+  return phi_resolve_acc(u.vin[0])
 
 class UOpGraph:
   def __init__(self):
@@ -218,6 +222,17 @@ class UOpGraph:
 
     # (recursively) remove childless uops
     self.remove_childless()
+
+    # store float4 upcasts directly if possible
+    replaced_stores: Dict[UOp,UOp] = {}
+    for u in self.uops:
+      if u.uop is not UOps.STORE or (val:=u.vin[-1]).uop is not UOps.CAST or cast(DType,val.dtype).count == 1: continue
+      if u.vin[0].uop is UOps.DEFINE_LOCAL: continue # TODO add support for local store
+      if all(el.uop is UOps.GEP for el in val.vin): replaced_stores[u] = val.vin[0].vin[0]
+      elif all(el.uop is UOps.PHI for el in val.vin): replaced_stores[u] = phi_resolve_acc(val)
+    for prev,new in replaced_stores.items():
+      self.add(UOps.STORE, prev.dtype, (prev.vin[0],prev.vin[1],new), insert_before=self.uops.index(prev))
+      self.uops.remove(prev)
 
     # add UOps.END*
     self.add_ends()

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -250,4 +250,3 @@ class UOpGraph:
         elif u.arg == "__cuda_mma_m16n8k16_f16_f32": flops += 2*(8*16*16)//32 * mults
         else: raise Exception("not implemented")
     return flops, mem
-

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -81,7 +81,8 @@ class CStyleLanguage(NamedTuple):
     if self.uses_vload and buf_dtype.scalar() == dtypes.float16 and var_dtype.scalar() != dtypes.float16:
       return f"vstore_half{'' if var_dtype.count == 1 else str(var_dtype.count)}({var_name}, 0, {buf_name}+{idx});"
     if var_dtype.count > 1:
-      return f"*(({self.smem_prefix if local and self.smem_prefix_for_cast else self.buffer_prefix}{buf_dtype.name}{var_dtype.count}*)({buf_name}+{idx})) = ({buf_dtype.name}{var_dtype.count}){var_name};"  # noqa: E501
+      prefix = self.smem_prefix if local and self.smem_prefix_for_cast else self.buffer_prefix
+      return f"*(({prefix}{buf_dtype.name}{var_dtype.count}*)({buf_name}+{idx})) = {var_name};"
     return f"*({buf_name}+{idx}) = {var_name};" if self.uses_ptr_arithmetic else f"{buf_name}[{idx}] = {var_name};"
 
   def render_local(self, name:str, dtype:DType, size:int): return self.smem_align + self.smem_prefix + f"{dtype.name} {name}[{size}];"


### PR DESCRIPTION
#3551
This optimization works with both:

1. PHI nodes `TestOps.test_gemm`
```
__kernel void r_2_16_8_16_4_4_4n2(__global float* data0, __global float* data1) {
  // this branch
  *((__global float4*)(data0+idx)) = acc0;
  // master
  *((__global float4*)(data0+idx)) = (float4)(float4)((acc0).x,(acc0).y,(acc0).z,(acc0).w);
}
```
2. float4 values `TestOps.test_avgpool2d`
```
__kernel void E_2_37_7_3_2_16_4n3(__global float* data0, __global float* data1) {
  // this branch
  *((__global float4*)(data0+idx)) = val0;
  // master
  *((__global float4*)(data0+idx)) = (float4)(float4)((val0).x,(val0).y,(val0).z,(val0).w);
}
```
I limited this to global stores only, because they're already childless.
Next is supporting local store and accurately updating its children in the UOpGraph.