### PR TITLE
fuzz schedule context vars

### DIFF
--- a/test/external/fuzz_schedule.py
+++ b/test/external/fuzz_schedule.py
@@ -20,30 +20,29 @@ def fuzz_schedule(outs: List[LazyBuffer]):
       if ts not in toposorts: toposorts[ts] = (dict(zip([v.key for v in ctx_vars], combination)), prescheduled)
   if DEBUG >= 1: print(colored(f"fuzzing {len(toposorts)} schedule permutations", "yellow"))
 
+  # setup ground truth
   ground_truth: Dict[LazyBuffer, memoryview] = {}
   # IMPORTANT: freeze prerealized bufs before ScheduleItem exec
   prerealized: Dict[LazyBuffer, memoryview] = {}
-  seed = Tensor._seed
+  seed, first = Tensor._seed, list(toposorts.items())[0]
+  for key in first[0]:
+    for out in (ps:=first[1][1][key]).outputs:
+      # freeze assign state before exec
+      if out.op is LoadOps.ASSIGN: prerealized[out] = out.buffer.as_buffer()
+    for x in ps.inputs:
+      if x not in ground_truth and x.device != "NPY": prerealized[x] = x.buffer.as_buffer()
+    si = ScheduleItem(ps.ast, tuple(x.buffer for x in ps.outputs if x.size != 0), tuple(x.buffer for x in ps.inputs if x.size != 0))
+    _exec_si(si, seed)
+    for out in ps.outputs:
+      ground_truth[out] = out.buffer.as_buffer()
+      del out.srcs # only schedule the LazyBuffer in this fuzz run
 
+  # exec and validate each permutation with new Buffers
   for i, (ts, (ctx, prescheduled)) in enumerate(toposorts.items()):
+    if i == 0: continue
     if DEBUG >= 1: print(colored(f"testing permutation {i} {ctx}", "yellow"))
     rawbufs: Dict[LazyBuffer, Buffer] = {}
     for key in ts:
-      # setup ground truth
-      if i == 0:
-        for out in (ps:=prescheduled[key]).outputs:
-          # freeze assign state before exec
-          if out.op is LoadOps.ASSIGN: prerealized[out] = out.buffer.as_buffer()
-        for x in ps.inputs:
-          if x not in ground_truth and x.device != "NPY": prerealized[x] = x.buffer.as_buffer()
-        si = ScheduleItem(ps.ast, tuple(x.buffer for x in ps.outputs if x.size != 0), tuple(x.buffer for x in ps.inputs if x.size != 0))
-        _exec_si(si, seed)
-        for out in ps.outputs:
-          ground_truth[out] = out.buffer.as_buffer()
-          del out.srcs # only schedule the LazyBuffer in this fuzz run
-        continue
-
-      # exec and validate the permutation with new Buffers
       for out in (ps:=prescheduled[key]).outputs:
         rawbufs[out] = Buffer(out.buffer.device, out.buffer.size, out.buffer.dtype)
         if out.op is LoadOps.ASSIGN: rawbufs[out].ensure_allocated().copyin(prerealized[out])

--- a/test/external/fuzz_schedule.py
+++ b/test/external/fuzz_schedule.py
@@ -12,30 +12,34 @@ from tinygrad.tensor import Tensor
 ctx_vars = { MULTIOUTPUT: (0, 1) }
 
 def fuzz_schedule(outs: List[LazyBuffer]):
-  toposorts: List[Tuple[Dict, List[LazyBuffer], Dict[LazyBuffer, _LBScheduleItem]]]  = []
+  toposorts: Dict[Tuple[LazyBuffer, ...], Tuple[Dict, Dict[LazyBuffer, _LBScheduleItem]]] = {}
   for combination in itertools.product(*ctx_vars.values()):
     for var, val in zip(ctx_vars, combination): var.value = val
     graph, in_degree, prescheduled = _graph_schedule(outs, set())
