### PR TITLE
perf: list comprehension into tuple

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -141,7 +141,7 @@ class Kernel:
   def acc_offsets(self, i:int) -> List[int]:
     if self.upcasted == 0: return [0]
     upcasted_i = self.upcasted_axis(i)
-    acc_strides = [x*(1-upcasted_i[::-1][i][2]) for i,x in enumerate(strides_for_shape(tuple(1 if r else s for s,_,r in upcasted_i[::-1])))]
+    acc_strides = [x*(1-upcasted_i[::-1][i][2]) for i,x in enumerate(strides_for_shape(tuple([1 if r else s for s,_,r in upcasted_i[::-1]])))]
     return [sum(t) for t in itertools.product(*[[y*acc_strides[i] for y in range(x[0])] for i,x in enumerate(upcasted_i[::-1])])]
 
   def get_float4_upcast_dim(self, i:int) -> List[int]:
@@ -253,7 +253,7 @@ class Kernel:
       if shape_idx_groups := get_contraction(self.output_shape, base_shape):
         special_strides: Tuple[sint, ...] = tuple()
         for i,g in enumerate(shape_idx_groups):
-          shape_piece = tuple(self.output_shape[x] for x in g)
+          shape_piece = tuple([self.output_shape[x] for x in g])
           assert prod(shape_piece) == base_shape[i], f"get_contraction was wrong? {shape_piece} != {base_shape[i]}"
           special_strides += strides_for_shape(shape_piece)
         # adding the fake image shape

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -110,7 +110,7 @@ class Linearizer(Kernel):
           buf_uop = self.buf_uops[i]
           assert buf_uop is not None, f"buffer {i} wasn't UOped"
           image_idx, valid = to_image_idx(buf.dtype.shape, idx, valid)
-          rendered_idx = self.uops.add(UOps.CAST, dtypes.int.vec(2), tuple(x.render(self.render_ops, self) for x in image_idx))
+          rendered_idx = self.uops.add(UOps.CAST, dtypes.int.vec(2), tuple([x.render(self.render_ops, self) for x in image_idx]))
           valid_tuple = (valid.render(self.render_ops, self), self.const(invalid_value, buf.dtype.base.vec(4))) if valid.min == 0 else tuple()
           self.load_cache[key] = self.uops.add(UOps.LOAD, buf.dtype.base.vec(4),
                                                (buf_uop, rendered_idx) + valid_tuple + ((barrier,) if barrier else ()))
@@ -161,7 +161,7 @@ class Linearizer(Kernel):
       if isinstance(buf.dtype, ImageDType):
         image_idx, valid = to_image_idx(buf.dtype.shape, idx, valid)
         rendered_idx = self.uops.add(UOps.CAST, dtypes.int.vec(2), \
-                      tuple(x.render(self.render_ops, self) for x in image_idx))
+                      tuple([x.render(self.render_ops, self) for x in image_idx]))
       else:
         rendered_idx = idx.render(self.render_ops, self)
       if valid.min == 1: stores.append(self.uops.add(UOps.STORE, None, (buf_uop, rendered_idx, var)))

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -268,7 +268,7 @@ class UOpGraph:
           recurse_cnt += 1
         changed += recurse_cnt
         # NOTE: this changes UOp, so we have to delete caches
-        up.vin = tuple(rewrite(x) for x in up.vin)
+        up.vin = tuple([rewrite(x) for x in up.vin])
         try: del up.parents
         except AttributeError: pass
         try: del up.cmp_tuple
@@ -313,7 +313,7 @@ class UOpGraph:
         graph[x].append(u)
       if u.uop is UOps.RANGE: loops.append(u)
       if u.uop is UOps.IF: ifs.append(u)
-    sink = UOp(UOps.SINK, None, tuple(x for x in sink.vin if x.uop is not UOps.NOOP))
+    sink = UOp(UOps.SINK, None, tuple([x for x in sink.vin if x.uop is not UOps.NOOP]))
     add_parents(sink)
 
     @functools.lru_cache(None)

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -78,7 +78,7 @@ class CompiledRunner(Runner):
     if local_size:
       lra['local_size'] = local_size
       assert len(local_size) == 3, "local size must have len 3"
-    return self.clprg(*[x._buf for x in rawbufs], **lra, vals=tuple(var_vals[k] for k in self.p.vars), wait=wait)
+    return self.clprg(*[x._buf for x in rawbufs], **lra, vals=tuple([var_vals[k] for k in self.p.vars]), wait=wait)
 
 class CustomOp(Runner):
   def __init__(self, fxn):

--- a/tinygrad/engine/search.py
+++ b/tinygrad/engine/search.py
@@ -90,7 +90,7 @@ def bufs_from_lin(lin:Linearizer, allocate:bool=True) -> List[Buffer]:
   for x in lin.membufs: bufsts[x.idx].append(x)
   rawbufs:List[Optional[Buffer]] = [None]*len(bufsts)
   for k,lx in bufsts.items():
