### PR TITLE
refactor: classmethods and super args

### DIFF
--- a/extra/qcom_gpu_driver/msm_kgsl.py
+++ b/extra/qcom_gpu_driver/msm_kgsl.py
@@ -57,7 +57,7 @@ class Structure(ctypes.Structure, AsDictMixin):
 
         args = dict(zip(self.__class__._field_names_(), args))
         args.update(kwds)
-        super(Structure, self).__init__(**args)
+        super().__init__(**args)
 
     @classmethod
     def _field_names_(cls):

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -208,19 +208,19 @@ class HCQCompatCompiled(Compiled):
     super().__init__(device, allocator, renderer, compiler, runtime, HCQGraph)
 
   @classmethod
-  def _read_signal(self, sig): raise NotImplementedError("need _read_signal") # reads a value for a signal
+  def _read_signal(cls, sig): raise NotImplementedError("need _read_signal") # reads a value for a signal
 
   @classmethod
-  def _read_timestamp(self, sig): raise NotImplementedError("need _read_timestamp") # reads a timestamp for a signal
+  def _read_timestamp(cls, sig): raise NotImplementedError("need _read_timestamp") # reads a timestamp for a signal
 
   @classmethod
-  def _set_signal(self, sig, value): raise NotImplementedError("need _set_signal") # sets a value for a signal
+  def _set_signal(cls, sig, value): raise NotImplementedError("need _set_signal") # sets a value for a signal
 
   @classmethod
-  def _get_signal(self, value=0, **kwargs): raise NotImplementedError("need _get_signal") # allocates a new signal
+  def _get_signal(cls, value=0, **kwargs): raise NotImplementedError("need _get_signal") # allocates a new signal
 
   @classmethod
-  def _wait_signal(self, signal, value=0, timeout=10000): raise NotImplementedError("need _wait_signal") # waits for a signal value
+  def _wait_signal(cls, signal, value=0, timeout=10000): raise NotImplementedError("need _wait_signal") # waits for a signal value
 
   def _gpu2cpu_time(self, gpu_time, is_copy): raise NotImplementedError("need _gpu2cpu_time")
 

--- a/tinygrad/runtime/autogen/amd_gpu.py
+++ b/tinygrad/runtime/autogen/amd_gpu.py
@@ -58,7 +58,7 @@ class Structure(ctypes.Structure, AsDictMixin):
 
         args = dict(zip(self.__class__._field_names_(), args))
         args.update(kwds)
-        super(Structure, self).__init__(**args)
+        super().__init__(**args)
 
     @classmethod
     def _field_names_(cls):

--- a/tinygrad/runtime/autogen/comgr.py
+++ b/tinygrad/runtime/autogen/comgr.py
@@ -98,7 +98,7 @@ class Structure(ctypes.Structure, AsDictMixin):
 
         args = dict(zip(self.__class__._field_names_(), args))
         args.update(kwds)
-        super(Structure, self).__init__(**args)
+        super().__init__(**args)
 
     @classmethod
     def _field_names_(cls):

--- a/tinygrad/runtime/autogen/cuda.py
+++ b/tinygrad/runtime/autogen/cuda.py
@@ -58,7 +58,7 @@ class Structure(ctypes.Structure, AsDictMixin):
 
         args = dict(zip(self.__class__._field_names_(), args))
         args.update(kwds)
-        super(Structure, self).__init__(**args)
+        super().__init__(**args)
 
     @classmethod
     def _field_names_(cls):

--- a/tinygrad/runtime/autogen/hip.py
+++ b/tinygrad/runtime/autogen/hip.py
@@ -58,7 +58,7 @@ class Structure(ctypes.Structure, AsDictMixin):
 
         args = dict(zip(self.__class__._field_names_(), args))
         args.update(kwds)
-        super(Structure, self).__init__(**args)
+        super().__init__(**args)
 
     @classmethod
     def _field_names_(cls):

--- a/tinygrad/runtime/autogen/hsa.py
+++ b/tinygrad/runtime/autogen/hsa.py
@@ -79,7 +79,7 @@ class Structure(ctypes.Structure, AsDictMixin):
 
         args = dict(zip(self.__class__._field_names_(), args))
         args.update(kwds)
-        super(Structure, self).__init__(**args)
+        super().__init__(**args)
 
     @classmethod
     def _field_names_(cls):

--- a/tinygrad/runtime/autogen/io_uring.py
+++ b/tinygrad/runtime/autogen/io_uring.py
@@ -58,7 +58,7 @@ class Structure(ctypes.Structure, AsDictMixin):
 
         args = dict(zip(self.__class__._field_names_(), args))
         args.update(kwds)
