### PR TITLE
test: valid is always bool [run_process_replay]

### DIFF
--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -145,7 +145,6 @@ class TestUOpGraph(TestUOps):
     self.assertEqual(out.src[1].op, UOps.CONST)
     self.assertEqual(out.src[1].arg, 6)
 
-  @unittest.skip("temp")
   def test_fold_gated_load(self):
     glbl0 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
     glbl1 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (1, False))
@@ -160,7 +159,6 @@ class TestUOpGraph(TestUOps):
     # the gate and invalid value are deleted from ld1
     self.assert_equiv_uops(ld1, UOp.load(glbl2, idx, dtype=dtypes.int))
 
-  @unittest.skip("temp")
   def test_fold_gated_load_local(self):
     glbl0 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
     smem = UOp(UOps.DEFINE_LOCAL, PtrDType(dtypes.int), (), ("temp", 1))
@@ -176,7 +174,6 @@ class TestUOpGraph(TestUOps):
     # the gate and invalid value are deleted from ld1
     self.assert_equiv_uops(ld1, UOp.load(smem, lidx+2, barrier, dtype=dtypes.int))
 
-  @unittest.skip("temp")
   def test_fold_gated_store(self):
     glbl = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
     idx0 = UOp.const(dtypes.int, 0)
@@ -188,6 +185,13 @@ class TestUOpGraph(TestUOps):
     # only the second store happens
     self.assertEqual(len(uops.uops), 4)
     self.assert_equiv_uops(uops[-1], UOp.store(glbl, idx1, val))
+
+  def test_asserts_bad_gate(self):
+    glbl0 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
+    idx = UOp.const(dtypes.int, 0)
+    bad_gate = UOp.const(dtypes.int, 1)
+    uops = UOpGraph([UOp(UOps.STORE, None, (glbl0, idx, UOp.const(dtypes.int, 42), bad_gate))])
+    with self.assertRaises(AssertionError): uops.linearize()
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -145,6 +145,7 @@ class TestUOpGraph(TestUOps):
     self.assertEqual(out.src[1].op, UOps.CONST)
     self.assertEqual(out.src[1].arg, 6)
 
+  @unittest.skip("temp")
   def test_fold_gated_load(self):
     glbl0 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
     glbl1 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (1, False))
@@ -159,6 +160,7 @@ class TestUOpGraph(TestUOps):
     # the gate and invalid value are deleted from ld1
     self.assert_equiv_uops(ld1, UOp.load(glbl2, idx, dtype=dtypes.int))
 
+  @unittest.skip("temp")
   def test_fold_gated_load_local(self):
     glbl0 = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
     smem = UOp(UOps.DEFINE_LOCAL, PtrDType(dtypes.int), (), ("temp", 1))
@@ -174,6 +176,7 @@ class TestUOpGraph(TestUOps):
     # the gate and invalid value are deleted from ld1
     self.assert_equiv_uops(ld1, UOp.load(smem, lidx+2, barrier, dtype=dtypes.int))
 
+  @unittest.skip("temp")
   def test_fold_gated_store(self):
     glbl = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), (0, True))
     idx0 = UOp.const(dtypes.int, 0)

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -215,7 +215,7 @@ class Linearizer(Kernel):
       if self.late_gate is not None: valid *= self.late_gate
       # TODO: let UPat check this once it's fast
       if valid.min == 1: stores.append(UOp(UOps.STORE, None, (buf_uop, rendered_idx, var)))
-      else: stores.append(UOp(UOps.STORE, None, (buf_uop, rendered_idx, var, valid.render(render_ops, self.loop_uops).cast(dtypes.bool))))
+      else: stores.append(UOp(UOps.STORE, None, (buf_uop, rendered_idx, var, valid.render(render_ops, self.loop_uops))))
     return stores
 
   # render loop

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -142,9 +142,7 @@ class Linearizer(Kernel):
     acc_count = 0
     for idx, valid, rep_idx in zip(e_idxs, e_valids, iter_idxs(expand_vars)):
       this_const, idx = (invalid_value, NumNode(0)) if valid.max == 0 else (const, idx)
