### PR TITLE
use f32 by default to calculate in randn

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -158,12 +158,10 @@ class TestTinygrad(unittest.TestCase):
 
   def test_randn_fp16(self):
     # low precision can result in inf from randn
-    old_default_float = dtypes.default_float
-    try:
-      dtypes.default_float = dtypes.float16
-      assert Tensor.randn((2, 128, 128)).abs().max().numpy().item() != float('inf')
-    finally:
-      dtypes.default_float = old_default_float
+    old_default_float, dtypes.default_float = dtypes.default_float, dtypes.float16
+    # this is way too small to fail consistently, increase to (4, 128, 128) if needed
+    assert Tensor.randn(2048).abs().max().numpy().item() != float('inf')
+    dtypes.default_float = old_default_float
 
   def test_zeros_like_has_same_dtype_and_shape(self):
     for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -156,6 +156,14 @@ class TestTinygrad(unittest.TestCase):
     except: raise
     finally: Tensor.rand = original_rand
 
+  def test_randn_fp16(self):
+    # low precision can result in inf from randn
+    old_default_float, dtypes.default_float = dtypes.default_float, dtypes.float16
+    try:
+      assert Tensor.randn((2, 128, 128)).abs().max().numpy().item() != float('inf')
+    finally:
+      dtypes.default_float = old_default_float
+
   def test_zeros_like_has_same_dtype_and_shape(self):
     for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
       a = Tensor([1, 2, 3], dtype=datatype)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -158,8 +158,9 @@ class TestTinygrad(unittest.TestCase):
 
   def test_randn_fp16(self):
     # low precision can result in inf from randn
-    old_default_float, dtypes.default_float = dtypes.default_float, dtypes.float16
+    old_default_float = dtypes.default_float
     try:
+      dtypes.default_float = dtypes.float16
       assert Tensor.randn((2, 128, 128)).abs().max().numpy().item() != float('inf')
     finally:
       dtypes.default_float = old_default_float

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -246,7 +246,7 @@ class Tensor:
   @staticmethod
   def randn(*shape, dtype:Optional[DType]=None, **kwargs) -> Tensor:
     # https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
-    src = Tensor.rand((2, *argfix(*shape)), dtype=least_upper_dtype(dtype or dtypes.default_float, dtypes.float32), **kwargs)
+    src = Tensor.rand((2, *argfix(*shape)), dtype=least_upper_float(dtype or dtypes.default_float), **kwargs)
     return src[0].mul(2*math.pi).cos().mul((1 - src[1]).log().mul(-2).sqrt()).cast(dtype or dtypes.default_float)
 
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -246,7 +246,7 @@ class Tensor:
   @staticmethod
   def randn(*shape, dtype:Optional[DType]=None, **kwargs) -> Tensor:
     # https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
-    src = Tensor.rand((2, *argfix(*shape)), dtype=dtypes.float32, **kwargs)
+    src = Tensor.rand((2, *argfix(*shape)), dtype=least_upper_dtype(dtype or dtypes.default_float, dtypes.float32), **kwargs)
     return src[0].mul(2*math.pi).cos().mul((1 - src[1]).log().mul(-2).sqrt()).cast(dtype or dtypes.default_float)
 
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -246,7 +246,7 @@ class Tensor:
   @staticmethod
   def randn(*shape, dtype:Optional[DType]=None, **kwargs) -> Tensor:
     # https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
-    src = Tensor.rand((2, *argfix(*shape)), **kwargs)
+    src = Tensor.rand((2, *argfix(*shape)), dtype=dtypes.float32, **kwargs)
     return src[0].mul(2*math.pi).cos().mul((1 - src[1]).log().mul(-2).sqrt()).cast(dtype or dtypes.default_float)
 
   @staticmethod


### PR DESCRIPTION
There are many places in the codebase where fp16 is not adequate for some particular calculation. sum() is handled well; it selects least upper dtype with float32. We might have to go around the codebase and do least upper dtype with float32 in all places that need it. 