### PR TITLE
tensor metadata

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -607,8 +607,8 @@ class TestInferenceMode(unittest.TestCase):
 
 class TestTensorMetadata(unittest.TestCase):
   def test_matmul(self):
-    x = Tensor(x_init, requires_grad=True)
-    W = Tensor(W_init, requires_grad=True)
+    x = Tensor.rand(3, requires_grad=True)
+    W = Tensor.rand(3, 3, requires_grad=True)
     out = x.matmul(W)
     assert out.lazydata.metadata.name == "matmul"
     s = create_schedule([out.lazydata])
@@ -616,7 +616,7 @@ class TestTensorMetadata(unittest.TestCase):
     assert s[-1].metadata[0].name == "matmul"
 
   def test_relu(self):
-    x = Tensor(x_init, requires_grad=True)
+    x = Tensor.rand(3, requires_grad=True)
     out = x.relu()
     assert out.lazydata.metadata.name == "relu"
     s = create_schedule([out.lazydata])

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -630,7 +630,6 @@ class TestTensorMetadata(unittest.TestCase):
     x = Tensor.rand(3, requires_grad=True)
     y = Tensor.rand(3, requires_grad=True)
     out = x.relu() * y.sigmoid()
-    print(out.lazydata)
     assert out.lazydata.metadata.name == "__mul__"
     assert out.lazydata.srcs[0].metadata.name == "relu"
     assert out.lazydata.srcs[1].metadata.name == "sigmoid"

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -623,5 +623,35 @@ class TestTensorMetadata(unittest.TestCase):
     assert len(s[-1].metadata) == 1
     assert s[-1].metadata[0].name == "relu"
 
+  def test_complex(self):
+    x = Tensor.rand(3, requires_grad=True)
+    y = Tensor.rand(3, requires_grad=True)
+    out = x.relu() * y.sigmoid()
+    assert out.lazydata.metadata.name == "__mul__"
+    assert out.lazydata.srcs[0].metadata.name == "relu"
+    assert out.lazydata.srcs[1].metadata.name == "sigmoid"
+    s = create_schedule([out.lazydata])
+    assert len(s[-1].metadata) == 3
+    assert s[-1].metadata[0].name == "relu"
+    assert s[-1].metadata[1].name == "sigmoid"
+    assert s[-1].metadata[2].name == "__mul__"
+
+  def test_complex_backward(self):
+    x = Tensor.rand(3, requires_grad=True)
+    y = Tensor.rand(3, requires_grad=True)
+    out = (x.relu() * y.sigmoid()).sum()
+    assert out.lazydata.metadata.name == "sum"
+    out.backward()
+    assert x.grad.lazydata.metadata.name == "relu"
+    assert x.grad.lazydata.metadata.backward
+    assert y.grad.lazydata.metadata.name == "sigmoid"
+    assert y.grad.lazydata.metadata.backward
+    s = create_schedule([out.lazydata, x.grad.lazydata, y.grad.lazydata])
+    assert len(s[-1].metadata) == 3
+    assert s[-1].metadata[0].name == "sigmoid"
+    assert s[-1].metadata[1].name == "sigmoid"
+    assert s[-1].metadata[1].backward
+    assert s[-1].metadata[2].name == "relu"
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -3,7 +3,7 @@ import torch
 import unittest, copy, mmap, random, math
 from tinygrad import Tensor, Device, dtypes
 from tinygrad.engine.schedule import create_schedule
-from tinygrad.helpers import getenv, temp, CI
+from tinygrad.helpers import getenv, temp, CI, _METADATA
 from extra.gradcheck import numerical_jacobian, jacobian, gradcheck
 from hypothesis import given, settings, strategies as strat
 from test.helpers import is_dtype_supported
@@ -607,6 +607,7 @@ class TestInferenceMode(unittest.TestCase):
 
 class TestTensorMetadata(unittest.TestCase):
   def test_matmul(self):
+    _METADATA.set(None)
     x = Tensor.rand(3, requires_grad=True)
     W = Tensor.rand(3, 3, requires_grad=True)
     out = x.matmul(W)
@@ -616,6 +617,7 @@ class TestTensorMetadata(unittest.TestCase):
     assert s[-1].metadata[0].name == "matmul"
 
   def test_relu(self):
+    _METADATA.set(None)
     x = Tensor.rand(3, requires_grad=True)
     out = x.relu()
     assert out.lazydata.metadata.name == "relu"
@@ -624,9 +626,11 @@ class TestTensorMetadata(unittest.TestCase):
     assert s[-1].metadata[0].name == "relu"
 
   def test_complex(self):
