### PR TITLE
change sqrt and reciprocal order in rsqrt

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -378,6 +378,11 @@ class TestOps(unittest.TestCase):
     helper_test_op([()], lambda x: x/2)
     helper_test_op([()], lambda x: 2/x)
 
+  def test_reciprocal(self):
+    helper_test_op([(45,65)], lambda x: x.reciprocal())
+  def test_reciprocal_exact(self):
+    helper_test_op(None, lambda x: x.reciprocal(), vals=[[-1.,0,1]])
+
   def test_mul_naninf(self):
     helper_test_op([(45,65)], lambda x: x*math.inf)
     helper_test_op([(45,65)], lambda x: x*-math.inf)
@@ -427,9 +432,14 @@ class TestOps(unittest.TestCase):
   def test_sqrt(self):
     helper_test_op([(45,65)], lambda x: x.sqrt())
     helper_test_op([()], lambda x: x.sqrt())
+  def test_sqrt_exact(self):
+    helper_test_op(None, lambda x: x.sqrt(), vals=[[-1.,0,1]])
+
   def test_rsqrt(self):
     helper_test_op([(45,65)], lambda x: x.rsqrt())
     helper_test_op([()], lambda x: x.rsqrt())
+  def test_rsqrt_exact(self):
+    helper_test_op(None, lambda x: x.rsqrt(), vals=[[-1.,0,1]])
 
   def test_xor(self):
     tor = torch.tensor([[1,-8,1],[32,1,6]], dtype=torch.int)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -438,6 +438,7 @@ class TestOps(unittest.TestCase):
   def test_rsqrt(self):
     helper_test_op([(45,65)], lambda x: x.rsqrt())
     helper_test_op([()], lambda x: x.rsqrt())
+  @unittest.skipIf(CI and Device.DEFAULT == "LLVM", "CI LLVM has nan issue at 0")
   def test_rsqrt_exact(self):
     helper_test_op(None, lambda x: x.rsqrt(), vals=[[-1.,0,1]])
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1136,7 +1136,7 @@ class Tensor:
   def sigmoid(self): return F.Sigmoid.apply(self.cast(least_upper_float(self.dtype)))
   def sin(self): return F.Sin.apply(self.cast(least_upper_float(self.dtype)))
   def sqrt(self): return F.Sqrt.apply(self.cast(least_upper_float(self.dtype)))
-  def rsqrt(self): return self.reciprocal().sqrt()
+  def rsqrt(self): return self.sqrt().reciprocal()
   def cos(self): return ((math.pi/2)-self).sin()
   def tan(self): return self.sin() / self.cos()
 


### PR DESCRIPTION
this matches rsqrt backward at 0 to torch. also added exact tests for reciprocal, sqrt, and rsqrt

see https://pytorch.org/docs/stable/notes/autograd.html#gradients-for-non-differentiable-functions for how torch defines derivative at these points