### PR TITLE
LoadOps.VIEW in the scheduler spec

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -6,6 +6,7 @@ import unittest
 import numpy as np
 from typing import List, Optional, Union
 from tinygrad import nn, dtypes
+from tinygrad.device import Device
 from tinygrad.tensor import Tensor
 from tinygrad.ops import BinaryOps, LoadOps, ReduceOps, UnaryOps
 from tinygrad.helpers import DEBUG, flatten, getenv
@@ -15,7 +16,7 @@ from tinygrad.engine.schedule import create_schedule
 from tinygrad.engine.realize import run_schedule
 from test.helpers import is_dtype_supported
 from tinygrad.function import Function
-from tinygrad.lazy import LazyBuffer
+from tinygrad.lazy import LazyBuffer, view_supported_devices
 
 class KernelCountException(Exception): pass
 def check_schedule(t:Union[Tensor, List[Tensor]], allowed:int, to_prerealize:Optional[List[Tensor]]=None, filter_loadops=True):
@@ -41,22 +42,6 @@ def check_schedule(t:Union[Tensor, List[Tensor]], allowed:int, to_prerealize:Opt
     l.hand_coded_optimizations()
     l.linearize()
   return sched
-
-class CycleBitcast(Function):
-  def bitwise_cast(self, x: LazyBuffer):
-    return x.cast(dtypes.int32, True, True)
-
-  def forward(self, x: LazyBuffer):
-    x = x.cast(dtypes.float32)
-    a = self.bitwise_cast(x)
-    b = self.bitwise_cast(x.e(UnaryOps.NEG))
-    return a.e(BinaryOps.ADD, b)
-
-class TestUOpSchedule(unittest.TestCase):
-  def test_multiple_bitcast_in_function(self):
-    a = Tensor.empty()
-    b = CycleBitcast.apply(a)
-    check_schedule(b, 1)
 
 class TestSchedule(unittest.TestCase):
   def test_basic_binop_fusion(self):
@@ -1169,6 +1154,23 @@ class TestSchedule(unittest.TestCase):
     p = np.pad(p, (1, 0), 'constant')
     p = np.tile(p, 2)
     np.testing.assert_allclose(tiny_ret, p)
+
+  @unittest.skipIf(Device.DEFAULT not in view_supported_devices, "subbuffer not supported")
+  def test_bitcast_subbufer(self):
+    a = Tensor.empty(1, dtype=dtypes.float32).realize()
+    b = CycleBitcast.apply(a)
+    check_schedule(b, 2) # this should fuse when it makes sense
+
+  def test_bitcast_disable_subbufer(self):
+    a = Tensor.empty(1, dtype=dtypes.float32).realize()
+    b = CycleBitcast.apply(a, allow_buffer_view=False)
+    check_schedule(b, 1)
+
+class CycleBitcast(Function):
+  def forward(self, x: LazyBuffer, allow_buffer_view=True):
+    a = x.e(UnaryOps.NEG).cast(dtypes.int32, True, allow_buffer_view)
+    b = x.cast(dtypes.int32, True, allow_buffer_view)
+    return a.e(BinaryOps.ADD, b)
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/tinygrad/multi.py
+++ b/tinygrad/multi.py
@@ -90,7 +90,8 @@ class MultiLazyBuffer:
 
   # passthroughs
   def is_realized(self) -> bool: return all(lb.base.realized is not None for lb, r in zip(self.lbs, self.real) if r is True)
-  def cast(self, dtype:DType, bitcast:bool=False, bitcast_no_fuse:bool=False): return MultiLazyBuffer([x.cast(dtype, bitcast, bitcast_no_fuse) for x in self.lbs], self.axis, self.real) # noqa: E501
+  def cast(self, dtype:DType, bitcast:bool=False, allow_buffer_view=True):
+    return MultiLazyBuffer([x.cast(dtype, bitcast, allow_buffer_view) for x in self.lbs], self.axis, self.real)
   def const(self, val:ConstType) -> MultiLazyBuffer: return MultiLazyBuffer([x.const(val) for x in self.lbs], self.axis, self.real)
   def assign(self, x:MultiLazyBuffer): return MultiLazyBuffer([s.assign(d) for s,d in zip(self.lbs, x.lbs)], self.axis, self.real)
   def contiguous(self): return MultiLazyBuffer([x.contiguous() for x in self.lbs], self.axis, self.real)


### PR DESCRIPTION
lazy.py has `allow_buffer_view` for cast and contiguous because it doesn't have enough information to select fusion vs a VIEW. The scheduler can decide subbuffer vs fusion instead.

fyi @hikettei 