### PR TITLE
search: add a BEAM_COMPARE env to optionally not compare to hc/tc

### DIFF
--- a/extra/optimization/search.py
+++ b/extra/optimization/search.py
@@ -23,12 +23,12 @@ if __name__ == '__main__':
     with open(args.file, 'r') as file:
      ast_strs = file.readlines()
 
-  for ast_str in ast_strs:
-    print(f"optimizing ast={ast_str}")
+  for i, ast_str in enumerate(ast_strs):
+    print(f"optimizing {i}/{len(ast_strs)}\nast={ast_str}")
     lin = ast_str_to_lin(ast_str, opts=device.compiler.compiler_opts)
-    rawbufs = bufs_from_lin(lin)
-    lin = beam_search(lin, rawbufs, getenv("BEAM", 8), bool(getenv("BEAM_ESTIMATE", 1)))
+    lin = beam_search(lin, getenv("BEAM", 8), bool(getenv("BEAM_ESTIMATE", 1)))
 
+    rawbufs = bufs_from_lin(lin)
     tm = time_linearizer(lin, rawbufs, allow_test_size=False, cnt=10)
     print(f"final time {tm*1e6:9.0f} us: {lin.colored_shape()}")
     print(lin.applied_opts)

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -233,21 +233,25 @@ class Compiled:
     if not NOOPT:
       if not (used_tensor_cores:=k.apply_tensor_cores(getenv("TC", 1))): k.hand_coded_optimizations()
       if BEAM >= 1:
-        lins = [(("tc" if used_tensor_cores else "hc"), k)]
-        if used_tensor_cores:
-          lins.append(("hc", Linearizer(*ast, opts=self.compiler.compiler_opts)))
-          lins[-1][1].hand_coded_optimizations()
+        from tinygrad.features.search import beam_search, time_linearizer, bufs_from_lin
         kb = Linearizer(*ast, opts=self.compiler.compiler_opts)
         kb.required_optimizations()
-        from tinygrad.features.search import beam_search, time_linearizer, bufs_from_lin
-        test_rawbuffers = bufs_from_lin(kb)    # allocate scratch buffers for optimization
-        lins.append((f"beam{BEAM.value}", beam_search(kb, test_rawbuffers, BEAM.value, bool(getenv("BEAM_ESTIMATE", 1)))))
-        timed = sorted([(nm, tk, time_linearizer(tk, test_rawbuffers, allow_test_size=False, clear_l2=True)) for nm, tk in lins], key=lambda x: x[2])
-        if DEBUG >= 1: print("  <  ".join(f"{nm:6s} : {lin.colored_shape(30, dense=True)} : {tm*1e6:8.2f} us" for nm, lin, tm in timed))
-        k = timed[0][1]
-        if logkern is not None and logkern_level > 1: logkern.writelines([f"{(lin.ast, lin.applied_opts)}\n" for (_,lin,_) in timed[1:]])
+        beam_lin = beam_search(kb, BEAM.value, bool(getenv("BEAM_ESTIMATE", 1)))
+        if getenv("BEAM_COMPARE", 1):
+          lins = [(("tc" if used_tensor_cores else "hc"), k)]
+          if used_tensor_cores:
+            lins.append(("hc", Linearizer(*ast, opts=self.compiler.compiler_opts)))
+            lins[-1][1].hand_coded_optimizations()
+          test_rawbuffers = bufs_from_lin(kb)    # allocate scratch buffers for optimization
+          lins.append((f"beam{BEAM.value}", beam_lin))
+          timed = sorted([(nm, tk, time_linearizer(tk, test_rawbuffers, allow_test_size=False, clear_l2=True)) for nm, tk in lins], key=lambda x: x[2])
+          if DEBUG >= 1: print("  <  ".join(f"{nm:6s} : {lin.colored_shape(30, dense=True)} : {tm*1e6:8.2f} us" for nm, lin, tm in timed))
+          k = timed[0][1]
+          if logkern is not None and logkern_level > 1: logkern.writelines([f"{(lin.ast, lin.applied_opts)}\n" for (_,lin,_) in timed[1:]])
+        else: k = beam_lin
     # TODO: check the correctness inline once compare_linearizer is in core
     if logkern is not None: logkern.writelines([f"{(k.ast, k.applied_opts)}\n"])
+    if DEBUG >= 4: print((k.ast, k.applied_opts))
     return k
 
   @functools.lru_cache(None)    # pylint: disable=method-cache-max-size-none


### PR DESCRIPTION
setting BEAM_COMPARE=0 will prevents additional memory allocation needed to do the timing tests, until the real buffers can be used