### PR TITLE
pad fusion tests

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -792,7 +792,12 @@ class TestSchedule(unittest.TestCase):
     run_schedule(check_schedule(out, 2))
     np.testing.assert_allclose(out.numpy(), np.pad(np.log2(a.numpy()), ((0, 1), (0, 1), (0, 1)), constant_values=1.0).sum())
 
-  def test_shrink_pad_fuse(self): pass
+  def test_shrink_pad_fuse(self):
+    a = Tensor.ones((3, )).contiguous().realize()
+    b = Tensor.ones((3, )).contiguous().realize()
+    out = (a + b).shrink(((0, 1),)).pad(((0, 1),)).contiguous()
+    run_schedule(check_schedule(out, 1))
+    np.testing.assert_equal(out.numpy(), [2, 0])
 
   # TODO: should not shuffle unsafe pad ops through any pads, even if buffer is shrunk overall (#3437)
   def test_shrink_pad_unsafe_nofuse(self):

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -777,7 +777,7 @@ class TestSchedule(unittest.TestCase):
     f = (b - d).sum() - e
     check_schedule([c, d, e, f], 3)
 
-  def test_pad_reduce_fuse(self):
+  def test_pad_reduce_safe(self):
     Tensor.manual_seed(0)
     a = Tensor.rand(3, 4, 5).realize()
     b = Tensor.rand(3, 4, 5).realize()
@@ -785,14 +785,14 @@ class TestSchedule(unittest.TestCase):
     run_schedule(check_schedule(out, 1))
     np.testing.assert_allclose(out.numpy(), np.pad(a.numpy()+b.numpy(), ((0, 1), (0, 1), (0, 1)), constant_values=1.0).sum())
 
-  def test_pad_reduce_log2_unsafe_nofuse(self):
+  def test_pad_reduce_usafe(self):
     Tensor.manual_seed(0)
     a = Tensor.rand(3, 4, 5).realize()
     out = a.log2().pad(((0, 1), (0, 1), (0, 1)), 1.0).sum().contiguous()
     run_schedule(check_schedule(out, 2))
     np.testing.assert_allclose(out.numpy(), np.pad(np.log2(a.numpy()), ((0, 1), (0, 1), (0, 1)), constant_values=1.0).sum())
 
-  def test_shrink_pad_fuse(self):
+  def test_shrink_pad_safe(self):
     a = Tensor.ones((3, )).contiguous().realize()
     b = Tensor.ones((3, )).contiguous().realize()
     out = (a + b).shrink(((0, 1),)).pad(((0, 1),)).contiguous()
@@ -800,7 +800,7 @@ class TestSchedule(unittest.TestCase):
     np.testing.assert_equal(out.numpy(), [2, 0])
 
   # TODO: should not shuffle unsafe pad ops through any pads, even if buffer is shrunk overall (#3437)
-  def test_shrink_pad_unsafe_nofuse(self):
+  def test_shrink_pad_unsafe(self):
     a = Tensor.ones((3, )).contiguous().realize()
     out = a.exp2().shrink(((0, 1),)).pad(((0, 1),)).contiguous()
     run_schedule(check_schedule(out, 1))

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -781,5 +781,11 @@ class TestSchedule(unittest.TestCase):
     out = (a + b).pad(((0, 1), (0, 1), (0, 1))).sum()
     check_schedule(out, 1)
 
+  def test_tiny_simple_pads_log2_unsafe(self):
+    Tensor.manual_seed(200)
+    a = Tensor.rand(3, 4, 5).realize()
+    out = a.log2().pad(((0, 1), (0, 1), (0, 1))).sum()
+    check_schedule(out, 2)
+
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -775,5 +775,11 @@ class TestSchedule(unittest.TestCase):
     f = (b - d).sum() - e
     check_schedule([c, d, e, f], 3)
 
