### PR TITLE
perf: faster element deletion during matching

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -268,9 +268,11 @@ class UOpGraph:
           recurse_cnt += 1
         changed += recurse_cnt
         # NOTE: this changes UOp, so we have to delete caches
-        up.vin = tuple(rewrite(x) for x in up.vin)
-        if hasattr(up, "parents"): del up.parents
-        if hasattr(up, "cmp_tuple"): del up.cmp_tuple
+        up.vin = tuple([rewrite(x) for x in up.vin])
+        try: del up.parents
+        except AttributeError: pass
+        try: del up.cmp_tuple
+        except AttributeError: pass
         # replace with cached nodes
         if found:=self.nodes.get(key:=up.tuple()): return found
         self.nodes[key] = up


### PR DESCRIPTION
`hasattr` is slow.


M3 Macbook
`PROFILE=0 python test/external/external_benchmark_schedule.py`
Before:
```
***** model forward in  16.69 ms
***** model schedule in   5.56 ms
***** model lower in 892.72 ms
```

After:
```
***** model forward in  16.70 ms
***** model schedule in   5.57 ms
***** model lower in 745.73 ms
```