### PR TITLE
hcq signal scheduler

### DIFF
--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -52,45 +52,52 @@ class HCQGraph(MultiGraphRunner):
     self.kickoff_value = 0
     self.graph_timeline = {dev: 0 for dev in self.devices}
 
+    signal_scheduling = {}
     self.exec_ptrs: Dict[int, Tuple[Any, int]] = {}
     self.copy_to_devs: Dict[Compiled, Set[Compiled]] = {dev: set() for dev in self.devices}
 
+    for j,ji in enumerate(self.jit_cache):
+      if isinstance(ji.prg, CompiledRunner):
+        deps = self.access_resources(ji.bufs[(outs:=ji.prg.p.outcount):], ji.bufs[:outs], (self.comp_signal[ji.prg.device], sig_val:=j+1))
+        deps = [x for x in deps if id(x[0]) != id(self.comp_signal[ji.prg.device])]
+
+        # NV should self wait if we have any other dependecies which brake the chained execution.
+        if ji.prg.device.dname.startswith("NV") and (len(deps) >= 1 or id(deps[0][1]) != id(self.comp_signal[ji.prg.device])):
+          deps.append((self.comp_signal[ji.prg.device], self.comp_signal_val[ji.prg.device]))
+
+        signal_scheduling[j] = (deps, None) # output signal
+        self.comp_signal_val[ji.prg.device] = sig_val
+      elif isinstance(ji.prg, BufferXfer):
+        dest, src = [cast(Buffer, x) for x in ji.bufs[0:2]]
+        deps = self.access_resources([src], [dest], (self.copy_signal[Device[src.device]], sig_val:=j+1))
+        deps = [x for x in deps if id(x[0]) != id(self.copy_signal[Device[src.device]])]
+        signal_scheduling[j] = (deps, j+1) # output signal
+        self.copy_signal_val[Device[src.device]] = sig_val
+        self.copy_to_devs[Device[dest.device]].add(Device[src.device])
+      for sig,val in deps: signal_scheduling[val - 1] = (signal_scheduling[val - 1][0], val) # set need output for signal, as it has deps
+
+    # Building hardware queues
     for dev in self.devices:
       self.comp_queues[dev].memory_barrier().wait(dev.timeline_signal, dev.timeline_value - 1).wait(self.kickoff_signal, self.kickoff_value)
       self.copy_queues[dev].wait(dev.timeline_signal, dev.timeline_value - 1).wait(self.kickoff_signal, self.kickoff_value)
 
     for j,ji in enumerate(self.jit_cache):
+      deps, signal_value = signal_scheduling[j]
+
       if isinstance(ji.prg, CompiledRunner):
-        exec_params = {}
-        deps = self.access_resources(ji.bufs[(outs:=ji.prg.p.outcount):], ji.bufs[:outs], (self.comp_signal[ji.prg.device], sig_val:=j+1))
-        deps = [x for x in deps if id(x[0]) != id(self.comp_signal[ji.prg.device])]
-
-        # On NV, to synchronize kernel execution, we must either issue a wait or chain executions to schedule them in order.
-        # Chaining executions is preferred when possible, as it is faster.
-        if ji.prg.device.dname.startswith("NV"):
-          if len(deps) == 0 and self.comp_signal_val[ji.prg.device] > 0:
-            exec_params['chain_exec_ptr'] = self.exec_ptrs[self.comp_signal_val[ji.prg.device] - 1][1]
-          else: deps.append((self.comp_signal[ji.prg.device], self.comp_signal_val[ji.prg.device]))
-
         for sig, val in deps: self.comp_queues[ji.prg.device].wait(sig, val)
-
-        self.exec_ptrs[j] = (self.comp_queues[ji.prg.device], len(self.comp_queues[ji.prg.device]))
         self.comp_queues[ji.prg.device].exec(ji.prg.clprg, self.kargs_addrs[j], *ji.prg.p.launch_dims(var_vals),
-                                             signal=self.comp_signal[ji.prg.device], signal_value=sig_val, **exec_params)
-        self.comp_signal_val[ji.prg.device] = sig_val
+                                             signal=self.comp_signal[ji.prg.device] if signal_value is not None else None, signal_value=signal_value)
+        self.exec_ptrs[j] = (self.comp_queues[ji.prg.device], len(self.comp_queues[ji.prg.device]) - 1)
       elif isinstance(ji.prg, BufferXfer):
         dest, src = [cast(Buffer, x) for x in ji.bufs[0:2]]
         Device[src.device]._gpu_map(dest._buf) #type: ignore
 