-        super(Structure, self).__init__(**args)
+        super().__init__(**args)
 
     @classmethod
     def _field_names_(cls):

--- a/tinygrad/runtime/autogen/kfd.py
+++ b/tinygrad/runtime/autogen/kfd.py
@@ -58,7 +58,7 @@ class Structure(ctypes.Structure, AsDictMixin):
 
         args = dict(zip(self.__class__._field_names_(), args))
         args.update(kwds)
-        super(Structure, self).__init__(**args)
+        super().__init__(**args)
 
     @classmethod
     def _field_names_(cls):

--- a/tinygrad/runtime/autogen/nv_gpu.py
+++ b/tinygrad/runtime/autogen/nv_gpu.py
@@ -58,7 +58,7 @@ class Structure(ctypes.Structure, AsDictMixin):
 
         args = dict(zip(self.__class__._field_names_(), args))
         args.update(kwds)
-        super(Structure, self).__init__(**args)
+        super().__init__(**args)
 
     @classmethod
     def _field_names_(cls):

--- a/tinygrad/runtime/autogen/opencl.py
+++ b/tinygrad/runtime/autogen/opencl.py
@@ -58,7 +58,7 @@ class Structure(ctypes.Structure, AsDictMixin):
 
         args = dict(zip(self.__class__._field_names_(), args))
         args.update(kwds)
-        super(Structure, self).__init__(**args)
+        super().__init__(**args)
 
     @classmethod
     def _field_names_(cls):

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -439,17 +439,17 @@ class AMDDevice(HCQCompatCompiled):
     kio.free_memory_of_gpu(self.kfd, handle=mem.handle)
 
   @classmethod
-  def _read_signal(self, sig): return sig.value
+  def _read_signal(cls, sig): return sig.value
 
   @classmethod
-  def _read_timestamp(self, sig): return sig.start_ts
+  def _read_timestamp(cls, sig): return sig.start_ts
 
   @classmethod
-  def _set_signal(self, sig, value): sig.value = value
+  def _set_signal(cls, sig, value): sig.value = value
 
   @classmethod
-  def _get_signal(self, value=0, **kwargs) -> hsa.amd_signal_t:
-    self._set_signal(ret := self.signals_pool.pop(), value)
+  def _get_signal(cls, value=0, **kwargs) -> hsa.amd_signal_t:
+    cls._set_signal(ret := cls.signals_pool.pop(), value)
     if (sync_event:=kwargs.get('sync_event')) is not None:
       ret.event_mailbox_ptr = AMDDevice.event_page.va_addr + sync_event.event_slot_index*8
       ret.event_id = sync_event.event_id
@@ -457,7 +457,7 @@ class AMDDevice(HCQCompatCompiled):
     return ret
 
   @classmethod
-  def _wait_signal(self, signal:hsa.amd_signal_t, value=0, timeout=10000):
+  def _wait_signal(cls, signal:hsa.amd_signal_t, value=0, timeout=10000):
     assert signal.event_id != 0, "can't wait on this signal"
     evt_arr = (kfd.struct_kfd_event_data)(event_id=signal.event_id)
 

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -538,21 +538,21 @@ class NVDevice(HCQCompatCompiled):
     NVDevice.devices.append(self)
 
   @classmethod
-  def _read_signal(self, sig): return sig[0]
+  def _read_signal(cls, sig): return sig[0]
 
   @classmethod
-  def _read_timestamp(self, sig): return sig[1]
+  def _read_timestamp(cls, sig): return sig[1]
 
   @classmethod
-  def _set_signal(self, sig, value): sig[0] = value
+  def _set_signal(cls, sig, value): sig[0] = value
 
   @classmethod
-  def _get_signal(self, value=0, **kwargs) -> memoryview:
-    self._set_signal(sig := self.signals_pool.pop(), value)
+  def _get_signal(cls, value=0, **kwargs) -> memoryview:
+    cls._set_signal(sig := cls.signals_pool.pop(), value)
     return sig
 
   @classmethod
-  def _wait_signal(self, signal, value=0, timeout=10000):
+  def _wait_signal(cls, signal, value=0, timeout=10000):
     start_time = time.time() * 1000
     while time.time() * 1000 - start_time < timeout:
       if signal[0] >= value: return


### PR DESCRIPTION
`super` needs no arguments, first arg of a `classmethod` should be `cls`. 

I left one exception 
https://github.com/tinygrad/tinygrad/blob/83da8b3558eb05e11edd900433e6ac92d67930c3/tinygrad/tensor.py#L33

```
 @classmethod
  def apply(fxn:Type[Function], *x:Tensor, **kwargs) -> Tensor:
```