### PR TITLE
#3953 Fixes TypeError in limit_dims_to_max method of Kernel.py

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -309,7 +309,7 @@ class Kernel:
 
   # ******************** helpers ********************
 
-  def _limit_size(self, x: Tuple[int], max_size: List[Union[int,float]]) -> Tuple[int, ...]:
+  def _limit_size(self, x: Tuple[sint], max_size: List[Union[int,float]]) -> Tuple[int, ...]:
     new_shape = list(x)
     for i in range(len(new_shape)):
       next_idx = (i + 1) % len(new_shape)

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -309,7 +309,7 @@ class Kernel:
 
   # ******************** helpers ********************
 
-  def _limit_size(self, x: Tuple[sint], max_size: List[Union[int,float]]) -> Tuple[int, ...]:
+  def _limit_size(self, x: Tuple[sint], max_size: List[Union[int,float]]) -> Tuple[sint, ...]:
     new_shape = list(x)
     for i in range(len(new_shape)):
       next_idx = (i + 1) % len(new_shape)


### PR DESCRIPTION
#3953 


The lambda function of `reshape_and_permute` expects a lambda function which takes in a `List[sint]` as input. But the lambda function here takes `x` as input which is then used as an input for `limit_size` method which expects a `List[int]`

https://github.com/tinygrad/tinygrad/blob/6c7df1445b287131862a628937e03e336c895c0c/tinygrad/codegen/kernel.py#L330


When I looked into the implementation of `reshape_and_permute` method, this lambda function is given a `List[sint]` as input from the shape method of shapetracker

![image](https://github.com/tinygrad/tinygrad/assets/79764496/8451dc74-5905-42f5-9130-e4a03692d75b)
