### PR TITLE
Improves error message when CUDA module fails to load.

### DIFF
--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -101,7 +101,7 @@ class CUDAProgram:
       if status != 0:
         del self.module
         cuda_disassemble(lib, device.arch)
-        raise RuntimeError("module load failed")
+        raise RuntimeError(f"module load failed with status code {status}: {cuda.cudaError_enum__enumvalues[status]}")
       check(cuda.cuModuleGetFunction(ctypes.byref(prg := cuda.CUfunction()), self.module, name.encode("utf-8")))
       self.prg = prg #type: ignore
 


### PR DESCRIPTION
This will hopefully help people troubleshoot their problem much more quickly.  This exception is the first thing I ran into when trying out TinyGrad, and the error gives no details to point to where I should start looking.  Now it tells me `CUDA_ERROR_UNSUPPORTED_PTX_VERSION` which is something I can search for.

I didn't add tests since the exact text of error messages isn't usually something that is tested, but I can write a regression test for this if that is desired.