### PR TITLE
Fix two bugs concerning `Tensor.to`.

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -339,6 +339,19 @@ class TestMoveTensor(unittest.TestCase):
     assert s.dtype == t.dtype
     assert s.requires_grad == t.requires_grad
 
+  @given(strat.sampled_from([d0, d1]))
+  def test_same_dev(self, dev):
+    x = Tensor([1,2,3], device=dev)
+    y = x.to(dev)
+    assert x is y
+
+  def test_to_grad(self):
+    x = Tensor.eye(3, requires_grad=True, device=self.d0)
+    y = Tensor([[2.0,0,-2.0]], requires_grad=True, device=self.d0)
+    z = y.matmul(x).to(self.d1).sum()
+    z.backward()
+    np.testing.assert_equal(x.grad.numpy(), [[2,2,2],[0,0,0],[-2,-2,-2]])
+
 class TestZeroShapeTensor(unittest.TestCase):
   def test_shape_stride(self):
     t = Tensor.rand(3, 2, 0)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -174,10 +174,12 @@ class Tensor:
     return np.frombuffer(self._data(), dtype=self.dtype.np).reshape(self.shape)
 
   def to(self, device:Optional[Union[str, Tuple[str, ...]]]) -> Tensor:
+    device = tuple(Device.canonicalize(x) for x in device) if isinstance(device, (tuple, list)) else Device.canonicalize(device)
     if device is None or device == self.device: return self
     if not isinstance(device, str): return self.shard(device)
     ret = Tensor(self.lazydata, device, requires_grad=self.requires_grad)
     if self.grad: ret.grad = self.grad.to(device)
+    if hasattr(self, '_ctx'): ret._ctx = self._ctx
     return ret
 
   def to_(self, device:Optional[Union[str, Tuple[str, ...]]]):


### PR DESCRIPTION
1. `Tensor.to` should return `self` if `device == self.device`. This was not the case if provided with non-canonical name of `self.device` (e.g. `HIP` and `HIP:0`).
2. `Tensor.to` result was missing graph (`_ctx`), even though `requires_grad` and `grad` were propagated .

Add corresponding tests.
~~As a bonus, missing return type for deepwalk~~ ←I think I get why it's missing now.