### PR TITLE
bump python version for CI runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,15 +64,15 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Cache python packages
       uses: actions/cache@v3
       with:
-        path: ${{ env.Python3_ROOT_DIR }}/lib/python3.8/site-packages
-        key: linting-packages-${{ hashFiles('**/setup.py') }}-3.8
+        path: ${{ env.Python3_ROOT_DIR }}/lib/python3.11/site-packages
+        key: linting-packages-${{ hashFiles('**/setup.py') }}-3.11
     - name: Install dependencies
       run: pip install -e '.[linting,testing]' --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Lint with pylint
@@ -118,14 +118,14 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Cache python packages
       uses: actions/cache@v3
       with:
-        path: ${{ env.Python3_ROOT_DIR }}/lib/python3.8/site-packages
+        path: ${{ env.Python3_ROOT_DIR }}/lib/python3.11/site-packages
         key: testing-packages-${{ hashFiles('**/setup.py') }}
     - name: Cache downloads
       uses: actions/cache@v3


### PR DESCRIPTION
I will need `graphlib` for multioutput but python 3.8 doesn't have it:
<img width="759" alt="Screenshot 2024-03-05 at 10 29 39 PM" src="https://github.com/tinygrad/tinygrad/assets/77887910/31450ce5-8d27-49f7-b073-fee35aea794e">

https://github.com/tinygrad/tinygrad/actions/runs/8146284687/job/22264451342
