### PR TITLE
multi reduce Tensor.var passing verify_lazyop

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -101,6 +101,7 @@ class TestLinearizer(unittest.TestCase):
     assert len(mutable_bufs) == len(stores) == 2
     assert [u.arg[0] for u in mutable_bufs] == [0, 1]
 
+  @unittest.skipIf(CI and Device.DEFAULT == "AMD", "remu doesn't have multiple wave syncs yet")
   def test_var_multireduce(self):
     Tensor.manual_seed(0)
     x = Tensor.randn(3, 27, 32).realize()
@@ -115,6 +116,7 @@ class TestLinearizer(unittest.TestCase):
     squares_sum = LazyOp(ReduceOps.SUM, (squares,), (2,))
     store = LazyOp(BufferOps.STORE, (squares_sum,), MemBuffer(0, dtypes.float, ShapeTracker.from_shape((3, 27, 1, 1))))
     helper_linearizer_ast((store, ), [x])
+    # tinygrad ref
     y_tiny = x.var(axis=2, correction=0)
     np.testing.assert_allclose(y_tiny.numpy(), x.numpy().var(axis=2, ddof=0), atol=1e-4, rtol=1e-4)
 

--- a/test/test_verify_lazyop.py
+++ b/test/test_verify_lazyop.py
@@ -4,13 +4,10 @@ from tinygrad.codegen.linearizer import Linearizer
 #from tinygrad.codegen.lowerer import Lowerer
 from tinygrad.engine.graph import print_tree
 from tinygrad.helpers import DEBUG
-from tinygrad.ops import BinaryOps, BufferOps, MemBuffer, LazyOp, ReduceOps, verify_lazyop
+from tinygrad.ops import BufferOps, MemBuffer, LazyOp, ReduceOps, verify_lazyop
 from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad import dtypes
 from tinygrad.shape.view import View
-
-class LazyOp(LazyOp):
-  def __add__(self, other:LazyOp): return LazyOp(BinaryOps.ADD, (self, other))
 
 class InvalidLazyOpException(Exception): pass
 def lower(*ast:LazyOp):

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -264,6 +264,8 @@ class Linearizer(Kernel):
   def render_reduceop(self, reduceop:LazyOp, accs:Dict[LazyOp, List[UOp]], loaded_buffers:Dict[Union[MemBuffer, ConstBuffer, LocalBuffer], List[UOp]],
                       global_idxs, local_idxs, upcast_idxs, full_upcast_idxs, reduce_idxs, fake_reduce_idxs,
                       alias_buf_idxs:List[Tuple[int, int, List]]) -> Tuple[List[NumNode|Variable], List[NumNode|Variable]]:
+    # reset late_gate
+    self.late_gate = None
     # reduce loop
     loop_ctx = self.render_loop(reduce_idxs, (i:=self.reduceops.index(reduceop))*2+2, True)
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -77,6 +77,12 @@ class LazyOp:
     const_vars = [x.arg.val for x in self.lazyops if x.op is BufferOps.CONST and isinstance(x.arg.val, Variable)]
     return sorted(set.union(*extract_vars, set(const_vars)), key=lambda v: v.expr)
 
+  # TODO: support non-lazyop
+  def __add__(self, x:LazyOp): return LazyOp(BinaryOps.ADD, (self, x))
+  def __sub__(self, x:LazyOp): return LazyOp(BinaryOps.ADD, (self, -x))
+  def __mul__(self, x:LazyOp): return LazyOp(BinaryOps.MUL, (self, x))
+  def __neg__(self): return LazyOp(UnaryOps.NEG, (self,))
+
 # **************** independent FlopCounter ****************
 
 @dataclass


### PR DESCRIPTION
Also added some syntactic sugar for LazyOp to help with the tests.

Linearizer generates an extra loop dim for mean:

```
kernel void r_81_32_32(device float* data0, const device float* data1, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int gidx0 = gid.x; /* 81 */
  int alu0 = (gidx0*32);
  float acc0 = 0.0f;
  for (int ridx0 = 0; ridx0 < 32; ridx0++) {
    float val0 = *(data1+alu0+ridx0);
    for (int ridx1 = 0; ridx1 < 32; ridx1++) {
      acc0 = (val0+acc0);
    }
  }
  float acc1 = 0.0f;
  for (int ridx2 = 0; ridx2 < 32; ridx2++) {
    float val1 = *(data1+alu0+ridx2);
    float alu1 = (val1+(-(acc0*0.03125f)));
    for (int ridx3 = 0; ridx3 < 32; ridx3++) {
      acc1 = ((alu1*alu1)+acc1);
    }
  }
  *(data0+gidx0) = acc1;
}
```
This should go away at some point, OK for correctness.