### PR TITLE
opencl on OSX does not support fp16 extension

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -28,12 +28,13 @@ def is_dtype_supported(dtype: DType, device: str = Device.DEFAULT):
     return device in {"RHIP", "HSA"} or (device == "CUDA" and not CI)
   if device in ["WEBGPU", "WEBGL"]: return dtype in [dtypes.float, dtypes.int32, dtypes.uint32]
   if device == "CUDA" and getenv("PTX") and dtype in (dtypes.int8, dtypes.uint8): return False
-  # for CI GPU, cl_khr_fp16 isn't supported
+  # for CI GPU and OSX, cl_khr_fp16 isn't supported
   # for CI LLVM, it segfaults because it can't link to the casting function
   # CUDACPU architecture is sm_35 but we need at least sm_70 to run fp16 ALUs
   # PYTHON supports half memoryview in 3.12+ https://github.com/python/cpython/issues/90751
   if dtype == dtypes.half:
-    if device in ["GPU", "LLVM", "CUDA"]: return not CI
+    if device == "GPU": return not CI and not OSX
+    if device in ["LLVM", "CUDA"]: return not CI
     if device == "PYTHON": return sys.version_info >= (3, 12)
   if dtype == dtypes.float64: return device != "METAL" and not (OSX and device == "GPU")
   return True


### PR DESCRIPTION
running `GPU=1 python -m pytest -rA test/test_dtype.py::TestHalfDtype::test_casts_from` on mac would fail.