### PR TITLE
proposal: multioutput JIT spec

### DIFF
--- a/tinygrad/features/jit.py
+++ b/tinygrad/features/jit.py
@@ -119,7 +119,7 @@ class TinyJit(Generic[ReturnType]):
       CacheCollector.start(var_vals)
       with Context(GRAPH=getenv("JITGRAPH", GRAPH.value)):
         self.ret = self.fxn(*args, **kwargs)
-        for p in get_parameters(self.ret): p.realize()
+        Tensor.corealize(get_parameters(self.ret))
       self.jit_cache = CacheCollector.finish()
       assert len(self.jit_cache) != 0, "didn't JIT anything!"
       # TODO: reset doesn't work if we delete this
@@ -135,7 +135,7 @@ class TinyJit(Generic[ReturnType]):
     elif self.cnt == 0:
       # jit ignore
       self.ret = self.fxn(*args, **kwargs)
-      for p in get_parameters(self.ret): p.realize()
+      Tensor.corealize(get_parameters(self.ret))
 
     # clear jit inputs
     for (j,i) in self.input_replace.keys(): self.jit_cache[j].rawbufs[i] = None


### PR DESCRIPTION
I think JIT should use Tensor.corealize to let the scheduler fuse outputs, the user can .realize() to opt-out of the fusion.

will enable the tests once multioutput is merged.