### PR TITLE
Shape changing bitcast and assert bitcast in disk

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -249,7 +249,7 @@ class TestUint8Dtype(TestDType):
 @unittest.skipIf(Device.DEFAULT == "WEBGL", "No bitcast on WebGL")
 class TestBitCast(unittest.TestCase):
   def test_shape_change_bitcast(self):
-    with self.assertRaises(AssertionError):
+    with self.assertRaises(RuntimeError):
       _test_bitcast(Tensor([100000], dtype=dtypes.float32), dtypes.uint8, [100000])
 
   def test_bitcast_float_to_int32(self):

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -249,9 +249,8 @@ class TestUint8Dtype(TestDType):
 @unittest.skipIf(Device.DEFAULT == "WEBGL", "No bitcast on WebGL")
 class TestBitCast(unittest.TestCase):
   def test_shape_change_bitcast(self):
-    with self.assertRaises(RuntimeError) as cm:
-      _test_bitcast(Tensor.empty((128,), dtype=dtypes.float32), dtypes.uint8)
-    self.assertEqual('shape changing bitcast only supported on DISK right now', str(cm.exception))
+    with self.assertRaises(AssertionError):
+      _test_bitcast(Tensor([100000], dtype=dtypes.float32), dtypes.uint8, [100000])
 
   def test_bitcast_float_to_int32(self):
     a = Tensor([1.,2,3])

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -1,4 +1,4 @@
-import unittest, operator, subprocess, tempfile, pathlib
+import unittest, operator, subprocess
 import numpy as np
 import torch
 from typing import Any, List

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -249,23 +249,9 @@ class TestUint8Dtype(TestDType):
 @unittest.skipIf(Device.DEFAULT == "WEBGL", "No bitcast on WebGL")
 class TestBitCast(unittest.TestCase):
   def test_shape_change_bitcast(self):
-    tmp = tempfile.mktemp()
-    _test_bitcast(Tensor([100000], dtype=dtypes.float32, device=f"DISK:{tmp}"), dtypes.uint32, [0x47C35000])
-    _test_bitcast(Tensor([100000], dtype=dtypes.float32, device=f"DISK:{tmp}"), dtypes.uint16, [0x5000, 0x47C3])
-    _test_bitcast(Tensor([100000], dtype=dtypes.float32, device=f"DISK:{tmp}"), dtypes.uint8, [0x00, 0x50, 0xC3, 0x47])
-
     with self.assertRaises(RuntimeError) as cm:
       _test_bitcast(Tensor.empty((128,), dtype=dtypes.float32), dtypes.uint8)
     self.assertEqual('shape changing bitcast only supported on DISK right now', str(cm.exception))
-
-    with self.assertRaises(RuntimeError) as cm:
-      Tensor.empty((3,), dtype=dtypes.int8, device=f"DISK:{tmp}").bitcast(dtypes.float16)
-    self.assertEqual('unsupported size in bitcast', str(cm.exception))
-
-    with self.assertRaises(RuntimeError) as cm:
-      Tensor.empty((4,), dtype=dtypes.int8, requires_grad=True, device=f"DISK:{tmp}").bitcast(dtypes.float16)
-    self.assertEqual('can\'t backprop through bitcast', str(cm.exception))
-    pathlib.Path(tmp).unlink()
 
   def test_bitcast_float_to_int32(self):
     a = Tensor([1.,2,3])

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -1,4 +1,4 @@
-import unittest, operator, subprocess
+import unittest, operator, subprocess, tempfile, pathlib
 import numpy as np
 import torch
 from typing import Any, List
@@ -249,21 +249,23 @@ class TestUint8Dtype(TestDType):
 @unittest.skipIf(Device.DEFAULT == "WEBGL", "No bitcast on WebGL")
 class TestBitCast(unittest.TestCase):
   def test_shape_change_bitcast(self):
