### PR TITLE
search: change to use "spawn" and limit the number of tasks per child

### DIFF
--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -19,7 +19,6 @@ EVAL_BS = getenv("EVAL_BS", BS)
 GPUS = [f'{Device.DEFAULT}:{i}' for i in range(getenv("GPUS", 1))]
 assert BS % len(GPUS) == 0, f"{BS=} is not a multiple of {len(GPUS)=}, uneven multi GPU is slow"
 assert EVAL_BS % len(GPUS) == 0, f"{EVAL_BS=} is not a multiple of {len(GPUS)=}, uneven multi GPU is slow"
-for x in GPUS: Device[x]
 
 if getenv("HALF"):
   dtypes.default_float = dtypes.float16

--- a/extra/gemm/simple_conv.py
+++ b/extra/gemm/simple_conv.py
@@ -16,15 +16,16 @@ COMP = getenv("COMP", 0)
 FLOPS = BS*K*K*CIN*HW*HW*COUT*2
 def rand_input(): return Tensor.rand(BS, CIN, HW, HW, dtype=dtype_in).realize(), Tensor.rand(COUT, CIN, K, K, dtype=dtype_in).realize()
 
-a, b = rand_input()
-for i in range(CNT):
-  if i > 0 and getenv("RAND", 0) != 0:
-    a, b = rand_input()
-  c = a.conv2d(b, padding=PADDING, acc_dtype=acc_dtype).realize()
+if __name__ == "__main__":
+  a, b = rand_input()
+  for i in range(CNT):
+    if i > 0 and getenv("RAND", 0) != 0:
+      a, b = rand_input()
+    c = a.conv2d(b, padding=PADDING, acc_dtype=acc_dtype).realize()
 
-if COMP:
-  import numpy as np, time, torch
-  torch_device = "cuda:0" if torch.cuda.is_available() else ("mps" if getenv("MPS", 0) else "cpu")
-  ta, tb = torch.from_numpy(a.numpy()).to(torch_device), torch.from_numpy(b.numpy()).to(torch_device)
-  tc = torch.nn.functional.conv2d(ta, tb, padding=PADDING)
-  np.testing.assert_allclose(c.numpy(), tc.cpu(), atol=1e-4, rtol=3e-2)
+  if COMP:
+    import numpy as np, time, torch
+    torch_device = "cuda:0" if torch.cuda.is_available() else ("mps" if getenv("MPS", 0) else "cpu")
+    ta, tb = torch.from_numpy(a.numpy()).to(torch_device), torch.from_numpy(b.numpy()).to(torch_device)
+    tc = torch.nn.functional.conv2d(ta, tb, padding=PADDING)
+    np.testing.assert_allclose(c.numpy(), tc.cpu(), atol=1e-4, rtol=3e-2)

--- a/extra/gemm/simple_matmul.py
+++ b/extra/gemm/simple_matmul.py
@@ -5,11 +5,13 @@ dtype_in = dtypes.half if getenv("HALF") else dtypes.float
 acc_dtype = dtypes.half if getenv("ACC_HALF") else None
 N = getenv("N", 4096)
 CNT = getenv("CNT", 10)
-a, b = Tensor.rand(N, N, dtype=dtype_in).realize(), Tensor.rand(N, N, dtype=dtype_in).realize()
-for i in range(CNT):
-  if i > 0 and getenv("RAND", 0) != 0:
-    a, b = Tensor.rand(N, N, dtype=dtype_in).realize(), Tensor.rand(N, N, dtype=dtype_in).realize()
-  c = a.matmul(b, acc_dtype=acc_dtype).realize()
-comp = a.numpy().astype(np.float32) @ b.numpy().astype(np.float32)
-nc = c.numpy()
-np.testing.assert_allclose(nc, comp, atol=1e-4, rtol=3e-2)
+
+if __name__ == "__main__":
+  a, b = Tensor.rand(N, N, dtype=dtype_in).realize(), Tensor.rand(N, N, dtype=dtype_in).realize()
+  for i in range(CNT):
+    if i > 0 and getenv("RAND", 0) != 0:
+      a, b = Tensor.rand(N, N, dtype=dtype_in).realize(), Tensor.rand(N, N, dtype=dtype_in).realize()
+    c = a.matmul(b, acc_dtype=acc_dtype).realize()
+  comp = a.numpy().astype(np.float32) @ b.numpy().astype(np.float32)
+  nc = c.numpy()
+  np.testing.assert_allclose(nc, comp, atol=1e-4, rtol=3e-2)

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -108,7 +108,8 @@ def beam_search(lin:Linearizer, rawbufs, amt:int, allow_test_size=True) -> Linea
   seen_libs = set()
 
   default_parallel, min_progress_micros = 1 if lin.opts.device in {"CUDA", "HSA"} else 0, getenv("BEAM_MIN_PROGRESS",0.01)
-  if beam_pool is None and getenv("PARALLEL", default_parallel): beam_pool = multiprocessing.Pool(multiprocessing.cpu_count(), _init_worker)
+  if beam_pool is None and getenv("PARALLEL", default_parallel):
+    beam_pool = multiprocessing.get_context("spawn").Pool(multiprocessing.cpu_count(), _init_worker, (), getenv("BEAM_MAX_TASKS_PER_CHILD", 16))
 
   try:
     var_vals = {k:(k.max+k.min)//2 for k in lin.ast[0].vars()}


### PR DESCRIPTION
also clean up some examples to use __main__ and not initialize resources outside of main

This limits the amount of memory leaked in the child processes.  For very large kernels, you might need to limit the tasks per child to even less by setting `BEAM_MAX_TASKS_PER_CHILD` to a lower number.

For this run `PYTHONPATH=. HSA=1 GPUS=6 LATEWINO=1 LATEBEAM=64 BEAM_UPCAST_MAX=16384 BEAM_LOCAL_MAX=512 BEAM_MIN_PROGRESS=5 BEAM_MAX_TASKS_PER_CHILD=32 STEPS=10 DEBUG=2 HALF=1 BS=1536 python3 ./examples/hlb_cifar10.py`, the parent process still leaked up to 30GB by the end of a 4.5hr run, but this is not addressed here.  The total memory usage peaked at 80GB during one late WINO kernel, so in hindsight, I should've run with lower max tasks.

Tested in HSA and CUDA.  Trying to do beam inside of the rocm/pytorch docker container didn't seem to work (hangs) but that might be due to other issues.