### PR TITLE
fusion tests from test_opt

### DIFF
--- a/test/external/external_test_opt.py
+++ b/test/external/external_test_opt.py
@@ -120,15 +120,6 @@ class TestOpt(unittest.TestCase):
       d.realize()
     np.testing.assert_allclose(d.numpy(), na*nb+nc, rtol=1e-5, atol=1e-7)
 
-  def test_fold_reduce_elementwise(self):
-    img = Tensor.ones(32).contiguous()
-    addme = Tensor.ones(1)
-    with CLCache() as cache:
-      ret = img.sum() + addme
-      ret.realize()
-      assert cache.count == 1, "optimizer didn't fold reduce/elementwise"
-    assert ret.item() == 33
-
   def test_fold_batchnorm(self):
     with Tensor.train():
       img = Tensor.ones(1,32,4,4).contiguous()
@@ -137,30 +128,6 @@ class TestOpt(unittest.TestCase):
         img_bn = bn(img).realize()
         print(img_bn)
         assert cache.count == 3, f"optimizer didn't fold batchnorm, got {cache.count}"
-
-  def test_fold_2convs_sgd_nesterov_momentum_wd(self):
-    with Tensor.train():
-      img = Tensor.ones(2,3,64,64)
-      c1 = nn.Conv2d(3,16,3,bias=False)
-      c2 = nn.Conv2d(16,32,3,bias=False)
-      opt = optim.SGD(get_parameters([c1, c2]), nesterov=True, momentum=0.9, weight_decay=0.1)
-      with CLCache(allowed=10):
-        opt.zero_grad()
-        c2(c1(img).relu()).relu().sum().backward()
-        opt.step()
-
-  def test_fold_4convs_sgd(self):
-    with Tensor.train():
-      img = Tensor.ones(2,3,64,64)
-      c1 = nn.Conv2d(3,4,3,bias=False)
-      c2 = nn.Conv2d(4,8,3,bias=False)
-      c3 = nn.Conv2d(8,16,3,bias=False)
-      c4 = nn.Conv2d(16,32,3,bias=False)
-      opt = optim.SGD(get_parameters([c1, c2, c3, c4]))
-      with CLCache(allowed=18):
-        opt.zero_grad()
-        c4(c3(c2(c1(img).relu()).relu()).relu()).relu().sum().backward()
-        opt.step()
 
   def test_fold_conv_batchnorm_sgd(self):
     with Tensor.train():

--- a/test/external/external_test_opt.py
+++ b/test/external/external_test_opt.py
@@ -4,7 +4,6 @@ import numpy as np
 import torch
 
 from tinygrad import nn, GlobalCounters, Tensor, Device
-from tinygrad.nn import optim
 from tinygrad.nn.state import get_parameters
 from tinygrad.engine.realize import capturing
 
@@ -120,27 +119,6 @@ class TestOpt(unittest.TestCase):
       d.realize()
     np.testing.assert_allclose(d.numpy(), na*nb+nc, rtol=1e-5, atol=1e-7)
 
-  def test_fold_batchnorm(self):
-    with Tensor.train():
-      img = Tensor.ones(1,32,4,4).contiguous()
-      bn = nn.BatchNorm2d(32, track_running_stats=False)
-      with CLCache() as cache:
-        img_bn = bn(img).realize()
-        print(img_bn)
-        assert cache.count == 3, f"optimizer didn't fold batchnorm, got {cache.count}"
-
-  def test_fold_conv_batchnorm_sgd(self):
-    with Tensor.train():
-      img = Tensor.ones(1,3,4,4)
-      c1 = nn.Conv2d(3,32,3)
-      bn = nn.BatchNorm2d(32, track_running_stats=False)
-      opt = optim.SGD(get_parameters([c1, bn]))
-      with CLCache(allowed=16): # this is too high
-        img_bn = bn(c1(img)).elu().sum()
-        opt.zero_grad()
-        img_bn.backward()
-        opt.step()
-
   def test_fold_conv_batchnorm_notrain(self):
     img = Tensor.ones(1,3,8,8)
     c1 = nn.Conv2d(3,32,3)
@@ -150,16 +128,6 @@ class TestOpt(unittest.TestCase):
     with CLCache() as cache:
       bn(c1(img)).relu().realize()
       assert cache.count == 1, f"optimizer didn't fold conv-batchnorm at test time, got {cache.count}"
