### PR TITLE
easier llama3 + fetch subdir

### DIFF
--- a/examples/llama3.py
+++ b/examples/llama3.py
@@ -194,11 +194,11 @@ if __name__ == "__main__":
 
   parser = argparse.ArgumentParser()
   parser.add_argument("--download_model", action="store_true")
-  parser.add_argument("--model", type=Path, required=True)
+  parser.add_argument("--model", type=Path)
   parser.add_argument("--size", choices=["8B", "70B"], default="8B")
   parser.add_argument("--shard", type=int, default=1)
   parser.add_argument("--quantize", choices=["int8", "nf4"])
-  parser.add_argument("--api", action="store_true")
+  parser.add_argument("--no_api", action="store_true")
   parser.add_argument("--host", type=str, default="0.0.0.0")
   parser.add_argument("--port", type=int, default=7776)
   parser.add_argument("--debug", action="store_true")
@@ -207,15 +207,14 @@ if __name__ == "__main__":
   parser.add_argument("--profile", action="store_true", help="Output profile data")
   args = parser.parse_args()
 
+  assert not (args.download_model and args.model), "either download or provide model"
   if args.download_model:
-    if not args.model.is_dir(): raise ValueError("for --download_model, --model must be a directory")
-    if not args.model.exists(): args.model.mkdir(parents=True)
-    fetch("https://huggingface.co/bofenghuang/Meta-Llama-3-8B/resolve/main/original/tokenizer.model", args.model / "tokenizer.model")
-    fetch("https://huggingface.co/TriAiExperiments/SFR-Iterative-DPO-LLaMA-3-8B-R/resolve/main/model-00001-of-00004.safetensors", args.model / "model-00001-of-00004.safetensors")
-    fetch("https://huggingface.co/TriAiExperiments/SFR-Iterative-DPO-LLaMA-3-8B-R/resolve/main/model-00002-of-00004.safetensors", args.model / "model-00002-of-00004.safetensors")
-    fetch("https://huggingface.co/TriAiExperiments/SFR-Iterative-DPO-LLaMA-3-8B-R/resolve/main/model-00003-of-00004.safetensors", args.model / "model-00003-of-00004.safetensors")
-    fetch("https://huggingface.co/TriAiExperiments/SFR-Iterative-DPO-LLaMA-3-8B-R/resolve/main/model-00004-of-00004.safetensors", args.model / "model-00004-of-00004.safetensors")
-    fetch("https://huggingface.co/TriAiExperiments/SFR-Iterative-DPO-LLaMA-3-8B-R/raw/main/model.safetensors.index.json", args.model / "model.safetensors.index.json")
+    fetch("https://huggingface.co/bofenghuang/Meta-Llama-3-8B/resolve/main/original/tokenizer.model", "tokenizer.model", subdir="llama3-8b-sfr")
+    fetch("https://huggingface.co/TriAiExperiments/SFR-Iterative-DPO-LLaMA-3-8B-R/resolve/main/model-00001-of-00004.safetensors", "model-00001-of-00004.safetensors", subdir="llama3-8b-sfr")
+    fetch("https://huggingface.co/TriAiExperiments/SFR-Iterative-DPO-LLaMA-3-8B-R/resolve/main/model-00002-of-00004.safetensors", "model-00002-of-00004.safetensors", subdir="llama3-8b-sfr")
+    fetch("https://huggingface.co/TriAiExperiments/SFR-Iterative-DPO-LLaMA-3-8B-R/resolve/main/model-00003-of-00004.safetensors", "model-00003-of-00004.safetensors", subdir="llama3-8b-sfr")
+    fetch("https://huggingface.co/TriAiExperiments/SFR-Iterative-DPO-LLaMA-3-8B-R/resolve/main/model-00004-of-00004.safetensors", "model-00004-of-00004.safetensors", subdir="llama3-8b-sfr")
+    args.model = fetch("https://huggingface.co/TriAiExperiments/SFR-Iterative-DPO-LLaMA-3-8B-R/raw/main/model.safetensors.index.json", "model.safetensors.index.json", subdir="llama3-8b-sfr")
 
   if args.seed is not None: Tensor.manual_seed(args.seed)
   print(f"seed = {Tensor._seed}")
@@ -230,7 +229,7 @@ if __name__ == "__main__":
   model = build_transformer(args.model, model_size=args.size, quantize=args.quantize, device=device)
   param_bytes = sum(x.lazydata.size * x.dtype.itemsize for x in get_parameters(model))
 
-  if args.api:
+  if not args.no_api:
     from bottle import Bottle, request, response, HTTPResponse, abort, static_file
     app = Bottle()
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(name='tinygrad',
             "networkx",
             "hypothesis",
             "nibabel",
+            "bottle",
         ],
         'docs': [
             "mkdocs-material",

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -150,9 +150,15 @@ class TestFetch(unittest.TestCase):
     assert(len(fetch('https://google.com', allow_caching=False).read_bytes())>0)
 
   def test_fetch_img(self):
-    img = fetch("https://media.istockphoto.com/photos/hen-picture-id831791190", allow_caching=False)
+    img = fetch("https://avatars.githubusercontent.com/u/132956020", allow_caching=False)
     with Image.open(img) as pimg:
-      assert pimg.size == (705, 1024)
+      assert pimg.size == (77, 77), pimg.size
+
+  def test_fetch_subdir(self):
+    img = fetch("https://avatars.githubusercontent.com/u/132956020", allow_caching=False, subdir="images")
+    with Image.open(img) as pimg:
+      assert pimg.size == (77, 77), pimg.size
+    assert img.parent.name == "images"
 
 class TestFullyFlatten(unittest.TestCase):
   def test_fully_flatten(self):

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -196,9 +196,11 @@ def diskcache(func):
 
 # *** http support ***
 
-def fetch(url:str, name:Optional[Union[pathlib.Path, str]]=None, allow_caching=not getenv("DISABLE_HTTP_CACHE")) -> pathlib.Path:
+def fetch(url:str, name:Optional[Union[pathlib.Path, str]]=None, subdir:Optional[str]=None,
+          allow_caching=not getenv("DISABLE_HTTP_CACHE")) -> pathlib.Path:
   if url.startswith(("/", ".")): return pathlib.Path(url)
-  fp = pathlib.Path(name) if name is not None and (isinstance(name, pathlib.Path) or '/' in name) else pathlib.Path(_cache_dir) / "tinygrad" / "downloads" / (name if name else hashlib.md5(url.encode('utf-8')).hexdigest())  # noqa: E501
+  if name is not None and (isinstance(name, pathlib.Path) or '/' in name): fp = pathlib.Path(name)
+  else: fp = pathlib.Path(_cache_dir) / "tinygrad" / "downloads" / (subdir or "") / (name if name else hashlib.md5(url.encode('utf-8')).hexdigest())
   if not fp.is_file() or not allow_caching:
     with urllib.request.urlopen(url, timeout=10) as r:
       assert r.status == 200


### PR DESCRIPTION
adds subdir support in the fetch download cache

flips `--api` to `--no_api` to have api enabled by default
