### PR TITLE
Adding the missing sys import

### DIFF
--- a/extra/datasets/openimages.py
+++ b/extra/datasets/openimages.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import math
 import json
 import numpy as np


### PR DESCRIPTION
```python
def download_image(bucket, image_id, data_dir):
  try:
    bucket.download_file(f"validation/{image_id}.jpg", f"{data_dir}/{image_id}.jpg")
  except botocore.exceptions.ClientError as exception:
    sys.exit(f"ERROR when downloading image `validation/{image_id}`: {str(exception)}")
```
Uses `sys` yet it wasn't imported.