### PR TITLE
rename Tensor.replace -> Tensor._replace

### DIFF
--- a/docs/tensor.md
+++ b/docs/tensor.md
@@ -46,7 +46,7 @@
 ::: tinygrad.Tensor.schedule_with_vars
 ::: tinygrad.Tensor.schedule
 ::: tinygrad.Tensor.realize
-::: tinygrad.Tensor.replace
+::: tinygrad.Tensor._replace
 ::: tinygrad.Tensor.assign
 ::: tinygrad.Tensor.detach
 ::: tinygrad.Tensor.to

--- a/docs/tensor.md
+++ b/docs/tensor.md
@@ -46,7 +46,6 @@
 ::: tinygrad.Tensor.schedule_with_vars
 ::: tinygrad.Tensor.schedule
 ::: tinygrad.Tensor.realize
-::: tinygrad.Tensor._replace
 ::: tinygrad.Tensor.assign
 ::: tinygrad.Tensor.detach
 ::: tinygrad.Tensor.to

--- a/examples/gpt2.py
+++ b/examples/gpt2.py
@@ -139,7 +139,7 @@ class GPT2:
 
     if HALF:
       for l in get_state_dict(model).values():
-        l.replace(l.half().realize())
+        l._replace(l.half().realize())
 
     return GPT2(model, tokenizer)
 

--- a/examples/llm.c/export.py
+++ b/examples/llm.c/export.py
@@ -14,7 +14,7 @@ TIMING = getenv("TIMING")
 if __name__ == "__main__":
   model = GPT(GPTConfig(n_layer=getenv("NLAYER", 12), n_head=12, n_embd=768))
   #model.load_pretrained()
-  for p in nn.state.get_parameters(model): p.replace(Tensor.empty(p.shape, dtype=p.dtype)) # fake load pretrained
+  for p in nn.state.get_parameters(model): p._replace(Tensor.empty(p.shape, dtype=p.dtype)) # fake load pretrained
 
   seen = set()
   #early_sched = create_schedule([x.lazydata for x in nn.state.get_parameters(model)], seen)

--- a/examples/mixtral.py
+++ b/examples/mixtral.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     else:
       device = Device.DEFAULT
     t.set_description(f"ram used: {GlobalCounters.mem_used/1e9:5.2f} GB, loading {k} to {device}")
-    model_state_dict[k].replace(state[k].to(device).half()).realize()
+    model_state_dict[k]._replace(state[k].to(device).half()).realize()
   if CI: print(f"ram used: {GlobalCounters.mem_used/1e9:5.2f} GB")
 
   from sentencepiece import SentencePieceProcessor

--- a/examples/stable_diffusion.py
+++ b/examples/stable_diffusion.py
@@ -600,7 +600,7 @@ if __name__ == "__main__":
 
   if args.fp16:
     for l in get_state_dict(model).values():
-      l.replace(l.cast(dtypes.float16).realize())
+      l._replace(l.cast(dtypes.float16).realize())
 
   # run through CLIP to get context
   tokenizer = ClipTokenizer()

--- a/examples/yolov8.py
+++ b/examples/yolov8.py
@@ -295,7 +295,7 @@ class DFL:
   def __init__(self, c1=16):
     self.conv = Conv2d(c1, 1, 1, bias=False)
     x = Tensor.arange(c1)
-    self.conv.weight.replace(x.reshape(1, c1, 1, 1))
+    self.conv.weight._replace(x.reshape(1, c1, 1, 1))
     self.c1 = c1
 
   def __call__(self, x):

--- a/extra/models/efficientnet.py
+++ b/extra/models/efficientnet.py
@@ -158,7 +158,7 @@ class EfficientNet:
       #vnp = vnp if vnp.shape != () else np.array([vnp])
 
       if mv.shape == vnp.shape:
-        mv.replace(vnp.to(mv.device))
+        mv._replace(vnp.to(mv.device))
       else:
         print("MISMATCH SHAPE IN %s, %r %r" % (k, mv.shape, vnp.shape))
 

--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -264,7 +264,7 @@ class TestMultiTensor(unittest.TestCase):
     z = layer(x)
 
     layer_sharded = nn.Embedding(vocab_size, embed_size)
-    layer_sharded.weight.replace(layer.weight.shard((d0, d1), axis=1)).realize()
+    layer_sharded.weight._replace(layer.weight.shard((d0, d1), axis=1)).realize()
     x_sharded = x.shard((d0, d1), axis=None)
     z_shard = layer_sharded(x_sharded)
 

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -125,9 +125,9 @@ def load_state_dict(model, state_dict:Dict[str, Tensor], strict=True, verbose=Tr
         if DEBUG >= 1: print(f"WARNING: not loading {k}")
         continue
       if isinstance((mlb:=v.lazydata), MultiLazyBuffer):
-        if isinstance(state_dict[k].lazydata, MultiLazyBuffer): v.replace(state_dict[k]).realize()
-        else: v.replace(state_dict[k].shard(mlb.device, mlb.axis)).realize()
-      else: v.replace(state_dict[k].to(v.device)).realize()
+        if isinstance(state_dict[k].lazydata, MultiLazyBuffer): v.assign(state_dict[k]).realize()
+        else: v.assign(state_dict[k].shard(mlb.device, mlb.axis)).realize()
+      else: v.assign(state_dict[k].to(v.device)).realize()
       if consume: del state_dict[k]
 
 # torch support!

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -168,7 +168,7 @@ class Tensor:
     run_schedule(*self.schedule_with_vars(*lst), do_update_stats=do_update_stats)
     return self
 
-  def replace(self, x:Tensor) -> Tensor:
+  def _replace(self, x:Tensor) -> Tensor:
     """
     Replace the data of this tensor with the data of another tensor. Only the shape of the tensors must match.
     """
@@ -193,7 +193,7 @@ class Tensor:
     assert self.dtype == x.dtype, f"assign dtype mismatch {self.dtype} != {x.dtype}"
     assert not isinstance(self.lazydata, MultiLazyBuffer) or self.lazydata.axis == x.lazydata.axis, "axis must match on MultiLazyBuffer"
     assert not x.requires_grad  # self requires_grad is okay?
-    if not self.lazydata.is_realized(): return self.replace(x)
+    if not self.lazydata.is_realized(): return self._replace(x)
     self.lazydata = self.lazydata.assign(x.lazydata)
     return self
   def detach(self) -> Tensor:


### PR DESCRIPTION
Tensor.replace shouldn't be used by users ([source](https://youtu.be/-iH5wvFnsKs?t=20290)).

- Renamed symbol `Tensor.replace` -> `Tensor._replace`
- Auto updated replace references in examples/
- Replaced with `Tensor.assign` in nn.state.load_state_dict
- Removed replace from docs