### PR TITLE
search: add additional 7 factors to the action space

### DIFF
--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -11,9 +11,9 @@ from tinygrad.tensor import Tensor
 from tinygrad.shape.symbolic import sym_infer, Variable
 
 actions = [Opt(op=OptOps.UPCAST, axis=axis, amt=amt) for amt in [0,2,3,4,5,7] for axis in range(6)]
-actions += [Opt(op=OptOps.UNROLL, axis=axis, amt=amt) for amt in [0,4] for axis in range(4)]
+actions += [Opt(op=OptOps.UNROLL, axis=axis, amt=amt) for amt in [0,4,7] for axis in range(4)]
 actions += [Opt(op=OptOps.LOCAL, axis=axis, amt=amt) for amt in [2,3,4,8,13,16,29] for axis in range(5)]
-actions += [Opt(op=OptOps.GROUPTOP, axis=axis, amt=amt) for amt in [13,16,29,32,256] for axis in range(3)]
+actions += [Opt(op=OptOps.GROUPTOP, axis=axis, amt=amt) for amt in [13,16,28,29,32,49,64,256] for axis in range(3)]
 actions += [Opt(op=OptOps.GROUP, axis=axis, amt=amt) for amt in [0,4,8,16] for axis in range(3)]
 actions += [Opt(op=OptOps.PADTO, axis=axis, amt=amt) for amt in [32] for axis in range(7)]
 actions += [Opt(op=OptOps.LOCAL, axis=0, amt=32), Opt(op=OptOps.UPCASTMID, axis=1, amt=4), Opt(op=OptOps.TC, axis=0, amt=0)]

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -145,7 +145,7 @@ _cache_dir: str = getenv("XDG_CACHE_HOME", os.path.expanduser("~/Library/Caches"
 CACHEDB: str = getenv("CACHEDB", os.path.abspath(os.path.join(_cache_dir, "tinygrad", "cache.db")))
 CACHELEVEL = getenv("CACHELEVEL", 2)
 
-VERSION = 14
+VERSION = 15
 _db_connection = None
 def db_connection():
   global _db_connection


### PR DESCRIPTION
also bump the DB version after the padded TC merge

Here's some stats on resnet search on this branch:


This run took 24 minutes to search from a clean disk cache:
```
flam@tiny19:~/tinygrad$ time PYTHONPATH=. CUDA=1 DEFAULT_FLOAT=HALF SPLIT_REDUCEOP=0 BS=1536 GPUS=6 BENCHMARK=10 TRAIN_BEAM=2 BEAM_UOPS_MAX=1200 BEAM_UPCAST_MAX=128 BEAM_MIN_PROGRESS=50 MODEL=resnet python3 examples/mlperf/model_train.py
training resnet
Training on ['CUDA:0', 'CUDA:1', 'CUDA:2', 'CUDA:3', 'CUDA:4', 'CUDA:5']
training with batch size 1536 for 37 epochs
    0 34841.15 ms run, 34704.29 ms python, 135.64 ms fetch data,    1.23 ms CUDA * 6,  7.03 loss, 0.00 acc, 0.004177 LR, 2.08 GB used,   1093.60 GFLOPS
    1 12432.41 ms run, 12395.74 ms python,  35.16 ms fetch data,    1.51 ms CUDA * 6,  7.01 loss, 0.00 acc, 0.008354 LR, 90.66 GB used,   3071.02 GFLOPS
    2  483.47 ms run,  126.55 ms python,  56.07 ms fetch data,  300.85 ms CUDA * 6,  7.03 loss, 0.00 acc, 0.012527 LR, 90.66 GB used,  78970.68 GFLOPS
    3  478.30 ms run,  102.28 ms python,  62.31 ms fetch data,  313.70 ms CUDA * 6,  7.03 loss, 0.00 acc, 0.016708 LR, 90.66 GB used,  79824.77 GFLOPS
    4  491.73 ms run,  109.60 ms python,  58.15 ms fetch data,  323.98 ms CUDA * 6,  7.02 loss, 0.00 acc, 0.020874 LR, 90.66 GB used,  77644.27 GFLOPS
    5  487.86 ms run,  104.39 ms python,  57.72 ms fetch data,  325.76 ms CUDA * 6,  7.02 loss, 0.00 acc, 0.025055 LR, 90.66 GB used,  78260.50 GFLOPS
    6  479.70 ms run,  100.60 ms python,  61.21 ms fetch data,  317.89 ms CUDA * 6,  7.02 loss, 0.00 acc, 0.029236 LR, 90.66 GB used,  79592.07 GFLOPS
    7  479.35 ms run,  102.54 ms python,  60.35 ms fetch data,  316.46 ms CUDA * 6,  7.03 loss, 0.00 acc, 0.033417 LR, 90.66 GB used,  79649.27 GFLOPS
    8  482.93 ms run,  101.63 ms python,  63.01 ms fetch data,  318.29 ms CUDA * 6,  7.02 loss, 0.00 acc, 0.037567 LR, 90.66 GB used,  79060.20 GFLOPS
    9  481.08 ms run,  103.11 ms python,  57.03 ms fetch data,  320.93 ms CUDA * 6,  7.02 loss, 0.00 acc, 0.041748 LR, 90.66 GB used,  79363.49 GFLOPS
Estimated training time: 4h8m
```

This run took 40 minutes to search from a clean disk cache:
```
flam@tiny19:~/tinygrad$ time PYTHONPATH=. CUDA=1 DEFAULT_FLOAT=HALF SPLIT_REDUCEOP=0 BS=1536 GPUS=6 BENCHMARK=10 TRAIN_BEAM=4 BEAM_UOPS_MAX=2000 BEAM_UPCAST_MAX=128 BEAM_MIN_PROGRESS=50 MODEL=resnet python3 examples/mlperf/model_train.py
training resnet
Training on ['CUDA:0', 'CUDA:1', 'CUDA:2', 'CUDA:3', 'CUDA:4', 'CUDA:5']
training with batch size 1536 for 37 epochs
    0 41567.07 ms run, 41429.08 ms python, 136.78 ms fetch data,    1.21 ms CUDA * 6,  7.03 loss, 0.00 acc, 0.004177 LR, 2.08 GB used,    918.00 GFLOPS
    1 12761.71 ms run, 12725.01 ms python,  35.24 ms fetch data,    1.47 ms CUDA * 6,  7.01 loss, 0.00 acc, 0.008354 LR, 90.66 GB used,   2996.14 GFLOPS
    2  433.12 ms run,  127.15 ms python,  56.19 ms fetch data,  249.78 ms CUDA * 6,  7.03 loss, 0.00 acc, 0.012527 LR, 90.66 GB used,  88280.56 GFLOPS
    3  420.89 ms run,   93.66 ms python,  64.16 ms fetch data,  263.07 ms CUDA * 6,  7.03 loss, 0.00 acc, 0.016708 LR, 90.66 GB used,  90844.74 GFLOPS
    4  422.34 ms run,  105.20 ms python,  57.89 ms fetch data,  259.25 ms CUDA * 6,  7.02 loss, 0.00 acc, 0.020874 LR, 90.66 GB used,  90533.61 GFLOPS
    5  422.07 ms run,  101.52 ms python,  60.49 ms fetch data,  260.06 ms CUDA * 6,  7.02 loss, 0.00 acc, 0.025055 LR, 90.66 GB used,  90590.91 GFLOPS
    6  424.99 ms run,  103.73 ms python,  60.28 ms fetch data,  260.98 ms CUDA * 6,  7.02 loss, 0.00 acc, 0.029236 LR, 90.66 GB used,  89968.47 GFLOPS
    7  428.14 ms run,  105.26 ms python,  56.95 ms fetch data,  265.92 ms CUDA * 6,  7.03 loss, 0.00 acc, 0.033417 LR, 90.66 GB used,  89307.35 GFLOPS
    8  420.94 ms run,  102.08 ms python,  60.62 ms fetch data,  258.24 ms CUDA * 6,  7.02 loss, 0.00 acc, 0.037567 LR, 90.66 GB used,  90833.91 GFLOPS
    9  422.09 ms run,  103.98 ms python,  56.08 ms fetch data,  262.04 ms CUDA * 6,  7.02 loss, 0.00 acc, 0.041748 LR, 90.66 GB used,  90586.10 GFLOPS
Estimated training time: 3h38m
```

Will still need to make search more efficient (less overall time and better performance).