### PR TITLE
replace CLANG dlopen with mmap+mprotect and remove linker

### DIFF
--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -36,7 +36,7 @@ class ClangProgram:
     if code_addr == -1: raise OSError('mmap failed to allocate memory')
     ctypes.memmove(code_addr, lib, len(lib))
     if mprotect(code_addr, len(lib), mmap_flags.PROT_READ | mmap_flags.PROT_EXEC, 0) < 0: raise OSError('mprotect failed to make memory executable')
-    self.fxn = ctypes.CFUNCTYPE(None)(code_addr + 0x0000000000003e44) # TODO: just get offset from symbol table?
+    self.fxn = ctypes.CFUNCTYPE(None)(code_addr + 0x0000000000003e44) # TODO: how to best get the function offset?
 
   def __call__(self, *bufs, vals=(), wait=False): return cpu_time_execution(lambda: self.fxn(*bufs, *vals), enable=wait)
 

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -1,9 +1,23 @@
-import ctypes, subprocess, pathlib, tempfile
+import ctypes, subprocess, pathlib, tempfile, math, mmap as mmap_flags
 from tinygrad.device import Compiled, MallocAllocator, Compiler, CompilerOptions
 from tinygrad.helpers import cpu_time_execution
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 
 CLANG_PROGRAM_HEADER = '#include <stdbool.h>\n#include <tgmath.h>\n#define max(x,y) ((x>y)?x:y)\n#define half __fp16\n'
+
+# implement jit as per here
+# https://gist.github.com/jumbojets/1d7008901826eb9de1f2aa608f368847
+# NOTE: mmap doesnt have mprotect, so have to load libc
+# https://github.com/python/cpython/issues/114233
+
+libc = ctypes.cdll.LoadLibrary(None)
+mmap = libc.mmap
+mmap.restype = ctypes.c_void_p
+mmap.argtypes = (ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_size_t)
+
+mprotect = libc.mprotect
+mprotect.restype = ctypes.c_int
+mprotect.argtypes = (ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_int)
 
 class ClangCompiler(Compiler):
   compiler_opts = CompilerOptions("CLANG", supports_float4=False, has_local=False)
@@ -18,10 +32,12 @@ class ClangCompiler(Compiler):
 class ClangProgram:
   def __init__(self, name:str, lib:bytes):
     self.name, self.lib = name, lib
-    # write to disk so we can load it
-    with tempfile.NamedTemporaryFile(delete=True) as cached_file_path:
-      pathlib.Path(cached_file_path.name).write_bytes(lib)
-      self.fxn = ctypes.CDLL(str(cached_file_path.name))[name]
+    mmap_size = 2**math.ceil(math.log2(len(lib))+1)
+    code_addr = mmap(None, mmap_size, mmap_flags.PROT_READ | mmap_flags.PROT_WRITE, mmap_flags.MAP_ANON | mmap_flags.MAP_PRIVATE, -1, 0)
+    if code_addr == -1: raise OSError('mmap failed to allocate memory')
+    ctypes.memmove(code_addr, lib, len(lib))
+    if mprotect(code_addr, mmap_size, mmap_flags.PROT_READ | mmap_flags.PROT_EXEC, 0) < 0: raise OSError('mprotect failed to make memory executable')
+    self.fxn = ctypes.CFUNCTYPE(None)(code_addr + 0x0000000000003e44) # TODO: just get offset from symbol table?
 
   def __call__(self, *bufs, vals=(), wait=False): return cpu_time_execution(lambda: self.fxn(*bufs, *vals), enable=wait)
 


### PR DESCRIPTION
Currently, only this minimal example works (because the offset into the shared library is hard-coded)

```py
N = 1024; a, b = Tensor.rand(N, N), Tensor.rand(N, N)
(a@b).realize()
```

A call to `mprotect` in addition `mmap` is necessary (at least for macOS) to remove write permission and add exec permission. Python's `mmap` module is [pending `mprotect`](https://github.com/python/cpython/pull/114674), so in the meantime, it seems we have to load libc--hopefully just once.

As mentioned in discord, certain kernels depend on libm/libc, making skipping the linker problematic. I believe the most straightforward solution here is to just attach our own implementations of the offending functions (`sin`/...), but I'm not sure its the best.

It is not yet clear to me that this will be a win over `CDLL`.

TODO:
- [ ] Dynamically find the function's offset into shared library without linker step
- [ ] Address `libm` dependency (we can't just skip linker)
- [ ] Clean up code (particularly, mmap/mprotect function usage)
- [ ] Benchmark