### PR TITLE
iterate over scoped uops once [run_process_replay]

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -361,8 +361,7 @@ class UOpGraph:
 
     # scope children impact the toposort and END* insertion
     end_for_uop = {UOps.IF:(UOps.STORE, UOps.ENDIF), UOps.RANGE:(UOps.PHI, UOps.ENDRANGE)}
-    loops, ifs = [x for x in in_degree if x.op is UOps.RANGE], [x for x in in_degree if x.op is UOps.IF]
-    scope_children = {p:get_recursive_children(p, end_for_uop[p.op][0]) for p in (loops+ifs)[::-1]}
+    scope_children = {p:get_recursive_children(p, end_for_uop[p.op][0]) for p in reversed(in_degree) if p.op in end_for_uop}
 
     queue:List[Tuple[int, UOp]] = []
     def push(u:UOp):


### PR DESCRIPTION
This diff is a small redundancy removal, turns out to be faster too:
```
***** model forward in  54.62 ms
***** model schedule in  17.24 ms
***** model lower in 1658.15 ms

***** model forward in  54.59 ms
***** model schedule in  17.36 ms
***** model lower in 1641.64 ms
```