### PR TITLE
use at least float32 for optim.lr

### DIFF
--- a/extra/lr_scheduler.py
+++ b/extra/lr_scheduler.py
@@ -66,7 +66,8 @@ class CosineAnnealingLR(LR_Scheduler):
     self.eta_max = optimizer.lr.numpy()[0]
 
   def get_lr(self) -> Tensor:
-    return Tensor([self.eta_min + 0.5 * (self.eta_max - self.eta_min) * (1 + math.cos((self.epoch_counter.numpy()[0]/self.T_max) * math.pi))], device=self.optimizer.device)
+    lr = self.eta_min + 0.5 * (self.eta_max - self.eta_min) * (1 + math.cos((self.epoch_counter.numpy()[0]/self.T_max) * math.pi))
+    return Tensor([lr], device=self.optimizer.device, dtype=self.optimizer.lr.dtype)
 
 class OneCycleLR(LR_Scheduler):
   def __init__(self, optimizer: Optimizer, max_lr: float, div_factor: float, final_div_factor: float, total_steps: int, pct_start: float,
@@ -88,4 +89,4 @@ class OneCycleLR(LR_Scheduler):
     return (self.epoch_counter < self.total_steps*self.pct_start).where(
       self._annealing_linear(self.initial_lr, self.max_lr, self.epoch_counter/(self.total_steps*self.pct_start)),
       self._annealing_linear(self.max_lr, self.min_lr, (self.epoch_counter-(self.total_steps*self.pct_start))/(self.total_steps*(1-self.pct_start)))
-    )
+    ).cast(self.optimizer.lr.dtype)

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 import unittest
 from tinygrad import Tensor, Device, dtypes
-from tinygrad.nn.optim import Adam, SGD, AdamW, Optimizer
+from tinygrad.nn.optim import Adam, SGD, AdamW
 from tinygrad.helpers import CI
 from test.helpers import is_dtype_supported
 
@@ -31,7 +31,7 @@ class TinyNet:
     out = out.mul(self.m).add(self.m).sum()
     return out
 
-def step(tensor, optim:Optimizer, steps=1, teeny=False, **kwargs):
+def step(tensor, optim, steps=1, teeny=False, **kwargs):
   net = TeenyNet(tensor) if teeny else TinyNet(tensor)
   optim = optim([net.x, net.W], **kwargs)
   for _ in range(steps):

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1,9 +1,10 @@
 import numpy as np
 import torch
 import unittest
-from tinygrad import Tensor, Device
-from tinygrad.nn.optim import Adam, SGD, AdamW
+from tinygrad import Tensor, Device, dtypes
+from tinygrad.nn.optim import Adam, SGD, AdamW, Optimizer
 from tinygrad.helpers import CI
+from test.helpers import is_dtype_supported
 
 np.random.seed(1337)
 x_init = np.random.randn(1,4).astype(np.float32)
@@ -30,7 +31,7 @@ class TinyNet:
     out = out.mul(self.m).add(self.m).sum()
     return out
 
-def step(tensor, optim, steps=1, teeny=False, **kwargs):
+def step(tensor, optim:Optimizer, steps=1, teeny=False, **kwargs):
   net = TeenyNet(tensor) if teeny else TinyNet(tensor)
   optim = optim([net.x, net.W], **kwargs)
   for _ in range(steps):
@@ -104,6 +105,15 @@ class TestOptim(unittest.TestCase):
         losses.append(loss.numpy())
 
       np.testing.assert_allclose(losses[0], losses[1], atol=1e-4, rtol=0)
+
+  @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
+  def test_mixed_precision(self):
+    old_default_float, dtypes.default_float = dtypes.default_float, dtypes.half
+    # weight update would overflow without upcasting
+    self._test_sgd(10, {'lr': 1e10}, 1e-6, 3e-4)
+    self._test_adam(1, {'lr': 1e10}, 1e-4, 1e-4)
+    self._test_adamw(1, {'lr': 1e10}, 1e-4, 1e-4)
+    dtypes.default_float = old_default_float
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
when doing mixed precision training (float32 weight, default_float=half), still use float32 to store lr. it would have been upcasted later in actual weight update, but would have lost precision. this improved resnet convergence significantly

<https://wandb.ai/chenyuxyz/tinygrad-examples_mlperf/runs/acsacuu2/overview?nw=nwuserchenyuxyz> trains to target on epoch 34. without this it does not hit target even at opoch 37.

although not intentional, it seems to drop kernel counts @Qazalin fyi