### PR TITLE
Update ops_disk.py

### DIFF
--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -31,7 +31,7 @@ class DiskAllocator(Allocator):
       except OSError: fd = os.open(self.device, os.O_RDWR|os.O_CREAT)
       if os.fstat(fd).st_size < size: os.ftruncate(fd, size)
       mem = mmap.mmap(fd, size)
-    if (hp := getattr(mmap, "MADV_HUGEPAGE", None)) is not None: mem.madvise(hp) # type: ignore
+    if (hp := getattr(mmap, "MADV_HUGEPAGE", None)) is not None and hp!=14: mem.madvise(hp) # type: ignore
     return DiskBuffer(UnderlyingDiskBuffer(fd, mem), size)
   def as_buffer(self, src:DiskBuffer): return src._buf()
   def copyin(self, dest:DiskBuffer, src:memoryview): dest._buf()[:] = src


### PR DESCRIPTION
fix for 
```
  File "/cache/home/nr620/tinygrad/examples/mamba.py", line 395, in from_pretrained
    load_state_dict(model, weights)
  File "/cache/home/nr620/tinygrad/tinygrad/nn/state.py", line 71, in load_state_dict
    v.assign(state_dict[k].shard(mlb.device, mlb.axis) if isinstance((mlb:=v.lazydata), MultiLazyBuffer) else state_dict[k].to(v.device)).realize()
  File "/cache/home/nr620/tinygrad/tinygrad/tensor.py", line 116, in realize
    run_schedule(self.lazydata.schedule())
  File "/cache/home/nr620/tinygrad/tinygrad/realize.py", line 62, in run_schedule
    Buffer(si.out.device, si.out.size, si.out.dtype, "PLACEHOLDER" if isinstance(prg, InterpretedASTRunner) else None, options=options)
  File "/cache/home/nr620/tinygrad/tinygrad/device.py", line 80, in __init__
    self._buf = opaque if opaque is not None else self.allocator.alloc(self.nbytes, options)
  File "/cache/home/nr620/tinygrad/tinygrad/device.py", line 140, in alloc
    return self._alloc_with_options(size, options) if options is not None else self._alloc(size)
  File "/cache/home/nr620/tinygrad/tinygrad/runtime/ops_disk.py", line 43, in _alloc
    if (hp := getattr(mmap, "MADV_HUGEPAGE", None)) is not None: mem.madvise(hp) # type: ignore
OSError: [Errno 22] Invalid argument
```