### PR TITLE
use float32 for rand buffer in test_beam_search and test in metal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -310,6 +310,8 @@ jobs:
       run: METAL=1 DEBUG=3 python test/test_ops.py TestOps.test_big_gemm
     - name: Test LLaMA compile speed
       run: PYTHONPATH="." METAL=1 python test/external/external_test_speed_llama.py
+    - name: Test Beam Search
+      run: PYTHONPATH="." METAL=1 IGNORE_BEAM_CACHE=1 python3 -m pytest extra/optimization/test_beam_search.py
     - name: Fuzz Test linearizer
       run: PYTHONPATH="." METAL=1 CACHELEVEL=0 FUZZ_BEAM=1 DEPTH=2 FUZZ_N=48 FUZZ_MAX_SIZE=10000000 python test/external/fuzz_linearizer.py
 

--- a/extra/optimization/test_beam_search.py
+++ b/extra/optimization/test_beam_search.py
@@ -7,8 +7,7 @@ from tinygrad.tensor import Tensor
 from tinygrad.nn import Conv2d
 
 def rand(*shape):
-  if CI: return Tensor(np.random.rand(*shape))
-  return Tensor.rand(*shape)
+  return Tensor(np.random.rand(*shape).astype(np.float32))
 
 class TestBeamSearch(unittest.TestCase):
   def setUp(self):


### PR DESCRIPTION
converted the rand in test to float32. I don't think it needs to be float64 which does not run with metal