+    _METADATA.set(None)
     x = Tensor.rand(3, requires_grad=True)
     y = Tensor.rand(3, requires_grad=True)
     out = x.relu() * y.sigmoid()
+    print(out.lazydata)
     assert out.lazydata.metadata.name == "__mul__"
     assert out.lazydata.srcs[0].metadata.name == "relu"
     assert out.lazydata.srcs[1].metadata.name == "sigmoid"
@@ -637,6 +641,7 @@ class TestTensorMetadata(unittest.TestCase):
     assert s[-1].metadata[2].name == "__mul__"
 
   def test_complex_backward(self):
+    _METADATA.set(None)
     x = Tensor.rand(3, requires_grad=True)
     y = Tensor.rand(3, requires_grad=True)
     out = (x.relu() * y.sigmoid()).sum()

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -1,7 +1,7 @@
 from typing import List, Dict, Optional, cast, Generator, Tuple
-import time
+import time, pprint
 from dataclasses import dataclass, replace
-from tinygrad.helpers import colored, getenv, DEBUG, GlobalCounters, ansilen, BEAM, NOOPT, all_int, CAPTURING
+from tinygrad.helpers import colored, getenv, DEBUG, GlobalCounters, ansilen, BEAM, NOOPT, all_int, CAPTURING, Metadata
 from tinygrad.ops import BufferOps, LoadOps, LazyOp
 from tinygrad.device import Device, Buffer
 from tinygrad.shape.symbolic import Variable, sym_infer, sint
@@ -148,7 +148,7 @@ def get_runner(dname:str, ast:Tuple[LazyOp, ...]) -> CompiledRunner:
 class ExecItem:
   prg: Runner
   bufs: List[Optional[Buffer]]
-  metadata: Optional[List[Optional[str]]] = None
+  metadata: Optional[List[Metadata]] = None
   def run(self, var_vals:Optional[Dict[Variable, int]]=None, wait=False, jit=False, do_update_stats=True) -> Optional[float]:
     bufs = [cast(Buffer, x) for x in self.bufs] if jit else [cast(Buffer, x).ensure_allocated() for x in self.bufs]
     et = self.prg(bufs, var_vals if var_vals is not None else {}, wait=wait or DEBUG >= 2)
@@ -160,7 +160,7 @@ class ExecItem:
       if DEBUG >= 2:
         ptm = (colored(f"{et*1e3:9.2f}ms", "yellow") if et > 0.01 else f"{et*1e6:9.2f}us") if et is not None else ""
         print(f"{colored(f'*** {self.prg.dname[:7]:7s} {GlobalCounters.kernel_count:4d}', 'magenta' if jit else ('green' if self.prg.first_run else None))} {self.prg.display_name+' '*(38-ansilen(self.prg.display_name))} arg {len(self.bufs):3d} mem {GlobalCounters.mem_used/1e9:5.2f} GB " +  # noqa: E501
-              (str() if et is None else f"tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({op_estimate/((et or 1e-20)*1e9):8.2f} GFLOPS, {mem_estimate/((et or 1e-20)*1e9):7.2f} GB/s) {self.metadata}"))  # noqa: E501
+              (str() if et is None else f"tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({op_estimate/((et or 1e-20)*1e9):8.2f} GFLOPS, {mem_estimate/((et or 1e-20)*1e9):7.2f} GB/s)  {[str(m) for m in self.metadata] if self.metadata else ''}"))  # noqa: E501
       self.prg.first_run = False
     return et
 
@@ -181,7 +181,14 @@ def lower_schedule_item(si:ScheduleItem) -> ExecItem:
   raise RuntimeError(f"don't know how to lower {ast}")
 
 def lower_schedule(schedule:List[ScheduleItem]) -> Generator[ExecItem, None, None]:
