### PR TITLE
UOps.RANGE toposort spec

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -108,17 +108,52 @@ class TestLinearizer(unittest.TestCase):
     self.assertEqual(k.uops.uops[-1].uop, UOps.ENDIF)
     self.assertLess(k.uops.uops.index([x for x in k.uops.uops if x.uop is UOps.STORE][-1]), k.uops.uops.index(k.uops.uops[-1]))
 
-  def test_nested_range_simple(self):
-    a = Tensor.randn(2, 1).realize()
+  def test_two_nested_range(self):
+    a = Tensor.randn(2, ).realize()
     out = a.reshape(2, 1).expand(2, 3).sum()
     lin = helper_linearizer_opt(out, wanna_output=[np.broadcast_to(a.numpy().reshape(2, 1), (2, 3)).sum()])[0]
-    ranges = [x for x in lin.uops if x.uop is UOps.RANGE]
-    print(ranges)
+    ranges = [i for i,u in enumerate(lin.uops) if u.uop is UOps.RANGE]
+    # RANGE -> LOAD -> RANGE -> PHI
+    assert ranges[1] == ranges[0]+2
+    assert lin.uops[ranges[0]+1].uop is UOps.LOAD
 
-  def test_range_simple(self):
-    t = Tensor([2, 2]).realize()
-    t = t.reshape(2, 1).pad(((1, 1), (1, 1)), 2).sum()
-    helper_linearizer_opt(t, wanna_output=[24])[-1]
+  def test_three_nested_range(self):
+    a = Tensor.randn(2, ).realize()
+    out = a.reshape(2, 1).expand(2, 3).expand(2, 2, 3).sum()
+    lin = helper_linearizer_opt(out, wanna_output=[np.broadcast_to(np.broadcast_to(a.numpy().reshape(2, 1), (2, 3)), (2, 2, 3)).sum()])[0]
+    ranges = [i for i,u in enumerate(lin.uops) if u.uop is UOps.RANGE]
+    # RANGE -> RANGE -> LOAD -> RANGE -> PHI
+    assert ranges[2] == ranges[1]+2 == ranges[0]+3
+    assert lin.uops[ranges[1]+1].uop is UOps.LOAD
+
+  def test_two_nested_range_alt_indexing(self):
+    a = Tensor([2, 2]).realize()
+    out = a.reshape(2, 1).pad(((1, 1), (1, 1)), 2).sum()
+    lin = helper_linearizer_opt(out, wanna_output=[24])[0]
+    ranges = [i for i,u in enumerate(lin.uops) if u.uop is UOps.RANGE]
+    # RANGE -> 4x ALU -> RANGE -> 9x ALU + 1x LOAD -> PHI
+    assert ranges[1] == ranges[0]+5
+    assert lin.uops[ranges[1]+11].uop is UOps.ENDRANGE
+
+  def test_range_outer_op(self):
+    a = Tensor.randn(4, 1).realize()
+    b = Tensor.randn(1, 1).realize()
+    out = (a + b[0]).sum() + b[0]
+    lin = helper_linearizer_opt(out, wanna_output=[(a.numpy()+b.numpy()[0]).sum()+b.numpy()[0]])[0]
+    ranges = [i for i,u in enumerate(lin.uops) if u.uop is UOps.RANGE]
+    # LOAD -> RANGE -> LOAD -> PHI
+    assert lin.uops[ranges[0]-2].uop is UOps.LOAD
+
+  def test_range_outer_op_nested_range(self):
+    a = Tensor.randn(2, ).realize()
+    b = Tensor.randn(1, 1).realize()
+    out = (a.reshape(2, 1).expand(2, 3) + b[0]).sum() + b[0]
+    lin = helper_linearizer_opt(out, wanna_output=[(np.broadcast_to(a.numpy().reshape(2, 1), (2, 3)) + b.numpy()[0]).sum() + b.numpy()[0]])[0]
+    ranges = [i for i,u in enumerate(lin.uops) if u.uop is UOps.RANGE]
+    # LOAD -> RANGE -> LOAD -> ALU -> RANGE -> PHI
+    assert lin.uops[ranges[0]-2].uop is UOps.LOAD
+    assert ranges[1] == ranges[0]+3
+    assert [x.uop for x in lin.uops[ranges[0]+1:ranges[0]+3]] == [UOps.LOAD, UOps.ALU]
 
   @unittest.expectedFailure
   def test_early_end_local(self):

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -108,6 +108,18 @@ class TestLinearizer(unittest.TestCase):
     self.assertEqual(k.uops.uops[-1].uop, UOps.ENDIF)
     self.assertLess(k.uops.uops.index([x for x in k.uops.uops if x.uop is UOps.STORE][-1]), k.uops.uops.index(k.uops.uops[-1]))
 
+  def test_nested_range_simple(self):
+    a = Tensor.randn(2, 1).realize()
+    out = a.reshape(2, 1).expand(2, 3).sum()
+    lin = helper_linearizer_opt(out, wanna_output=[np.broadcast_to(a.numpy().reshape(2, 1), (2, 3)).sum()])[0]
+    ranges = [x for x in lin.uops if x.uop is UOps.RANGE]
+    print(ranges)
+
+  def test_range_simple(self):
+    t = Tensor([2, 2]).realize()
+    t = t.reshape(2, 1).pad(((1, 1), (1, 1)), 2).sum()
+    helper_linearizer_opt(t, wanna_output=[24])[-1]
+
   @unittest.expectedFailure
   def test_early_end_local(self):
     shape, output_shape = (32,), (1,)

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Tuple, Any, Dict, List, DefaultDict, Set, Callable
+from typing import Iterator, Optional, Tuple, Any, Dict, List, DefaultDict, Set, Callable
 import functools, itertools, heapq
 from collections import defaultdict
 from enum import Enum, auto
@@ -235,7 +235,7 @@ class UOpGraph:
     self.nodes: Dict[Tuple, UOp] = {}
     self._uops: Optional[List[UOp]] = None
 
-  def __iter__(self): return iter(self.uops)
+  def __iter__(self) -> Iterator[UOp]: return iter(self.uops)
 
   def vars(self) -> List[Variable]: return [x.arg for x in self.uops if x.uop is UOps.DEFINE_VAR]
   def globals(self) -> List[Tuple[int, bool]]: return [x.arg for x in self.uops if x.uop is UOps.DEFINE_GLOBAL]

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -236,6 +236,7 @@ class UOpGraph:
     self._uops: Optional[List[UOp]] = None
 
   def __iter__(self) -> Iterator[UOp]: return iter(self.uops)
+  def __getitem__(self, index) -> UOp: return self.uops[index]
 
   def vars(self) -> List[Variable]: return [x.arg for x in self.uops if x.uop is UOps.DEFINE_VAR]
   def globals(self) -> List[Tuple[int, bool]]: return [x.arg for x in self.uops if x.uop is UOps.DEFINE_GLOBAL]


### PR DESCRIPTION
Layout of how toposorting loops_children should behave given:

1. `n` nested loops
2. outer uops (not children of loops) before PHI
3. outer uops after PHI
4. children position with dependance on _some_ loops