### PR TITLE
perf: faster pattern matcher

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -110,22 +110,43 @@ def __unmatch(m1:Union[T, Set[T]], m2:T) -> bool:
   return False
 
 def _match(uop:UOp, pat:UPat, store:Dict[str, UOp]) -> bool:
-  if pat.name in store and store[pat.name] is not uop: return False
+  if pat.arg is not None and __unmatch(pat.arg, uop.arg):return False, store
+  if pat.op is not None and __unmatch(pat.op, uop.op):return False, store
+  if pat.name in store and store[pat.name] is not uop: return False, store
   if pat.name is not None: store[pat.name] = uop
-  if pat.arg is not None and __unmatch(pat.arg, uop.arg): return False
-  if pat.dtype is not None and uop.dtype is not None and __unmatch(pat.dtype, uop.dtype): return False
-  if pat.op is not None and __unmatch(pat.op, uop.op): return False
-  if pat.src is None: return True
+  if pat.dtype is not None and uop.dtype is not None and __unmatch(pat.dtype, uop.dtype): return False, store
+  if pat.src is None:return True, store
   # only one if it's a tuple
   # try all permutations if it's a list
   # repeat if it's a UPat
   for vp in itertools.permutations(pat.src) if isinstance(pat.src,list) else ([pat.src] if isinstance(pat.src,tuple) else [(pat.src,)*len(uop.src)]):
-    if len(uop.src) != len(vp) and (len(uop.src) not in pat.allow_len): return False
+    if len(uop.src) != len(vp) and (len(uop.src) not in pat.allow_len): return False, store
     new_store = store.copy()
-    if all(_match(uu, vv, new_store) for uu, vv in zip(uop.src, vp)):
+    for uu, vv in zip(uop.src, vp):
+      res, new_store = _match(uu, vv, new_store)
+      if not res: break
+    else:
       store.update(new_store)
-      return True
-  return False
+      return True, store
+  return False, store
+
+@functools.lru_cache(None)
+def recursive_rewrite(pm: PatternMatcher, up:UOp) -> UOp:
+  recurse_cnt = 0
+  while (rewritten := rewrite_on_match(pm, up)) is not None:
+    assert recurse_cnt < 100, f"recursive_rewrite looped {up} <--> {rewritten}"
+    up = rewritten
+    recurse_cnt += 1
+  if up.src and (new_src := tuple(recursive_rewrite(pm, x) for x in up.src)) != up.src:
+      return UOp(up.op, up.dtype, new_src, up.arg)
+  return up
+
+@functools.lru_cache(None)
+def rewrite_on_match(pm, uop:UOp) -> Optional[UOp]:
+  for p,fxn in itertools.chain(pm.pdict[(uop.op, uop.arg)], pm.pdict[(uop.op, None)]):
+    res, store = _match(uop, p, {})
+    if res: return fxn(**store)
+  return None
 
 class PatternMatcher:
   def __init__(self, patterns:List[Tuple[Union[UPat, UOp], Callable]]):
@@ -139,26 +160,10 @@ class PatternMatcher:
         for uop in p.op: self.pdict[(uop, p.arg)].append((p, fxn))
       else:
         self.pdict[(p.op, p.arg)].append((p, fxn))
+    
 
-  @functools.lru_cache(None)
-  def recursive_rewrite(self, u:UOp) -> UOp:
-    recurse_cnt = 0
-    up = u
-    # locally recursively rewrite
-    while (rewritten := self.rewrite_on_match(up)) is not None:
-      assert recurse_cnt < 100, f"recursive_rewrite looped {up} <--> {rewritten}"
-      up = rewritten
-    if up.src:
-      new_src = tuple(self.recursive_rewrite(x) for x in up.src)
-      if new_src != up.src:
-        up = UOp(up.op, up.dtype, new_src, up.arg)
-    return up
 
-  def rewrite_on_match(self, uop:UOp) -> Optional[UOp]:
-    for p,fxn in itertools.chain(self.pdict[(uop.op, uop.arg)], self.pdict[(uop.op, None)]):
-      store: Dict[str, UOp] = {}
-      if _match(uop, p, store): return fxn(**store)
-    return None
+
 
 def sum_collapse(phi_input, loop, val1, val2):
   for v1,v2 in [(val1, val2), (val2, val1)]:
@@ -305,10 +310,9 @@ class UOpGraph:
       print(f"{i:4d} {str(u.op):20s}: {str(u.dtype) if u.dtype is not None else '':25s} " f"{str([self.uops.index(x) for x in u.src]):32s} {u.arg}")
 
   def graph_rewrite(self, sink, pm):
-    # recursive rewrite
     changed = getenv("UOPS_REWRITE", True)
     while changed:
-      rewritten = pm.recursive_rewrite(sink)
+      rewritten = recursive_rewrite(pm, sink)
       changed = sink != rewritten
       sink = rewritten
     self.nodes[sink] = sink

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -111,7 +111,7 @@ def __unmatch(m1:Union[T, Set[T]], m2:T) -> bool:
   elif m2 != m1: return True
   return False
 
-def _match(uop:UOp, pat:UPat, store:Dict[str, UOp]) -> bool:
+def _match(uop:UOp, pat:UPat, store:Dict[str, UOp]) -> Tuple[bool, Dict]:
   if pat.name in store and store[pat.name] is not uop: return False, store
   if pat.name is not None: store[pat.name] = uop
   if pat.op is not None and __unmatch(pat.op, uop.op):return False, store
