### PR TITLE
Benchmarks for individual resnet layers

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -268,6 +268,8 @@ jobs:
       run: time HSA=1 DEFAULT_FLOAT=HALF STEPS=350 BS=1536 GPUS=6 TARGET_EVAL_ACC_PCT=93.3 python3 examples/hlb_cifar10.py | tee train_cifar_six_gpu.txt
     - name: Run MLPerf resnet eval on training data
       run: time HSA=1 MODEL=resnet python3 examples/mlperf/model_eval.py
+    - name: Run single MLPerf resnet training layers with BEAM
+      run: DEBUG=0 JITCNT=10 BEAM=2 DEFAULT_FLOAT=HALF CNT=5 python test/external/external_benchmark_resnet.py BenchmarkResnetTrain.test_layer1 BenchmarkResnetTrain.test_layer2_in
     - name: Run 10 MLPerf ResNet50 training steps (1 gpu)
       run: HSA=1 BENCHMARK=10 BS=128 GPUS=1 MODEL=resnet python3 examples/mlperf/model_train.py | tee train_resnet_one_gpu.txt
     - name: Run 10 MLPerf ResNet50 training steps (6 gpu)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -268,8 +268,6 @@ jobs:
       run: time HSA=1 DEFAULT_FLOAT=HALF STEPS=350 BS=1536 GPUS=6 TARGET_EVAL_ACC_PCT=93.3 python3 examples/hlb_cifar10.py | tee train_cifar_six_gpu.txt
     - name: Run MLPerf resnet eval on training data
       run: time HSA=1 MODEL=resnet python3 examples/mlperf/model_eval.py
-    - name: Run single MLPerf resnet training layers with BEAM=2
-      run: BEAM=2 CNT=5 JITCNT=10 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py BenchmarkResnetTrain.test_layer1 BenchmarkResnetTrain.test_layer2_in
     - name: Run 10 MLPerf ResNet50 training steps (1 gpu)
       run: HSA=1 BENCHMARK=10 BS=128 GPUS=1 MODEL=resnet python3 examples/mlperf/model_train.py | tee train_resnet_one_gpu.txt
     - name: Run 10 MLPerf ResNet50 training steps (6 gpu)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -268,8 +268,8 @@ jobs:
       run: time HSA=1 DEFAULT_FLOAT=HALF STEPS=350 BS=1536 GPUS=6 TARGET_EVAL_ACC_PCT=93.3 python3 examples/hlb_cifar10.py | tee train_cifar_six_gpu.txt
     - name: Run MLPerf resnet eval on training data
       run: time HSA=1 MODEL=resnet python3 examples/mlperf/model_eval.py
-    - name: Run single MLPerf resnet training layers with BEAM
-      run: DEBUG=0 JITCNT=10 BEAM=2 DEFAULT_FLOAT=HALF CNT=5 python test/external/external_benchmark_resnet.py BenchmarkResnetTrain.test_layer1 BenchmarkResnetTrain.test_layer2_in
+    - name: Run single MLPerf resnet training layers with BEAM=2
+      run: BEAM=2 CNT=5 JITCNT=10 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py BenchmarkResnetTrain.test_layer1 BenchmarkResnetTrain.test_layer2_in
     - name: Run 10 MLPerf ResNet50 training steps (1 gpu)
       run: HSA=1 BENCHMARK=10 BS=128 GPUS=1 MODEL=resnet python3 examples/mlperf/model_train.py | tee train_resnet_one_gpu.txt
     - name: Run 10 MLPerf ResNet50 training steps (6 gpu)

--- a/examples/mlperf/initializers.py
+++ b/examples/mlperf/initializers.py
@@ -19,6 +19,7 @@ def he_normal(*shape, a: float = 0.00, **kwargs) -> Tensor:
 class Conv2dHeNormal(nn.Conv2d):
   def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0, dilation=1, groups=1, bias=True):
     super().__init__(in_channels, out_channels, kernel_size, stride=stride, padding=padding, dilation=dilation, groups=groups, bias=bias)
