### PR TITLE
Fix kwargs in JIT

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -98,17 +98,17 @@ class TestJit(unittest.TestCase):
 
   def test_reorder_kwargs_jit(self):
     @TinyJit
-    def add_kwargs(first, second): return (first+second).realize()
+    def add_kwargs(first, second): return (first/second).realize()
     for _ in range(2):
       a = Tensor.randn(10, 10)
       b = Tensor.randn(10, 10)
-      c = add_kwargs(second=a, first=b)
-      np.testing.assert_allclose(c.numpy(), a.numpy()+b.numpy(), atol=1e-4, rtol=1e-5)
+      c = add_kwargs(second=b, first=a)
+      np.testing.assert_allclose(c.numpy(), a.numpy()/b.numpy(), atol=1e-4, rtol=1e-5)
     for _ in range(2):
       a = Tensor.randn(10, 10)
       b = Tensor.randn(10, 10)
       c = add_kwargs(first=a, second=b)
-      np.testing.assert_allclose(c.numpy(), a.numpy()+b.numpy(), atol=1e-4, rtol=1e-5)
+      np.testing.assert_allclose(c.numpy(), a.numpy()/b.numpy(), atol=1e-4, rtol=1e-5)
     assert_jit_cache_len(add_kwargs, 1)
 
   def test_array_jit(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -96,6 +96,21 @@ class TestJit(unittest.TestCase):
       np.testing.assert_allclose(c.numpy(), a.numpy()+b.numpy(), atol=1e-4, rtol=1e-5)
     assert_jit_cache_len(add_kwargs, 1)
 
+  def test_reorder_kwargs_jit(self):
+    @TinyJit
+    def add_kwargs(first, second): return (first+second).realize()
+    for _ in range(2):
+      a = Tensor.randn(10, 10)
+      b = Tensor.randn(10, 10)
+      c = add_kwargs(second=a, first=b)
+      np.testing.assert_allclose(c.numpy(), a.numpy()+b.numpy(), atol=1e-4, rtol=1e-5)
+    for _ in range(2):
+      a = Tensor.randn(10, 10)
+      b = Tensor.randn(10, 10)
+      c = add_kwargs(first=a, second=b)
+      np.testing.assert_allclose(c.numpy(), a.numpy()+b.numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(add_kwargs, 1)
+
   def test_array_jit(self):
     @TinyJit
     def add_array(a, arr): return (a+arr[0]).realize()

--- a/tinygrad/features/jit.py
+++ b/tinygrad/features/jit.py
@@ -91,7 +91,7 @@ class TinyJit(Generic[ReturnType]):
 
   def __call__(self, *args, **kwargs) -> ReturnType:
     # all inputs (except const) are realized
-    input_tensors: Dict[Union[int, str], Union[LazyBuffer, MultiLazyBuffer]] = { cast(Union[int, str], k):v.realize().lazydata for k,v in itertools.chain(enumerate(args), kwargs.items()) if v.__class__ is Tensor }  # noqa: E501
+    input_tensors: Dict[Union[int, str], Union[LazyBuffer, MultiLazyBuffer]] = { cast(Union[int, str], k):v.realize().lazydata for k,v in itertools.chain(enumerate(args), sorted(kwargs.items(), lambda x: x[0])) if v.__class__ is Tensor }  # noqa: E501
     expected_name_sts_dtype_device = tuple([(k, v.st.unbind()[0] if isinstance(v, LazyBuffer) else ShapeTracker.from_shape(v.shape), v.dtype, v.device) for k,v in input_tensors.items()]) #noqa: E501
 
     # get rawbuffers

--- a/tinygrad/features/jit.py
+++ b/tinygrad/features/jit.py
@@ -91,7 +91,7 @@ class TinyJit(Generic[ReturnType]):
 
   def __call__(self, *args, **kwargs) -> ReturnType:
     # all inputs (except const) are realized
-    input_tensors: Dict[Union[int, str], Union[LazyBuffer, MultiLazyBuffer]] = { cast(Union[int, str], k):v.realize().lazydata for k,v in itertools.chain(enumerate(args), sorted(kwargs.items(), key=lambda x: x[0])) if v.__class__ is Tensor }  # noqa: E501
+    input_tensors: Dict[Union[int, str], Union[LazyBuffer, MultiLazyBuffer]] = { cast(Union[int, str], k):v.realize().lazydata for k,v in itertools.chain(enumerate(args), sorted(kwargs.items(), key=lambda x: str(x[0]))) if v.__class__ is Tensor }  # noqa: E501
     expected_name_sts_dtype_device = tuple([(k, v.st.unbind()[0] if isinstance(v, LazyBuffer) else ShapeTracker.from_shape(v.shape), v.dtype, v.device) for k,v in input_tensors.items()]) #noqa: E501
 
     # get rawbuffers

--- a/tinygrad/features/jit.py
+++ b/tinygrad/features/jit.py
@@ -91,7 +91,7 @@ class TinyJit(Generic[ReturnType]):
 
   def __call__(self, *args, **kwargs) -> ReturnType:
     # all inputs (except const) are realized
-    input_tensors: Dict[Union[int, str], Union[LazyBuffer, MultiLazyBuffer]] = { cast(Union[int, str], k):v.realize().lazydata for k,v in itertools.chain(enumerate(args), sorted(kwargs.items(), lambda x: x[0])) if v.__class__ is Tensor }  # noqa: E501
+    input_tensors: Dict[Union[int, str], Union[LazyBuffer, MultiLazyBuffer]] = { cast(Union[int, str], k):v.realize().lazydata for k,v in itertools.chain(enumerate(args), sorted(kwargs.items(), key=lambda x: x[0])) if v.__class__ is Tensor }  # noqa: E501
     expected_name_sts_dtype_device = tuple([(k, v.st.unbind()[0] if isinstance(v, LazyBuffer) else ShapeTracker.from_shape(v.shape), v.dtype, v.device) for k,v in input_tensors.items()]) #noqa: E501
 
     # get rawbuffers

--- a/tinygrad/features/jit.py
+++ b/tinygrad/features/jit.py
@@ -91,7 +91,7 @@ class TinyJit(Generic[ReturnType]):
 
   def __call__(self, *args, **kwargs) -> ReturnType:
     # all inputs (except const) are realized
-    input_tensors: Dict[Union[int, str], Union[LazyBuffer, MultiLazyBuffer]] = { cast(Union[int, str], k):v.realize().lazydata for k,v in itertools.chain(enumerate(args), sorted(kwargs.items(), key=lambda x: str(x[0]))) if v.__class__ is Tensor }  # noqa: E501
+    input_tensors: Dict[Union[int, str], Union[LazyBuffer, MultiLazyBuffer]] = { cast(Union[int, str], k):v.realize().lazydata for k,v in itertools.chain(enumerate(args), sorted(kwargs.items())) if v.__class__ is Tensor }  # noqa: E501
     expected_name_sts_dtype_device = tuple([(k, v.st.unbind()[0] if isinstance(v, LazyBuffer) else ShapeTracker.from_shape(v.shape), v.dtype, v.device) for k,v in input_tensors.items()]) #noqa: E501
 
     # get rawbuffers


### PR DESCRIPTION
Minor bug fix: Currently calling the same `JIT`ted function with different kwargs breaks because the `expected_name_sts_dtype_device` changes.

This fixes the issue, but if it feels hacky, I can add a test or find a better solve (imo `itertools.chain`-ing the args and kwargs together isn't the best way of doing this).