-    for ts in find_all_toposorts(graph, in_degree): toposorts.append((dict(zip([v.key for v in ctx_vars], combination)), ts, prescheduled))
+    for ts in find_all_toposorts(graph, in_degree):
+      if ts not in toposorts: toposorts[ts] = (dict(zip([v.key for v in ctx_vars], combination)), prescheduled)
   if DEBUG >= 1: print(colored(f"fuzzing {len(toposorts)} schedule permutations", "yellow"))
 
   # setup ground truth
   ground_truth: Dict[LazyBuffer, memoryview] = {}
   # IMPORTANT: freeze prerealized bufs before ScheduleItem exec
   prerealized: Dict[LazyBuffer, memoryview] = {}
-  seed = Tensor._seed
-  for key in toposorts[0][1]:
-    for out in (ps:=toposorts[0][2][key]).outputs:
+  seed, first = Tensor._seed, list(toposorts.items())[0]
+  for key in first[0]:
+    for out in (ps:=first[1][1][key]).outputs:
       # freeze assign state before exec
       if out.op is LoadOps.ASSIGN: prerealized[out] = out.buffer.as_buffer()
     for x in ps.inputs:
       if x not in ground_truth and x.device != "NPY": prerealized[x] = x.buffer.as_buffer()
     si = ScheduleItem(ps.ast, tuple(x.buffer for x in ps.outputs if x.size != 0), tuple(x.buffer for x in ps.inputs if x.size != 0))
     _exec_si(si, seed)
-    for out in ps.outputs: ground_truth[out] = out.buffer.as_buffer()
+    for out in ps.outputs:
+      ground_truth[out] = out.buffer.as_buffer()
+      del out.srcs # only schedule the LazyBuffer in this fuzz run
 
   # exec and validate each permutation with new Buffers
-  for i, (ctx, ts, prescheduled) in enumerate(toposorts[1:]):
+  for i, (ts, (ctx, prescheduled)) in enumerate(toposorts.items()):
+    if i == 0: continue
     if DEBUG >= 1: print(colored(f"testing permutation {i} {ctx}", "yellow"))
     rawbufs: Dict[LazyBuffer, Buffer] = {}
     for key in ts:
@@ -50,7 +54,6 @@ def fuzz_schedule(outs: List[LazyBuffer]):
       si = ScheduleItem(ps.ast, tuple(rawbufs[x] for x in ps.outputs if x.size != 0), tuple(rawbufs[x] for x in ps.inputs if x.size != 0))
       _exec_si(si, seed)
       for out in ps.outputs:
-        if hasattr(out, "srcs"): del out.srcs  # can only schedule once
         outbuf = np.frombuffer(rawbufs[out].as_buffer(), out.dtype.np)
         try: np.testing.assert_allclose(outbuf, np.frombuffer(ground_truth[out], out.dtype.np), atol=1e-2, rtol=1e-2)
         except Exception as e:
@@ -64,9 +67,9 @@ def _exec_si(si: ScheduleItem, seed:int):
   ei.run()
 
 T = TypeVar("T")
-def find_all_toposorts(graph:DefaultDict[T, List[T]], in_degree:DefaultDict[T, int]) -> List[List[T]]:
+def find_all_toposorts(graph:DefaultDict[T, List[T]], in_degree:DefaultDict[T, int]) -> List[Tuple[T, ...]]:
   visited: Set[T] = set()
-  ret: List[List[T]] = []
+  ret: List[Tuple[T, ...]] = []
   path: List[T] = []
 
   def recurse_paths(path:List[T]):
