### PR TITLE
Nest ifs for dtype and uop in pattern matcher

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -99,10 +99,14 @@ def _match(uop:UOp, pat:UPat, store:Dict[str, UOp]) -> bool:
     if isinstance(pat.arg, set):
       if uop.arg not in pat.arg: return False
     elif uop.arg != pat.arg: return False
-  if isinstance(pat.dtype, set) and uop.dtype not in pat.dtype: return False
-  if isinstance(pat.dtype, DType) and uop.dtype != pat.dtype: return False
-  if isinstance(pat.uop, set) and uop.uop not in pat.uop: return False
-  if isinstance(pat.uop, UOps) and uop.uop != pat.uop: return False
+  if pat.dtype is not None:
+    if isinstance(pat.dtype, set):
+      if uop.dtype not in pat.dtype: return False
+    elif uop.dtype != pat.dtype: return False
+  if pat.uop is not None:
+    if isinstance(pat.uop, set):
+      if uop.uop not in pat.uop: return False
+    elif uop.uop != pat.uop: return False
   if pat.vin is None: return True
   # only one if it's a tuple
   # try all permutations if it's a list


### PR DESCRIPTION
Makes things consistent with arg, also this addresses most of the performance regression in #4791.

Average over 10 runs on an m1 macbook air:

master
```
forward 29.906 ms
schedule 9.563 ms
lower 1571.959 ms ​
```

this branch:
```
forward 29.568 ms
schedule 9.413 ms
lower 1479.284 ms ​
```