### PR TITLE
Verify the acc dtype in linearizer

### DIFF
--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -230,7 +230,7 @@ class TestLinearizerFailures(unittest.TestCase):
     opts = [Opt(op=OptOps.PADTO, axis=3, amt=32), Opt(op=OptOps.LOCAL, axis=3, amt=32), Opt(op=OptOps.UPCAST, axis=3, amt=4), Opt(op=OptOps.UPCAST, axis=3, amt=0)]
 
     with self.assertRaises(AssertionError):
-      helper_test_lin(Linearizer(ast), opts, failed_platforms=[], atol=1.0)
+      helper_test_lin(Linearizer(ast), opts, failed_platforms=["LLVM", "GPU", "CLANG"], atol=1.0)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -225,6 +225,12 @@ class TestLinearizerFailures(unittest.TestCase):
     opts = [Opt(op=OptOps.TC, axis=0, amt=1), Opt(op=OptOps.PADTO, axis=2, amt=32)]
     helper_test_lin(Linearizer(ast), opts, failed_platforms=[], atol=1.0)
 
+  def test_failure_30(self):
+    ast = LazyOp(op=BufferOps.STORE, src=(LazyOp(op=UnaryOps.CAST, src=(LazyOp(op=ReduceOps.SUM, src=(LazyOp(op=UnaryOps.CAST, src=(LazyOp(op=BinaryOps.MUL, src=(LazyOp(op=BufferOps.LOAD, src=(), arg=MemBuffer(idx=1, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(256, 1, 12, 31, 31, 3, 2, 2), strides=(3072, 0, 0, 32, 1, 1024, 32, 1), offset=0, mask=None, contiguous=False),)))), LazyOp(op=BufferOps.LOAD, src=(), arg=MemBuffer(idx=2, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(256, 1, 12, 31, 31, 3, 2, 2), strides=(0, 0, 12, 0, 0, 4, 2, 1), offset=0, mask=None, contiguous=False),))))), arg=None),), arg=(dtypes.float, False)),), arg=(7, 6, 5)),), arg=(dtypes.half, False)),), arg=MemBuffer(idx=0, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(256, 1, 12, 31, 31, 1, 1, 1), strides=(11532, 0, 961, 31, 1, 0, 0, 0), offset=0, mask=None, contiguous=True),))))
+    opts = [Opt(op=OptOps.PADTO, axis=3, amt=32), Opt(op=OptOps.LOCAL, axis=3, amt=32), Opt(op=OptOps.UPCAST, axis=3, amt=4), Opt(op=OptOps.UPCAST, axis=3, amt=0)]
+
+    with self.assertRaises(AssertionError):
+      helper_test_lin(Linearizer(ast), opts, failed_platforms=[], atol=1.0)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -175,7 +175,7 @@ class UOpGraph:
   def type_verify(self):
     for u in self.uops:
       uop, arg, vin, dtype = u.uop, u.arg, u.vin, u.dtype
-      if uop is UOps.CONST: assert dtype is not None and type(arg) is type(dtypes.as_const(arg, dtype)), f"{arg} type does not match {dtype}"
+      if uop in [UOps.CONST, UOps.DEFINE_ACC]: assert dtype is not None and type(arg) is type(dtypes.as_const(arg, dtype)), f"{arg} type does not match {dtype}"
       if uop is UOps.ALU:
         if arg in UnaryOps:
           assert dtype == vin[0].dtype, f"{arg} dtype mismatch {dtype=} != {vin[0].dtype=}"

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -175,7 +175,8 @@ class UOpGraph:
   def type_verify(self):
     for u in self.uops:
       uop, arg, vin, dtype = u.uop, u.arg, u.vin, u.dtype
-      if uop in [UOps.CONST, UOps.DEFINE_ACC]: assert dtype is not None and type(arg) is type(dtypes.as_const(arg, dtype)), f"{arg} type does not match {dtype}"
+      if uop in [UOps.CONST, UOps.DEFINE_ACC]:
+        assert dtype is not None and type(arg) is type(dtypes.as_const(arg, dtype)), f"{arg} type does not match {dtype}"
       if uop is UOps.ALU:
         if arg in UnaryOps:
           assert dtype == vin[0].dtype, f"{arg} dtype mismatch {dtype=} != {vin[0].dtype=}"


### PR DESCRIPTION
These opts caused a float DEFINE_ACC with an int arg:
```
UOps.DEFINE_ACC     : dtypes.float              []                               0
```