### PR TITLE
Clang openmp

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -380,7 +380,7 @@ jobs:
           path: ~/.cache/tinygrad/downloads/
           key: downloads-cache-${{ matrix.backend }}-${{ env.DOWNLOAD_CACHE_VERSION }}
       - name: Set env
-        run: printf "${{ matrix.backend == 'llvm' && 'LLVM=1' || matrix.backend == 'clang' && 'CLANG=1' || matrix.backend == 'clang-omp' && 'CLANG=1 OMP=1' || matrix.backend == 'gpu' && 'GPU=1' || matrix.backend == 'cuda' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\n' || matrix.backend == 'PTX' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\nPTX=1' || matrix.backend == 'triton' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\nTRITON=1\nTRITON_PTXAS_PATH=/usr/bin/ptxas' || matrix.backend == 'hip' && 'RHIP=1\nFORWARD_ONLY=1' }}" >> $GITHUB_ENV
+        run: printf "${{ matrix.backend == 'llvm' && 'LLVM=1' || matrix.backend == 'clang' && 'CLANG=1' || matrix.backend == 'clang-omp' && 'CLANG=1\nOMP=1' || matrix.backend == 'gpu' && 'GPU=1' || matrix.backend == 'cuda' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\n' || matrix.backend == 'PTX' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\nPTX=1' || matrix.backend == 'triton' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\nTRITON=1\nTRITON_PTXAS_PATH=/usr/bin/ptxas' || matrix.backend == 'hip' && 'RHIP=1\nFORWARD_ONLY=1' }}" >> $GITHUB_ENV
       - name: Install OpenMP
         if: matrix.backend == 'clang-omp'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -356,7 +356,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        backend: [llvm, clang, gpu, cuda, hip, ptx] #, triton]
+        backend: [llvm, clang, clang-omp, gpu, cuda, hip, ptx] #, triton]
 
     name: Tests on (${{ matrix.backend }})
     runs-on: ubuntu-latest
@@ -380,7 +380,12 @@ jobs:
           path: ~/.cache/tinygrad/downloads/
           key: downloads-cache-${{ matrix.backend }}-${{ env.DOWNLOAD_CACHE_VERSION }}
       - name: Set env
-        run: printf "${{ matrix.backend == 'llvm' && 'LLVM=1' || matrix.backend == 'clang' && 'CLANG=1' || matrix.backend == 'gpu' && 'GPU=1' || matrix.backend == 'cuda' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\n' || matrix.backend == 'PTX' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\nPTX=1' || matrix.backend == 'triton' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\nTRITON=1\nTRITON_PTXAS_PATH=/usr/bin/ptxas' || matrix.backend == 'hip' && 'RHIP=1\nFORWARD_ONLY=1' }}" >> $GITHUB_ENV
+        run: printf "${{ matrix.backend == 'llvm' && 'LLVM=1' || matrix.backend == 'clang' && 'CLANG=1' || matrix.backend == 'clang-omp' && 'CLANG=1 OMP=1' || matrix.backend == 'gpu' && 'GPU=1' || matrix.backend == 'cuda' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\n' || matrix.backend == 'PTX' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\nPTX=1' || matrix.backend == 'triton' && 'FORWARD_ONLY=1\nJIT=1\nOPT=2\nCUDA=1\nCUDACPU=1\nTRITON=1\nTRITON_PTXAS_PATH=/usr/bin/ptxas' || matrix.backend == 'hip' && 'RHIP=1\nFORWARD_ONLY=1' }}" >> $GITHUB_ENV
+      - name: Install OpenMP
+        if: matrix.backend == 'clang-omp'
+        run: |
+          sudo apt update -y
+          sudo apt install -y libomp-dev
       - name: Install OpenCL
         if: matrix.backend == 'gpu'
         run: |

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 # bottom ones are asm only
 class UOps(Enum):
