### PR TITLE
Tensor.__setitem__

### DIFF
--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -1,0 +1,12 @@
+import unittest
+from tinygrad import Tensor
+
+import numpy as np
+
+class TestAssign(unittest.TestCase):
+  def test_set_value(self):
+    n = np.random.random((10, 10, 10)).astype(np.float32)
+    t = Tensor(n)
+    t[2:5,6:9,:] = 3
+    n[2:5,6:9,:] = 3
+    np.testing.assert_allclose(t.numpy(), n)


### PR DESCRIPTION
this will never get fast, maybe we pass st into assign? and use output shapetracker

`CLANG=1 NOOPT=1 DEBUG=4 python -m pytest -rA test/test_setitem.py`

```
void E_10_10_10(float* restrict data0, const float* restrict data1) {
  for (int ridx0 = 0; ridx0 < 10; ridx0++) {
    for (int ridx1 = 0; ridx1 < 10; ridx1++) {
      for (int ridx2 = 0; ridx2 < 10; ridx2++) {
        int alu0 = ((ridx0*100)+(ridx1*10)+ridx2);
        float val0 = ((((ridx0*(-1))<(-1))*(ridx0<5)*((ridx1*(-1))<(-5))*(ridx1<9))?data1[alu0]:0.0f);
        float val1 = data1[alu0];
        data0[alu0] = ((bool)(val0)?3.0f:val1);
      }
    }
  }
}
```