### PR TITLE
Pattern Matcher Tests

### DIFF
--- a/test/test_pattern_matcher.py
+++ b/test/test_pattern_matcher.py
@@ -11,14 +11,14 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(uop1.arg, uop2.arg)
 
   def test_simple_match(self):
-    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.CONST, 'dtype': dtypes.float}, lambda x: x)])
+    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.float}, lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.int, arg=1)
     self.assertEqual(matcher.rewrite(c1), c1)
     self.assertEqual(matcher.rewrite(c2), None)
 
   def test_dtype_set(self):
-    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.CONST, 'dtype': set([dtypes.float32, dtypes.float64, dtypes.bool])}, lambda x: x)])
+    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.CONST, "dtype": set([dtypes.float32, dtypes.float64, dtypes.bool])}, lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.float64, arg=1.0)
     c3 = UOp(UOps.CONST, dtypes.float16, arg=1.0)
@@ -31,7 +31,7 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(matcher.rewrite(c5), c5)
 
   def test_vin_one(self):
-    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.ALU, 'vin':({'uop': UOps.CONST}, {'uop': UOps.CONST})},
+    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.ALU, "vin":({"uop": UOps.CONST}, {"uop": UOps.CONST})},
                                lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.float, arg=2.0)
@@ -40,7 +40,7 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(matcher.rewrite(c2), None)
 
   def test_vin_permutations(self):
-    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.ALU, 'vin':[{'uop': UOps.CONST}, {'uop': UOps.ALU}]}, lambda x: x)])
+    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.ALU, "vin":[{"uop": UOps.CONST}, {"uop": UOps.ALU}]}, lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.float, arg=2.0)
     c3 = UOp(UOps.ALU, dtypes.float, (c1,c2), BinaryOps.ADD)
@@ -53,7 +53,7 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(matcher.rewrite(c6), None)
 
   def test_vin_repeat(self):
-    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.ALU, 'vin': {'uop': UOps.CONST}}, lambda x: x)])
+    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.ALU, "vin": {"uop": UOps.CONST}}, lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.float, arg=2.0)
     c3 = UOp(UOps.ALU, dtypes.float, (c1,c2), BinaryOps.ADD)
@@ -62,14 +62,14 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(matcher.rewrite(c4), None)
 
   def test_constant_arg(self):
-    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.CONST, 'arg': 42}, lambda x: x)])
+    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.CONST, "arg": 42}, lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.int, arg=42)
     c2 = UOp(UOps.CONST, dtypes.int, arg=43)
     self.assertEqual(matcher.rewrite(c1), c1)
     self.assertEqual(matcher.rewrite(c2), None)
 
   def test_gep_const(self):
