### PR TITLE
fix reshape size check from symbolic shape to int shape

### DIFF
--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -121,11 +121,10 @@ class TestSymbolicReshapeFromContiguous(unittest.TestCase):
 
   def test_reshape_into_symbols_bad_shape(self):
     vi = Variable("i", 1, 10).bind(4)
-    # TODO: this never actually worked, it relied on lazy
-    #with self.assertRaises(ValueError):
-    #  Tensor.rand(4, 6).reshape(vi, 6).reshape(1, 77) # reshape to a different size new shape through symbolic shape
-    with self.assertRaises(AssertionError):
-      Tensor.rand(3, 4).reshape(3, (vi+1)) # reshape into non-Variable Node
+    with self.assertRaises(ValueError):
+      Tensor.rand(4, 6).reshape(vi, 6).reshape(1, 77) # reshape to a different size new shape through symbolic shape
+    with self.assertRaises(ValueError):
+      Tensor.rand(3, 4).reshape(3, (vi+1)) # reshape into different int size
 
   def test_two_symbol_reshape(self):
     for i in range(1, 6):
@@ -147,8 +146,8 @@ class TestSymbolicReshapeFromContiguous(unittest.TestCase):
     new_shape = (1, 1, (NumNode(1)+Variable('start_pos', 1, 128).bind(2)), 16, 64)
     assert view.reshape(new_shape) is None
 
-    view = View(shape=(2, 1, (NumNode(1)+Variable('start_pos', 1, 128)), 16, 64), strides=(0, 0, 1024, 64, 1), offset=131072, mask=((1, 2), (0, 1), (0, (NumNode(1)+Variable('start_pos', 1, 128))), (0, 16), (0, 64)), contiguous=False)   # noqa: E501
-    new_shape = (2, (NumNode(1)+Variable('start_pos', 1, 128)), 16, 64)
+    view = View(shape=(2, 1, (NumNode(1)+Variable('start_pos', 1, 128).bind(2)), 16, 64), strides=(0, 0, 1024, 64, 1), offset=131072, mask=((1, 2), (0, 1), (0, (NumNode(1)+Variable('start_pos', 1, 128).bind(2))), (0, 16), (0, 64)), contiguous=False)   # noqa: E501
+    new_shape = (2, (NumNode(1)+Variable('start_pos', 1, 128).bind(2)), 16, 64)
     assert view.reshape(new_shape) is None
 
 class TestSymbolicReshapeFromNonContiguous(unittest.TestCase):

--- a/test/test_tensor_variable.py
+++ b/test/test_tensor_variable.py
@@ -45,6 +45,14 @@ class TestTensorVariable(unittest.TestCase):
     ret = t.mean(axis=1).reshape(2, 1).numpy()
     assert np.all(ret == 1)
 
+  def test_symbolic_mean_2d_add(self):
+    add_term = Variable("c", 0, 10).bind(1)
+    vv = Variable("a", 1, 10).bind(1)
+    vv2 = Variable("b", 1, 10).bind(1)
+    t = Tensor.ones(2, 2).contiguous().reshape(vv2+add_term, vv+add_term)
+    ret = t.mean().item()
+    assert ret == 1
+
   def test_symbolic_var(self):
     vv = Variable("a", 1, 10).bind(2)
     t = Tensor.ones(2, 2).contiguous().reshape(2, vv)


### PR DESCRIPTION
Added `.val` for all sint Nodes and use that to get int_size. Also reshape_and_permute shares the same code path, but the Variables are no longer bound so passed the check in that case

fix #4501 too as we now support reshape into MulNode and SumNode provided that the int_size are the same