### PR TITLE
fix: unused loop variables

### DIFF
--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -362,7 +362,7 @@ class Linearizer(Kernel):
       self.load_cache.clear()
 
       if reduceop is not self.reduceops[-1]:
-        for j in self.upcast_in_mid_reduce_axes:
+        for _ in self.upcast_in_mid_reduce_axes:
           self.upcasted -= 1
           self.group_for_reduces += 1
         assert self.buf_uops[out_buf] is not None, "Local reduce buf must have been uoped at this point"

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -350,7 +350,7 @@ def _internal_memory_planner(buffers:List[Union[List[Buffer], Tuple[Buffer, ...]
     if i == last_appearance[buf]:
       if assigned[buf] not in local_cache[key]: local_cache[key].append(assigned[buf])
 
-  for i,u in enumerate(buffers):
+  for u in buffers:
     for buf in u:
       # all unallocated unparented buffers are fair game to replace
       if buf.is_allocated() or buf.lb_refcount > 0: continue

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -194,7 +194,7 @@ def torch_load(fn:str) -> Dict[str, Tensor]:
     with tarfile.open(fn, "r") as tar:
       storages_offset = tar.getmember('storages').offset_data
       f = unwrap(tar.extractfile('storages'))
-      for i in range(TorchPickle(f).load()):  # num_storages
+      for _ in range(TorchPickle(f).load()):  # num_storages
         (key, _, storage_type), sz = TorchPickle(f).load(), struct.unpack('<q', f.read(8))[0]
         offsets[key] = storages_offset + f.tell()
         f.seek(sz*storage_type.itemsize, 1)


### PR DESCRIPTION
Not enabling the ruff rule (B007) because there is a usecase where this variable might be used after the loop. https://github.com/astral-sh/ruff/issues/10723
