### PR TITLE
ops_disk.py: Fix for issue https://github.com/tinygrad/tinygrad/issues/4139

### DIFF
--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -89,7 +89,6 @@ class DiskDevice(Compiled):
       os.close(self.fd)
       self.fd = None
       self.size = None
-    if self.mem: self.mem.close()
   @functools.lru_cache(None)    # pylint: disable=method-cache-max-size-none
   def get_runner(self, *ast:LazyOp):
     assert len(ast) == 1, "DiskRunner doesn't support multioutput kernels."


### PR DESCRIPTION
fix for issue https://github.com/tinygrad/tinygrad/issues/4139

Proper handling for device and device file descriptor initializations to fix AttributeError introduced by https://github.com/tinygrad/tinygrad/pull/4129

Only free when the opaque(buffer) is a DiskBuffer

Update test case