### PR TITLE
Replace tqdm

### DIFF
--- a/extra/augment.py
+++ b/extra/augment.py
@@ -6,11 +6,11 @@ cwd = Path.cwd()
 sys.path.append(cwd.as_posix())
 sys.path.append((cwd / 'test').as_posix())
 from extra.datasets import fetch_mnist
-from tqdm import trange
+from helpers import progress_bar
 
 def augment_img(X, rotate=10, px=3):
   Xaug = np.zeros_like(X)
-  for i in trange(len(X)):
+  for i in progress_bar(range(len(X))):
     im = Image.fromarray(X[i])
     im = im.rotate(np.random.randint(-rotate,rotate), resample=Image.BICUBIC)
     w, h = X.shape[1:]

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -15,10 +15,10 @@ def prod(x:Iterable[T]) -> Union[T,int]: return functools.reduce(operator.mul, x
 OSX = platform.system() == "Darwin"
 CI = os.getenv("CI", "") != ""
 def progress_bar(iterable, length=50, fill='█'):
-    start = time(); print(f'{0}% | {'-'*length} 0/{len(iterable)} 00:00<?,?it/s', end='\r')
+    start = time(); print(f'{0}%|{' '*length} 0/{len(iterable)} 00:00<?,?it/s', end='\r')
     for i, item in enumerate(iterable):
-        yield item; elapsed, percent, bar = time()-start, round(100*((i+1)/float(len(iterable))),1),fill*int(length * (i+1) // len(iterable)) + '-' * (length - int(length * (i+1) // len(iterable)))
-        print(f'{percent}% |{bar}|{i+1}/{len(iterable)}[{strftime("%H:%M:%S", gmtime(elapsed))}<{strftime("%H:%M:%S",gmtime(elapsed-elapsed/(percent/100)))},{str(round((i+1)/elapsed,2))+'it/s' if (i+1)/elapsed>=0.1 else str(round(elapsed/(i+1),2))+'s/it'}]', end='\n' if i+1==len(iterable) else '\r') 
+        yield item; elapsed, percent, bar = time.time()-start, round(100*((i+1)/float(len(iterable))),1),fill * int(length*(i+1)//len(iterable)) + ' ' * (length-int(length*(i+1)//len(iterable)))
+        print(f'{percent}%|{bar}|{i+1}/{len(iterable)}[{time.strftime("%H:%M:%S", time.gmtime(elapsed))}<{time.strftime("%H:%M:%S",time.gmtime(elapsed*(1-1/(percent/100)))},{str(round((i+1)/elapsed,2))+'it/s' if (i+1)/elapsed>=0.1 else str(round(elapsed/(i+1),2))+'s/it'}]', end='\n' if i+1==len(iterable) else '\r') 
 def dedup(x:Iterable[T]): return list(dict.fromkeys(x))   # retains list order
 def argfix(*x):
   if x and x[0].__class__ in (tuple, list):

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -16,10 +16,10 @@ def prod(x:Iterable[T]) -> Union[T,int]: return functools.reduce(operator.mul, x
 OSX = platform.system() == "Darwin"
 CI = os.getenv("CI", "") != ""
 def progress_bar(iterable, length=50, fill='█'):
-    start = time(); print(f'{0}%|{' '*length} 0/{len(iterable)} 00:00<?,?it/s', end='\r')
+    start = time.time(); print(f'{0}%|{' '*length} 0/{len(iterable)} 00:00<?,?it/s', end='\r')
     for i, item in enumerate(iterable):
-        yield item; elapsed, percent, bar = time.time()-start, round(100*((i+1)/float(len(iterable))),1),fill * int(length*(i+1)//len(iterable)) + ' ' * (length-int(length*(i+1)//len(iterable)))
-        print(f'{percent}%|{bar}|{i+1}/{len(iterable)}[{time.strftime("%H:%M:%S", time.gmtime(elapsed))}<{time.strftime("%H:%M:%S",time.gmtime(elapsed*(1-1/(percent/100)))},{str(round((i+1)/elapsed,2))+'it/s' if (i+1)/elapsed>=0.1 else str(round(elapsed/(i+1),2))+'s/it'}]', end='\n' if i+1==len(iterable) else '\r') 
+        yield item; elapsed, percent, bar = time.time()-start, round(100*((i+1)/float(len(iterable))),1),fill*int(length * (i+1) // len(iterable)) + ' ' * (length - int(length * (i+1) // len(iterable)))
+        print(f'{percent}%|{bar}|{i+1}/{len(iterable)}[{time.strftime("%H:%M:%S", time.gmtime(elapsed))}<{time.strftime("%H:%M:%S",time.gmtime(elapsed-elapsed/(percent/100)))},{str(round((i+1)/elapsed,2))+'it/s' if (i+1)/elapsed>=0.1 else str(round(elapsed/(i+1),2))+'s/it'}]', end='\n' if i+1==len(iterable) else '\r')
 def dedup(x:Iterable[T]): return list(dict.fromkeys(x))   # retains list order
 def argfix(*x):
   if x and x[0].__class__ in (tuple, list):

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -18,7 +18,7 @@ CI = os.getenv("CI", "") != ""
 def progress_bar(iterable, length=50, fill='█'):
     start = time.time(); print('{0}%|{1} 0/{2} 00:00<?,?it/s'.format(0, ' ' * length, len(iterable)), end='\r')
     for i, item in enumerate(iterable):
-        yield item; elapsed, percent, bar = time.time() - start, round(100 * ((i + 1) / float(len(iterable))), 1), fill * int(length * (i + 1) // len(iterable)) + ' ' * (length - int(length * (i + 1) // len(iterable)))
+        yield item; elapsed, percent, bar = time.time()-start, round(100*((i+1)/float(len(iterable))),1), fill * int(length*(i+1)//len(iterable)) + ' ' * (length-int(length*(i+1)//len(iterable)))
         print("{0}%|{1}|{2}/{3}[{4}<{5},{6}]".format(percent,bar,i+1,len(iterable), time.strftime("%H:%M:%S", time.gmtime(elapsed)),time.strftime("%H:%M:%S", time.gmtime(elapsed*(1-1/(percent/100)))),str(round((i+1)/elapsed,2)) + 'it/s' if (i+1)/elapsed >= 0.1 else str(round(elapsed/(i+1),2))+'s/it'), end='\n' if i+1==len(iterable) else '\r')
 def dedup(x:Iterable[T]): return list(dict.fromkeys(x))   # retains list order
 def argfix(*x):

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -16,8 +16,7 @@ def prod(x:Iterable[T]) -> Union[T,int]: return functools.reduce(operator.mul, x
 OSX = platform.system() == "Darwin"
 CI = os.getenv("CI", "") != ""
 def progress_bar(iterable, length=50, fill='█'):
-    start = time.time()
-    print('{0}%|{1} 0/{2} 00:00<?,?it/s'.format(0, ' ' * length, len(iterable)), end='\r')
+    start = time.time(); print('{0}%|{1} 0/{2} 00:00<?,?it/s'.format(0, ' ' * length, len(iterable)), end='\r')
     for i, item in enumerate(iterable):
         yield item; elapsed, percent, bar = time.time() - start, round(100 * ((i + 1) / float(len(iterable))), 1), fill * int(length * (i + 1) // len(iterable)) + ' ' * (length - int(length * (i + 1) // len(iterable)))
         print("{0}%|{1}|{2}/{3}[{4}<{5},{6}]".format(percent,bar,i+1,len(iterable), time.strftime("%H:%M:%S", time.gmtime(elapsed)),time.strftime("%H:%M:%S", time.gmtime(elapsed*(1-1/(percent/100)))),str(round((i+1)/elapsed,2)) + 'it/s' if (i+1)/elapsed >= 0.1 else str(round(elapsed/(i+1),2))+'s/it'), end='\n' if i+1==len(iterable) else '\r')

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -16,10 +16,11 @@ def prod(x:Iterable[T]) -> Union[T,int]: return functools.reduce(operator.mul, x
 OSX = platform.system() == "Darwin"
 CI = os.getenv("CI", "") != ""
 def progress_bar(iterable, length=50, fill='█'):
-    start = time.time(); print(f'{0}%|{' '*length} 0/{len(iterable)} 00:00<?,?it/s', end='\r')
+    start = time.time()
+    print('{0}%|{1} 0/{2} 00:00<?,?it/s'.format(0, ' ' * length, len(iterable)), end='\r')
     for i, item in enumerate(iterable):
-        yield item; elapsed, percent, bar = time.time()-start, round(100*((i+1)/float(len(iterable))),1),fill*int(length * (i+1) // len(iterable)) + ' ' * (length - int(length * (i+1) // len(iterable)))
-        print(f'{percent}%|{bar}|{i+1}/{len(iterable)}[{time.strftime("%H:%M:%S", time.gmtime(elapsed))}<{time.strftime("%H:%M:%S",time.gmtime(elapsed-elapsed/(percent/100)))},{str(round((i+1)/elapsed,2))+'it/s' if (i+1)/elapsed>=0.1 else str(round(elapsed/(i+1),2))+'s/it'}]', end='\n' if i+1==len(iterable) else '\r')
+        yield item; elapsed, percent, bar = time.time() - start, round(100 * ((i + 1) / float(len(iterable))), 1), fill * int(length * (i + 1) // len(iterable)) + ' ' * (length - int(length * (i + 1) // len(iterable)))
+        print("{0}%|{1}|{2}/{3}[{4}<{5},{6}]".format(percent,bar,i+1,len(iterable), time.strftime("%H:%M:%S", time.gmtime(elapsed)),time.strftime("%H:%M:%S", time.gmtime(elapsed*(1-1/(percent/100)))),str(round((i+1)/elapsed,2)) + 'it/s' if (i+1)/elapsed >= 0.1 else str(round(elapsed/(i+1),2))+'s/it'), end='\n' if i+1==len(iterable) else '\r')
 def dedup(x:Iterable[T]): return list(dict.fromkeys(x))   # retains list order
 def argfix(*x):
   if x and x[0].__class__ in (tuple, list):

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os, functools, platform, time, re, contextlib, operator, hashlib, pickle, sqlite3, cProfile, pstats, tempfile, pathlib, string, ctypes
 import itertools, urllib.request, subprocess
+import tqdm
 from typing import Dict, Tuple, Union, List, ClassVar, Optional, Iterable, Any, TypeVar, TYPE_CHECKING, Callable, Sequence
 if TYPE_CHECKING:  # TODO: remove this and import TypeGuard from typing once minimum python supported version is 3.10
   from typing_extensions import TypeGuard

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import os, functools, platform, time, re, contextlib, operator, hashlib, pickle, sqlite3, cProfile, pstats, tempfile, pathlib, string, ctypes
 import itertools, urllib.request, subprocess
-from tqdm import tqdm
 from typing import Dict, Tuple, Union, List, ClassVar, Optional, Iterable, Any, TypeVar, TYPE_CHECKING, Callable, Sequence
 if TYPE_CHECKING:  # TODO: remove this and import TypeGuard from typing once minimum python supported version is 3.10
   from typing_extensions import TypeGuard
@@ -15,7 +14,11 @@ def prod(x:Iterable[T]) -> Union[T,int]: return functools.reduce(operator.mul, x
 # NOTE: helpers is not allowed to import from anything else in tinygrad
 OSX = platform.system() == "Darwin"
 CI = os.getenv("CI", "") != ""
-
+def progress_bar(iterable, length=50, fill='█'):
+    start = time(); print(f'{0}% | {'-'*length} 0/{len(iterable)} 00:00<?,?it/s', end='\r')
+    for i, item in enumerate(iterable):
+        yield item; elapsed, percent, bar = time()-start, round(100*((i+1)/float(len(iterable))),1),fill*int(length * (i+1) // len(iterable)) + '-' * (length - int(length * (i+1) // len(iterable)))
+        print(f'{percent}% |{bar}|{i+1}/{len(iterable)}[{strftime("%H:%M:%S", gmtime(elapsed))}<{strftime("%H:%M:%S",gmtime(elapsed-elapsed/(percent/100)))},{str(round((i+1)/elapsed,2))+'it/s' if (i+1)/elapsed>=0.1 else str(round(elapsed/(i+1),2))+'s/it'}]', end='\n' if i+1==len(iterable) else '\r') 
 def dedup(x:Iterable[T]): return list(dict.fromkeys(x))   # retains list order
 def argfix(*x):
   if x and x[0].__class__ in (tuple, list):


### PR DESCRIPTION
progress bar behaving same in terms of output data. 

still need to change variables to make it visually look identical, and change the import statements inside most of the files.

Note: this can replace the progress bar and the trange function. 
Don't think we can do much more (e.g tqdm.write) within 5 lines, but replacing those other commands shouldn't be an issue.

Test script:

```from tqdm import tqdm
import random
import time

def progress_bar(iterable, length=50, fill='█'):
    start = time.time(); print('{0}%|{1} 0/{2} 00:00<?,?it/s'.format(0, ' ' * length, len(iterable)), end='\r')
    for i, item in enumerate(iterable):
        yield item; elapsed, percent, bar = time.time()-start, round(100*((i+1)/float(len(iterable))),1), fill * int(length*(i+1)//len(iterable)) + ' ' * (length-int(length*(i+1)//len(iterable)))
        print("{0}%|{1}|{2}/{3}[{4}<{5},{6}]".format(percent,bar,i+1,len(iterable), time.strftime("%H:%M:%S", time.gmtime(elapsed)),time.strftime("%H:%M:%S", time.gmtime(elapsed*(1-1/(percent/100)))),str(round((i+1)/elapsed,2)) + 'it/s' if (i+1)/elapsed >= 0.1 else str(round(elapsed/(i+1),2))+'s/it'), end='\n' if i+1==len(iterable) else '\r')

def test():
   random_sleep = [random.random() for i in range(10)]
   for i in progress_bar(range(10)):
      time.sleep(random_sleep[i])
   for i in tqdm(range(10)):
      time.sleep(random_sleep[i])
      
test()