-  while len(schedule): yield lower_schedule_item(schedule.pop(0))
+  while len(schedule):
+    try: yield lower_schedule_item(si := schedule.pop(0))
+    except Exception as e:
+      if DEBUG >= 2:
+        print(f"error lowering {si.ast[0].op}")
+        print("tensor operations:")
+        pprint.pprint(si.metadata, indent=2)
+      raise e
 
 # **************** main run function ****************
 

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -160,7 +160,7 @@ class ExecItem:
       if DEBUG >= 2:
         ptm = (colored(f"{et*1e3:9.2f}ms", "yellow") if et > 0.01 else f"{et*1e6:9.2f}us") if et is not None else ""
         print(f"{colored(f'*** {self.prg.dname[:7]:7s} {GlobalCounters.kernel_count:4d}', 'magenta' if jit else ('green' if self.prg.first_run else None))} {self.prg.display_name+' '*(38-ansilen(self.prg.display_name))} arg {len(self.bufs):3d} mem {GlobalCounters.mem_used/1e9:5.2f} GB " +  # noqa: E501
-              (str() if et is None else f"tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({op_estimate/((et or 1e-20)*1e9):8.2f} GFLOPS, {mem_estimate/((et or 1e-20)*1e9):7.2f} GB/s)" +  # noea: E501
+              (str() if et is None else f"tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({op_estimate/((et or 1e-20)*1e9):8.2f} GFLOPS, {mem_estimate/((et or 1e-20)*1e9):7.2f} GB/s)" +  # noqa: E501
                f"{[repr(m) if DEBUG >= 3 else str(m) for m in self.metadata] if self.metadata else ''}"))
       self.prg.first_run = False
     return et

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -160,7 +160,8 @@ class ExecItem:
       if DEBUG >= 2:
         ptm = (colored(f"{et*1e3:9.2f}ms", "yellow") if et > 0.01 else f"{et*1e6:9.2f}us") if et is not None else ""
         print(f"{colored(f'*** {self.prg.dname[:7]:7s} {GlobalCounters.kernel_count:4d}', 'magenta' if jit else ('green' if self.prg.first_run else None))} {self.prg.display_name+' '*(38-ansilen(self.prg.display_name))} arg {len(self.bufs):3d} mem {GlobalCounters.mem_used/1e9:5.2f} GB " +  # noqa: E501
-              (str() if et is None else f"tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({op_estimate/((et or 1e-20)*1e9):8.2f} GFLOPS, {mem_estimate/((et or 1e-20)*1e9):7.2f} GB/s)  {[str(m) for m in self.metadata] if self.metadata else ''}"))  # noqa: E501
+              (str() if et is None else f"tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({op_estimate/((et or 1e-20)*1e9):8.2f} GFLOPS, {mem_estimate/((et or 1e-20)*1e9):7.2f} GB/s)" +  # noea: E501
+               f"{[repr(m) if DEBUG >= 3 else str(m) for m in self.metadata] if self.metadata else ''}"))
       self.prg.first_run = False
     return et
 

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -148,6 +148,7 @@ def get_runner(dname:str, ast:Tuple[LazyOp, ...]) -> CompiledRunner:
 class ExecItem:
   prg: Runner
   bufs: List[Optional[Buffer]]
+  metadata: Optional[List[Optional[str]]] = None
   def run(self, var_vals:Optional[Dict[Variable, int]]=None, wait=False, jit=False, do_update_stats=True) -> Optional[float]:
     bufs = [cast(Buffer, x) for x in self.bufs] if jit else [cast(Buffer, x).ensure_allocated() for x in self.bufs]
     et = self.prg(bufs, var_vals if var_vals is not None else {}, wait=wait or DEBUG >= 2)
@@ -159,7 +160,7 @@ class ExecItem:
       if DEBUG >= 2:
         ptm = (colored(f"{et*1e3:9.2f}ms", "yellow") if et > 0.01 else f"{et*1e6:9.2f}us") if et is not None else ""
         print(f"{colored(f'*** {self.prg.dname[:7]:7s} {GlobalCounters.kernel_count:4d}', 'magenta' if jit else ('green' if self.prg.first_run else None))} {self.prg.display_name+' '*(38-ansilen(self.prg.display_name))} arg {len(self.bufs):3d} mem {GlobalCounters.mem_used/1e9:5.2f} GB " +  # noqa: E501
-              (str() if et is None else f"tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({op_estimate/((et or 1e-20)*1e9):8.2f} GFLOPS, {mem_estimate/((et or 1e-20)*1e9):7.2f} GB/s)"))  # noqa: E501
+              (str() if et is None else f"tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({op_estimate/((et or 1e-20)*1e9):8.2f} GFLOPS, {mem_estimate/((et or 1e-20)*1e9):7.2f} GB/s) f{self.metadata}"))  # noqa: E501
       self.prg.first_run = False
     return et
 
@@ -167,7 +168,7 @@ def lower_schedule_item(si:ScheduleItem) -> ExecItem:
   assert len(set(x.device for x in si.bufs)) == 1 or si.ast[0].op is LoadOps.COPY or getenv("USE_COPY_KERNEL")
   if si.ast[0].op is BufferOps.STORE:
     runner = get_runner(si.outputs[0].device, si.ast)
