### PR TITLE
perf: faster broadcasted

### DIFF
--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -51,6 +51,7 @@ class dtypes:
   @staticmethod  # NOTE: isinstance(True, int) is True in python
   def from_py(x) -> DType: return dtypes.default_float if isinstance(x, float) else dtypes.bool if isinstance(x, bool) else dtypes.default_int
   @staticmethod
+  @functools.lru_cache(maxsize=None)
   def as_const(val: ConstType, dtype:DType): return int(val) if dtypes.is_int(dtype) else float(val) if dtypes.is_float(dtype) else bool(val)
   @staticmethod
   def fields() -> Dict[str, DType]: return DTYPES_DICT

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -65,8 +65,9 @@ def _apply_winograd_matrix(mat, t:Tensor, dims:int) -> Tensor:
   ret = sum(prod(col[idx] for col, idx in zip(matcols, mat_is)) * t_[mat_is] for mat_is in itertools.product(range(len(mat[0])), repeat=dims))
   assert isinstance(ret, Tensor), "sum didn't return a Tensor"
   return ret
-
+@functools.lru_cache(maxsize=None)
 def _pad_left(*shps:Tuple[sint, ...], v=1): return tuple((v,) * (max(len(i_) for i_ in shps) - len(i)) + i for i in shps)
+@functools.lru_cache(maxsize=None)
 def _broadcast_shape(*shps:Tuple[sint, ...]): return tuple(0 if any(sh_ == 0 for sh_ in sh) else max(sh) for sh in zip(*_pad_left(*shps)))
 
 class Tensor:
@@ -2265,11 +2266,12 @@ class Tensor:
     return self / (1 + self.abs())
 
   # ***** broadcasted elementwise ops *****
-  def _broadcast_to(self, shape:Tuple[sint, ...]):
+  def _broadcast_to(self, shape:Tuple[sint, ...]) -> Tensor:
+    if self.shape == shape: return self
     reshape_arg, _ = _pad_left(self.shape, shape)
     if self.ndim > len(shape) or not all(sh in {s,1} or (s==0 and sh==1) for sh,s in zip(reshape_arg, shape)):
       raise ValueError(f"cannot broadcast tensor with shape={self.shape} to {shape=}")
-    return F.Expand.apply(self.reshape(reshape_arg), shape=shape) if shape != self.shape else self
+    return F.Expand.apply(self.reshape(reshape_arg) if self.shape != reshape_arg else self, shape=shape)
 
   def _broadcasted(self, y:Union[Tensor, ConstType], reverse:bool=False, match_dtype:bool=True) -> Tuple[Tensor, Tensor]:
     x: Tensor = self
@@ -2280,16 +2282,13 @@ class Tensor:
       else: y_dtype = dtypes.from_py(y)
       if isinstance(y, Node): y = Tensor.from_node(y, device=self.device)
       else: y = Tensor(dtypes.as_const(y, y_dtype), self.device, y_dtype, requires_grad=False)
-
-    if match_dtype:
+    if match_dtype and not x.dtype == y.dtype:
       output_dtype = least_upper_dtype(x.dtype, y.dtype)
-      x, y = x.cast(output_dtype), y.cast(output_dtype)
-
-    if reverse: x, y = y, x
-
-    # broadcast
-    out_shape = _broadcast_shape(x.shape, y.shape)
-    return x._broadcast_to(out_shape), y._broadcast_to(out_shape)
+      x,y = x.cast(output_dtype), y.cast(output_dtype)
+    if not x.shape == y.shape:
+      out_shape = _broadcast_shape(x.shape, y.shape)
+      x,y = x._broadcast_to(out_shape), y._broadcast_to(out_shape)
+    return (y,x) if reverse else (x,y)
 
   def _to_const_val(self, x:Union[Tensor, ConstType]) -> Union[Tensor, ConstType]:
     # TODO: update with multi

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2285,7 +2285,7 @@ class Tensor:
 
     if match_dtype and x.dtype != y.dtype:
       output_dtype = least_upper_dtype(x.dtype, y.dtype)
-      x,y = x.cast(output_dtype), y.cast(output_dtype)
+      x, y = x.cast(output_dtype), y.cast(output_dtype)
 
     if reverse: x, y = y, x
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2282,10 +2282,10 @@ class Tensor:
       else: y_dtype = dtypes.from_py(y)
       if isinstance(y, Node): y = Tensor.from_node(y, device=self.device)
       else: y = Tensor(dtypes.as_const(y, y_dtype), self.device, y_dtype, requires_grad=False)
-    if match_dtype and not x.dtype == y.dtype:
+    if match_dtype and x.dtype != y.dtype:
       output_dtype = least_upper_dtype(x.dtype, y.dtype)
       x,y = x.cast(output_dtype), y.cast(output_dtype)
-    if not x.shape == y.shape:
+    if x.shape != y.shape:
       out_shape = _broadcast_shape(x.shape, y.shape)
       x,y = x._broadcast_to(out_shape), y._broadcast_to(out_shape)
     return (y,x) if reverse else (x,y)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2266,7 +2266,7 @@ class Tensor:
     return self / (1 + self.abs())
 
   # ***** broadcasted elementwise ops *****
-  def _broadcast_to(self, shape:Tuple[sint, ...]):
+  def _broadcast_to(self, shape:Tuple[sint, ...]) -> Tensor:
     if self.shape == shape: return self
     reshape_arg, _ = _pad_left(self.shape, shape)
     if self.ndim > len(shape) or not all(sh in {s,1} or (s==0 and sh==1) for sh,s in zip(reshape_arg, shape)):


### PR DESCRIPTION
`python -O test/external/external_test_speed_llama.py`

```
codegen(0)      mean runtime:  156.81ms, runs:   211.31,  127.76,  143.96,  137.93,  163.09
codegen(1)      mean runtime:  146.98ms, runs:   180.12,  137.88,  131.49,  145.81,  139.59
methodcache     mean runtime:   97.35ms, runs:    98.19,   92.33,  106.65,   95.18,   94.42
profile         mean runtime:  292.48ms, runs:   295.51,  290.46,  290.33,  291.24,  294.87
```


```
codegen(0)      mean runtime:  143.93ms, runs:   201.36,  118.72,  138.20,  128.39,  132.97
codegen(1)      mean runtime:  135.96ms, runs:   178.92,  114.88,  131.54,  123.23,  131.22
methodcache     mean runtime:   87.19ms, runs:    87.80,   97.08,   83.61,   83.77,   83.72
profile         mean runtime:  255.64ms, runs:   260.40,  254.79,  256.24,  253.32,  253.47
```