### PR TITLE
setitem no return value

### DIFF
--- a/test/imported/test_indexing.py
+++ b/test/imported/test_indexing.py
@@ -1519,7 +1519,7 @@ class TestNumpy(unittest.TestCase):
   def test_broaderrors_indexing(self):
     a = Tensor.zeros(5, 5)
     self.assertRaises(IndexError, a.__getitem__, ([0, 1], [0, 1, 2]))
-    self.assertRaises(IndexError, a.__setitem__, ([0, 1], [0, 1, 2]), 0)
+    self.assertRaises(IndexError, a.contiguous().__setitem__, ([0, 1], [0, 1, 2]), 0)
 
   # TODO out of bound getitem does not raise error
   '''

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -21,6 +21,11 @@ class TestSetitem(unittest.TestCase):
     t[1] = 5
     np.testing.assert_allclose(t.numpy(), [[0, 1], [5, 5]])
 
+  def test_setitem_into_noncontiguous(self):
+    t = Tensor.ones(4)
+    assert not t.lazydata.st.contiguous
+    with self.assertRaises(AssertionError): t[1] = 5
+
   def test_simple_jit_setitem(self):
     @TinyJit
     def f(t:Tensor, a:Tensor):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -812,7 +812,9 @@ class Tensor:
     if isinstance(self.device, str) and self.device.startswith("DISK"): self.__getitem__(indices).assign(v)
     # TODO: broadcast v to the shape here, refactor for const v and one way broadcast_shape
     if not isinstance(v, Tensor): v = Tensor(v, self.device, self.dtype)
-    assign_to = self.contiguous().realize().__getitem__(indices)
+    assign_to = self.realize().__getitem__(indices)
+    # NOTE: we check that indices is valid first
+    assert cast(LazyBuffer, self.lazydata).st.contiguous, "setitem target needs to be contiguous"
     # NOTE: contiguous to prevent const folding.
     assign_to.assign(v._broadcast_to(broadcast_shape(assign_to.shape, v.shape)).contiguous()).realize()
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -809,11 +809,11 @@ class Tensor:
     return ret
 
   def __setitem__(self, indices, v:Union[Tensor, ConstType]) -> None:
-    # NOTE: check that setitem target is valid first
-    assert all(lb.st.contiguous for lb in self.lazydata.lbs), "setitem target needs to be contiguous"
     if isinstance(self.device, str) and self.device.startswith("DISK"):
       self.__getitem__(indices).assign(v)
       return
+    # NOTE: check that setitem target is valid first
+    assert all(lb.st.contiguous for lb in self.lazydata.lbs), "setitem target needs to be contiguous"
     if not isinstance(v, (Tensor, float, int, bool)): raise TypeError(f"can't set a {type(v).__name__} to a Tensor")
     if not isinstance(v, Tensor): v = Tensor(v, device=self.device, dtype=self.dtype)
     assign_to = self.realize().__getitem__(indices)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -812,7 +812,9 @@ class Tensor:
     if isinstance(self.device, str) and self.device.startswith("DISK"): self.__getitem__(indices).assign(v)
     # TODO: broadcast v to the shape here, refactor for const v and one way broadcast_shape
     if not isinstance(v, Tensor): v = Tensor(v, self.device, self.dtype)
-    assign_to = self.contiguous().realize().__getitem__(indices)
+    assign_to = self.realize().__getitem__(indices)
+    # NOTE: we check that indices is valid first
+    assert self.lazydata.contiguous(), "setitem target needs to be contiguous"
     # NOTE: contiguous to prevent const folding.
     assign_to.assign(v._broadcast_to(broadcast_shape(assign_to.shape, v.shape)).contiguous()).realize()
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -812,9 +812,7 @@ class Tensor:
     if isinstance(self.device, str) and self.device.startswith("DISK"): self.__getitem__(indices).assign(v)
     # TODO: broadcast v to the shape here, refactor for const v and one way broadcast_shape
     if not isinstance(v, Tensor): v = Tensor(v, self.device, self.dtype)
-    assign_to = self.realize().__getitem__(indices)
-    # NOTE: we check that indices is valid first
-    assert self.lazydata.contiguous(), "setitem target needs to be contiguous"
+    assign_to = self.contiguous().realize().__getitem__(indices)
     # NOTE: contiguous to prevent const folding.
     assign_to.assign(v._broadcast_to(broadcast_shape(assign_to.shape, v.shape)).contiguous()).realize()
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -809,15 +809,17 @@ class Tensor:
     return ret
 
   def __setitem__(self, indices, v:Union[Tensor, ConstType]) -> None:
-    assert self.lazydata.st.contiguous if isinstance(self.lazydata, LazyBuffer) else all(lb.st.contiguous for lb in self.lazydata.lbs), \
-      "setitem target needs to be contiguous"
-    if isinstance(self.device, str) and self.device.startswith("DISK"): self.__getitem__(indices).assign(v)
-    # TODO: broadcast v to the shape here, refactor for const v and one way broadcast_shape
-    if not isinstance(v, Tensor): v = Tensor(v, self.device, self.dtype)
+    # NOTE: check that setitem target is valid first
+    assert all(lb.st.contiguous for lb in self.lazydata.lbs), "setitem target needs to be contiguous"
+    if isinstance(self.device, str) and self.device.startswith("DISK"):
+      self.__getitem__(indices).assign(v)
+      return
+    if not isinstance(v, (Tensor, float, int, bool)): raise TypeError(f"can't set a {type(v).__name__} to a Tensor")
+    if not isinstance(v, Tensor): v = Tensor(v, device=self.device, dtype=self.dtype)
     assign_to = self.realize().__getitem__(indices)
-    # NOTE: we check that indices is valid first
     # NOTE: contiguous to prevent const folding.
-    assign_to.assign(v._broadcast_to(broadcast_shape(assign_to.shape, v.shape)).contiguous()).realize()
+    v = v._broadcast_to(broadcast_shape(assign_to.shape, v.shape)).contiguous()
+    assign_to.assign(v).realize()
 
   # NOTE: using slice is discouraged and things should migrate to pad and shrink
   def slice(self, arg:Sequence[Optional[Tuple[int, sint]]], value:float=0) -> Tensor:


### PR DESCRIPTION
don't think setitem returns anything ([jax reference](https://github.com/google/jax/blob/main/jax/_src/basearray.pyi#L51))
a little unsure if this affects any previous DISK tensor implementations

also before the assert for contiguous was always returning True while not actually doing anything.
might've been the problem Cameron on discord was running into (I also accidentally ran into this thinking it was scheduler problem)