### PR TITLE
BERT: Checkpoint loading tests

### DIFF
--- a/examples/mlperf/helpers.py
+++ b/examples/mlperf/helpers.py
@@ -230,6 +230,11 @@ def init_bert_from_checkpoint(model, ckpt_dir:str):
         t = t.reshape(*x.shape)
       x.assign(t)
 
+def get_data_bert(GPUS:list[str], it):
+  data: dict[str, Tensor] = next(it)
+  for key in data.keys(): data[key].shard_(GPUS, axis=0)
+  return data
+
 @functools.lru_cache(maxsize=None)
 def load_tf_weights_to_dict(checkpoint_path):
   os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'

--- a/examples/mlperf/helpers.py
+++ b/examples/mlperf/helpers.py
@@ -4,6 +4,9 @@ import numpy as np
 from tinygrad.nn import state
 from tinygrad.tensor import Tensor
 from tinygrad.dtype import dtypes
+from tinygrad.nn.state import get_state_dict
+
+from extra.models.bert import BertForMLPerf
 
 #
 # checkpointing utils
@@ -216,6 +219,18 @@ def get_mlperf_bert_model(config_path:str):
     config["attention_probs_dropout_prob"], 
     config["hidden_dropout_prob"]
   )
+
+def init_bert_from_checkpoint(model:BertForMLPerf, ckpt_dir:str):
+  for tinygrad_key, x in get_state_dict(model).items():
+    if not tinygrad_key.endswith("lm_output.weight"): # lm_output.weight already is word embedding
+      t = load_from_tf2_ckpt(key=tinygrad_key, ckpt_dir=ckpt_dir)
+      if any(k in tinygrad_key for k in ["intermediate.dense.weight", "output.dense.weight", "clsf_output.weight"]) and "attention" not in tinygrad_key:
+        t = t.transpose() 
+      elif any(k in tinygrad_key for k in ["self", "output.dense", "clsf_pooler", "lm_transform"]) and "weight" in tinygrad_key:
+        t = t.reshape(*x.shape).transpose()
+      elif all(k in tinygrad_key for k in ["self", "bias"]):
+        t = t.reshape(*x.shape)
+      x.assign(t)
 
 @functools.lru_cache(maxsize=None)
 def load_tf_weights_to_dict(checkpoint_path):

--- a/examples/mlperf/helpers.py
+++ b/examples/mlperf/helpers.py
@@ -6,8 +6,6 @@ from tinygrad.tensor import Tensor
 from tinygrad.dtype import dtypes
 from tinygrad.nn.state import get_state_dict
 
-from extra.models.bert import BertForMLPerf
-
 #
 # checkpointing utils
 #
@@ -220,7 +218,7 @@ def get_mlperf_bert_model(config_path:str):
     config["hidden_dropout_prob"]
   )
 
-def init_bert_from_checkpoint(model:BertForMLPerf, ckpt_dir:str):
+def init_bert_from_checkpoint(model, ckpt_dir:str):
   for tinygrad_key, x in get_state_dict(model).items():
     if not tinygrad_key.endswith("lm_output.weight"): # lm_output.weight already is word embedding
       t = load_from_tf2_ckpt(key=tinygrad_key, ckpt_dir=ckpt_dir)

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -291,16 +291,11 @@ def eval_step_bert(model, input_ids:Tensor, segment_ids:Tensor, attention_mask:T
     "next_sentence_accuracy": clsf_accuracy.realize(), 
     "next_sentence_loss": clsf_loss.realize()
     }
-  
-def get_data_bert(GPUS:list[str], it):
-  data: dict[str, Tensor] = next(it)
-  for key in data.keys(): data[key].shard_(GPUS, axis=0)
-  return data
 
 def train_bert():
   # NOTE: pip install tensorflow, wandb required
   from examples.mlperf.dataloader import batch_load_train_bert, batch_load_val_bert
