### PR TITLE
verify_lazyop with multi reduce

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -154,9 +154,8 @@ def verify_lazyop(*ast:LazyOp):
     for x in op.src: dfs(x, st)
     # only reduceop is allowed to change shape, limited to turning n to 1
     if op.op in ReduceOps:
-      expected_shape = tuple(1 if i in op.arg else s for i,s in enumerate(sts[op.src[0]].shape))
-      assert st.shape == expected_shape, f"unexpected reduceop shape {st.shape} != {expected_shape}"
-      st = ShapeTracker.from_shape(expected_shape)
+      assert isinstance(op.arg, tuple)
+      st = ShapeTracker.from_shape(tuple(1 if i in op.arg else s for i,s in enumerate(sts[op.src[0]].shape)))
     else:
       # movementops are pushed to the edges with LOAD
       if op.op in BufferOps: st = op.arg.st


### PR DESCRIPTION
Consolidates all the shape asserts to the implicit movement ops check.
The assert in l158 was incomplete for multi reduce, the shape equivalence assert already catches this too.

kernel.py needs shapetracker fixups to not reduce the extra axis:
```
__kernel void r_32_32_32(__global float* data0, const __global float* data1) {
  float acc0 = 0.0f;
  for (int ridx0 = 0; ridx0 < 32; ridx0++) {
    for (int ridx1 = 0; ridx1 < 32; ridx1++) {
      for (int ridx2 = 0; ridx2 < 32; ridx2++) {
        float val0 = data1[(ridx0*32)+ridx2];
        acc0 = (val0+acc0);
      }
    }
  }
  float acc1 = 0.0f;
  for (int ridx3 = 0; ridx3 < 32; ridx3++) {
    for (int ridx4 = 0; ridx4 < 32; ridx4++) {
      for (int ridx5 = 0; ridx5 < 32; ridx5++) {
        float val1 = data1[(ridx3*32)+ridx5];
        acc1 = (val1+acc0+acc1);
      }
    }
  }
  data0[0] = acc1;
}
```
