### PR TITLE
Rust Code "accelerator" - Part 1 - Adding size of global buffers in Uops graph

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -45,7 +45,7 @@ class TestLinearizer(unittest.TestCase):
     lin.linearize()
 
     stores = [u for u in lin.uops if u.uop is UOps.STORE]
-    mutable_bufs = [u for u in lin.uops if u.uop is UOps.DEFINE_GLOBAL and u.arg[-1]]
+    mutable_bufs = [u for u in lin.uops if u.uop is UOps.DEFINE_GLOBAL and u.arg[-2]]
     assert len(mutable_bufs) == len(stores) == 2
     assert [u.arg[0] for u in mutable_bufs] == [0, 1]
 

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -195,7 +195,7 @@ class Linearizer(Kernel):
       if isinstance(buf, MemBuffer):
         self.buf_uops[i] = self.uops.add(UOps.DEFINE_GLOBAL,
                                          buf.dtype if isinstance(buf.dtype, ImageDType) else PtrDType(buf.dtype), (),
-                                         (buf.idx, f"data{buf.idx}", any(buf.idx == x.idx for x in self.outbufs)))
+                                         (buf.idx, f"data{buf.idx}", any(buf.idx == x.idx for x in self.outbufs), buf.st.size))
     # add var vals
     for i,var in enumerate(self.vars):
       assert var.expr is not None

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -152,7 +152,7 @@ class UOpGraph:
     if simplify and (rewritten:=constant_folder.rewrite(ret)) is not None:
       if rewritten in self.uops: return rewritten  # ignore cachable
       ret = rewritten
-    key = (ret.uop, ret.dtype, ret.vin, ret.arg)
+    key = (ret.uop, ret.dtype, ret.vin, ret.arg if ret.uop is not UOps.DEFINE_GLOBAL else (ret.arg[0],ret.arg[1],ret.arg[2]))
     if insert_before is None: insert_before = len(self.uops)
     # check if the cached expr is valid with the given insert place.
     if cachable and (expr:=self.saved_exprs.get(key, None)) is not None and self.uops.index(expr) <= insert_before: return expr


### PR DESCRIPTION
This is the first patch for adding a Rust Code "accelerator".  As expected the requirements and layout is fairly similar CLANG, however there is a major difference.  The Rust compiler needs to know how big arrays are.

When called from a function like this, the compiler will handle sizing the parameters data0..data3 for the function r_4_32()
```
fn r_4_32(data0: &mut [f32], data1: &[f32], data2: &[f32], data3: &[f32]) {
    data0[0] = data1[0] * data2[0] + data1[1] * data3[1]
}

pub extern "C" fn net(input0: &[f32; 32], output0: &mut [f32; 4]) {
   let buf1 = [0.0; 64];
   let buf2 = [0.0; 128];
   r_4_32(output0, input0, &buf1, &buf2);
}
```
However when using FFI to connect to python we need to specify the size like this:
```
pub extern "C" fn r_4_32(data0: &mut [f32; 4], data1: &[f32; 32], data2: &[f32; 64], data3: &[f32; 128]) {
    data0[0] = data1[0] * data2[0] + data1[1] * data3[1]
}
```
To enable this sizing feature I made the following changes:
* Add size field to args of DEFINE_GLOBAL node in the UOps graph for Rust to size input/output arrays
* Adapt dedup key to ignore size, apparently we can get redundant buffers in the graph.
* Fixed test