### PR TITLE
slightly faster nf4 llama

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -226,8 +226,9 @@ def NF4Linear(block_size):
       self.scale = Tensor.empty(int(out_features * in_features / block_size), 1, dtype=dtypes.float16)
 
     def __call__(self, x: Tensor) -> Tensor:
-      high_bits, low_bits = self.weight.div(2 ** 4, upcast=False), (self.weight * 2 ** 4).contiguous().div(2 ** 4, upcast=False)
-      unpacked = Tensor.stack([high_bits, low_bits], dim=-1).flatten()
+      high_bits = self.weight
+      low_bits = (self.weight * 2 ** 4).contiguous()
+      unpacked = Tensor.stack([high_bits, low_bits], dim=-1).div(2 ** 4, upcast=False)
       unscaled = CODE[unpacked].to(x.device).reshape(-1, block_size) * self.scale
       return x.linear(unscaled.reshape(self.out_features, self.in_features).T)
 


### PR DESCRIPTION
`BEAM=2 PYTHONPATH=. JIT=1 python3 examples/llama.py --quantize=nf4 --gen=3 --temperature=0 --count=10 --prompt="Hello." --size 8B --timing` on M1 Max

this
```
enqueue in   5.65 ms
total 306.70 ms, 3.26 tok/s, 353.75 GB/s, param 16.43 GB/s
 the
enqueue in   5.82 ms
total 306.67 ms, 3.26 tok/s, 353.79 GB/s, param 16.44 GB/s
 forum
enqueue in   5.87 ms
total 306.58 ms, 3.26 tok/s, 353.90 GB/s, param 16.44 GB/s
 and
enqueue in   5.65 ms
total 308.55 ms, 3.24 tok/s, 351.65 GB/s, param 16.34 GB/s
 I
```

master
```
enqueue in   5.95 ms
total 342.78 ms, 2.92 tok/s, 360.30 GB/s, param 14.70 GB/s
 the
enqueue in   5.97 ms
total 342.82 ms, 2.92 tok/s, 360.27 GB/s, param 14.70 GB/s
 forum
enqueue in   6.00 ms
total 342.24 ms, 2.92 tok/s, 360.88 GB/s, param 14.73 GB/s
 and
enqueue in   5.95 ms
total 342.33 ms, 2.92 tok/s, 360.79 GB/s, param 14.72 GB/s
 I
```

also with beam the output is slightly different. might be numerical issue?