### PR TITLE
[PoC] get kernel metadata from comgr, assert no spilled registers

### DIFF
--- a/tinygrad/runtime/driver/hip_comgr.py
+++ b/tinygrad/runtime/driver/hip_comgr.py
@@ -1,5 +1,6 @@
 import ctypes
 import tinygrad.runtime.autogen.comgr as comgr
+from tinygrad.helpers import DEBUG
 
 def check(status):
   if status != 0:
@@ -12,6 +13,48 @@ def _get_comgr_data(data_set, data_type):
   check(comgr.amd_comgr_get_data(data_exec, ctypes.byref(sz), (dat := ctypes.create_string_buffer(sz.value))))
   check(comgr.amd_comgr_release_data(data_exec))
   return bytes(dat)
+def _get_comgr_data_metadata(data_set, data_type):
+  check(comgr.amd_comgr_action_data_get_data(data_set, data_type, 0, ctypes.byref(data_exec := comgr.amd_comgr_data_t())))
+  check(comgr.amd_comgr_get_data_metadata(data_exec, ctypes.byref(data_metadata := comgr.amd_comgr_metadata_node_t())))
+
+  metadata_keys = []
+  @ctypes.CFUNCTYPE(comgr.amd_comgr_status_t, comgr.amd_comgr_metadata_node_t, comgr.amd_comgr_metadata_node_t, ctypes.c_void_p)
+  def _map_callback(k, v, _):
+    check(comgr.amd_comgr_get_metadata_string(k, ctypes.byref(sz := ctypes.c_uint64()), None))
+    check(comgr.amd_comgr_get_metadata_string(k, ctypes.byref(sz), (kstr := ctypes.create_string_buffer(sz.value))))
+    metadata_keys.append(kstr)
+    return comgr.AMD_COMGR_STATUS_SUCCESS
+
+  def walk(node):
+    check(comgr.amd_comgr_get_metadata_kind(node, ctypes.byref(kind := comgr.amd_comgr_metadata_kind_t())))
+    if kind.value == comgr.AMD_COMGR_METADATA_KIND_MAP:
+      metadata_keys.clear()
+      check(comgr.amd_comgr_iterate_map_metadata(node, _map_callback, ctypes.c_void_p()))
+      ret = {}
+      # need to copy, since the global metadata_keys buffer can change in recursion
+      for k in metadata_keys[:]:
+        check(comgr.amd_comgr_metadata_lookup(node, k, ctypes.byref(map_v := comgr.amd_comgr_metadata_node_t())))
+        ret[k.value.decode()] = walk(map_v)
+        check(comgr.amd_comgr_destroy_metadata(map_v))
+    elif kind.value == comgr.AMD_COMGR_METADATA_KIND_LIST:
+      check(comgr.amd_comgr_get_metadata_list_size(node, ctypes.byref(list_sz := ctypes.c_uint64())))
+      ret = []
+      for i in range(list_sz.value):
+        check(comgr.amd_comgr_index_list_metadata(node, ctypes.c_size_t(i), ctypes.byref(list_v := comgr.amd_comgr_metadata_node_t())))
+        ret.append(walk(list_v))
+        check(comgr.amd_comgr_destroy_metadata(list_v))
+    elif kind.value == comgr.AMD_COMGR_METADATA_KIND_STRING:
+      check(comgr.amd_comgr_get_metadata_string(node, ctypes.byref(sz := ctypes.c_uint64()), None))
+      check(comgr.amd_comgr_get_metadata_string(node, ctypes.byref(sz), (rstr := ctypes.create_string_buffer(sz.value))))
+      ret = rstr.value.decode()
+    else:
+      assert False
+    return ret
+  ret = walk(data_metadata)
+
+  check(comgr.amd_comgr_destroy_metadata(data_metadata))
+  check(comgr.amd_comgr_release_data(data_exec))
+  return ret
 
 # AMD_COMGR_SAVE_TEMPS=1 AMD_COMGR_REDIRECT_LOGS=stdout AMD_COMGR_EMIT_VERBOSE_LOGS=1
 def compile_hip(prg:str, arch="gfx1100") -> bytes:
