### PR TITLE
test case to show clang and python doing math in double

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -530,5 +530,26 @@ class TestAutoCastType(unittest.TestCase):
     assert (Tensor([1, 2], dtype=dtypes.float16) / 2).dtype == dtypes.float16
     assert (Tensor([1, 2], dtype=dtypes.float16) / 2.0).dtype == dtypes.float16
 
+class TestImplicitFunctionTypeChange(unittest.TestCase):
+  def test_functions(self):
+    result = []
+    for func in [
+      lambda t: t.exp(),
+      lambda t: t.exp2(),
+      lambda t: t.log(),
+      lambda t: t.log2(),
+      lambda t: t.sqrt(),
+      lambda t: t.sin(),
+    ]:
+      t = func(Tensor([4.0, 3.0])).max() == func(Tensor([4.0, 3.0]))
+      result.append(t.numpy().sum())
+
+    if Device.DEFAULT not in ["PYTHON", "CLANG"]:
+      assert all(result)
+    else:
+      # CLANG and PYTHON function default returns in double, and comparison to float can fail
+      # TODO: fix this
+      assert not all(result)
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
clang and python ALU for sqrt/sin/exp2/log2 returns double for math, so even if in tinygrad dtypes those are all floats, the comparison might be float to double and can fail. There might also be an issue if we changed default float to half