@@ -81,10 +84,10 @@ def find_all_toposorts(graph:DefaultDict[T, List[T]], in_degree:DefaultDict[T, i
       for u in graph[v]: in_degree[u] += 1
       path.pop()
       visited.remove(v)
-    if len(path) == len(in_degree): ret.append([*path])
+    if len(path) == len(in_degree): ret.append(tuple([*path]))
   recurse_paths(path)
 
   if len(ret) == 0: raise RuntimeError("detected cycle in the graph")
   # verify all paths are unique
-  assert len(ret) == len(set(map(tuple, ret)))
+  assert len(ret) == len(set(ret))
   return ret

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -235,7 +235,6 @@ def _graph_schedule(outs:List[LazyBuffer], seen:Set[LazyBuffer]) -> Tuple[Defaul
     for assign in parents_assigns:
       graph[key].append(assign)
       in_degree[assign] += 1
-    for out in lsi.outputs: del out.srcs  # can only schedule once
 
   return graph, in_degree, prescheduled
 
@@ -253,6 +252,7 @@ def create_schedule_with_vars(outs:List[LazyBuffer], seen:Optional[Set[LazyBuffe
       kernel_number += 1
       for out in ps.outputs: realized_lazybuffer(out, kernel_number)
     var_vals = merge_dicts([var_vals, ps.var_vals])
+    for out in ps.outputs: del out.srcs  # can only schedule once
     schedule.append(si:=ScheduleItem(ps.ast, tuple(x.buffer for x in ps.outputs if x.size != 0), tuple(x.buffer for x in ps.inputs if x.size != 0)))
     if logops and si.ast[0].op not in LoadOps and not any(i.device.startswith("DISK:") for i in si.inputs): logops.write(str(si.ast)+"\n")
     for x in graph[ps.outputs[0]]:

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -84,10 +84,11 @@ class Context(contextlib.ContextDecorator):
 class ContextVar:
   _cache: ClassVar[Dict[str, ContextVar]] = {}
   value: int
+  key: str
   def __new__(cls, key, default_value):
     if key in ContextVar._cache: return ContextVar._cache[key]
     instance = ContextVar._cache[key] = super().__new__(cls)
-    instance.value = getenv(key, default_value)
+    instance.value, instance.key = getenv(key, default_value), key
     return instance
   def __bool__(self): return bool(self.value)
   def __ge__(self, x): return self.value >= x


### PR DESCRIPTION
eg.
```py
a = Tensor.empty(32, 32)
Tensor.corealize([a.sum() + 2, a.sum() * 4])
```
Fuzzes MULTIOUTPUT=0,1
```
fuzzing 3 schedule permutations
*** METAL      1 empty       1024 dtypes.float          arg   1 mem  0.00 GB tm      0.00us/     0.00ms (    0.00 GFLOPS,    0.00 GB/s)
*** METAL      2 r_256_4                                arg   2 mem  0.00 GB tm      8.92us/     0.01ms (    0.23 GFLOPS,    0.46 GB/s)
*** METAL      3 r_256_4n1                              arg   2 mem  0.00 GB tm      9.71us/     0.02ms (    0.21 GFLOPS,    0.42 GB/s)
testing permutation 0 {'MULTIOUTPUT': 0}
*** METAL      4 empty       1024 dtypes.float          arg   1 mem  0.00 GB tm      0.00us/     0.02ms (    0.00 GFLOPS,    0.00 GB/s)
*** METAL      5 r_256_4n1                              arg   2 mem  0.00 GB tm      9.71us/     0.03ms (    0.21 GFLOPS,    0.42 GB/s)
*** METAL      6 r_256_4                                arg   2 mem  0.00 GB tm      7.87us/     0.04ms (    0.26 GFLOPS,    0.52 GB/s)
testing permutation 1 {'MULTIOUTPUT': 1}
*** METAL      7 empty       1024 dtypes.float          arg   1 mem  0.00 GB tm      0.00us/     0.04ms (    0.00 GFLOPS,    0.00 GB/s)
*** METAL      8 r2_256_4                               arg   3 mem  0.00 GB tm      9.25us/     0.05ms (    0.22 GFLOPS,    0.44 GB/s)
```