+    self.in_channels, self.out_channels = in_channels, out_channels  # for testing
     self.weight = he_normal(out_channels, in_channels//groups, *self.kernel_size, a=0.0, dtype=dtypes.float32)
     if bias: self.bias = self.bias.cast(dtypes.float32)
   def __call__(self, x: Tensor):

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -70,20 +70,20 @@ class BenchmarkResnetTrain(unittest.TestCase):
       best_tm = tm if best_tm is None or tm < best_tm else best_tm
     print(f"\r{name:42s}: {best_tm * 1000: 4.2f} ms, {flops / 10**12 / tm: 3.2f} tflops")
 
-  def test_layer1_in(self): self._test_layer(*self._get_layer(0, 0))
-  def test_layer1(self): self._test_layer(*self._get_layer(0, 1))
+  def test_layer1_1(self): self._test_layer(*self._get_layer(0, 0))
+  def test_layer1_2(self): self._test_layer(*self._get_layer(0, 1))
 
-  def test_layer2_in(self): self._test_layer(*self._get_layer(1, 0))
+  def test_layer2_1(self): self._test_layer(*self._get_layer(1, 0))
 
-  def test_layer2(self): self._test_layer(*self._get_layer(1, 1))
+  def test_layer2_2(self): self._test_layer(*self._get_layer(1, 1))
 
-  def test_layer3_in(self): self._test_layer(*self._get_layer(2, 0))
+  def test_layer3_1(self): self._test_layer(*self._get_layer(2, 0))
 
-  def test_layer3(self): self._test_layer(*self._get_layer(2, 1))
+  def test_layer3_2(self): self._test_layer(*self._get_layer(2, 1))
 
-  def test_layer4_in(self): self._test_layer(*self._get_layer(3, 0))
+  def test_layer4_1(self): self._test_layer(*self._get_layer(3, 0))
 
-  def test_layer4(self): self._test_layer(*self._get_layer(3, 1))
+  def test_layer4_2(self): self._test_layer(*self._get_layer(3, 1))
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -74,7 +74,7 @@ class BenchmarkResnetTrain(unittest.TestCase):
       if mem_used is None: mem_used = GlobalCounters.mem_used
       tm = (et-st) / JITCNT
       best_tm = tm if best_tm is None or tm < best_tm else best_tm
-    print(f"\r{name:42s}: {best_tm * 1000:>8.2f} ms, {flops / 10**12 / tm:>7.2f} tflops, {mem_used / 10**9: 7.2f} GB used")
+    print(f"\r{name:42s}: {best_tm * 1000:>9.2f} ms, {flops / 10**12 / tm:>7.2f} tflops, {mem_used / 10**9: 7.2f} GB used")
 
   def test_layer1_1(self): self._test_layer(*self._get_layer(0, 0))
   def test_layer1_2(self): self._test_layer(*self._get_layer(0, 1))

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -74,7 +74,7 @@ class BenchmarkResnetTrain(unittest.TestCase):
       if mem_used is None: mem_used = GlobalCounters.mem_used
       tm = (et-st) / JITCNT
       best_tm = tm if best_tm is None or tm < best_tm else best_tm
-    print(f"\r{name:42s}: {best_tm * 1000:>7.2f} ms, {flops / 10**12 / tm:>5.2f} tflops, {mem_used / 10**9: 5.2f} GB used")
+    print(f"\r{name:42s}: {best_tm * 1000:>8.2f} ms, {flops / 10**12 / tm:>5.2f} tflops, {mem_used / 10**9: 5.2f} GB used")
 
   def test_layer1_1(self): self._test_layer(*self._get_layer(0, 0))
   def test_layer1_2(self): self._test_layer(*self._get_layer(0, 1))

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -12,6 +12,7 @@ from examples.mlperf.initializers import Conv2dHeNormal, Linear
 from examples.hlb_cifar10 import UnsyncedBatchNorm
 
 # benchmark: BEAM=2 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
+# benchmark only one layer: BEAM=2 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py BenchmarkResnetTrain.test_layer1_2
 # inspect:   DEBUG=2 BEAM=2 JITCNT=1 CNT=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
 # inspect convs:   DEBUG=2 BEAM=2 CONV=1 JITCNT=1 CNT=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
 # inspect convs with batchnorm: DEBUG=2 BEAM=2 CONV=1 BN=1 JITCNT=1 CNT=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -4,7 +4,6 @@ import unittest
 
 from tinygrad import Tensor, TinyJit
 from tinygrad.helpers import getenv, GlobalCounters
-from tinygrad import nn
 from tinygrad.nn.optim import SGD
 from tinygrad.nn.state import get_parameters
 

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -74,7 +74,7 @@ class BenchmarkResnetTrain(unittest.TestCase):
       if mem_used is None: mem_used = GlobalCounters.mem_used
       tm = (et-st) / JITCNT
       best_tm = tm if best_tm is None or tm < best_tm else best_tm
-    print(f"\r{name:42s}: {best_tm * 1000:>8.2f} ms, {flops / 10**12 / tm:>5.2f} tflops, {mem_used / 10**9: 5.2f} GB used")
+    print(f"\r{name:42s}: {best_tm * 1000:>8.2f} ms, {flops / 10**12 / tm:>7.2f} tflops, {mem_used / 10**9: 7.2f} GB used")
 
   def test_layer1_1(self): self._test_layer(*self._get_layer(0, 0))
   def test_layer1_2(self): self._test_layer(*self._get_layer(0, 1))

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -11,7 +11,7 @@ from extra.models import resnet
 from examples.mlperf.initializers import Conv2dHeNormal, Linear
 from examples.hlb_cifar10 import UnsyncedBatchNorm
 
-# benchmark: BEAM=2 JITCNT=10 CNT=5 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
+# benchmark: BEAM=2 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
 # inspect:   DEBUG=2 BEAM=2 JITCNT=1 CNT=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
 # inspect convs:   DEBUG=2 BEAM=2 CONV=1 JITCNT=1 CNT=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
 # inspect convs with batchnorm: DEBUG=2 BEAM=2 CONV=1 BN=1 JITCNT=1 CNT=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
@@ -50,7 +50,7 @@ class BenchmarkResnetTrain(unittest.TestCase):
   def _test_layer(self, name, layer, cin, xy):
     optim = SGD(get_parameters(layer), bs / 128 * 1.0)  # need sgd for some params but not consequential for benchmarking
 
-    JITCNT = getenv("JITCNT", 1)
+    JITCNT = getenv("JITCNT", 10)
     @TinyJit
     def step(x):
       for _ in range(JITCNT):

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -19,6 +19,8 @@ from examples.hlb_cifar10 import UnsyncedBatchNorm
 # inspect convs with batchnorm:     DEBUG=2 BEAM=2 CONV=1 BN=1 JITCNT=1 CNT=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
 # etc
 
+# memory will be slightly high with JITCNT > 1
+
 bs = getenv("BS", 64)
 
 class BenchmarkResnetTrain(unittest.TestCase):

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -76,9 +76,9 @@ class BenchmarkResnetTrain(unittest.TestCase):
       step(x)._data()
       et = time.perf_counter()
 
-      if flops is None: flops = GlobalCounters.global_ops
-      mem_used = GlobalCounters.mem_used
-      kernels = GlobalCounters.kernel_count
+      if flops is None: flops = GlobalCounters.global_ops / JITCNT
+      mem_used = GlobalCounters.mem_used  # a little high with JITCNT > 1 fsr
+      kernels = GlobalCounters.kernel_count // JITCNT
       tm = (et-st) / JITCNT
       best_tm = tm if best_tm is None or tm < best_tm else best_tm
     print(f"\r{name:42s}: {best_tm * 1000:>9.2f} ms, {flops / 10**12 / tm:>7.2f} tflops, {mem_used / 10**9: 7.2f} GB used, {kernels:>6d} kernels")

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -14,9 +14,9 @@ from examples.hlb_cifar10 import UnsyncedBatchNorm
 # benchmark memory or kernel count: DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
 # benchmark speed:                  BEAM=2 JITCNT=10 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
 # benchmark only one layer:         BEAM=2 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py BenchmarkResnetTrain.test_layer1_2
-# inspect:                          DEBUG=2 BEAM=2 CNT=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
-# inspect convs:                    DEBUG=2 BEAM=2 CONV=1 CNT=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
-# inspect convs with batchnorm:     DEBUG=2 BEAM=2 CONV=1 BN=1 JITCNT=1 CNT=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
+# inspect:                          DEBUG=2 BEAM=2 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
+# inspect convs:                    DEBUG=2 BEAM=2 CONV=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
+# inspect convs with batchnorm:     DEBUG=2 BEAM=2 CONV=1 BN=1 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
 # etc
 
 # memory will be slightly high with JITCNT > 1

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -1,0 +1,89 @@
+import functools
+import time
+import unittest
+
+from tinygrad import Tensor, TinyJit
+from tinygrad.helpers import getenv, GlobalCounters
+from tinygrad import nn
+from tinygrad.nn.optim import SGD
+from tinygrad.nn.state import get_parameters
+
+from extra.models import resnet
+from examples.mlperf.initializers import Conv2dHeNormal, Linear
+from examples.hlb_cifar10 import UnsyncedBatchNorm
+
+bs = getenv("BS", 64)
+
+class BenchmarkResnetTrain(unittest.TestCase):
+  def _get_layer(self, layer_i, slice_i):
+    # isolate to conv, with or without BN
+    conv = getenv("CONV", 0)
+    bn = getenv("BN", 0)
+
+    if not hasattr(self, 'model'):
+      resnet.Conv2d = Conv2dHeNormal
+      resnet.Linear = Linear
+      if not getenv("SYNCBN"): resnet.BatchNorm = functools.partial(UnsyncedBatchNorm, num_devices=1)
+      self.model = resnet.ResNet50()
+      self.layers = [self.model.layer1, self.model.layer2, self.model.layer3, self.model.layer4]
+
+    layer = self.layers[layer_i][slice_i]
+    xy = 112 >> layer_i
+    if layer_i > 0: xy >>= (1 if slice_i > 0 else 0)
+    name = f"layer{layer_i+1} slice{slice_i+1}"
+
+    # get specific conv (0 or 1)
+    if conv:
+      if bn: f = lambda x: layer.bn2(layer.conv2(x))
+      else: f = layer.conv2
+      cin = layer.conv2.in_channels
+      xy = xy // layer.conv1.stride
+      return f"{name} conv2 x{(bs, cin, xy, xy)} k{layer.conv1.weight.shape}" + (" bn" if bn else ""), f, cin, xy
+
+    cin = layer.conv1.in_channels
+    return f"{name} x{(bs, cin, xy, xy)}", layer, cin, xy
+  def _test_layer(self, name, layer, cin, xy):
+    optim = SGD(get_parameters(layer), bs / 128 * 1.0)  # need sgd for some params but not consequential for benchmarking
+
+    JITCNT = getenv("JITCNT", 1)
+    @TinyJit
+    def step(x):
+      for _ in range(JITCNT):
+        y = layer(x).relu()
+        y.mean().backward()
+        optim.step([y, x.grad])
+      return y.detach()
+
+    CNT = getenv("CNT", 5)
+    best_tm = None
+    flops = None
+    for i in range(CNT):
+      x = Tensor.randn(bs, cin, xy, xy, requires_grad=True).realize()
+      GlobalCounters.reset()
+
+      st = time.perf_counter()
+      step(x)._data()
+      et = time.perf_counter()
+
+      if flops is None: flops = GlobalCounters.global_ops
+      tm = (et-st) / JITCNT
+      best_tm = tm if best_tm is None or tm < best_tm else best_tm
+    print(f"\r{name:42s}: {best_tm * 1000: 4.2f} ms, {flops / 10**12 / tm: 3.2f} tflops")
+
+  def test_layer1_in(self): self._test_layer(*self._get_layer(0, 0))
+  def test_layer1(self): self._test_layer(*self._get_layer(0, 1))
+
+  def test_layer2_in(self): self._test_layer(*self._get_layer(1, 0))
+
+  def test_layer2(self): self._test_layer(*self._get_layer(1, 1))
+
+  def test_layer3_in(self): self._test_layer(*self._get_layer(2, 0))
+
+  def test_layer3(self): self._test_layer(*self._get_layer(2, 1))
+
+  def test_layer4_in(self): self._test_layer(*self._get_layer(3, 0))
+
+  def test_layer4(self): self._test_layer(*self._get_layer(3, 1))
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -56,7 +56,7 @@ class BenchmarkResnetTrain(unittest.TestCase):
 
     CNT = getenv("CNT", 5)
     best_tm = None
-    flops = None
+    flops, mem_used = None, None
     for i in range(CNT):
       x = Tensor.randn(bs, cin, xy, xy, requires_grad=True).realize()
       GlobalCounters.reset()
@@ -66,9 +66,10 @@ class BenchmarkResnetTrain(unittest.TestCase):
       et = time.perf_counter()
 
       if flops is None: flops = GlobalCounters.global_ops
+      if mem_used is None: mem_used = GlobalCounters.mem_used
       tm = (et-st) / JITCNT
       best_tm = tm if best_tm is None or tm < best_tm else best_tm
-    print(f"\r{name:42s}: {best_tm * 1000: 4.2f} ms, {flops / 10**12 / tm: 3.2f} tflops")
+    print(f"\r{name:42s}: {best_tm * 1000: 4.2f} ms, {flops / 10**12 / tm: 3.2f} tflops, {mem_used / 10**9: 2.2f} GB used")
 
   def test_layer1_1(self): self._test_layer(*self._get_layer(0, 0))
   def test_layer1_2(self): self._test_layer(*self._get_layer(0, 1))

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -74,7 +74,7 @@ class BenchmarkResnetTrain(unittest.TestCase):
       if mem_used is None: mem_used = GlobalCounters.mem_used
       tm = (et-st) / JITCNT
       best_tm = tm if best_tm is None or tm < best_tm else best_tm
-    print(f"\r{name:42s}: {best_tm * 1000: 4.2f} ms, {flops / 10**12 / tm: 3.2f} tflops, {mem_used / 10**9: 2.2f} GB used")
+    print(f"\r{name:42s}: {best_tm * 1000:>7.2f} ms, {flops / 10**12 / tm:>5.2f} tflops, {mem_used / 10**9: 5.2f} GB used")
 
   def test_layer1_1(self): self._test_layer(*self._get_layer(0, 0))
   def test_layer1_2(self): self._test_layer(*self._get_layer(0, 1))


### PR DESCRIPTION
Helpful for BEAMING / inspecting only a portion of the run, with a simple optimizer. Can test individual layers, individual convolutions w or w/o batchnorm. Remember to set JITCNT=high if you are benchmarking and not inspecting!

```
$ BEAM=0 DEBUG=0 JITCNT=10 CNT=5 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
layer1 slice2 x(64, 256, 112, 112)        :  211.17 ms,  16.50 tflops
layer1 slice1 x(64, 64, 112, 112)         :  177.96 ms,  21.00 tflops
layer2 slice2 x(64, 512, 28, 28)          :  20.77 ms,  41.01 tflops
layer2 slice1 x(64, 256, 56, 56)          :  50.12 ms,  29.00 tflops
layer3 slice2 x(64, 1024, 14, 14)         :  18.51 ms,  45.73 tflops
layer3 slice1 x(64, 512, 28, 28)          :  30.78 ms,  46.95 tflops
layer4 slice2 x(64, 2048, 7, 7)           :  42.72 ms,  19.73 tflops
layer4 slice1 x(64, 1024, 14, 14)         :  30.50 ms,  47.17 tflops
```

Seems like the first layer is taking all the time without BEAM.
