### PR TITLE
More improvements for resnet layer bench

### DIFF
--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -95,7 +95,8 @@ class BenchmarkResnetTrain(unittest.TestCase):
       if kernels is None: kernels = GlobalCounters.kernel_count // JITCNT
       tm = (et-st) / JITCNT
       if best_tm is None or tm < best_tm: best_tm = tm
-    print(f"\r{name:42s}: {best_tm * 1000:>9.2f} ms, {flops / 10**12 / best_tm:>7.2f} tflops, {mem_used / 10**9: 7.2f} GB used, {kernels:>6d} kernels")
+    print(f"\r{name:42s}: {best_tm * 1000:>9.2f} ms, {flops / 10**12 / best_tm:>7.2f} tflops,"
+          f"{mem_used / 10**9: 7.2f} GB used, {kernels:>6d} kernels")
     return best_tm, flops, mem, kernels
 
   def test_layer1_1(self): self._est(*self._test_layer(*self._get_layer(0, 0)), 1)

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -118,7 +118,7 @@ class BenchmarkResnetTrain(unittest.TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    print(f"estimated step tm: {cls.est_tm * 1000.0:.2f} ms, {cls.est_flops / 10 ** 12 / cls.est_tm:.3f} tflops, "
+    print(f"\restimated step tm: {cls.est_tm * 1000.0:.2f} ms, {cls.est_flops / 10 ** 12 / cls.est_tm:.3f} tflops, "
           f"{cls.est_mem / 10 ** 9 / cls.est_tm:.2f} GB/s, {cls.est_kernels} kernels")
 
 

--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -95,7 +95,7 @@ class BenchmarkResnetTrain(unittest.TestCase):
       if kernels is None: kernels = GlobalCounters.kernel_count // JITCNT
       tm = (et-st) / JITCNT
       if best_tm is None or tm < best_tm: best_tm = tm
-    print(f"\r{name:42s}: {best_tm * 1000:>9.2f} ms, {flops / 10**12 / best_tm:>7.2f} tflops,"
+    print(f"\r{name:42s}: {best_tm * 1000:>9.2f} ms, {flops / 10**12 / best_tm:>7.2f} tflops, "
           f"{mem_used / 10**9: 7.2f} GB used, {kernels:>6d} kernels")
     return best_tm, flops, mem, kernels
 


### PR DESCRIPTION
- I got some details wrong before
  - the strides happen in conv2
  - there is a maxpool2d with stride 2 just before layer1
- add time/tflops/GBs/kernel estimates based on weighted sum
- allow getting convs other than conv2
- improve the JIT benchmarking setup

LMK thoughts.

Still testing these changes, will use them for benchmarking ksrc, split reduce, other things.

```
(venv) chaos@tiny15:~/tinygrad$ JITCNT=20 PARALLEL=10 BEAM=4 BS=256 DEFAULT_FLOAT=HALF python test/external/external_benchmark_resnet.py
layer1 slice1 x(256, 64, 56, 56)          :     41.86 ms,    9.32 tflops,    4.43 GB used,     81 kernels
layer1 slice2 x(256, 256, 56, 56)         :     35.02 ms,   10.05 tflops,    5.66 GB used,     63 kernels
layer2 slice1 x(256, 256, 56, 56)         :     39.34 ms,   15.00 tflops,    4.85 GB used,     81 kernels
layer2 slice2 x(256, 512, 28, 28)         :     21.60 ms,   15.90 tflops,    2.84 GB used,     63 kernels
layer3 slice1 x(256, 512, 28, 28)         :     29.71 ms,   19.57 tflops,    2.45 GB used,     81 kernels
layer3 slice2 x(256, 1024, 14, 14)        :     15.96 ms,   21.28 tflops,    1.43 GB used,     63 kernels
layer4 slice1 x(256, 1024, 14, 14)        :     25.00 ms,   23.07 tflops,    1.28 GB used,     81 kernels
layer4 slice2 x(256, 2048, 7, 7)          :     12.06 ms,   27.99 tflops,    0.76 GB used,     63 kernels
.estimated step tm: 374.67 ms, 16.671 tflops, 400.71 GB/s, 1080 kernels

----------------------------------------------------------------------
Ran 8 tests in 81.276s

OK
```