### PR TITLE
llama concat_weights always send to device[0] first

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -211,7 +211,7 @@ class LLaMa:
     model = Transformer(**params["args"], linear=linear, max_context=MAX_CONTEXT, jit=jit)
 
     if model_path.is_dir():
-      weights = concat_weights([load(filename) for filename in [f"{model_path}/consolidated.{i:02d}.pth" for i in range(params["files"])]], device[0] if isinstance(device, tuple) else device)
+      weights = concat_weights([load(filename) for filename in [f"{model_path}/consolidated.{i:02d}.pth" for i in range(params["files"])]], device)
     else:
       weights = load(str(model_path))
     if "model.embed_tokens.weight" in weights:

--- a/examples/llama3.py
+++ b/examples/llama3.py
@@ -148,7 +148,7 @@ def build_transformer(model_path: Path, model_size="8B", quantize=None, device=N
   if model_path.is_dir():
     if (model_path / "model.safetensors.index.json").exists(): weights = load(str(model_path / "model.safetensors.index.json"))
     elif (model_path / "model.safetensors").exists(): weights = load(str(model_path / "model.safetensors"))
-    else: weights = concat_weights([load(str(model_path / f"consolidated.{i:02d}.pth")) for i in range(MODEL_PARAMS[model_size]["files"])], device[0] if isinstance(device, tuple) else device)
+    else: weights = concat_weights([load(str(model_path / f"consolidated.{i:02d}.pth")) for i in range(MODEL_PARAMS[model_size]["files"])], device)
   else:
     weights = load(str(model_path))
   if "model.embed_tokens.weight" in weights:


### PR DESCRIPTION
removing that fixed the llama shard weight double copy. it was from #3966 but i think we fixed replace after that