### PR TITLE
generic gate folding

### DIFF
--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -90,9 +90,9 @@ class TestUOpGraph(unittest.TestCase):
     ld1 = UOp(UOps.LOAD, dtypes.int, (glbl2, idx, UOp.const(dtypes.bool, True), UOp.const(dtypes.int, 3)))
     uops = UOpGraph([UOp(UOps.STORE, None, (glbl0, idx, ld0+ld1))])
     ld0, ld1 = uops[-1].src[2].src
-    # ld0 folds to the invalid value
+    # ld0 becomes the invalid value
     self.assert_equiv_uops(ld0, UOp.const(dtypes.int, 2))
-    # ld1 folds to the valid value
+    # the gate and invalid value are deleted from ld1
     self.assert_equiv_uops(ld1, UOp.load(glbl2, idx, dtype=dtypes.int))
 
   def test_fold_gated_load_local(self):
@@ -105,9 +105,9 @@ class TestUOpGraph(unittest.TestCase):
     ld1 = UOp(UOps.LOAD, dtypes.int, (smem, lidx+2, UOp.const(dtypes.bool, True), UOp.const(dtypes.int, 3), barrier))
     uops = UOpGraph([UOp(UOps.STORE, None, (glbl0, lidx, ld0+ld1))])
     ld0, ld1 = uops[-1].src[2].src
-    # ld0 folds to the invalid value
+    # ld0 becomes the invalid value
     self.assert_equiv_uops(ld0, UOp.const(dtypes.int, 2))
-    # ld1 folds to the valid value
+    # the gate and invalid value are deleted from ld1
     self.assert_equiv_uops(ld1, UOp.load(smem, lidx+2, barrier, dtype=dtypes.int))
 
   def test_fold_gated_store(self):

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -5,6 +5,13 @@ from tinygrad.ops import BinaryOps, TernaryOps, UnaryOps
 from tinygrad.codegen.uops import UOpGraph, UOps, UOp
 
 class TestUOpGraph(unittest.TestCase):
+  # TODO: move to test.helpers
+  def assert_equiv_uops(self, uop1:UOp, uop2:UOp):
+    # NOTE: direct UOps __eq__ is comparing object reference, use this function to compare two uops
+    self.assertEqual(uop1.op, uop2.op)
+    self.assertEqual(uop1.dtype, uop2.dtype)
+    self.assertEqual(uop1.arg, uop2.arg)
+
   def test_add_constant_fold(self):
     c1 = UOp(UOps.CONST, dtypes.float, arg=1.0)
     c2 = UOp(UOps.CONST, dtypes.float, arg=2.0)
@@ -71,6 +78,44 @@ class TestUOpGraph(unittest.TestCase):
     self.assertEqual(out.arg, BinaryOps.ADD)
     self.assertEqual(out.src[1].op, UOps.CONST)
     self.assertEqual(out.src[1].arg, 6)