-    _test_bitcast(Tensor([100000], dtype=dtypes.float32, device="DISK:/tmp/dummy.txt"), dtypes.uint32, [0x47C35000])
-    _test_bitcast(Tensor([100000], dtype=dtypes.float32, device="DISK:/tmp/dummy.txt"), dtypes.uint16, [0x5000, 0x47C3])
-    _test_bitcast(Tensor([100000], dtype=dtypes.float32, device="DISK:/tmp/dummy.txt"), dtypes.uint8, [0x00, 0x50, 0xC3, 0x47])
+    tmp = tempfile.mktemp()
+    _test_bitcast(Tensor([100000], dtype=dtypes.float32, device=f"DISK:{tmp}"), dtypes.uint32, [0x47C35000])
+    _test_bitcast(Tensor([100000], dtype=dtypes.float32, device=f"DISK:{tmp}"), dtypes.uint16, [0x5000, 0x47C3])
+    _test_bitcast(Tensor([100000], dtype=dtypes.float32, device=f"DISK:{tmp}"), dtypes.uint8, [0x00, 0x50, 0xC3, 0x47])
 
     with self.assertRaises(RuntimeError) as cm:
       _test_bitcast(Tensor.empty((128,), dtype=dtypes.float32), dtypes.uint8)
     self.assertEqual('shape changing bitcast only supported on DISK right now', str(cm.exception))
 
     with self.assertRaises(RuntimeError) as cm:
-      Tensor.empty((3,), dtype=dtypes.int8, device="DISK:/tmp/dummy.txt").bitcast(dtypes.float16)
+      Tensor.empty((3,), dtype=dtypes.int8, device=f"DISK:{tmp}").bitcast(dtypes.float16)
     self.assertEqual('unsupported size in bitcast', str(cm.exception))
 
     with self.assertRaises(RuntimeError) as cm:
-      Tensor.empty((4,), dtype=dtypes.int8, requires_grad=True, device="DISK:/tmp/dummy.txt").bitcast(dtypes.float16)
+      Tensor.empty((4,), dtype=dtypes.int8, requires_grad=True, device=f"DISK:{tmp}").bitcast(dtypes.float16)
     self.assertEqual('can\'t backprop through bitcast', str(cm.exception))
+    pathlib.Path(tmp).unlink()
 
   def test_bitcast_float_to_int32(self):
     a = Tensor([1.,2,3])

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -253,15 +253,15 @@ class TestBitCast(unittest.TestCase):
     _test_bitcast(Tensor([100000], dtype=dtypes.float32, device="DISK:/tmp/dummy.txt"), dtypes.uint16, [0x5000, 0x47C3])
     _test_bitcast(Tensor([100000], dtype=dtypes.float32, device="DISK:/tmp/dummy.txt"), dtypes.uint8, [0x00, 0x50, 0xC3, 0x47])
 
-    with self.assertRaises(AssertionError) as cm:
+    with self.assertRaises(RuntimeError) as cm:
       _test_bitcast(Tensor.empty((128,), dtype=dtypes.float32), dtypes.uint8)
     self.assertEqual('shape changing bitcast only supported on DISK right now', str(cm.exception))
 
-    with self.assertRaises(AssertionError) as cm:
+    with self.assertRaises(RuntimeError) as cm:
       Tensor.empty((3,), dtype=dtypes.int8, device="DISK:/tmp/dummy.txt").bitcast(dtypes.float16)
-    self.assertEqual('wrong size', str(cm.exception))
+    self.assertEqual('unsupported size in bitcast', str(cm.exception))
 
-    with self.assertRaises(AssertionError) as cm:
+    with self.assertRaises(RuntimeError) as cm:
       Tensor.empty((4,), dtype=dtypes.int8, requires_grad=True, device="DISK:/tmp/dummy.txt").bitcast(dtypes.float16)
     self.assertEqual('can\'t backprop through bitcast', str(cm.exception))
 

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -1,10 +1,9 @@
-import pathlib, unittest
+import pathlib, tempfile, unittest
 import numpy as np
 from tinygrad import Tensor, Device, dtypes
 from tinygrad.dtype import DType
 from tinygrad.nn.state import safe_load, safe_save, get_state_dict, torch_load
 from tinygrad.helpers import Timing, fetch, temp
-import tempfile
 from test.helpers import is_dtype_supported
 
 def compare_weights_both(url):

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -72,6 +72,15 @@ class TestRawDiskBuffer(unittest.TestCase):
     with self.assertRaises(RuntimeError) as cm:
       Tensor.empty((4,), dtype=dtypes.int16, requires_grad=True, device=f"disk:{tmp}").cast(dtypes.float16)
     self.assertEqual('attempted to cast disk buffer (bitcast only)', str(cm.exception))
