### PR TITLE
docs: add warning message for conda users when using METAL

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -17,6 +17,7 @@ class MetalCompiler(Compiler):
   def __init__(self, device:Optional[MetalDevice]):
     self.device = device
     super().__init__("compile_metal")
+    if getenv("METAL") == 1 and (getenv("CONDA_DEFAULT_ENV", "") or getenv("CONDA_PREFIX", "")): print("WARNING: it looks like you might be running conda and using METAL backend. If you experience issues with \"MTLLibrary is not formatted as a MetalLib file\" try switching to system python or using METAL_XCODE. If you aren't using conda, report this in the following issue: https://github.com/tinygrad/tinygrad/issues/2226")
   def render(self, name:str, uops) -> str: return MetalRenderer(name, uops)
   def compile(self, src:str) -> bytes:
     if self.device is None:


### PR DESCRIPTION
This is a temporary help for users encountering the "MTLLibrary is not formatted as a MetalLib file" bug.

This bug occurs when users run tinygrad in a conda env.
workarounds for now are using METAL_XCODE=1 or switching off conda to system python.

edit: maybe I should add the disable compiler cache env var to that message too ?