### PR TITLE
fix einsum output str

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -615,6 +615,8 @@ class TestOps(unittest.TestCase):
     helper_test_op([(150,150)], lambda a: torch.einsum('ji', a), lambda a: Tensor.einsum('ji', a))
     helper_test_op([(20,30,40)], lambda a: torch.einsum('jki', a), lambda a: Tensor.einsum('jki', a))
     helper_test_op([(20,30,40)], lambda a: torch.einsum('dog', a), lambda a: Tensor.einsum('dog', a))
+    # no -> and empty rhs
+    helper_test_op([(20,30),(30,40)], lambda a, b: torch.einsum('ij,jk', a, b), lambda a, b: Tensor.einsum('ij,jk', a, b))
     # sum all elements
     helper_test_op([(20,30,40)], lambda a: torch.einsum('ijk->', a), lambda a: Tensor.einsum('ijk->', a))
     # column sum

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1552,7 +1552,8 @@ class Tensor:
     """
     xs:Tuple[Tensor] = argfix(*raw_xs)
     formula = formula.replace(" ", "")
-    inputs_str, output = formula.split("->") if "->" in formula else (formula, ''.join(ch for ch in sorted(formula) if formula.count(ch) == 1 and ch.isalpha()))
+    inputs_str, output = formula.split("->") if "->" in formula else (formula, \
+                                                                       ''.join(c for c in sorted(formula) if formula.count(c) == 1 and c.isalpha()))
     inputs = [x for x in cast(str,inputs_str).split(',')]
     assert len(xs) == len(inputs), f"number of inputs doesn't match number of operands in formula, expected {len(inputs)}, got {len(xs)}"
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1552,7 +1552,7 @@ class Tensor:
     """
     xs:Tuple[Tensor] = argfix(*raw_xs)
     formula = formula.replace(" ", "")
-    inputs_str, output = formula.split("->") if "->" in formula else (formula, sorted(formula))
+    inputs_str, output = formula.split("->") if "->" in formula else (formula, ''.join(ch for ch in sorted(formula) if formula.count(ch) == 1 and ch.isalpha()))
     inputs = [x for x in cast(str,inputs_str).split(',')]
     assert len(xs) == len(inputs), f"number of inputs doesn't match number of operands in formula, expected {len(inputs)}, got {len(xs)}"
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1554,7 +1554,7 @@ class Tensor:
     formula = formula.replace(" ", "")
     inputs_str, output = formula.split("->") if "->" in formula else (formula, \
                                                                        ''.join(c for c in sorted(formula) if formula.count(c) == 1 and c.isalpha()))
-    inputs = [x for x in cast(str,inputs_str).split(',')]
+    inputs = [x for x in inputs_str.split(',')]
     assert len(xs) == len(inputs), f"number of inputs doesn't match number of operands in formula, expected {len(inputs)}, got {len(xs)}"
 
     # map the value of each letter in the formula


### PR DESCRIPTION
Found this small bug on the einsum output string while implementing ellipsis support for einsum.

Bug occurs when there's no "->" in the formula (so empty rhs) and multiple input operands

In this case output string should be sorted and repeated characters should be summed over (removed)