-      valid_uop = valid.render(render_ops, self.loop_uops) if valid.min == 0 and valid.max == 1 else UOp.const(dtypes.bool, valid.b)
-      # TODO: temp assert, this is done in type_verify already
-      assert valid_uop.dtype is dtypes.bool, f"unexpected dtype {valid_uop.dtype} {valid} {valid.render()} {valid_uop}"
+      valid_uop = UOp.const(dtypes.bool, valid.b) if valid.min == valid.max else valid.render(render_ops, self.loop_uops)
       key = f"{'' if acc is None else self.reduceops.index(acc)}{localtype}{'CONST'+str(this_const) if this_const is not None and acc is None else (buf.idx if isinstance(buf, MemBuffer) else cast(LocalBuffer, buf).name)}{idx.render()}{valid.render()}"  # noqa: E501
       if key not in self.load_cache:
         if acc is not None:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -141,9 +141,8 @@ class Linearizer(Kernel):
     invalid_value = 0
     acc_count = 0
     for idx, valid, rep_idx in zip(e_idxs, e_valids, iter_idxs(expand_vars)):
-      has_valid = valid.min == 0 and valid.max == 1
       this_const, idx = (invalid_value, NumNode(0)) if valid.max == 0 else (const, idx)
-      valid_uop = valid.render(render_ops, self.loop_uops) if has_valid else UOp.const(dtypes.bool, valid.b)
+      valid_uop = valid.render(render_ops, self.loop_uops) if valid.min == 0 and valid.max == 1 else UOp.const(dtypes.bool, valid.b)
       # TODO: temp assert, this is done in type_verify already
       assert valid_uop.dtype is dtypes.bool, f"unexpected dtype {valid_uop.dtype} {valid} {valid.render()} {valid_uop}"
       key = f"{'' if acc is None else self.reduceops.index(acc)}{localtype}{'CONST'+str(this_const) if this_const is not None and acc is None else (buf.idx if isinstance(buf, MemBuffer) else cast(LocalBuffer, buf).name)}{idx.render()}{valid.render()}"  # noqa: E501
@@ -153,7 +152,7 @@ class Linearizer(Kernel):
           acc_count += 1
         elif this_const is not None:
           self.load_cache[key] = UOp.const(localtype, this_const)
-          if has_valid:
+          if valid.min == 0 and valid.max == 1:
             self.load_cache[key] = UOp.alu(TernaryOps.WHERE, valid_uop, self.load_cache[key], UOp.const(localtype, invalid_value))
         elif isinstance(buf.dtype, ImageDType):
           buf_uop = self.buf_uops[i]

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -142,7 +142,7 @@ class Linearizer(Kernel):
     acc_count = 0
     for idx, valid, rep_idx in zip(e_idxs, e_valids, iter_idxs(expand_vars)):
       this_const, idx = (invalid_value, NumNode(0)) if valid.max == 0 else (const, idx)
-      valid_uop = UOp.const(dtypes.bool, True) if valid.max == 0 else valid.render(render_ops, self.loop_uops)
+      valid_uop = valid.render(render_ops, self.loop_uops) if valid.min == 0 and valid.max != 0 else UOp.const(dtypes.bool, True)
       assert valid_uop.dtype is dtypes.bool, f"unexpected dtype {valid_uop.dtype} {valid} {valid.render()} {valid_uop}"
       key = f"{'' if acc is None else self.reduceops.index(acc)}{localtype}{'CONST'+str(this_const) if this_const is not None and acc is None else (buf.idx if isinstance(buf, MemBuffer) else cast(LocalBuffer, buf).name)}{idx.render()}{valid.render()}"  # noqa: E501
       if key not in self.load_cache:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -141,8 +141,10 @@ class Linearizer(Kernel):
     invalid_value = 0
     acc_count = 0
     for idx, valid, rep_idx in zip(e_idxs, e_valids, iter_idxs(expand_vars)):
+      has_valid = valid.min == 0 and valid.max == 1
       this_const, idx = (invalid_value, NumNode(0)) if valid.max == 0 else (const, idx)