-  from examples.mlperf.helpers import get_mlperf_bert_model, init_bert_from_checkpoint
+  from examples.mlperf.helpers import get_mlperf_bert_model, init_bert_from_checkpoint, get_data_bert
   from examples.mlperf.lr_schedulers import PolynomialDecayWithWarmup
 
   config = {}
@@ -435,7 +430,7 @@ def train_bert():
       BEAM.value = EVAL_BEAM
 
       for _ in tqdm(range(max_eval_steps), desc="Evaluating", total=max_eval_steps, disable=BENCHMARK):
-        eval_data = data_get(eval_it)
+        eval_data = get_data_bert(GPUS, eval_it)
         GlobalCounters.reset()
         st = time.time()
 

--- a/test/external/mlperf_bert/external_test_checkpoint_loading.py
+++ b/test/external/mlperf_bert/external_test_checkpoint_loading.py
@@ -12,9 +12,9 @@ from tinygrad.device import Device
 from tinygrad.helpers import getenv
 from tinygrad.nn.state import get_state_dict
 
-from examples.mlperf.helpers import get_mlperf_bert_model, init_bert_from_checkpoint
+from examples.mlperf.helpers import get_mlperf_bert_model, init_bert_from_checkpoint, get_data_bert
 from examples.mlperf.dataloader import batch_load_val_bert
-from examples.mlperf.model_train import eval_step_bert, get_data_bert
+from examples.mlperf.model_train import eval_step_bert
 
 if __name__ == "__main__":
   BASEDIR = os.environ["BASEDIR"] = getenv("BASEDIR", "/raid/datasets/wiki")

