### PR TITLE
remove define global without child

### DIFF
--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -393,7 +393,7 @@ class Linearizer(Kernel):
     # optimize the uops
     self.uops.uoptimize()
     # indices of global buffers that are used in kernel
-    self.buf_idxs = [uop.arg[0] for uop in self.uops.uops if uop.uop is UOps.DEFINE_GLOBAL]
+    self.uops.buf_idxs = [uop.arg[0] for uop in self.uops.uops if uop.uop is UOps.DEFINE_GLOBAL]
 
     # maybe graph the uops
     if DEBUG >= 5: self.uops.print()

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -392,6 +392,8 @@ class Linearizer(Kernel):
 
     # optimize the uops
     self.uops.uoptimize()
+    # indices of global buffers that are used in kernel
+    self.buf_idxs = [uop.arg[0] for uop in self.uops.uops if uop.uop is UOps.DEFINE_GLOBAL]
 
     # maybe graph the uops
     if DEBUG >= 5: self.uops.print()

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -135,6 +135,9 @@ class UOpGraph:
     # global uop cache
     self.saved_exprs: Dict[Tuple, UOp] = dict()
 
+    # indeices of global buffers that used in kernel, updated after linearize
+    self.buf_idxs: Optional[List[int]] = None
+
   def __iter__(self): return iter(self.uops)
 
   def vars(self) -> List[Variable]: return [x.arg for x in self.uops if x.uop is UOps.DEFINE_VAR]

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -357,8 +357,7 @@ class UOpGraph:
     self.simplify_phi_loops(get_recursive_parents)
 
     # (recursively) remove childless uops
-    # TODO: remove DEFINE_GLOBAL from here
-    self.remove_childless(set(x for x in self.uops if x.uop in {UOps.DEFINE_GLOBAL, UOps.STORE}))
+    self.remove_childless(keep=set(x for x in self.uops if x.uop in {UOps.STORE}))
 
     # store float4 upcasts directly if possible
     self.fix_to_store_directly()

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -220,7 +220,7 @@ class Compiled:
     ops, mem = k.uops.flops_mem()
     run_count = prod((k.global_size if k.global_size else []) + (k.local_size if k.local_size else []))
     # NOTE: we use min here to ignore the indexing FLOPS
-    ret = CompiledASTRunner(k.name, self.compiler.render(to_function_name(k.name), k.uops), self.dname, k.global_size, k.local_size, k.buf_idxs,
+    ret = CompiledASTRunner(k.name, self.compiler.render(to_function_name(k.name), k.uops), self.dname, k.global_size, k.local_size, k.uops.buf_idxs,
                             k.uops.vars(), min(info.flops, ops * run_count), min(info.mem_estimate, mem * run_count), outcount=len(k.outbufs))
     return ret
 

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -160,7 +160,6 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:UOpGraph) -> str
         bufs.append((args.expr, (dtype,False)))
         r[u] = args.expr
       elif uop is UOps.DEFINE_GLOBAL:
-        assert len(bufs) == args[0], f"missed a global buffer {len(bufs)} {args}"
         bufs.append((args[1], (dtype,args[2])))
         r[u] = args[1]
       elif uop is UOps.WMMA: kk(f"{lang.render_dtype(dtype)} {ssa(u, 'wmma')} = __{args[0]}({r[vin[0]]}, {r[vin[1]]}, {r[vin[2]]});")

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -73,7 +73,7 @@ class PythonProgram:
         dl[i] = dtype
         if uop is UOps.DEFINE_GLOBAL:
           assert dtype.fmt is not None
-          ul[i] = [pbufs[self.buf_idxs.index(arg[0])].cast(dtype.fmt)] * warp_size
+          ul[i] = [pbufs[self.buf_idxs.index(arg[0]) if self.buf_idxs is not None else arg[0]].cast(dtype.fmt)] * warp_size
         elif uop is UOps.DEFINE_LOCAL:
           assert dtype.fmt is not None
           lbuf = memoryview(bytearray(arg[1]*dtype.itemsize))


### PR DESCRIPTION
Appending fake global is incorrect because the unused buffer can be in the middle. And the buffer map information no available to the caller after compilation based on lib alone.

This pr implemented `UOpGraph.buf_idxs` that's updated in `linearize` after childless UOps removal. The caller uses it to filter the input buffers. This does not require renderer change.

@geohot thoughts on this approach?