+
+  def test_fold_gated_load(self):
+    glbl0 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
+    glbl1 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (1, False))
+    glbl2 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (2, False))
+    idx = UOp.const(dtypes.int, 0)
+    ld0 = UOp(UOps.LOAD, dtypes.int, (glbl1, idx, UOp.const(dtypes.bool, False), UOp.const(dtypes.int, 2)))
+    ld1 = UOp(UOps.LOAD, dtypes.int, (glbl2, idx, UOp.const(dtypes.bool, True), UOp.const(dtypes.int, 3)))
+    uops = UOpGraph([UOp(UOps.STORE, None, (glbl0, idx, ld0+ld1))])
+    ld0, ld1 = uops[-1].src[2].src
+    # ld0 folds to the invalid value
+    self.assert_equiv_uops(ld0, UOp.const(dtypes.int, 2))
+    # ld1 folds to the valid value
+    self.assert_equiv_uops(ld1, UOp.load(glbl1, idx, dtype=dtypes.int))
+
+  def test_fold_gated_load_local(self):
+    glbl0 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
+    smem = UOp(UOps.DEFINE_LOCAL, PtrDType(dtypes.int), (), ("temp", 16))
+    idx0 = UOp.const(dtypes.int, 0)
+    idx1 = UOp.const(dtypes.int, 1)
+    ld0 = UOp(UOps.LOAD, dtypes.int, (smem, idx0, UOp.const(dtypes.bool, False), UOp.const(dtypes.int, 2)))
+    ld1 = UOp(UOps.LOAD, dtypes.int, (smem, idx1, UOp.const(dtypes.bool, True), UOp.const(dtypes.int, 3)))
+    uops = UOpGraph([UOp(UOps.STORE, None, (glbl0, idx0, ld0+ld1))])
+    ld0, ld1 = uops[-1].src[2].src
+    # ld0 folds to the invalid value
+    self.assert_equiv_uops(ld0, UOp.const(dtypes.int, 2))
+    # ld1 folds to the valid value
+    self.assert_equiv_uops(ld1, UOp.load(smem, idx1, dtype=dtypes.int))
+
+  def test_fold_gated_store(self):
+    glbl = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
+    idx = UOp.const(dtypes.int, 0)
+    val = UOp.const(dtypes.int, 42)
+    st0 = UOp(UOps.STORE, None, (glbl, idx, val, UOp.const(dtypes.bool, False)))
+    st1 = UOp(UOps.STORE, None, (glbl, idx+1, val, UOp.const(dtypes.bool, True)))
+    uops = UOpGraph([st0, st1])
+    self.assertEqual(len(uops.uops), 4)
+    self.assert_equiv_uops(uops[-1], UOp.store(glbl, idx+1, val))
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -97,19 +97,18 @@ class TestUOpGraph(unittest.TestCase):
 
   def test_fold_gated_load_local(self):
     glbl0 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
-    smem = UOp(UOps.DEFINE_LOCAL, PtrDType(dtypes.int), (), ("temp", 16))
-    idx0 = UOp.const(dtypes.int, 0)
-    idx1 = UOp.const(dtypes.int, 1)
-    st = UOp(UOps.STORE, None, (smem, idx0, UOp.const(dtypes.int, 2)))
+    smem = UOp(UOps.DEFINE_LOCAL, PtrDType(dtypes.int), (), ("temp", 1))
+    lidx = UOp(UOps.SPECIAL, dtypes.int, (), (0, "lidx1", 16))
+    st = UOp(UOps.STORE, None, (smem, lidx, UOp.load(glbl0, lidx, dtype=dtypes.int)))
     barrier = UOp(UOps.BARRIER, None, (st, ))
-    ld0 = UOp(UOps.LOAD, dtypes.int, (smem, idx0, UOp.const(dtypes.bool, False), UOp.const(dtypes.int, 2), barrier))
-    ld1 = UOp(UOps.LOAD, dtypes.int, (smem, idx1, UOp.const(dtypes.bool, True), UOp.const(dtypes.int, 3), barrier))
-    uops = UOpGraph([UOp(UOps.STORE, None, (glbl0, idx0, ld0+ld1))])
+    ld0 = UOp(UOps.LOAD, dtypes.int, (smem, lidx+1, UOp.const(dtypes.bool, False), UOp.const(dtypes.int, 2), barrier))
+    ld1 = UOp(UOps.LOAD, dtypes.int, (smem, lidx+2, UOp.const(dtypes.bool, True), UOp.const(dtypes.int, 3), barrier))
+    uops = UOpGraph([UOp(UOps.STORE, None, (glbl0, lidx, ld0+ld1))])
     ld0, ld1 = uops[-1].src[2].src
     # ld0 folds to the invalid value
     self.assert_equiv_uops(ld0, UOp.const(dtypes.int, 2))
     # ld1 folds to the valid value
-    self.assert_equiv_uops(ld1, UOp.load(smem, idx1, barrier, dtype=dtypes.int))
+    self.assert_equiv_uops(ld1, UOp.load(smem, lidx+2, barrier, dtype=dtypes.int))
 
   def test_fold_gated_store(self):
     glbl = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
@@ -119,6 +118,7 @@ class TestUOpGraph(unittest.TestCase):
     st0 = UOp(UOps.STORE, None, (glbl, idx0, val, UOp.const(dtypes.bool, False)))
     st1 = UOp(UOps.STORE, None, (glbl, idx1, val, UOp.const(dtypes.bool, True)))
     uops = UOpGraph([st0, st1])
