### PR TITLE
dropout uses where instead of mul

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2643,7 +2643,8 @@ class Tensor:
     ```
     """
     if not Tensor.training or p == 0: return self
-    return self * (Tensor.rand(*self.shape, requires_grad=False, dtype=dtypes.default_float, device=self.device) >= p) * (1/(1.0 - p))
+    mask = (Tensor.rand(*self.shape, requires_grad=False, dtype=dtypes.default_float, device=self.device) >= p).realize()
+    return mask.where(self / (1.0 - p), 0)
 
   def one_hot(self, num_classes:int) -> Tensor:
     """


### PR DESCRIPTION
beam with `TRAIN_STEPS=200000 DEBUG=2 BEAM_MIN_PROGRESS=30 IGNORE_JIT_FIRST_BEAM=1 TRAIN_BEAM=3 EVAL_BEAM=3 HALF_LINEAR=1 THREEFRY=1 BENCHMARK=10 BS=18 EVAL_BS=18 GPUS=6 WANDB=0 MODEL=bert python3 examples/mlperf/model_train.py`

and run with `TRAIN_STEPS=200000 BEAM_MIN_PROGRESS=30 IGNORE_JIT_FIRST_BEAM=1 TRAIN_BEAM=3 EVAL_BEAM=3 HALF_LINEAR=1 THREEFRY=1 BS=18 EVAL_BS=18 GPUS=6 WANDB=1 MODEL=bert python3 examples/mlperf/model_train.py`