### PR TITLE
Fix for the errors i ran into in Issue4344

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,5 +169,5 @@ Some examples of running tests locally:
 ```sh
 python3 -m pip install -e '.[testing]'  # install extra deps for testing
 python3 test/test_ops.py                # just the ops tests
-python3 -m pytest test/                 # whole test suite
+python3 -m pytest -n=auto test/         # whole test suite
 ```


### PR DESCRIPTION
Adding check if not in CI for GC tests
This way i can run: python3 -m pytest test/ on mac without any errors.
And also be able to use python3.8