### PR TITLE
fix UOps.CAST noop for vectorized dtypes

### DIFF
--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -1,7 +1,7 @@
 import unittest
 from tinygrad import dtypes, Variable
 from tinygrad.dtype import PtrDType
-from tinygrad.ops import BinaryOps, MemBuffer, TernaryOps, UnaryOps
+from tinygrad.ops import BinaryOps, TernaryOps, UnaryOps
 from tinygrad.codegen.uops import UOpGraph, UOps
 
 class TestUOpGraph(unittest.TestCase):

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -1,6 +1,7 @@
 import unittest
 from tinygrad import dtypes, Variable
-from tinygrad.ops import BinaryOps, TernaryOps
+from tinygrad.dtype import PtrDType
+from tinygrad.ops import BinaryOps, MemBuffer, TernaryOps, UnaryOps
 from tinygrad.codegen.uops import UOpGraph, UOps
 
 class TestUOpGraph(unittest.TestCase):
@@ -49,6 +50,18 @@ class TestUOpGraph(unittest.TestCase):
     out = g.uops[-1]
     self.assertEqual(out.uop, UOps.CONST)
     self.assertEqual(out.arg, 0)
+
+  def test_cast_vectorized_fold(self):
+    g = UOpGraph()
+    d0 = g.add(UOps.DEFINE_GLOBAL, PtrDType(dtypes.float), arg=(0, True))
+    idx = g.add(UOps.CONST, dtypes.int, arg=0)
+    ld = g.add(UOps.LOAD, dtypes.float.vec(2), (d0, idx))
+    cast = g.add(UOps.CAST, dtypes.float.vec(2), (ld,))
+    x = g.add(UOps.GEP, dtypes.float, (cast, ), arg=0)
+    alu = g.add(UOps.ALU, dtypes.float, (x, ), UnaryOps.SQRT)
+    out = g.add(UOps.STORE, dtypes.float, (d0, idx, alu), UnaryOps.SQRT)
+    g.add(UOps.SINK, None, (out,))
+    self.assertEqual(len([x for x in g.uops if x.uop is UOps.CAST]), 0)
 
   def test_depth_2_const_fold(self):
     g = UOpGraph()

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -225,7 +225,7 @@ constant_folder = PatternMatcher([
                                                      {"__name__": "c", "uop": UOps.CONST, "dtype": dtypes.int})},
     lambda c,x: UOp(UOps.ALU, dtypes.bool, (UOp.const(c.dtype, -c.arg), x), BinaryOps.CMPLT)),
   # cast NOOP (NOTE: it's `is` to deal with PtrDType)
-  ({"__name__": "root", "uop": UOps.CAST}, lambda root: root.vin[0] if root.dtype is root.vin[0].dtype else None),
+  ({"__name__": "root", "uop": UOps.CAST}, lambda root: root.vin[0] if root.dtype == root.vin[0].dtype else None),
 ])
 
 # *** uop graph ***


### PR DESCRIPTION
dtypes.float.vec(2) is not dtypes.float.vec(2) but == works

before:
```
kernel void test(device float* data0, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  float2 val0 = (float2)(*((device float2*)(data0+0)));
  *(data0+0) = sqrt((float2)(val0).x);
}
```

after:
```
kernel void test(device float* data0, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  float2 val0 = (float2)(*((device float2*)(data0+0)));
  *(data0+0) = sqrt(val0.x);
}
```