### PR TITLE
hcq add memory_barrier

### DIFF
--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -118,7 +118,7 @@ class HCQGraph(MultiGraphRunner):
 
     for dev in self.devices:
       # Submit sync with world and queues.
-      self.comp_hcq_t().wait(dev.timeline_signal, dev.timeline_value - 1) \
+      self.comp_hcq_t().memory_barrier().wait(dev.timeline_signal, dev.timeline_value - 1) \
                        .wait(self.kickoff_signal, self.kickoff_value).submit(dev)
       self.comp_queues[dev].submit(dev)
 

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -84,11 +84,11 @@ class HWPM4Queue:
 
   def ptr(self) -> int: return len(self.q)
 
-  def hdp_flush(self):
+  def memory_barrier(self):
     self.q += [amd_gpu.PACKET3(amd_gpu.PACKET3_WAIT_REG_MEM, 5), amd_gpu.WAIT_REG_MEM_MEM_SPACE(0) | amd_gpu.WAIT_REG_MEM_OPERATION(1) | \
       amd_gpu.WAIT_REG_MEM_FUNCTION(WAIT_REG_MEM_FUNCTION_EQ) | amd_gpu.WAIT_REG_MEM_ENGINE(0), nbioreg(regBIF_BX_PF1_GPU_HDP_FLUSH_REQ),
       nbioreg(regBIF_BX_PF1_GPU_HDP_FLUSH_DONE), 0xffffffff, 0xffffffff, 0x20]
-    return self
+    return self.invalidate_cache()
 
   def invalidate_cache(self, addr=0x0, sz=(1 << 64)-1, gli=1, glm=1, glk=1, glv=1, gl1=1, gl2=1):
     self.q += [amd_gpu.PACKET3(amd_gpu.PACKET3_ACQUIRE_MEM, 6), 0, #0x80000000,
@@ -101,7 +101,7 @@ class HWPM4Queue:
     return self
 
   def exec(self, prg, kernargs, global_size:Tuple[int,int,int]=(1,1,1), local_size:Tuple[int,int,int]=(1,1,1), signal=None, signal_value=0):
-    self.hdp_flush().invalidate_cache()
+    self.invalidate_cache()
 
     user_data = [*data64_le(kernargs)]
     if hasattr(prg, 'dispatch_packet_offset'):
@@ -131,9 +131,9 @@ class HWPM4Queue:
 
   def update_exec(self, cmd_ptr, global_size, local_size):
     # Patch the exec cmd with new launch dims
-    assert self.q[cmd_ptr + 67] == amd_gpu.PACKET3(amd_gpu.PACKET3_DISPATCH_DIRECT, 3),"The pointer does not point to a packet of this type"
-    self.q[cmd_ptr + 59 : cmd_ptr + 62] = array.array('I', local_size)
-    self.q[cmd_ptr + 68 : cmd_ptr + 71] = array.array('I', global_size)
+    assert self.q[cmd_ptr + 60] == amd_gpu.PACKET3(amd_gpu.PACKET3_DISPATCH_DIRECT, 3),"The pointer does not point to a packet of this type"
+    self.q[cmd_ptr + 52 : cmd_ptr + 55] = array.array('I', local_size)
+    self.q[cmd_ptr + 61 : cmd_ptr + 64] = array.array('I', global_size)
 
     if (dp:=self.ptr_to_dispatch_packet.get(cmd_ptr)) is not None:
       dp.workgroup_size_x, dp.workgroup_size_y, dp.workgroup_size_z = local_size[0], local_size[1], local_size[2]
@@ -204,9 +204,6 @@ class HWCopyQueue:
     self.cmd_sizes.append(len(arr))
 
   def copy(self, dest, src, copy_size):
-    # HDP flush
-    self._q([amd_gpu.SDMA_OP_POLL_REGMEM, 0, 0x80000000, 0, 0, 0])
-
     # Invalidate cache inv
     self._q([amd_gpu.SDMA_OP_GCR_REQ, 0, amd_gpu.SDMA_GCR_GLM_INV | amd_gpu.SDMA_GCR_GLK_INV | amd_gpu.SDMA_GCR_GLK_WB | amd_gpu.SDMA_GCR_GLV_INV | \
       amd_gpu.SDMA_GCR_GL1_INV | amd_gpu.SDMA_GCR_GL2_WB | amd_gpu.SDMA_GCR_GL2_INV, 0, 0])
@@ -316,7 +313,7 @@ class AMDProgram:
 
     self.prog_addr = self.lib_gpu.va_addr + entry_point + code.kernel_code_entry_byte_offset
 
-    HWPM4Queue().invalidate_cache().submit(self.device)
+    HWPM4Queue().memory_barrier().submit(self.device)
 
   # NOTE: no programs are ever freed
   def __del__(self):
@@ -337,7 +334,7 @@ class AMDProgram:
     for i in range(len(vals)): args_st.__setattr__(f'v{i}', vals[i])
 
     q = HWPM4Queue()
-    q.wait(self.device.timeline_signal, self.device.timeline_value - 1)
+    q.wait(self.device.timeline_signal, self.device.timeline_value - 1).memory_barrier()
     if wait: q.timestamp(ctypes.addressof(self.device.timeline_signal) + getattr(hsa.amd_signal_t, 'start_ts').offset)
     q.exec(self, self.device.kernargs_ptr, global_size, local_size)
     if wait: q.timestamp(ctypes.addressof(self.device.timeline_signal) + getattr(hsa.amd_signal_t, 'end_ts').offset)

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -92,7 +92,7 @@ class HWQueue:
 
   def ptr(self) -> int: return self.next_cmd_index
 
-  def memory_barrier(self): pass
+  def memory_barrier(self): return self
 
   def wait(self, signal, value=0):
     self.q += [nvmethod(0, nv_gpu.NVC56F_SEM_ADDR_LO, 5), *nvdata64_le(ctypes.addressof(from_mv(signal))), *nvdata64_le(value),

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -92,6 +92,8 @@ class HWQueue:
 
   def ptr(self) -> int: return self.next_cmd_index
 
+  def memory_barrier(self): pass
+
   def wait(self, signal, value=0):
     self.q += [nvmethod(0, nv_gpu.NVC56F_SEM_ADDR_LO, 5), *nvdata64_le(ctypes.addressof(from_mv(signal))), *nvdata64_le(value),
                (3 << 0) | (1 << 24)] # ACQUIRE | PAYLOAD_SIZE_64BIT


### PR DESCRIPTION
Add `memory_barrier` to HCQ API. Calling this function ensures that all preceding writes are visible to any agent (GPU or CPU). This allows controlling HDP flushes and removes the need to call it from every execution. For now, it is implemented only for AMD; will relax NV constraints later.