### PR TITLE
limit pickled objects [run_process_replay]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,11 @@ jobs:
         COMMIT_MESSAGE=$(printf '%q' "$RAW_COMMIT_MESSAGE")
         RAW_PR_TITLE="${{ github.event.pull_request.title }}"
         PR_TITLE=$(printf '%q' "$RAW_PR_TITLE")
-        if { echo "$COMMIT_MESSAGE" | grep -q "run_process_replay" || \
-             [ "${{ github.event.inputs.run_process_replay }}" == "true" ] || \
-             echo "$PR_TITLE" | grep -q "run_process_replay"; } && [ "$GITHUB_REF_NAME" != "master" ]; then
+
+        if { echo "$COMMIT_MESSAGE" | grep -q "run_process_replay" || echo "$PR_TITLE" | grep -q "run_process_replay" || [ "${{ github.event.inputs.run_process_replay }}" = "true" ]; } && [ "$GITHUB_REF_NAME" != "master" ]; then
           echo "RUN_PROCESS_REPLAY=1" >> $GITHUB_OUTPUT
           echo "enabled process replay"
-          if echo "$COMMIT_MESSAGE" | grep -q "no_assert"; then
+          if { echo "$COMMIT_MESSAGE" | grep -q "no_assert" || echo "$PR_TITLE" | grep -q "no_assert"; }; then
             echo "ASSERT_PROCESS_REPLAY=0" >> $GITHUB_OUTPUT
             echo "running process replay in diff-only mode"
           else

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -2,7 +2,6 @@
 # compare kernels created by HEAD against master
 import difflib, pickle
 from tinygrad.codegen.linearizer import Linearizer
-from tinygrad.device import Device
 from tinygrad.helpers import colored, db_connection, VERSION, getenv, tqdm
 
 page_size = 100

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -11,7 +11,7 @@ row_count = cur.execute(f"select count(*) from 'process_replay_{VERSION}'").fetc
 for offset in tqdm(range(0, row_count, page_size)):
   cur.execute(f"SELECT val FROM 'process_replay_{VERSION}' LIMIT ? OFFSET ?", (page_size, offset))
   for row in cur.fetchall():
-    name, ast, opts, applied_opts, compare_src = pickle.loads(row[0])
+    ast, opts, applied_opts, name, compare_src = pickle.loads(row[0])
     k = Linearizer(*ast, opts=opts)
     for opt in applied_opts: k.apply_opt(opt)
     good_src = k.opts.render(name, k.linearize().uops)

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -12,7 +12,7 @@ row_count = cur.execute(f"select count(*) from 'process_replay_{VERSION}'").fetc
 for offset in tqdm(range(0, row_count, page_size)):
   cur.execute(f"SELECT val FROM 'process_replay_{VERSION}' LIMIT ? OFFSET ?", (page_size, offset))
   for row in cur.fetchall():
-    name, ast, device, applied_opts, compare_uops, compare_src = pickle.loads(row[0])
+    name, ast, device, applied_opts, compare_src = pickle.loads(row[0])
     k = Linearizer(*ast, opts=Device[device].renderer)
     for opt in applied_opts: k.apply_opt(opt)
     good_src = k.opts.render(name, k.linearize().uops)

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -12,8 +12,8 @@ row_count = cur.execute(f"select count(*) from 'process_replay_{VERSION}'").fetc
 for offset in tqdm(range(0, row_count, page_size)):
   cur.execute(f"SELECT val FROM 'process_replay_{VERSION}' LIMIT ? OFFSET ?", (page_size, offset))
   for row in cur.fetchall():
-    name, ast, device, applied_opts, compare_src = pickle.loads(row[0])
-    k = Linearizer(*ast, opts=Device[device].renderer)
+    name, ast, opts, applied_opts, compare_src = pickle.loads(row[0])
+    k = Linearizer(*ast, opts=opts)
     for opt in applied_opts: k.apply_opt(opt)
     good_src = k.opts.render(name, k.linearize().uops)
     try: assert compare_src == good_src
