### PR TITLE
Multireduce Kernels - Move render_reduceop call to ast_parse

### DIFF
--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -46,5 +46,19 @@ class TestUOpGraph(unittest.TestCase):
     self.assertEqual(out.uop, UOps.CONST)
     self.assertEqual(out.arg, 0)
 
+  def test_cursor(self):
+    g = UOpGraph()
+    one = g.add(UOps.CONST, dtypes.int, arg=1)
+    four = g.add(UOps.CONST, dtypes.int, arg=4)
+    g.cursor = one
+    g.add(UOps.CONST, dtypes.int, arg=0)
+    g.cursor = four
+    g.add(UOps.CONST, dtypes.int, arg=2)
+    g.add(UOps.CONST, dtypes.int, arg=3)
+    g.cursor = None
+    g.add(UOps.CONST, dtypes.int, arg=5)
+    for i,u in enumerate(g.uops): self.assertEqual(u.arg, i)
+
+
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -131,6 +131,8 @@ class UOpGraph:
   def __init__(self, start_uops:Optional[List[UOp]]=None):
     # list of uops
     self.uops: List[UOp] = [] if start_uops is None else start_uops
+    # if set, UOpGraph.add will add new uops before this cursor
+    self.cursor: Optional[UOp] = None
 
     # global uop cache
     self.saved_exprs: Dict[Tuple, UOp] = dict()
@@ -155,7 +157,7 @@ class UOpGraph:
       if rewritten in self.uops: return rewritten  # ignore cachable
       ret = rewritten
     key = (ret.uop, ret.dtype, ret.vin, ret.arg)
-    if insert_before is None: insert_before = len(self.uops)
+    if insert_before is None: insert_before = self.uops.index(self.cursor) if self.cursor else len(self.uops)
     # check if the cached expr is valid with the given insert place.
     if cachable and (expr:=self.saved_exprs.get(key, None)) is not None and self.uops.index(expr) <= insert_before: return expr
     self.uops.insert(insert_before, ret)


### PR DESCRIPTION
Having multiple reduceops and multiple outputs means that:
```
self.lazyops = flatten([op.lazyops for op in self.ast])
reduceops = [x for x in self.lazyops if x.op in ReduceOps]
```

doesn't necessarily produce an in-order list of reduceops, so we can't just render them by running through a loop
this moves the `render_reduceop` call to within `ast_parse` so that they can be properly ordered by recursion, ordering them elsewhere requires finding their dependencies which was pretty slow

it uses the UOpGraph.cursor to write the reduce before any for loops or if statements, so if we run into a reduceop from within a reduceop it can go back and render it in the right place

it's a solution to the problem @Qazalin pointed out in #4220

tbh I don't know if this is the most elegant solution but it seemed like the most robust