### PR TITLE
CUDAGraph release input buffer references

### DIFF
--- a/tinygrad/runtime/graph/cuda.py
+++ b/tinygrad/runtime/graph/cuda.py
@@ -55,6 +55,9 @@ class CUDAGraph(MultiDeviceJITGraph):
 
     self.instance = init_c_var(cuda.CUgraphExec(), lambda x: check(cuda.cuGraphInstantiate_v2(ctypes.byref(x), self.graph, None, None, 0)))
 
+    # clear jit inputs to allow their memory to be freed/reused
+    for (j,i) in self.input_replace.keys(): self.jit_cache[j].rawbufs[i] = None
+
   def __call__(self, input_rawbuffers: List[Buffer], var_vals: Dict[Variable, int], wait=False, jit=False) -> Optional[float]:
     # Update rawbuffers in the c_args struct.
     for (j,i),input_idx in self.input_replace.items():

--- a/tinygrad/runtime/graph/hsa.py
+++ b/tinygrad/runtime/graph/hsa.py
@@ -112,6 +112,9 @@ class HSAGraph(MultiDeviceJITGraph):
     for sig in self.signals_to_reset: hsa.hsa_signal_silent_store_relaxed(sig, 0)
     hsa.hsa_signal_silent_store_relaxed(self.finish_signal, 0)
 
+    # clear jit inputs to allow their memory to be freed/reused
+    for (j,i) in self.input_replace.keys(): self.jit_cache[j].rawbufs[i] = None
+
   def __call__(self, input_rawbuffers: List[Buffer], var_vals: Dict[Variable, int], wait=False, jit=False) -> Optional[float]:
     # Wait and restore signals
     hsa.hsa_signal_wait_scacquire(self.finish_signal, hsa.HSA_SIGNAL_CONDITION_LT, 1, (1 << 64) - 1, hsa.HSA_WAIT_STATE_ACTIVE)

--- a/tinygrad/runtime/graph/metal.py
+++ b/tinygrad/runtime/graph/metal.py
@@ -51,6 +51,9 @@ class MetalGraph:
     self.command_buffer: Any = None
     if len(var_vals): self.int_buf_view = self.int_buf.contents().as_buffer(self.int_buf.length()).cast('i')
 
+    # clear jit inputs to allow their memory to be freed/reused
+    for (j,i) in self.input_replace.keys(): self.jit_cache[j].rawbufs[i] = None
+
   def __call__(self, input_rawbuffers: List[Buffer], var_vals: Dict[Variable, int], wait=False, jit=False) -> Optional[float]:
     # NOTE: you at least can't update the ints if this is running
     if self.command_buffer is not None and self.command_buffer in self.device.mtl_buffers_in_flight: wait_check(self.command_buffer)


### PR DESCRIPTION
CUDAGraph (and other graphs) keep references to the input buffers in jit_cache.rawbufs. This doesn't allow the buffers to be freed/reused. I added code to remove these references like in TinyJit. For example, the following code uses around twice the necessary memory with around half of it stuck after making the graph:

```python
from tinygrad import Tensor,Device,TinyJit
from tinygrad.helpers import Context
import os

@TinyJit
def kernel(w,x):
  res = ((w+x).max(-1)).sum()
  return res.realize()

def step():
  data = Tensor.rand(1024*256,1024,device="cuda").realize()
  with Context(DEBUG=1):
    res = kernel(w,data).item()
  return res

w = Tensor.rand(1024,device="cuda").realize()
for _ in range(4):
  res = step()
  os.system("echo 1 $(nvidia-smi --query-gpu=memory.used --format=csv,noheader)")
  Device["cuda"].allocator.free_cache()
  os.system("echo 2 $(nvidia-smi --query-gpu=memory.used --format=csv,noheader)")

```
Output:
```
1 1290 MiB
2 264 MiB
JIT captured 3 kernels with 2 inputs
1 1292 MiB
2 1290 MiB
1 2316 MiB
2 1290 MiB
1 2316 MiB
2 1290 MiB
```
With this PR the output becomes:
```
1 1290 MiB
2 264 MiB
JIT captured 3 kernels with 2 inputs
1 1292 MiB
2 266 MiB
1 1292 MiB
2 266 MiB
1 1292 MiB
2 266 MiB
```
I didn't add the code as a test case, because it needs cuda.