### PR TITLE
feat: add support for `prefix` in `load_state_dict`

### DIFF
--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -68,7 +68,7 @@ def load_state_dict(model, state_dict:Dict[str, Tensor], prefix:str='', strict=T
       if f"{prefix}{k}" not in state_dict and not strict:
         if DEBUG >= 1: print(f"WARNING: not loading {k}")
         continue
-      v.assign(state_dict[f"{prefix}{k}"].shard(mlb.device, mlb.axis) if isinstance((mlb:=v.lazydata), MultiLazyBuffer) else state_dict[f"{prefix}{k}"].to(v.device)).realize()
+      v.assign(state_dict[f"{prefix}{k}"].shard(mlb.device, mlb.axis) if isinstance((mlb:=v.lazydata), MultiLazyBuffer) else state_dict[f"{prefix}{k}"].to(v.device)).realize() # noqa: E501
       if consume: del state_dict[f"{prefix}{k}"]
 
 # torch support!


### PR DESCRIPTION
Also, this is super useful for instance when loading weights, for a model that doesn't need all of the weights. I'm already using this to load weights from `clip-vit-large-patch14`, but only load the text related weights wit `prefix="text_model."`.

Also matches API of `load_state_dict` with `get_state_dict`.