-  LOOP = auto(); IF = auto(); ENDLOOP = auto(); SPECIAL = auto() # loops can be global, local, or other # noqa: E702
+  LOOP = auto(); IF = auto(); ENDLOOP = auto(); ENDIF = auto(); SPECIAL = auto() # loops can be global, local, or other # noqa: E702
   DEFINE_GLOBAL = auto(); DEFINE_VAR = auto(); DEFINE_LOCAL = auto(); DEFINE_ACC = auto() # this defines buffers # noqa: E702
   LOAD = auto(); STORE = auto(); CONST = auto(); BARRIER = auto(); PHI = auto() # noqa: E702
   ALU = auto(); WMMA = auto(); CAST = auto(); BITCAST = auto(); GEP = auto(); NOOP = auto() # noqa: E702
@@ -208,6 +208,9 @@ class UOpGraph:
         # add END of loops after the last thing that (recursively) depends on them
         insert_before = self.uops.index(sorted(list(self.get_recursive_children(u)), key=self.uops.index)[-1])+1
         self.add(UOps.ENDLOOP, None, (u,), cachable=False, insert_before=insert_before)
+      elif u.uop is UOps.IF:
+        # END any if statements at the end of the uops
+        self.add(UOps.ENDIF, None, (u,), cachable=False)
 
   def fix_loop_scope(self, get_recursive_parents:Callable[..., Set[UOp]]):
     loop_stack: List[List[UOp]] = [[]]

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 # bottom ones are asm only
 class UOps(Enum):
-  LOOP = auto(); IF = auto(); ENDLOOP = auto(); ENDIF = auto(); SPECIAL = auto() # loops can be global, local, or other # noqa: E702
+  LOOP = auto(); IF = auto(); ENDLOOP = auto(); SPECIAL = auto() # loops can be global, local, or other # noqa: E702
   DEFINE_GLOBAL = auto(); DEFINE_VAR = auto(); DEFINE_LOCAL = auto(); DEFINE_ACC = auto() # this defines buffers # noqa: E702
   LOAD = auto(); STORE = auto(); CONST = auto(); BARRIER = auto(); PHI = auto() # noqa: E702
   ALU = auto(); WMMA = auto(); CAST = auto(); BITCAST = auto(); GEP = auto(); NOOP = auto() # noqa: E702
@@ -208,9 +208,6 @@ class UOpGraph:
         # add END of loops after the last thing that (recursively) depends on them
         insert_before = self.uops.index(sorted(list(self.get_recursive_children(u)), key=self.uops.index)[-1])+1
         self.add(UOps.ENDLOOP, None, (u,), cachable=False, insert_before=insert_before)
-      elif u.uop is UOps.IF:
-        # END any if statements at the end of the uops
-        self.add(UOps.ENDIF, None, (u,), cachable=False)
 
   def fix_loop_scope(self, get_recursive_parents:Callable[..., Set[UOp]]):
     loop_stack: List[List[UOp]] = [[]]

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Optional, NamedTuple, Tuple, Union, DefaultDict, cast, Literal, Callable
-import math, functools
+import math, functools, itertools
 from collections import defaultdict, Counter
 from tinygrad.codegen.linearizer import UOps, UOp
 from tinygrad.ops import UnaryOps, BinaryOps, TernaryOps
@@ -123,7 +123,8 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:UOpGraph) -> str
     else:
       assert dtype is not None, f"None dtype for uop {uop}"
       if uop is UOps.LOOP:
-        if depth is 1: kk(lang.first_loop_prefix.format(nloops=sum(u.uop is UOps.LOOP for u in uops)))
+        if depth is 1 and (collapse:=sum(1 for u in itertools.takewhile(lambda u: u.uop is not UOps.DEFINE_ACC, uops) if u.uop is UOps.LOOP)) != 0:
+          kk(lang.first_loop_prefix.format(collapse))
         kk(f"for (int {(expr := ssa('ridx',u))} = {r[vin[0]]}; {expr} < {r[vin[1]]}; {expr}++) {{")
         depth += 1
       elif uop is UOps.ALU:

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -123,7 +123,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:UOpGraph) -> str
     else:
       assert dtype is not None, f"None dtype for uop {uop}"
       if uop is UOps.LOOP:
