### PR TITLE
use None in UOp.cmp_tuple for UOps.ALU [run_process_replay]

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -38,8 +38,7 @@ class UOp:
   @functools.cached_property
   def cmp_tuple(self):
     # NOTE: this sort of DEFINE_VAR shouldn't have to be here. only for PTX
-    return (self.op.value, (self.arg if self.op is not UOps.DEFINE_VAR else self.arg.expr) if self.op is not UOps.ALU else \
-            (type(self.op), self.op.value), self.dtype, self.src)
+    return (self.op.value, (self.arg if self.op is not UOps.DEFINE_VAR else self.arg.expr) if self.op is not UOps.ALU else None, self.dtype, self.src)
   def __lt__(self, x:UOp): return self.cmp_tuple < x.cmp_tuple
   def __repr__(self):
     return f"{str(self.op):20s}: {str(self.dtype) if self.dtype is not None else '':25s} {str([x.op for x in self.src]):32s} {self.arg}"


### PR DESCRIPTION
if `self.op is UOps.ALU`, `(type(self.op), self.op.value)` is always the same. is there a reason to construct it this way?