### PR TITLE
perf: graph_rewrite line reduction and make it a little bit faster

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -294,14 +294,10 @@ class UOpGraph:
         changed += recurse_cnt
         # NOTE: this changes UOp, so we have to delete caches
         up.vin = tuple(rewrite(x) for x in up.vin)
-        try: del up.parents
-        except AttributeError: pass
-        try: del up.cmp_tuple
-        except AttributeError: pass
+        if 'parents' in up.__dict__: delattr(up, 'parents')
+        if 'cmp_tuple' in up.__dict__: delattr(up, 'cmp_tuple')
         # replace with cached nodes
-        if found:=self.nodes.get(key:=up.tuple()): return found
-        self.nodes[key] = up
-        return up
+        return self.nodes.setdefault(up.tuple(), up)
       sink = rewrite(sink)
       run_cnt += 1
       assert run_cnt < 100, "exceeded 100 rewrite loops!"


### PR DESCRIPTION
Tried to make rewrite fast but in the end it's not significantly faster than before.  
However I've achieved some line reduction that are nice to have, I guess.

In my local bench `PROFILE=0 python test/external/external_benchmark_schedule.py` lower was like ~30ms faster so has i said not significantly faster. But the new way to refresh cached property is [indeed faster](https://pastebin.com/xNKgyRg8).

The setdefault is exactly the same speed but it's nice for line reduction