### PR TITLE
multitensor shouldn't recompile

### DIFF
--- a/test/external/external_test_speed_llama.py
+++ b/test/external/external_test_speed_llama.py
@@ -4,7 +4,7 @@ from examples.llama import Transformer, MODEL_PARAMS
 from tinygrad.tensor import Tensor
 from tinygrad import Device
 from tinygrad.nn.state import get_state_dict
-from tinygrad.device import Allocator
+from tinygrad.device import Allocator, method_cache
 from tinygrad.helpers import Profiling
 
 class FakeProgram:
@@ -31,7 +31,7 @@ class TestLLaMASpeed(unittest.TestCase):
     print("assigned empty tensors, doing warmup")
 
     def run_llama(st, empty_method_cache=True):
-      if empty_method_cache: Device[Device.DEFAULT].get_runner.cache_clear()
+      if empty_method_cache: method_cache.clear()
       tms = [time.perf_counter()]
       for i in range(5):
         model(Tensor([[1,2,3,4]]), i).realize()

--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -1,7 +1,7 @@
 import unittest, functools, random
 from typing import List
 from tinygrad import Tensor, Device, nn, GlobalCounters, TinyJit
-from tinygrad.device import BufferCopy
+from tinygrad.device import BufferCopy, CompiledRunner
 from tinygrad.ops import LoadOps, ReduceOps
 from tinygrad.helpers import CI, prod, Context
 from tinygrad.nn.state import get_parameters, get_state_dict
@@ -48,10 +48,9 @@ class TestMultiTensor(unittest.TestCase):
     sched = create_schedule(out.lazydata.lbs)
     names = []
     for si, ei in zip(sched[:], lower_schedule(sched)):
-      names.append(ei.prg.name)
+      if isinstance(ei.prg, CompiledRunner): names.append(ei.prg.name)
       ei.run()
-    assert names[-4] == names[-3]
-    assert names[-2] == names[-1]
+    assert names[-2] == names[-1], "function was relinearized"
 
   def test_sharded_memory(self):
     # Buffer may be stuck in track_cross_buffer

--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -6,6 +6,7 @@ from tinygrad.ops import LoadOps, ReduceOps
 from tinygrad.helpers import CI, prod, Context
 from tinygrad.nn.state import get_parameters, get_state_dict
 from tinygrad.engine.schedule import create_schedule
+from tinygrad.engine.realize import lower_schedule
 from tinygrad.features.multi import all_reduce, MultiLazyBuffer
 from random import randint
 import numpy as np
@@ -39,6 +40,18 @@ class TestMultiTensor(unittest.TestCase):
     for lb in X.lazydata.lbs:
       assert lb.shape == (128,)
     (X + X).realize()
+
+  def test_shard_no_recompile(self):
+    X = Tensor.ones(256).contiguous().realize()
+    X.shard_((d0, d1), 0)
+    out = (X + X)
+    sched = create_schedule(out.lazydata.lbs)
+    names = []
+    for si, ei in zip(sched[:], lower_schedule(sched)):
+      names.append(ei.prg.name)
+      ei.run()
+    assert names[-4] == names[-3]
+    assert names[-2] == names[-1]
 
   def test_sharded_memory(self):
     # Buffer may be stuck in track_cross_buffer

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -205,8 +205,8 @@ class MultiDeviceJITGraph(Runner):
   def __call__(self, rawbufs:List[Buffer], var_vals:Dict[Variable, int], wait=False, jit=False) -> Optional[float]:
     raise NotImplementedError("override this")
 
-method_cache = {}
-base_method_cache = {}
+method_cache: Dict[Tuple[str, Tuple[LazyOp, ...]], CompiledRunner] = {}
+base_method_cache: Dict[Tuple[str, Tuple[LazyOp, ...]], CompiledRunner]  = {}
 logkern, logkern_level = open(getenv("LOGKERN", ""), "a") if getenv("LOGKERN", "") else None, getenv("LOGKERN_LEVEL", 1)
 class Compiled:
   def __init__(self, device:str, allocator:Allocator, compiler:Optional[Compiler], runtime, graph=None):