-    matcher = PatternMatcher([({'__name__': "root", 'uop': UOps.GEP, 'vin': ({'__name__': "c", 'uop': UOps.CONST},)},
+    matcher = PatternMatcher([({"__name__": "root", "uop": UOps.GEP, "vin": ({"__name__": "c", "uop": UOps.CONST},)},
                                lambda root, c: UOp.const(root.dtype, c.arg))])
     c0 = UOp(UOps.CONST, dtypes.int, arg=42)
     c1 = UOp(UOps.CONST, dtypes.int, arg=42)
@@ -77,7 +77,7 @@ class TestPatternMatcher(unittest.TestCase):
     self.assert_equiv_uops(matcher.rewrite(a1), c0)
     
   def test_cast_const(self):
-    matcher = PatternMatcher([({'__name__': "root", 'uop': UOps.CAST, 'vin': {'__name__': "c", 'uop': UOps.CONST}},
+    matcher = PatternMatcher([({"__name__": "root", "uop": UOps.CAST, "vin": {"__name__": "c", "uop": UOps.CONST}},
                                lambda root, c: UOp.const(root.dtype, c.arg))])
     c0 = UOp(UOps.CONST, dtypes.float, arg=42)
     c1 = UOp(UOps.CONST, dtypes.int, arg=42)
@@ -85,37 +85,37 @@ class TestPatternMatcher(unittest.TestCase):
     self.assert_equiv_uops(matcher.rewrite(a1), c0)
   
   def test_zero_add(self):
-    matcher = PatternMatcher([({'uop': UOps.ALU, 'arg': BinaryOps.ADD, 'vin': [{'__name__': "x"},
-                                                                                      {'uop': UOps.CONST, 'arg': 0}]}, lambda x: x)])
+    matcher = PatternMatcher([({"uop": UOps.ALU, "arg": BinaryOps.ADD, "vin": [{"__name__": "x"},
+                                                                                      {"uop": UOps.CONST, "arg": 0}]}, lambda x: x)])
     c0 = UOp(UOps.CONST, dtypes.float, arg=0.0)
-    x = UOp(UOps.LOAD, dtypes.float, arg='x')
+    x = UOp(UOps.LOAD, dtypes.float, arg="x")
     a1 = UOp(UOps.ALU, dtypes.float, (c0,x), BinaryOps.ADD)
     a2 = UOp(UOps.ALU, dtypes.float, (x,c0), BinaryOps.ADD)
     self.assertEqual(matcher.rewrite(a1), x)
     self.assertEqual(matcher.rewrite(a2), x)
 
   def test_sub_zero(self):
-    matcher = PatternMatcher([({'uop': UOps.ALU, 'arg': BinaryOps.SUB, 'vin': ({'__name__': "x"},
-                                                                                      {'uop': UOps.CONST, 'arg': 0})}, lambda x: x)])
+    matcher = PatternMatcher([({"uop": UOps.ALU, "arg": BinaryOps.SUB, "vin": ({"__name__": "x"},
+                                                                                      {"uop": UOps.CONST, "arg": 0})}, lambda x: x)])
     c0 = UOp(UOps.CONST, dtypes.float, arg=0.0)
-    x = UOp(UOps.LOAD, dtypes.float, arg='x')
+    x = UOp(UOps.LOAD, dtypes.float, arg="x")
     a1 = UOp(UOps.ALU, dtypes.float, (c0,x), BinaryOps.SUB)
     a2 = UOp(UOps.ALU, dtypes.float, (x,c0), BinaryOps.SUB)
     self.assertEqual(matcher.rewrite(a1), None)
     self.assertEqual(matcher.rewrite(a2), x)
 
   def test_zero_mul(self):
-    matcher = PatternMatcher([({'uop': UOps.ALU, 'arg': BinaryOps.MUL, 'vin': [{},
-                                                    {'__name__': "c", 'uop': UOps.CONST, 'arg': 0}]}, lambda c: c)])
+    matcher = PatternMatcher([({"uop": UOps.ALU, "arg": BinaryOps.MUL, "vin": [{},
+                                                    {"__name__": "c", "uop": UOps.CONST, "arg": 0}]}, lambda c: c)])
     c0 = UOp(UOps.CONST, dtypes.float, arg=0.0)
-    x = UOp(UOps.LOAD, dtypes.float, arg='x')
+    x = UOp(UOps.LOAD, dtypes.float, arg="x")
     a1 = UOp(UOps.ALU, dtypes.float, (c0,x), BinaryOps.MUL)
     a2 = UOp(UOps.ALU, dtypes.float, (x,c0), BinaryOps.MUL)
     self.assertEqual(matcher.rewrite(a1), c0)
     self.assertEqual(matcher.rewrite(a2), c0)
 
   def test_self_sub(self):
-    matcher = PatternMatcher([({'uop': UOps.ALU, 'arg': BinaryOps.SUB, 'vin': ({'__name__': "x"}, {'__name__': "x"})},
+    matcher = PatternMatcher([({"uop": UOps.ALU, "arg": BinaryOps.SUB, "vin": ({"__name__": "x"}, {"__name__": "x"})},
                                lambda x: UOp.const(x.dtype, 0))])   # x-x -> 0
     c0_int = UOp(UOps.CONST, dtypes.int, arg=0)
     c0_float = UOp(UOps.CONST, dtypes.float, arg=0.0)
@@ -127,9 +127,9 @@ class TestPatternMatcher(unittest.TestCase):
     self.assert_equiv_uops(matcher.rewrite(a2), c0_float)
 
   def test_fold_neg_mul(self):
-    matcher = PatternMatcher([({'uop': UOps.ALU, 'arg': BinaryOps.MUL,
-                                       'vin': [{'__name__': "x"}, {'uop': UOps.CONST, 'arg': -1}]}, lambda x: -x)])
-    c1 = UOp(UOps.LOAD, dtypes.float, arg='xx')
+    matcher = PatternMatcher([({"uop": UOps.ALU, "arg": BinaryOps.MUL,
+                                       "vin": [{"__name__": "x"}, {"uop": UOps.CONST, "arg": -1}]}, lambda x: -x)])
+    c1 = UOp(UOps.LOAD, dtypes.float, arg="xx")
     c2 = UOp(UOps.CONST, dtypes.float, arg=-1)
     a1 = UOp(UOps.ALU, dtypes.float, (c1,c2), BinaryOps.MUL)
     a2 = UOp(UOps.ALU, dtypes.float, (c1), UnaryOps.NEG)
@@ -137,9 +137,9 @@ class TestPatternMatcher(unittest.TestCase):
 
   def test_nested_pattern(self):
     matcher = PatternMatcher([
-        ({'__name__': "x", 'uop': UOps.ALU, 'vin': [
-            {'uop': UOps.ALU, 'vin': [{'uop': UOps.CONST}, {'uop': UOps.CONST}]},
-            {'uop': UOps.CONST}]
+        ({"__name__": "x", "uop": UOps.ALU, "vin": [
+            {"uop": UOps.ALU, "vin": [{"uop": UOps.CONST}, {"uop": UOps.CONST}]},
+            {"uop": UOps.CONST}]
         }, lambda x: x)
     ])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
@@ -153,10 +153,10 @@ class TestPatternMatcher(unittest.TestCase):
   def test_rewrite_graph_folds(self):
     uops = UOpGraph()
     uops.add(UOps.CONST, dtypes.float, arg=2.0, simplify=False)
-    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.CONST, 'dtype': dtypes.float},
+    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.float},
                                 lambda x: UOp(UOps.CAST, dtypes.int, (UOp(UOps.ALU, x.dtype, (x, x), BinaryOps.ADD),)))])
     matcher.rewrite_graph(uops)
-    # TODO: fix this. it's 2 now
+    # TODO: fix this. it"s 2 now
     # self.assertEqual(len(uops.uops), 1)
     self.assertEqual(len(uops.uops), 2)
     self.assert_equiv_uops(UOp(UOps.CONST, dtypes.int, arg=4), uops.uops[-1])
@@ -165,7 +165,7 @@ class TestPatternMatcher(unittest.TestCase):
   def test_rewrite_graph_adds(self):
     uops = UOpGraph()
     uops.add(UOps.CONST, dtypes.int, arg=2, simplify=False)
-    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.CONST, 'dtype': dtypes.int},
+    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.int},
                                lambda x: UOp(UOps.STORE, x.dtype, (UOp(UOps.DEFINE_GLOBAL, x.dtype, tuple(), None), x)))])
     matcher.rewrite_graph(uops)
     uops.remove_childless(set(x for x in uops if x.uop in {UOps.STORE}))
@@ -180,5 +180,5 @@ class TestPatternMatcher(unittest.TestCase):
     self.assert_equiv_uops(e2, uops.uops[1])
     self.assert_equiv_uops(e3, uops.uops[2])
 
-if __name__ == '__main__':
+if __name__ == "__main__":
   unittest.main(verbosity=2)

--- a/test/test_pattern_matcher.py
+++ b/test/test_pattern_matcher.py
@@ -75,7 +75,7 @@ class TestPatternMatcher(unittest.TestCase):
     c1 = UOp(UOps.CONST, dtypes.int, arg=42)
     a1 = UOp(UOps.GEP, dtypes.int, (c1,))
     self.assert_equiv_uops(matcher.rewrite(a1), c0)
-    
+
   def test_cast_const(self):
     matcher = PatternMatcher([({"__name__": "root", "uop": UOps.CAST, "vin": {"__name__": "c", "uop": UOps.CONST}},
                                lambda root, c: UOp.const(root.dtype, c.arg))])
@@ -83,7 +83,7 @@ class TestPatternMatcher(unittest.TestCase):
     c1 = UOp(UOps.CONST, dtypes.int, arg=42)
     a1 = UOp(UOps.CAST, dtypes.float, (c1,))
     self.assert_equiv_uops(matcher.rewrite(a1), c0)
-  
+
   def test_zero_add(self):
     matcher = PatternMatcher([({"uop": UOps.ALU, "arg": BinaryOps.ADD, "vin": [{"__name__": "x"},
                                                                                       {"uop": UOps.CONST, "arg": 0}]}, lambda x: x)])

--- a/test/test_pattern_matcher.py
+++ b/test/test_pattern_matcher.py
@@ -124,7 +124,7 @@ class TestPatternMatcher(unittest.TestCase):
     c1 = UOp(UOps.CONST, dtypes.float, arg=42.0)
     c2 = UOp(UOps.CONST, dtypes.float, arg=-1.0)
     a1 = UOp(UOps.ALU, dtypes.float, (c1,c2), BinaryOps.MUL)
-    a2 = UOp(UOps.ALU, dtypes.float, (c1), UnaryOps.NEG)
+    a2 = UOp(UOps.ALU, dtypes.float, (c1,), UnaryOps.NEG)
     self.assert_equiv_uops(matcher.rewrite(a1), a2)
 
   def test_nested_pattern(self):

--- a/test/test_pattern_matcher.py
+++ b/test/test_pattern_matcher.py
@@ -171,7 +171,7 @@ class TestPatternMatcher(unittest.TestCase):
     a2 = UOp(UOps.ALU, dtypes.int, (a1,c1), BinaryOps.CMPLT)
     a3 = UOp(UOps.ALU, dtypes.bool, (c1_neg, c2), BinaryOps.CMPLT)
     self.assert_equiv_uops(matcher.rewrite(a2), a3)
-  
+
   @unittest.skip("no longer supported")
   def test_rewrite_graph_folds(self):
     uops = UOpGraph()

--- a/test/test_pattern_matcher.py
+++ b/test/test_pattern_matcher.py
@@ -271,5 +271,5 @@ class TestPatternMatcher(unittest.TestCase):
     self.assert_equiv_uops(e2, uops.uops[1])
     self.assert_equiv_uops(e3, uops.uops[2])
 
-if __name__ == "__main__":
+if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/test_pattern_matcher.py
+++ b/test/test_pattern_matcher.py
@@ -129,13 +129,6 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(matcher.rewrite(c6), None)
     self.assertEqual(matcher.rewrite(c7), c7)
 
-  def test_constant_arg(self):
-    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.CONST, "arg": 42}, lambda x: x)])
-    c1 = UOp(UOps.CONST, dtypes.int, arg=42)
-    c2 = UOp(UOps.CONST, dtypes.int, arg=43)
-    self.assertEqual(matcher.rewrite(c1), c1)
-    self.assertEqual(matcher.rewrite(c2), None)
-
   def test_cast_const(self):
     matcher = PatternMatcher([({"__name__": "root", "uop": UOps.CAST, "vin": {"__name__": "c", "uop": UOps.CONST}},
                                lambda root, c: UOp.const(root.dtype, c.arg))])