--- a/test/external/mlperf_bert/external_test_checkpoint_loading.py
+++ b/test/external/mlperf_bert/external_test_checkpoint_loading.py
@@ -36,9 +36,9 @@ def eval_step(input_ids:Tensor, segment_ids:Tensor, attention_mask:Tensor, maske
   lm_loss = lm_logits.sparse_categorical_crossentropy(masked_lm_ids, ignore_index=masked_lm_weights)
   clsf_loss = clsf_logits.binary_crossentropy_logits(next_sentence_labels)
   return {
-    "masked_lm_accuracy": mlm_accuracy.realize(), 
-    "masked_lm_loss": lm_loss.realize(), 
-    "next_sentence_accuracy": clsf_accuracy.realize(), 
+    "masked_lm_accuracy": mlm_accuracy.realize(),
+    "masked_lm_loss": lm_loss.realize(),
+    "next_sentence_accuracy": clsf_accuracy.realize(),
     "next_sentence_loss": clsf_loss.realize()
     }
 

--- a/test/external/mlperf_bert/external_test_checkpoint_loading.py
+++ b/test/external/mlperf_bert/external_test_checkpoint_loading.py
@@ -1,0 +1,82 @@
+# Test whether pretrained weights from first BERT pretraining phase have been loaded correctly
+# Usage:
+# 1. Download the BERT checkoints with `wikipedia_download.py`
+#    Command: BASEDIR=/path/to/wiki python3 wikipedia_download.py
+# 2. Run this script. (Adjust EVAL_BS and GPUS as needed)
+#    Command: EVAL_BEAM=4 DEFAULT_FLOAT=half GPUS=6 BASEDIR=/path/to/wiki python3 test/external/mlperf_bert/external_test_checkpoint_loading.py
+import os
+from tqdm import tqdm
+
+from tinygrad.tensor import Tensor
+from tinygrad.device import Device
+from tinygrad.engine.jit import TinyJit
+from tinygrad.helpers import getenv
+from tinygrad.nn.state import get_state_dict
+from examples.mlperf.helpers import get_mlperf_bert_model, init_bert_from_checkpoint
+from examples.mlperf.dataloader import batch_load_val_bert
+
+# Copied from `examples/mlperf/model_train.py` in `train_bert``
+def data_get(it):
+  data: dict[str, Tensor] = next(it)
+  for key in data.keys(): data[key].shard_(GPUS, axis=0)
+  return data
+
+# Copied from `examples/mlperf/model_train.py` in `train_bert``
+@TinyJit
+def eval_step(input_ids:Tensor, segment_ids:Tensor, attention_mask:Tensor, masked_positions:Tensor, masked_lm_ids:Tensor, masked_lm_weights:Tensor, next_sentence_labels:Tensor): # noqa: E501
+  lm_logits, clsf_logits = model(input_ids, segment_ids, attention_mask, masked_positions)
+
+  clsf_predictions = clsf_logits.log_softmax().argmax(-1)
+  clsf_accuracy = (clsf_predictions == next_sentence_labels).float().mean()
+
+  mlm_predictions = lm_logits.log_softmax().argmax(-1)
+  mask = (masked_lm_weights == 1.0)
+  mlm_accuracy = (mlm_predictions == masked_lm_ids).where(mask, 0).sum() / mask.float().sum()
+
+  lm_loss = lm_logits.sparse_categorical_crossentropy(masked_lm_ids, ignore_index=masked_lm_weights)
+  clsf_loss = clsf_logits.binary_crossentropy_logits(next_sentence_labels)
+  return {
+    "masked_lm_accuracy": mlm_accuracy.realize(), 
+    "masked_lm_loss": lm_loss.realize(), 
+    "next_sentence_accuracy": clsf_accuracy.realize(), 
+    "next_sentence_loss": clsf_loss.realize()
+    }
+
+if __name__ == "__main__":
+  BASEDIR = os.environ["BASEDIR"] = getenv("BASEDIR", "/raid/datasets/wiki")
+  INIT_CKPT_DIR = getenv("INIT_CKPT_DIR", BASEDIR)
+  GPUS = [f"{Device.DEFAULT}:{i}" for i in range(getenv("GPUS", 1))]
+  EVAL_BS = getenv("EVAL_BS", 4 * len(GPUS))
+  max_eval_steps = (10000 + EVAL_BS - 1) // EVAL_BS
+
+  for i in range(10):
+    assert os.path.exists(os.path.join(BASEDIR, "eval", f"{i}.pkl")), \
+      f"File {i}.pkl does not exist in {os.path.join(BASEDIR, 'eval')}"
+
+  required_files = ["checkpoint", "model.ckpt-28252.data-00000-of-00001", "model.ckpt-28252.index"]
+  assert all(os.path.exists(os.path.join(INIT_CKPT_DIR, f)) for f in required_files), \
+    f"Missing checkpoint files in INIT_CKPT_DIR: {required_files}"
+
+  Tensor.training = False
+
+  model = get_mlperf_bert_model(os.path.join(BASEDIR, "bert_config.json"))
+  init_bert_from_checkpoint(model, INIT_CKPT_DIR) # Test the actual loading of the checkpoint
+
+  for _, x in get_state_dict(model).items():
+    x.realize().to_(GPUS)
+
+  eval_accuracy = []
+  eval_it = iter(batch_load_val_bert(EVAL_BS))
+
+  for _ in tqdm(range(max_eval_steps), desc="Evaluating", total=max_eval_steps):
+    eval_data = data_get(eval_it)
+    eval_result: dict[str, Tensor] = eval_step(eval_data["input_ids"], eval_data["segment_ids"], eval_data["input_mask"], \
+                                               eval_data["masked_lm_positions"], eval_data["masked_lm_ids"], \
+                                               eval_data["masked_lm_weights"], eval_data["next_sentence_labels"])
+
+    mlm_accuracy = eval_result["masked_lm_accuracy"].numpy().item()
+    eval_accuracy.append(mlm_accuracy)
+
+  total_lm_accuracy = sum(eval_accuracy) / len(eval_accuracy)
+  assert total_lm_accuracy >= 0.34, "Checkpoint loaded incorrectly. Accuracy should be very close to 0.34085 as per MLPerf BERT README."
+  print(f"Checkpoint loaded correctly. Accuracy of {total_lm_accuracy*100:.3f}% achieved. (Reference: 34.085%)")

--- a/test/external/mlperf_bert/external_test_checkpoint_loading.py
+++ b/test/external/mlperf_bert/external_test_checkpoint_loading.py
@@ -9,38 +9,12 @@ from tqdm import tqdm
 
 from tinygrad.tensor import Tensor
 from tinygrad.device import Device
-from tinygrad.engine.jit import TinyJit
 from tinygrad.helpers import getenv
 from tinygrad.nn.state import get_state_dict
+
 from examples.mlperf.helpers import get_mlperf_bert_model, init_bert_from_checkpoint
 from examples.mlperf.dataloader import batch_load_val_bert
-
-# Copied from `examples/mlperf/model_train.py` in `train_bert``
-def data_get(it):
-  data: dict[str, Tensor] = next(it)
-  for key in data.keys(): data[key].shard_(GPUS, axis=0)
-  return data
-
-# Copied from `examples/mlperf/model_train.py` in `train_bert``
-@TinyJit
-def eval_step(input_ids:Tensor, segment_ids:Tensor, attention_mask:Tensor, masked_positions:Tensor, masked_lm_ids:Tensor, masked_lm_weights:Tensor, next_sentence_labels:Tensor): # noqa: E501
-  lm_logits, clsf_logits = model(input_ids, segment_ids, attention_mask, masked_positions)
-
-  clsf_predictions = clsf_logits.log_softmax().argmax(-1)
-  clsf_accuracy = (clsf_predictions == next_sentence_labels).float().mean()
-
-  mlm_predictions = lm_logits.log_softmax().argmax(-1)
-  mask = (masked_lm_weights == 1.0)
-  mlm_accuracy = (mlm_predictions == masked_lm_ids).where(mask, 0).sum() / mask.float().sum()
-
-  lm_loss = lm_logits.sparse_categorical_crossentropy(masked_lm_ids, ignore_index=masked_lm_weights)
-  clsf_loss = clsf_logits.binary_crossentropy_logits(next_sentence_labels)
-  return {
-    "masked_lm_accuracy": mlm_accuracy.realize(),
-    "masked_lm_loss": lm_loss.realize(),
-    "next_sentence_accuracy": clsf_accuracy.realize(),
-    "next_sentence_loss": clsf_loss.realize()
-    }
+from examples.mlperf.model_train import eval_step_bert, get_data_bert
 
 if __name__ == "__main__":
   BASEDIR = os.environ["BASEDIR"] = getenv("BASEDIR", "/raid/datasets/wiki")
@@ -69,8 +43,8 @@ if __name__ == "__main__":
   eval_it = iter(batch_load_val_bert(EVAL_BS))
 
   for _ in tqdm(range(max_eval_steps), desc="Evaluating", total=max_eval_steps):
-    eval_data = data_get(eval_it)
-    eval_result: dict[str, Tensor] = eval_step(eval_data["input_ids"], eval_data["segment_ids"], eval_data["input_mask"], \
+    eval_data = get_data_bert(GPUS, eval_it)
+    eval_result: dict[str, Tensor] = eval_step_bert(model, eval_data["input_ids"], eval_data["segment_ids"], eval_data["input_mask"], \
                                                eval_data["masked_lm_positions"], eval_data["masked_lm_ids"], \
                                                eval_data["masked_lm_weights"], eval_data["next_sentence_labels"])
 


### PR DESCRIPTION
I think a standalone test to check whether checkpoint loading functionality is correct, is quite helpful to catch regressions caused by incorrect weight mapping or mixed precision changes in the forward pass. MLperf recommends [this](https://github.com/mlcommons/training/blob/master/language_model/tensorflow/bert/README.md#stopping-criteria).