### PR TITLE
bug: this should be a comparison to None

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -274,7 +274,7 @@ class UOpGraph:
         if hasattr(up, "parents"): del up.parents
         if hasattr(up, "cmp_tuple"): del up.cmp_tuple
         # replace with cached nodes
-        if found:=self.nodes.get(key:=up.tuple()): return found
+        if (found:=self.nodes.get(key:=up.tuple())) is not None: return found
         else: self.nodes[key] = up
         return up
       sink = rewrite(sink)


### PR DESCRIPTION
I'm pretty sure this is a (minor) bug. This `.get` functions as an existence check here (default return is `None`). By checking its falseness instead of comparing to `None`, this will not return on values existing in `self.nodes` that are `False` such as `0`.

And equivalent and probably clearer (but potentially slower) statement here would be:

`if (key:=up.tuple()) in self.nodes: return self.nodes[key]`