-        if depth == 1 and (collapse:=sum(1 for u in itertools.takewhile(lambda u: u.uop is not UOps.DEFINE_ACC, uops) if u.uop is UOps.LOOP)) != 0:
+        if depth == 1 and (collapse:=sum(u.uop is UOps.LOOP for u in itertools.takewhile(lambda u: u.uop is not UOps.DEFINE_ACC, uops))) != 0:
           kk(lang.first_loop_prefix.format(collapse))
         kk(f"for (int {(expr := ssa('ridx',u))} = {r[vin[0]]}; {expr} < {r[vin[1]]}; {expr}++) {{")
         depth += 1

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, NamedTuple, Tuple, Union, DefaultDict, cast, Literal, Callable
+from typing import Dict, List, Optional, NamedTuple, Tuple, DefaultDict, cast
 import math, functools
 from collections import defaultdict, Counter
 from tinygrad.codegen.linearizer import UOps, UOp
@@ -31,7 +31,7 @@ class CStyleLanguage(NamedTuple):
     BinaryOps.DIV: lambda a,b,dtype: f"({a}/{b})", BinaryOps.MAX: lambda a,b,dtype: f"max({a},{b})", BinaryOps.MOD: lambda a,b,dtype: f"({a}%{b})",
     BinaryOps.CMPLT: lambda a,b,dtype: f"({a}<{b})", BinaryOps.CMPEQ: lambda a,b,dtype: f"({a}=={b})", BinaryOps.XOR: lambda a,b,dtype: f"({a}^{b})",
     TernaryOps.WHERE: lambda a,b,c,dtype: f"({a}?{b}:{c})"}
-  
+
   def workitem_code(self, idx, access, size, n_workitems):
     code = [f"#pragma omp parallel for collapse({n_workitems})"] if idx[0] in ["g","i"] and idx[-1] == "0" else []
     return code + [f"for(int {idx} = 0; {idx} < {size}; {idx}++) {{"]

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Optional, NamedTuple, Tuple, Union, DefaultDict, cast, Literal, Callable
-import math, functools, itertools
+import math, functools
 from collections import defaultdict, Counter
 from tinygrad.codegen.linearizer import UOps, UOp
 from tinygrad.ops import UnaryOps, BinaryOps, TernaryOps
@@ -177,7 +177,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:UOpGraph) -> str
         r[u] = (r[vin[0]] if from_ssa else f"{(r[vin[0]])}") + (f"[{args}]" if vin[0].dtype.count > 4 else f".{'xyzw'[args]}")
       else: raise RuntimeError(f"failed to render {uop}")
 
-  # TODO: hacky
+  # TODO: hacky, not good but its not immediately obvious what to do here
   if not lang.code_for_workitem:
     for _ in range(sum(u.uop is UOps.SPECIAL for u in uops)):
       kk("}")

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -16,7 +16,7 @@ class CStyleLanguage(NamedTuple):
   smem_prefix_for_cast: bool = True
   arg_int_prefix: str = "const int"
   barrier: str = ""
-  first_loop_prefix: str = ""
+  first_loop_prefix: Optional[str] = None
   code_for_workitem: Dict[Union[Literal["g"], Literal["l"], Literal["i"]], Callable] = {}
   global_max: List[int] = []
   local_max: List[int] = []
@@ -124,7 +124,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:UOpGraph) -> str
       assert dtype is not None, f"None dtype for uop {uop}"
       if uop is UOps.LOOP:
         if depth == 1 and (collapse:=sum(u.uop is UOps.LOOP for u in itertools.takewhile(lambda u: u.uop is not UOps.DEFINE_ACC, uops))) != 0:
-          kk(lang.first_loop_prefix.format(collapse))
+          if lang.first_loop_prefix: kk(lang.first_loop_prefix.format(collapse))
         kk(f"for (int {(expr := ssa('ridx',u))} = {r[vin[0]]}; {expr} < {r[vin[1]]}; {expr}++) {{")
         depth += 1
       elif uop is UOps.ALU:

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -121,7 +121,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:UOpGraph) -> str
       kk(f"if ({r[vin[0]]}) {{")
       depth += 1
     elif uop is UOps.BARRIER: kk(lang.barrier)
-    elif uop is UOps.ENDLOOP: end_scope()
+    elif uop in {UOps.ENDLOOP, UOps.ENDIF}: end_scope()
     elif uop is UOps.STORE:
       assert vin[0].dtype is not None and vin[2].dtype is not None
       rendered_store = lang.render_store(r[vin[0]], vin[0].dtype, r[vin[2]], vin[2].dtype, strip_parens(r[vin[1]]), vin[0].uop is UOps.DEFINE_LOCAL)
