### PR TITLE
Fix in `_reshape_mask`

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -987,23 +987,15 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (0,0,0,0), value=1), lambda x: x.pad((None, None), value=1))
 
   def test_pad_reshape(self):
-    a = Tensor.ones((2,)).reshape((1, 2))
-    b = torch.ones((2,)).reshape((1, 2))
-    helper_test_op([],
-                   lambda: torch.nn.functional.pad(b, (0, 1, 1, 0)).reshape((3, 2)),
-                   lambda: a.pad2d((0, 1, 1, 0)).reshape((3, 2)), forward_only=True)
-
-    a = Tensor.ones((2,)).reshape((1, 2))
-    b = torch.ones((2,)).reshape((1, 2))
-    helper_test_op([],
-                   lambda: torch.nn.functional.pad(b, (0, 2, 1, 1)).reshape((4, 3)),
-                   lambda: a.pad2d((0, 2, 1, 1)).reshape((4, 3)), forward_only=True)
-
-    a = Tensor.ones((2,)).reshape((1, 1, 1, 2))
-    b = torch.ones((2,)).reshape((1, 1, 1, 2))
-    helper_test_op([],
-                   lambda: torch.nn.functional.pad(b, (0, 4, 2, 2, 1, 2, 0, 2)).reshape((4, 3, 6, 5)),
-                   lambda: a.pad(((0, 2), (1,2), (2,2), (0,4))).reshape((4, 3, 6, 5)), forward_only=True)
+    helper_test_op([(1, 2)],
+                   lambda x: torch.nn.functional.pad(x, (0, 1, 1, 0)).reshape((3, 2)),
+                   lambda x: x.pad2d((0, 1, 1, 0)).reshape((3, 2)), forward_only=True)
+    helper_test_op([(1, 2)],
+                   lambda x: torch.nn.functional.pad(x, (0, 2, 1, 1)).reshape((4, 3)),
+                   lambda x: x.pad2d((0, 2, 1, 1)).reshape((4, 3)), forward_only=True)
+    helper_test_op([(1, 1, 1, 2)],
+                   lambda x: torch.nn.functional.pad(x, (0, 4, 2, 2, 1, 2, 0, 2)).reshape((4, 3, 6, 5)),
+                   lambda x: x.pad(((0, 2), (1, 2), (2, 2), (0, 4))).reshape((4, 3, 6, 5)), forward_only=True)
 
   @unittest.skipIf(Device.DEFAULT == "WEBGL", "incorrect result")
   def test_pad_slice(self):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -985,7 +985,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4), value=-math.inf), lambda x: x.pad(((3,4), (1,2)), value=-math.inf))
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (0,0,3,4), value=1), lambda x: x.pad(((3,4), None), value=1))
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (0,0,0,0), value=1), lambda x: x.pad((None, None), value=1))
-  
+
   def test_pad_reshape(self):
     a = Tensor.ones((2,)).reshape((1, 2))
     b = torch.ones((2,)).reshape((1, 2))

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -985,6 +985,25 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4), value=-math.inf), lambda x: x.pad(((3,4), (1,2)), value=-math.inf))
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (0,0,3,4), value=1), lambda x: x.pad(((3,4), None), value=1))
     helper_test_op([(3,3)], lambda x: torch.nn.functional.pad(x, (0,0,0,0), value=1), lambda x: x.pad((None, None), value=1))
+  
+  def test_pad_reshape(self):
+    a = Tensor.ones((2,)).reshape((1, 2))
+    b = torch.ones((2,)).reshape((1, 2))
+    helper_test_op([],
+                   lambda: torch.nn.functional.pad(b, (0, 1, 1, 0)).reshape((3, 2)),
+                   lambda: a.pad2d((0, 1, 1, 0)).reshape((3, 2)), forward_only=True)
+
+    a = Tensor.ones((2,)).reshape((1, 2))
+    b = torch.ones((2,)).reshape((1, 2))
+    helper_test_op([],
+                   lambda: torch.nn.functional.pad(b, (0, 2, 1, 1)).reshape((4, 3)),
+                   lambda: a.pad2d((0, 2, 1, 1)).reshape((4, 3)), forward_only=True)
+
+    a = Tensor.ones((2,)).reshape((1, 1, 1, 2))
+    b = torch.ones((2,)).reshape((1, 1, 1, 2))
+    helper_test_op([],
+                   lambda: torch.nn.functional.pad(b, (0, 4, 2, 2, 1, 2, 0, 2)).reshape((4, 3, 6, 5)),
+                   lambda: a.pad(((0, 2), (1,2), (2,2), (0,4))).reshape((4, 3, 6, 5)), forward_only=True)
 
   @unittest.skipIf(Device.DEFAULT == "WEBGL", "incorrect result")
   def test_pad_slice(self):