@@ -236,7 +229,7 @@ class TestPatternMatcher(unittest.TestCase):
     c1_neg = UOp(UOps.CONST, dtypes.int, arg=-42)
     c2 = UOp(UOps.CONST, dtypes.int, arg=50)
     a1 = UOp(UOps.ALU, dtypes.int, (c2,), UnaryOps.NEG)
-    a2 = UOp(UOps.ALU, dtypes.int, (a1,c1), BinaryOps.CMPLT)
+    a2 = UOp(UOps.ALU, dtypes.bool, (a1,c1), BinaryOps.CMPLT)
     a3 = UOp(UOps.ALU, dtypes.bool, (c1_neg, c2), BinaryOps.CMPLT)
     self.assert_equiv_uops(matcher.rewrite(a2), a3)
 

--- a/test/test_pattern_matcher.py
+++ b/test/test_pattern_matcher.py
@@ -68,14 +68,6 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(matcher.rewrite(c1), c1)
     self.assertEqual(matcher.rewrite(c2), None)
 
-  def test_gep_const(self):
-    matcher = PatternMatcher([({"__name__": "root", "uop": UOps.GEP, "vin": ({"__name__": "c", "uop": UOps.CONST},)},
-                               lambda root, c: UOp.const(root.dtype, c.arg))])
-    c0 = UOp(UOps.CONST, dtypes.int, arg=42)
-    c1 = UOp(UOps.CONST, dtypes.int, arg=42)
-    a1 = UOp(UOps.GEP, dtypes.int, (c1,), arg=42)
-    self.assert_equiv_uops(matcher.rewrite(a1), c0)
-
   def test_cast_const(self):
     matcher = PatternMatcher([({"__name__": "root", "uop": UOps.CAST, "vin": {"__name__": "c", "uop": UOps.CONST}},
                                lambda root, c: UOp.const(root.dtype, c.arg))])