-        deps = self.access_resources([src], [dest], (self.copy_signal[Device[src.device]], sig_val:=j+1))
-        deps.append((self.copy_signal[Device[src.device]], self.copy_signal_val[Device[src.device]]))
-        self.copy_signal_val[Device[src.device]] = sig_val
-
         for sig,val in deps: self.copy_queues[Device[src.device]].wait(sig, val)
         self.copy_queues[Device[src.device]].copy(dest._buf.va_addr, src._buf.va_addr, dest.nbytes) \
-                                            .signal(self.copy_signal[Device[src.device]], sig_val)
-        self.copy_to_devs[Device[dest.device]].add(Device[src.device])
+                                            .signal(self.copy_signal[Device[src.device]], signal_value)
 
+    # Finilize queues
     for dev in self.devices:
       if self.copy_signal_val[dev] > 0: self.comp_queues[dev].wait(self.copy_signal[dev], self.copy_signal_val[dev])
       for dep_dev in self.copy_to_devs[dev]: self.comp_queues[dev].wait(self.copy_signal[dep_dev], self.copy_signal_val[dep_dev])

--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -52,7 +52,7 @@ class HCQGraph(MultiGraphRunner):
     self.kickoff_value = 0
     self.graph_timeline = {dev: 0 for dev in self.devices}
 
-    signal_scheduling = {}
+    signal_scheduling: Dict[int, Tuple[List, Optional[int]]] = {}
     self.exec_ptrs: Dict[int, Tuple[Any, int]] = {}
     self.copy_to_devs: Dict[Compiled, Set[Compiled]] = {dev: set() for dev in self.devices}
 
@@ -114,7 +114,7 @@ class HCQGraph(MultiGraphRunner):
     for dev in self.devices:
       dev._set_signal(self.comp_signal[dev], 0)
       dev._set_signal(self.copy_signal[dev], 0)
-    dev._set_signal(self.kickoff_signal, self.kickoff_value)
+    self.devices[0]._set_signal(self.kickoff_signal, self.kickoff_value)
 
     # Update rawbuffers
     for (j,i),input_idx in self.input_replace.items(): self.ji_args_bufs[j][i] = input_rawbuffers[input_idx]._buf.va_addr

--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -59,7 +59,8 @@ class HCQGraph(MultiGraphRunner):
     # Schedule signals
     for j,ji in enumerate(self.jit_cache):
       if isinstance(ji.prg, CompiledRunner):
-        deps = self.access_resources(ji.bufs[(outs:=ji.prg.p.outcount):], ji.bufs[:outs], (self.comp_signal[dev:=ji.prg.device], sig_val:=j+1))
+        deps = self.access_resources(ji.bufs[(outs:=ji.prg.p.outcount):], ji.bufs[:outs], (self.comp_signal[(dev:=ji.prg.device)], sig_val:=j+1))
+        if (val:=self.comp_signal_val[dev]) > 0: deps = [x for x in deps if id(x[0]) != id(self.comp_signal[dev])] + [(self.comp_signal[dev], val)]
 
         # Remove self-dependency for AMD or NV with only 1 same-queue dep, since NV chains 2+ kernels in this case, eliminating dep need.
         if (dname:=dev.dname.split(":", 1)[0]) == "AMD" or (dname == "NV" and len(deps) == 1 and id(deps[0][0]) == id(self.comp_signal[dev])):
@@ -68,7 +69,8 @@ class HCQGraph(MultiGraphRunner):
         signal_scheduling[j] = (deps, None) # on compute kernels, we can skip signals by default, since no dependencies might be there.
         self.comp_signal_val[dev] = sig_val
       elif isinstance(ji.prg, BufferXfer):
-        deps = self.access_resources([src:=ji.bufs[0]], [dest:=ji.bufs[1]], (self.copy_signal[Device[src.device]], sig_val:=j+1))
+        dest, src = [cast(Buffer, x) for x in ji.bufs[0:2]]
+        deps = self.access_resources([src], [dest], (self.copy_signal[Device[src.device]], sig_val:=j+1))
         deps = [x for x in deps if id(x[0]) != id(self.copy_signal[Device[src.device]])]
         signal_scheduling[j] = (deps, j+1)
         self.copy_signal_val[Device[src.device]] = sig_val

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -172,15 +172,15 @@ class HWComputeQueue(HWQueue):
       qmd.release0_payload_upper = signal_value >> 32
       qmd.release0_enable = 1
 