@@ -140,7 +140,7 @@ def recursive_rewrite(pm: PatternMatcher, up:UOp) -> UOp:
     up = rewritten
     recurse_cnt += 1
   if up.src and (new_src := tuple(recursive_rewrite(pm, x) for x in up.src)) != up.src:
-      return UOp(up.op, up.dtype, new_src, up.arg)
+    return UOp(up.op, up.dtype, new_src, up.arg)
   return up
 
 @functools.lru_cache(None)

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -112,11 +112,11 @@ def __unmatch(m1:Union[T, Set[T]], m2:T) -> bool:
   return False
 
 def _match(uop:UOp, pat:UPat, store:Dict[str, UOp]) -> bool:
-  if pat.arg is not None and __unmatch(pat.arg, uop.arg):return False, store
-  if pat.op is not None and __unmatch(pat.op, uop.op):return False, store
   if pat.name in store and store[pat.name] is not uop: return False, store
   if pat.name is not None: store[pat.name] = uop
+  if pat.op is not None and __unmatch(pat.op, uop.op):return False, store
   if pat.dtype is not None and uop.dtype is not None and __unmatch(pat.dtype, uop.dtype): return False, store
+  if pat.arg is not None and __unmatch(pat.arg, uop.arg):return False, store
   if pat.src is None:return True, store
   # only one if it's a tuple
   # try all permutations if it's a list
@@ -162,9 +162,6 @@ class PatternMatcher:
         for uop in p.op: self.pdict[(uop, p.arg)].append((p, fxn))
       else:
         self.pdict[(p.op, p.arg)].append((p, fxn))
-    
-
-
 
 
 def sum_collapse(phi_input, loop, val1, val2):

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -149,7 +149,7 @@ class PatternMatcher:
   @functools.lru_cache(None)  # pylint: disable=method-cache-max-size-none
   def recursive_rewrite(self: PatternMatcher, up:UOp) -> UOp:
     recurse_cnt = 0
-    while (rewritten := self.rewrite_on_match(up)) is not None:
+    while (rewritten := self.rewrite(up)) is not None:
       assert recurse_cnt < 100, f"recursive_rewrite looped {up} <--> {rewritten}"
       up = rewritten
       recurse_cnt += 1
@@ -157,7 +157,7 @@ class PatternMatcher:
       return UOp(up.op, up.dtype, new_src, up.arg)
     return up
 
-  def rewrite_on_match(self, uop:UOp) -> Optional[UOp]:
+  def rewrite(self, uop:UOp) -> Optional[UOp]:
     for p,fxn in itertools.chain(self.pdict[(uop.op, uop.arg)], self.pdict[(uop.op, None)]):
       store: Dict[str, UOp] = {}
       if _match(uop, p, store): return fxn(**store)

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -58,10 +58,12 @@ class UOp:
   def max(self, x): return UOp.alu(BinaryOps.MAX, self, x)
   def min(self, x): return -UOp.alu(BinaryOps.MAX, -self, -x)
   @staticmethod
+  @functools.lru_cache(None)
   def const(dtype:Optional[DType], b:ConstType|Variable):
     if isinstance(b, Variable): return UOp(UOps.DEFINE_VAR, dtype, (), b)
     return UOp(UOps.CONST, dtype, arg=dtypes.as_const(b, dtype) if dtype is not None else b)
   @staticmethod
+  @functools.lru_cache(None)
   def alu(arg, *src:UOp): return UOp(UOps.ALU, dtypes.bool if arg in {BinaryOps.CMPLT, BinaryOps.CMPNE} else src[-1].dtype, src, arg)
   @staticmethod
   def load(*src:UOp, dtype:Optional[DType]=None, **kwargs): return UOp(UOps.LOAD, dtype, tuple(src)+tuple(kwargs.values()))

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -141,7 +141,7 @@ class PatternMatcher:
         self.pdict[(p.op, p.arg)].append((p, fxn))
 
   @functools.lru_cache(None)
-  def recursive_rewrite(self, u:UOp) -> UOp:
+  def recursive_rewrite(self, u:UOp) -> Tuple[UOp, bool]:
     changed = False
     recurse_cnt = 0
     up = u
@@ -150,7 +150,6 @@ class PatternMatcher:
       assert recurse_cnt < 100, f"recursive_rewrite looped {up} <--> {rewritten}"
       up = rewritten
       changed = True
-    # NOTE: this changes UOp, so we have to delete caches
     if up.src:
       new_src, c = tuple(zip(*[self.recursive_rewrite(x) for x in up.src]))
       if any(c):


### PR DESCRIPTION
722.45/530.45 = 1.36

Timings with `PROFILE=0 python -O test/external/external_benchmark_schedule.py` (best out of 5)

master
```
***** model forward in  15.73 ms
***** model schedule in   5.30 ms
***** model lower in 722.45 ms
```

This branch
```
***** model forward in  15.29 ms
***** model schedule in   5.06 ms
***** model lower in 530.45 ms
```

* rewrite methods on patternmatcher, cache recursive rewrite

cc: @DKormann Any ideas on this? Frozen UOp should allow for fast hashes and better caching.