+
+    # Those two should be moved to test_dtype.py:test_shape_change_bitcast after bitcast works on non-disk
+    with self.assertRaises(RuntimeError) as cm:
+      Tensor.empty((3,), dtype=dtypes.int8, device=f"DISK:{tmp}").bitcast(dtypes.float16)
+    self.assertEqual('unsupported size in bitcast', str(cm.exception))
+
+    with self.assertRaises(RuntimeError) as cm:
+      Tensor.empty((4,), dtype=dtypes.int8, requires_grad=True, device=f"DISK:{tmp}").bitcast(dtypes.float16)
+    self.assertEqual('can\'t backprop through bitcast', str(cm.exception))
     pathlib.Path(tmp).unlink()
 
 @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu doesn't support uint8 datatype")

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -67,6 +67,10 @@ class TestRawDiskBuffer(unittest.TestCase):
     t.bitcast(dtypes.float32).assign(Tensor.full((128, 32), 3.1415927, dtype=dtypes.float32)).realize()
     _test_bitcasted(t, dtypes.float32, 3.1415927)
     _test_bitcasted(t, dtypes.uint32, 0x40490FDB)
+    # doesn't suport normal cast
+    with self.assertRaises(RuntimeError) as cm:
+      Tensor.empty((4,), dtype=dtypes.int16, requires_grad=True, device="DISK:/tmp/dt_b1.txt").cast(dtypes.float16)
+    self.assertEqual('attempted to cast disk buffer (bitcast only)', str(cm.exception))
 
 @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu doesn't support uint8 datatype")
 class TestSafetensors(unittest.TestCase):

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -68,18 +68,18 @@ class TestRawDiskBuffer(unittest.TestCase):
     _test_bitcasted(t, dtypes.float32, 3.1415927)
     _test_bitcasted(t, dtypes.uint32, 0x40490FDB)
     # doesn't suport normal cast
-    with self.assertRaises(RuntimeError) as cm:
-      Tensor.empty((4,), dtype=dtypes.int16, requires_grad=True, device=f"disk:{tmp}").cast(dtypes.float16)
-    self.assertEqual('attempted to cast disk buffer (bitcast only)', str(cm.exception))
+    with self.assertRaises(RuntimeError):
+      Tensor.empty((4,), dtype=dtypes.int16, device=f"disk:{tmp}").cast(dtypes.float16)
 
     # Those two should be moved to test_dtype.py:test_shape_change_bitcast after bitcast works on non-disk
-    with self.assertRaises(RuntimeError) as cm:
+    with self.assertRaises(RuntimeError):
+      # should fail because 3 int8 is 3 bytes but float16 is two and 3 isn't a multiple of 2
       Tensor.empty((3,), dtype=dtypes.int8, device=f"DISK:{tmp}").bitcast(dtypes.float16)
-    self.assertEqual('unsupported size in bitcast', str(cm.exception))
 
-    with self.assertRaises(RuntimeError) as cm:
+    with self.assertRaises(RuntimeError):
+      # should fail because backprop through bitcast is undefined
       Tensor.empty((4,), dtype=dtypes.int8, requires_grad=True, device=f"DISK:{tmp}").bitcast(dtypes.float16)
-    self.assertEqual('can\'t backprop through bitcast', str(cm.exception))
+
     pathlib.Path(tmp).unlink()
 
 @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu doesn't support uint8 datatype")

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -82,6 +82,7 @@ class LazyBuffer:
       return self.base.cast(dtype, bitcast)._view(self.st)
     new_shape = self.shape
     if bitcast and self.dtype.itemsize != dtype.itemsize:
+      assert self.device.startswith("DISK"), "shape changing bitcast only supported on DISK right now"
       assert all_int(new_shape), "shape changing bitcast with symbolic shape isn't supported yet"
       # https://pytorch.org/docs/stable/generated/torch.Tensor.view.html
       assert (new_shape[-1]*self.dtype.itemsize) % dtype.itemsize == 0, "wrong size"

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -82,10 +82,10 @@ class LazyBuffer:
       return self.base.cast(dtype, bitcast)._view(self.st)
     new_shape = self.shape
     if bitcast and self.dtype.itemsize != dtype.itemsize:
-      assert self.device.startswith("DISK"), "shape changing bitcast only supported on DISK right now"
-      assert all_int(new_shape), "shape changing bitcast with symbolic shape isn't supported yet"
+      if not self.device.startswith("DISK"): raise RuntimeError("shape changing bitcast only supported on DISK right now")
+      if not all_int(new_shape): raise RuntimeError("shape changing bitcast with symbolic shape isn't supported yet")
       # https://pytorch.org/docs/stable/generated/torch.Tensor.view.html
