### PR TITLE
always use f32 for rand source of randn 

### DIFF
--- a/test/test_randomness.py
+++ b/test/test_randomness.py
@@ -103,7 +103,7 @@ class TestRandomness(unittest.TestCase):
     self.assertTrue(normal_test(Tensor.randn))
     self.assertTrue(equal_distribution(Tensor.randn, torch.randn, lambda x: np.random.randn(*x)))
 
-  @given(strat.sampled_from([dtypes.float, dtypes.float16]))#, dtypes.bfloat16]))  # TODO: add bfloat16
+  @given(strat.sampled_from([dtypes.float, dtypes.float16, dtypes.bfloat16]))
   @unittest.skipIf(Device.DEFAULT=="RHIP", "broken in HIP CI")
   def test_randn_finite(self, default_float):
     if not is_dtype_supported(default_float): return
@@ -113,10 +113,9 @@ class TestRandomness(unittest.TestCase):
     t = Tensor.randn(1024, 1024)
     mx = t.max().numpy().item()
     mn = t.min().numpy().item()
-    if default_float == dtypes.float or (default_float == dtypes.float16 and not THREEFRY.value):
-      print(f"testing with {default_float=}")
-      assert math.isfinite(mx), mx
-      assert math.isfinite(mn), mn
+    print(f"testing with {default_float=}")
+    assert math.isfinite(mx), mx
+    assert math.isfinite(mn), mn
     dtypes.default_float = old_default_float
 
   def test_randint(self):

--- a/test/test_randomness.py
+++ b/test/test_randomness.py
@@ -104,7 +104,8 @@ class TestRandomness(unittest.TestCase):
     self.assertTrue(equal_distribution(Tensor.randn, torch.randn, lambda x: np.random.randn(*x)))
 
   @given(strat.sampled_from([dtypes.float, dtypes.float16, dtypes.bfloat16]))
-  @unittest.skipIf(Device.DEFAULT=="RHIP", "broken in HIP CI")
+  @unittest.skipIf(Device.DEFAULT=="RHIP", "float16 broken in HIP CI")
+  @unittest.skipIf(Device.DEFAULT=="HSA", "bfloat16 local buffer broken in HSA")
   def test_randn_finite(self, default_float):
     if not is_dtype_supported(default_float): return
     old_default_float = dtypes.default_float

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -292,7 +292,7 @@ class Tensor:
   @staticmethod
   def randn(*shape, dtype:Optional[DType]=None, **kwargs) -> Tensor:
     # https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
-    src = Tensor.rand((2, *argfix(*shape)), **kwargs)
+    src = Tensor.rand((2, *argfix(*shape)), **{**kwargs, "dtype": dtypes.float32})
     return src[0].mul(2*math.pi).cos().mul((1 - src[1]).log().mul(-2).sqrt()).cast(dtype or dtypes.default_float)
 
   @staticmethod


### PR DESCRIPTION
fixed bfloat16 randn to not have inf.
don't really care about float64. threefry is float32 based too.

