### PR TITLE
bfloat16 Tensor.rand

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -468,7 +468,7 @@ jobs:
         run: python -m pytest -n=auto test/ -k 'not (half or test_efficientnet_safetensors)' --ignore=test/external --ignore=test/models --durations=20
       - name: Run pytest (hip)
         if: matrix.backend=='hip'
-        run: python -m pytest -n=auto test/test_ops.py test/test_dtype.py test/test_dtype_alu.py test/test_linearizer.py test/imported/test_indexing.py test/external/external_test_hip_compile.py --durations=20
+        run: python -m pytest -n=auto test/test_ops.py test/test_dtype.py test/test_dtype_alu.py test/test_linearizer.py test/test_randomness.py test/imported/test_indexing.py test/external/external_test_hip_compile.py --durations=20
 
   #testunicorn:
   #  name: ARM64 unicorn Test

--- a/test/test_randomness.py
+++ b/test/test_randomness.py
@@ -1,9 +1,11 @@
 import math
 import unittest
+from functools import partial
+
 import numpy as np
 import torch
 from tinygrad import nn, dtypes, Tensor
-from functools import partial
+from test.helpers import is_dtype_supported
 
 # https://gist.github.com/devries/11405101
 def ksprob(a):
@@ -60,12 +62,27 @@ class TestRandomness(unittest.TestCase):
 
   def test_rand_half(self):
     N = 128
-    x = Tensor.rand((2, N, N), dtype=dtypes.half).realize().numpy()
+    x = Tensor.rand((2, N, N), dtype=dtypes.half)
+    assert x.dtype == dtypes.half
+    x = x.realize().numpy()
     ones = np.take(x, np.where(x == 1))
     zeros = np.take(x, np.where(x == 0))
     self.assertTrue(ones.size == 0)
     self.assertTrue(zeros.size > 0)
     equal_distribution(lambda *x: Tensor.rand(*x, dtype=dtypes.float16), torch.rand, lambda x: np.random.rand(*x), shape=(2, N, N))
+
+  @unittest.skipUnless(is_dtype_supported(dtypes.bfloat16), "need bfloat16 support")
+  def test_rand_bfloat16(self):
+    N = 128
+    x = Tensor.rand((2, N, N), dtype=dtypes.bfloat16)
+    assert x.dtype == dtypes.bfloat16
+    # TODO: fix this property for bfloat16 random
+    # x = x.realize().float().numpy()
+    # ones = np.take(x, np.where(x == 1))
+    # zeros = np.take(x, np.where(x == 0))
+    # self.assertTrue(ones.size == 0)
+    # self.assertTrue(zeros.size > 0)
+    equal_distribution(lambda *x: Tensor.rand(*x, dtype=dtypes.bfloat16).float(), torch.rand, lambda x: np.random.rand(*x), shape=(2, N, N))
 
   def test_randn(self):
     self.assertTrue(normal_test(Tensor.randn))

--- a/test/test_randomness.py
+++ b/test/test_randomness.py
@@ -64,7 +64,7 @@ class TestRandomness(unittest.TestCase):
     N = 128
     x = Tensor.rand((2, N, N), dtype=dtypes.half)
     assert x.dtype == dtypes.half
-    x = x.realize().numpy()
+    x = x.numpy()
     ones = np.take(x, np.where(x == 1))
     zeros = np.take(x, np.where(x == 0))
     self.assertTrue(ones.size == 0)
@@ -77,7 +77,7 @@ class TestRandomness(unittest.TestCase):
     x = Tensor.rand((2, N, N), dtype=dtypes.bfloat16)
     assert x.dtype == dtypes.bfloat16
     # TODO: fix this property for bfloat16 random
-    # x = x.realize().float().numpy()
+    # x = x.numpy()
     # ones = np.take(x, np.where(x == 1))
     # zeros = np.take(x, np.where(x == 0))
     # self.assertTrue(ones.size == 0)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -226,7 +226,12 @@ class Tensor:
   def manual_seed(seed=0): Tensor._seed = seed
 
   @staticmethod
-  def rand(*shape, **kwargs): return Tensor._loadop(LoadOps.CUSTOM, argfix(*shape), arg=custom_random, **kwargs)
+  def rand(*shape, **kwargs):
+    if kwargs.get("dtype") == dtypes.bfloat16:
+      # TODO: remove this once we use threefry for rand.
+      kwargs.pop("dtype")
+      return Tensor.rand(*shape, **kwargs, dtype=dtypes.float).cast(dtypes.bfloat16)
+    return Tensor._loadop(LoadOps.CUSTOM, argfix(*shape), arg=custom_random, **kwargs)
 
   # ***** creation helper functions *****
 


### PR DESCRIPTION
for numpy based random, generate one for float then cast for bfloat16.

close #3653 (for the devices that support bf16 buffer)