@@ -181,7 +181,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:UOpGraph) -> str
         r[u] = (r[vin[0]] if from_ssa else f"{(r[vin[0]])}") + (f"[{args}]" if vin[0].dtype.count > 4 else f".{'xyzw'[args]}")
       else: raise RuntimeError(f"failed to render {uop}")
 
-  while depth > 1: end_scope() # End of if statements and SPECIAL loops
+  while depth > 1: end_scope() # end of workitem loops
 
   return lang.render_kernel(function_name, kernel, bufs, uops)
 

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -123,7 +123,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:UOpGraph) -> str
     else:
       assert dtype is not None, f"None dtype for uop {uop}"
       if uop is UOps.LOOP:
-        if depth is 1 and (collapse:=sum(1 for u in itertools.takewhile(lambda u: u.uop is not UOps.DEFINE_ACC, uops) if u.uop is UOps.LOOP)) != 0:
+        if depth == 1 and (collapse:=sum(1 for u in itertools.takewhile(lambda u: u.uop is not UOps.DEFINE_ACC, uops) if u.uop is UOps.LOOP)) != 0:
           kk(lang.first_loop_prefix.format(collapse))
         kk(f"for (int {(expr := ssa('ridx',u))} = {r[vin[0]]}; {expr} < {r[vin[1]]}; {expr}++) {{")
         depth += 1

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -16,6 +16,7 @@ class CStyleLanguage(NamedTuple):
   smem_prefix_for_cast: bool = True
   arg_int_prefix: str = "const int"
   barrier: str = ""
+  first_loop_prefix: str = ""
   code_for_workitem: Dict[Union[Literal["g"], Literal["l"], Literal["i"]], Callable] = {}
   global_max: List[int] = []
   local_max: List[int] = []
@@ -122,6 +123,7 @@ def uops_to_cstyle(lang:CStyleLanguage, function_name:str, uops:UOpGraph) -> str
     else:
       assert dtype is not None, f"None dtype for uop {uop}"
       if uop is UOps.LOOP:
+        if depth is 1: kk(lang.first_loop_prefix.format(nloops=sum(u.uop is UOps.LOOP for u in uops)))
         kk(f"for (int {(expr := ssa('ridx',u))} = {r[vin[0]]}; {expr} < {r[vin[1]]}; {expr}++) {{")
         depth += 1
       elif uop is UOps.ALU:

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -3,7 +3,7 @@ from tinygrad.device import Compiled, MallocAllocator, Compiler, CompilerOptions
 from tinygrad.helpers import cpu_time_execution, getenv
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 
-OMP_HEADER, OMP_PRAGMA, OMP_FLAGS = ("#include <omp.h>\n", "#pragma omp parallel for collapse({nloops})", "-Xpreprocessor -fopenmp -lomp") if getenv("OMP", 1) else ("", "", "")
+OMP_HEADER, OMP_PRAGMA, OMP_FLAGS = ("#include <omp.h>\n", "#pragma omp parallel for collapse({})", "-Xpreprocessor -fopenmp -lomp") if getenv("OMP", 1) else ("", "", "")
 CLANG_PROGRAM_HEADER = OMP_HEADER +'#include <stdbool.h>\n#include <tgmath.h>\n#define max(x,y) ((x>y)?x:y)\n#define half __fp16\n'
 
 class ClangCompiler(Compiler):

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -3,12 +3,12 @@ from tinygrad.device import Compiled, MallocAllocator, Compiler, CompilerOptions
 from tinygrad.helpers import cpu_time_execution, getenv
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 
-OMP_HEADER, OMP_PRAGMA, OMP_FLAGS = ("#include <omp.h>\n", "#pragma omp parallel for collapse({})", "-Xpreprocessor -fopenmp -lomp") if getenv("OMP", 0) else ("", "", "")
+OMP_HEADER, OMP_PRAGMA, OMP_FLAGS = ("#include <omp.h>\n", "#pragma omp parallel for collapse({})", "-Xpreprocessor -fopenmp -lomp") if getenv("OMP", 0) else ("", "", "")  # noqa: E501
 CLANG_PROGRAM_HEADER = OMP_HEADER +'#include <stdbool.h>\n#include <tgmath.h>\n#define max(x,y) ((x>y)?x:y)\n#define half __fp16\n'
 
 class ClangCompiler(Compiler):
   compiler_opts = CompilerOptions("CLANG", supports_float4=False, has_local=False)