--- a/test/test_pattern_matcher.py
+++ b/test/test_pattern_matcher.py
@@ -73,13 +73,13 @@ class TestPatternMatcher(unittest.TestCase):
                                lambda root, c: UOp.const(root.dtype, c.arg))])
     c0 = UOp(UOps.CONST, dtypes.int, arg=42)
     c1 = UOp(UOps.CONST, dtypes.int, arg=42)
-    a1 = UOp(UOps.GEP, dtypes.int, (c1,))
+    a1 = UOp(UOps.GEP, dtypes.int, (c1,), arg=42)
     self.assert_equiv_uops(matcher.rewrite(a1), c0)
 
   def test_cast_const(self):
     matcher = PatternMatcher([({"__name__": "root", "uop": UOps.CAST, "vin": {"__name__": "c", "uop": UOps.CONST}},
                                lambda root, c: UOp.const(root.dtype, c.arg))])
-    c0 = UOp(UOps.CONST, dtypes.float, arg=42)
+    c0 = UOp(UOps.CONST, dtypes.float, arg=42.0)
     c1 = UOp(UOps.CONST, dtypes.int, arg=42)
     a1 = UOp(UOps.CAST, dtypes.float, (c1,))
     self.assert_equiv_uops(matcher.rewrite(a1), c0)
