### PR TITLE
test: ConstBuffer with vals that aren't ConstType

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -6,7 +6,7 @@ from tinygrad.ops import LoadOps, BufferOps, LazyOp, ReduceOps, ConstBuffer, Mem
 from tinygrad.engine.graph import log_lazybuffer, realized_lazybuffer
 from tinygrad.helpers import GRAPH, DEBUG, MULTIOUTPUT, SAVE_SCHEDULE, GlobalCounters, colored, prod, dedup, all_int, merge_dicts, getenv
 from tinygrad.shape.symbolic import Variable
-from tinygrad.dtype import ImageDType, dtypes, DType
+from tinygrad.dtype import ConstType, ImageDType, dtypes, DType
 from tinygrad.lazy import LazyBuffer
 from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.device import Buffer
@@ -56,8 +56,13 @@ def _recursive_lazyop(buf:LazyBuffer, inputs:List[LazyBuffer], outputs:Tuple[Laz
   if buf.op is LoadOps.CONST:
     unbound_st, st_var_vals = st.simplify().unbind()
     var_vals.update(st_var_vals)
-    if isinstance(buf.arg, Variable): var_vals.__setitem__(*buf.arg.unbind())
-    return LazyOp(BufferOps.CONST, (), ConstBuffer(buf.arg, buf.dtype, unbound_st))
+    if isinstance(buf.arg, Variable):
+      var_vals.__setitem__(*buf.arg.unbind())
+      #value = buf.arg.val?
+      val = buf.arg
+    else: val = buf.arg
+    assert isinstance(val, ConstType), f"cannot create ConstBuffer of type {type(val)}"
+    return LazyOp(BufferOps.CONST, (), ConstBuffer(val, buf.dtype, unbound_st))
 
   # if we aren't fusing it, it's a load and we add it to the inputs
   if buf.realized is not None or (buf in realizes and buf not in outputs):


### PR DESCRIPTION
ConstBuffer's interface only defines ConstType as valid vals:

```
class ConstBuffer:
  val: ConstType
```
but symbolic var/mean can create ConstBuffers of bound Variables:
```
# test/test_symbolic_jit.py TestSymbolicJit.test_var 
  0 ━┳ STORE MemBuffer(idx=0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(1, 1), strides=(0, 0), offset=0, mask=None, contiguous=True),)))
  1  ┗━┳ DIV 
  2    ┣━┳ SUM (0, 1)
  3    ┃ ┗━━ LOAD MemBuffer(idx=1, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(Variable('i', 1, 10), 3), strides=(3, 1), offset=0, mask=None, contiguous=True),)))
  4    ┗━┳ CAST dtypes.float
  5      ┗━┳ MUL 
  6        ┣━━ CONST ConstBuffer(val=Variable('i', 1, 10).bind(4), dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1, 1), strides=(0, 0), offset=0, mask=None, contiguous=True),)))
  7        ┗━━ CONST ConstBuffer(val=3, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1, 1), strides=(0, 0), offset=0, mask=None, contiguous=True),)))
```

These bound variables also break process replay tests.