### PR TITLE
perf: slots on frozen UPat [run_process_replay]

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -91,7 +91,7 @@ def uop_alu_resolve(u:UOp) -> sint:
 
 # *** simplification logic ***
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class UPat:
   op: Optional[Union[UOps, Set[UOps]]] = None
   arg: Any = None


### PR DESCRIPTION
Gives a bit of (free?) speed here. No `_dict__` and `__weakref__`, and ⚠️ only from Python 3.10 onwards.

```
***** model forward in  15.60 ms
***** model schedule in   5.27 ms
***** model lower in 741.09 ms
```


```
***** model forward in  15.80 ms
***** model schedule in   5.34 ms
***** model lower in 691.38 ms
```
