### PR TITLE
Fix batchnorm shapes for resnet.load_pretrained

### DIFF
--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -126,6 +126,7 @@ class ResNet:
     return self.forward(x)
 
   def load_from_pretrained(self):
+    import numpy as np
     # TODO replace with fake torch load
 
     model_urls = {
@@ -149,6 +150,9 @@ class ResNet:
       if dat.shape == ():
         assert obj.shape == (1,), obj.shape
         dat = dat.reshape(1)
+      if len(obj.shape)==2 and len(dat.shape)==1 and obj.shape[1]==dat.shape[0]:
+        dat = dat.reshape(1, obj.shape[1])
+        dat = np.broadcast_to(dat, obj.shape)
       assert obj.shape == dat.shape, (k, obj.shape, dat.shape)
       obj.assign(dat)
 

--- a/extra/models/resnet.py
+++ b/extra/models/resnet.py
@@ -126,7 +126,6 @@ class ResNet:
     return self.forward(x)
 
   def load_from_pretrained(self):
-    import numpy as np
     # TODO replace with fake torch load
 
     model_urls = {
@@ -147,14 +146,8 @@ class ResNet:
         print("skipping fully connected layer")
         continue # Skip FC if transfer learning
 
-      if dat.shape == ():
-        assert obj.shape == (1,), obj.shape
-        dat = dat.reshape(1)
-      if len(obj.shape)==2 and len(dat.shape)==1 and obj.shape[1]==dat.shape[0]:
-        dat = dat.reshape(1, obj.shape[1])
-        dat = np.broadcast_to(dat, obj.shape)
-      assert obj.shape == dat.shape, (k, obj.shape, dat.shape)
-      obj.assign(dat)
+      if 'bn' not in k and 'downsample' not in k: assert obj.shape == dat.shape, (k, obj.shape, dat.shape)
+      obj.assign(dat.reshape(obj.shape))
 
 ResNet18 = lambda num_classes=1000: ResNet(18, num_classes=num_classes)
 ResNet34 = lambda num_classes=1000: ResNet(34, num_classes=num_classes)


### PR DESCRIPTION
Update shapes to work with unsynced batchnorm

Need to use unsynced instead of synced to get fp16 training working for retinanet, This is also a bug which I think has to do with lack of casting in synced batchnorm. I tried fixing, but it increased step times.

Repro:
```
import functools
from typing import List
from tinygrad import dtypes, Tensor, GlobalCounters
from tinygrad.helpers import getenv
from extra.models import resnet
from examples.mlperf.initializers import Conv2dHeNormal, Linear
from examples.hlb_cifar10 import UnsyncedBatchNorm

def _sum(x:List[Tensor]):
  ans = x[0].mean()
  for xx in x[1:]:
    ans+=xx.mean()
  return ans 

if getenv('BN', 1): resnet.BatchNorm = functools.partial(UnsyncedBatchNorm, num_devices=1)
resnet.Conv2d = Conv2dHeNormal
resnet.Linear = Linear

res = resnet.ResNeXt50_32X4D()
res.load_from_pretrained()
res.fc = None

X = Tensor.zeros((10, 3, 800, 800))

out = res.forward(X)
print(_sum(out).numpy(), dtypes.default_float)
print(f"{GlobalCounters.mem_used / 1e9:.2f} GB used")
```

```DISABLE_COMPILER_CACHE=1 DEFAULT_FLOAT=float16 BN=1 python3 fptest.py```
Change BN and def_float vals

fp16
- BN=0    inf
- BN=1    0.6377
fp32
- BN=0    0.6375836
- BN=1    0.6375836