-    return ExecItem(runner, [si.bufs[x[0]] for x in runner.p.globals])
+    return ExecItem(runner, [si.bufs[x[0]] for x in runner.p.globals], si.metadata)
   out, ast = si.outputs[0], si.ast[0]
   if ast.op is LoadOps.COPY:
     kernel_type = BufferCopy

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -161,7 +161,7 @@ class ExecItem:
         ptm = (colored(f"{et*1e3:9.2f}ms", "yellow") if et > 0.01 else f"{et*1e6:9.2f}us") if et is not None else ""
         print(f"{colored(f'*** {self.prg.dname[:7]:7s} {GlobalCounters.kernel_count:4d}', 'magenta' if jit else ('green' if self.prg.first_run else None))} {self.prg.display_name+' '*(38-ansilen(self.prg.display_name))} arg {len(self.bufs):3d} mem {GlobalCounters.mem_used/1e9:5.2f} GB " +  # noqa: E501
               (str() if et is None else f"tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({op_estimate/((et or 1e-20)*1e9):8.2f} GFLOPS, {mem_estimate/((et or 1e-20)*1e9):7.2f} GB/s)" +  # noqa: E501
-               f"{[repr(m) if DEBUG >= 3 else str(m) for m in self.metadata] if self.metadata else ''}"))
+               f" {[repr(m) if DEBUG >= 3 else str(m) for m in self.metadata] if self.metadata else ''}"))
       self.prg.first_run = False
     return et
 
@@ -183,7 +183,8 @@ def lower_schedule_item(si:ScheduleItem) -> ExecItem:
 
 def lower_schedule(schedule:List[ScheduleItem]) -> Generator[ExecItem, None, None]:
   while len(schedule):
