### PR TITLE
run clang using stdout

### DIFF
--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -9,11 +9,8 @@ class ClangCompiler(Compiler):
   compiler_opts = CompilerOptions("CLANG", supports_float4=False, has_local=False)
   def render(self, name:str, uops) -> str: return CLANG_PROGRAM_HEADER + uops_to_cstyle(CStyleLanguage(buffer_suffix=" restrict"), name, uops)
   def compile(self, src:str) -> bytes:
-    # TODO: remove file write. sadly clang doesn't like the use of /dev/stdout here
-    with tempfile.NamedTemporaryFile(delete=True) as output_file:
-      subprocess.check_output(args=('clang -shared -march=native -O2 -Wall -Werror -x c -fPIC - -o '+ str(output_file.name)).split(),
-                              input=src.encode('utf-8'))
-      return pathlib.Path(output_file.name).read_bytes()
+    return subprocess.run(args=('clang -shared -march=native -O2 -Wall -Werror -x c -fPIC - -o').split(),
+      input=src.encode('utf-8'), check=True, capture_output=True).stdout
 
 class ClangProgram:
   def __init__(self, name:str, lib:bytes):


### PR DESCRIPTION
using `subprocess.run` with arguments `check=True, capture_output=True` and returning it with `.stdout` then you can use stdout instead of a file