+  def test_tiny_simple_pads(self):
+    a = Tensor.rand(3, 4, 5).realize()
+    b = Tensor.rand(3, 4, 5).realize()
+    out = (a + b).pad(((0, 1), (0, 1), (0, 1))).sum()
+    check_schedule(out, 1)
+
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -128,7 +128,9 @@ def _recurse_lb(buf:LazyBuffer, realizes:Dict[LazyBuffer, None], allbufs:Dict[La
   if GRAPH: log_lazybuffer(buf, scheduled)
   if buf.base != buf:
     # realize all places where the buffer is expanded
-    if prod(buf.base.st.shape) < prod(buf.st.shape):
+    if not getenv("PADFUSE", 1):
+      realizes[buf.base] = None
+    elif prod(buf.base.st.shape) < prod(buf.st.shape):
       if len(buf.st.views) == 1 and buf.st.views[-1].mask and all_int(buf.base.st.shape) and \
           prod(buf.base.st.shape) >= prod([y-x for x,y in buf.st.views[-1].mask]):
         simple_pads.add(buf.base)

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -128,9 +128,7 @@ def _recurse_lb(buf:LazyBuffer, realizes:Dict[LazyBuffer, None], allbufs:Dict[La
   if GRAPH: log_lazybuffer(buf, scheduled)
   if buf.base != buf:
     # realize all places where the buffer is expanded
-    if not getenv("PADFUSE", 1):
-      realizes[buf.base] = None
-    elif prod(buf.base.st.shape) < prod(buf.st.shape):
+    if prod(buf.base.st.shape) < prod(buf.st.shape):
       if len(buf.st.views) == 1 and buf.st.views[-1].mask and all_int(buf.base.st.shape) and \
           prod(buf.base.st.shape) >= prod([y-x for x,y in buf.st.views[-1].mask]):
         simple_pads.add(buf.base)

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -129,10 +129,12 @@ def _recurse_lb(buf:LazyBuffer, realizes:Dict[LazyBuffer, None], allbufs:Dict[La
   if buf.base != buf:
     # realize all places where the buffer is expanded
     if prod(buf.base.st.shape) < prod(buf.st.shape):
+      """
       if len(buf.st.views) == 1 and buf.st.views[-1].mask and all_int(buf.base.st.shape) and \
           prod(buf.base.st.shape) >= prod([y-x for x,y in buf.st.views[-1].mask]):
         simple_pads.add(buf.base)
-      elif buf.base.op is UnaryOps.CAST and isinstance(buf.base.srcs[0].dtype, ImageDType) and isinstance(buf.base.arg[0], ImageDType):
+      """
+      if buf.base.op is UnaryOps.CAST and isinstance(buf.base.srcs[0].dtype, ImageDType) and isinstance(buf.base.arg[0], ImageDType):
         pass # don't realize image to image casts. this is part of a larger problem
       else:
         realizes[buf.base] = None

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -129,12 +129,10 @@ def _recurse_lb(buf:LazyBuffer, realizes:Dict[LazyBuffer, None], allbufs:Dict[La
   if buf.base != buf:
     # realize all places where the buffer is expanded
     if prod(buf.base.st.shape) < prod(buf.st.shape):
-      """
       if len(buf.st.views) == 1 and buf.st.views[-1].mask and all_int(buf.base.st.shape) and \
           prod(buf.base.st.shape) >= prod([y-x for x,y in buf.st.views[-1].mask]):
         simple_pads.add(buf.base)
-      """
-      if buf.base.op is UnaryOps.CAST and isinstance(buf.base.srcs[0].dtype, ImageDType) and isinstance(buf.base.arg[0], ImageDType):
+      elif buf.base.op is UnaryOps.CAST and isinstance(buf.base.srcs[0].dtype, ImageDType) and isinstance(buf.base.arg[0], ImageDType):
         pass # don't realize image to image casts. this is part of a larger problem
       else:
         realizes[buf.base] = None


### PR DESCRIPTION
We don't have good piecewise testing for simple_pads - only `TestHandCodedOpts` covers this in unit tests.

- [x] assert pad and shrink are detected as a pad
- [x] full spec of pad fusion

+np.testing.assert_equal outs - kernel count isn't enough.