### PR TITLE
fix commavq benchmark

### DIFF
--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -650,7 +650,7 @@ def Attention(x:Tensor, weights, bias:Optional[Tensor]=None, mask_index:Optional
   if unidirectional:  # gpt-style
     assert hidden_size == v_hidden_size
     xqkv = x.linear(weights, bias)
-    xq, xk, xv = [xqkv.slice([None, None, (i*hidden_size, (i+1)*hidden_size)]) for i in range(3)]
+    xq, xk, xv = [xqkv._slice([None, None, (i*hidden_size, (i+1)*hidden_size)]) for i in range(3)]
   else:  # bert-style
     wq, wk, wv = weights[:,:hidden_size], weights[:,hidden_size:hidden_size+v_hidden_size], weights[:,hidden_size+v_hidden_size:]
     bq, bk, bv = (bias[:hidden_size], bias[hidden_size:hidden_size+v_hidden_size], bias[hidden_size+v_hidden_size]) if bias is not None else None


### PR DESCRIPTION
the Attention implementation in onnx_ops uses `.slice` (renamed after #4706).

This silently failed because of a very generic try/catch. I think if we expect an error it should be very explicit.

failing case: https://github.com/tinygrad/tinygrad/actions/runs/9227046271/job/25388152110
with ._slice: https://github.com/tinygrad/tinygrad/actions/runs/9227069833