@@ -88,7 +88,7 @@ class TestPatternMatcher(unittest.TestCase):
     matcher = PatternMatcher([({"uop": UOps.ALU, "arg": BinaryOps.ADD, "vin": [{"__name__": "x"},
                                                                                       {"uop": UOps.CONST, "arg": 0}]}, lambda x: x)])
     c0 = UOp(UOps.CONST, dtypes.float, arg=0.0)
-    x = UOp(UOps.LOAD, dtypes.float, arg="x")
+    x = UOp(UOps.CONST, dtypes.float, arg=55.0)
     a1 = UOp(UOps.ALU, dtypes.float, (c0,x), BinaryOps.ADD)
     a2 = UOp(UOps.ALU, dtypes.float, (x,c0), BinaryOps.ADD)
     self.assertEqual(matcher.rewrite(a1), x)
@@ -98,7 +98,7 @@ class TestPatternMatcher(unittest.TestCase):
     matcher = PatternMatcher([({"uop": UOps.ALU, "arg": BinaryOps.SUB, "vin": ({"__name__": "x"},
                                                                                       {"uop": UOps.CONST, "arg": 0})}, lambda x: x)])
     c0 = UOp(UOps.CONST, dtypes.float, arg=0.0)
-    x = UOp(UOps.LOAD, dtypes.float, arg="x")
+    x = UOp(UOps.CONST, dtypes.float, arg=42.0)
     a1 = UOp(UOps.ALU, dtypes.float, (c0,x), BinaryOps.SUB)
     a2 = UOp(UOps.ALU, dtypes.float, (x,c0), BinaryOps.SUB)
     self.assertEqual(matcher.rewrite(a1), None)
@@ -108,7 +108,7 @@ class TestPatternMatcher(unittest.TestCase):
     matcher = PatternMatcher([({"uop": UOps.ALU, "arg": BinaryOps.MUL, "vin": [{},
                                                     {"__name__": "c", "uop": UOps.CONST, "arg": 0}]}, lambda c: c)])
     c0 = UOp(UOps.CONST, dtypes.float, arg=0.0)
-    x = UOp(UOps.LOAD, dtypes.float, arg="x")
+    x = UOp(UOps.CONST, dtypes.float, arg=42.0)
     a1 = UOp(UOps.ALU, dtypes.float, (c0,x), BinaryOps.MUL)
     a2 = UOp(UOps.ALU, dtypes.float, (x,c0), BinaryOps.MUL)
     self.assertEqual(matcher.rewrite(a1), c0)
@@ -129,8 +129,8 @@ class TestPatternMatcher(unittest.TestCase):
   def test_fold_neg_mul(self):
     matcher = PatternMatcher([({"uop": UOps.ALU, "arg": BinaryOps.MUL,
                                        "vin": [{"__name__": "x"}, {"uop": UOps.CONST, "arg": -1}]}, lambda x: -x)])
-    c1 = UOp(UOps.LOAD, dtypes.float, arg="xx")
-    c2 = UOp(UOps.CONST, dtypes.float, arg=-1)
+    c1 = UOp(UOps.CONST, dtypes.float, arg=42.0)
+    c2 = UOp(UOps.CONST, dtypes.float, arg=-1.0)
     a1 = UOp(UOps.ALU, dtypes.float, (c1,c2), BinaryOps.MUL)
     a2 = UOp(UOps.ALU, dtypes.float, (c1), UnaryOps.NEG)
     self.assert_equiv_uops(matcher.rewrite(a1), a2)

--- a/test/test_pattern_matcher.py
+++ b/test/test_pattern_matcher.py
@@ -1,6 +1,6 @@
 import unittest
 from tinygrad.dtype import dtypes
