### PR TITLE
reduce children fusion tests

### DIFF
--- a/test/external/external_test_opt.py
+++ b/test/external/external_test_opt.py
@@ -194,6 +194,16 @@ class TestOpt(unittest.TestCase):
         opt.step()
         assert cache.count == 5, f"optimizer didn't fold conv-backward SGD, got {cache.count}"
 
+  def test_fold_conv_adam(self):
+    with Tensor.train():
+      img = Tensor.ones(2,3,4,4)
+      c1 = nn.Conv2d(3,32,3)
+      opt = optim.Adam(get_parameters(c1))
+      with CLCache(allowed=10):
+        opt.zero_grad()
+        c1(img).relu().sum().backward()
+        opt.step()
+
   def test_fold_2convs_sgd(self):
     with Tensor.train():
       img = Tensor.ones(2,3,64,64)

--- a/test/external/external_test_opt.py
+++ b/test/external/external_test_opt.py
@@ -198,10 +198,21 @@ class TestOpt(unittest.TestCase):
     with Tensor.train():
       img = Tensor.ones(2,3,4,4)
       c1 = nn.Conv2d(3,32,3)
-      opt = optim.Adam(get_parameters(c1))
+      opt = optim.Adam(get_parameters(c1), lr=1e-4)
       with CLCache(allowed=10):
         opt.zero_grad()
         c1(img).relu().sum().backward()
+        opt.step()
+
+  def test_fold_2convs_adam(self):
+    with Tensor.train():
+      img = Tensor.ones(2,3,64,64)
+      c1 = nn.Conv2d(3,16,3,bias=False)
+      c2 = nn.Conv2d(16,32,3,bias=False)
+      opt = optim.Adam(get_parameters([c1, c2]), lr=1e-4)
+      with CLCache(allowed=13):
+        opt.zero_grad()
+        c2(c1(img).relu()).relu().sum().backward()
         opt.step()
 
   def test_fold_2convs_sgd(self):
@@ -211,6 +222,17 @@ class TestOpt(unittest.TestCase):
       c2 = nn.Conv2d(16,32,3,bias=False)
       opt = optim.SGD(get_parameters([c1, c2]))
       with CLCache(allowed=8):
+        opt.zero_grad()
+        c2(c1(img).relu()).relu().sum().backward()
+        opt.step()
+
+  def test_fold_2convs_sgd_nesterov_momentum_wd(self):
+    with Tensor.train():
+      img = Tensor.ones(2,3,64,64)
+      c1 = nn.Conv2d(3,16,3,bias=False)
+      c2 = nn.Conv2d(16,32,3,bias=False)
+      opt = optim.SGD(get_parameters([c1, c2]), nesterov=True, momentum=0.9, weight_decay=0.1)
+      with CLCache(allowed=10):
         opt.zero_grad()
         c2(c1(img).relu()).relu().sum().backward()
         opt.step()


### PR DESCRIPTION
The main focus is on differentiating fusion in these 3 graph variants:

![graph 11 (2)](https://github.com/Qazalin/tinyfork/assets/77887910/f70b0eea-1a52-44cb-8b12-a1dd56b1b1b8)

for expand, reduce, shrink and same size contiguous children.