### PR TITLE
only fold empty shape const for advanced indexing

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -422,7 +422,7 @@ class Tensor:
     else: indices = [indices]
 
     # turn scalar Tensors into const val for int indexing if possible
-    indices = [self._to_const_val(i) if isinstance(i, Tensor) else i for i in indices]
+    indices = [self._to_const_val(i) if isinstance(i, Tensor) and i.shape == (0,) else i for i in indices]
     # move Tensor indices to the same device as self
     indices = [i.to(self.device) if isinstance(i, Tensor) else i for i in indices]
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -422,7 +422,7 @@ class Tensor:
     else: indices = [indices]
 
     # turn scalar Tensors into const val for int indexing if possible
-    indices = [self._to_const_val(i) if isinstance(i, Tensor) and i.shape == (0,) else i for i in indices]
+    indices = [self._to_const_val(i) if isinstance(i, Tensor) and i.shape == () else i for i in indices]
     # move Tensor indices to the same device as self
     indices = [i.to(self.device) if isinstance(i, Tensor) else i for i in indices]
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -422,7 +422,8 @@ class Tensor:
     else: indices = [indices]
 
     # turn scalar Tensors into const val for int indexing if possible
-    indices = [self._to_const_val(i) if isinstance(i, Tensor) and i.shape == () else i for i in indices]
+    indices = [i.lazydata.base.arg if isinstance(i, Tensor) and isinstance(i.lazydata, LazyBuffer) and i.shape == () \
+               and i.lazydata.is_unrealized_const() else i for i in indices]
     # move Tensor indices to the same device as self
     indices = [i.to(self.device) if isinstance(i, Tensor) else i for i in indices]
 


### PR DESCRIPTION
fixes #4048 
Yeah, only empty shape Tensors can be folded into int indexing.
Anything with shape has to be done through advanced indexing.

Lemme think if there's a better fix though