### PR TITLE
Fix UOpGraph rewrite of double op

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -63,22 +63,26 @@ class PatternMatcher:
     # uop is required, arg is optional
     for p,fxn in self.patterns: self.pdict[(p.get("uop"), p.get("arg", None))].append((p, fxn))
 
-  def rewrite(self, uop:UOp) -> Optional[UOp]:
+  def rewrite(self, uop:UOp) -> Optional[Tuple]:
     for p,fxn in itertools.chain(self.pdict[(uop.uop, uop.arg)], self.pdict[(uop.uop, None)]):
       store: Dict[str, UOp] = {}
-      if _match(uop, p, store): return fxn(**store)
+      if _match(uop, p, store): return store.values(), fxn(**store)
     return None
 
   def rewrite_graph(self, uops: UOpGraph):
     replace: Dict[UOp, UOp] = {}
     seen: Set[UOp] = set()
-    for u in uops:
+    remove: Set[UOp] = set()
+    for i, u in enumerate(uops):
       if u in seen: continue
       seen.add(u)
       for o,n in replace.items():
         if o in u.vin and u is not n:
           u.vin = tuple(n if x == o else x for x in u.vin)
-      if rew := self.rewrite(u): replace[u] = rew
+      if ret := self.rewrite(u):
+        ux, rew = ret
+        replace[u] = rew
+        remove.update([x for x in uops.uops[i-1:i+1] if x in ux and x != u])
 
     for o,n in replace.items():
       queue = [n]
@@ -89,6 +93,7 @@ class PatternMatcher:
           for vv in uops.uops + queue: vv.vin = tuple(new if x is q else x for x in vv.vin)
         else: queue.extend([qq for qq in queue[-1].vin if qq not in uops.uops])
       if not any([o in u.vin for u in uops]): uops.uops.remove(o)
+    for x in remove: uops.uops.remove(x)
 
 constant_folder = PatternMatcher([
   # const rules
@@ -151,7 +156,8 @@ class UOpGraph:
   def add(self, uop:UOps, dtype:Optional[DType]=None, vin:Tuple[UOp, ...]=tuple(), arg:Any=None, cachable=True, insert_before=None,
           simplify=True) -> UOp:
     ret = UOp(uop, dtype, vin, arg) if uop is not UOps.CONST else UOp.const(dtype, arg)
-    if simplify and (rewritten:=constant_folder.rewrite(ret)) is not None:
+    if simplify and (r:=constant_folder.rewrite(ret)) is not None:
+      _, rewritten = r
       if rewritten in self.uops: return rewritten  # ignore cachable
       ret = rewritten
     key = (ret.uop, ret.dtype, ret.vin, ret.arg)

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -89,7 +89,7 @@ class PatternMatcher:
           for vv in uops.uops + queue: vv.vin = tuple(new if x is q else x for x in vv.vin)
         else: queue.extend([qq for qq in queue[-1].vin if qq not in uops.uops])
       if not any([o in u.vin for u in uops]): uops.uops.remove(o)
-    uops.remove_childless(set(x for x in uops if x.uop in {UOps.DEFINE_GLOBAL, UOps.STORE}))
+    uops.uoptimize()
 
 constant_folder = PatternMatcher([
   # const rules

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -84,7 +84,7 @@ class PatternMatcher:
       ux: List[UOp] = []
       if rew := self.rewrite(u, ux):
         replace[u] = rew
-        remove.update([x for x in uops.uops[i-1:i+1] if x in ux and x != u])
+        if i > 0 and (x := uops.uops[i-1]) in ux and x != u: remove.add(x)
 
     for o,n in replace.items():
       queue = [n]


### PR DESCRIPTION
I'm attempting AMX integration in LLVM and used the same pattern matcher from PTX to rewrite the graph with `TernaryOps.MULACC`. I want to fuse the `Mul` and `Add` to support the AMX FMA operation.
<img width="1013" alt="image" src="https://github.com/tinygrad/tinygrad/assets/3257091/34876b77-65ca-4805-ba8a-6094f27e85cd">

I noticed that the `Add` operation gets rewritten but the `Mul` operation doesn't. I'm still new to the code so unless my understanding is wrong, this looks like a bug. `Mulacc` should replace both `Mul` and `Add`.
<img width="1038" alt="image" src="https://github.com/tinygrad/tinygrad/assets/3257091/97f3fc81-e606-4393-b331-bfc643483818">

Steps to reproduce

Use this pattern and a simple matmul program.
```python
matcher = PatternMatcher([
    ({"__name__": "root", "uop": UOps.ALU, "arg": BinaryOps.ADD, "dtype": set([dtypes.float32]),
      "vin": [{"__name__": "non_muls"}, {"__name__": "muls", "uop": UOps.ALU, "arg": BinaryOps.MUL}]},
      lambda root, muls, non_muls : UOp(UOps.ALU, root.dtype, muls.vin + (non_muls,), TernaryOps.MULACC))
  ])
```

```python
N = 32
a = Tensor.randn((N,N), dtype=dtypes.float32)
b = Tensor.randn((N,N), dtype=dtypes.float32)
c = a.matmul(b)
c.numpy()
```

I ran code with `NOOPT=1` for simplicity. Without `NOOPT` there are a ton of muls and adds added (number of ops jumps from 21 to 750) but no replacement with mulacc and I'm not sure why. That is a separate issue that I need to look into to understand.

Bug fix results in the right output, though I'm not confident I've generalized the solution enough.
<img width="1034" alt="image" src="https://github.com/tinygrad/tinygrad/assets/3257091/ed2f085d-8d2e-494e-8fb5-d4895e14f477">