-  def render(self, name:str, uops) -> str: return CLANG_PROGRAM_HEADER + uops_to_cstyle(CStyleLanguage(buffer_suffix=" restrict", first_loop_prefix=OMP_PRAGMA), name, uops)
+  def render(self, name:str, uops) -> str: return CLANG_PROGRAM_HEADER + uops_to_cstyle(CStyleLanguage(buffer_suffix=" restrict", first_loop_prefix=OMP_PRAGMA), name, uops)  # noqa: E501
   def compile(self, src:str) -> bytes:
     # TODO: remove file write. sadly clang doesn't like the use of /dev/stdout here
     with tempfile.NamedTemporaryFile(delete=True) as output_file:

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -3,8 +3,8 @@ from tinygrad.device import Compiled, MallocAllocator, Compiler, CompilerOptions
 from tinygrad.helpers import cpu_time_execution, getenv
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 
-CLANG_PROGRAM_HEADER = '#include <omp.h>\n#include <stdbool.h>\n#include <tgmath.h>\n#define max(x,y) ((x>y)?x:y)\n#define half __fp16\n'
-OMP_PRAGMA, OMP_FLAGS = ("#pragma omp parallel for collapse({nloops})", "-Xpreprocessor -fopenmp -lomp") if getenv("OMP", 1) else ("", "")
+OMP_HEADER, OMP_PRAGMA, OMP_FLAGS = ("#include <omp.h>\n", "#pragma omp parallel for collapse({nloops})", "-Xpreprocessor -fopenmp -lomp") if getenv("OMP", 1) else ("", "", "")
+CLANG_PROGRAM_HEADER = OMP_HEADER +'#include <stdbool.h>\n#include <tgmath.h>\n#define max(x,y) ((x>y)?x:y)\n#define half __fp16\n'
 
 class ClangCompiler(Compiler):
   compiler_opts = CompilerOptions("CLANG", supports_float4=False, has_local=False)

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -3,7 +3,7 @@ from tinygrad.device import Compiled, MallocAllocator, Compiler, CompilerOptions
 from tinygrad.helpers import cpu_time_execution, getenv
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 
-OMP_HEADER, OMP_PRAGMA, OMP_FLAGS = ("#include <omp.h>\n", "#pragma omp parallel for collapse({})", "-Xpreprocessor -fopenmp -lomp") if getenv("OMP", 1) else ("", "", "")
+OMP_HEADER, OMP_PRAGMA, OMP_FLAGS = ("#include <omp.h>\n", "#pragma omp parallel for collapse({})", "-Xpreprocessor -fopenmp -lomp") if getenv("OMP", 0) else ("", "", "")
 CLANG_PROGRAM_HEADER = OMP_HEADER +'#include <stdbool.h>\n#include <tgmath.h>\n#define max(x,y) ((x>y)?x:y)\n#define half __fp16\n'
 
 class ClangCompiler(Compiler):

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -24,7 +24,8 @@ class ClangProgram:
       pathlib.Path(cached_file_path.name).write_bytes(lib)
       self.fxn = ctypes.CDLL(str(cached_file_path.name))[name]
 
