### PR TITLE
Disable slow test_padto_matmul for PTX 

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1319,7 +1319,7 @@ class TestKernelOpts(unittest.TestCase):
       check_fused_tc_opt(tc, r0, r1, [a, b, c, d])
 
   def test_padto_matmul(self):
-    if CI and Device.DEFAULT in ["AMD", "NV"]: self.skipTest("super slow on CUDA and AMD because of the big grid dims")
+    if CI and Device.DEFAULT in ["AMD", "NV", "CUDA"]: self.skipTest("super slow on CUDA and AMD because of the big grid dims")
     N = 17 * 17
     Tensor.manual_seed(289)
     a = Tensor.rand(N, N)


### PR DESCRIPTION
Disabled on AMD and NV but was enabled for PTX
```
289.44s call     test/test_linearizer.py::TestKernelOpts::test_padto_matmul
```
