### PR TITLE
speed up graph rewrite by flattening out loops [run_process_replay]

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -307,30 +307,6 @@ class UOpGraph:
     for i,u in enumerate(self):
       print(f"{i:4d} {str(u.op):20s}: {str(u.dtype) if u.dtype is not None else '':25s} " f"{str([self.uops.index(x) for x in u.src]):32s} {u.arg}")
 
-  # def graph_rewrite(self, sink:UOp, pm:PatternMatcher):
-  #   # recursive rewrite
-  #   changed = getenv("UOPS_REWRITE", 1)
-  #   run_cnt = 0
-  #   @functools.lru_cache(None)
-  #   def rewrite(u:UOp) -> UOp:
-  #     nonlocal changed
-  #     recurse_cnt = 0
-  #     up = u
-  #     # locally recursively rewrite
-  #     while (rewritten := pm.rewrite(up)):
-  #       assert recurse_cnt < 100, f"recursive_rewrite looped {up} <--> {rewritten}"
-  #       up = rewritten
-  #       recurse_cnt += 1
-  #     changed += recurse_cnt
-  #     up = UOp(up.op, up.dtype, tuple(rewrite(x) for x in up.src), up.arg)
-  #     return self.nodes.setdefault(up.tuple(), up) # replace with cached nodes
-  #   while changed:
-  #     changed = 0
-  #     sink = rewrite(sink)
-  #     run_cnt += 1
-  #     assert run_cnt < 100, "exceeded 100 rewrite loops!"
-  #   return sink
-
   def graph_rewrite(self, sink, pm):
     @functools.lru_cache(None)
     def rewrite(pm: PatternMatcher, up:UOp) -> UOp:

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -307,26 +307,45 @@ class UOpGraph:
     for i,u in enumerate(self):
       print(f"{i:4d} {str(u.op):20s}: {str(u.dtype) if u.dtype is not None else '':25s} " f"{str([self.uops.index(x) for x in u.src]):32s} {u.arg}")
 
-  def graph_rewrite(self, sink:UOp, pm:PatternMatcher):
-    # recursive rewrite
-    changed = getenv("UOPS_REWRITE", 1)
-    run_cnt = 0
+  # def graph_rewrite(self, sink:UOp, pm:PatternMatcher):
+  #   # recursive rewrite
+  #   changed = getenv("UOPS_REWRITE", 1)
+  #   run_cnt = 0
+  #   @functools.lru_cache(None)
+  #   def rewrite(u:UOp) -> UOp:
+  #     nonlocal changed
+  #     recurse_cnt = 0
+  #     up = u
+  #     # locally recursively rewrite
+  #     while (rewritten := pm.rewrite(up)):
+  #       assert recurse_cnt < 100, f"recursive_rewrite looped {up} <--> {rewritten}"
+  #       up = rewritten
+  #       recurse_cnt += 1
+  #     changed += recurse_cnt
+  #     up = UOp(up.op, up.dtype, tuple(rewrite(x) for x in up.src), up.arg)
+  #     return self.nodes.setdefault(up.tuple(), up) # replace with cached nodes
+  #   while changed:
+  #     changed = 0
+  #     sink = rewrite(sink)
+  #     run_cnt += 1
+  #     assert run_cnt < 100, "exceeded 100 rewrite loops!"
+  #   return sink
+
+  def graph_rewrite(self, sink, pm):
     @functools.lru_cache(None)
-    def rewrite(u:UOp) -> UOp:
-      nonlocal changed
+    def rewrite(pm: PatternMatcher, up:UOp) -> UOp:
       recurse_cnt = 0
-      up = u
-      # locally recursively rewrite
-      while (rewritten := pm.rewrite(up)):
+      while (rewritten:=pm.rewrite(up)) is not None:
         assert recurse_cnt < 100, f"recursive_rewrite looped {up} <--> {rewritten}"
         up = rewritten
         recurse_cnt += 1
