### PR TITLE
test unary and more reduces in test_flopcounter

### DIFF
--- a/test/unit/test_flopcounter.py
+++ b/test/unit/test_flopcounter.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python
 import unittest
 from tinygrad import dtypes
-from tinygrad.ops import LazyOp, BinaryOps, ReduceOps, get_lazyop_info, BufferOps, MemBuffer
+from tinygrad.ops import LazyOp, UnaryOps, BinaryOps, ReduceOps, get_lazyop_info, BufferOps, MemBuffer
 from tinygrad.shape.shapetracker import ShapeTracker
 
 class TestFlopCounter(unittest.TestCase):
   def setUp(self):
     self.buf0 = LazyOp(BufferOps.LOAD, (), MemBuffer(1, dtypes.float32, ShapeTracker.from_shape((4,))))
     self.buf1 = LazyOp(BufferOps.LOAD, (), MemBuffer(2, dtypes.float32, ShapeTracker.from_shape((4,))))
+    self.buf2 = LazyOp(BufferOps.LOAD, (), MemBuffer(2, dtypes.float32, ShapeTracker.from_shape((4,4))))
+
+  def test_flops_sin(self):
+    op0 = LazyOp(UnaryOps.SIN, (self.buf0,), None)
+    info = get_lazyop_info(op0)
+    self.assertEqual(info.flops, 4)
 
   def test_flops_add(self):
     op0 = LazyOp(BinaryOps.ADD, (self.buf0,self.buf1,), None)
@@ -39,6 +45,23 @@ class TestFlopCounter(unittest.TestCase):
     op2 = LazyOp(BinaryOps.ADD, (op1, op1,), None)
     info = get_lazyop_info(op2)
     self.assertEqual(info.flops, 9)
+
+  def test_flops_sum1d(self):
+    op0 = LazyOp(ReduceOps.SUM, (self.buf0,), (0,))
+    info = get_lazyop_info(op0)
+    self.assertEqual(info.flops, 4)
+    self.assertEqual(info.shape, (1,))
+
+  def test_flops_sum2d(self):
+    op0 = LazyOp(ReduceOps.SUM, (self.buf2,), (0,))
+    info = get_lazyop_info(op0)
+    self.assertEqual(info.flops, 16)
+    self.assertEqual(info.shape, (1,4))
+
+    op1 = LazyOp(ReduceOps.SUM, (op0,), (1,))
+    info = get_lazyop_info(op1)
+    self.assertEqual(info.flops, 16+4)
+    self.assertEqual(info.shape, (1,1))
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
cannot really catch a spec change error without testing the new spec explicitly, but we don't intended to change the lazy spec lightly

another possible way to catch reduce flopcounter shape would be type checking InterpretedFlopCounter and throw error if `in` results in `Never`