-from tinygrad.ops import BinaryOps
+from tinygrad.ops import BinaryOps, UnaryOps
 from tinygrad.codegen.uops import UOpGraph, UOps, PatternMatcher, UOp
 
 class TestPatternMatcher(unittest.TestCase):
@@ -11,25 +11,28 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(uop1.arg, uop2.arg)
 
   def test_simple_match(self):
-    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.float}, lambda x: x)])
+    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.CONST, 'dtype': dtypes.float}, lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.int, arg=1)
     self.assertEqual(matcher.rewrite(c1), c1)
     self.assertEqual(matcher.rewrite(c2), None)
 
   def test_dtype_set(self):
-    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.CONST, "dtype": set([dtypes.float32, dtypes.float64])}, lambda x: x)])
+    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.CONST, 'dtype': set([dtypes.float32, dtypes.float64, dtypes.bool])}, lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.float64, arg=1.0)
     c3 = UOp(UOps.CONST, dtypes.float16, arg=1.0)
     c4 = UOp(UOps.CONST, dtypes.int, arg=1)
+    c5 = UOp(UOps.CONST, dtypes.bool, arg=True)
     self.assertEqual(matcher.rewrite(c1), c1)
     self.assertEqual(matcher.rewrite(c2), c2)
     self.assertEqual(matcher.rewrite(c3), None)
     self.assertEqual(matcher.rewrite(c4), None)
+    self.assertEqual(matcher.rewrite(c5), c5)
 
   def test_vin_one(self):
-    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.ALU, "vin":({"uop": UOps.CONST}, {"uop": UOps.CONST})}, lambda x: x)])
+    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.ALU, 'vin':({'uop': UOps.CONST}, {'uop': UOps.CONST})},
+                               lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.float, arg=2.0)
     c3 = UOp(UOps.ALU, dtypes.float, (c1,c2), BinaryOps.ADD)
@@ -37,7 +40,7 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(matcher.rewrite(c2), None)
 
   def test_vin_permutations(self):
-    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.ALU, "vin":[{"uop": UOps.CONST}, {"uop": UOps.ALU}]}, lambda x: x)])
+    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.ALU, 'vin':[{'uop': UOps.CONST}, {'uop': UOps.ALU}]}, lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.float, arg=2.0)
     c3 = UOp(UOps.ALU, dtypes.float, (c1,c2), BinaryOps.ADD)
@@ -50,7 +53,7 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(matcher.rewrite(c6), None)
 
   def test_vin_repeat(self):
-    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.ALU, "vin":{"uop": UOps.CONST}}, lambda x: x)])
+    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.ALU, 'vin': {'uop': UOps.CONST}}, lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.float, arg=2.0)
     c3 = UOp(UOps.ALU, dtypes.float, (c1,c2), BinaryOps.ADD)
@@ -58,11 +61,99 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(matcher.rewrite(c3), c3)
     self.assertEqual(matcher.rewrite(c4), None)
 