@@ -21,8 +21,6 @@ for offset in tqdm(range(0, row_count, page_size)):
       print("PROCESS REPLAY DETECTED CHANGE")
       print(ast)
       print(applied_opts)
-      print(k.applied_opts)
-      print(device, k.opts.device)
       diff = list(difflib.unified_diff(good_src.splitlines(), compare_src.splitlines()))
       for line in diff:
         print(colored(line, "red" if line.startswith("-") else "green" if line.startswith("+") else None))

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -21,6 +21,8 @@ for offset in tqdm(range(0, row_count, page_size)):
       print("PROCESS REPLAY DETECTED CHANGE")
       print(ast)
       print(applied_opts)
+      print(k.applied_opts)
+      print(device, k.opts.device)
       diff = list(difflib.unified_diff(good_src.splitlines(), compare_src.splitlines()))
       for line in diff:
         print(colored(line, "red" if line.startswith("-") else "green" if line.startswith("+") else None))

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -520,7 +520,7 @@ class Linearizer(Kernel):
     self.linearize()
     info = get_lazyop_info(self.ast[0])
     src = self.opts.render(name:=to_function_name(self.name), self.uops)
-    if getenv("RUN_PROCESS_REPLAY"): diskcache_put("process_replay", id(self), (name, self.ast, self.opts.device, self.applied_opts, self.uops, src))
+    if getenv("RUN_PROCESS_REPLAY"): diskcache_put("process_replay", id(self), (name, self.ast, self.opts.device, self.applied_opts, src))
     ops, mem = self.uops.flops_mem()
     run_count = prod((self.global_size if self.global_size else []) + (self.local_size if self.local_size else []))
     # NOTE: we use min here to ignore the indexing FLOPS

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -520,7 +520,7 @@ class Linearizer(Kernel):
     self.linearize()
     info = get_lazyop_info(self.ast[0])
     src = self.opts.render(name:=to_function_name(self.name), self.uops)
-    if getenv("RUN_PROCESS_REPLAY"): diskcache_put("process_replay", id(self), (name, self.ast, self.opts.device, self.applied_opts, src))
+    if getenv("RUN_PROCESS_REPLAY"): diskcache_put("process_replay", id(self), (name, self.ast, self.opts, self.applied_opts, src))
     ops, mem = self.uops.flops_mem()
     run_count = prod((self.global_size if self.global_size else []) + (self.local_size if self.local_size else []))
     # NOTE: we use min here to ignore the indexing FLOPS

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -520,7 +520,7 @@ class Linearizer(Kernel):
     self.linearize()
     info = get_lazyop_info(self.ast[0])
     src = self.opts.render(name:=to_function_name(self.name), self.uops)
-    if getenv("RUN_PROCESS_REPLAY"): diskcache_put("process_replay", id(self), (name, self.ast, self.opts, self.applied_opts, src))
+    if getenv("RUN_PROCESS_REPLAY"): diskcache_put("process_replay", id(self), (self.ast, self.opts, self.applied_opts, name, src))
     ops, mem = self.uops.flops_mem()
     run_count = prod((self.global_size if self.global_size else []) + (self.local_size if self.local_size else []))
     # NOTE: we use min here to ignore the indexing FLOPS

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -519,8 +519,8 @@ class Linearizer(Kernel):
   def to_program(self) -> Program:
     self.linearize()
     info = get_lazyop_info(self.ast[0])
-    src = self.opts.render(to_function_name(self.name), self.uops)
-    if getenv("RUN_PROCESS_REPLAY"): diskcache_put("process_replay", id(self), (self, src))
+    src = self.opts.render(name:=to_function_name(self.name), self.uops)
+    if getenv("RUN_PROCESS_REPLAY"): diskcache_put("process_replay", id(self), (name, self.ast, self.opts.device, self.applied_opts, self.uops, src))
     ops, mem = self.uops.flops_mem()
     run_count = prod((self.global_size if self.global_size else []) + (self.local_size if self.local_size else []))
     # NOTE: we use min here to ignore the indexing FLOPS


### PR DESCRIPTION
As long as we can recreate LazyOp, OptOps and Renderer, process replay should run correctly. Fixes #5143