-
-  def test_fold_conv_batchnorm(self):
-    with Tensor.train():
-      img = Tensor.ones(1,3,8,8)
-      c1 = nn.Conv2d(3,32,3)
-      bn = nn.BatchNorm2d(32, track_running_stats=False)
-      with CLCache() as cache:
-        img_conv = bn(c1(img)).relu().realize()
-        print(img_conv)
-        assert cache.count == 4, f"optimizer didn't fold conv-batchnorm, got {cache.count}"
 
   def test_fold_conv_elu(self):
     img = Tensor.ones(1,4,8,8)
@@ -174,15 +142,6 @@ class TestOpt(unittest.TestCase):
     img = Tensor.ones(1,4,8,8)
     c1 = nn.Conv2d(4, 4, kernel_size=3)
     c2 = nn.Conv2d(4, 4, kernel_size=3)
-    with CLCache() as cache:
-      img_conv = img.sequential([c1, Tensor.relu, c2, Tensor.relu]).realize()
-      print(img_conv)
-      assert cache.count == 2, "optimizer didn't fold conv/relu"
-
-  def test_fold_conv_relu_nobias(self):
-    img = Tensor.ones(1,4,8,8)
-    c1 = nn.Conv2d(4, 4, kernel_size=3, bias=False)
-    c2 = nn.Conv2d(4, 4, kernel_size=3, bias=False)
     with CLCache() as cache:
       img_conv = img.sequential([c1, Tensor.relu, c2, Tensor.relu]).realize()
       print(img_conv)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -4,13 +4,9 @@
 
 import unittest
 from typing import List, Optional, Union
-from extra.models.convnext import ConvNeXt
-from extra.models.efficientnet import EfficientNet
-from extra.models.resnet import ResNet18
-from extra.models.vit import ViT
 from tinygrad.tensor import Tensor
 from tinygrad.ops import LoadOps, ReduceOps
-from tinygrad.helpers import DEBUG, GRAPH, flatten, getenv
+from tinygrad.helpers import DEBUG, GRAPH, flatten
 from tinygrad.codegen.linearizer import Linearizer
 from tinygrad.features.graph import print_tree, realized_lazybuffer
 from tinygrad.engine.schedule import create_schedule
@@ -683,38 +679,6 @@ class TestSchedule(unittest.TestCase):
     # c = a + 2
     # sched = check_schedule([b, c], 4)
     # doesn't store either in half because it doesn't chase
-
-  def test_convnext(self):
-    model = ConvNeXt()
-    for p in nn.state.get_parameters(model): p.assign(Tensor.zeros(p.shape, dtype=p.dtype).contiguous().realize())
-    img = Tensor.randn(1, 3, 224, 224)
-    check_schedule(model(img), 144)
-
-  def test_enet(self):
-    model = EfficientNet(getenv("ENET_NUM", 0), has_se=False)
-    for p in nn.state.get_parameters(model): p.assign(Tensor.zeros(p.shape, dtype=p.dtype).contiguous().realize())
-    img = Tensor.randn(1, 3, 224, 224).realize()
-    check_schedule(model.forward(img), 51)
-
-  def test_enet_se(self):
-    model = EfficientNet(getenv("ENET_NUM", 0), has_se=True)
-    for p in nn.state.get_parameters(model): p.assign(Tensor.zeros(p.shape, dtype=p.dtype).contiguous().realize())
-    img = Tensor.randn(1, 3, 224, 224).realize()
-    # TODO: this seems very high
-    check_schedule(model.forward(img), 115)
-
-  def test_resnet(self):
-    model = ResNet18()
-    for p in nn.state.get_parameters(model): p.assign(Tensor.zeros(p.shape, dtype=p.dtype).contiguous().realize())
-    img = Tensor.randn(1, 3, 224, 224).realize()
-    check_schedule(model.forward(img), 23)
-
-  def test_vit(self):
-    model = ViT(embed_dim=192, num_heads=3)
-    for p in nn.state.get_parameters(model): p.assign(Tensor.zeros(p.shape, dtype=p.dtype).contiguous().realize())
-    img = Tensor.randn(1, 3, 224, 224).realize()
-    # NOTE: this is way too high
-    check_schedule(model.forward(img), 209)
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -4,9 +4,13 @@
 
 import unittest
 from typing import List, Optional, Union
+from extra.models.convnext import ConvNeXt
+from extra.models.efficientnet import EfficientNet
+from extra.models.resnet import ResNet18
+from extra.models.vit import ViT
 from tinygrad.tensor import Tensor
 from tinygrad.ops import LoadOps, ReduceOps