+  def test_constant_arg(self):
+    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.CONST, 'arg': 42}, lambda x: x)])
+    c1 = UOp(UOps.CONST, dtypes.int, arg=42)
+    c2 = UOp(UOps.CONST, dtypes.int, arg=43)
+    self.assertEqual(matcher.rewrite(c1), c1)
+    self.assertEqual(matcher.rewrite(c2), None)
+
+  def test_gep_const(self):
+    matcher = PatternMatcher([({'__name__': "root", 'uop': UOps.GEP, 'vin': ({'__name__': "c", 'uop': UOps.CONST},)},
+                               lambda root, c: UOp.const(root.dtype, c.arg))])
+    c0 = UOp(UOps.CONST, dtypes.int, arg=42)
+    c1 = UOp(UOps.CONST, dtypes.int, arg=42)
+    a1 = UOp(UOps.GEP, dtypes.int, (c1,))
+    self.assert_equiv_uops(matcher.rewrite(a1), c0)
+    
+  def test_cast_const(self):
+    matcher = PatternMatcher([({'__name__': "root", 'uop': UOps.CAST, 'vin': {'__name__': "c", 'uop': UOps.CONST}},
+                               lambda root, c: UOp.const(root.dtype, c.arg))])
+    c0 = UOp(UOps.CONST, dtypes.float, arg=42)
+    c1 = UOp(UOps.CONST, dtypes.int, arg=42)
+    a1 = UOp(UOps.CAST, dtypes.float, (c1,))
+    self.assert_equiv_uops(matcher.rewrite(a1), c0)
+  
+  def test_zero_add(self):
+    matcher = PatternMatcher([({'uop': UOps.ALU, 'arg': BinaryOps.ADD, 'vin': [{'__name__': "x"},
+                                                                                      {'uop': UOps.CONST, 'arg': 0}]}, lambda x: x)])
+    c0 = UOp(UOps.CONST, dtypes.float, arg=0.0)
+    x = UOp(UOps.LOAD, dtypes.float, arg='x')
+    a1 = UOp(UOps.ALU, dtypes.float, (c0,x), BinaryOps.ADD)
+    a2 = UOp(UOps.ALU, dtypes.float, (x,c0), BinaryOps.ADD)
+    self.assertEqual(matcher.rewrite(a1), x)
+    self.assertEqual(matcher.rewrite(a2), x)
+
+  def test_sub_zero(self):
+    matcher = PatternMatcher([({'uop': UOps.ALU, 'arg': BinaryOps.SUB, 'vin': ({'__name__': "x"},
+                                                                                      {'uop': UOps.CONST, 'arg': 0})}, lambda x: x)])
+    c0 = UOp(UOps.CONST, dtypes.float, arg=0.0)
+    x = UOp(UOps.LOAD, dtypes.float, arg='x')
+    a1 = UOp(UOps.ALU, dtypes.float, (c0,x), BinaryOps.SUB)
+    a2 = UOp(UOps.ALU, dtypes.float, (x,c0), BinaryOps.SUB)
+    self.assertEqual(matcher.rewrite(a1), None)
+    self.assertEqual(matcher.rewrite(a2), x)
+
+  def test_zero_mul(self):
+    matcher = PatternMatcher([({'uop': UOps.ALU, 'arg': BinaryOps.MUL, 'vin': [{},
+                                                    {'__name__': "c", 'uop': UOps.CONST, 'arg': 0}]}, lambda c: c)])
+    c0 = UOp(UOps.CONST, dtypes.float, arg=0.0)
+    x = UOp(UOps.LOAD, dtypes.float, arg='x')
+    a1 = UOp(UOps.ALU, dtypes.float, (c0,x), BinaryOps.MUL)
+    a2 = UOp(UOps.ALU, dtypes.float, (x,c0), BinaryOps.MUL)
+    self.assertEqual(matcher.rewrite(a1), c0)
+    self.assertEqual(matcher.rewrite(a2), c0)
+
+  def test_self_sub(self):
+    matcher = PatternMatcher([({'uop': UOps.ALU, 'arg': BinaryOps.SUB, 'vin': ({'__name__': "x"}, {'__name__': "x"})},
+                               lambda x: UOp.const(x.dtype, 0))])   # x-x -> 0
+    c0_int = UOp(UOps.CONST, dtypes.int, arg=0)
+    c0_float = UOp(UOps.CONST, dtypes.float, arg=0.0)
+    c1 = UOp(UOps.CONST, dtypes.int, arg=10)
+    c2 = UOp(UOps.CONST, dtypes.float, arg=55.55)
+    a1 = UOp(UOps.ALU, dtypes.int, (c1,c1), BinaryOps.SUB)
+    a2 = UOp(UOps.ALU, dtypes.float, (c2,c2), BinaryOps.SUB)
+    self.assert_equiv_uops(matcher.rewrite(a1), c0_int)
+    self.assert_equiv_uops(matcher.rewrite(a2), c0_float)
+
+  def test_fold_neg_mul(self):
+    matcher = PatternMatcher([({'uop': UOps.ALU, 'arg': BinaryOps.MUL,
+                                       'vin': [{'__name__': "x"}, {'uop': UOps.CONST, 'arg': -1}]}, lambda x: -x)])
+    c1 = UOp(UOps.LOAD, dtypes.float, arg='xx')
+    c2 = UOp(UOps.CONST, dtypes.float, arg=-1)
+    a1 = UOp(UOps.ALU, dtypes.float, (c1,c2), BinaryOps.MUL)
+    a2 = UOp(UOps.ALU, dtypes.float, (c1), UnaryOps.NEG)
+    self.assert_equiv_uops(matcher.rewrite(a1), a2)
+
+  def test_nested_pattern(self):
+    matcher = PatternMatcher([
+        ({'__name__': "x", 'uop': UOps.ALU, 'vin': [
+            {'uop': UOps.ALU, 'vin': [{'uop': UOps.CONST}, {'uop': UOps.CONST}]},
+            {'uop': UOps.CONST}]
+        }, lambda x: x)
+    ])
+    c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
+    c2 = UOp(UOps.CONST, dtypes.float, arg=2.0)
+    inner_op = UOp(UOps.ALU, dtypes.float, (c1, c2), BinaryOps.ADD)
+    outer_op = UOp(UOps.ALU, dtypes.float, (inner_op, c2), BinaryOps.ADD)
+    self.assertEqual(matcher.rewrite(outer_op), outer_op)
+    self.assertEqual(matcher.rewrite(inner_op), None)
+
   @unittest.skip("no longer supported")
   def test_rewrite_graph_folds(self):
     uops = UOpGraph()
     uops.add(UOps.CONST, dtypes.float, arg=2.0, simplify=False)
