### PR TITLE
fix outdated URL in showcase docs

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -8,7 +8,7 @@ Despite being a tiny library, tinygrad is capable of doing a lot of things. From
 
 You can either pass in the URL of a picture to discover what it is:
 ```sh
-python3 examples/efficientnet.py https://media.istockphoto.com/photos/hen-picture-id831791190
+python3 examples/efficientnet.py ./test/models/efficientnet/Chicken.jpg
 ```
 Or, if you have a camera and OpenCV installed, you can detect what is in front of you:
 ```sh


### PR DESCRIPTION
This PR addresses outdated URLs in
https://github.com/tinygrad/tinygrad/blob/8500265561dc7402a7773e9c8bd58713d49461b6/docs/showcase.md?plain=1#L11
by replacing them with valid image file paths in repo.

Your attention is appreciated, but I understand if this PR is disregarded.

Thank you,