### PR TITLE
fix: not using private metal api methods.

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
-import os, subprocess, pathlib, ctypes, tempfile, functools
-import Metal, libdispatch
+import os, subprocess, ctypes, functools
+import Metal
 from typing import List, Set, Any, Tuple, Optional
-from tinygrad.helpers import prod, getenv, DEBUG, unwrap2
+from tinygrad.helpers import prod, getenv, unwrap2
 from tinygrad.device import Compiled, LRUAllocator, Compiler, CompilerOptions
 from tinygrad.renderer.cstyle import MetalRenderer
 


### PR DESCRIPTION
Here is my pr to fix conda. It may seem weird but i'll explain.
I've been trying to debug the MTLInvalidLibrary issue for two months now. I've learned a lot about how metal does it's compilation. Metal has it's own cache for compiled shaders (and even the thing we were putting in lib wasn't really an executable and is getting compiled another time by metal with a different compilation requestType each time we call newFunctionWithName_). Using libraryDataContents was not a good decision as it as a private api and doesn't seem compatible with old libSystem.B versions.
As metal has it's own cache, it's okay to just cache the shader source with tinygrad. I didn't observe any slowdowns using METAL=1 on this commit.
I also removed the dissasembler part because:
- it wasn't compatible with the new way of handling the library
- the apple dissasembler isn't even a part of tinygrad's master anymore
- it was using lines for nothing

If anyone is interested I can make a little writeup on everything I tried and uncovered trying to get the compiled shader to be correct.