### PR TITLE
Fix softmax.argmax issue

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -752,7 +752,6 @@ class TestOps(unittest.TestCase):
     helper_test_op([(10,10,10)], lambda x: x.softmax(0), atol=1e-7, grad_atol=1e-7)
     helper_test_op([(10,10,10)], lambda x: x.softmax(1), atol=1e-7, grad_atol=1e-7)
     helper_test_op([(10,10,10)], lambda x: x.softmax(2), atol=1e-7, grad_atol=1e-7)
-  @unittest.skipIf(CI and Device.DEFAULT in ["CLANG", "PYTHON"], "Broken ISSUE #3552")
   def test_softmax_argmax(self):
     helper_test_op([(45,65)], lambda x: x.softmax(0).argmax(), forward_only=True, atol=1e-7, grad_atol=1e-7)
     helper_test_op([(45,65)], lambda x: x.softmax(1).argmax(), forward_only=True, atol=1e-7, grad_atol=1e-7)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -595,11 +595,12 @@ class Tensor:
     return m - ss.log()
 
   def argmax(self, axis=None, keepdim=False):
+    def _eq(a:Tensor, b:Tensor): return (a - b).abs() < 1e-6 if a.is_floating_point() else a == b
     if axis is None:
-      idx = (self == self.max(axis)) * Tensor.arange(prod(self.shape)-1,-1,-1, requires_grad=False, device=self.device).reshape(self.shape)
+      idx = _eq(self, self.max(axis)) * Tensor.arange(prod(self.shape)-1,-1,-1, requires_grad=False, device=self.device).reshape(self.shape)
       return (prod(self.shape) - idx.max() - 1).cast(dtypes.default_int)
     axis = axis + len(self.shape) if axis < 0 else axis
-    m = self == self.max(axis=axis, keepdim=True)
+    m = _eq(self, self.max(axis, keepdim=True))
     idx = m * Tensor.arange(self.shape[axis]-1,-1,-1, requires_grad=False, device=self.device).reshape(self.shape[axis], *[1]*(self.ndim-axis-1))
     return (self.shape[axis]-idx.max(axis=axis, keepdim=keepdim)-1).cast(dtypes.default_int)
   def argmin(self, axis=None, keepdim=False): return (-self).argmax(axis=axis, keepdim=keepdim)


### PR DESCRIPTION
argmax is finding max + finding argmax. The finding max part fused with softmax and introduced numerical error. The resulting max can be different from any of the tensor element, and argmax returned size - 1 as a result. One way to fix it is to include eps when comparing with float max.

Also there's no mismatch if there's a realize between softmax and argmax.

Fixed #3552 but I don't really like this. Open as a draft for now.