-    if self.cmd_idx_to_qmd.get(len(self) - 1) is None:
+    if (prev_qmd:=self.cmd_idx_to_qmd.get(len(self) - 1)) is None:
       self.q += [nvmethod(1, nv_gpu.NVC6C0_INVALIDATE_SHADER_CACHES_NO_WFI, 1), (1 << 12) | (1 << 4) | (1 << 0)]
       self.q += [nvmethod(1, nv_gpu.NVC6C0_SEND_PCAS_A, 0x1), qmd_addr >> 8]
       self.q += [nvmethod(1, nv_gpu.NVC6C0_SEND_SIGNALING_PCAS2_B, 0x1), 9]
     else:
-      self.cmd_idx_to_qmd[len(self) - 1].dependent_qmd0_pointer = qmd_addr >> 8
-      self.cmd_idx_to_qmd[len(self) - 1].dependent_qmd0_action = 1
-      self.cmd_idx_to_qmd[len(self) - 1].dependent_qmd0_prefetch = 1
-      self.cmd_idx_to_qmd[len(self) - 1].dependent_qmd0_enable = 1
+      prev_qmd.dependent_qmd0_pointer = qmd_addr >> 8
+      prev_qmd.dependent_qmd0_action = 1
+      prev_qmd.dependent_qmd0_prefetch = 1
+      prev_qmd.dependent_qmd0_enable = 1
     return self._mark_command_end()
 
   def update_exec(self, cmd_idx, global_size, local_size):

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -155,7 +155,7 @@ class HWComputeQueue(HWQueue):
     self.q += [nvmethod(1, nv_gpu.NVC6C0_LOAD_INLINE_DATA, len(data), typ=6)] + [x for x in data]
     return self._mark_command_end()
 
-  def exec(self, prg, kernargs, global_size=(1,1,1), local_size=(1,1,1), signal=None, signal_value=0, chain_exec_ptr=None):
+  def exec(self, prg, kernargs, global_size=(1,1,1), local_size=(1,1,1), signal=None, signal_value=0):
     ctypes.memmove(qmd_addr:=(kernargs + round_up(prg.constbuf_0_size, 1 << 8)), ctypes.addressof(prg.qmd), 0x40 * 4)
     self.cmd_idx_to_qmd[len(self)] = qmd = qmd_struct_t.from_address(qmd_addr) # Save qmd for later update
     self.cmd_idx_to_global_dims[len(self)] = to_mv(qmd_addr + nv_gpu.NVC6C0_QMDV03_00_CTA_RASTER_WIDTH[1] // 8, 12).cast('I')
@@ -172,15 +172,15 @@ class HWComputeQueue(HWQueue):
       qmd.release0_payload_upper = signal_value >> 32
       qmd.release0_enable = 1
 
-    if chain_exec_ptr is None:
+    if self.cmd_idx_to_qmd.get(len(self) - 1) is None:
       self.q += [nvmethod(1, nv_gpu.NVC6C0_INVALIDATE_SHADER_CACHES_NO_WFI, 1), (1 << 12) | (1 << 4) | (1 << 0)]
       self.q += [nvmethod(1, nv_gpu.NVC6C0_SEND_PCAS_A, 0x1), qmd_addr >> 8]
       self.q += [nvmethod(1, nv_gpu.NVC6C0_SEND_SIGNALING_PCAS2_B, 0x1), 9]
     else:
-      self.cmd_idx_to_qmd[chain_exec_ptr].dependent_qmd0_pointer = qmd_addr >> 8
-      self.cmd_idx_to_qmd[chain_exec_ptr].dependent_qmd0_action = 1
-      self.cmd_idx_to_qmd[chain_exec_ptr].dependent_qmd0_prefetch = 1
-      self.cmd_idx_to_qmd[chain_exec_ptr].dependent_qmd0_enable = 1
+      self.cmd_idx_to_qmd[len(self) - 1].dependent_qmd0_pointer = qmd_addr >> 8
+      self.cmd_idx_to_qmd[len(self) - 1].dependent_qmd0_action = 1
+      self.cmd_idx_to_qmd[len(self) - 1].dependent_qmd0_prefetch = 1
+      self.cmd_idx_to_qmd[len(self) - 1].dependent_qmd0_enable = 1
     return self._mark_command_end()
 
   def update_exec(self, cmd_idx, global_size, local_size):


### PR DESCRIPTION
NV llama now:
```
enqueue in   3.87 ms
total   8.53 ms, 117.21 tok/s, 1638.39 GB/s, param 1580.82 GB/s
 male
```

Rework of #4916