### PR TITLE
fix typing for test to run in py38

### DIFF
--- a/test/test_fuzz_shape_ops.py
+++ b/test/test_fuzz_shape_ops.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import unittest
 from math import prod
 


### PR DESCRIPTION
Fix for test `test/test_fuzz_shape_ops.py` to be able to run by python3.8
`python3 -m pytest test/test_fuzz_shape_ops.py` would others fail.