-      assert (new_shape[-1]*self.dtype.itemsize) % dtype.itemsize == 0, "wrong size"
+      if not (new_shape[-1]*self.dtype.itemsize) % dtype.itemsize == 0: raise RuntimeError("unsupported size in bitcast")
       new_shape = new_shape[:-1] + ((new_shape[-1]*self.dtype.itemsize) // dtype.itemsize,)
     return create_lazybuffer(self.device, ShapeTracker.from_shape(new_shape), dtype, UnaryOps.CAST, (dtype, bitcast), (self,))
 

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -76,10 +76,17 @@ class LazyBuffer:
 
   def cast(self, dtype:DType, bitcast:bool=False):
     if self.dtype == dtype: return self
+    if self.device.startswith("DISK") and not bitcast: raise RuntimeError("attempted to cast disk buffer (bitcast only)")
     # TODO: applying this makes gpt2 slower
     if getenv("CAST_BEFORE_VIEW", 1) and dtype.itemsize <= self.dtype.itemsize and self != self.base:
       return self.base.cast(dtype, bitcast)._view(self.st)
-    return create_lazybuffer(self.device, ShapeTracker.from_shape(self.shape), dtype, UnaryOps.CAST, (dtype, bitcast), (self,))
+    new_shape = self.shape
+    if bitcast and self.dtype.itemsize != dtype.itemsize:
+      assert all_int(new_shape), "shape changing bitcast with symbolic shape isn't supported yet"
+      # https://pytorch.org/docs/stable/generated/torch.Tensor.view.html
+      assert (new_shape[-1]*self.dtype.itemsize) % dtype.itemsize == 0, "wrong size"
+      new_shape = new_shape[:-1] + ((new_shape[-1]*self.dtype.itemsize) // dtype.itemsize,)
+    return create_lazybuffer(self.device, ShapeTracker.from_shape(new_shape), dtype, UnaryOps.CAST, (dtype, bitcast), (self,))
 
   def is_unrealized_const(self): return not self.base.realized and self.base.op is LoadOps.CONST
   def is_unrealized_contiguous_const(self): return self.base == self and not self.base.realized and self.op is LoadOps.CONST

--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -53,7 +53,7 @@ class DiskRunner(JITRunner):
     # TODO: there shouldn't actually be casts here, bitcasts should fold into the load
     if ast.src[0].op == UnaryOps.CAST:
       top_src = ast.src[0].src[0]
-      # TODO: assert that this is bitcast
+      assert ast.src[0].arg[1], "disk only supports bitcasts, not normal casts"
       self.new_dtype = ast.src[0].arg[0]
     else:
       top_src = ast.src[0]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1028,7 +1028,7 @@ class Tensor:
     return self.to("LLVM").bitcast(dtypes.uint16).cast(dtypes.uint32).mul(1<<16).bitcast(dtypes.float32).cast(dtype)
   def cast(self, dtype:DType) -> Tensor: return self if self.dtype == dtype else mlops.Cast.apply(self, dtype=dtype)
   def bitcast(self, dtype:DType) -> Tensor:
-    assert self.dtype.itemsize == dtype.itemsize, "can't bitcast mismatched dtype itemsizes"
+    assert not self.requires_grad, "can't backprop through bitcast"
     return mlops.Cast.apply(self, dtype=dtype, bitcast=True) if self.dtype != dtype else self
   def float(self) -> Tensor: return self.cast(dtypes.float32)
   def half(self) -> Tensor: return self.cast(dtypes.float16)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1028,7 +1028,7 @@ class Tensor:
     return self.to("LLVM").bitcast(dtypes.uint16).cast(dtypes.uint32).mul(1<<16).bitcast(dtypes.float32).cast(dtype)
   def cast(self, dtype:DType) -> Tensor: return self if self.dtype == dtype else mlops.Cast.apply(self, dtype=dtype)
   def bitcast(self, dtype:DType) -> Tensor:
-    assert not self.requires_grad, "can't backprop through bitcast"
+    if self.requires_grad: raise RuntimeError("can't backprop through bitcast")
     return mlops.Cast.apply(self, dtype=dtype, bitcast=True) if self.dtype != dtype else self
   def float(self) -> Tensor: return self.cast(dtypes.float32)
   def half(self) -> Tensor: return self.cast(dtypes.float16)


### PR DESCRIPTION
On master disk doesn't assert that a cast is bitcast and does it as a bitcast even if it's a normal cast.
This behaviour is a footgun at least and broken at most. Also this is required (kinda, not really but it would make things much cleaner) for my zero copy offset buffers