### PR TITLE
correct device for validation test in model benchmark CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ jobs:
     # TODO: why is this test not reliable?
     #- name: Run Stable Diffusion
     #  run: python3 examples/stable_diffusion.py --seed 0 --noshow --timing | tee sd.txt
-    - name: Run model inference benchmark with METAL and CLANG
+    - name: Run model inference benchmark
       run: METAL=1 python3 test/external/external_model_benchmark.py
     - name: Test speed vs torch
       run: BIG=2 MPS=1 python3 test/test_speed_v_torch.py | tee torch_speed.txt
@@ -104,7 +104,7 @@ jobs:
         mkdir -p weights
         ln -s ~/tinygrad/weights/LLaMA weights/LLaMA
     - name: Run model inference benchmark
-      run: CUDA=1 NOCLANG=1 python3 test/external/external_model_benchmark.py
+      run: CUDA=1 python3 test/external/external_model_benchmark.py
     - name: Test speed vs torch
       run: CUDA=1 BIG=2 TORCHCUDA=1 python3 test/test_speed_v_torch.py | tee torch_speed.txt
     - name: Run Tensor Core GEMM

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
     #- name: Run Stable Diffusion
     #  run: python3 examples/stable_diffusion.py --seed 0 --noshow --timing | tee sd.txt
     - name: Run model inference benchmark
-      run: METAL=1 python3 test/external/external_model_benchmark.py
+      run: METAL=1 NOCLANG=1 python3 test/external/external_model_benchmark.py
     - name: Test speed vs torch
       run: BIG=2 MPS=1 python3 test/test_speed_v_torch.py | tee torch_speed.txt
     - name: Run Tensor Core GEMM
@@ -104,7 +104,7 @@ jobs:
         mkdir -p weights
         ln -s ~/tinygrad/weights/LLaMA weights/LLaMA
     - name: Run model inference benchmark
-      run: CUDA=1 python3 test/external/external_model_benchmark.py
+      run: CUDA=1 NOCLANG=1 python3 test/external/external_model_benchmark.py
     - name: Test speed vs torch
       run: CUDA=1 BIG=2 TORCHCUDA=1 python3 test/test_speed_v_torch.py | tee torch_speed.txt
     - name: Run Tensor Core GEMM

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ jobs:
     # TODO: why is this test not reliable?
     #- name: Run Stable Diffusion
     #  run: python3 examples/stable_diffusion.py --seed 0 --noshow --timing | tee sd.txt
-    - name: Run model inference benchmark
+    - name: Run model inference benchmark with METAL and CLANG
       run: METAL=1 python3 test/external/external_model_benchmark.py
     - name: Test speed vs torch
       run: BIG=2 MPS=1 python3 test/test_speed_v_torch.py | tee torch_speed.txt

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
     #- name: Run Stable Diffusion
     #  run: python3 examples/stable_diffusion.py --seed 0 --noshow --timing | tee sd.txt
     - name: Run model inference benchmark
-      run: METAL=1 NOCLANG=1 python3 test/external/external_model_benchmark.py
+      run: METAL=1 python3 test/external/external_model_benchmark.py
     - name: Test speed vs torch
       run: BIG=2 MPS=1 python3 test/test_speed_v_torch.py | tee torch_speed.txt
     - name: Run Tensor Core GEMM


### PR DESCRIPTION
Before both `METAL` and `CUDA` were validating with only the `CLANG` backend
Now CI validation runs for the intended specified backend.

Or if we remove `NOCLANG`, validation test runs for both specified backend and `CLANG`