### PR TITLE
end-to-end multioutput

### DIFF
--- a/test/test_corealize.py
+++ b/test/test_corealize.py
@@ -1,0 +1,36 @@
+from typing import List
+import unittest
+from test.helpers import assert_jit_cache_len
+from tinygrad.ops import GlobalCounters
+from tinygrad.tensor import Tensor
+from tinygrad.features.jit import TinyJit
+
+def helper_test_corealize(outs: List[Tensor], kernel_count: int):
+  GlobalCounters.reset()
+  Tensor.corealize(outs)
+  assert GlobalCounters.kernel_count == kernel_count
+
+class TestCorealize(unittest.TestCase):
+  def test_simple_group(self):
+    a, b = Tensor([1,2]).realize(), Tensor([3,4]).realize()
+    helper_test_corealize([a+b, a*b], 1)
+
+  def test_ungroup_reduce(self):
+    a, b = Tensor([1]).realize(), Tensor([3,4]).realize()
+    helper_test_corealize([a.float(), b.sum()+1], 2)
+
+  def test_simple_jit_group(self):
+    @TinyJit
+    def fxn(a, b): return a + b, a * b
+    for i in range(3):
+      a, b = Tensor([i, 1, 2]), Tensor([i])
+      fxn(a, b)
+    assert_jit_cache_len(fxn, 1)
+
+  def test_jit_ungroup_reduce(self):
+    @TinyJit
+    def fxn(a, b): return a + b, a.sum()
+    for i in range(3):
+      a, b = Tensor([i, 1, 2]), Tensor([i])
+      fxn(a, b)
+    assert_jit_cache_len(fxn, 2)

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -142,7 +142,7 @@ class TestDTypeALU(unittest.TestCase):
   def test_int32_midcast_float(self, a, b, c, op1, op2): universal_test_midcast(a, b, c, op1, op2, dtypes.int32, dtypes.float32)
 
   # Metal and CUDACPU and HIP behave differently than numpy in CI for overflows
-  skip_overflow = CI and (Device.DEFAULT == "HIP" or getenv("CUDACPU"))
+  skip_overflow = CI and (Device.DEFAULT in ["HIP", "HSA"] or getenv("CUDACPU"))
   @given(strat.floats(width=32, min_value=0, max_value=10.0) if skip_overflow else ht.float32,
          strat.floats(width=32, min_value=0, max_value=10.0) if skip_overflow else ht.float32,
          ht.int32, strat.sampled_from(binary_operations), strat.sampled_from(integer_binary_operations))

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -336,7 +336,7 @@ class TestSchedule(unittest.TestCase):
     out = bn1(conv1(x)).relu()
     out = bn2(conv2(out))
     out = (out + x).relu()
-    check_schedule(out, 4)
+    check_schedule(out, 3)
 
   def test_contiguous_while_contiguous(self):
     x = Tensor.empty(1, 64, 32, 32)

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -43,11 +43,11 @@ class JITRunner:
   def __init__(self):
     self.op_estimate:sint = 0
     self.mem_estimate:sint = 0
-  def exec(self, rawbufs:List[Buffer], var_vals:Optional[Dict[Variable, int]]=None) -> Optional[float]:
+  def exec(self, rawbufs:List[Buffer], var_vals:Optional[Dict[Variable, int]]=None, outbufs:Optional[List[Buffer]]=None) -> Optional[float]:
     var_vals = var_vals if var_vals is not None else {}
     from tinygrad.features.jit import CacheCollector
     et = self(rawbufs, var_vals)
-    CacheCollector.add(self, rawbufs, var_vals)
+    CacheCollector.add(self, rawbufs, var_vals, outbufs)
     return et
   def __call__(self, rawbufs:List[Buffer], var_vals:Dict[Variable, int], wait=False, jit=False) -> Optional[float]:
     raise NotImplementedError("override this")


### PR DESCRIPTION
`Tensor.corealize` attempts to fuse the outputs.
The scheduler groups buffers using a basic level ordering algorithm. Getting to 1 kernel Adam requires smarter realize grouping, tinygrad has all the infrastructure to run multioutput DAGs.