-from tinygrad.helpers import DEBUG, GRAPH, flatten
+from tinygrad.helpers import DEBUG, GRAPH, flatten, getenv
 from tinygrad.codegen.linearizer import Linearizer
 from tinygrad.features.graph import print_tree, realized_lazybuffer
 from tinygrad.engine.schedule import create_schedule
@@ -556,6 +560,44 @@ class TestSchedule(unittest.TestCase):
     layer(x).relu().sum().backward()
     check_schedule(opt.schedule_step(), 14)
 
+  def test_adam_conv_fuse(self):
+    with Tensor.train():
+      img = Tensor.empty(2,3,4,4)
+      c1 = nn.Conv2d(3,32,3)
+      opt = nn.optim.Adam(nn.state.get_parameters(c1), lr=1e-4)
+      opt.zero_grad()
+      c1(img).relu().sum().backward()
+      check_schedule(opt.schedule_step(), 14)
+
+  def test_adam_2convs_fuse(self):
+    with Tensor.train():
+      img = Tensor.empty(2,3,4,4)
+      c1 = nn.Conv2d(3,16,3,bias=False)
+      c2 = nn.Conv2d(16,32,3,bias=False)
+      opt = nn.optim.Adam(nn.state.get_parameters([c1, c2]), lr=1e-4)
+      opt.zero_grad()
+      c2(c1(img).relu()).relu().sum().backward()
+      check_schedule(opt.schedule_step(), 15)
+
+  def test_sgd_conv_fuse(self):
+    with Tensor.train():
+      img = Tensor.empty(2,3,4,4)
+      c1 = nn.Conv2d(3,32,3)
+      opt = nn.optim.SGD(nn.state.get_parameters(c1))
+      opt.zero_grad()
+      c1(img).relu().sum().backward()
+      check_schedule(opt.schedule_step(), 7)
+
+  def test_sgd_2convs_fuse(self):
+    with Tensor.train():
+      img = Tensor.empty(2,3,4,4)
+      c1 = nn.Conv2d(3,16,3,bias=False)
+      c2 = nn.Conv2d(16,32,3,bias=False)
+      opt = nn.optim.SGD(nn.state.get_parameters([c1, c2]))
+      opt.zero_grad()
+      c2(c1(img).relu()).relu().sum().backward()
+      check_schedule(opt.schedule_step(), 7)
+
   @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
   def test_prefer_half_buffer(self):
     x = Tensor.ones(4).contiguous().realize()
@@ -592,6 +634,38 @@ class TestSchedule(unittest.TestCase):
     # c = a + 2
     # sched = check_schedule([b, c], 4)
     # doesn't store either in half because it doesn't chase
+
+  def test_convnext(self):
+    model = ConvNeXt()
+    for p in nn.state.get_parameters(model): p.assign(Tensor.zeros(p.shape, dtype=p.dtype).contiguous().realize())
+    img = Tensor.randn(1, 3, 224, 224)
+    check_schedule(model(img), 144)
+
+  def test_enet(self):
+    model = EfficientNet(getenv("ENET_NUM", 0), has_se=False)
+    for p in nn.state.get_parameters(model): p.assign(Tensor.zeros(p.shape, dtype=p.dtype).contiguous().realize())
+    img = Tensor.randn(1, 3, 224, 224).realize()
+    check_schedule(model.forward(img), 51)
+
+  def test_enet_se(self):
+    model = EfficientNet(getenv("ENET_NUM", 0), has_se=True)
+    for p in nn.state.get_parameters(model): p.assign(Tensor.zeros(p.shape, dtype=p.dtype).contiguous().realize())
+    img = Tensor.randn(1, 3, 224, 224).realize()
+    # TODO: this seems very high
+    check_schedule(model.forward(img), 115)
+
+  def test_resnet(self):
+    model = ResNet18()
+    for p in nn.state.get_parameters(model): p.assign(Tensor.zeros(p.shape, dtype=p.dtype).contiguous().realize())
+    img = Tensor.randn(1, 3, 224, 224).realize()
+    check_schedule(model.forward(img), 23)
+
+  def test_vit(self):
+    model = ViT(embed_dim=192, num_heads=3)
+    for p in nn.state.get_parameters(model): p.assign(Tensor.zeros(p.shape, dtype=p.dtype).contiguous().realize())
+    img = Tensor.randn(1, 3, 224, 224).realize()
+    # NOTE: this is way too high
+    check_schedule(model.forward(img), 209)
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)


### PR DESCRIPTION
`test_llama` remains in external_test_opt because `model.forward` calls realize internally.