-    try: yield lower_schedule_item(si := schedule.pop(0))
+    si = schedule.pop(0)
+    try: yield lower_schedule_item(si)
     except Exception as e:
       if DEBUG >= 2:
         print(f"error lowering {si.ast[0].op}")

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -160,7 +160,7 @@ class ExecItem:
       if DEBUG >= 2:
         ptm = (colored(f"{et*1e3:9.2f}ms", "yellow") if et > 0.01 else f"{et*1e6:9.2f}us") if et is not None else ""
         print(f"{colored(f'*** {self.prg.dname[:7]:7s} {GlobalCounters.kernel_count:4d}', 'magenta' if jit else ('green' if self.prg.first_run else None))} {self.prg.display_name+' '*(38-ansilen(self.prg.display_name))} arg {len(self.bufs):3d} mem {GlobalCounters.mem_used/1e9:5.2f} GB " +  # noqa: E501
-              (str() if et is None else f"tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({op_estimate/((et or 1e-20)*1e9):8.2f} GFLOPS, {mem_estimate/((et or 1e-20)*1e9):7.2f} GB/s) f{self.metadata}"))  # noqa: E501
+              (str() if et is None else f"tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({op_estimate/((et or 1e-20)*1e9):8.2f} GFLOPS, {mem_estimate/((et or 1e-20)*1e9):7.2f} GB/s) {self.metadata}"))  # noqa: E501
       self.prg.first_run = False
     return et
 

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -117,7 +117,7 @@ def _schedule_group(outs:Tuple[LazyBuffer, ...], realizes:Dict[LazyBuffer, None]
       output_view, vv = output_view.simplify().unbind()
       if vv: var_vals.update(vv)
       ast.append(LazyOp(BufferOps.STORE, (lop, ), MemBuffer(i, out.dtype, output_view)))
-  return tuple(ast), tuple(inputs), var_vals, dedup([x[0].metadata for x in cache if x[0].metadata and x not in inputs])
+  return tuple(ast), tuple(inputs), var_vals, dedup([x[0].metadata for x in cache if x[0].metadata and x[0] not in inputs])
 
 # *** DAG creation: decide which LazyBuffers should realize ***
 

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -23,7 +23,7 @@ logops = open(getenv("LOGOPS", ""), "a") if getenv("LOGOPS", "") else None
 class ScheduleItem:
   ast: Tuple[LazyOp, ...]
   bufs: Tuple[Buffer, ...]
-  metadata: List[Metadata]
+  metadata: Optional[List[Metadata]] = None
   @property
   def outputs(self) -> Tuple[Buffer, ...]:
     """Read/write or write only buffers in the schedule."""

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Tuple, List, Dict, Optional, Set, DefaultDict, Union, get_args
 from tinygrad.ops import LoadOps, BufferOps, LazyOp, ReduceOps, ConstBuffer, MemBuffer, UNSAFE_PAD_OPS, UnaryOps
 from tinygrad.engine.graph import log_lazybuffer, realized_lazybuffer
-from tinygrad.helpers import GRAPH, DEBUG, MULTIOUTPUT, SAVE_SCHEDULE, GlobalCounters, colored, prod, dedup, all_int, merge_dicts, getenv
+from tinygrad.helpers import GRAPH, DEBUG, MULTIOUTPUT, SAVE_SCHEDULE, GlobalCounters, colored, prod, dedup, all_int, merge_dicts, getenv, Metadata
 from tinygrad.shape.symbolic import Variable
 from tinygrad.dtype import ConstType, ImageDType, dtypes, DType
 from tinygrad.lazy import LazyBuffer
@@ -23,7 +23,7 @@ logops = open(getenv("LOGOPS", ""), "a") if getenv("LOGOPS", "") else None
 class ScheduleItem:
   ast: Tuple[LazyOp, ...]
   bufs: Tuple[Buffer, ...]
-  metadata: List[Optional[str]]
+  metadata: List[Metadata]
   @property
   def outputs(self) -> Tuple[Buffer, ...]:
     """Read/write or write only buffers in the schedule."""
@@ -42,7 +42,7 @@ class _LBScheduleItem:
   outputs: Tuple[LazyBuffer, ...]
   inputs: Tuple[LazyBuffer, ...]
   var_vals: Dict[Variable, int]
-  metadata: List[Optional[str]]
+  metadata: List[Metadata]
 
 def _recursive_lazyop(buf:LazyBuffer, inputs:List[LazyBuffer], outputs:Tuple[LazyBuffer, ...], var_vals:Dict[Variable, int], st:ShapeTracker,
                       realizes:Dict[LazyBuffer, None], assign_targets:Dict[LazyBuffer, LazyBuffer], cache) -> LazyOp:

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import os, functools, platform, time, re, contextlib, operator, hashlib, pickle, sqlite3, cProfile, pstats, tempfile, pathlib, string, ctypes, sys
-import itertools, urllib.request, subprocess, shutil, math, json
+import itertools, urllib.request, subprocess, shutil, math, json, contextvars
 from typing import Dict, Tuple, Union, List, ClassVar, Optional, Iterable, Any, TypeVar, TYPE_CHECKING, Callable, Sequence
 if TYPE_CHECKING:  # TODO: remove this and import TypeGuard from typing once minimum python supported version is 3.10
   from typing_extensions import TypeGuard
@@ -104,6 +104,8 @@ DEBUG, IMAGE, BEAM, NOOPT, JIT = ContextVar("DEBUG", 0), ContextVar("IMAGE", 0),
 WINO, THREEFRY, CAPTURING = ContextVar("WINO", 0), ContextVar("THREEFRY", 0), ContextVar("CAPTURING", 1)
 GRAPH, GRAPHPATH, SAVE_SCHEDULE, RING = ContextVar("GRAPH", 0), getenv("GRAPHPATH", "/tmp/net"), ContextVar("SAVE_SCHEDULE", 0), ContextVar("RING", 1)
 MULTIOUTPUT, PROFILE = ContextVar("MULTIOUTPUT", 1), ContextVar("PROFILE", 0)
+
+_METADATA = contextvars.ContextVar("_METADATA", default=None)
 
 # **************** global state Counters ****************
 

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -106,7 +106,7 @@ WINO, THREEFRY, CAPTURING = ContextVar("WINO", 0), ContextVar("THREEFRY", 0), Co
 GRAPH, GRAPHPATH, SAVE_SCHEDULE, RING = ContextVar("GRAPH", 0), getenv("GRAPHPATH", "/tmp/net"), ContextVar("SAVE_SCHEDULE", 0), ContextVar("RING", 1)
 MULTIOUTPUT, PROFILE = ContextVar("MULTIOUTPUT", 1), ContextVar("PROFILE", 0)
 
-@dataclass
+@dataclass(frozen=True)
 class Metadata:
   name: str
   backward: bool = False

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -112,9 +112,8 @@ class Metadata:
   backward: bool = False
   caller: Optional[str] = None
   def __hash__(self): return hash(self.name)
-  def __repr__(self): return self.name + (" bw" if self.backward else "") + (f" - {self.caller}" if self.caller else "")
+  def __repr__(self): return str(self) + (f" - {self.caller}" if self.caller else "")
   def __str__(self): return self.name + (" bw" if self.backward else "")
-
 _METADATA: contextvars.ContextVar[Optional[Metadata]] = contextvars.ContextVar("_METADATA", default=None)
 
 # **************** global state Counters ****************

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -109,8 +109,8 @@ MULTIOUTPUT, PROFILE = ContextVar("MULTIOUTPUT", 1), ContextVar("PROFILE", 0)
 @dataclass(frozen=True)
 class Metadata:
   name: str
+  caller: str
   backward: bool = False
-  caller: Optional[str] = None
   def __hash__(self): return hash(self.name)
   def __repr__(self): return str(self) + (f" - {self.caller}" if self.caller else "")
   def __str__(self): return self.name + (" bw" if self.backward else "")

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -102,7 +102,7 @@ class ContextVar:
   def __lt__(self, x): return self.value < x
 
 DEBUG, IMAGE, BEAM, NOOPT, JIT = ContextVar("DEBUG", 0), ContextVar("IMAGE", 0), ContextVar("BEAM", 0), ContextVar("NOOPT", 0), ContextVar("JIT", 1)
-WINO, THREEFRY, CAPTURING = ContextVar("WINO", 0), ContextVar("THREEFRY", 0), ContextVar("CAPTURING", 1)
+WINO, THREEFRY, CAPTURING, TRACEMETA = ContextVar("WINO", 0), ContextVar("THREEFRY", 0), ContextVar("CAPTURING", 1), ContextVar("TRACEMETA", 1)
 GRAPH, GRAPHPATH, SAVE_SCHEDULE, RING = ContextVar("GRAPH", 0), getenv("GRAPHPATH", "/tmp/net"), ContextVar("SAVE_SCHEDULE", 0), ContextVar("RING", 1)
 MULTIOUTPUT, PROFILE = ContextVar("MULTIOUTPUT", 1), ContextVar("PROFILE", 0)
 

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os, functools, platform, time, re, contextlib, operator, hashlib, pickle, sqlite3, cProfile, pstats, tempfile, pathlib, string, ctypes, sys
 import itertools, urllib.request, subprocess, shutil, math, json, contextvars
+from dataclasses import dataclass
 from typing import Dict, Tuple, Union, List, ClassVar, Optional, Iterable, Any, TypeVar, TYPE_CHECKING, Callable, Sequence
 if TYPE_CHECKING:  # TODO: remove this and import TypeGuard from typing once minimum python supported version is 3.10
   from typing_extensions import TypeGuard
@@ -105,7 +106,16 @@ WINO, THREEFRY, CAPTURING = ContextVar("WINO", 0), ContextVar("THREEFRY", 0), Co
 GRAPH, GRAPHPATH, SAVE_SCHEDULE, RING = ContextVar("GRAPH", 0), getenv("GRAPHPATH", "/tmp/net"), ContextVar("SAVE_SCHEDULE", 0), ContextVar("RING", 1)
 MULTIOUTPUT, PROFILE = ContextVar("MULTIOUTPUT", 1), ContextVar("PROFILE", 0)
 
-_METADATA = contextvars.ContextVar("_METADATA", default=None)
+@dataclass
+class Metadata:
+  name: str
+  backward: bool = False
+  caller: Optional[str] = None
+  def __hash__(self): return hash(self.name)
+  def __repr__(self): return self.name + (" bw" if self.backward else "") + (f" - {self.caller}" if self.caller else "")
+  def __str__(self): return self.name + (" bw" if self.backward else "")
+
+_METADATA: contextvars.ContextVar[Optional[Metadata]] = contextvars.ContextVar("_METADATA", default=None)
 
 # **************** global state Counters ****************
 

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import math
 from typing import Union, Optional, Any, Tuple, List
 from tinygrad.dtype import dtypes, DType, ConstType
-from tinygrad.helpers import prod, getenv, all_int, all_same, DEBUG
+from tinygrad.helpers import prod, getenv, all_int, all_same, DEBUG, _METADATA
 from tinygrad.ops import LoadOps, UnaryOps, BinaryOps, TernaryOps, ReduceOps, Op, exec_alu, python_alu
 from tinygrad.shape.symbolic import sint, Variable
 from tinygrad.shape.shapetracker import ShapeTracker
@@ -18,7 +18,7 @@ def create_lazybuffer(device:str, st:ShapeTracker, dtype:DType, op:Optional[Op]=
   cache_key = (device, st, dtype, op, arg, tuple(ref(x) for x in srcs)) if base is None else (st, ref(base))
   if enable_cache and (rret := lazycache.get(cache_key, None)): return rret
 
-  ret = LazyBuffer(device, st, dtype, op, arg, srcs, base=base)
+  ret = LazyBuffer(device, st, dtype, op, arg, srcs, base=base, metadata=_METADATA.get())
   if enable_cache: lazycache[cache_key] = ret
   return ret
 
@@ -26,8 +26,8 @@ view_supported_devices = {"LLVM", "CLANG", "CUDA", "NV", "AMD", "DISK"}
 class LazyBuffer:
   def __init__(self, device:str, st:ShapeTracker, dtype:DType,
                op:Optional[Op]=None, arg:Any=None, srcs:Tuple[LazyBuffer, ...]=(),
-               base:Optional[LazyBuffer]=None):
-    self.device, self.st, self.dtype, self.shape, self.size = device, st, dtype, st.shape, st.size
+               base:Optional[LazyBuffer]=None, metadata:Optional[str]=None):
+    self.device, self.st, self.dtype, self.shape, self.size, self.metadata = device, st, dtype, st.shape, st.size, metadata
     self._base: Optional[LazyBuffer] = None
     if base is None:
       # properties on base

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import math
 from typing import Union, Optional, Any, Tuple, List
 from tinygrad.dtype import dtypes, DType, ConstType
-from tinygrad.helpers import prod, getenv, all_int, all_same, DEBUG, _METADATA
+from tinygrad.helpers import prod, getenv, all_int, all_same, DEBUG, _METADATA, Metadata
 from tinygrad.ops import LoadOps, UnaryOps, BinaryOps, TernaryOps, ReduceOps, Op, exec_alu, python_alu
 from tinygrad.shape.symbolic import sint, Variable
 from tinygrad.shape.shapetracker import ShapeTracker
@@ -26,7 +26,7 @@ view_supported_devices = {"LLVM", "CLANG", "CUDA", "NV", "AMD", "DISK"}
 class LazyBuffer:
   def __init__(self, device:str, st:ShapeTracker, dtype:DType,
                op:Optional[Op]=None, arg:Any=None, srcs:Tuple[LazyBuffer, ...]=(),
-               base:Optional[LazyBuffer]=None, metadata:Optional[str]=None):
+               base:Optional[LazyBuffer]=None, metadata:Optional[Metadata]=None):
     self.device, self.st, self.dtype, self.shape, self.size, self.metadata = device, st, dtype, st.shape, st.size, metadata
     self._base: Optional[LazyBuffer] = None
     if base is None:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3035,7 +3035,7 @@ def _metadata_wrapper(fn):
     caller_func = caller_frame.f_code.co_name
     caller_lineno = caller_frame.f_lineno
 
