### PR TITLE
use custom KernelOptError in kernel opt

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1,7 +1,7 @@
 import numpy as np
 import unittest
 
-from tinygrad.codegen.kernel import Opt, OptOps, tensor_cores
+from tinygrad.codegen.kernel import Opt, OptOps, KernelOptError, tensor_cores
 from tinygrad.codegen.linearizer import Linearizer, UOp, UOps, expand_node, expand_idxs
 from tinygrad.device import Device, Buffer
 from tinygrad.ops import BinaryOps, BufferOps, MemBuffer, ConstBuffer, LazyOp, LoadOps, TernaryOps
@@ -669,9 +669,9 @@ class TestLinearizerOpts(unittest.TestCase):
     ])
 
     # cannot pad a reduce axis
-    with self.assertRaises(AssertionError):
+    with self.assertRaises(KernelOptError):
       helper_linearizer_opt(a.max(), [[Opt(OptOps.PADTO, 0, 32)],])
-    with self.assertRaises(AssertionError):
+    with self.assertRaises(KernelOptError):
       helper_linearizer_opt(a.max(0), [[Opt(OptOps.PADTO, 1, 32)],])
 
   def test_padto_where(self):

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E501
 import unittest, random
 import numpy as np
+from tinygrad.codegen.kernel import KernelOptError
 from tinygrad.codegen.linearizer import Linearizer
 from tinygrad.features.search import Opt, OptOps
 from tinygrad import Device, dtypes, Tensor
@@ -25,7 +26,7 @@ def helper_test_lin(lin: Linearizer, opts, failed_platforms):
   for opt in opts:
     try:
       lin.apply_opt(opt)
-    except AssertionError:
+    except KernelOptError:
       # it's considered fixed if we invalidated the opts
       assert Device.DEFAULT not in failed_platforms
 

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -1,11 +1,12 @@
 from typing import Dict, List, cast, DefaultDict, Optional, Tuple, Callable
 import itertools, functools, random, math, time, multiprocessing, traceback, signal
+from collections import defaultdict
 from tinygrad.device import Device, Compiled, Buffer, CompiledASTRunner, Compiler
 from tinygrad.ops import MemBuffer
 from tinygrad.helpers import prod, flatten, DEBUG, CACHELEVEL, diskcache_get, diskcache_put, getenv, Context, colored, to_function_name
 from tinygrad.dtype import ImageDType
 from tinygrad.codegen.linearizer import Linearizer
-from collections import defaultdict
+from tinygrad.codegen.kernel import KernelOptError
 from tinygrad.tensor import Tensor
 from tinygrad.shape.symbolic import sym_infer, Variable
 
@@ -89,7 +90,7 @@ def get_linearizer_actions(lin:Linearizer, include_0=True) -> Dict[int, Lineariz
         if c in {"cyan", "green", "white"}: lcl *= s
       if up > max_up or lcl > max_lcl or ("green" in lin2.colors() and up*lcl > 2 ** 15): continue
       acted_lins[i+1] = lin2
-    except Exception:
+    except KernelOptError:
       pass
   return acted_lins
 


### PR DESCRIPTION
be more specific about invalid kernel opt, used that in test_linearizer_failures.

make BEAM kernel search work even with assertion disabled.

`BEAM=2 python3 -O examples/llama.py  --temperature=0 --count=10 --prompt="Hello." --timing`