### PR TITLE
search: add a tool that beam searches one or more kernels

### DIFF
--- a/extra/optimization/search.py
+++ b/extra/optimization/search.py
@@ -1,0 +1,36 @@
+import argparse
+
+from tinygrad import dtypes
+from tinygrad.helpers import BEAM, getenv
+from tinygrad.device import Device, Compiled
+from tinygrad.codegen.linearizer import Linearizer
+from tinygrad.features.search import time_linearizer, beam_search, bufs_from_lin
+from tinygrad.ops import LazyOp, BinaryOps, UnaryOps, ReduceOps, BufferOps, MemBuffer, ConstBuffer
+from tinygrad.shape.shapetracker import ShapeTracker
+from tinygrad.shape.view import View
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description="Run a search for the optimal opts for a kernel", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  parser.add_argument("--ast", type=str, default=None, help="the ast for the kernel to be optimized")
+  parser.add_argument("--file", type=str, default=None, help="a file containing asts to be optimized, one per line")
+  args = parser.parse_args()
+
+  device: Compiled = Device[Device.DEFAULT]
+  print(f"optimizing for {Device.DEFAULT}")
+
+  if args.ast is not None:
+    asts = [eval(args.ast)]
+  elif args.file is not None:
+    with open(args.file, 'r') as file:
+     lines = file.readlines()
+    asts = [eval(line) for line in lines]
+
+  for ast in asts:
+    print(f"optimizing ast={ast}")
+    lin = Linearizer(ast, device.compiler.linearizer_opts)
+    rawbufs = bufs_from_lin(lin)
+    lin = beam_search(lin, rawbufs, getenv("BEAM", 8), bool(getenv("BEAM_ESTIMATE", 1)))
+
+    tm = time_linearizer(lin, rawbufs, allow_test_size=False, cnt=10)
+    print(f"final time {tm*1e6:9.0f} us: {lin.colored_shape()}")
+    print(lin.applied_opts)


### PR DESCRIPTION
this will make it easier to reproduce some of the memory faults we're seeing on HSA.

Currently with both the stock `rocm-6.0.2` and the new `hipruntime-03072024`, I believe the following command will trigger a page fault in about 10 seconds:

```
PYTHONPATH=. HSA=1 DEBUG=2 BEAM=64 BEAM_UPCAST_MAX=16384 BEAM_LOCAL_MAX=512 BEAM_MIN_PROGRESS=5 python3 ./extra/optimization/search.py --ast "LazyOp(op=BufferOps.STORE, src=(LazyOp(op=ReduceOps.SUM, src=(LazyOp(op=BinaryOps.MUL, src=(LazyOp(op=BufferOps.LOAD, src=(), arg=MemBuffer(idx=1, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(6, 6, 512, 1, 512, 256, 2, 2), strides=(786432, 131072, 0, 0, 256, 1, 0, 0), offset=0, mask=None, contiguous=False),)))), LazyOp(op=BufferOps.LOAD, src=(), arg=MemBuffer(idx=2, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(6, 6, 512, 1, 512, 256, 2, 2), strides=(6291456, 1048576, 2048, 0, 4, 0, 2, 1), offset=0, mask=None, contiguous=False),))))), arg=None),), arg=(4,)),), arg=MemBuffer(idx=0, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(6, 6, 512, 1, 1, 256, 2, 2), strides=(3145728, 524288, 1024, 0, 0, 4, 2, 1), offset=0, mask=None, contiguous=True),))))"
```

alternatively stick that ast into a single line file and run it with `--file ../bad_kernel.txt`.