+    # only the second store happens
     self.assertEqual(len(uops.uops), 4)
     self.assert_equiv_uops(uops[-1], UOp.store(glbl, idx1, val))
 

--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -290,24 +290,6 @@ class TestLocalAccess(unittest.TestCase):
     sres = uop(uops, UOps.LOAD, dtypes.int32, (smem, ofs))
     self.assertEqual(_test_uops_result(dtypes.int32, uops, sres), 42)
 
-class TestGateFolding(unittest.TestCase):
-  def test_fold_load(self):
-    glbl0 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
-    glbl1 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (1, False))
-    glbl2 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (2, False))
-    idx = UOp.const(dtypes.int, 0)
-    ld0 = UOp(UOps.LOAD, dtypes.int, (glbl1, idx, UOp.const(dtypes.bool, False), UOp.const(dtypes.int, 42)))
-    ld1 = UOp(UOps.LOAD, dtypes.int, (glbl2, idx, UOp.const(dtypes.bool, True), UOp.const(dtypes.int, 42)))
-    uops = UOpGraph([UOp(UOps.STORE, None, (glbl0, idx, ld0 + ld1))])
-    code = Device[Device.DEFAULT].renderer.render("test", uops)
-    if DEBUG >= 4: print(code)
-
-  def test_fold_load_local(self):
-    pass
-  def test_fold_store(self):
-    pass
-
-
 @unittest.skipUnless(Device.DEFAULT in {"CUDA"} and getenv("PTX"), "This only tests assembly backends")
 class TestAssembly(unittest.TestCase):
   def test_bitshift_left(self):

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -256,10 +256,11 @@ constant_folder = PatternMatcher([
   # cast NOOP (NOTE: it's str to deal with PtrDType)
   (UPat(UOps.CAST, name="root"), lambda root: root.src[0] if str(root.dtype) == str(root.src[0].dtype) else None),
   # fold gated LOAD/STORE
-  (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(dtypes.int, 1), UOp.cvar("var")), lambda buf,idx,var: UOp.load(buf, idx, dtype=var.dtype)),
-  (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(dtypes.int, 1), UOp.cvar("var"), UOp.var("barrier")),
+  (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(None, 1), UOp.cvar("var")), lambda buf,idx,var: UOp.load(buf, idx, dtype=var.dtype)),
+  (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(None, 1), UOp.cvar("var"), UOp.var("barrier")),
    lambda buf,idx,var,barrier: UOp.load(buf, idx, barrier, dtype=var.dtype)),
-  (UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(dtypes.int, 1)), UOp.store),
+  (UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(None, 1)), UOp.store),
+  #(UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(None, 0)), lambda buf,idx,val: UOp(UOps.NOOP)),
 ])
 
 # *** uop graph ***
@@ -465,8 +466,8 @@ class UOpGraph:
         if uop is UOps.DEFINE_ACC: arg = arg[0]
         assert dtype is not None and type(arg) is type(dtypes.as_const(arg, dtype)), f"type of {arg=} does not match {dtype}"
       if uop in {UOps.CAST, UOps.BITCAST}: assert arg is None   # type is the output type, not an arg
-      if uop is UOps.LOAD and len(src) > 2: assert src[2].dtype is dtypes.bool
-      if uop is UOps.STORE and len(src) == 4: assert src[3].dtype is dtypes.bool
+      #if uop is UOps.LOAD and len(src) > 2: assert src[2].dtype is dtypes.bool
+      #if uop is UOps.STORE and len(src) == 4: assert src[3].dtype is dtypes.bool
       if uop is UOps.ALU:
         if arg in UnaryOps:
           assert dtype == src[0].dtype, f"{arg} dtype mismatch {dtype=} != {src[0].dtype=}"

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -259,8 +259,10 @@ constant_folder = PatternMatcher([
   (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(None, 1), UOp.cvar("var")), lambda buf,idx,var: UOp.load(buf, idx, dtype=var.dtype)),
   (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(None, 1), UOp.cvar("var"), UOp.var("barrier")),
    lambda buf,idx,var,barrier: UOp.load(buf, idx, barrier, dtype=var.dtype)),