--- a/test/unit/test_shapetracker.py
+++ b/test/unit/test_shapetracker.py
@@ -560,14 +560,30 @@ class TestShapeTrackerFuzzFailures(unittest.TestCase):
 
 class TestMaskedShapeTracker(unittest.TestCase):
   def test_pad_1x1(self):
-    self.st = CheckingShapeTracker((1,1))
-    self.st.pad(((1,1), (1,1)))
-    self.st.assert_same()
+    self.st1 = CheckingShapeTracker((1,1))
+    self.st1.pad(((1,1), (1,1)))
+    self.st1.assert_same()
 
   def test_pad_2x2(self):
-    self.st = CheckingShapeTracker((2,2))
-    self.st.pad(((1,1), (1,1)))
-    self.st.assert_same()
+    self.st1 = CheckingShapeTracker((2,2))
+    self.st1.pad(((1,1), (1,1)))
+    self.st1.assert_same()
+  
+  def test_pad_reshape(self):
+    st1 = CheckingShapeTracker((1, 2))
+    st1.pad(((1, 0), (0, 1)))
+    st1.reshape((3, 2))
+    st1.assert_same()
+
+    st2 = CheckingShapeTracker((1, 2))
+    st2.pad(((1, 1), (0, 2)))
+    st2.reshape((4, 3))
+    st2.assert_same()
+
+    st3 = CheckingShapeTracker((1, 1, 1, 2))
+    st3.pad(((0, 2), (1, 2), (2, 2), (0, 4)))
+    st3.reshape((4, 3, 6, 5))
+    st3.assert_same()
 
 class TestShapeTracker(unittest.TestCase):
   def setUp(self):

--- a/test/unit/test_shapetracker.py
+++ b/test/unit/test_shapetracker.py
@@ -568,7 +568,7 @@ class TestMaskedShapeTracker(unittest.TestCase):
     self.st1 = CheckingShapeTracker((2,2))
     self.st1.pad(((1,1), (1,1)))
     self.st1.assert_same()
-  
+
   def test_pad_reshape(self):
     st1 = CheckingShapeTracker((1, 2))
     st1.pad(((1, 0), (0, 1)))

--- a/test/unit/test_shapetracker.py
+++ b/test/unit/test_shapetracker.py
@@ -560,14 +560,14 @@ class TestShapeTrackerFuzzFailures(unittest.TestCase):
 
 class TestMaskedShapeTracker(unittest.TestCase):
   def test_pad_1x1(self):
-    self.st1 = CheckingShapeTracker((1,1))
-    self.st1.pad(((1,1), (1,1)))
-    self.st1.assert_same()
+    self.st = CheckingShapeTracker((1,1))
+    self.st.pad(((1,1), (1,1)))
+    self.st.assert_same()
 
   def test_pad_2x2(self):
-    self.st1 = CheckingShapeTracker((2,2))
-    self.st1.pad(((1,1), (1,1)))
-    self.st1.assert_same()
+    self.st = CheckingShapeTracker((2,2))
+    self.st.pad(((1,1), (1,1)))
+    self.st.assert_same()
 
   def test_pad_reshape(self):
     st1 = CheckingShapeTracker((1, 2))

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -52,7 +52,8 @@ def _reshape_mask(view: View, new_shape:Tuple[sint, ...]) -> Tuple[Optional[Tupl
         if mask[1] - mask[0] < 1: return ((0, 0),) * len(new_shape), False # invalid mask
 
       else: # mask can only be splitted if reshape doesn't cut across the mask.
-        if ((l % next_stride != 0 or r % next_stride != 0) and l // next_stride != (r - 1) // next_stride): return view.mask, True
+        if (((l % next_stride != 0 or r % next_stride != 0) and l // next_stride != (r - 1) // next_stride)
+            or old_dim % next_stride != 0): return view.mask, True
         new_mask.append((l % next_stride // curr_stride, (r - 1) % next_stride // curr_stride + 1))
         curr_stride, new_dim = next_stride,  next(r_new_shape, 1) # need to get mask for next dimension
 


### PR DESCRIPTION
Addresses the issue in #4109.

The issue appears when `old_dim` has n instances of `next_stride` but with a remainder. This remainder will push the position of the mask and might cross the axis boundary.