### PR TITLE
docs: update page headers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+# tinygrad documentation
+
 Welcome to the docs for tinygrad. This page is for users of the tinygrad library. tinygrad is not 1.0 yet, but it will be soon. The API has been pretty stable for a while.
 
 While you can `pip install tinygrad`, we encourage you to install from source:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,4 @@
-# tinygrad Quick Start Guide
+# Quick Start Guide
 
 This guide assumes no prior knowledge of pytorch or any other deep learning framework, but does assume some basic knowledge of neural networks.
 It is intended to be a very quick overview of the high level API that tinygrad provides.

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,4 +1,4 @@
-# tinygrad Showcase
+# Showcase
 
 Despite being a tiny library, tinygrad is capable of doing a lot of things. From state-of-the-art [vision](https://arxiv.org/abs/1905.11946) to state-of-the-art [language](https://arxiv.org/abs/1706.03762) models.
 


### PR DESCRIPTION
replaced the "Index" from Home page with "tinygrad documentation"