@@ -255,12 +255,11 @@ class Compiled:
     if DEBUG >= 4: print((k.ast, k.applied_opts)) # print here to show final applied_opts for all kernels instead of just in beam_search
     return k
 
-  #@functools.lru_cache(None)    # pylint: disable=method-cache-max-size-none
   def get_runner(self, *ast:LazyOp) -> CompiledRunner:
     if cret:=method_cache.get((self.dname, ast)): return cret
     if bret:=base_method_cache.get((self.dname.split(":")[0], ast)):
       method_cache[(self.dname, ast)] = ret = bret.to_other_device(self.dname)
-      return ret
-    base_method_cache[(self.dname.split(":")[0], ast)] = method_cache[(self.dname, ast)] = ret = self.to_program(self.get_linearizer(*ast))
+    else:
+      base_method_cache[(self.dname.split(":")[0], ast)] = method_cache[(self.dname, ast)] = ret = self.to_program(self.get_linearizer(*ast))
     return ret
 

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -169,11 +169,15 @@ class CompiledRunner(Runner):
     self.vars: List[Variable] = [] if variables is None else variables
     self.op_estimate, self.mem_estimate = op_estimate, mem_estimate
 
+  def to_other_device(self, dname:str):
+    return CompiledRunner(self.display_name, self.prg, dname, self.global_size, self.local_size, self.vars,
+                          self.op_estimate, self.mem_estimate, self.lib, self.outcount)
+
   @property
   def device(self): return Device[self.dname]
 
   def __reduce__(self):
-    return self.__class__, (self.name, self.prg, self.dname, self.global_size, self.local_size,
+    return self.__class__, (self.display_name, self.prg, self.dname, self.global_size, self.local_size,
                             self.vars, self.op_estimate, self.mem_estimate, self.lib)
 
   def launch_dims(self, var_vals):
@@ -201,6 +205,8 @@ class MultiDeviceJITGraph(Runner):
   def __call__(self, rawbufs:List[Buffer], var_vals:Dict[Variable, int], wait=False, jit=False) -> Optional[float]:
     raise NotImplementedError("override this")
 
+method_cache = {}
+base_method_cache = {}
 logkern, logkern_level = open(getenv("LOGKERN", ""), "a") if getenv("LOGKERN", "") else None, getenv("LOGKERN_LEVEL", 1)
 class Compiled:
   def __init__(self, device:str, allocator:Allocator, compiler:Optional[Compiler], runtime, graph=None):
@@ -215,7 +221,7 @@ class Compiled:
     run_count = prod((k.global_size if k.global_size else []) + (k.local_size if k.local_size else []))
     # NOTE: we use min here to ignore the indexing FLOPS
     ret = CompiledRunner(k.name, self.compiler.render(to_function_name(k.name), k.uops), self.dname, k.global_size, k.local_size,
-                            k.uops.vars(), min(info.flops, ops * run_count), min(info.mem_estimate, mem * run_count), outcount=len(k.outbufs))
+                         k.uops.vars(), min(info.flops, ops * run_count), min(info.mem_estimate, mem * run_count), outcount=len(k.outbufs))
     return ret
 
   def get_linearizer(self, *ast:LazyOp) -> Linearizer:
@@ -249,5 +255,12 @@ class Compiled:
     if DEBUG >= 4: print((k.ast, k.applied_opts)) # print here to show final applied_opts for all kernels instead of just in beam_search
     return k
 
-  @functools.lru_cache(None)    # pylint: disable=method-cache-max-size-none
-  def get_runner(self, *ast:LazyOp) -> CompiledRunner: return self.to_program(self.get_linearizer(*ast))
+  #@functools.lru_cache(None)    # pylint: disable=method-cache-max-size-none
+  def get_runner(self, *ast:LazyOp) -> CompiledRunner:
+    if cret:=method_cache.get((self.dname, ast)): return cret
+    if bret:=base_method_cache.get((self.dname.split(":")[0], ast)):
+      method_cache[(self.dname, ast)] = ret = bret.to_other_device(self.dname)
+      return ret
+    base_method_cache[(self.dname.split(":")[0], ast)] = method_cache[(self.dname, ast)] = ret = self.to_program(self.get_linearizer(*ast))
+    return ret
+

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -170,15 +170,15 @@ class CompiledRunner(Runner):
     self.op_estimate, self.mem_estimate = op_estimate, mem_estimate
 
   def to_other_device(self, dname:str):