@@ -22,6 +65,7 @@ def compile_hip(prg:str, arch="gfx1100") -> bytes:
 
   check(comgr.amd_comgr_create_data_set(ctypes.byref(data_set_src := comgr.amd_comgr_data_set_t())))
   check(comgr.amd_comgr_create_data_set(ctypes.byref(data_set_bc := comgr.amd_comgr_data_set_t())))
+  check(comgr.amd_comgr_create_data_set(ctypes.byref(data_set_asm := comgr.amd_comgr_data_set_t())))
   check(comgr.amd_comgr_create_data_set(ctypes.byref(data_set_reloc := comgr.amd_comgr_data_set_t())))
   check(comgr.amd_comgr_create_data_set(ctypes.byref(data_set_exec := comgr.amd_comgr_data_set_t())))
 
@@ -37,11 +81,22 @@ def compile_hip(prg:str, arch="gfx1100") -> bytes:
     print(_get_comgr_data(data_set_bc, comgr.AMD_COMGR_DATA_KIND_LOG).decode())
     raise RuntimeError("compile failed")
   check(comgr.amd_comgr_action_info_set_options(action_info, b"-O3 -mllvm -amdgpu-internalize-symbols"))
-  check(comgr.amd_comgr_do_action(comgr.AMD_COMGR_ACTION_CODEGEN_BC_TO_RELOCATABLE, action_info, data_set_bc, data_set_reloc))
+  check(comgr.amd_comgr_do_action(comgr.AMD_COMGR_ACTION_CODEGEN_BC_TO_ASSEMBLY, action_info, data_set_bc, data_set_asm))
+  if DEBUG >= 6:
+    # there is more info in the assembly than in the metaata
+    asm = _get_comgr_data(data_set_asm, comgr.AMD_COMGR_DATA_KIND_SOURCE)
+    print(asm.decode())
+  check(comgr.amd_comgr_do_action(comgr.AMD_COMGR_ACTION_ASSEMBLE_SOURCE_TO_RELOCATABLE, action_info, data_set_asm, data_set_reloc))
   check(comgr.amd_comgr_action_info_set_options(action_info, b""))
   check(comgr.amd_comgr_do_action(comgr.AMD_COMGR_ACTION_LINK_RELOCATABLE_TO_EXECUTABLE, action_info, data_set_reloc, data_set_exec))
+  metadata = _get_comgr_data_metadata(data_set_exec, comgr.AMD_COMGR_DATA_KIND_EXECUTABLE)
+  if DEBUG >= 6:
+    import json
+    print(json.dumps(metadata, indent=2))
+  sgpr_spill, vgpr_spill = metadata["amdhsa.kernels"][0][".sgpr_spill_count"], metadata["amdhsa.kernels"][0][".vgpr_spill_count"]
+  assert sgpr_spill == "0" and vgpr_spill == "0", f"spilled registers: s{sgpr_spill} v{vgpr_spill}"
   ret = _get_comgr_data(data_set_exec, comgr.AMD_COMGR_DATA_KIND_EXECUTABLE)
   check(comgr.amd_comgr_release_data(data_src))
-  for x in [data_set_src, data_set_bc, data_set_reloc, data_set_exec]: check(comgr.amd_comgr_destroy_data_set(x))
+  for x in [data_set_src, data_set_bc, data_set_asm, data_set_reloc, data_set_exec]: check(comgr.amd_comgr_destroy_data_set(x))
   check(comgr.amd_comgr_destroy_action_info(action_info))
   return ret


### PR DESCRIPTION
There is some info the compiler can give (in the asm): 

