### PR TITLE
look for unsafe pad ops in multiview ShapeTrackers

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -144,6 +144,8 @@ def _recurse_lb(buf:LazyBuffer, realizes:Dict[LazyBuffer, None], allbufs:Dict[La
         pass # don't realize image to image casts. this is part of a larger problem
       else:
         realizes[buf.base] = None
+    # check all other pads for safe fusion
+    elif any(v.mask is not None for v in buf.st.views): simple_pads.add(buf.base)
     return _recurse_lb(buf.base, realizes, allbufs, simple_pads, children)
   # base
   allbufs[buf] = None


### PR DESCRIPTION
Currently the scheduler only accounts for the last view, it should instead check all views in the ShapeTracker for masks and correctly unfuse unsafe pads:
`(View(shape=(2, 4), strides=(0, 1), offset=-1, mask=((0, 2), (1, 4)), contiguous=False), View(shape=(8,), strides=(1,), offset=0, mask=None, contiguous=True))`

Kernel diff with NOOPT=1

master:
```
kernel void E_8(device float* data0, const device float* data1, const device float* data2, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int gidx0 = gid.x; /* 8 */
  int alu0 = (gidx0%4);
  bool alu1 = (0<alu0);
  float val0 = (alu1?*(data1+alu0+(-1)):0.0f);
  float val1 = (alu1?*(data2+0):0.0f);
  *(data0+gidx0) = (val0*(1/val1));
}
```

this branch:
```
kernel void E_3_3(device float* data0, const device float* data1, const device float* data2, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int gidx1 = gid.x; /* 3 */
  int gidx0 = gid.y; /* 3 */
  int alu0 = ((gidx0*3)+gidx1);
  float val0 = *(data1+alu0);
  float val1 = *(data2+gidx0);
  *(data0+alu0) = (val0*(1/val1));
}

kernel void C_8(device float* data0, const device float* data1, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int gidx0 = gid.x; /* 8 */
  int alu0 = (gidx0%4);
  float val0 = ((0<alu0)?*(data1+alu0+(-1)):0.0f);
  *(data0+gidx0) = val0;
}
```


This is an issue in 0.0.9, a combination of upcast + upat hide the issue in fused E_8 by folding the division by 0 to a literal 0 in master:
```
kernel void E_2_4(device float* data0, const device float* data1, const device float* data2, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int lidx0 = lid.x; /* 2 */
  float val0 = *(data1+0);
  float val1 = *(data1+1);
  float val2 = *(data1+2);
  float val3 = *(data2+0);
  float alu0 = (1/val3);
  *((device float4*)(data0+lidx0*4)) = float4(0.0f,(val0*alu0),(val1*alu0),(val2*alu0));
}
```