-    token = _METADATA.set(Metadata(name=fn.__name__, caller=f"{caller_module}.{caller_func}:{caller_lineno}"))
+    token = _METADATA.set(Metadata(name=fn.__name__, caller=f"{caller_module}:{caller_lineno}::{caller_func}"))
     ret = fn(*args, **kwargs)
     _METADATA.reset(token)
     return ret

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3110,8 +3110,6 @@ def _metadata_wrapper(fn):
       caller_frame = sys._getframe(frame := frame + 1)
       caller_module = caller_frame.f_globals.get("__name__", None)
       if caller_module is None: return fn(*args, **kwargs)
-    caller_func = caller_frame.f_code.co_name
-    caller_lineno = caller_frame.f_lineno
 
     # if its called from a lambda in tinygrad we want to look two more frames up
     if caller_module.startswith("tinygrad") and caller_func == "<lambda>": caller_frame = sys._getframe(frame := frame + 2)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3126,7 +3126,6 @@ def _metadata_wrapper(fn):
     return ret
   return _wrapper
 
-if DEBUG >= 2:
-  for name, fn in inspect.getmembers(Tensor, inspect.isfunction):
-    if name in ["__class__", "__init__", "__repr__", "backward", "sequential"]: continue
-    setattr(Tensor, name, functools.wraps(fn)(_metadata_wrapper(fn)))
+for name, fn in inspect.getmembers(Tensor, inspect.isfunction):
+  if name in ["__class__", "__init__", "__repr__", "backward", "sequential"]: continue
+  setattr(Tensor, name, functools.wraps(fn)(_metadata_wrapper(fn)))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -779,7 +779,7 @@ class Tensor:
 
     for t0 in reversed(self._deepwalk()):
       if t0.grad is None: raise RuntimeError(f"tensor {t0} has no grad")
