### PR TITLE
Don't touch UOps.DEFINE_GLOBAL

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -88,12 +88,14 @@ class UOpGraph:
     return ret
 
   def remove_childless(self):
+    UOPS_W_SIDE_EFFECTS = {UOps.DEFINE_GLOBAL, UOps.STORE}
+
     while 1:
       has_child: Set[UOp] = set()
       for ru in self.uops:
         for vu in ru.vin:
           has_child.add(vu)
-      nu: List[UOp] = [x for x in self.uops if x in has_child or x.uop is UOps.STORE]
+      nu: List[UOp] = [x for x in self.uops if x in has_child or x.uop in UOPS_W_SIDE_EFFECTS]
       if len(nu) == len(self.uops): break
       if DEBUG >= 4: print(f"reduced UOp count from {len(self.uops)} to {len(nu)}")
       self.uops = nu


### PR DESCRIPTION
2c19ab6561f4f70f7bc4cac002fa4f0fc8e81c4d broke sharded LLaMA with ring_allreduce (#3000).
Simple reproducer:
```python
DEVICE = "CLANG"   # NOTE: you can change this!

import struct
from tinygrad.dtype import dtypes
from tinygrad.device import Buffer, Device
from tinygrad.ops import LazyOp, BufferOps, MemBuffer, ConstBuffer, BinaryOps
from tinygrad.shape.shapetracker import ShapeTracker

# allocate some buffers + load in values
out = Buffer(DEVICE, 1, dtypes.int32)
a = Buffer(DEVICE, 1, dtypes.int32).copyin(memoryview(bytearray(struct.pack("I", 2))))
b = Buffer(DEVICE, 1, dtypes.int32).copyin(memoryview(bytearray(struct.pack("I", 3))))
# NOTE: a._buf is the same as the return from MallocAllocator.alloc

# describe the computation
ld_1 = LazyOp(BufferOps.LOAD, (), MemBuffer(1, dtypes.int32, ShapeTracker.from_shape((1,))))
ld_2 = LazyOp(BufferOps.LOAD, (), MemBuffer(2, dtypes.int32, ShapeTracker.from_shape((1,))))
zero = LazyOp(BufferOps.CONST, (), ConstBuffer(0, dtypes.int32, ShapeTracker.from_shape((1,))))
alu0 = LazyOp(BinaryOps.MUL, (ld_1, zero))
alu1 = LazyOp(BinaryOps.ADD, (alu0, ld_2))
st_0 = LazyOp(BufferOps.STORE, (alu1,), MemBuffer(0, dtypes.int32, ShapeTracker.from_shape((1,))))

# convert the computation to a "linearized" format (print the format)
lin = Device[DEVICE].get_linearizer(st_0).linearize()
for u in lin.uops: print(u)

# compile a program (and print the source)
fxn = Device[DEVICE].to_program(lin)
print(fxn.prg)
# NOTE: fxn.clprg is the ClangProgram

# run the program
fxn.exec([out, a, b])

# check the data out
assert out.as_buffer().cast('I')[0] == 3
```
Before:
```
(.venv) [user@macbook ~/src/tinygrad]% DEBUG=5 python fun6.py
  0 ━┳ STORE MemBuffer(idx=0, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),)))
  1  ┗━┳ ADD 
  2    ┣━┳ MUL 
  3    ┃ ┣━━ LOAD MemBuffer(idx=1, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),)))
  4    ┃ ┗━━ CONST ConstBuffer(val=0, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),)))
  5    ┗━━ LOAD MemBuffer(idx=2, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),)))
reduced UOp count from 7 to 6
reduced UOp count from 6 to 5
   0 UOps.DEFINE_GLOBAL  : ptr.dtypes.int            []                               (0, 'data0')
   1 UOps.DEFINE_GLOBAL  : ptr.dtypes.int            []                               (2, 'data2')
   2 UOps.CONST          : dtypes.int                []                               0
   3 UOps.LOAD           : dtypes.int                [1, 2]                           None
   4 UOps.STORE          :                           [0, 2, 3]                        None
UOps.DEFINE_GLOBAL  : ptr.dtypes.int            []                               (0, 'data0')
UOps.DEFINE_GLOBAL  : ptr.dtypes.int            []                               (2, 'data2')
UOps.CONST          : dtypes.int                []                               0
UOps.LOAD           : dtypes.int                [<UOps.DEFINE_GLOBAL: 6>, <UOps.CONST: 12>] None
UOps.STORE          :                           [<UOps.DEFINE_GLOBAL: 6>, <UOps.CONST: 12>, <UOps.LOAD: 10>] None
Traceback (most recent call last):
  File "/Users/user/src/tinygrad/fun6.py", line 28, in <module>
    fxn = Device[DEVICE].to_program(lin)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/device.py", line 243, in to_program
    ret = CompiledASTRunner(k.name, self.compiler.render(to_function_name(k.name), k.uops), self, k.global_size, k.local_size,
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/runtime/ops_clang.py", line 11, in render
    def render(self, name:str, uops) -> str: return uops_to_cstyle(CStyleLanguage(buffer_suffix=" restrict"), name, uops)
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/src/tinygrad/tinygrad/renderer/cstyle.py", line 168, in uops_to_cstyle
    assert len(bufs) == args[0], f"missed a global buffer {len(bufs)} {args}"
           ^^^^^^^^^^^^^^^^^^^^
AssertionError: missed a global buffer 1 (2, 'data2')
(.venv) [user@macbook ~/src/tinygrad]%
```
After:
```
(.venv) [user@macbook ~/src/tinygrad]% DEBUG=5 python fun6.py          
  0 ━┳ STORE MemBuffer(idx=0, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),)))
  1  ┗━┳ ADD 
  2    ┣━┳ MUL 
  3    ┃ ┣━━ LOAD MemBuffer(idx=1, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),)))
  4    ┃ ┗━━ CONST ConstBuffer(val=0, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),)))
  5    ┗━━ LOAD MemBuffer(idx=2, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),)))
reduced UOp count from 7 to 6
   0 UOps.DEFINE_GLOBAL  : ptr.dtypes.int            []                               (0, 'data0')
   1 UOps.DEFINE_GLOBAL  : ptr.dtypes.int            []                               (1, 'data1')
   2 UOps.DEFINE_GLOBAL  : ptr.dtypes.int            []                               (2, 'data2')
   3 UOps.CONST          : dtypes.int                []                               0
   4 UOps.LOAD           : dtypes.int                [2, 3]                           None
   5 UOps.STORE          :                           [0, 3, 4]                        None
UOps.DEFINE_GLOBAL  : ptr.dtypes.int            []                               (0, 'data0')
UOps.DEFINE_GLOBAL  : ptr.dtypes.int            []                               (1, 'data1')
UOps.DEFINE_GLOBAL  : ptr.dtypes.int            []                               (2, 'data2')
UOps.CONST          : dtypes.int                []                               0
UOps.LOAD           : dtypes.int                [<UOps.DEFINE_GLOBAL: 6>, <UOps.CONST: 12>] None
UOps.STORE          :                           [<UOps.DEFINE_GLOBAL: 6>, <UOps.CONST: 12>, <UOps.LOAD: 10>] None
void E_(int* restrict data0, const int* restrict data1, const int* restrict data2) {
  int val0 = data2[0];
  data0[0] = val0;
}
void E_(int* restrict data0, const int* restrict data1, const int* restrict data2) {
  int val0 = data2[0];
  data0[0] = val0;
}
*** CLANG      1 E_                                     arg   3 mem  0.00 GB tm     13.08us/     0.01ms (    0.00 GFLOPS,    0.00 GB/s)
avg:     0.00 GFLOPS     0.00 GB/s           total:     1 kernels     0.00 GOPS     0.00 GB     0.01 ms
(.venv) [user@macbook ~/src/tinygrad]%
```