### PR TITLE
test: delete the extra cast in cstyle load [run_process_replay] [no_assert]

### DIFF
--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -4,7 +4,7 @@ import functools, itertools, heapq, math
 from collections import defaultdict
 from enum import Enum, auto
 from dataclasses import dataclass, field
-from tinygrad.dtype import ConstType, dtypes, DType
+from tinygrad.dtype import ConstType, ImageDType, dtypes, DType
 from tinygrad.shape.symbolic import sint, Variable
 from tinygrad.ops import UnaryOps, BinaryOps, TernaryOps, exec_alu
 from tinygrad.helpers import prod, DEBUG, getenv
@@ -99,7 +99,7 @@ def type_verify(uops):
     if uop in {UOps.CAST, UOps.BITCAST}: assert arg is None   # type is the output type, not an arg
     if uop is UOps.CAST and dtype is not None and dtype.count > 1: assert len(src) == dtype.count
     if uop is UOps.LOAD and len(src) > 3 and src[2].op is UOps.ALU:
-      assert src[0].dtype == dtype.scalar(), f"{uop} dtype mismatch {src[0].dtype=} != {dtype.scalar()}"
+      assert (dtypes.float if isinstance(buf_dtype:=src[0].dtype, ImageDType) else buf_dtype) == dtype.scalar()
       assert src[2].dtype == dtypes.bool and src[3].dtype == dtype
     if uop is UOps.STORE:
       assert dtype is None, f"{uop} dtype must be None, got {dtype}"

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -98,7 +98,9 @@ def type_verify(uops):
       assert dtype is not None and type(arg) is type(dtypes.as_const(arg, dtype)), f"type of {arg=} does not match {dtype}"
     if uop in {UOps.CAST, UOps.BITCAST}: assert arg is None   # type is the output type, not an arg
     if uop is UOps.CAST and dtype is not None and dtype.count > 1: assert len(src) == dtype.count
-    if uop is UOps.LOAD and len(src) > 3 and src[2].op is UOps.ALU: assert src[2].dtype == dtypes.bool and src[3].dtype == dtype
+    if uop is UOps.LOAD and len(src) > 3 and src[2].op is UOps.ALU:
+      assert src[0].dtype == dtype.scalar(), f"{uop} dtype mismatch {src[0].dtype=} != {dtype.scalar()}"
+      assert src[2].dtype == dtypes.bool and src[3].dtype == dtype
     if uop is UOps.STORE:
       assert dtype is None, f"{uop} dtype must be None, got {dtype}"
       if len(src) == 4: assert src[3].dtype == dtypes.bool, f"gate dtype mismatch {src[3].dtype} != {dtypes.bool}"

--- a/tinygrad/codegen/uops.py
+++ b/tinygrad/codegen/uops.py
@@ -4,7 +4,7 @@ import functools, itertools, heapq, math
 from collections import defaultdict
 from enum import Enum, auto
 from dataclasses import dataclass, field
-from tinygrad.dtype import ConstType, ImageDType, dtypes, DType
+from tinygrad.dtype import ConstType, dtypes, DType
 from tinygrad.shape.symbolic import sint, Variable
 from tinygrad.ops import UnaryOps, BinaryOps, TernaryOps, exec_alu
 from tinygrad.helpers import prod, DEBUG, getenv
@@ -98,9 +98,7 @@ def type_verify(uops):
       assert dtype is not None and type(arg) is type(dtypes.as_const(arg, dtype)), f"type of {arg=} does not match {dtype}"
     if uop in {UOps.CAST, UOps.BITCAST}: assert arg is None   # type is the output type, not an arg
     if uop is UOps.CAST and dtype is not None and dtype.count > 1: assert len(src) == dtype.count
-    if uop is UOps.LOAD and len(src) > 3 and src[2].op is UOps.ALU:
-      assert (dtypes.float if isinstance(buf_dtype:=src[0].dtype, ImageDType) else buf_dtype) == dtype.scalar()
-      assert src[2].dtype == dtypes.bool and src[3].dtype == dtype
+    if uop is UOps.LOAD and len(src) > 3 and src[2].op is UOps.ALU: assert src[2].dtype == dtypes.bool and src[3].dtype == dtype
     if uop is UOps.STORE:
       assert dtype is None, f"{uop} dtype must be None, got {dtype}"
       if len(src) == 4: assert src[3].dtype == dtypes.bool, f"gate dtype mismatch {src[3].dtype} != {dtypes.bool}"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -57,10 +57,8 @@ class CStyleLanguage(Renderer):
     if self.uses_vload and buf_dtype.scalar() == dtypes.float16 and output_dtype.scalar() != dtypes.float16:
       return f"vload_half{'' if output_dtype.count == 1 else str(output_dtype.count)}(0, {buf_name}+{idx})"
     if output_dtype.count > 1:
-      out_val = f"*(({self.smem_prefix if local and self.smem_prefix_for_cast else self.buffer_prefix}{self.render_dtype(buf_dtype)}{output_dtype.count}*)({buf_name}+{idx}))"  # noqa: E501
-    else:
-      out_val = f"*({buf_name}+{idx})" if self.uses_ptr_arithmetic else f"{buf_name}[{idx}]"
-    return self.render_cast([out_val], output_dtype) if output_dtype != buf_dtype else out_val
+      return f"*(({self.smem_prefix if local and self.smem_prefix_for_cast else self.buffer_prefix}{self.render_dtype(buf_dtype)}{output_dtype.count}*)({buf_name}+{idx}))"  # noqa: E501
+    return f"*({buf_name}+{idx})" if self.uses_ptr_arithmetic else f"{buf_name}[{idx}]"
 
   def get_kernel_modifier(self, uops:UOpGraph) -> str: return ""
   def render_kernel(self, function_name:str, kernel:List[str], bufs:List[Tuple[str,Tuple[DType,bool]]], uops:UOpGraph, prefix=None) -> str:


### PR DESCRIPTION
CI proves in cstyle backends a float4 load is already the correct dtype.
also, LOAD's buf_dtype always matches its output_dtype.scalar() (except for PTX where src[0].dtype is rewritten as u64).

```diff
-  float4 val0 = (float4)(*((float4*)(data1+alu0+460)));
+  float4 val0 = *((float4*)(data1+alu0+460));
```