### PR TITLE
simple fix llama shard with quantize

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -139,7 +139,8 @@ class AbsmaxQuantizedLinear:
   def quantize(tensors):
     new_tensors = {}
     for name,v in tensors.items():
-      if "feed_forward" in name or ("attention.w") in name or name == "output.weight":
+      if "feed_forward" in name or "attention.w" in name or name == "output.weight":
+        assert "weight" in name, name
         scale = v.abs().max(axis=1) / 127.0
         int8_weight = (v.T/scale).T.cast(dtype=dtypes.int8)
         new_tensors[name] = int8_weight
@@ -158,17 +159,6 @@ class LLaMa:
     jit = bool(getenv("JIT", 1))
     model = Transformer(**params["args"], linear=AbsmaxQuantizedLinear, max_context=MAX_CONTEXT, jit=jit) if quantize else Transformer(**params["args"], max_context=MAX_CONTEXT, jit=jit)
 
-    if isinstance(device, tuple):
-      for k,v in nn.state.get_state_dict(model).items():
-        if '.attention.' in k: v.shard_(device, axis=-1)
-        elif '.feed_forward.' in k: v.shard_(device, axis=-1)
-        elif 'tok_embeddings.weight' in k: v.shard_(device, axis=-1)
-        elif 'output.weight' in k: v.shard_(device, axis=-1)
-        #elif k.endswith('.weight'): v.shard_(device, axis=-1)
-        #elif 'norm.' in k: v.shard_(device, axis=-1)
-        else: v.shard_(device, axis=None)
-        #print(k, v.shape, v.lazydata.axis)
-
     if model_path.is_dir():
       weights = concat_weights([load(filename) for filename in [f"{model_path}/consolidated.{i:02d}.pth" for i in range(params["files"])]])
     else:
@@ -181,6 +171,19 @@ class LLaMa:
     if quantize:
       weights = AbsmaxQuantizedLinear.quantize(weights)
       for _,v in weights.items(): v.realize()
+
+    if isinstance(device, tuple):
+      for k,v in nn.state.get_state_dict(model).items():
+        if 'scale' in k: v.shard_(device, axis=None)  # from quantized
+        elif '.attention.' in k: v.shard_(device, axis=-1)
+        elif '.feed_forward.' in k: v.shard_(device, axis=-1)
+        elif 'tok_embeddings.weight' in k: v.shard_(device, axis=-1)
+        elif 'output.weight' in k: v.shard_(device, axis=-1)
+        #elif k.endswith('.weight'): v.shard_(device, axis=-1)
+        #elif 'norm.' in k: v.shard_(device, axis=-1)
+        else: v.shard_(device, axis=None)
+        #print(k, v.shape, v.lazydata.axis)
+
     load_state_dict(model, weights, strict=False, consume=True)
 
     return LLaMa(model, sp_model)


### PR DESCRIPTION
copy scale on all device for now. naive sharding does not work because scale needs expand to really save memory.

70B does not work due to HSA_STATUS_ERROR_OUT_OF_RESOURCES.

`python3 examples/llama.py --gen 2 --size 13B --shard 6 --prompt "Hello." --count 10 --temperature 0 --timing --quantize`

13B on 6 gpus uses 47 GB v.s. 34 GB quantized