### PR TITLE
add mem/s to external_benchmark_resnet

### DIFF
--- a/test/external/external_benchmark_resnet.py
+++ b/test/external/external_benchmark_resnet.py
@@ -95,8 +95,8 @@ class BenchmarkResnetTrain(unittest.TestCase):
       if kernels is None: kernels = GlobalCounters.kernel_count // JITCNT
       tm = (et-st) / JITCNT
       if best_tm is None or tm < best_tm: best_tm = tm
-    print(f"\r{name:42s}: {best_tm * 1000:>9.2f} ms, {flops / 10**12 / best_tm:>7.2f} tflops, "
-          f"{mem_used / 10**9: 7.2f} GB used, {kernels:>6d} kernels")
+    print(f"\r{name:38s}: {best_tm * 1000:>9.2f} ms, {flops / 10**12 / best_tm:>6.2f} tflops, {mem / 10**9 / best_tm:>5.0f} GB/s, "
+          f"{mem_used / 10**9: 6.2f} GB used, {kernels:>5d} kernels")
     return best_tm, flops, mem, kernels
 
   def test_layer1_1(self): self._est(*self._test_layer(*self._get_layer(0, 0)), 1)


### PR DESCRIPTION
```
time PYTHONPATH=. DEBUG=0 PARALLEL=10 SPLIT_REDUCEOP=0 JITCNT=20 BEAM=3 BEAM_UOPS_MAX=1500 BEAM_UPCAST_MAX=128 BEAM_LOCAL_MAX=1024 BEAM_MIN_PROGRESS=50 DEFAULT_FLOAT=HALF BS=256 python test/external/external_benchmark_resnet.py
layer1 slice1 x(256, 64, 56, 56)      :     37.09 ms,  10.53 tflops,   669 GB/s,   4.43 GB used,    80 kernels
layer1 slice2 x(256, 256, 56, 56)     :     30.41 ms,  11.58 tflops,   610 GB/s,   5.66 GB used,    62 kernels
layer2 slice1 x(256, 256, 56, 56)     :     40.94 ms,  14.41 tflops,   443 GB/s,   4.85 GB used,    80 kernels
layer2 slice2 x(256, 512, 28, 28)     :     23.35 ms,  14.72 tflops,   398 GB/s,   2.84 GB used,    62 kernels
layer3 slice1 x(256, 512, 28, 28)     :     30.24 ms,  19.22 tflops,   302 GB/s,   2.45 GB used,    80 kernels
layer3 slice2 x(256, 1024, 14, 14)    :     15.07 ms,  22.53 tflops,   311 GB/s,   1.43 GB used,    62 kernels
layer4 slice1 x(256, 1024, 14, 14)    :     31.25 ms,  18.46 tflops,   151 GB/s,   1.28 GB used,    80 kernels
layer4 slice2 x(256, 2048, 7, 7)      :     17.90 ms,  18.86 tflops,   137 GB/s,   0.76 GB used,    62 kernels
estimated step tm: 381.54 ms, 16.374 tflops, 393.56 GB/s, 1064 kernels
```