-      token = _METADATA.set(dataclasses.replace(md, backward=True) if (md := _METADATA.get()) is not None else None)
+      token = _METADATA.set(dataclasses.replace(md, backward=True) if (md := t0._ctx.metadata) is not None else None)
       grads = t0._ctx.backward(t0.grad.lazydata)
       _METADATA.reset(token)
       grads = [Tensor(g, device=self.device, requires_grad=False) if g is not None else None

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3023,7 +3023,7 @@ def _metadata_wrapper(fn):
     caller_func = caller_frame.f_code.co_name
     if caller_module is None: return fn(*args, **kwargs)
 
-    # if its called from a __ method we want to look one more frame up
+    # if its called from a __ method in tinygrad we want to look one more frame up
     if caller_module.startswith("tinygrad") and caller_func.startswith("__"): caller_frame = sys._getframe(frame := frame + 1)
     caller_module = caller_frame.f_globals.get("__name__", None)
     if caller_module is None: return fn(*args, **kwargs)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3043,5 +3043,4 @@ def _metadata_wrapper(fn):
 
 for name, fn in inspect.getmembers(Tensor, inspect.isfunction):
   if name in ["__class__", "__init__", "__repr__", "backward", "sequential"]: continue
-  if name.startswith("__"): continue
   setattr(Tensor, name, functools.wraps(fn)(_metadata_wrapper(fn)))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from tinygrad.dtype import DType, dtypes, ImageDType, ConstType, least_upper_float, least_upper_dtype, sum_acc_dtype
 from tinygrad.helpers import argfix, make_pair, flatten, prod, all_int, round_up, merge_dicts, argsort, getenv, get_shape, fully_flatten, dedup
-from tinygrad.helpers import IMAGE, DEBUG, WINO, THREEFRY, _METADATA, Metadata
+from tinygrad.helpers import IMAGE, DEBUG, WINO, THREEFRY, _METADATA, Metadata, TRACEMETA
 from tinygrad.lazy import LazyBuffer
 from tinygrad.multi import MultiLazyBuffer
 from tinygrad.ops import LoadOps, truncate
@@ -3126,6 +3126,7 @@ def _metadata_wrapper(fn):
     return ret
   return _wrapper
 
-for name, fn in inspect.getmembers(Tensor, inspect.isfunction):
-  if name in ["__class__", "__init__", "__repr__", "backward", "sequential"]: continue
-  setattr(Tensor, name, functools.wraps(fn)(_metadata_wrapper(fn)))
+if TRACEMETA >= 1:
+  for name, fn in inspect.getmembers(Tensor, inspect.isfunction):
+    if name in ["__class__", "__init__", "__repr__", "backward", "sequential"]: continue
+    setattr(Tensor, name, functools.wraps(fn)(_metadata_wrapper(fn)))


### PR DESCRIPTION
like #4225 and #4197 and #3302

`traceback` is really slow, just grabbing a frame is relatively fast.

DEBUG=2 output:
```
*** AMD      829 r_512_11_11_32_2_2                     arg   2 mem 12.94 GB tm     74.60us/   349.07ms (  106.30 GFLOPS,  531.49 GB/s) ['max_pool2d']
*** AMD      830 r_128_11_11_32_4_2_2                   arg   3 mem 12.94 GB tm    362.12us/   349.43ms (   87.59 GFLOPS,  131.39 GB/s) ['max_pool2d bw']
*** AMD      831 r_64_16_3_8_3_3_256_3_4_3_3            arg   4 mem 12.94 GB tm   3679.48us/   353.11ms ( 3325.44 GFLOPS,    6.32 GB/s) ['conv2d', 'relu']
*** AMD      832 r_2_8_7_7_8_16_512_4_4_3_3             arg   4 mem 12.95 GB tm   5374.20us/   358.48ms ( 2754.03 GFLOPS,    4.93 GB/s) ['conv2d', 'relu']
*** AMD      833 r_2_8_5_5_8_16_512_4_4_3_3n1           arg   5 mem 12.95 GB tm   3012.84us/   361.50ms ( 2508.58 GFLOPS,    7.44 GB/s) ['conv2d', 'relu', 'relu bw', '__sub__', 'square bw', '__add__']
*** AMD      834 r_8_32_25_2_16_3_128_3_4_4             arg   3 mem 12.95 GB tm   3841.96us/   365.34ms ( 1965.08 GFLOPS,   10.99 GB/s) ['conv2d bw']
*** AMD      835 r_8_32_8_16_4_7_7_4                    arg   3 mem 12.95 GB tm    105.88us/   365.44ms (  272.96 GFLOPS,  399.86 GB/s) ['relu bw', 'conv2d bw']
```

error from #5269
```
error lowering BufferOps.STORE
tensor operations:
[ kaiming_uniform - __main__:18::__init__,
  kaiming_uniform - __main__:19::__init__,
  cat - __main__:39::test_bug,
  __rmul__ - __main__:12::optimal_mse,
  abs - __main__:12::optimal_mse,
  sum - __main__:12::optimal_mse]
```

~~about 10ms or 20% slower:~~ now 5ms or 10% slower:
without:
```
***** model forward in  52.90 ms
***** model forward in  52.82 ms
***** model forward in  53.45 ms
***** model forward in  52.53 ms
***** model forward in  53.60 ms
***** model forward in  53.68 ms
***** model forward in  52.81 ms
***** model forward in  52.45 ms
***** model forward in  52.90 ms
***** model forward in  53.62 ms
```
with:
```
***** model forward in  57.12 ms
***** model forward in  57.77 ms
***** model forward in  56.08 ms
***** model forward in  57.04 ms
***** model forward in  57.88 ms
***** model forward in  56.86 ms
***** model forward in  57.93 ms
***** model forward in  57.37 ms
***** model forward in  56.70 ms
***** model forward in  56.81 ms
```