### PR TITLE
test crossing diamond assigns

### DIFF
--- a/test/test_assign.py
+++ b/test/test_assign.py
@@ -175,6 +175,17 @@ class TestAssign(unittest.TestCase):
     np.testing.assert_allclose(a.numpy(), 5)
     np.testing.assert_allclose(b.numpy(), 8)
 
+  def test_assign_double_diamond(self):
+    a = Tensor.full((4,), 2).contiguous().realize()
+    b = Tensor.full((4,), 3).contiguous().realize()
+    a_prev = a*4
+    b_prev = b+3
+    b += a_prev.contiguous()
+    a += b_prev.contiguous()
+    Tensor.realize(a, b)
+    np.testing.assert_equal(b.numpy(), 11)
+    np.testing.assert_equal(a.numpy(), 8)
+
   def test_crossunder_assign(self):
     # NOTE: should *not* raise AssertionError from numpy
     with self.assertRaises(RuntimeError):


### PR DESCRIPTION
We have a similar version of this graph
![graph 5](https://github.com/tinygrad/tinygrad/assets/77887910/d4960fa7-487e-4147-a029-d10226fcfe83)


in [beautiful_mnist](https://tiny-tools-client.vercel.app/?id=3fd076fc9c6644b9b60b63f69fa457ac):
![graph 4](https://github.com/tinygrad/tinygrad/assets/77887910/4c8a8ec2-a027-42a2-9109-ccfd510213d7)

where fusing the assign child causes a cycle.