-    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.float},
+    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.CONST, 'dtype': dtypes.float},
                                 lambda x: UOp(UOps.CAST, dtypes.int, (UOp(UOps.ALU, x.dtype, (x, x), BinaryOps.ADD),)))])
     matcher.rewrite_graph(uops)
     # TODO: fix this. it's 2 now
@@ -74,7 +165,7 @@ class TestPatternMatcher(unittest.TestCase):
   def test_rewrite_graph_adds(self):
     uops = UOpGraph()
     uops.add(UOps.CONST, dtypes.int, arg=2, simplify=False)
-    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.int},
+    matcher = PatternMatcher([({'__name__': "x", 'uop': UOps.CONST, 'dtype': dtypes.int},
                                lambda x: UOp(UOps.STORE, x.dtype, (UOp(UOps.DEFINE_GLOBAL, x.dtype, tuple(), None), x)))])
     matcher.rewrite_graph(uops)
     uops.remove_childless(set(x for x in uops if x.uop in {UOps.STORE}))

--- a/test/test_pattern_matcher.py
+++ b/test/test_pattern_matcher.py
@@ -156,7 +156,7 @@ class TestPatternMatcher(unittest.TestCase):
     matcher = PatternMatcher([({"__name__": "x", "uop": UOps.CONST, "dtype": dtypes.float},
                                 lambda x: UOp(UOps.CAST, dtypes.int, (UOp(UOps.ALU, x.dtype, (x, x), BinaryOps.ADD),)))])
     matcher.rewrite_graph(uops)
-    # TODO: fix this. it"s 2 now
+    # TODO: fix this. it's 2 now
     # self.assertEqual(len(uops.uops), 1)
     self.assertEqual(len(uops.uops), 2)
     self.assert_equiv_uops(UOp(UOps.CONST, dtypes.int, arg=4), uops.uops[-1])

--- a/test/test_pattern_matcher.py
+++ b/test/test_pattern_matcher.py
@@ -1,6 +1,6 @@
 import unittest
 from tinygrad.dtype import dtypes
-from tinygrad.ops import BinaryOps, UnaryOps, TernaryOps
+from tinygrad.ops import BinaryOps, TernaryOps, UnaryOps
 from tinygrad.codegen.uops import UOpGraph, UOps, PatternMatcher, UOp
 
 class TestPatternMatcher(unittest.TestCase):
@@ -82,8 +82,7 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(matcher.rewrite(c5), c5)
 
   def test_vin_one(self):
-    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.ALU, "vin":({"uop": UOps.CONST}, {"uop": UOps.CONST})},
-                               lambda x: x)])
+    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.ALU, "vin":({"uop": UOps.CONST}, {"uop": UOps.CONST})}, lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.float, arg=2.0)
     c3 = UOp(UOps.ALU, dtypes.float, (c1,c2), BinaryOps.ADD)
@@ -110,7 +109,7 @@ class TestPatternMatcher(unittest.TestCase):
     self.assertEqual(matcher.rewrite(c6), None)
 
   def test_vin_repeat(self):
-    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.ALU, "vin": {"uop": UOps.CONST}}, lambda x: x)])
+    matcher = PatternMatcher([({"__name__": "x", "uop": UOps.ALU, "vin":{"uop": UOps.CONST}}, lambda x: x)])
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.float, arg=2.0)
     c3 = UOp(UOps.ALU, dtypes.float, (c1,c2), BinaryOps.ADD)


### PR DESCRIPTION
This is a reopen of #4744 because I'm confident that the closing comment was for another pr as this pr only dealt with testing the existing pattern matcher functionality. There was no line getbacks or functionality changes. Once this pr gets merged to master, I can be able to prove that #4670 introduces no functional changes. 