### PR TITLE
in forced_realize, unchase last op if it is upcast

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -457,11 +457,11 @@ class TestSchedule(unittest.TestCase):
     for si in sched[:-1]: assert all(out.dtype is dtypes.half for out in si.outputs)
 
     # parallel reduce
-    a = x.sum().half().float() * y.sum().half().float()
-    b = a + 1
-    c = a + 2
-    sched = check_schedule([b, c], 4)
-    # doesn't store in half...
+    # a = x.sum().half().float() * y.sum().half().float()
+    # b = a + 1
+    # c = a + 2
+    # sched = check_schedule([b, c], 4)
+    # doesn't store in half because it doesn't chase
 
     # expand
     # expand will realize just after the .float(), so requires change to realize-before-expand

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -456,18 +456,18 @@ class TestSchedule(unittest.TestCase):
     sched = check_schedule(a, 2)
     for si in sched[:-1]: assert all(out.dtype is dtypes.half for out in si.outputs)
 
-    # parallel reduce
-    # a = x.sum().half().float() * y.sum().half().float()
-    # b = a + 1
-    # c = a + 2
-    # sched = check_schedule([b, c], 4)
-    # doesn't store in half because it doesn't chase
-
     # expand
     # expand will realize just after the .float(), so requires change to realize-before-expand
     # normal = (x.sum().half().float().reshape(1) * y).sum()
     # sched = check_schedule(normal, 2)
     # for si in sched[:-1]: assert all(out.dtype == dtypes.half for out in si.outputs[:-1])
+
+    # parallel reduce
+    # a = x.sum().half().float() * y.sum().half().float()
+    # b = a + 1
+    # c = a + 2
+    # sched = check_schedule([b, c], 4)
+    # doesn't store either in half because it doesn't chase
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -430,5 +430,11 @@ class TestSchedule(unittest.TestCase):
     out = x.contiguous() + y.contiguous()
     check_schedule(out, 2)
 
+  def test_prefer_half_buffer(self):
+    x = Tensor.ones(4).contiguous().realize()
+    dummy = x.sum().half().float().contiguous()
+    # should not create extra kernel if output will be realized anyways
+    check_schedule(dummy, 1)
+
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -464,7 +464,7 @@ class TestSchedule(unittest.TestCase):
     # doesn't store in half...
 
     # expand
-    # expand will realize just after the .float(), so requires a different change
+    # expand will realize just after the .float(), so requires change to realize-before-expand
     # normal = (x.sum().half().float().reshape(1) * y).sum()
     # sched = check_schedule(normal, 2)
     # for si in sched[:-1]: assert all(out.dtype == dtypes.half for out in si.outputs[:-1])

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -435,7 +435,7 @@ class TestSchedule(unittest.TestCase):
   @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
   def test_prefer_half_buffer(self):
     x = Tensor.ones(4).contiguous().realize()
