### PR TITLE
Fix JITItem count assert for HSAGraph

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -2,7 +2,6 @@ from tinygrad.device import JITRunner
 from tinygrad.nn.state import get_parameters
 from tinygrad import Tensor
 from tinygrad.helpers import Context
-from tinygrad.runtime.graph.hsa import HSAGraph
 
 def derandomize_model(model):
   with Context(GRAPH=0):
@@ -12,10 +11,9 @@ def derandomize_model(model):
 
 def assert_jit_cache_len(fxn, expected_len):
   assert len(fxn.jit_cache) > 0
-  if issubclass(type(fxn.jit_cache[0].prg), JITRunner) and not isinstance(fxn.jit_cache[0].prg, HSAGraph):
+  # until we have a better way of typing the prg in JitItem
+  if issubclass(type(fxn.jit_cache[0].prg), JITRunner) and not type(fxn.jit_cache[0].prg).__name__.endswith('Graph'):
     assert len(fxn.jit_cache) == expected_len
   else:
     assert len(fxn.jit_cache) == 1
-    # until we have a better way of typing the prg in JitItem
-    assert type(fxn.jit_cache[0].prg).__name__.endswith('Graph')
     assert len(fxn.jit_cache[0].prg.jit_cache) == expected_len

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -2,6 +2,7 @@ from tinygrad.device import JITRunner
 from tinygrad.nn.state import get_parameters
 from tinygrad import Tensor
 from tinygrad.helpers import Context
+from tinygrad.runtime.graph.hsa import HSAGraph
 
 def derandomize_model(model):
   with Context(GRAPH=0):
@@ -11,7 +12,7 @@ def derandomize_model(model):
 
 def assert_jit_cache_len(fxn, expected_len):
   assert len(fxn.jit_cache) > 0
-  if issubclass(type(fxn.jit_cache[0].prg), JITRunner):
+  if issubclass(type(fxn.jit_cache[0].prg), JITRunner) and not isinstance(fxn.jit_cache[0].prg, HSAGraph):
     assert len(fxn.jit_cache) == expected_len
   else:
     assert len(fxn.jit_cache) == 1


### PR DESCRIPTION
Since HSAGraph inherits from JITRunner the assert wasn't treating that JITItem as a Graph.
`HSA=1 python3 -m unittest test.test_jit.TestJit.test_jit_multiple_outputs` should pass after this.