### PR TITLE
Fix for "MTLLibrary is not formatted as a MetalLib file" issue

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -50,7 +50,7 @@ class MetalProgram:
         shader.write(lib)
         shader.flush()
         os.system(f"cd {pathlib.Path(__file__).parents[2]}/disassemblers/applegpu && python3 compiler_explorer.py {shader.name}")
-    assert lib[:4] == b"MTLB", "Invalid Metal library. Could be due to using conda. Try system python or METAL_XCODE=1 DISABLE_COMPILER_CACHE=1."
+    assert lib[:4] in (b"MTLB", b"\xcb\xfe\xba\xbe"), "Invalid Metal library. Could be due to using conda. Try system python or METAL_XCODE=1 DISABLE_COMPILER_CACHE=1."
     data = libdispatch.dispatch_data_create(lib, len(lib), None, None)
     self.library = unwrap2(self.device.device.newLibraryWithData_error_(data, None))
     self.fxn = self.library.newFunctionWithName_(name)

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -50,7 +50,6 @@ class MetalProgram:
         shader.write(lib)
         shader.flush()
         os.system(f"cd {pathlib.Path(__file__).parents[2]}/disassemblers/applegpu && python3 compiler_explorer.py {shader.name}")
-    assert lib[:4] in (b"MTLB", b"\xcb\xfe\xba\xbe"), "Invalid Metal library. Could be due to using conda. Try system python or METAL_XCODE=1 DISABLE_COMPILER_CACHE=1."
     data = libdispatch.dispatch_data_create(lib, len(lib), None, None)
     self.library = unwrap2(self.device.device.newLibraryWithData_error_(data, None))
     self.fxn = self.library.newFunctionWithName_(name)


### PR DESCRIPTION
Fix for: [#2226](https://github.com/tinygrad/tinygrad/issues/2226)

Tested on: `macOS 14.4.1` (GPU: `M3 Max`)

Was able to run `test/test_ops.py` with no failures in a conda environment, whereas previously it would fail with a stream of MTLLibrary errors similar to linked issue. Should be possible by extension to run tinygrad without depending on an existing Xcode installation, but haven't tested that thoroughly