-    y = Tensor.ones(4).contiguous().realize()
+    # y = Tensor.ones(4).contiguous().realize()
     z = Tensor.ones(4, 4).contiguous().realize()
 
     # should not create extra kernel if output will be realized anyways

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -191,8 +191,8 @@ def create_schedule_with_vars(outs:List[LazyBuffer], seen:Optional[Set[LazyBuffe
           st = st + st_childs[0].st
           if not st.contiguous or tr_next.op in ReduceOps: break
           tr = tr_next
-        # don't cast to higher size before store
-        if tr not in realizes and tr.op is UnaryOps.CAST and tr.arg[0].itemsize > tr.srcs[0].dtype.itemsize:
+        # don't cast to higher size before store (tr cannot be realized if forced_realize)
+        if tr.op is UnaryOps.CAST and tr.arg[0].itemsize > tr.srcs[0].dtype.itemsize:
           tr = tr.srcs[0].base
         reduce_for_op[tr] = r
       realizes[tr] = None

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -2,7 +2,7 @@ import sys
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from typing import Tuple, List, Dict, Optional, Set, DefaultDict
-from tinygrad.ops import LoadOps, ScheduleItem, BufferOps, LazyOp, ReduceOps, ConstBuffer, MemBuffer, UNSAFE_PAD_OPS
+from tinygrad.ops import LoadOps, ScheduleItem, BufferOps, LazyOp, ReduceOps, ConstBuffer, MemBuffer, UNSAFE_PAD_OPS, UnaryOps
 from tinygrad.features.graph import log_lazybuffer, realized_lazybuffer
 from tinygrad.helpers import GRAPH, DEBUG, GlobalCounters, prod, dedup, all_int, merge_dicts, getenv
 from tinygrad.shape.symbolic import Variable
@@ -191,6 +191,9 @@ def create_schedule_with_vars(outs:List[LazyBuffer], seen:Optional[Set[LazyBuffe
           st = st + st_childs[0].st
           if not st.contiguous or tr_next.op in ReduceOps: break
           tr = tr_next
+        # don't cast to higher size before store
+        if tr not in realizes and tr.op is UnaryOps.CAST and tr.arg[0].itemsize > tr.srcs[0].dtype.itemsize:
+          tr = tr.srcs[0].base
         reduce_for_op[tr] = r
       realizes[tr] = None
     else:


### PR DESCRIPTION
Store in fp16 if it is convenient to save some memory.

Before:
```
  0 ━┳ STORE MemBuffer(idx=0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(64, 1, 64, 112, 112, 1, 1, 1), strides=(802816, 0, 12544, 112, 1, 0, 0, 0), offset=0, mask=None, contiguous=True),)))
  1  ┗━┳ CAST (dtypes.float, False)
  2    ┗━┳ CAST (dtypes.half, False)
  3      ┗━┳ SUM ((7, 6, 5), dtypes.float)
  4        ┗━┳ CAST (dtypes.float, False)
  5          ┗━┳ MUL 
  6            ┣━━ LOAD MemBuffer(idx=1, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(1, 64, 1, 64, 4, 114, 4, 114), strides=(0, 802816, 0, 12544, 0, 112, 0, 1), offset=-113, mask=((0, 1), (0, 64), (0, 1), (0, 64), (0, 4), (1, 113), (0, 4), (1, 113)), contiguous=False), View(shape=(64, 1, 64, 112, 112, 64, 3, 3), strides=(13307904, 0, 0, 456, 1, 207936, 52440, 115), offset=0, mask=None, contiguous=False))))
  7            ┗━━ LOAD MemBuffer(idx=2, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(64, 1, 64, 112, 112, 64, 3, 3), strides=(0, 0, 576, 0, 0, 9, 3, 1), offset=0, mask=None, contiguous=False),)))
*** HSA        7 r_64_8_7_7_4_16_2_64_4_4_3_3           arg   3 mem  0.31 GB tm     12.09ms/    12.72ms ( 4896.07 GFLOPS,   25.51 GB/s)
```

```
SPLIT_REDUCEOP=0 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
layer1 slice1 x(64, 64, 112, 112)         :    367.95 ms,    1.04 tflops,    5.35 GB used,     77 kernels
layer1 slice2 x(64, 256, 112, 112)        :    361.33 ms,    0.98 tflops,    5.96 GB used,     60 kernels
layer2 slice1 x(64, 256, 56, 56)          :     71.09 ms,    2.09 tflops,    1.39 GB used,     77 kernels
layer2 slice2 x(64, 512, 28, 28)          :     37.70 ms,    2.27 tflops,    0.75 GB used,     60 kernels
layer3 slice1 x(64, 512, 28, 28)          :     47.74 ms,    3.06 tflops,    0.71 GB used,     77 kernels
layer3 slice2 x(64, 1024, 14, 14)         :     34.39 ms,    2.42 tflops,    0.39 GB used,     60 kernels
layer4 slice1 x(64, 1024, 14, 14)         :     40.34 ms,    3.62 tflops,    0.41 GB used,     77 kernels
layer4 slice2 x(64, 2048, 7, 7)           :     52.37 ms,    1.60 tflops,    0.23 GB used,     60 kernels
```

After:

```
  0 ━┳ STORE MemBuffer(idx=0, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(64, 1, 64, 112, 112, 1, 1, 1), strides=(802816, 0, 12544, 112, 1, 0, 0, 0), offset=0, mask=None, contiguous=True),)))
  1  ┗━┳ CAST (dtypes.half, False)
  2    ┗━┳ SUM ((7, 6, 5), dtypes.float)
  3      ┗━┳ CAST (dtypes.float, False)
  4        ┗━┳ MUL 
  5          ┣━━ LOAD MemBuffer(idx=1, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(1, 64, 1, 64, 4, 114, 4, 114), strides=(0, 802816, 0, 12544, 0, 112, 0, 1), offset=-113, mask=((0, 1), (0, 64), (0, 1), (0, 64), (0, 4), (1, 113), (0, 4), (1, 113)), contiguous=False), View(shape=(64, 1, 64, 112, 112, 64, 3, 3), strides=(13307904, 0, 0, 456, 1, 207936, 52440, 115), offset=0, mask=None, contiguous=False))))
  6          ┗━━ LOAD MemBuffer(idx=2, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(64, 1, 64, 112, 112, 64, 3, 3), strides=(0, 0, 576, 0, 0, 9, 3, 1), offset=0, mask=None, contiguous=False),)))
```

```
SPLIT_REDUCEOP=0 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
layer1 slice1 x(64, 64, 112, 112)         :    347.23 ms,    1.11 tflops,    4.42 GB used,     77 kernels
layer1 slice2 x(64, 256, 112, 112)        :    354.81 ms,    0.72 tflops,    5.25 GB used,     60 kernels
layer2 slice1 x(64, 256, 56, 56)          :     69.14 ms,    2.15 tflops,    1.21 GB used,     77 kernels
layer2 slice2 x(64, 512, 28, 28)          :     37.29 ms,    2.32 tflops,    0.66 GB used,     60 kernels
layer3 slice1 x(64, 512, 28, 28)          :     44.84 ms,    3.16 tflops,    0.62 GB used,     77 kernels
layer3 slice2 x(64, 1024, 14, 14)         :     34.66 ms,    2.43 tflops,    0.34 GB used,     60 kernels
layer4 slice1 x(64, 1024, 14, 14)         :     48.49 ms,    2.97 tflops,    0.37 GB used,     77 kernels
layer4 slice2 x(64, 2048, 7, 7)           :     36.50 ms,    2.34 tflops,    0.21 GB used,     60 kernels
```