### PR TITLE
assert `__setitem__` if used other than disk

### DIFF
--- a/test/imported/test_indexing.py
+++ b/test/imported/test_indexing.py
@@ -1525,7 +1525,8 @@ class TestNumpy(unittest.TestCase):
   def test_broaderrors_indexing(self):
     a = Tensor.zeros(5, 5)
     self.assertRaises(IndexError, a.__getitem__, ([0, 1], [0, 1, 2]))
-    self.assertRaises(IndexError, a.__setitem__, ([0, 1], [0, 1, 2]), 0)
+    # TODO setitem
+    # self.assertRaises(IndexError, a.__setitem__, ([0, 1], [0, 1, 2]), 0)
 
   # TODO setitem
   '''

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -505,7 +505,9 @@ class Tensor:
         ret = ret.permute(ret_dims[first_dim:first_dim+max_idx_dim] + ret_dims[:first_dim] + ret_dims[first_dim+max_idx_dim:])
     return ret
 
-  def __setitem__(self,indices,v): return self.__getitem__(indices).assign(v)
+  def __setitem__(self,indices,v):
+    if isinstance(self.device, str) and self.device.startswith("DISK"): return self.__getitem__(indices).assign(v)
+    raise NotImplementedError("not implemented yet")
 
   # NOTE: using slice is discouraged and things should migrate to pad and shrink
   def slice(self, arg:Sequence[Optional[Tuple[int, sint]]], value:float=0) -> Tensor:


### PR DESCRIPTION
assign is more stable now, can start to think about #3394 