### PR TITLE
fix lazy r const folding with variable shape

### DIFF
--- a/test/test_symbolic_jit.py
+++ b/test/test_symbolic_jit.py
@@ -177,6 +177,17 @@ class TestSymbolicJit(unittest.TestCase):
       np.testing.assert_allclose(symbolic, expected, atol=1e-6, rtol=1e-6)
     assert_jit_cache_len(jf, 1)
 
+  def test_ones_sum(self):
+    def f(a): return a.sum().realize()
+    jf = TinyJit(f)
+    for i in range(1, 5):
+      vi = Variable("i", 1, 10).bind(i)
+      # TODO: without contiguous, the CONST shape are different in jit
+      t = Tensor.ones(i).contiguous()
+      symbolic = jf(t.reshape(vi)).item()
+      expected = f(t).item()
+      np.testing.assert_equal(symbolic, expected)
+
   def test_mean(self):
     def f(a): return a.mean().realize()
     def f0(a): return a.mean(0).realize()

--- a/test/test_symbolic_ops.py
+++ b/test/test_symbolic_ops.py
@@ -141,6 +141,14 @@ class TestSymbolicOps(unittest.TestCase):
       expected = a.shrink(((3,5),(i,i+2))).numpy()
       np.testing.assert_allclose(symbolic, expected, atol=1e-6, rtol=1e-6)
 
+  def test_ones_sum(self):
+    for i in range(1, 5):
+      vi = Variable("i", 1, 10).bind(i)
+      t = Tensor.ones(i)
+      symbolic = t.reshape(vi).sum().item()
+      expected = t.sum().item()
+      np.testing.assert_equal(symbolic, expected)
+
   def test_mean(self):
     for i in range(1, 5):
       vi = Variable("i", 1, 10).bind(i)

--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -173,6 +173,17 @@ class TestSymbolicShrink(unittest.TestCase):
     t = Tensor.rand(3, 5).shrink(((0, 2), (vi, vi+1)))
     assert t.shape == (2, 1)
 
+class TestSymbolicPad(unittest.TestCase):
+  def test_pad(self):
+    v = Variable("v", 1, 100).bind(5)
+    t = Tensor.ones(5).reshape(v).pad(((4, 0),)).reshape(9)
+    assert t.shape == (9,)
+    st = t.lazydata.st
+    print(st)
+    # TODO: fix this, required for symbolic arange
+    with self.assertRaises(RuntimeError):
+      st.expr_idxs()
+
 class TestSymbolicShapeExpr(unittest.TestCase):
   def test_symbolic_expr_idxs(self):
     # taken from symbolic shape llama


### PR DESCRIPTION
currently not supporting const fold symbolic shape. I think it's possible with a refactor to `Tensor.from_node`.
also added some failed required tests for symbolic arange.