### PR TITLE
uops const fold rules to prevent tautological compare warnings

### DIFF
--- a/test/test_const_folding.py
+++ b/test/test_const_folding.py
@@ -141,6 +141,12 @@ class TestTautologicalCompare(unittest.TestCase):
     # True < bool is always false
     np.testing.assert_equal((True < Tensor([True, False])).numpy(), [False, False])
 
+  def test_truth_table(self):
+    np.testing.assert_equal((Tensor(False) < Tensor(False)).numpy(), False)
+    np.testing.assert_equal((Tensor(False) < Tensor(True)).numpy(), True)
+    np.testing.assert_equal((Tensor(True) < Tensor(False)).numpy(), False)
+    np.testing.assert_equal((Tensor(True) < Tensor(True)).numpy(), False)
+
   @unittest.skipIf(Device.DEFAULT=="LLVM", "LLVM compare with nan is incorrect")
   def test_a_eq_a(self):
     # self eq is always true for int or bool

--- a/test/test_const_folding.py
+++ b/test/test_const_folding.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest, math
 from tinygrad import Tensor, Device
 from tinygrad.engine.schedule import create_schedule
 from tinygrad.features.multi import MultiLazyBuffer
@@ -142,14 +142,21 @@ class TestTautologicalCompare(unittest.TestCase):
     np.testing.assert_equal((True < Tensor([True, False])).numpy(), [False, False])
 
   def test_a_eq_a(self):
-    # self eq is always true
+    # self eq is always true for int or bool
     a = Tensor([1, 2, 3])
     np.testing.assert_equal((a == a).numpy(), [True, True, True])
 
+    a = Tensor([math.nan, 1.0, 2.0])
+    np.testing.assert_equal((a == a).numpy(), [False, True, True])
+
   def test_a_ne_a(self):
-    # self not eq is always false
+    # self not eq is always false for int or bool
     a = Tensor([1, 2, 3])
     np.testing.assert_equal((a != a).numpy(), [False, False, False])
+
+    # except nan
+    a = Tensor([math.nan, 1.0, 2.0])
+    np.testing.assert_equal((a != a).numpy(), [True, False, False])
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_const_folding.py
+++ b/test/test_const_folding.py
@@ -141,6 +141,7 @@ class TestTautologicalCompare(unittest.TestCase):
     # True < bool is always false
     np.testing.assert_equal((True < Tensor([True, False])).numpy(), [False, False])
 
+  @unittest.skipIf(Device.DEFAULT=="LLVM", "LLVM compare with nan is incorrect")
   def test_a_eq_a(self):
     # self eq is always true for int or bool
     a = Tensor([1, 2, 3])
@@ -149,6 +150,7 @@ class TestTautologicalCompare(unittest.TestCase):
     a = Tensor([math.nan, 1.0, 2.0])
     np.testing.assert_equal((a == a).numpy(), [False, True, True])
 
+  @unittest.skipIf(Device.DEFAULT=="LLVM", "LLVM compare with nan is incorrect")
   def test_a_ne_a(self):
     # self not eq is always false for int or bool
     a = Tensor([1, 2, 3])

--- a/test/test_const_folding.py
+++ b/test/test_const_folding.py
@@ -131,5 +131,25 @@ class TestMultiConstFolding(unittest.TestCase):
     _check_ast_count(0, t ** 1)
     _check_ast_count(0, 1 ** t)
 
+class TestTautologicalCompare(unittest.TestCase):
+  # without const folding, these would have triggered -Wtautological-compare in clang
+  def test_lt_false(self):
+    # bool < False is always false
+    np.testing.assert_equal((Tensor([True, False]) < False).numpy(), [False, False])
+
+  def test_true_lt(self):
+    # True < bool is always false
+    np.testing.assert_equal((True < Tensor([True, False])).numpy(), [False, False])
+
+  def test_a_eq_a(self):
+    # self eq is always true
+    a = Tensor([1, 2, 3])
+    np.testing.assert_equal((a == a).numpy(), [True, True, True])
+
+  def test_a_ne_a(self):
+    # self not eq is always false
+    a = Tensor([1, 2, 3])
+    np.testing.assert_equal((a != a).numpy(), [False, False, False])
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_const_folding.py
+++ b/test/test_const_folding.py
@@ -147,7 +147,7 @@ class TestTautologicalCompare(unittest.TestCase):
     np.testing.assert_equal((Tensor(True) < Tensor(False)).numpy(), False)
     np.testing.assert_equal((Tensor(True) < Tensor(True)).numpy(), False)
 
-  @unittest.skip("not implement yet")
+  @unittest.skip("not implemented yet")
   def test_a_eq_a(self):
     # self eq is always true for int or bool
     a = Tensor([1, 2, 3])
@@ -157,7 +157,7 @@ class TestTautologicalCompare(unittest.TestCase):
     a = Tensor([math.nan, 1.0, 2.0])
     np.testing.assert_equal((a == a).numpy(), [False, True, True])
 
-  @unittest.skip("not implement yet")
+  @unittest.skip("not implemented yet")
   def test_a_ne_a(self):
     # self not eq is always false for int or bool
     a = Tensor([1, 2, 3])

--- a/test/test_const_folding.py
+++ b/test/test_const_folding.py
@@ -147,22 +147,23 @@ class TestTautologicalCompare(unittest.TestCase):
     np.testing.assert_equal((Tensor(True) < Tensor(False)).numpy(), False)
     np.testing.assert_equal((Tensor(True) < Tensor(True)).numpy(), False)
 
