### PR TITLE
hotfix: use dtype.scalar() for cstyle render_cast [run_process_replay] [no_assert]

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -44,8 +44,8 @@ class CStyleLanguage(Renderer):
   def render_const(self, x:ConstType, dtype:DType) -> str:
     if math.isnan(x): val = "NAN"
     elif math.isinf(x): val = ("-" if x < 0 else "") + "INFINITY"
-    elif dtype == dtypes.bool: val = "1" if x else "0"
-    elif dtype == dtypes.float: val = f"{x}f"
+    elif dtype.scalar() == dtypes.bool: val = "1" if x else "0"
+    elif dtype.scalar() == dtypes.float: val = f"{x}f"
     else: val = str(x)
     return (self.render_cast([val] * dtype.count, dtype) if dtype.count > 1 or dtype not in [dtypes.float, dtypes.int, dtypes.bool] else val)
 


### PR DESCRIPTION
kernel diff:
```diff
 extern "C" __global__ void C_3_8_4(float* data0) {
   int gidx0 = blockIdx.x; /* 3 */
   int lidx1 = threadIdx.x; /* 8 */
-  *((float4*)(data0+(gidx0*32)+(lidx1*4))) = make_float4(4.0,4.0,4.0,4.0);
+  *((float4*)(data0+(gidx0*32)+(lidx1*4))) = make_float4(4.0f,4.0f,4.0f,4.0f);
 }
 ```