### PR TITLE
docs: Update referenced yaml in `yolov8.py`

### DIFF
--- a/examples/yolov8.py
+++ b/examples/yolov8.py
@@ -407,7 +407,7 @@ if __name__ == '__main__':
     sys.exit(1)
   pre_processed_image = preprocess(image)
 
-  # Different YOLOv8 variants use different w , r, and d multiples. For a list , refer to this yaml file (the scales section) https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/v8/yolov8.yaml
+  # Different YOLOv8 variants use different w , r, and d multiples. For a list , refer to this yaml file (the scales section) https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/v8/yolov8.yaml
   depth, width, ratio = get_variant_multiples(yolo_variant)
   yolo_infer = YOLOv8(w=width, r=ratio, d=depth, num_classes=80)
 


### PR DESCRIPTION
As per the "Key Changes" section of [this July 2023 PR](https://github.com/ultralytics/ultralytics/pull/3748), the YAML files have since been relocated (_previously [here](https://github.com/ultralytics/ultralytics/tree/2c6fc0a4443b9cf805ef17b1cfdd71a98693b4d4/ultralytics/models/v8)_).

As such, since the reference comment doesn't point to a fixed commit, the URL leads to a 404.