-      changed += recurse_cnt
-      up = UOp(up.op, up.dtype, tuple(rewrite(x) for x in up.src), up.arg)
-      return self.nodes.setdefault(up.tuple(), up) # replace with cached nodes
+      up = UOp(up.op, up.dtype, tuple(rewrite(pm, x) for x in up.src), up.arg)
+      return self.nodes.setdefault(up.tuple(), up)
+    changed = getenv("UOPS_REWRITE", True)
+    run_cnt = 0
     while changed:
-      changed = 0
-      sink = rewrite(sink)
+      changed = sink != (rewritten:=rewrite(pm, sink))
+      sink = rewritten
       run_cnt += 1
       assert run_cnt < 100, "exceeded 100 rewrite loops!"
     return sink

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -315,7 +315,7 @@ class UOpGraph:
         assert recurse_cnt < 100, f"recursive_rewrite looped {up} <--> {rewritten}"
         up = rewritten
         recurse_cnt += 1
-      up = UOp(up.op, up.dtype, tuple(rewrite(pm, x) for x in up.src), up.arg)
+      up = UOp(up.op, up.dtype, tuple(rewrite(x) for x in up.src), up.arg)
       return self.nodes.setdefault(up.tuple(), up)
     changed = getenv("UOPS_REWRITE", True)
     run_cnt = 0

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -311,21 +311,21 @@ class UOpGraph:
     # recursive rewrite
     changed = getenv("UOPS_REWRITE", 1)
     run_cnt = 0
+    @functools.lru_cache(None)
+    def rewrite(u:UOp) -> UOp:
+      nonlocal changed
+      recurse_cnt = 0
+      up = u
+      # locally recursively rewrite
+      while (rewritten := pm.rewrite(up)):
+        assert recurse_cnt < 100, f"recursive_rewrite looped {up} <--> {rewritten}"
+        up = rewritten
+        recurse_cnt += 1
+      changed += recurse_cnt
+      up = UOp(up.op, up.dtype, tuple(rewrite(x) for x in up.src), up.arg)
+      return self.nodes.setdefault(up.tuple(), up) # replace with cached nodes
     while changed:
       changed = 0
-      @functools.lru_cache(None)
-      def rewrite(u:UOp) -> UOp:
-        nonlocal changed
-        recurse_cnt = 0
-        up = u
-        # locally recursively rewrite
-        while (rewritten := pm.rewrite(up)):
-          assert recurse_cnt < 100, f"recursive_rewrite looped {up} <--> {rewritten}"
-          up = rewritten
-          recurse_cnt += 1
-        changed += recurse_cnt
-        up = UOp(up.op, up.dtype, tuple(rewrite(x) for x in up.src), up.arg)
-        return self.nodes.setdefault(up.tuple(), up) # replace with cached nodes
       sink = rewrite(sink)
       run_cnt += 1
       assert run_cnt < 100, "exceeded 100 rewrite loops!"

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -309,7 +309,7 @@ class UOpGraph:
 
   def graph_rewrite(self, sink, pm):
     @functools.lru_cache(None)
-    def rewrite(pm: PatternMatcher, up:UOp) -> UOp:
+    def rewrite(up:UOp) -> UOp:
       recurse_cnt = 0
       while (rewritten:=pm.rewrite(up)) is not None:
         assert recurse_cnt < 100, f"recursive_rewrite looped {up} <--> {rewritten}"
@@ -320,7 +320,7 @@ class UOpGraph:
     changed = getenv("UOPS_REWRITE", True)
     run_cnt = 0
     while changed:
-      changed = sink != (rewritten:=rewrite(pm, sink))
+      changed = sink != (rewritten:=rewrite(sink))
       sink = rewritten
       run_cnt += 1
       assert run_cnt < 100, "exceeded 100 rewrite loops!"


### PR DESCRIPTION
this is faster because rewrite cache only gets created once per rewrite. speedup no added complexity