### PR TITLE
llama: prevent device initialization outside of __main__

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -160,7 +160,7 @@ class LLaMa:
     model = Transformer(**params["args"], linear=AbsmaxQuantizedLinear, max_context=MAX_CONTEXT, jit=jit) if quantize else Transformer(**params["args"], max_context=MAX_CONTEXT, jit=jit)
 
     if model_path.is_dir():
-      weights = concat_weights([load(filename) for filename in [f"{model_path}/consolidated.{i:02d}.pth" for i in range(params["files"])]], device)
+      weights = concat_weights([load(filename) for filename in [f"{model_path}/consolidated.{i:02d}.pth" for i in range(params["files"])]], device[0] if isinstance(device, tuple) else device)
     else:
       weights = load(str(model_path))
     if "model.embed_tokens.weight" in weights:

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -106,7 +106,7 @@ MODEL_PARAMS = {
 
 
 # **** helper functions ****
-def concat_weights(models, device=Device.DEFAULT):
+def concat_weights(models, device=None):
   def convert(name) -> Tensor:
     disk_tensors: List[Tensor] = [model[name] for model in models]
     if len(disk_tensors) == 1 or len(disk_tensors[0].shape) == 1:
@@ -160,7 +160,7 @@ class LLaMa:
     model = Transformer(**params["args"], linear=AbsmaxQuantizedLinear, max_context=MAX_CONTEXT, jit=jit) if quantize else Transformer(**params["args"], max_context=MAX_CONTEXT, jit=jit)
 
     if model_path.is_dir():
-      weights = concat_weights([load(filename) for filename in [f"{model_path}/consolidated.{i:02d}.pth" for i in range(params["files"])]])
+      weights = concat_weights([load(filename) for filename in [f"{model_path}/consolidated.{i:02d}.pth" for i in range(params["files"])]], device)
     else:
       weights = load(str(model_path))
     if "model.embed_tokens.weight" in weights:


### PR DESCRIPTION
causes HSA resources leakages in child compile processes

To repro and make a tinybox REAALLY angry, do the following on master vs here: `PYTHONPATH=. DEBUG=2 BEAM=2 BEAM_MAX_TASKS_PER_CHILD=1 python3 examples/llama.py --gen 1 --size '7B' --temperature 0 --count 10 --prompt "Hello." --timing`.

You'll need to `rocm-smi -d N --gpureset` after to sort of recover (even after reset the default GPU is at 25Mhz and not 0Mhz).
