### PR TITLE
Fast nn.embeddings()

### DIFF
--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -126,8 +126,6 @@ class Embedding:
     self.weight = Tensor.glorot_uniform(vocab_size, embed_size)
 
   def __call__(self, idx:Tensor) -> Tensor:
-    if not hasattr(self, 'vocab_counter'):
-      self.vocab_counter = Tensor.arange(self.vocab_size, requires_grad=False, device=self.weight.device).reshape(1, 1, self.vocab_size)
     batch_size, seqlen = idx.shape
     if seqlen == 0: return Tensor.empty(batch_size, 0, self.embed_size, device=self.weight.device)
-    return (self.vocab_counter == idx.unsqueeze(2)).expand(*idx.shape, self.vocab_size) @ self.weight
+    return self.weight.unsqueeze(0).expand(idx.numel(), -1, -1).gather(idx.flatten().unsqueeze(-1).unsqueeze(-1).expand(-1, -1, self.embed_size), 1).reshape(batch_size, seqlen, self.embed_size)

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -128,4 +128,4 @@ class Embedding:
   def __call__(self, idx:Tensor) -> Tensor:
     batch_size, seqlen = idx.shape
     if seqlen == 0: return Tensor.empty(batch_size, 0, self.embed_size, device=self.weight.device)
-    return self.weight.unsqueeze(0).expand(idx.numel(), -1, -1).gather(idx.flatten().unsqueeze(-1).unsqueeze(-1).expand(-1, -1, self.embed_size), 1).reshape(batch_size, seqlen, self.embed_size)
+    return self.weight.unsqueeze(0).expand(idx.numel(), -1, -1).gather(idx.reshape(-1, 1, 1).expand(-1, -1, self.embed_size), 1).reshape(batch_size, seqlen, self.embed_size)

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -128,4 +128,6 @@ class Embedding:
   def __call__(self, idx:Tensor) -> Tensor:
     batch_size, seqlen = idx.shape
     if seqlen == 0: return Tensor.empty(batch_size, 0, self.embed_size, device=self.weight.device)
-    return self.weight.unsqueeze(0).expand(idx.numel(), -1, -1).gather(idx.reshape(-1, 1, 1).expand(-1, -1, self.embed_size), 1).reshape(batch_size, seqlen, self.embed_size)
+    return self.weight.unsqueeze(0).expand(idx.numel(), -1, -1)\
+      .gather(idx.reshape(-1, 1, 1).expand(-1, -1, self.embed_size), 1)\
+      .reshape(batch_size, seqlen, self.embed_size)


### PR DESCRIPTION
This is  candidate to bounty "O(n) nn.Embedding in one kernel without new ops (supporting BS=128)".

# Speed comparison: 

## Tested with HIP (6950xt) device using:
vocab = 30000
embed_size = 2048
batch_size = 16
seqlen = 4096

Thoses value can represent a realistic workload with a LLM.

## Result : 
### old  : 
code : 
```py
emb = Embedding(vocab, embed_size)

for i in range(10):
    with Timing(f"Time {i}: "):
        idx = Tensor.randint(batch_size, seqlen, low=0, high=vocab)
        emb(idx).numpy()
```
output: 
```
Time 0: 2667.48 ms
Time 1: 1930.70 ms
Time 2: 1937.66 ms
Time 3: 1933.96 ms
Time 4: 1939.21 ms
Time 5: 1942.05 ms
Time 6: 1940.59 ms
Time 7: 1939.59 ms
Time 8: 1943.01 ms
Time 9: 1940.18 ms
```

###  new: 
code : 
```py
emb = Embedding(vocab, embed_size)

for i in range(10):
    with Timing(f"Time {i}: "):
        idx = Tensor.randint(batch_size, seqlen, low=0, high=vocab)
        emb(idx).numpy()
```

output: 
```
Time 0: 1073.69 ms
Time 1: 760.05 ms
Time 2: 763.81 ms
Time 3: 763.07 ms
Time 4: 765.82 ms
Time 5: 764.50 ms
Time 6: 765.77 ms
Time 7: 766.25 ms
Time 8: 766.29 ms
Time 9: 765.94 ms
```
