### PR TITLE
use UOps.STORE as barrier in lowering

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -772,13 +772,13 @@ class TestLinearizer(unittest.TestCase):
     def get_recursive(uop): return set.union(set(uop.src), [uop], *[get_recursive(v) for v in uop.src])
     local_stores = [u for u in k.uops if u.op is UOps.STORE and any(x.op is UOps.DEFINE_LOCAL for x in get_recursive(u.src[0]))]
     global_stores = [u for u in k.uops if u.op is UOps.STORE and any(x.op is UOps.DEFINE_GLOBAL for x in get_recursive(u.src[0]))]
-    barrier = [u for u in k.uops if u.op is UOps.BARRIER][0]
+    barriers = [u for u in k.uops if u.op is UOps.BARRIER]
     # check that the float4 cast collapses for all stores
     for store in local_stores+global_stores:
       assert store.src[-1].dtype == dtypes.float.vec(2) and store.src[-1].op is not UOps.CAST
     # check the children's vins
-    assert barrier.src == tuple(local_stores)
-    assert len([u for u in k.uops if u.op is UOps.IF and u.src[-1] == barrier]) == 1
+    assert len(barriers) == 1
+    assert len([u for u in k.uops if u.op is UOps.IF and u.src[-1] == local_stores[-1]]) == 1
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -335,7 +335,7 @@ class UOpGraph:
     # fixup gated stores with an IF block to save extra local loads
     @functools.lru_cache(None)
     def _dfs(u:UOp, gate:UOp) -> UOp:
-      if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER:
+      if u.op is UOps.LOAD and u.src[-1].op is UOps.STORE:
         if_uop = UOp(UOps.IF, None, (gate, u.src[-1]))
         return UOp(u.op, u.dtype, u.src[:-1]+(if_uop,), u.arg)
       if (replace_source:=tuple(_dfs(x, gate) for x in u.src)) != u.src: return UOp(u.op, u.dtype, replace_source, u.arg)
@@ -360,7 +360,7 @@ class UOpGraph:
       return set.union(set((x,)) if include_self else set(), *([get_recursive_children(u, end, True) for u in children[x] if x.op is not end]))
 
     # scope children impact the toposort and END* insertion
-    end_for_uop = {UOps.IF:(UOps.STORE, UOps.ENDIF), UOps.RANGE:(UOps.PHI, UOps.ENDRANGE)}
+    end_for_uop = {UOps.IF:(UOps.STORE, UOps.ENDIF), UOps.RANGE:(UOps.PHI, UOps.ENDRANGE), UOps.DEFINE_LOCAL:(UOps.STORE, UOps.BARRIER)}
     scope_children = {p:get_recursive_children(p, end_for_uop[p.op][0]) for p in reversed(in_degree) if p.op in end_for_uop}
 
     queue:List[Tuple[int, UOp]] = []

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -444,7 +444,7 @@ class UOpGraph:
           arg = src[0].arg
         assert dtype is not None and type(arg) is type(dtypes.as_const(arg, dtype)), f"type of {arg=} does not match {dtype}"
       if uop in {UOps.CAST, UOps.BITCAST}: assert arg is None   # type is the output type, not an arg
-      if uop is UOps.LOAD and len(src) > 2 and src[2].op not in {UOps.IF, UOps.BARRIER}: assert src[2].dtype == dtypes.bool
+      if uop is UOps.LOAD and len(src) > 2 and src[-1].op is UOps.ALU: assert src[-1].dtype == dtypes.bool
       if uop is UOps.STORE and len(src) == 4: assert src[3].dtype == dtypes.bool
       if uop is UOps.ALU:
         if arg in UnaryOps:

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -391,7 +391,7 @@ class UOpGraph:
       for u, ss in scope_children.items():
         if x in ss:
           ss.remove(x)
-          if u.op is UOps.RANGE: assert u.op is not UOps.BARRIER, "toposorted barrier inside loop"
+          if u.op is UOps.RANGE: assert x.op is not UOps.BARRIER, "toposorted barrier inside loop"
           if len(ss) == 0: self._uops.append(UOp(end_for_uop[u.op][1], None, (u,)))
       for u in children[x]:
         in_degree[u] -= 1

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -391,6 +391,7 @@ class UOpGraph:
       for u, ss in scope_children.items():
         if x in ss:
           ss.remove(x)
+          if u.op is UOps.RANGE: assert u.op is not UOps.BARRIER, "toposorted barrier inside loop"
           if len(ss) == 0: self._uops.append(UOp(end_for_uop[u.op][1], None, (u,)))
       for u in children[x]:
         in_degree[u] -= 1

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -141,7 +141,7 @@ class CStyleLanguage(Renderer):
         elif uop is UOps.LOAD:
           val = self.render_load(dtype, r[src[0]], src[0].dtype, strip_parens(r[src[1]]), src[0].op is UOps.DEFINE_LOCAL)
           # NOTE: this relies on the load not happening if it's in the unselected branch
-          if len(src) > 3: val = self.code_for_op[TernaryOps.WHERE](r[src[2]], val, r[src[3]], dtype)
+          if len(src) > 3 and src[-1].op is UOps.ALU: val = self.code_for_op[TernaryOps.WHERE](r[src[2]], val, r[src[-1]], dtype)
           kk(f"{self.render_dtype(dtype)} {ssa('val',u)} = {val};")
         elif uop is UOps.PHI:
           kk(f"{r[src[0]]} = {r[src[1]]};")


### PR DESCRIPTION
auto-inserts BARRIER in the uop toposort once all the STORE children of a LocalBuffer are toposorted. Unblocks #4957

- [x] insert BARRIER in uops
- [ ] dedup UOps.IF gates for upcasted stores