-      valid_uop = valid.render(render_ops, self.loop_uops) if valid.min == 0 and valid.max != 0 else UOp.const(dtypes.bool, True)
+      valid_uop = valid.render(render_ops, self.loop_uops) if has_valid else UOp.const(dtypes.bool, valid.b)
+      # TODO: temp assert, this is done in type_verify already
       assert valid_uop.dtype is dtypes.bool, f"unexpected dtype {valid_uop.dtype} {valid} {valid.render()} {valid_uop}"
       key = f"{'' if acc is None else self.reduceops.index(acc)}{localtype}{'CONST'+str(this_const) if this_const is not None and acc is None else (buf.idx if isinstance(buf, MemBuffer) else cast(LocalBuffer, buf).name)}{idx.render()}{valid.render()}"  # noqa: E501
       if key not in self.load_cache:
@@ -151,9 +153,8 @@ class Linearizer(Kernel):
           acc_count += 1
         elif this_const is not None:
           self.load_cache[key] = UOp.const(localtype, this_const)
-          if valid.min == 0 and valid.max == 1:
-            valid_rendered = valid.render(render_ops, self.loop_uops)
-            self.load_cache[key] = UOp.alu(TernaryOps.WHERE, valid_rendered, self.load_cache[key], UOp.const(localtype, invalid_value))
+          if has_valid:
+            self.load_cache[key] = UOp.alu(TernaryOps.WHERE, valid_uop, self.load_cache[key], UOp.const(localtype, invalid_value))
         elif isinstance(buf.dtype, ImageDType):
           buf_uop = self.buf_uops[i]
           assert buf_uop is not None, f"buffer {i} wasn't UOped"
@@ -215,7 +216,7 @@ class Linearizer(Kernel):
       if self.late_gate is not None: valid *= self.late_gate
       # TODO: let UPat check this once it's fast
       if valid.min == 1: stores.append(UOp(UOps.STORE, None, (buf_uop, rendered_idx, var)))
-      else: stores.append(UOp(UOps.STORE, None, (buf_uop, rendered_idx, var, valid.render(render_ops, self.loop_uops))))
+      elif valid.max == 1: stores.append(UOp(UOps.STORE, None, (buf_uop, rendered_idx, var, valid.render(render_ops, self.loop_uops))))
     return stores
 
   # render loop

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -265,17 +265,20 @@ constant_folder = PatternMatcher([
   # cast NOOP (NOTE: it's str to deal with PtrDType)
   (UPat(UOps.CAST, name="root"), lambda root: root.src[0] if str(root.dtype) == str(root.src[0].dtype) else None),
   # fold gated LOAD/STORE
-  (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(None, 1), UOp.cvar("var")), lambda buf,idx,var: UOp.load(buf, idx, dtype=var.dtype)),
-  (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(None, 1), UOp.cvar("var"), UOp.var("barrier")),
-   lambda buf,idx,var,barrier: UOp.load(buf, idx, barrier, dtype=var.dtype)),
-  (UOp.load(UOp.var(), UOp.var(), UOp.const(dtypes.bool, False), UOp.cvar("var")), lambda var: var),
-  (UOp.load(UOp.var(), UOp.var(), UOp.const(dtypes.bool, False), UOp.cvar("var"), UOp.var()), lambda var: var),
-  (UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(dtypes.bool, True)), UOp.store),
-  (UOp.store(UOp.var(), UOp.var(), UOp.var(), UOp.const(None, 0)), lambda: UOp(UOps.NOOP)),
   # remove NOOPs from SINK
   (UPat(UOps.SINK, name="root"),
     lambda root: UOp(UOps.SINK, root.dtype, a, root.arg) if len(a:=tuple(x for x in root.src if x.op is not UOps.NOOP)) != len(root.src) else None)
 ])
