### PR TITLE
Multireduce Kernels: Allow IF blocks to terminate early

### DIFF
--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -46,5 +46,40 @@ class TestUOpGraph(unittest.TestCase):
     self.assertEqual(out.uop, UOps.CONST)
     self.assertEqual(out.arg, 0)
 
+  def test_early_endif(self):
+    g = UOpGraph()
+    g.add(UOps.IF, vin=(g.add(UOps.CONST, dtypes.bool, arg=True),), cachable=False)
+    g.add(UOps.CONST, dtypes.int, arg=0)
+    g.add_ends()
+    self.assertEqual(len([x for x in g.uops if x.uop is UOps.ENDIF]), 1, "UOpGraph.add_ends() should not add any extra ENDIFs")
+    self.assertEqual(g.uops[-1].uop, UOps.ENDIF, "UOpGraph.add_ends() should add ENDIF to the end of the graph")
+
+    g = UOpGraph()
+    if0 = g.add(UOps.IF, vin=(g.add(UOps.CONST, dtypes.bool, arg=True),), cachable=False)
+    before_endif = g.add(UOps.CONST, dtypes.int, arg=0)
+    endif = g.add(UOps.ENDIF, vin=(if0,), cachable=False)
+    after_endif = g.add(UOps.CONST, dtypes.int, arg=1)
+    g.add_ends()
+    self.assertEqual(len([x for x in g.uops if x.uop is UOps.ENDIF]), 1, "UOpGraph.add_ends() should not add any extra ENDIFs")
+    self.assertLess(g.uops.index(before_endif), g.uops.index(endif), "Early ENDIF should stay at it's place in the graph")
+    self.assertLess(g.uops.index(endif), g.uops.index(after_endif), "Early ENDIF should stay at it's place in the graph")
+
+    g = UOpGraph()
+    if0 = g.add(UOps.IF, vin=(g.add(UOps.CONST, dtypes.bool, arg=True),), cachable=False)
+    before_endif = g.add(UOps.CONST, dtypes.int, arg=0)
+    endif = g.add(UOps.ENDIF, vin=(if0,), cachable=False)
+    after_endif = g.add(UOps.CONST, dtypes.int, arg=1)
+    if1 = g.add(UOps.IF, vin=(g.add(UOps.CONST, dtypes.bool, arg=False),), cachable=False)
+    after_if2 = g.add(UOps.CONST, dtypes.int, arg=2)
+    g.add_ends()
+    self.assertEqual(len([x for x in g.uops if x.uop is UOps.ENDIF]), 2, "UOpGraph.add_ends() should not add any extra ENDIFs")
+    self.assertLess(g.uops.index(before_endif), g.uops.index(endif), "Early ENDIF should stay at it's place in the graph")
+    self.assertLess(g.uops.index(endif), g.uops.index(after_endif), "Early ENDIF should stay at it's place in the graph")
+    self.assertLess(g.uops.index(after_endif), g.uops.index(if1))
+    self.assertLess(g.uops.index(if1), g.uops.index(after_if2))
+    self.assertEqual(g.uops[-1].uop, UOps.ENDIF, "UOpGraph.add_ends() should add ENDIF to the end of the graph")
+    self.assertIn(if1, g.uops[-1].vin, "UOpGraph.add_ends() should add ENDIF for the unclosed IF")
+
+
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -54,32 +54,5 @@ class TestUOpGraph(unittest.TestCase):
     self.assertEqual(len([x for x in g.uops if x.uop is UOps.ENDIF]), 1, "UOpGraph.add_ends() should not add any extra ENDIFs")
     self.assertEqual(g.uops[-1].uop, UOps.ENDIF, "UOpGraph.add_ends() should add ENDIF to the end of the graph")
 
