### PR TITLE
fix dtype mismatch for bool ops in multi

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -141,7 +141,7 @@ class TestMultiTensor(unittest.TestCase):
     W = Tensor.randn(8, 8).realize()
     X.shard_(devices_4, 0)
     W.shard_(devices_4, 0)
-    O = X.shrink(((0, 2),None)).mul(W.shrink(((0, 2),None))) < 2
+    O = X.shrink(((0, 2), None)) * W.shrink(((0, 2), None)) < 2
     np.testing.assert_allclose(O.numpy(), X.numpy()[0:2]*W.numpy()[0:2] < 2)
 
   @given(strat.sampled_from((4, 5)), strat.sampled_from((devices_2, devices_3)), strat.sampled_from((ReduceOps.SUM, ReduceOps.MAX)),

--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -135,6 +135,15 @@ class TestMultiTensor(unittest.TestCase):
     O = X + W
     np.testing.assert_allclose(O.numpy(), 2)
 
+  def test_elementwise_dtype(self):
+    Tensor.manual_seed(0)
+    X = Tensor.randn(8, 8).realize()
+    W = Tensor.randn(8, 8).realize()
+    X.shard_(devices_4, 0)
+    W.shard_(devices_4, 0)
+    O = X.shrink(((0, 2),None)).mul(W.shrink(((0, 2),None))) < 2
+    np.testing.assert_allclose(O.numpy(), X.numpy()[0:2]*W.numpy()[0:2] < 2)
+
   @given(strat.sampled_from((4, 5)), strat.sampled_from((devices_2, devices_3)), strat.sampled_from((ReduceOps.SUM, ReduceOps.MAX)),
          strat.sampled_from((None, 0, 1)), strat.sampled_from((None, 0, 1)), strat.sampled_from((1, 0, -1)))
   def test_simple_reduce(self, N, devices, rop, shard_axis, reduce_axis, sign):

--- a/tinygrad/multi.py
+++ b/tinygrad/multi.py
@@ -114,8 +114,9 @@ class MultiLazyBuffer:
       else: srcs.append(to_sharded([mlb.copy_to_device(lb.device) for lb in mlb.lbs], axis))
     new_real_lbs = {i:lsrcs[0].e(op, *lsrcs[1:], arg=arg) for i,(lsrcs,r) in enumerate(zip(zip(*srcs),new_real)) if r}
     # NOTE: const dtype should match real
-    return MultiLazyBuffer([new_real_lbs[i] if r else lsrcs[0].const(0).cast(new_real_lbs.popitem()[1].dtype)
-                            for i, (lsrcs,r) in enumerate(zip(zip(*srcs),new_real))], axis, new_real)
+    real_dtype = list(new_real_lbs.values())[0].dtype
+    return MultiLazyBuffer([new_real_lbs[i] if r else lsrcs[0].const(0).cast(real_dtype) \
+        for i, (lsrcs,r) in enumerate(zip(zip(*srcs),new_real))], axis, new_real)
 
   def _shape_to_single_shard(self, shape:Tuple[sint, ...], lb:LazyBuffer) -> Tuple[sint, ...]:
     return tuple(lb.shape[self.axis] if a == self.axis else s for a,s in enumerate(shape))

--- a/tinygrad/multi.py
+++ b/tinygrad/multi.py
@@ -114,7 +114,7 @@ class MultiLazyBuffer:
       else: srcs.append(to_sharded([mlb.copy_to_device(lb.device) for lb in mlb.lbs], axis))
     new_real_lbs = {i:lsrcs[0].e(op, *lsrcs[1:], arg=arg) for i,(lsrcs,r) in enumerate(zip(zip(*srcs),new_real)) if r}
     # NOTE: const dtype should match real
-    real_dtype = list(new_real_lbs.values())[0].dtype
+    real_dtype = next(iter(new_real_lbs.values())).dtype
     return MultiLazyBuffer([new_real_lbs[i] if r else lsrcs[0].const(0).cast(real_dtype) \
         for i, (lsrcs,r) in enumerate(zip(zip(*srcs),new_real))], axis, new_real)
 

--- a/tinygrad/multi.py
+++ b/tinygrad/multi.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Optional, Union, Any, Tuple, List
 import functools, itertools, operator
 from tinygrad.helpers import all_same, all_int, dedup, round_up, prod, DEBUG, RING
-from tinygrad.dtype import DType, ConstType
+from tinygrad.dtype import DType, ConstType, dtypes
 from tinygrad.ops import BinaryOps, LoadOps, UnaryOps, TernaryOps, ReduceOps
 from tinygrad.lazy import LazyBuffer
 from tinygrad.shape.shapetracker import sint
@@ -113,7 +113,10 @@ class MultiLazyBuffer:
       elif mlb.axis is None and axis is not None: srcs.append(to_sharded(mlb.lbs, axis))
       else: srcs.append(to_sharded([mlb.copy_to_device(lb.device) for lb in mlb.lbs], axis))
     # NOTE: lsrcs[-1].const(0) is correct for where
-    return MultiLazyBuffer([lsrcs[0].e(op, *lsrcs[1:], arg=arg) if r else lsrcs[-1].const(0) for lsrcs,r in zip(zip(*srcs),new_real)], axis, new_real)
+    # NOTE: const dtype should match real
+    # new_real_lbs = {i:lsrcs[0].e(op, *lsrcs[1:], arg=arg) for i, (lsrcs,r) in enumerate(zip(zip(*srcs),new_real)) if r}
+    return MultiLazyBuffer([lsrcs[0].e(op, *lsrcs[1:], arg=arg) if r else lsrcs[-1].const(0).cast(dtypes.bool if op in \
+        {BinaryOps.CMPNE, BinaryOps.CMPLT} else lsrcs[-1].dtype) for lsrcs,r in zip(zip(*srcs),new_real)], axis, new_real)
 
   def _shape_to_single_shard(self, shape:Tuple[sint, ...], lb:LazyBuffer) -> Tuple[sint, ...]:
     return tuple(lb.shape[self.axis] if a == self.axis else s for a,s in enumerate(shape))


### PR DESCRIPTION
`test_elementwise_dtype` https://github.com/tinygrad/tinygrad/pull/5299/commits/ea5f83b87f5fa3620c0fb0830f7f8447456cc7c9 gives:
```
AssertionError: all multilazybuffer needs same dtype, getting [dtypes.bool, dtypes.float, dtypes.float, dtypes.float]
```

Because `CMPLT = auto(); CMPNE = auto();` change the dtype.


unblocks #5187 