### PR TITLE
search: fix actions space checks to ignore TC axis and amt

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -274,8 +274,15 @@ class TestLinearizer(unittest.TestCase):
         prg.exec(real_bufs)
         result = np.frombuffer(real_bufs[0].as_buffer(), real_bufs[0].dtype.np)
 
+        # ensure the results for each choice of axis matches
         if golden_result is None: golden_result = np.frombuffer(real_bufs[0].as_buffer(), real_bufs[0].dtype.np)
         np.testing.assert_allclose(result, golden_result, atol=0.1, rtol=0.15)
+
+      # check that get_linearizer_actions produces all 9 options
+      from tinygrad.features.search import get_linearizer_actions
+      tc_actions = [k for i, k in get_linearizer_actions(Linearizer(realized_ast), False).items() if k.applied_opts[0].op == OptOps.TC]
+      assert len(tc_actions) == 9, f"get_linearizer_actions should contain 9 possible TC actions, only got {len(tc_actions)}"
+
 
   def test_limit_dims_to_max_5d_global(self):
     t = Tensor.empty(3, 4, 5, 6, 7).pad(((1, 1), (1, 1), (1, 1), (1, 1), (1, 1))) + 1

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -85,8 +85,8 @@ def bufs_from_lin(lin:Linearizer, allocate:bool=True) -> List[Buffer]:
 def get_linearizer_actions(lin:Linearizer, include_0=True) -> Dict[int, Linearizer]:
   acted_lins, max_up, max_lcl = {0:lin} if include_0 else {}, getenv("BEAM_UPCAST_MAX", 256), getenv("BEAM_LOCAL_MAX", 256)
   for i,a in enumerate(actions):
-    if a.axis is not None and a.op is not OptOps.TC and \
-      ((a.axis >= lin.shape_len) or (lin.full_shape[a.axis] == a.amt and Opt(a.op, a.axis, 0) in actions)): continue
+    if a.axis is not None and a.op is not OptOps.TC and a.axis >= lin.shape_len: continue
+    if a.axis is not None and a.op is not OptOps.TC and lin.full_shape[a.axis] == a.amt and Opt(a.op, a.axis, 0) in actions: continue
     lin2 = lin.copy()
     try:
       lin2.apply_opt(a)

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -85,8 +85,8 @@ def bufs_from_lin(lin:Linearizer, allocate:bool=True) -> List[Buffer]:
 def get_linearizer_actions(lin:Linearizer, include_0=True) -> Dict[int, Linearizer]:
   acted_lins, max_up, max_lcl = {0:lin} if include_0 else {}, getenv("BEAM_UPCAST_MAX", 256), getenv("BEAM_LOCAL_MAX", 256)
   for i,a in enumerate(actions):
-    if a.axis is not None and a.axis >= lin.shape_len: continue
-    if a.axis is not None and lin.full_shape[a.axis] == a.amt and Opt(a.op, a.axis, 0) in actions: continue
+    if a.axis is not None and a.op is not OptOps.TC and \
+      ((a.axis >= lin.shape_len) or (lin.full_shape[a.axis] == a.amt and Opt(a.op, a.axis, 0) in actions)): continue
     lin2 = lin.copy()
     try:
       lin2.apply_opt(a)


### PR DESCRIPTION
Fixes `get_linearizer_actions` to fully test all possible TC actions.  thanks to @chaosagent for pointing this out in discord.

Doesn't seem to regress, only improve on prior performance:

for tiny red / `HSA=1`:

| branch  | settings | setup (m:ss) | step time (ms) | flops (TF) |
| --- | --- | --- | --- |  --- |
| tc_reduce_choice | `SPLIT_REDUCEOP=1` | 15:48 | 455ms | 83 TF |  
| this branch | `SPLIT_REDUCEOP=1` | 15:52 | 427ms | 89 TF |  

for tiny green / `CUDA=1`:

| branch  | settings | setup (m:ss) | step time (ms) | flops (TF) |
| --- | --- | --- | --- |  --- |
| tc_reduce_choice | `SPLIT_REDUCEOP=1` | 25:34 (OOM), 19:36 (OOM) | 305ms, 304ms | 125TF, 125TF |
| this branch | `SPLIT_REDUCEOP=1` | 20:43 | 300ms | 127TF |