-    g = UOpGraph()
-    if0 = g.add(UOps.IF, vin=(g.add(UOps.CONST, dtypes.bool, arg=True),), cachable=False)
-    before_endif = g.add(UOps.CONST, dtypes.int, arg=0)
-    endif = g.add(UOps.ENDIF, vin=(if0,), cachable=False)
-    after_endif = g.add(UOps.CONST, dtypes.int, arg=1)
-    g.add_ends()
-    self.assertEqual(len([x for x in g.uops if x.uop is UOps.ENDIF]), 1, "UOpGraph.add_ends() should not add any extra ENDIFs")
-    self.assertLess(g.uops.index(before_endif), g.uops.index(endif), "Early ENDIF should stay at it's place in the graph")
-    self.assertLess(g.uops.index(endif), g.uops.index(after_endif), "Early ENDIF should stay at it's place in the graph")
-
-    g = UOpGraph()
-    if0 = g.add(UOps.IF, vin=(g.add(UOps.CONST, dtypes.bool, arg=True),), cachable=False)
-    before_endif = g.add(UOps.CONST, dtypes.int, arg=0)
-    endif = g.add(UOps.ENDIF, vin=(if0,), cachable=False)
-    after_endif = g.add(UOps.CONST, dtypes.int, arg=1)
-    if1 = g.add(UOps.IF, vin=(g.add(UOps.CONST, dtypes.bool, arg=False),), cachable=False)
-    after_if2 = g.add(UOps.CONST, dtypes.int, arg=2)
-    g.add_ends()
-    self.assertEqual(len([x for x in g.uops if x.uop is UOps.ENDIF]), 2, "UOpGraph.add_ends() should not add any extra ENDIFs")
-    self.assertLess(g.uops.index(before_endif), g.uops.index(endif), "Early ENDIF should stay at it's place in the graph")
-    self.assertLess(g.uops.index(endif), g.uops.index(after_endif), "Early ENDIF should stay at it's place in the graph")
-    self.assertLess(g.uops.index(after_endif), g.uops.index(if1))
-    self.assertLess(g.uops.index(if1), g.uops.index(after_if2))
-    self.assertEqual(g.uops[-1].uop, UOps.ENDIF, "UOpGraph.add_ends() should add ENDIF to the end of the graph")
-    self.assertIn(if1, g.uops[-1].vin, "UOpGraph.add_ends() should add ENDIF for the unclosed IF")
-
-
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -211,9 +211,9 @@ class UOpGraph:
         self.add(UOps.ENDLOOP, None, (u,), cachable=False, insert_before=insert_before)
       elif u.uop is UOps.IF:
         # add END of if after the barrier of the store of the result
-        insert_before = ([i for i in range(self.uops.index(u), len(self.uops)-1) if self.uops[i].uop is UOps.BARRIER and \
-                      self.uops[i+1].uop is UOps.LOAD and all([x.vin[0] in self.uops[i+1].vin for x in self.uops[i].vin])] + [None])[0]
-        self.add(UOps.ENDIF, None, (u,), cachable=False, insert_before=insert_before)
+        barriers = ([i for i in range(self.uops.index(u), len(self.uops)-1) if self.uops[i].uop is UOps.BARRIER \
+                and self.uops[i+1].uop is UOps.LOAD and all([x.vin[0] in self.uops[i+1].vin for x in self.uops[i].vin])] + [None])[0]
+        self.add(UOps.ENDIF, None, (u,), cachable=False, insert_before=barriers)
 
   def fix_loop_scope(self, get_recursive_parents:Callable[..., Set[UOp]]):
     loop_stack: List[List[UOp]] = [[]]

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -209,7 +209,7 @@ class UOpGraph:
         # add END of loops after the last thing that (recursively) depends on them
         insert_before = self.uops.index(sorted(list(self.get_recursive_children(u)), key=self.uops.index)[-1])+1
         self.add(UOps.ENDLOOP, None, (u,), cachable=False, insert_before=insert_before)
-      elif u.uop is UOps.IF:
+      elif u.uop is UOps.IF and all(u not in x.vin for x in self.uops if x.uop is UOps.ENDIF):
         # END any if statements at the end of the uops
         self.add(UOps.ENDIF, None, (u,), cachable=False)
 


### PR DESCRIPTION
this pr modifies `UOpGraph.add_ends()` so that it doesn't double add ENDIFs inserted by the linearizer
this will let the linearizer terminate if blocks early when it has to render another reduceop

ex. in standard deviation

```
__kernel void r_128_16_4n3(__global float* data0, const __global float* data1) {
  ...                                                 // first reduceop
  temp[lidx1] = acc0;
  barrier(CLK_LOCAL_MEM_FENCE);
  if (alu1) {
    float acc1 = 0.0f;
    for (int ridx1 = 0; ridx1 < 16; ridx1++) {
      float val1 = temp[ridx1];
      acc1 = (val1+acc1);
    }
    temp[0] = acc1;
  }                                                   // terminate the if block early
  barrier(CLK_LOCAL_MEM_FENCE);                       // put the ENDIF in the vin of this barrier
  float val2 = temp[0];
  float acc2 = 0.0f;
  for (int ridx2 = 0; ridx2 < 4; ridx2++) {           // second reduceop
    float val3 = data1[alu0+ridx2];
    acc2 = ((val3-(val2*0.015625f))+acc2);
  }
  temp[lidx1] = acc2;
  ...
}
```

the linearizer will have to also put the ENDIF in a `vin` so it doesn't get optimized away by `UOpGraph.remove_childless()`. I think putting it in the vin of the barrier makes the most sense