### PR TITLE
Incomplete/buggy rule breaks process replay on #4976

### DIFF
--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -151,7 +151,7 @@ class TestNonFloatUOps(TestUOps):
 
     value = -y+x
     uops = UOpGraph([UOp(UOps.STORE, None, (data0, idx, value))])
-    with self.assertRaises(AssertionError): assert uops[-1].vin[2].arg is BinaryOps.SUB
+    assert uops[-1].vin[2].arg is BinaryOps.SUB
 
 class TestBoolUOps(TestUOps):
   def _test_uop_bool_fxn(self, op, fxn):

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -181,7 +181,7 @@ constant_folder = PatternMatcher([
   # -(-x) -> x
   (UPat(UOps.ALU, UnaryOps.NEG, (UPat(UOps.ALU, UnaryOps.NEG, (UPat(name="x"),)))), lambda x: x),
   # x+-y -> x-y
-  (UPat(UOps.ALU, BinaryOps.ADD, (UPat(name="x"), UPat(UOps.ALU, UnaryOps.NEG, name="my"))), lambda x, my: x-my.vin[0]),
+  (UPat(UOps.ALU, BinaryOps.ADD, [UPat(name="x"), UPat(UOps.ALU, UnaryOps.NEG, name="my")]), lambda x, my: x-my.vin[0]),
   # -1*x -> -x
   (UPat(UOps.ALU, BinaryOps.MUL, [UPat(name="x"), UPat(UOps.CONST, -1)]), lambda x: -x),
   # bool < False is always false, True < bool is always false


### PR DESCRIPTION
x+-y -> x-y rule didn't cover -y+x which is the same because a + b = b + a and my nicer uops always does that, but because this rule didn't cover that case that it was probably supposed to cover process replay broke

Here's diff:
<img width="1303" alt="image" src="https://github.com/tinygrad/tinygrad/assets/83587632/c245a875-9799-4b2b-ba28-4dfc59d1cb6f">
Old rule:  21)))+(-(((val
New rule: val21)))-(((val
etc