### PR TITLE
remove set in function.Flip getting arg

### DIFF
--- a/tinygrad/function.py
+++ b/tinygrad/function.py
@@ -205,7 +205,7 @@ class Shrink(Function):
 
 class Flip(Function):
   def forward(self, x:LazyBuffer, axis:Tuple[int, ...]) -> LazyBuffer:
-    self.arg = tuple([-1 if i in set(axis) else 1 for i in range(len(x.shape))])
+    self.arg = tuple([-1 if i in axis else 1 for i in range(len(x.shape))])
     return x.stride(self.arg)
 
   def backward(self, grad_output:LazyBuffer) -> LazyBuffer: return grad_output.stride(self.arg)


### PR DESCRIPTION
contructing set for every i is expensive and unnecessary.

```
print(timeit.timeit("a = tuple([-1 if i in set((0, 2, 3)) else 1 for i in range(7)])"))
print(timeit.timeit("a = tuple([-1 if i in (0, 2, 3) else 1 for i in range(7)])"))
```
```
0.8064187910640612
0.34930695802904665
```