no nan loss training resnet with bf16
this
```
training resnet
Training on ['CUDA:0']
training with batch size 128 for 41 epochs
    0 64281.37 ms run, 64267.41 ms python,  12.40 ms fetch data,    1.56 ms CUDA * 1,  7.07 loss, 0.00 acc, 0.000011 LR, 0.17 GB used,     49.38 GFLOPS
    1 9314.52 ms run, 9309.47 ms python,   3.79 ms fetch data,    1.26 ms CUDA * 1,  7.03 loss, 0.00 acc, 0.000021 LR, 12.52 GB used,    340.80 GFLOPS
    2 1042.35 ms run,    5.93 ms python,   5.02 ms fetch data, 1031.39 ms CUDA * 1,  7.09 loss, 0.00 acc, 0.000032 LR, 12.52 GB used,   3045.39 GFLOPS
    3 1044.67 ms run,    4.12 ms python,   4.99 ms fetch data, 1035.57 ms CUDA * 1,  7.00 loss, 0.00 acc, 0.000042 LR, 12.52 GB used,   3038.62 GFLOPS
    4 1062.27 ms run,    4.45 ms python,   6.05 ms fetch data, 1051.76 ms CUDA * 1,  7.00 loss, 0.00 acc, 0.000053 LR, 12.52 GB used,   2988.29 GFLOPS
    5 1028.82 ms run,    4.23 ms python,   4.04 ms fetch data, 1020.54 ms CUDA * 1,  7.04 loss, 0.00 acc, 0.000064 LR, 12.52 GB used,   3085.45 GFLOPS
    6 1040.22 ms run,    3.89 ms python,   4.47 ms fetch data, 1031.86 ms CUDA * 1,  7.05 loss, 0.00 acc, 0.000074 LR, 12.52 GB used,   3051.62 GFLOPS
    7 1031.19 ms run,    3.78 ms python,   4.11 ms fetch data, 1023.30 ms CUDA * 1,  7.03 loss, 0.00 acc, 0.000085 LR, 12.52 GB used,   3078.35 GFLOPS
    8 1043.36 ms run,    3.74 ms python,   5.10 ms fetch data, 1034.52 ms CUDA * 1,  7.02 loss, 0.00 acc, 0.000095 LR, 12.52 GB used,   3042.45 GFLOPS
    9 1042.55 ms run,    3.70 ms python,   4.13 ms fetch data, 1034.72 ms CUDA * 1,  7.08 loss, 0.00 acc, 0.000106 LR, 12.52 GB used,   3044.81 GFLOPS
Estimated training time: 119h56m
```

master
```
training resnet
Training on ['CUDA:0']
training with batch size 128 for 41 epochs
    0 19865.33 ms run, 19852.49 ms python,  11.28 ms fetch data,    1.55 ms CUDA * 1,   nan loss, 0.00 acc, 0.000011 LR, 0.17 GB used,    159.79 GFLOPS
    1 3046.13 ms run, 3041.42 ms python,   3.61 ms fetch data,    1.10 ms CUDA * 1,   nan loss, 0.01 acc, 0.000021 LR, 12.52 GB used,   1042.09 GFLOPS
    2 1046.92 ms run,    5.58 ms python,   3.61 ms fetch data, 1037.73 ms CUDA * 1,   nan loss, 0.00 acc, 0.000032 LR, 12.52 GB used,   3032.08 GFLOPS
    3 1068.76 ms run,    3.69 ms python,   4.38 ms fetch data, 1060.69 ms CUDA * 1,   nan loss, 0.00 acc, 0.000042 LR, 12.52 GB used,   2970.14 GFLOPS
    4 1042.35 ms run,    3.75 ms python,   4.87 ms fetch data, 1033.74 ms CUDA * 1,   nan loss, 0.00 acc, 0.000053 LR, 12.52 GB used,   3045.38 GFLOPS
    5 1051.49 ms run,    3.55 ms python,   4.06 ms fetch data, 1043.89 ms CUDA * 1,   nan loss, 0.00 acc, 0.000064 LR, 12.52 GB used,   3018.90 GFLOPS
    6 1041.02 ms run,    4.14 ms python,   4.39 ms fetch data, 1032.49 ms CUDA * 1,   nan loss, 0.00 acc, 0.000074 LR, 12.52 GB used,   3049.27 GFLOPS
    7 1054.93 ms run,    3.77 ms python,   3.92 ms fetch data, 1047.25 ms CUDA * 1,   nan loss, 0.00 acc, 0.000085 LR, 12.52 GB used,   3009.06 GFLOPS
    8 1054.79 ms run,    3.83 ms python,   4.67 ms fetch data, 1046.29 ms CUDA * 1,   nan loss, 0.00 acc, 0.000095 LR, 12.52 GB used,   3009.47 GFLOPS
    9 1042.78 ms run,    3.61 ms python,   5.23 ms fetch data, 1033.95 ms CUDA * 1,   nan loss, 0.02 acc, 0.000106 LR, 12.52 GB used,   3044.12 GFLOPS
Estimated training time: 120h14m
```