### PR TITLE
Improve type hints for optimizer

### DIFF
--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -21,7 +21,7 @@ class Optimizer:
   def realize(self, extra=None):
     # NOTE: in extra is too late for most of the params due to issues with assign
     Tensor.corealize(extra + self.params + self.buffers if extra is not None else self.params + self.buffers)
-    
+
   def step(self) -> None: raise NotImplementedError
 
 class SGD(Optimizer):

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -21,6 +21,8 @@ class Optimizer:
   def realize(self, extra=None):
     # NOTE: in extra is too late for most of the params due to issues with assign
     Tensor.corealize(extra + self.params + self.buffers if extra is not None else self.params + self.buffers)
+    
+  def step(self) -> None: raise NotImplementedError
 
 class SGD(Optimizer):
   def __init__(self, params: List[Tensor], lr=0.001, momentum=0, weight_decay=0.0, nesterov=False):


### PR DESCRIPTION
Currently using functions that take an arbitary optimizer as a parameter is impossible with type hints
```py
def train_step(optimizer: nn.optim.Optimizer)
...
        optimizer.step() # error - no member named step
...
```