### PR TITLE
Fixed UNet Call Params

### DIFF
--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -53,7 +53,7 @@ class TestRealWorld(unittest.TestCase):
     model = UNetModel(**unet_params)
     derandomize_model(model)
     @TinyJit
-    def test(t, t2): return model(t, 801, t2).realize()
+    def test(t, t2): return model(t, Tensor([801]), t2).realize()
     helper_test("test_sd", lambda: (Tensor.randn(1, 4, 64, 64),Tensor.randn(1, 77, 768)), test, 18.0, 953)
 
   def test_mini_stable_diffusion(self):


### PR DESCRIPTION
## Overview

The `test_real_world.py` was not updated properly and was calling UNet with the wrong params, causing an exception when run.

## Testing

```
$ python3.10 test/models/test_real_world.py
<frozen importlib._bootstrap>:914: ImportWarning: _SixMetaPathImporter.find_spec() not found; falling back to find_module()
test_gpt2: used 0.84 GB and 4 kernels in 11.21 ms
.test_llama: used 14.02 GB and 5 kernels in 199.53 ms
.test_mini_sd: used 0.00 GB and 2 kernels in 0.12 ms
.test_sd: used 4.84 GB and 7 kernels in 441.92 ms
.train_cifar: used 2.57 GB and 3 kernels in 216.24 ms
..train_mnist: used 0.06 GB and 2 kernels in 4.05 ms
.
----------------------------------------------------------------------
Ran 7 tests in 81.659s

OK
```
