### PR TITLE
configure derandomizing CI tests

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -8,7 +8,7 @@ from tinygrad import Device, Tensor, dtypes
 from hypothesis import given, settings, strategies as strat
 from test.helpers import is_dtype_supported, rand_for_dtype
 
-settings.register_profile("my_profile", max_examples=200, deadline=None)
+settings.register_profile("my_profile", max_examples=200, deadline=None, derandomize=getenv("DERANDOMIZE_CI", False))
 settings.load_profile("my_profile")
 
 core_dtypes = list(DTYPES_DICT.values())

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -11,7 +11,7 @@ from tinygrad.engine.realize import run_schedule
 from tinygrad.ops import UnaryOps
 from test.helpers import is_dtype_supported
 
-settings.register_profile("my_profile", max_examples=200, deadline=None)
+settings.register_profile("my_profile", max_examples=200, deadline=None, derandomize=getenv("DERANDOMIZE_CI", False))
 settings.load_profile("my_profile")
 print(settings.default)
 

--- a/test/test_fuzz_shape_ops.py
+++ b/test/test_fuzz_shape_ops.py
@@ -7,11 +7,11 @@ from hypothesis.extra import numpy as stn
 import numpy as np
 import torch
 from tinygrad import Tensor, Device
-from tinygrad.helpers import CI
+from tinygrad.helpers import CI, getenv
 
 
 settings.register_profile(__file__, settings.default,
-                          max_examples=100 if CI else 250, deadline=None)
+                          max_examples=100 if CI else 250, deadline=None, derandomize=getenv("DERANDOMIZE_CI", False))
 
 
 # torch wraparound for large numbers

--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -2,7 +2,7 @@ import unittest, functools, random
 from typing import List
 from tinygrad import Tensor, Device, nn, GlobalCounters, TinyJit, dtypes
 from tinygrad.ops import LoadOps, ReduceOps
-from tinygrad.helpers import CI, prod, Context
+from tinygrad.helpers import CI, getenv, prod, Context
 from tinygrad.nn.state import get_parameters, get_state_dict
 from tinygrad.engine.schedule import create_schedule
 from tinygrad.engine.realize import lower_schedule, BufferCopy, CompiledRunner
@@ -12,7 +12,7 @@ import numpy as np
 from hypothesis import given, strategies as strat, settings
 from test.helpers import is_dtype_supported
 
-settings.register_profile("my_profile", max_examples=200, deadline=None)
+settings.register_profile("my_profile", max_examples=200, deadline=None, derandomize=getenv("DERANDOMIZE_CI", False))
 settings.load_profile("my_profile")
 
 d_zero = f"{Device.DEFAULT}:0"

--- a/test/test_randomness.py
+++ b/test/test_randomness.py
@@ -4,11 +4,11 @@ from functools import partial
 import numpy as np
 import torch
 from tinygrad import nn, dtypes, Tensor, Device
-from tinygrad.helpers import THREEFRY
+from tinygrad.helpers import THREEFRY, getenv
 from test.helpers import is_dtype_supported
 from hypothesis import given, settings, strategies as strat
 
-settings.register_profile("my_profile", max_examples=200, deadline=None)
+settings.register_profile("my_profile", max_examples=200, deadline=None, derandomize=getenv("DERANDOMIZE_CI", False))
 settings.load_profile("my_profile")
 
 # https://gist.github.com/devries/11405101

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -3,11 +3,11 @@ import torch
 import unittest, copy
 import mmap
 from tinygrad import Tensor, Device, dtypes
-from tinygrad.helpers import temp, CI
+from tinygrad.helpers import getenv, temp, CI
 from extra.gradcheck import numerical_jacobian, jacobian, gradcheck
 from hypothesis import given, settings, strategies as strat
 
-settings.register_profile("my_profile", max_examples=200, deadline=None)
+settings.register_profile("my_profile", max_examples=200, deadline=None, derandomize=getenv("DERANDOMIZE_CI", False))
 settings.load_profile("my_profile")
 
 x_init = np.random.randn(1,3).astype(np.float32)


### PR DESCRIPTION
This makes running process replay tests on the entire CI possible,
the flag enforces a deterministic hash for hypothesis. https://hypothesis.readthedocs.io/en/latest/settings.html