### PR TITLE
save the LazyBuffer graph in SAVE_SCHEDULE

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -1,4 +1,4 @@
-import sys, pickle, atexit
+import sys, pickle
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from typing import Tuple, List, Dict, Optional, Set, DefaultDict
@@ -238,7 +238,6 @@ def _graph_schedule(outs:List[LazyBuffer], seen:Set[LazyBuffer]) -> Tuple[Defaul
 
   return graph, in_degree, prescheduled
 
-SCHEDULES: List[ScheduleItem] = []
 def create_schedule_with_vars(outs:List[LazyBuffer], seen:Optional[Set[LazyBuffer]]=None) -> Tuple[List[ScheduleItem], Dict[Variable, int]]:
   if seen is None: seen = set()
   graph, in_degree, prescheduled = _graph_schedule(outs, seen)
@@ -265,11 +264,8 @@ def create_schedule_with_vars(outs:List[LazyBuffer], seen:Optional[Set[LazyBuffe
     raise RuntimeError(f"cycle detected in graph, prescheduled {len(prescheduled)} but only scheduled {len(schedule)}")
   if DEBUG >= 1 and len(schedule) >= 10: print(f"scheduled {len(schedule)} kernels")
   if SAVE_SCHEDULE:
-    def _save():
-      print(f"saving {len(SCHEDULES)} schedule items to", fp:="schedule.pkl")
-      pickle.dump(SCHEDULES, open(fp, "wb"))
-    if len(SCHEDULES) == 0: atexit.register(_save)
-    SCHEDULES.extend(schedule)
+    print(f"saving {len(schedule)} schedule items to", fp:="schedule.pkl")
+    pickle.dump((graph, prescheduled), open(fp, "wb"))
   return schedule, var_vals
 
 def create_schedule(outs:List[LazyBuffer], seen:Optional[Set[LazyBuffer]]=None) -> List[ScheduleItem]:


### PR DESCRIPTION
`ScheduleItem` obfuscates the LazyBuffer - we can't rebuild a directed graph for ASSIGN.

eg: `SAVE_SCHEDULE=1 python3 examples/llm.c/export.py`

pickle List[ScheduleItem]:

<img width="1728" alt="Screenshot 2024-04-22 at 11 26 08 AM" src="https://github.com/tinygrad/tinygrad/assets/77887910/b1c484e0-8121-4106-8fc3-57de4ac632a4">

pickle the graph:
<img width="1383" alt="Screenshot 2024-04-22 at 11 31 55 AM" src="https://github.com/tinygrad/tinygrad/assets/77887910/0162e77e-ad14-4770-ad25-545ef8250323">