### PR TITLE
keep UOps.CAST in PHI-GEP fold for unmatching dtypes

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -544,6 +544,15 @@ class TestLinearizer(unittest.TestCase):
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.supports_float4, "device doesn't support float4")
   def test_grouped_store_phis(self):
+    """
+    float4 acc0 = float4(0.0,0.0,0.0,0.0);
+    {
+      acc0 = // ...
+    }
+    *((device float4*)(data0+alu2)) = float4(acc0.x,acc0.y,acc0.z,acc0.w);
+    simplifies to:
+    *((device float4*)(data0+alu2)) = acc0;
+    """
     x, y = Tensor.randn(64,64), Tensor.randn(64,64)
     out = x.matmul(y)
     k = helper_linearizer_opt(out)[-1]
@@ -619,14 +628,27 @@ class TestLinearizer(unittest.TestCase):
     assert out.vin[-1].uop is UOps.CAST and out.vin[-1].dtype == dtypes.float.vec(2)
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.supports_float4 and is_dtype_supported(dtypes.half), "need backends that support float4")
-  def test_acc_nofold_unmatching_dtypes(self):
-    # acc is half4, store is float4.
+  def test_acc_include_cast_unmatching_dtypes(self):
+    """
+    half4 acc0 = half4(0.0,0.0,0.0,0.0);
+    {
+      acc0 = // ...
+    }
+    *((device float4*)(data0+alu0)) = float4(acc0.x,acc0.y,acc0.z,acc0.w);
+    simplifies to:
+    *((device float4*)(data0+alu0)) = (float4)(acc0);
+    """
     ld0 = LazyOp(BufferOps.LOAD, (), MemBuffer(idx=1, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(1, 3, 11008, 4096), strides=(0, 4096, 0, 1), offset=0, mask=None, contiguous=False),)))) # noqa: E501
     ld1 = LazyOp(BufferOps.LOAD, (), MemBuffer(idx=2, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(1, 3, 11008, 4096), strides=(0, 0, 4096, 1), offset=0, mask=None, contiguous=False),)))) # noqa: E501
     cast = LazyOp(BinaryOps.MUL, (ld0, ld1))
     sum = LazyOp(ReduceOps.SUM, (cast, ), (3, ))
     st = LazyOp(BufferOps.STORE, (sum,), MemBuffer(idx=0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(1, 3, 11008, 1), strides=(0, 11008, 1, 0), offset=0, mask=None, contiguous=True),)))) # noqa: E501
-    helper_linearizer_ast((st, ), [Tensor.empty(1, 3, 11008, 4096).realize()])
+    k = helper_linearizer_ast((st, ), [Tensor.empty(1, 3, 11008, 4096).realize()])[-1]
+    # check that gep->vectorize collapses but CAST remains
+    store_vals = [u.vin[-1] for u in k.uops if u.uop is UOps.STORE]
+    for val in store_vals:
+      assert val.dtype == dtypes.float.vec(4) and val.uop is UOps.CAST
+      assert len(val.vin) == 1 and val.vin[0].uop is UOps.PHI
 
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.supports_float4, "need backends that support float4")
 class TestFloat4(unittest.TestCase):

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -618,8 +618,6 @@ class TestLinearizer(unittest.TestCase):
     out = [u for u in k.uops if u.uop is UOps.STORE][0]
     assert out.vin[-1].uop is UOps.CAST and out.vin[-1].dtype == dtypes.float.vec(2)
 
-  # TODO this broke llama BEAM=2
-  @unittest.expectedFailure
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.supports_float4 and is_dtype_supported(dtypes.half), "need backends that support float4")
   def test_acc_nofold_unmatching_dtypes(self):
     # acc is half4, store is float4.

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -643,7 +643,7 @@ class TestLinearizer(unittest.TestCase):
     cast = LazyOp(BinaryOps.MUL, (ld0, ld1))
     sum = LazyOp(ReduceOps.SUM, (cast, ), (3, ))
     st = LazyOp(BufferOps.STORE, (sum,), MemBuffer(idx=0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(1, 3, 11008, 1), strides=(0, 11008, 1, 0), offset=0, mask=None, contiguous=True),)))) # noqa: E501
-    k = helper_linearizer_ast((st, ), [Tensor.empty(1, 3, 11008, 4096).realize()])[-1]
+    k = helper_linearizer_ast((st, ), [Tensor.empty(1, 3, 11008, 4096).realize(), Tensor.empty(1, 3, 11008, 4096).realize()])[-1]
     # check that gep->vectorize collapses but CAST remains
     store_vals = [u.vin[-1] for u in k.uops if u.uop is UOps.STORE]
     for val in store_vals:

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -635,8 +635,6 @@ class TestLinearizer(unittest.TestCase):
       acc0 = // ...
     }
     *((device float4*)(data0+alu0)) = float4(acc0.x,acc0.y,acc0.z,acc0.w);