-  def __call__(self, *bufs, global_size=(1,1,1), local_size=(1,1,1), vals=(), wait=False): return cpu_time_execution(lambda: self.fxn(*bufs, *vals), enable=wait)
+  def __call__(self, *bufs, global_size=None, local_size=None, vals=(), wait=False):
+    return cpu_time_execution(lambda: self.fxn(*bufs, *vals), enable=wait)
 
 class ClangDevice(Compiled):
   def __init__(self, device:str): super().__init__(device, MallocAllocator, ClangCompiler("compile_clang"), ClangProgram)

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -1,4 +1,4 @@
-import ctypes, subprocess, pathlib, tempfile
+import ctypes, subprocess, pathlib, tempfile, os, math
 from tinygrad.device import Compiled, MallocAllocator, Compiler, CompilerOptions
 from tinygrad.helpers import cpu_time_execution, getenv
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
@@ -7,7 +7,7 @@ OMP_HEADER, OMP_FLAGS = ("#include <omp.h>\n", "-Xpreprocessor -fopenmp -lomp") 
 CLANG_PROGRAM_HEADER = OMP_HEADER +'#include <stdbool.h>\n#include <tgmath.h>\n#define max(x,y) ((x>y)?x:y)\n#define half __fp16\n'
 
 class ClangCompiler(Compiler):
-  compiler_opts = CompilerOptions("CLANG", supports_float4=False, has_local=OMP_SET)
+  compiler_opts = CompilerOptions("CLANG", supports_float4=False, has_local=OMP_SET, global_max=[1,1,64], local_max=[2,1,1])
   def render(self, name:str, uops) -> str: return CLANG_PROGRAM_HEADER + uops_to_cstyle(CStyleLanguage(buffer_suffix=" restrict"), name, uops)
   def compile(self, src:str) -> bytes:
     # TODO: remove file write. sadly clang doesn't like the use of /dev/stdout here
@@ -25,6 +25,9 @@ class ClangProgram:
       self.fxn = ctypes.CDLL(str(cached_file_path.name))[name]
 
   def __call__(self, *bufs, global_size=None, local_size=None, vals=(), wait=False):
+    # NOTE: local needs exact number of threads, but global could be dynamic and blocked. maybe global should even be serial
+    if global_size is not None: os.environ["OMP_NUM_THREADS"] = ",".join(map(str, [math.prod(global_size)] + ([math.prod(local_size)] if local_size is not None else [])))
+    if global_size is not None and local_size is not None: os.environ["OMP_MAX_ACTIVE_LEVELS"] = "2"
     return cpu_time_execution(lambda: self.fxn(*bufs, *vals), enable=wait)
 
 class ClangDevice(Compiled):

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -3,12 +3,13 @@ from tinygrad.device import Compiled, MallocAllocator, Compiler, CompilerOptions
 from tinygrad.helpers import cpu_time_execution, getenv
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 
-OMP_HEADER, OMP_PRAGMA, OMP_FLAGS = ("#include <omp.h>\n", "#pragma omp parallel for collapse({})", "-Xpreprocessor -fopenmp -lomp") if getenv("OMP", 0) else ("", "", "")  # noqa: E501
+OMP_HEADER, OMP_PRAGMA, OMP_FLAGS = ("#include <omp.h>\n", "#pragma omp parallel for collapse({})", "-Xpreprocessor -fopenmp -lomp") if getenv("OMP", 0) else ("", None, "")  # noqa: E501
 CLANG_PROGRAM_HEADER = OMP_HEADER +'#include <stdbool.h>\n#include <tgmath.h>\n#define max(x,y) ((x>y)?x:y)\n#define half __fp16\n'
 
 class ClangCompiler(Compiler):
   compiler_opts = CompilerOptions("CLANG", supports_float4=False, has_local=False)
-  def render(self, name:str, uops) -> str: return CLANG_PROGRAM_HEADER + uops_to_cstyle(CStyleLanguage(buffer_suffix=" restrict", first_loop_prefix=OMP_PRAGMA), name, uops)  # noqa: E501
+  def render(self, name:str, uops) -> str:
+    return CLANG_PROGRAM_HEADER + uops_to_cstyle(CStyleLanguage(buffer_suffix=" restrict", first_loop_prefix=OMP_PRAGMA), name, uops)
   def compile(self, src:str) -> bytes:
     # TODO: remove file write. sadly clang doesn't like the use of /dev/stdout here
     with tempfile.NamedTemporaryFile(delete=True) as output_file:


### PR DESCRIPTION
OpenMP support for the CLANG runtime. Default is on, but `OMP=0` will turn it off.

On mac, this assumes that `/usr/local` contains OpenMP (see: https://iscinumpy.gitlab.io/post/omp-on-high-sierra/)

TODO:
- [x] pass tests in CI (might be some correctness/omp install/linux issues).