### PR TITLE
generalize the uops toposort spec to ptx

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -119,7 +119,6 @@ class TestLinearizer(unittest.TestCase):
     lin = helper_linearizer_opt(out, wanna_output=[np.broadcast_to(a.numpy().reshape(2, 1), (2, 3)).sum()])[0]
     ranges = [i for i,u in enumerate(lin.uops) if u.op is UOps.RANGE]
     # RANGE -> LOAD -> RANGE -> PHI
-    assert len(ranges) == 2
     assert any(x.op is UOps.LOAD for x in lin.uops[ranges[0]:ranges[1]])
 
   def test_three_nested_range(self):

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -136,7 +136,6 @@ class TestLinearizer(unittest.TestCase):
     out = a.reshape(2, 1).pad(((1, 1), (1, 1)), 2).sum()
     lin = helper_linearizer_opt(out, wanna_output=[24])[0]
     ranges = [i for i,u in enumerate(lin.uops) if u.op is UOps.RANGE]
-    lin.uops.print()
     # RANGE -> ALU -> RANGE -> ALU + LOAD -> PHI
     assert any(x.op is UOps.ALU for x in lin.uops[ranges[0]:ranges[1]])
     assert not any(x.op is UOps.LOAD for x in lin.uops[ranges[0]:ranges[1]])


### PR DESCRIPTION
the old asserts were bad because they were too strict about UOp count (which the PatternMatcher can mutate).

these tests should only care about relative position rather than absolute measures. 