-    simplifies to:
-    *((device float4*)(data0+alu0)) = (float4)(acc0);
     """
     ld0 = LazyOp(BufferOps.LOAD, (), MemBuffer(idx=1, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(1, 3, 11008, 4096), strides=(0, 4096, 0, 1), offset=0, mask=None, contiguous=False),)))) # noqa: E501
     ld1 = LazyOp(BufferOps.LOAD, (), MemBuffer(idx=2, dtype=dtypes.half, st=ShapeTracker(views=(View(shape=(1, 3, 11008, 4096), strides=(0, 0, 4096, 1), offset=0, mask=None, contiguous=False),)))) # noqa: E501
@@ -648,7 +646,7 @@ class TestLinearizer(unittest.TestCase):
     store_vals = [u.vin[-1] for u in k.uops if u.uop is UOps.STORE]
     for val in store_vals:
       assert val.dtype == dtypes.float.vec(4) and val.uop is UOps.CAST
-      assert len(val.vin) == 1 and val.vin[0].uop is UOps.PHI
+      assert len(val.vin) == 4 and all(v.uop is UOps.PHI for v in val.vin)
 
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.supports_float4, "need backends that support float4")
 class TestFloat4(unittest.TestCase):

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -216,10 +216,14 @@ constant_folder = PatternMatcher([
   # CAST-PHI-GEP -> PHI-CAST
   ({"__name__": "root", "uop": UOps.CAST, "vin":
     tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val"},), "arg": i}, {"__name__": f"v{i}"})} for i in range(4))},
-    lambda root, val, v0, v1, v2, v3: UOp(UOps.PHI, val.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1, v2, v3))))),
+    lambda root, val, v0, v1, v2, v3: UOp(UOps.PHI, val.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1, v2, v3)))) if root.dtype == val.dtype
+    else UOp(UOps.CAST, root.dtype, (UOp(UOps.PHI, val.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1, v2, v3)))), ))
+   ),
   ({"__name__": "root", "uop": UOps.CAST, "vin":
     tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val"},), "arg": i}, {"__name__": f"v{i}"})} for i in range(2))},
-    lambda root, val, v0, v1: UOp(UOps.PHI, val.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1))))),
+    lambda root, val, v0, v1: UOp(UOps.PHI, val.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1)))) if root.dtype == val.dtype
+    else UOp(UOps.CAST, root.dtype, (UOp(UOps.PHI, val.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1)))), ))
+   ),
   # NEG/CMPLT -> CMPLT
   ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({"uop": UOps.ALU, "arg": UnaryOps.NEG, "vin": ({"__name__": "x"},)},
                                                      {"__name__": "c", "uop": UOps.CONST, "dtype": dtypes.int})},

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -77,6 +77,8 @@ def _match(uop:UOp, pattern:Dict[str, Any], store:Dict[str, UOp]) -> bool:
     elif k == "dtype":
       if isinstance(v, set):
         if uop.dtype not in v: return False
+      elif isinstance(v, str):
+        if uop.dtype != store[v].dtype: return False
       elif uop.dtype != v: return False
     elif k == "uop":
       if isinstance(v, set):
@@ -213,17 +215,15 @@ constant_folder = PatternMatcher([
   ({"uop": UOps.STORE, "vin": ({"__name__": "buf"}, {"__name__": "idx"}, {"uop": UOps.CAST, "vin":
                                 tuple({"uop": UOps.GEP, "vin": ({"__name__": "val"},), "arg": i} for i in range(2))})},
    lambda buf,idx,val: UOp(UOps.STORE, None, (buf, idx, val))),
-  # CAST-PHI-GEP -> PHI-CAST if dtypes match
-  *(({"__name__": "root", "uop": UOps.CAST, "dtype": dtype, "vin":
-    tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val", "dtype": dtype},),
+  # CAST-PHI-GEP -> PHI-CAST only if dtypes match
+  ({"__name__": "root", "uop": UOps.CAST, "vin":
+    tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val", "dtype": "root"},),
                                      "arg": i}, {"__name__": f"v{i}"})} for i in range(4))},
-    lambda root, val, v0, v1, v2, v3: UOp(UOps.PHI, root.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1, v2, v3)))))
-    for dtype in [dtypes.float.vec(4), dtypes.half.vec(4), dtypes.int.vec(4)]),
-  *(({"__name__": "root", "uop": UOps.CAST, "dtype": dtype, "vin":
-    tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val", "dtype": dtype},),
+    lambda root, val, v0, v1, v2, v3: UOp(UOps.PHI, root.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1, v2, v3))))),
+  ({"__name__": "root", "uop": UOps.CAST, "vin":
+    tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val", "dtype": "root"},),
                                      "arg": i}, {"__name__": f"v{i}"})} for i in range(2))},
-    lambda root, val, v0, v1: UOp(UOps.PHI, root.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1)))))
-    for dtype in [dtypes.float.vec(2), dtypes.half.vec(2), dtypes.int.vec(2)]),
+    lambda root, val, v0, v1: UOp(UOps.PHI, root.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1))))),
   # NEG/CMPLT -> CMPLT
   ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({"uop": UOps.ALU, "arg": UnaryOps.NEG, "vin": ({"__name__": "x"},)},
                                                      {"__name__": "c", "uop": UOps.CONST, "dtype": dtypes.int})},

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -213,19 +213,17 @@ constant_folder = PatternMatcher([
   ({"uop": UOps.STORE, "vin": ({"__name__": "buf"}, {"__name__": "idx"}, {"uop": UOps.CAST, "vin":
                                 tuple({"uop": UOps.GEP, "vin": ({"__name__": "val"},), "arg": i} for i in range(2))})},
    lambda buf,idx,val: UOp(UOps.STORE, None, (buf, idx, val))),
-  # CAST-PHI-GEP -> PHI-CAST
+  # CAST-PHI-GEP -> PHI-CAST if dtypes match
   *(({"__name__": "root", "uop": UOps.CAST, "dtype": dtype, "vin":
-    tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val", "dtype": dtype},), "arg": i}, {"__name__": f"v{i}"})}
-          for i in range(4))},
+    tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val", "dtype": dtype},),
+                                     "arg": i}, {"__name__": f"v{i}"})} for i in range(4))},
     lambda root, val, v0, v1, v2, v3: UOp(UOps.PHI, root.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1, v2, v3)))))
-    for dtype in [dtypes.float.vec(4), dtypes.half.vec(4), dtypes.int.vec(4)]
-  ),
+    for dtype in [dtypes.float.vec(4), dtypes.half.vec(4), dtypes.int.vec(4)]),
   *(({"__name__": "root", "uop": UOps.CAST, "dtype": dtype, "vin":
-    tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val", "dtype": dtype},), "arg": i}, {"__name__": f"v{i}"})}
-          for i in range(2))},
+    tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val", "dtype": dtype},),
+                                     "arg": i}, {"__name__": f"v{i}"})} for i in range(2))},
     lambda root, val, v0, v1: UOp(UOps.PHI, root.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1)))))
-    for dtype in [dtypes.float.vec(2), dtypes.half.vec(2), dtypes.int.vec(2)]
-  ),
+    for dtype in [dtypes.float.vec(2), dtypes.half.vec(2), dtypes.int.vec(2)]),
   # NEG/CMPLT -> CMPLT
   ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({"uop": UOps.ALU, "arg": UnaryOps.NEG, "vin": ({"__name__": "x"},)},
                                                      {"__name__": "c", "uop": UOps.CONST, "dtype": dtypes.int})},

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -216,10 +216,10 @@ constant_folder = PatternMatcher([
   # CAST-PHI-GEP -> PHI-CAST
   ({"__name__": "root", "uop": UOps.CAST, "vin":
     tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val"},), "arg": i}, {"__name__": f"v{i}"})} for i in range(4))},
-    lambda root, val, v0, v1, v2, v3: UOp(UOps.PHI, root.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1, v2, v3))))),
+    lambda root, val, v0, v1, v2, v3: UOp(UOps.PHI, val.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1, v2, v3))))),
   ({"__name__": "root", "uop": UOps.CAST, "vin":
     tuple({"uop": UOps.PHI, "vin": ({"uop": UOps.GEP, "vin": ({"__name__": "val"},), "arg": i}, {"__name__": f"v{i}"})} for i in range(2))},
-    lambda root, val, v0, v1: UOp(UOps.PHI, root.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1))))),
+    lambda root, val, v0, v1: UOp(UOps.PHI, val.dtype, (val, UOp(UOps.CAST, val.dtype, (v0, v1))))),
   # NEG/CMPLT -> CMPLT
   ({"uop": UOps.ALU, "arg": BinaryOps.CMPLT, "vin": ({"uop": UOps.ALU, "arg": UnaryOps.NEG, "vin": ({"__name__": "x"},)},
                                                      {"__name__": "c", "uop": UOps.CONST, "dtype": dtypes.int})},


### PR DESCRIPTION
In master the uop simplifier folds a PHI-GEP-CAST even if PHI is half4 and CAST is float4:
```
    half4 acc0 = half4(0.0,0.0,0.0,0.0);
    {
      acc0 = // ...
    }
    *((device float4*)(data0+alu0)) = float4(acc0.x,acc0.y,acc0.z,acc0.w);
    becomes:
    *((device float4*)(data0+alu0)) = acc0;
```
We should only fold CAST if the PHI and CAST dtypes match.