### PR TITLE
do not sleep immediately in amd's wait_signal

### DIFF
--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -462,16 +462,14 @@ class AMDDevice(Compiled):
   @classmethod
   def _wait_signal(self, signal:hsa.amd_signal_t, value=0, timeout=10000):
     assert signal.event_id != 0, "can't wait on this signal"
+    evt_arr = (kfd.struct_kfd_event_data)(event_id=signal.event_id)
 
     # Wait active for 5s, then going to sleep.
     start_time = time.time() * 1000
-    while (time.time() * 1000 - start_time) < (active_wait := max(5000, timeout)):
+    while time_spent:=(time.time() * 1000 - start_time) < timeout:
       if signal.value >= value: return
-
-    evt_arr = kfd.struct_kfd_event_data(event_id=signal.event_id)
-    if (wait_sleeping := timeout - int(active_wait)) > 0:
-      kio.wait_events(AMDDevice.kfd, events_ptr=ctypes.addressof(evt_arr), num_events=1, wait_for_all=1, timeout=wait_sleeping)
-    if signal.value < value: raise RuntimeError(f"wait_signal: not set to {value}, but {signal.value}, {timeout} ms TIMEOUT!")
+      if time_spent > 5000: kio.wait_events(AMDDevice.kfd, events_ptr=ctypes.byref(evt_arr), num_events=1, wait_for_all=1, timeout=1000)
+    raise RuntimeError(f"wait_signal: not set to {value}, but {signal.value}, {timeout} ms TIMEOUT!")
 
   def __init__(self, device:str=""):
     if AMDDevice.kfd == -1:

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -462,13 +462,16 @@ class AMDDevice(Compiled):
   @classmethod
   def _wait_signal(self, signal:hsa.amd_signal_t, value=0, timeout=10000):
     assert signal.event_id != 0, "can't wait on this signal"
-    evt_arr = (kfd.struct_kfd_event_data)(event_id=signal.event_id)
 
+    # Wait active for 5s, then going to sleep.
     start_time = time.time() * 1000
-    while (time.time() * 1000 - start_time) < timeout:
+    while (time.time() * 1000 - start_time) < (active_wait := max(5000, timeout)):
       if signal.value >= value: return
-      # kio.wait_events(AMDDevice.kfd, events_ptr=ctypes.addressof(evt_arr), num_events=1, wait_for_all=1, timeout=100)
-    raise RuntimeError(f"wait_signal: not set to {value}, but {signal.value}, {timeout} ms TIMEOUT!")
+
+    evt_arr = kfd.struct_kfd_event_data(event_id=signal.event_id)
+    if (wait_sleeping := timeout - int(active_wait)) > 0:
+      kio.wait_events(AMDDevice.kfd, events_ptr=ctypes.addressof(evt_arr), num_events=1, wait_for_all=1, timeout=wait_sleeping)
+    if signal.value < value: raise RuntimeError(f"wait_signal: not set to {value}, but {signal.value}, {timeout} ms TIMEOUT!")
 
   def __init__(self, device:str=""):
     if AMDDevice.kfd == -1:

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -466,7 +466,7 @@ class AMDDevice(Compiled):
 
     # Wait active for 5s, then going to sleep.
     start_time = time.time() * 1000
-    while time_spent:=(time.time() * 1000 - start_time) < timeout:
+    while (time_spent:=time.time() * 1000 - start_time) < timeout:
       if signal.value >= value: return
       if time_spent > 5000: kio.wait_events(AMDDevice.kfd, events_ptr=ctypes.addressof(evt_arr), num_events=1, wait_for_all=1, timeout=1000)
     raise RuntimeError(f"wait_signal: not set to {value}, but {signal.value}, {timeout} ms TIMEOUT!")

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -468,7 +468,7 @@ class AMDDevice(Compiled):
     start_time = time.time() * 1000
     while time_spent:=(time.time() * 1000 - start_time) < timeout:
       if signal.value >= value: return
-      if time_spent > 5000: kio.wait_events(AMDDevice.kfd, events_ptr=ctypes.byref(evt_arr), num_events=1, wait_for_all=1, timeout=1000)
+      if time_spent > 5000: kio.wait_events(AMDDevice.kfd, events_ptr=ctypes.addressof(evt_arr), num_events=1, wait_for_all=1, timeout=1000)
     raise RuntimeError(f"wait_signal: not set to {value}, but {signal.value}, {timeout} ms TIMEOUT!")
 
   def __init__(self, device:str=""):

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -467,7 +467,7 @@ class AMDDevice(Compiled):
     start_time = time.time() * 1000
     while (time.time() * 1000 - start_time) < timeout:
       if signal.value >= value: return
-      kio.wait_events(AMDDevice.kfd, events_ptr=ctypes.addressof(evt_arr), num_events=1, wait_for_all=1, timeout=100)
+      # kio.wait_events(AMDDevice.kfd, events_ptr=ctypes.addressof(evt_arr), num_events=1, wait_for_all=1, timeout=100)
     raise RuntimeError(f"wait_signal: not set to {value}, but {signal.value}, {timeout} ms TIMEOUT!")
 
   def __init__(self, device:str=""):


### PR DESCRIPTION
hmm, this syscall was really slow. it caused this python time jumps.

```
61   53.93 ms run,   20.71 ms python,   33.22 ms AMD * 6,  761.67 loss, 0.000583 LR, 8.85 GB used,  37310.47 GFLOPS,   2012.20 GOPS
 62   53.89 ms run,   20.83 ms python,   33.05 ms AMD * 6,  765.66 loss, 0.000521 LR, 8.85 GB used,  37340.07 GFLOPS,   2012.20 GOPS
 63   53.85 ms run,   20.84 ms python,   33.01 ms AMD * 6,  763.53 loss, 0.000459 LR, 8.85 GB used,  37364.62 GFLOPS,   2012.20 GOPS
 64   53.77 ms run,   20.62 ms python,   33.15 ms AMD * 6,  771.70 loss, 0.000397 LR, 8.85 GB used,  37420.01 GFLOPS,   2012.20 GOPS
 65   53.93 ms run,   20.75 ms python,   33.18 ms AMD * 6,  756.53 loss, 0.000335 LR, 8.85 GB used,  37309.97 GFLOPS,   2012.20 GOPS
```

vs

```
61   61.96 ms run,   29.13 ms python,   32.83 ms AMD * 6,  761.67 loss, 0.000583 LR, 8.85 GB used,  32475.64 GFLOPS,   2012.20 GOPS
 62   65.94 ms run,   34.19 ms python,   31.76 ms AMD * 6,  765.66 loss, 0.000521 LR, 8.85 GB used,  30513.60 GFLOPS,   2012.20 GOPS
 63   63.61 ms run,   27.84 ms python,   35.77 ms AMD * 6,  763.53 loss, 0.000459 LR, 8.85 GB used,  31631.09 GFLOPS,   2012.20 GOPS
 64   54.31 ms run,   21.23 ms python,   33.08 ms AMD * 6,  771.70 loss, 0.000397 LR, 8.85 GB used,  37049.80 GFLOPS,   2012.20 GOPS
 65   54.06 ms run,   23.03 ms python,   31.03 ms AMD * 6,  756.53 loss, 0.000335 LR, 8.85 GB used,  37221.12 GFLOPS,   2012.20 GOPS
```
