### PR TITLE
Fix Tensor's __repr__ for printing out grad

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -334,6 +334,12 @@ class TestTinygrad(unittest.TestCase):
     with self.assertRaises(TypeError):
       _a = Tensor([3]) in [Tensor([3]), Tensor([4]), Tensor([5])]
 
+  def test_repr_with_grad(self):
+    a = Tensor([1])
+    b = Tensor([1])
+    c = (a + b).mean().backward()
+    print(c)
+
 @unittest.skipIf(CI and Device.DEFAULT in {"GPU", "CUDA", "METAL"}, "no GPU CI")
 class TestMoveTensor(unittest.TestCase):
   d0, d1 = f"{Device.DEFAULT}:0", f"{Device.DEFAULT}:1"

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -111,7 +111,7 @@ class Tensor:
     else:
       self.lazydata = data if data.device == device else data.copy_to_device(device)
 
-  def __repr__(self): return f"<Tensor {self.lazydata!r} on {self.device} with grad {(self.grad.lazydata if self.grad else None)!r}>"
+  def __repr__(self): return f"<Tensor {self.lazydata!r} on {self.device} with grad {(self.grad.lazydata if self.grad is not None else None)!r}>"
 
   # Python has a non moving GC, so this should be okay
   def __hash__(self): return id(self)


### PR DESCRIPTION
This PR fixes a small issue when checking for `self.grad` inside `__repr__` after the implementation of `__bool__`.

Here's a simple way to reproduce the issue:
<img width="826" alt="Screenshot 2024-03-10 at 4 11 45 PM" src="https://github.com/tinygrad/tinygrad/assets/51974347/144a0007-f700-46a3-8f46-611287ee3c32">

Here's the case when the fix is applied:
<img width="1185" alt="Screenshot 2024-03-10 at 4 12 53 PM" src="https://github.com/tinygrad/tinygrad/assets/51974347/ae8201ce-2abe-4c7d-aaed-1dfdfaaf602c">