### PR TITLE
 more realistic edge behavior for resnet benchmark 

### DIFF
--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -55,6 +55,7 @@ class BenchmarkResnetTrain(unittest.TestCase):
     return f"{name} x{(bs, cin, xy, xy)}", [layer], cin, xy
   def _test_layer(self, name, layer, cin, xy):
     optim = SGD(get_parameters(layer), bs / 128 * 1.0)  # need sgd for some params but not consequential for benchmarking
+    Tensor.corealize([t.assign(t) for t in get_parameters(layer)])
 
     JITCNT = getenv("JITCNT", 1)
     Tensor.training = True

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -66,7 +66,7 @@ class BenchmarkResnetTrain(unittest.TestCase):
 
         y = x.sequential(layer).contiguous().contiguous_backward()
         y.sum().backward()
-        if getenv("ASSIGN", 1): optim.step([y, x.grad])
+        if getenv("ASSIGN", 1): Tensor.corealize([y, x.grad] + optim.schedule_step())
         else: Tensor.corealize([y, x.grad] + [t.grad for t in optim.params])
       return y.detach()
 


### PR DESCRIPTION
For full layers, there was double relu.

bn(conv(x)).grad and bn(conv(x)) are realized if you stack layers, use contiguous to match it

`SAVE_SCHEDULE=1 CNT=1 ASSIGN=0 SPLIT_REDUCEOP=0 CONV=1 BN=1 BS=256 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py BenchmarkResnetTrain.test_layer1_1`

![image](https://github.com/tinygrad/tinygrad/assets/2350134/d769dbe5-df63-47b5-ab0a-d0954355e873)