-  @unittest.skipIf(Device.DEFAULT=="LLVM", "LLVM compare with nan is incorrect")
+  @unittest.skip("not implement yet")
   def test_a_eq_a(self):
     # self eq is always true for int or bool
     a = Tensor([1, 2, 3])
     np.testing.assert_equal((a == a).numpy(), [True, True, True])
 
+    # not true for nan
     a = Tensor([math.nan, 1.0, 2.0])
     np.testing.assert_equal((a == a).numpy(), [False, True, True])
 
-  @unittest.skipIf(Device.DEFAULT=="LLVM", "LLVM compare with nan is incorrect")
+  @unittest.skip("not implement yet")
   def test_a_ne_a(self):
     # self not eq is always false for int or bool
     a = Tensor([1, 2, 3])
     np.testing.assert_equal((a != a).numpy(), [False, False, False])
 
-    # except nan
+    # not true for nan
     a = Tensor([math.nan, 1.0, 2.0])
     np.testing.assert_equal((a != a).numpy(), [True, False, False])
 

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -79,7 +79,7 @@ constant_folder = PatternMatcher([
   # bool < False is always false, True < bool is always false
   ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({}, {"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.bool, "arg": False})}, lambda x: x),
   ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.bool, "arg": True}, {})},
-   lambda x: UOp.const(x.dtype, False)),
+    lambda x: UOp.const(dtypes.bool, False)),
   # a conditional with the same results either way is a noop, also fold const conditionals
   ({"uop": UOps.ALU, "arg": TernaryOps.WHERE, "vin": ({}, {"__name__": "val"}, {"__name__": "val"})}, lambda val: val),
   ({"uop": UOps.ALU, "arg": TernaryOps.WHERE, "vin": ({"__name__": "gate", "uop": UOps.CONST}, {"__name__": "c0"}, {"__name__": "c1"})},

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -82,7 +82,7 @@ constant_folder = PatternMatcher([
   ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({}, {"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.bool, "arg": False})}, lambda x: x),
   ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.bool, "arg": True}, {})},
    lambda x: UOp.const(x.dtype, False)),
-  # x == x is always true
+  # x == x is always true for non-float
   ({"uop": UOps.ALU, "arg": BinaryOps.CMPEQ, "vin": ({"__name__": "x", "dtype": lambda dt: not dtypes.is_float(dt)}, {"__name__": "x"})},
    lambda x: UOp.const(dtypes.bool, True)),
   # a conditional with the same results either way is a noop, also fold const conditionals

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -51,9 +51,7 @@ def _match(uop:UOp, pattern:Dict[str, Any], store:Dict[str, UOp]) -> bool:
           return True
       return False
     else:
-      if callable(v):
-        if not v(uop.__getattribute__(k)): return False
-      elif uop.__getattribute__(k) != v: return False
+      if uop.__getattribute__(k) != v: return False
   return True
 
 class PatternMatcher:
@@ -82,9 +80,6 @@ constant_folder = PatternMatcher([
   ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({}, {"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.bool, "arg": False})}, lambda x: x),
   ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.bool, "arg": True}, {})},
    lambda x: UOp.const(x.dtype, False)),
-  # x == x is always true for non-float
-  ({"uop": UOps.ALU, "arg": BinaryOps.CMPEQ, "vin": ({"__name__": "x", "dtype": lambda dt: not dtypes.is_float(dt)}, {"__name__": "x"})},
-   lambda x: UOp.const(dtypes.bool, True)),
   # a conditional with the same results either way is a noop, also fold const conditionals
   ({"uop": UOps.ALU, "arg": TernaryOps.WHERE, "vin": ({}, {"__name__": "val"}, {"__name__": "val"})}, lambda val: val),
   ({"uop": UOps.ALU, "arg": TernaryOps.WHERE, "vin": ({"__name__": "gate", "uop": UOps.CONST}, {"__name__": "c0"}, {"__name__": "c1"})},

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -76,6 +76,12 @@ constant_folder = PatternMatcher([
   # x+-y -> x-y
   ({"uop": UOps.ALU, "arg": BinaryOps.ADD, "vin": ({"__name__": "x"}, {"__name__": "my", "uop": UOps.ALU, "arg": UnaryOps.NEG})},
     lambda x, my: UOp(UOps.ALU, x.dtype, (x, my.vin[0]), BinaryOps.SUB)),
+  # bool < False is always false, True < bool is always false
+  ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({}, {"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.bool, "arg": False})}, lambda x: x),
+  ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.bool, "arg": True}, {})},
+   lambda x: UOp.const(x.dtype, False)),
+  # x == x is always true
+  ({"uop": UOps.ALU, "arg": BinaryOps.CMPEQ, "vin": ({"__name__": "x"}, {"__name__": "x"})}, lambda x: UOp.const(dtypes.bool, True)),
   # a conditional with the same results either way is a noop, also fold const conditionals
   ({"uop": UOps.ALU, "arg": TernaryOps.WHERE, "vin": ({}, {"__name__": "val"}, {"__name__": "val"})}, lambda val: val),
   ({"uop": UOps.ALU, "arg": TernaryOps.WHERE, "vin": ({"__name__": "gate", "uop": UOps.CONST}, {"__name__": "c0"}, {"__name__": "c1"})},


### PR DESCRIPTION
`bool < false` is false, `true < bool` is false

(`a == a` is true, `a != a` is false is not implemented in this pr due to issues with float and nan)