### PR TITLE
Fix Tensor.dropout() with multigpu

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -363,6 +363,13 @@ class TestMultiTensor(unittest.TestCase):
     with self.assertRaises(AssertionError):
       # don't allow assigns that change axes
       t_none.assign(t_zero)
+  
+  def test_dropout_on_shard(self):
+    Tensor.training = True
+    X = Tensor.ones(256).to(devices_2)
+    output = X.dropout(0.5)
+    output.numpy()
+    Tensor.training = False
 
 @unittest.skipIf(CI and Device.DEFAULT in {"GPU", "CUDA", "METAL"}, "no GPU CI")
 class TestShrinkMultiTensorShardedAxis(unittest.TestCase):

--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -363,7 +363,7 @@ class TestMultiTensor(unittest.TestCase):
     with self.assertRaises(AssertionError):
       # don't allow assigns that change axes
       t_none.assign(t_zero)
-  
+
   def test_dropout_on_shard(self):
     Tensor.training = True
     X = Tensor.ones(256).to(devices_2)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -202,7 +202,11 @@ class Tensor:
 
   @staticmethod
   def _loadop(op, shape, device:Optional[Union[Tuple[str], str]]=None, dtype:Optional[DType]=None, arg=None, **kwargs):
-    return Tensor(_loadop(op, shape, dtype or dtypes.default_float, device if device else Device.canonicalize(device), arg, kwargs.get("src", None)), dtype=dtype, device=device, **kwargs)
+    device, dtype, src = device if device else Device.canonicalize(device), dtype or dtypes.default_float, kwargs.get("src", None)
+    if isinstance(device, tuple):
+      return Tensor(MultiLazyBuffer([LazyBuffer.loadop(op, shape, dtype, d, arg, src) for d in device], None), device, dtype, **kwargs)
+    else: 
+      return Tensor(LazyBuffer.loadop(op, shape, dtype, device, arg, src), device, dtype, **kwargs)
 
   @staticmethod
   def empty(*shape, **kwargs): return Tensor._loadop(LoadOps.EMPTY, argfix(*shape), **kwargs)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -205,8 +205,7 @@ class Tensor:
     device, dtype, src = device if device else Device.canonicalize(device), dtype or dtypes.default_float, kwargs.get("src", None)
     if isinstance(device, tuple):
       return Tensor(MultiLazyBuffer([LazyBuffer.loadop(op, shape, dtype, d, arg, src) for d in device], None), device, dtype, **kwargs)
-    else:
-      return Tensor(LazyBuffer.loadop(op, shape, dtype, device, arg, src), device, dtype, **kwargs)
+    return Tensor(LazyBuffer.loadop(op, shape, dtype, device, arg, src), device, dtype, **kwargs)
 
   @staticmethod
   def empty(*shape, **kwargs): return Tensor._loadop(LoadOps.EMPTY, argfix(*shape), **kwargs)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -201,8 +201,8 @@ class Tensor:
   # ***** creation llop entrypoint *****
 
   @staticmethod
-  def _loadop(op, shape, device:Optional[str]=None, dtype:Optional[DType]=None, arg=None, **kwargs):
-    return Tensor(LazyBuffer.loadop(op, shape, dtype or dtypes.default_float, Device.canonicalize(device), arg), dtype=dtype, device=device, **kwargs)
+  def _loadop(op, shape, device:Optional[Union[Tuple[str], str]]=None, dtype:Optional[DType]=None, arg=None, **kwargs):
+    return Tensor(_loadop(op, shape, dtype or dtypes.default_float, device if device else Device.canonicalize(device), arg, kwargs.get("src", None)), dtype=dtype, device=device, **kwargs)
 
   @staticmethod
   def empty(*shape, **kwargs): return Tensor._loadop(LoadOps.EMPTY, argfix(*shape), **kwargs)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -202,10 +202,10 @@ class Tensor:
 
   @staticmethod
   def _loadop(op, shape, device:Optional[Union[Tuple[str], str]]=None, dtype:Optional[DType]=None, arg=None, **kwargs):
-    device, dtype, src = device if device else Device.canonicalize(device), dtype or dtypes.default_float, kwargs.get("src", None)
     if isinstance(device, tuple):
-      return Tensor(MultiLazyBuffer([LazyBuffer.loadop(op, shape, dtype, d, arg, src) for d in device], None), device, dtype, **kwargs)
-    return Tensor(LazyBuffer.loadop(op, shape, dtype, device, arg, src), device, dtype, **kwargs)
+      return Tensor(MultiLazyBuffer([LazyBuffer.loadop(op, shape, dtype or dtypes.default_float, Device.canonicalize(d), arg) \
+                                      for d in device], None), device, dtype, **kwargs)
+    return Tensor(LazyBuffer.loadop(op, shape, dtype or dtypes.default_float, Device.canonicalize(device), arg), device, dtype, **kwargs)
 
   @staticmethod
   def empty(*shape, **kwargs): return Tensor._loadop(LoadOps.EMPTY, argfix(*shape), **kwargs)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -205,7 +205,7 @@ class Tensor:
     device, dtype, src = device if device else Device.canonicalize(device), dtype or dtypes.default_float, kwargs.get("src", None)
     if isinstance(device, tuple):
       return Tensor(MultiLazyBuffer([LazyBuffer.loadop(op, shape, dtype, d, arg, src) for d in device], None), device, dtype, **kwargs)
-    else: 
+    else:
       return Tensor(LazyBuffer.loadop(op, shape, dtype, device, arg, src), device, dtype, **kwargs)
 
   @staticmethod


### PR DESCRIPTION
Right now `.dropout()` can not be used with multigpu. `.rand()`, which is called under the hood, uses `Tensor._loadop()` which cannot handle multidevice strings.