### PR TITLE
extra/threefry.py for mem usage

### DIFF
--- a/extra/threefry.py
+++ b/extra/threefry.py
@@ -1,0 +1,10 @@
+import os
+if "DEBUG" not in os.environ: os.environ["DEBUG"] = "2"
+if "THREEFRY" not in os.environ: os.environ["THREEFRY"] = "1"
+
+from tinygrad import Tensor, GlobalCounters
+
+for N in [10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000]:
+  GlobalCounters.reset()
+  Tensor.rand(N).realize()
+  print(f"N {N:>20_}, global_ops {GlobalCounters.global_ops:>20_}, global_mem {GlobalCounters.global_mem:>20_}")


### PR DESCRIPTION
for now it needs 8N mem to generate size N rand
```
*** HSA        1 r_7812500_32_250000000_4_4             arg   2 mem  4.00 GB tm   4534.53us/     4.53ms ( 2646.36 GFLOPS,  882.12 GB/s)
*** HSA        2 E_n8                                   arg   1 mem  4.00 GB tm      4.40us/     4.54ms (    0.00 GFLOPS,    0.00 GB/s)
*** HSA        3 E_3906250_32_4                         arg   2 mem  6.00 GB tm   7556.89us/    12.10ms ( 7278.12 GFLOPS,  793.98 GB/s)
*** HSA        4 E_3906250_32_4n1                       arg   2 mem  8.00 GB tm   7408.09us/    19.50ms ( 7829.28 GFLOPS,  809.93 GB/s)
*** HSA        5 E_7812500_32_4                         arg   3 mem  8.00 GB tm   9222.01us/    28.73ms (  325.31 GFLOPS, 1084.36 GB/s)
N        1_000_000_000, global_ops      128_000_000_001, global_mem       26_000_000_008
```