-    return CompiledRunner(self.display_name, self.prg, dname, self.global_size, self.local_size, self.vars,
-                          self.op_estimate, self.mem_estimate, self.lib, self.outcount)
+    return CompiledRunner(self.display_name, self.prg, dname, self.global_size, self.local_size,
+                          self.vars, self.op_estimate, self.mem_estimate, self.lib, self.outcount)
 
   @property
   def device(self): return Device[self.dname]
 
   def __reduce__(self):
     return self.__class__, (self.display_name, self.prg, self.dname, self.global_size, self.local_size,
-                            self.vars, self.op_estimate, self.mem_estimate, self.lib)
+                            self.vars, self.op_estimate, self.mem_estimate, self.lib, self.outcount)
 
   def launch_dims(self, var_vals):
     global_size = [sym_infer(sz, var_vals) for sz in self.global_size] if self.global_size is not None else self.global_size


### PR DESCRIPTION
On master:
```
tiny@tiny14:~/tinygrad$ BS=1536 GPUS=6 python3 examples/hlb_cifar10.py
shuffling training dataset in 2196.98 ms (epoch=0)
  0 24073.57 ms run, 24073.25 ms python,    0.31 ms CUDA * 6, 1182.99 loss, 0.000015 LR, 1.11 GB used,     83.79 GFLOPS,   2017.22 GOPS
  1 8122.71 ms run, 8122.15 ms python,    0.56 ms CUDA * 6, 1181.49 loss, 0.000030 LR, 12.35 GB used,    248.21 GFLOPS,   2016.16 GOPS
  2   62.91 ms run,   23.67 ms python,   39.24 ms CUDA * 6, 1179.67 loss, 0.000045 LR, 12.35 GB used,  32048.85 GFLOPS,   2016.16 GOPS
  3   61.12 ms run,   20.80 ms python,   40.32 ms CUDA * 6, 1171.41 loss, 0.000060 LR, 12.35 GB used,  32984.38 GFLOPS,   2016.16 GOPS
  4   61.12 ms run,   20.59 ms python,   40.52 ms CUDA * 6, 1165.13 loss, 0.000075 LR, 12.35 GB used,  32989.38 GFLOPS,   2016.16 GOPS
```

This branch:
```
tiny@tiny14:~/tinygrad$ BS=1536 GPUS=6 python3 examples/hlb_cifar10.py
shuffling training dataset in 2186.14 ms (epoch=0)
  0 8932.78 ms run, 8932.48 ms python,    0.30 ms CUDA * 6, 1181.03 loss, 0.000015 LR, 1.11 GB used,    225.82 GFLOPS,   2017.22 GOPS
  1 4206.60 ms run, 4206.13 ms python,    0.48 ms CUDA * 6, 1176.76 loss, 0.000030 LR, 12.35 GB used,    479.28 GFLOPS,   2016.16 GOPS
  2   61.18 ms run,   23.17 ms python,   38.01 ms CUDA * 6, 1175.29 loss, 0.000045 LR, 12.35 GB used,  32952.34 GFLOPS,   2016.16 GOPS
  3   60.11 ms run,   18.60 ms python,   41.51 ms CUDA * 6, 1171.62 loss, 0.000060 LR, 12.35 GB used,  33539.83 GFLOPS,   2016.16 GOPS
  4   53.93 ms run,   12.73 ms python,   41.20 ms CUDA * 6, 1168.32 loss, 0.000075 LR, 12.35 GB used,  37381.52 GFLOPS,   2016.16 GOPS
  ```