### PR TITLE
Implement a gradient scaling operation

### DIFF
--- a/test/test_gradscale.py
+++ b/test/test_gradscale.py
@@ -1,0 +1,116 @@
+import unittest
+import numpy as np
+
+from tinygrad import Tensor
+from tinygrad.nn.optim import Adam
+from tinygrad.nn import Linear
+
+
+def _get_test_scales():
+    ints = [i for i in range(-10, 11)]
+    floats = [float(i) for i in ints]
+    fractions = [10 ** i for i in range(-6, 7)]
+
+    return ints + floats + fractions
+
+
+class TestGradScale(unittest.TestCase):
+
+    def test_int_dtype(self):
+        # define integer variable
+        x = Tensor([1, 1])
+        a = Tensor([5, 2], requires_grad=True)
+        b = Tensor(1, requires_grad=True)
+
+        # for gradients on integer variables, scaling with floating values
+        # will lead to conversion to int after the multiplication
+        for c in _get_test_scales():
+            a.grad, b.grad = None, None
+            (a.gradscale(c) * x + b.gradscale(c)).sum().backward()
+
+            # unscaled grad of a is 1 and thus equal to c
+            np.testing.assert_allclose(a.grad.numpy(), np.array((int(c), int(c))))
+            # unscaled of b is 1+1=2 (a has 2 dims) and thus equal to 2*c
+            np.testing.assert_allclose(b.grad.numpy(), np.array((int(c * 2),)))
+
+    def test_float_dtype(self):
+        # define float variables
+        x = Tensor([1.0, 1.0])
+        a = Tensor([5.0, 2.0], requires_grad=True)
+        b = Tensor(10.0, requires_grad=True)
+
+        # for floating variables, the gradients are simply scaled
+        for c in _get_test_scales():
+            a.grad, b.grad = None, None
+            (a.gradscale(c) * x + b.gradscale(c)).sum().backward()
+
+            # unscaled grad of a is 1 and thus equal to c
+            np.testing.assert_allclose(a.grad.numpy(), np.array((c, c)))
+            # unscaled of b is 1+1=2 (a has 2 dims) and thus equal to 2*c
+            np.testing.assert_allclose(b.grad.numpy(), np.array((c * 2,)))
+
+    def test_identity_scale(self):
+        # input
+        Tensor.manual_seed(42)
+        x = Tensor.rand((100, 20))
+
+        # network
+        fc = Linear(20, 3)
+        fc.weight.requires_grad = True
+        fc.bias.requires_grad = True
+
+        # compute gradient without scaling
+        fc(x).sigmoid().sum().backward()
+        weight_grad = fc.weight.grad.numpy()
+        bias_grad = fc.bias.grad.numpy()
+
+        # compute gradient with scaling of 1
+        fc.weight.grad, fc.bias.grad = None, None
+        fc(x).sigmoid().gradscale(1).sum().backward()
+        weight_grad_scaled = fc.weight.grad.numpy()
+        bias_grad_scaled = fc.bias.grad.numpy()
+
+        np.testing.assert_allclose(weight_grad, weight_grad_scaled)
+        np.testing.assert_allclose(bias_grad, bias_grad_scaled)
+
+    def test_descendants(self):
+        # input
+        Tensor.manual_seed(42)
+        x = Tensor.rand((100, 20))
+
+        # network
+        fc1 = Linear(20, 10)
+        fc2 = Linear(10, 5)
+        fc3 = Linear(5, 1)
+
+        # set require_grads to `True`
+        opt = Adam([fc1.weight, fc1.bias, fc2.weight, fc2.bias, fc3.weight, fc3.bias])
+
+        # forward without scaling
+        h1 = fc1(x).sigmoid()
+        h2 = fc2(h1).sigmoid()
+        h3 = fc3(h2).sigmoid()
+        h3.mean().backward()
+        gradients = [e.grad.numpy() for e in opt.params]
+
+        # forward with scaling after third layer
+        opt.zero_grad()
+        h1 = fc1(x).sigmoid()
+        h2 = fc2(h1).sigmoid().gradscale(0.5)
+        h3 = fc3(h2).sigmoid()
+        h3.mean().backward()
+        scaled_gradients = [e.grad.numpy() for e in opt.params]
+
+        # gradients of layer 3 should be equal
+        np.testing.assert_allclose(gradients[-1], scaled_gradients[-1])
+        np.testing.assert_allclose(gradients[-2], scaled_gradients[-2])
+
+        # gradients of layer 1 and 2 should be half as big due to grad scaling
+        np.testing.assert_allclose(gradients[0], scaled_gradients[0] * 2)
+        np.testing.assert_allclose(gradients[1], scaled_gradients[1] * 2)
+        np.testing.assert_allclose(gradients[2], scaled_gradients[2] * 2)
+        np.testing.assert_allclose(gradients[3], scaled_gradients[3] * 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_gradscale.py
+++ b/test/test_gradscale.py
@@ -7,110 +7,108 @@ from tinygrad.nn import Linear
 
 
 def _get_test_scales():
-    ints = [i for i in range(-10, 11)]
-    floats = [float(i) for i in ints]
-    fractions = [10 ** i for i in range(-6, 7)]
+  ints = [i for i in range(-10, 11)]
+  floats = [float(i) for i in ints]
+  fractions = [10 ** i for i in range(-6, 7)]
 
-    return ints + floats + fractions
+  return ints + floats + fractions
 
 
 class TestGradScale(unittest.TestCase):
+  def test_int_dtype(self):
+    # define integer variable
+    x = Tensor([1, 1])
+    a = Tensor([5, 2], requires_grad=True)
+    b = Tensor(1, requires_grad=True)
 
-    def test_int_dtype(self):
-        # define integer variable
-        x = Tensor([1, 1])
-        a = Tensor([5, 2], requires_grad=True)
-        b = Tensor(1, requires_grad=True)
+    # for gradients on integer variables, scaling with floating values
+    # will lead to conversion to int after the multiplication
+    for c in _get_test_scales():
+      a.grad, b.grad = None, None
+      (a.gradscale(c) * x + b.gradscale(c)).sum().backward()
 
-        # for gradients on integer variables, scaling with floating values
-        # will lead to conversion to int after the multiplication
-        for c in _get_test_scales():
-            a.grad, b.grad = None, None
-            (a.gradscale(c) * x + b.gradscale(c)).sum().backward()
+      # unscaled grad of a is 1 and thus equal to c
+      np.testing.assert_allclose(a.grad.numpy(), np.array((int(c), int(c))))
+      # unscaled of b is 1+1=2 (a has 2 dims) and thus equal to 2*c
+      np.testing.assert_allclose(b.grad.numpy(), np.array((int(c * 2),)))
 
-            # unscaled grad of a is 1 and thus equal to c
-            np.testing.assert_allclose(a.grad.numpy(), np.array((int(c), int(c))))
-            # unscaled of b is 1+1=2 (a has 2 dims) and thus equal to 2*c
-            np.testing.assert_allclose(b.grad.numpy(), np.array((int(c * 2),)))
+  def test_float_dtype(self):
+    # define float variables
+    x = Tensor([1.0, 1.0])
+    a = Tensor([5.0, 2.0], requires_grad=True)
+    b = Tensor(10.0, requires_grad=True)
 
-    def test_float_dtype(self):
-        # define float variables
-        x = Tensor([1.0, 1.0])
-        a = Tensor([5.0, 2.0], requires_grad=True)
-        b = Tensor(10.0, requires_grad=True)
+    # for floating variables, the gradients are simply scaled
+    for c in _get_test_scales():
+      a.grad, b.grad = None, None
+      (a.gradscale(c) * x + b.gradscale(c)).sum().backward()
 
-        # for floating variables, the gradients are simply scaled
-        for c in _get_test_scales():
-            a.grad, b.grad = None, None
-            (a.gradscale(c) * x + b.gradscale(c)).sum().backward()
+      # unscaled grad of a is 1 and thus equal to c
+      np.testing.assert_allclose(a.grad.numpy(), np.array((c, c)))
+      # unscaled of b is 1+1=2 (a has 2 dims) and thus equal to 2*c
+      np.testing.assert_allclose(b.grad.numpy(), np.array((c * 2,)))
 
-            # unscaled grad of a is 1 and thus equal to c
-            np.testing.assert_allclose(a.grad.numpy(), np.array((c, c)))
-            # unscaled of b is 1+1=2 (a has 2 dims) and thus equal to 2*c
-            np.testing.assert_allclose(b.grad.numpy(), np.array((c * 2,)))
+  def test_identity_scale(self):
+    # input
+    Tensor.manual_seed(42)
+    x = Tensor.rand((100, 20))
 
-    def test_identity_scale(self):
-        # input
-        Tensor.manual_seed(42)
-        x = Tensor.rand((100, 20))
+    # network
+    fc = Linear(20, 3)
+    fc.weight.requires_grad = True
+    fc.bias.requires_grad = True
 
-        # network
-        fc = Linear(20, 3)
-        fc.weight.requires_grad = True
-        fc.bias.requires_grad = True
+    # compute gradient without scaling
+    fc(x).sigmoid().sum().backward()
+    weight_grad = fc.weight.grad.numpy()
+    bias_grad = fc.bias.grad.numpy()
 
-        # compute gradient without scaling
-        fc(x).sigmoid().sum().backward()
-        weight_grad = fc.weight.grad.numpy()
-        bias_grad = fc.bias.grad.numpy()
+    # compute gradient with scaling of 1
+    fc.weight.grad, fc.bias.grad = None, None
+    fc(x).sigmoid().gradscale(1).sum().backward()
+    weight_grad_scaled = fc.weight.grad.numpy()
+    bias_grad_scaled = fc.bias.grad.numpy()
 
-        # compute gradient with scaling of 1
-        fc.weight.grad, fc.bias.grad = None, None
-        fc(x).sigmoid().gradscale(1).sum().backward()
-        weight_grad_scaled = fc.weight.grad.numpy()
-        bias_grad_scaled = fc.bias.grad.numpy()
+    np.testing.assert_allclose(weight_grad, weight_grad_scaled)
+    np.testing.assert_allclose(bias_grad, bias_grad_scaled)
 
-        np.testing.assert_allclose(weight_grad, weight_grad_scaled)
-        np.testing.assert_allclose(bias_grad, bias_grad_scaled)
+  def test_descendants(self):
+    # input
+    Tensor.manual_seed(42)
+    x = Tensor.rand((100, 20))
 
-    def test_descendants(self):
-        # input
-        Tensor.manual_seed(42)
-        x = Tensor.rand((100, 20))
+    # network
+    fc1 = Linear(20, 10)
+    fc2 = Linear(10, 5)
+    fc3 = Linear(5, 1)
 
-        # network
-        fc1 = Linear(20, 10)
-        fc2 = Linear(10, 5)
-        fc3 = Linear(5, 1)
+    # set require_grads to `True`
+    opt = Adam([fc1.weight, fc1.bias, fc2.weight, fc2.bias, fc3.weight, fc3.bias])
 
-        # set require_grads to `True`
-        opt = Adam([fc1.weight, fc1.bias, fc2.weight, fc2.bias, fc3.weight, fc3.bias])
+    # forward without scaling
+    h1 = fc1(x).sigmoid()
+    h2 = fc2(h1).sigmoid()
+    h3 = fc3(h2).sigmoid()
+    h3.mean().backward()
+    gradients = [e.grad.numpy() for e in opt.params]
 
-        # forward without scaling
-        h1 = fc1(x).sigmoid()
-        h2 = fc2(h1).sigmoid()
-        h3 = fc3(h2).sigmoid()
-        h3.mean().backward()
-        gradients = [e.grad.numpy() for e in opt.params]
+    # forward with scaling after third layer
+    opt.zero_grad()
+    h1 = fc1(x).sigmoid()
+    h2 = fc2(h1).sigmoid().gradscale(0.5)
+    h3 = fc3(h2).sigmoid()
+    h3.mean().backward()
+    scaled_gradients = [e.grad.numpy() for e in opt.params]
 
-        # forward with scaling after third layer
-        opt.zero_grad()
-        h1 = fc1(x).sigmoid()
-        h2 = fc2(h1).sigmoid().gradscale(0.5)
-        h3 = fc3(h2).sigmoid()
-        h3.mean().backward()
-        scaled_gradients = [e.grad.numpy() for e in opt.params]
+    # gradients of layer 3 should be equal
+    np.testing.assert_allclose(gradients[-1], scaled_gradients[-1])
+    np.testing.assert_allclose(gradients[-2], scaled_gradients[-2])
 
-        # gradients of layer 3 should be equal
-        np.testing.assert_allclose(gradients[-1], scaled_gradients[-1])
-        np.testing.assert_allclose(gradients[-2], scaled_gradients[-2])
-
-        # gradients of layer 1 and 2 should be half as big due to grad scaling
-        np.testing.assert_allclose(gradients[0], scaled_gradients[0] * 2)
-        np.testing.assert_allclose(gradients[1], scaled_gradients[1] * 2)
-        np.testing.assert_allclose(gradients[2], scaled_gradients[2] * 2)
-        np.testing.assert_allclose(gradients[3], scaled_gradients[3] * 2)
-
+    # gradients of layer 1 and 2 should be half as big due to grad scaling
+    np.testing.assert_allclose(gradients[0], scaled_gradients[0] * 2)
+    np.testing.assert_allclose(gradients[1], scaled_gradients[1] * 2)
+    np.testing.assert_allclose(gradients[2], scaled_gradients[2] * 2)
+    np.testing.assert_allclose(gradients[3], scaled_gradients[3] * 2)
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/tinygrad/function.py
+++ b/tinygrad/function.py
@@ -138,6 +138,14 @@ class Div(Function):
     return grad_output.e(BinaryOps.DIV, self.y) if self.needs_input_grad[0] else None, \
            grad_output.e(UnaryOps.NEG).e(BinaryOps.MUL, self.x).e(BinaryOps.DIV, self.y.e(BinaryOps.MUL, self.y)) if self.needs_input_grad[1] else None  # noqa: E501
 
+class GradScale(Function):
+  def forward(self, x:LazyBuffer, scale:LazyBuffer):
+    self.scale = scale
+    return x
+
+  def backward(self, grad_output: LazyBuffer):
+    return grad_output.e(BinaryOps.MUL, self.scale), None
+
 # ************* ternary ops *************
 
 class Where(Function):

--- a/tinygrad/function.py
+++ b/tinygrad/function.py
@@ -138,14 +138,6 @@ class Div(Function):
     return grad_output.e(BinaryOps.DIV, self.y) if self.needs_input_grad[0] else None, \
            grad_output.e(UnaryOps.NEG).e(BinaryOps.MUL, self.x).e(BinaryOps.DIV, self.y.e(BinaryOps.MUL, self.y)) if self.needs_input_grad[1] else None  # noqa: E501
 
-class GradScale(Function):
-  def forward(self, x:LazyBuffer, scale:LazyBuffer):
-    self.scale = scale
-    return x
-
-  def backward(self, grad_output: LazyBuffer):
-    return grad_output.e(BinaryOps.MUL, self.scale), None
-
 # ************* ternary ops *************
 
 class Where(Function):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2367,7 +2367,8 @@ class Tensor:
     """
     Multiplies the gradient of `self` with `scale`.
     """
-    return F.GradScale.apply(*self._broadcasted(scale))
+    inverse_scale = 1 - scale if -1 <= scale <= 1 else -1 / scale
+    return (self * scale) + (self.detach() * inverse_scale)
 
   def xor(self, x:Union[Tensor, ConstType], reverse=False) -> Tensor:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2363,6 +2363,12 @@ class Tensor:
     if upcast: numerator, denominator = numerator.cast(least_upper_float(numerator.dtype)), denominator.cast(least_upper_float(denominator.dtype))
     return F.Div.apply(numerator, denominator)
 
+  def gradscale(self, scale:Union[int, "float"]):
+    """
+    Multiplies the gradient of `self` with `scale`.
+    """
+    return F.GradScale.apply(*self._broadcasted(scale))
+
   def xor(self, x:Union[Tensor, ConstType], reverse=False) -> Tensor:
     """
     Computes bitwise xor of `self` and `x`.


### PR DESCRIPTION
As a side-project, I'm implementing wav2vec 2.0 pre-training and fine-tuning in TinyGrad. During this process I expect to come across some bugs or unimplemented features. Two features I know are not available are the gumbel-softmax operation and gradient scaling. 
 
Hereby a PR which adds the gradient scaling operation. I think this is useful not only for my use-case (in wav2vec 2.0, the gradient of the first 7 layers should be 10x smaller than other layers), but also for implementing adversarial losses (e.g., for GANs you can maximize the loss by doing `loss.gradscale(-1).backward()`). 