### PR TITLE
WIP: O(n) embedding: put it in one kernel

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -228,7 +228,7 @@ class Tensor:
   def arange(start, stop=None, step=1, **kwargs):
     if stop is None: stop, start = start, 0
     dtype = kwargs.pop("dtype", dtypes.default_float if any(isinstance(x, float) for x in (start, stop, step)) else dtypes.default_int)
-    return (Tensor.full((math.ceil((stop-start)/step),), step, dtype=dtype, **kwargs).cumsum() + (start - step)).cast(dtype)
+    return (Tensor.full((math.ceil((stop-start)/step),), step, dtype=dtype, **kwargs)._cumsum() + (start - step)).cast(dtype)
 
   @staticmethod
   def eye(dim:int, **kwargs):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -228,7 +228,7 @@ class Tensor:
   def arange(start, stop=None, step=1, **kwargs):
     if stop is None: stop, start = start, 0
     dtype = kwargs.pop("dtype", dtypes.default_float if any(isinstance(x, float) for x in (start, stop, step)) else dtypes.default_int)
-    return (Tensor.full((math.ceil((stop-start)/step),), step, dtype=dtype, **kwargs)._cumsum() + (start - step)).cast(dtype)
+    return (Tensor.full((math.ceil((stop-start)/step)-1,), step, dtype=dtype, **kwargs)._cumsum(_first_zero=True)).cast(dtype)
 
   @staticmethod
   def eye(dim:int, **kwargs):


### PR DESCRIPTION
`NOOPT=1 TC=0 DEBUG=4 GRAPH=1 python3 test/external/external_test_mnist_data_select.py`

```C
#include <metal_stdlib>
using namespace metal;
kernel void r_512_784_60000(device float* data0, const device int* data1, const device int* data2, const device float* data3, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int gidx0 = gid.y; /* 512 */
  int gidx1 = gid.x; /* 784 */
  float acc0 = 0.0f;
  int val0 = *(data1+gidx0);
  for (int ridx0 = 0; ridx0 < 60000; ridx0++) {
    int val1 = *(data2+ridx0);
    float val2 = *(data3+gidx1+(ridx0*784));
    acc0 = (((float)((val0==val1))*val2)+acc0);
  }
  *(data0+(gidx0*784)+gidx1) = acc0;
}
```