+  (UOp.load(UOp.var(), UOp.var(), UOp.const(None, 0), UOp.cvar("var")), lambda var: var),
+  (UOp.load(UOp.var(), UOp.var(), UOp.const(None, 0), UOp.cvar("var"), UOp.var("")), lambda var: var),
   (UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(None, 1)), UOp.store),
-  #(UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(None, 0)), lambda buf,idx,val: UOp(UOps.NOOP)),
+  (UOp.store(UOp.var(), UOp.var(), UOp.var(), UOp.const(None, 0)), lambda: UOp(UOps.NOOP)),
 ])
 
 # *** uop graph ***

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -465,6 +465,8 @@ class UOpGraph:
         if uop is UOps.DEFINE_ACC: arg = arg[0]
         assert dtype is not None and type(arg) is type(dtypes.as_const(arg, dtype)), f"type of {arg=} does not match {dtype}"
       if uop in {UOps.CAST, UOps.BITCAST}: assert arg is None   # type is the output type, not an arg
+      if uop is UOps.LOAD and len(src) > 2: assert src[2].dtype is dtypes.bool
+      if uop is UOps.STORE and len(src) == 4: assert src[3].dtype is dtypes.bool
       if uop is UOps.ALU:
         if arg in UnaryOps:
           assert dtype == src[0].dtype, f"{arg} dtype mismatch {dtype=} != {src[0].dtype=}"

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -468,7 +468,7 @@ class UOpGraph:
         if uop is UOps.DEFINE_ACC: arg = arg[0]
         assert dtype is not None and type(arg) is type(dtypes.as_const(arg, dtype)), f"type of {arg=} does not match {dtype}"
       if uop in {UOps.CAST, UOps.BITCAST}: assert arg is None   # type is the output type, not an arg
-      if uop is UOps.LOAD and len(src) > 2 and src[2].op is not UOps.IF: assert src[2].dtype is dtypes.bool
+      if uop is UOps.LOAD and len(src) > 2 and src[2].op not in {UOps.IF, UOps.BARRIER}: assert src[2].dtype is dtypes.bool
       if uop is UOps.STORE and len(src) == 4: assert src[3].dtype is dtypes.bool
       if uop is UOps.ALU:
         if arg in UnaryOps:

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -468,8 +468,8 @@ class UOpGraph:
         if uop is UOps.DEFINE_ACC: arg = arg[0]
         assert dtype is not None and type(arg) is type(dtypes.as_const(arg, dtype)), f"type of {arg=} does not match {dtype}"
       if uop in {UOps.CAST, UOps.BITCAST}: assert arg is None   # type is the output type, not an arg
-      #if uop is UOps.LOAD and len(src) > 2: assert src[2].dtype is dtypes.bool
-      #if uop is UOps.STORE and len(src) == 4: assert src[3].dtype is dtypes.bool
+      if uop is UOps.LOAD and len(src) > 2 and src[2].op is not UOps.IF: assert src[2].dtype is dtypes.bool
+      if uop is UOps.STORE and len(src) == 4: assert src[3].dtype is dtypes.bool
       if uop is UOps.ALU:
         if arg in UnaryOps:
           assert dtype == src[0].dtype, f"{arg} dtype mismatch {dtype=} != {src[0].dtype=}"

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -260,7 +260,7 @@ constant_folder = PatternMatcher([
   (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(None, 1), UOp.cvar("var"), UOp.var("barrier")),
    lambda buf,idx,var,barrier: UOp.load(buf, idx, barrier, dtype=var.dtype)),
   (UOp.load(UOp.var(), UOp.var(), UOp.const(None, 0), UOp.cvar("var")), lambda var: var),
-  (UOp.load(UOp.var(), UOp.var(), UOp.const(None, 0), UOp.cvar("var"), UOp.var("")), lambda var: var),
+  (UOp.load(UOp.var(), UOp.var(), UOp.const(None, 0), UOp.cvar("var"), UOp.var()), lambda var: var),
   (UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(None, 1)), UOp.store),
   (UOp.store(UOp.var(), UOp.var(), UOp.var(), UOp.const(None, 0)), lambda: UOp(UOps.NOOP)),
 ])


### PR DESCRIPTION
This diff folds symbolic NumNode 0 and 1 and CONST literal True and False gates.
After the symbolic removal we should always render a literal boolean for valid and remove the `None` in UPat.