### PR TITLE
fuzz_linearizer: add --ast and --file params to read kernels

### DIFF
--- a/extra/optimization/helpers.py
+++ b/extra/optimization/helpers.py
@@ -1,4 +1,5 @@
 # stuff needed to unpack a kernel
+from typing import Tuple
 from tinygrad.ops import LazyOp, TernaryOps, BinaryOps, UnaryOps, ReduceOps, BufferOps, MemBuffer, ConstBuffer
 from tinygrad.codegen.kernel import Opt, OptOps
 from tinygrad.dtype import dtypes
@@ -9,8 +10,8 @@ inf, nan = float('inf'), float('nan')
 
 # kernel unpacker
 from tinygrad.codegen.linearizer import Linearizer
-def ast_str_to_ast(ast_str:str) -> LazyOp: return eval(ast_str)
-def ast_str_to_lin(ast_str:str, opts=None): return Linearizer(ast_str_to_ast(ast_str), opts=opts)
+def ast_str_to_ast(ast_str:str) -> Tuple[LazyOp,...]: return val if isinstance(val:=eval(ast_str), tuple) else (val,)
+def ast_str_to_lin(ast_str:str, opts=None): return Linearizer(*ast_str_to_ast(ast_str), opts=opts)
 def kern_str_to_lin(kern_str:str, opts=None):
   (ast, applied_opts,) = eval(kern_str)
   k = Linearizer(*ast, opts=opts)

--- a/extra/optimization/search.py
+++ b/extra/optimization/search.py
@@ -1,13 +1,12 @@
 import argparse
+from extra.optimization.helpers import ast_str_to_lin
 
 from tinygrad import dtypes
 from tinygrad.helpers import BEAM, getenv
 from tinygrad.device import Device, Compiled
 from tinygrad.codegen.linearizer import Linearizer
 from tinygrad.features.search import time_linearizer, beam_search, bufs_from_lin
-from tinygrad.ops import LazyOp, BinaryOps, UnaryOps, ReduceOps, BufferOps, MemBuffer, ConstBuffer
-from tinygrad.shape.shapetracker import ShapeTracker
-from tinygrad.shape.view import View
+
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(description="Run a search for the optimal opts for a kernel", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -19,15 +18,14 @@ if __name__ == '__main__':
   print(f"optimizing for {Device.DEFAULT}")
 
   if args.ast is not None:
-    asts = [eval(args.ast)]
+    ast_strs = [args.ast]
   elif args.file is not None:
     with open(args.file, 'r') as file:
-     lines = file.readlines()
-    asts = [eval(line) for line in lines]
+     ast_strs = file.readlines()
 
-  for ast in asts:
-    print(f"optimizing ast={ast}")
-    lin = Linearizer(ast, device.compiler.linearizer_opts)
+  for ast_str in ast_strs:
+    print(f"optimizing ast={ast_str}")
+    lin = ast_str_to_lin(ast_str, opts=device.compiler.linearizer_opts)
     rawbufs = bufs_from_lin(lin)
     lin = beam_search(lin, rawbufs, getenv("BEAM", 8), bool(getenv("BEAM_ESTIMATE", 1)))
 

--- a/extra/to_movement_ops.py
+++ b/extra/to_movement_ops.py
@@ -1,12 +1,15 @@
 from tqdm import tqdm
 import itertools
+from enum import Enum, auto
 from collections import defaultdict
 from typing import List, Tuple, DefaultDict
 from extra.optimization.helpers import load_worlds, ast_str_to_ast
-from tinygrad.ops import MovementOps, BufferOps, LazyOp
+from tinygrad.ops import BufferOps, LazyOp
 from tinygrad.helpers import prod
 from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.shape.symbolic import sym_infer, Node
+
+class MovementOps(Enum): RESHAPE = auto(); PERMUTE = auto(); EXPAND = auto(); PAD = auto(); SHRINK = auto(); STRIDE = auto(); AS_STRIDED = auto() # noqa: E702
 
 def apply_mop(st: ShapeTracker, mop_arg: Tuple[MovementOps, Tuple]) -> ShapeTracker:
   mop, arg = mop_arg
@@ -142,6 +145,7 @@ def test_interpret_ast(ast:LazyOp):
 if __name__ == "__main__":
   ast_strs = load_worlds(False, False, True)[:4000]
   for ast_str in tqdm(ast_strs):
-    test_interpret_ast(ast_str_to_ast(ast_str))
+    for op in ast_str_to_ast(ast_str):
+      test_interpret_ast(op)
 
   print(f"avg length of mop = {sum(k*v for k,v in c.items()) / sum(c.values()):.2f}")

--- a/test/external/fuzz_linearizer.py
+++ b/test/external/fuzz_linearizer.py
@@ -1,4 +1,4 @@
-import random, traceback, ctypes
+import random, traceback, ctypes, argparse
 from typing import List, Tuple, DefaultDict
 import numpy as np
 from collections import defaultdict
@@ -159,7 +159,22 @@ def fuzz_linearizer(lin: Linearizer):
   return failures
 
 if __name__ == "__main__":
-  ast_strs = load_worlds(filter_reduce=False, filter_novariable=False)
+  parser = argparse.ArgumentParser(description="Run a fuzz testing on one or more kernels", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  parser.add_argument("--ast", type=str, default=None, help="the ast for the kernel to be optimized")
+  parser.add_argument("--file", type=str, default=None, help="a file containing asts to be optimized, one per line")
+  args = parser.parse_args()
+
+  if args.ast is not None:
+    print("loaded AST from CLI")
+    ast_strs = [args.ast]
+  elif args.file is not None:
+    print(f"loading ASTs from file '{args.file}'")
+    with open(args.file, 'r') as file:
+      ast_strs = file.readlines()
+  else:
+    print("loading ASTs from world")
+    ast_strs = load_worlds(filter_reduce=False, filter_novariable=False)
+
   print(f"{len(ast_strs)=}")
   tested = 0
   failed_ids = []


### PR DESCRIPTION
also fix up ast_str_to_str to support the new tuple of LazyOps

This will make it easier to integrate specific fuzz'ing of models into CI (i.e. use LOGOPS=/tmp/gpt2-asts.txt while running gpt2.py), then pass this to `fuzz_linearizer.py --file /tmp/gpt2-asts.txt`