### PR TITLE
potential bug in hcq graph for multi gpu

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -309,7 +309,7 @@ def create_schedule_with_vars(outs:List[LazyBuffer], seen:Optional[Set[LazyBuffe
     for out in ps.outputs: del out.srcs  # can only schedule once
     schedule.append(si:=ScheduleItem(ps.ast, tuple(x.buffer for x in (ps.outputs+ps.inputs) if x.size != 0)))
     if logops and si.ast[0].op not in LoadOps and not any(i.device.startswith("DISK:") for i in si.inputs): logops.write(str(si.ast)+"\n")
-    for x in graph[ps.outputs[0]]:
+    for x in graph[ps.outputs[0]][::-1]:
       in_degree[x] -= 1
       if in_degree[x] == 0: queue.append(prescheduled[x])
 


### PR DESCRIPTION
was testing this scheduler enqueue order because it made single gpu llm.c faster. I would expect any topological order works.

But training resnet with JIT=1, the loss is not going down. It has faster step time, maybe some kernels are not executed properly.
JIT=2 seems fine, a lot slower but loss is going down.

JIT=1 https://wandb.ai/chenyuxyz/tinygrad-examples_mlperf/runs/iosm77yr?nw=nwuserchenyuxyz
JIT=2 https://wandb.ai/chenyuxyz/tinygrad-examples_mlperf/runs/tfgrgsc9?nw=nwuserchenyuxyz

@nimlgen fyi. I can test with CUDA / NV tomorrow to isolate the issue further.