```
        .amdhsa_kernel r_128_64_16_8_1024_4_4_4
                .amdhsa_group_segment_fixed_size 0
                .amdhsa_private_segment_fixed_size 0
                .amdhsa_kernarg_size 24
                .amdhsa_user_sgpr_count 14
                .amdhsa_user_sgpr_dispatch_ptr 0
                .amdhsa_user_sgpr_queue_ptr 0
                .amdhsa_user_sgpr_kernarg_segment_ptr 1
                .amdhsa_user_sgpr_dispatch_id 0
                .amdhsa_user_sgpr_private_segment_size 0
                .amdhsa_wavefront_size32 1
                .amdhsa_uses_dynamic_stack 0
                .amdhsa_enable_private_segment 0
                .amdhsa_system_sgpr_workgroup_id_x 1
                .amdhsa_system_sgpr_workgroup_id_y 1
                .amdhsa_system_sgpr_workgroup_id_z 0
                .amdhsa_system_sgpr_workgroup_info 0
                .amdhsa_system_vgpr_workitem_id 1
                .amdhsa_next_free_vgpr 54
                .amdhsa_next_free_sgpr 16
                .amdhsa_float_round_mode_32 0
                .amdhsa_float_round_mode_16_64 0
                .amdhsa_float_denorm_mode_32 3
                .amdhsa_float_denorm_mode_16_64 3
                .amdhsa_dx10_clamp 1
                .amdhsa_ieee_mode 1
                .amdhsa_fp16_overflow 0
                .amdhsa_workgroup_processor_mode 0
                .amdhsa_memory_ordered 1
                .amdhsa_forward_progress 0
                .amdhsa_shared_vgpr_count 0
                .amdhsa_exception_fp_ieee_invalid_op 0
                .amdhsa_exception_fp_denorm_src 0
                .amdhsa_exception_fp_ieee_div_zero 0
                .amdhsa_exception_fp_ieee_overflow 0
                .amdhsa_exception_fp_ieee_underflow 0
                .amdhsa_exception_fp_ieee_inexact 0
                .amdhsa_exception_int_div_zero 0
        .end_amdhsa_kernel
        .text
.Lfunc_end0:
        .size   r_128_64_16_8_1024_4_4_4, .Lfunc_end0-r_128_64_16_8_1024_4_4_4
                                        ; -- End function
        .section        .AMDGPU.csdata
; Kernel info:
; codeLenInByte = 904
; NumSgprs: 18
; NumVgprs: 54
; ScratchSize: 0
; MemoryBound: 0
; FloatMode: 240
; IeeeMode: 1
; LDSByteSize: 0 bytes/workgroup (compile time only)
; SGPRBlocks: 2
; VGPRBlocks: 6
; NumSGPRsForWavesPerEU: 18
; NumVGPRsForWavesPerEU: 54
; Occupancy: 16
; WaveLimiterHint : 1
; COMPUTE_PGM_RSRC2:SCRATCH_EN: 0
; COMPUTE_PGM_RSRC2:USER_SGPR: 14
; COMPUTE_PGM_RSRC2:TRAP_HANDLER: 0
; COMPUTE_PGM_RSRC2:TGID_X_EN: 1
; COMPUTE_PGM_RSRC2:TGID_Y_EN: 1
; COMPUTE_PGM_RSRC2:TGID_Z_EN: 0
; COMPUTE_PGM_RSRC2:TIDIG_COMP_CNT: 1
        .text
        .p2alignl 7, 3214868480
        .fill 96, 4, 3214868480
        .ident  "clang version 17.0.0"
        .section        ".note.GNU-stack"
        .addrsig
        .amdgpu_metadata
---
amdhsa.kernels:
  - .args:
      - .address_space:  global
        .name:           data0.coerce
        .offset:         0
        .size:           8
        .value_kind:     global_buffer
      - .address_space:  global
        .name:           data1.coerce
        .offset:         8
        .size:           8
        .value_kind:     global_buffer
      - .address_space:  global
        .name:           data2.coerce
        .offset:         16
        .size:           8
        .value_kind:     global_buffer
    .group_segment_fixed_size: 0
    .kernarg_segment_align: 8
    .kernarg_segment_size: 24
    .language:       OpenCL C
    .language_version:
      - 2
      - 0
    .max_flat_workgroup_size: 1024
    .name:           r_128_64_16_8_1024_4_4_4
    .private_segment_fixed_size: 0
    .sgpr_count:     18
    .sgpr_spill_count: 0
    .symbol:         r_128_64_16_8_1024_4_4_4.kd
    .uniform_work_group_size: 1
    .uses_dynamic_stack: false
    .vgpr_count:     54
    .vgpr_spill_count: 0
    .wavefront_size: 32
    .workgroup_processor_mode: 0
amdhsa.target:   amdgcn-amd-amdhsa--gfx1100
amdhsa.version:
  - 1
  - 2

```

@flammit wanna try if this eliminates bad kernels?