### PR TITLE
Compare State Dicts Helper Function

### DIFF
--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -129,6 +129,15 @@ def load_state_dict(model, state_dict:Dict[str, Tensor], strict=True, verbose=Tr
       else: v.replace(state_dict[k].to(v.device)).realize()
       if consume: del state_dict[k]
 
+def compare_state_dicts(left_state_dict:Dict, right_state_dict:Dict, left_name:str="Model", right_name:str="Weights") -> None:
+  """
+  Compares 2 state dicts, printing which keys are missing from another for debugging purposes.
+  """
+  left_keys, right_keys = set(left_state_dict.keys()), set(right_state_dict.keys())
+  left_only, right_only = left_keys.difference(right_keys), right_keys.difference(left_keys)
+  blocks = ["\n".join([f"\n{n} Only:"]+sorted(list(s))) for s,n in ((left_only,left_name), (right_only,right_name)) if len(s) > 0]
+  print("Both state dicts contain the same keys" if len(blocks) == 0 else "\n".join(blocks)+"\n")
+
 # torch support!
 
 def torch_load(fn:str) -> Dict[str, Tensor]:


### PR DESCRIPTION
## Overview

Proposed up-streaming of helper function that takes in 2 state dicts and prints which keys are missing from another.

Very useful when implementing an existing model (like StableDiffusion) for inference to check for weight key mismatching.

## Testing

Note: only the keys are used by the function, accepts full state dict for easier calling. This function was also properly tested with a full model and weights file.

```python
>>> compare_state_dicts({"proj_in.weight":0,"proj_in.bias":0}, {"proj_in.weight":0,"proj_in.bias":0})
Both state dicts contain the same keys
```

```python
>>> compare_state_dicts({"proj_in.weight":0,"proj_in.bias":0,"sigmas":0}, {"proj_in.weight":0,"proj_in.bias":0})

Model Only:
sigmas

```

```python
>>> compare_state_dicts({"proj_in.weight":0,"proj_in.bias":0}, {"proj_in.weight":0,"proj_in.bias":0,"pos_ids":0,"tok_ids":0})

Weights Only:
pos_ids
tok_ids

```

```python
>>> compare_state_dicts({"proj_in.weight":0,"proj_in.bias":0,"sigmas":0}, {"proj_in.weight":0,"proj_in.bias":0,"pos_ids":0,"tok_ids":0})

Model Only:
sigmas

Weights Only:
pos_ids
tok_ids

```