-    buf_size = prod(lx[0].dtype.shape) if isinstance(lx[0].dtype, ImageDType) else max(y.st.real_size() for y in lx)
+    buf_size = prod(lx[0].dtype.shape) if isinstance(lx[0].dtype, ImageDType) else max([y.st.real_size() for y in lx])
     if buf_size == 0: buf_size = 1  # create a size 1 buffer if no cell is accessed in kernel. # TODO: remove from kernel input in this case.
     rawbufs[k] = Buffer(lin.opts.device, buf_size, lx[0].dtype).allocate() if allocate else Buffer(lin.opts.device, buf_size, lx[0].dtype)
   assert all(r is not None for r in rawbufs)

--- a/tinygrad/function.py
+++ b/tinygrad/function.py
@@ -175,7 +175,7 @@ class Max(Function):
 # NOTE: this is sum in reverse
 class Expand(Function):
   def forward(self, x:LazyBuffer, shape:Tuple[int, ...]) -> LazyBuffer:
-    self.expanded_axis = tuple(i for i, (si, so) in enumerate(zip(x.shape, shape)) if si != so)
+    self.expanded_axis = tuple([i for i, (si, so) in enumerate(zip(x.shape, shape)) if si != so])
     return x.expand(shape)
 
   def backward(self, grad_output:LazyBuffer) -> LazyBuffer:

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -255,7 +255,7 @@ class LayerNorm:
   """
   def __init__(self, normalized_shape:Union[int, Tuple[int, ...]], eps:float=1e-5, elementwise_affine:bool=True):
     self.normalized_shape = (normalized_shape,) if isinstance(normalized_shape, int) else tuple(normalized_shape)
-    self.axis, self.eps, self.elementwise_affine = tuple(-1-i for i in range(len(self.normalized_shape))), eps, elementwise_affine
+    self.axis, self.eps, self.elementwise_affine = tuple([-1-i for i in range(len(self.normalized_shape))]), eps, elementwise_affine
     self.weight, self.bias = (Tensor.ones(*self.normalized_shape), Tensor.zeros(*self.normalized_shape)) if elementwise_affine else (None, None)
 
   def __call__(self, x:Tensor):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -98,7 +98,7 @@ InterpretedFlopCounter: Dict[Op, Callable] = {
   UnaryOps.BITCAST: lambda self,arg: FlopCounter(self.shape, self.consume_flops(), self.mem),   # bitcast uses no flops
   **{op:lambda self: FlopCounter(self.shape, self.consume_flops() + prod(self.shape), self.mem) for op in UnaryOps if op not in {UnaryOps.CAST, UnaryOps.BITCAST}},  # noqa: E501
   **{op:lambda self,y: FlopCounter(self.shape, self.consume_flops() + y.consume_flops() + prod(self.shape), {**self.mem, **y.mem}) for op in BinaryOps},  # noqa: E501
-  **{op:lambda self,axis: FlopCounter(tuple(1 if i in axis else s for i,s in enumerate(self.shape)), self.consume_flops() + prod(self.shape), self.mem) for op in ReduceOps},  # noqa: E501
+  **{op:lambda self,axis: FlopCounter(tuple([1 if i in axis else s for i,s in enumerate(self.shape)]), self.consume_flops() + prod(self.shape), self.mem) for op in ReduceOps},  # noqa: E501
   TernaryOps.WHERE: lambda self,y,z: FlopCounter(self.shape, self.consume_flops() + y.consume_flops() + z.consume_flops() + prod(self.shape), {**self.mem, **y.mem, **z.mem})}  # noqa: E501
 
 @functools.lru_cache(None)

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -301,7 +301,7 @@ def _make_hip_code_for_op():
   def wrapper(key, func):
     def cast_bf16(*args):
       if args[-1] == dtypes.bfloat16:
-        operands = tuple(f"(float)({arg})" for arg in (args[1:-1] if key is TernaryOps.WHERE else args[:-1]))
+        operands = tuple([f"(float)({arg})" for arg in (args[1:-1] if key is TernaryOps.WHERE else args[:-1])])
         return f"(hip_bfloat16)({func(*(((args[0],) if key is TernaryOps.WHERE else ()) + operands), dtypes.float)})"
       return func(*args)
     return cast_bf16

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -46,7 +46,7 @@ class CLProgram:
   def __call__(self, *bufs:ctypes._CData, global_size:Tuple[int,int,int]=(1,1,1), local_size:Optional[Tuple[int,int,int]]=None, vals:Tuple[int, ...]=(), wait=False) -> Optional[float]:  # noqa: E501
     for i,b in enumerate(bufs): cl.clSetKernelArg(self.kernel, i, ctypes.sizeof(b), ctypes.byref(b))
     for i,v in enumerate(vals,start=len(bufs)): cl.clSetKernelArg(self.kernel, i, 4, ctypes.byref(ctypes.c_int32(v)))
-    if local_size is not None: global_size = cast(Tuple[int,int,int], tuple(int(g*l) for g,l in zip(global_size, local_size)))
+    if local_size is not None: global_size = cast(Tuple[int,int,int], tuple([int(g*l) for g,l in zip(global_size, local_size)]))
     event = cl.cl_event() if wait else None
     check(cl.clEnqueueNDRangeKernel(self.device.queue, self.kernel, len(global_size), None, (ctypes.c_size_t * len(global_size))(*global_size), (ctypes.c_size_t * len(local_size))(*local_size) if local_size else None, 0, None, event))  # noqa: E501
     if wait:


### PR DESCRIPTION
I know this looks like a stupid change, but it faster.


`python -O test/external/external_test_speed_llama.py`
Master
```
codegen(0)      mean runtime:  163.41ms, runs:   226.75,  130.42,  153.60,  140.43,  165.87
codegen(1)      mean runtime:  151.51ms, runs:   186.51,  147.10,  134.03,  146.45,  143.48
methodcache     mean runtime:   95.64ms, runs:    96.14,   91.87,  105.24,   92.51,   92.43
profile         mean runtime:  288.83ms, runs:   294.96,  285.53,  286.74,  289.17,  287.78
```

This branch
```
codegen(0)      mean runtime:  146.92ms, runs:   202.84,  123.40,  128.18,  142.59,  137.59
codegen(1)      mean runtime:  140.57ms, runs:   182.68,  122.07,  125.13,  139.34,  133.60
methodcache     mean runtime:   89.00ms, runs:    90.11,   88.46,   88.54,   88.56,   89.34
profile         mean runtime:  279.01ms, runs:   293.13,  270.80,  275.18,  279.12,  276.84
```


`JIT=0 python3 -O examples/llama.py --gen 1 --prompt "Hello." --count 10 --temperature 0 --timing`

This branch
```
loaded weights in 2380.07 ms, 13.48 GB loaded at 5.66 GB/s
Hello.
enqueue in 330.22 ms
total 887.98 ms, 1.13 tok/s, 18.83 GB/s, param 15.18 GB/s
 I
enqueue in 182.48 ms
total 185.18 ms, 5.40 tok/s, 72.87 GB/s, param 72.79 GB/s
'
enqueue in 161.80 ms
total 165.91 ms, 6.03 tok/s, 81.34 GB/s, param 81.24 GB/s
m
enqueue in 147.75 ms
total 151.88 ms, 6.58 tok/s, 88.86 GB/s, param 88.75 GB/s
 a
enqueue in 147.57 ms
total 151.68 ms, 6.59 tok/s, 88.98 GB/s, param 88.87 GB/s
 
enqueue in 162.20 ms
total 166.34 ms, 6.01 tok/s, 81.14 GB/s, param 81.03 GB/s
2
enqueue in 148.70 ms
total 152.75 ms, 6.55 tok/s, 88.36 GB/s, param 88.24 GB/s
0
enqueue in 151.88 ms
total 156.05 ms, 6.41 tok/s, 86.50 GB/s, param 86.38 GB/s
 year
enqueue in 171.88 ms
total 175.97 ms, 5.68 tok/s, 76.71 GB/s, param 76.60 GB/s
 old
enqueue in 153.78 ms
total 157.88 ms, 6.33 tok/s, 85.50 GB/s, param 85.38 GB/s
 male
output validated
```


Master
```
loaded weights in 2422.06 ms, 13.48 GB loaded at 5.56 GB/s
Hello.
enqueue in 345.56 ms
total 982.70 ms, 1.02 tok/s, 17.02 GB/s, param 13.72 GB/s
 I
enqueue in 206.61 ms
total 209.24 ms, 4.78 tok/s, 64.49 GB/s, param 64.42 GB/s
'
enqueue in 153.88 ms
total 158.01 ms, 6.33 tok/s, 85.41 GB/s, param 85.31 GB/s
m
enqueue in 169.73 ms
total 173.81 ms, 5.75 tok/s, 77.64 GB/s, param 77.55 GB/s
 a
enqueue in 154.73 ms
total 158.84 ms, 6.30 tok/s, 84.97 GB/s, param 84.86 GB/s
 
enqueue in 171.65 ms
total 175.82 ms, 5.69 tok/s, 76.77 GB/s, param 76.66 GB/s
2
enqueue in 160.64 ms
total 164.85 ms, 6.07 tok/s, 81.87 GB/s, param 81.76 GB/s
0
enqueue in 158.37 ms
total 162.63 ms, 6.15 tok/s, 83.00 GB/s, param 82.88 GB/s
 year
enqueue in 175.09 ms
total 179.39 ms, 5.57 tok/s, 75.25 GB/s, param 75.14 GB/s
 old
enqueue in 163.71 ms
total 168.01 ms, 5.95 tok/s, 80.35 GB/s, param 80.23 GB/s
 male
output validated
```