+
+"""
+(UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(dtypes.bool, True), UOp.cvar("var")), lambda buf,idx,var: UOp.load(buf, idx, dtype=var.dtype)),
+(UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(dtypes.bool, True), UOp.cvar("var"), UOp.var("barrier")),
+ lambda buf,idx,var,barrier: UOp.load(buf, idx, barrier, dtype=var.dtype)),
+(UOp.load(UOp.var(), UOp.var(), UOp.const(dtypes.bool, False), UOp.cvar("var")), lambda var: var),
+(UOp.load(UOp.var(), UOp.var(), UOp.const(dtypes.bool, False), UOp.cvar("var"), UOp.var()), lambda var: var),
+(UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(dtypes.bool, True)), UOp.store),
+(UOp.store(UOp.var(), UOp.var(), UOp.var(), UOp.const(dtypes.bool, False)), lambda: UOp(UOps.NOOP)),
+"""
 
 # *** uop graph ***
 

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -265,20 +265,17 @@ constant_folder = PatternMatcher([
   # cast NOOP (NOTE: it's str to deal with PtrDType)
   (UPat(UOps.CAST, name="root"), lambda root: root.src[0] if str(root.dtype) == str(root.src[0].dtype) else None),
   # fold gated LOAD/STORE
+  (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(dtypes.bool, True), UOp.cvar("var")), lambda buf,idx,var: UOp.load(buf, idx, dtype=var.dtype)),
+  (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(dtypes.bool, True), UOp.cvar("var"), UOp.var("barrier")),
+   lambda buf,idx,var,barrier: UOp.load(buf, idx, barrier, dtype=var.dtype)),
+  (UOp.load(UOp.var(), UOp.var(), UOp.const(dtypes.bool, False), UOp.cvar("var")), lambda var: var),
+  (UOp.load(UOp.var(), UOp.var(), UOp.const(dtypes.bool, False), UOp.cvar("var"), UOp.var()), lambda var: var),
+  (UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(dtypes.bool, True)), UOp.store),
+  (UOp.store(UOp.var(), UOp.var(), UOp.var(), UOp.const(dtypes.bool, False)), lambda: UOp(UOps.NOOP)),
   # remove NOOPs from SINK
   (UPat(UOps.SINK, name="root"),
     lambda root: UOp(UOps.SINK, root.dtype, a, root.arg) if len(a:=tuple(x for x in root.src if x.op is not UOps.NOOP)) != len(root.src) else None)
 ])
-
-"""
-(UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(dtypes.bool, True), UOp.cvar("var")), lambda buf,idx,var: UOp.load(buf, idx, dtype=var.dtype)),
-(UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(dtypes.bool, True), UOp.cvar("var"), UOp.var("barrier")),
- lambda buf,idx,var,barrier: UOp.load(buf, idx, barrier, dtype=var.dtype)),
-(UOp.load(UOp.var(), UOp.var(), UOp.const(dtypes.bool, False), UOp.cvar("var")), lambda var: var),
-(UOp.load(UOp.var(), UOp.var(), UOp.const(dtypes.bool, False), UOp.cvar("var"), UOp.var()), lambda var: var),
-(UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(dtypes.bool, True)), UOp.store),
-(UOp.store(UOp.var(), UOp.var(), UOp.var(), UOp.const(dtypes.bool, False)), lambda: UOp(UOps.NOOP)),
-"""
 
 # *** uop graph ***
 

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -269,9 +269,9 @@ constant_folder = PatternMatcher([
   (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(None, 1), UOp.cvar("var")), lambda buf,idx,var: UOp.load(buf, idx, dtype=var.dtype)),
   (UOp.load(UOp.var("buf"), UOp.var("idx"), UOp.const(None, 1), UOp.cvar("var"), UOp.var("barrier")),
    lambda buf,idx,var,barrier: UOp.load(buf, idx, barrier, dtype=var.dtype)),
-  (UOp.load(UOp.var(), UOp.var(), UOp.const(None, 0), UOp.cvar("var")), lambda var: var),
-  (UOp.load(UOp.var(), UOp.var(), UOp.const(None, 0), UOp.cvar("var"), UOp.var()), lambda var: var),
-  (UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(None, 1)), UOp.store),
+  (UOp.load(UOp.var(), UOp.var(), UOp.const(dtypes.bool, False), UOp.cvar("var")), lambda var: var),
+  (UOp.load(UOp.var(), UOp.var(), UOp.const(dtypes.bool, False), UOp.cvar("var"), UOp.var()), lambda var: var),
+  (UOp.store(UOp.var("buf"), UOp.var("idx"), UOp.var("val"), UOp.const(dtypes.bool, True)), UOp.store),
   (UOp.store(UOp.var(), UOp.var(), UOp.var(), UOp.const(None, 0)), lambda: UOp(UOps.NOOP)),
   # remove NOOPs from SINK
   (UPat(UOps.SINK, name="root"),


### PR DESCRIPTION
Prevents the Linearizer from rendering NumNode(0) and NumNode(1) for valids. Now all non-bool gates are asserted in the UOps type checker.