### PR TITLE
mini refactor: simpler view.unbind

### DIFF
--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -121,14 +121,13 @@ class View:
 
   @functools.lru_cache(None)  # pylint: disable=method-cache-max-size-none
   def unbind(self) -> Tuple[View, Dict[Variable, int]]:
-    var_unboundvar_val = [(v, v.unbind()) for v in self.vars()]
-    unbound_vars = {v:uv for v,(uv,_) in var_unboundvar_val}
-    new_shape = tuple([s if isinstance(s, int) else s.substitute(unbound_vars) for s in self.shape])
-    new_strides = tuple([s if isinstance(s, int) else s.substitute(unbound_vars) for s in self.strides])
-    new_offset = self.offset if isinstance(self.offset, int) else self.offset.substitute(unbound_vars)
-    new_mask = tuple((a if isinstance(a, int) else a.substitute(unbound_vars),
-                      b if isinstance(b, int) else b.substitute(unbound_vars)) for (a, b) in self.mask) if self.mask is not None else None
-    return View.create(new_shape, new_strides, new_offset, new_mask), dict(x[1] for x in var_unboundvar_val)
+    unbound_vars = {v:v.unbind()[0] for v in self.vars()}
+    def substitute(x): return x if isinstance(x, int) else x.substitute(unbound_vars)
+    new_shape = tuple(map(substitute, self.shape))
+    new_strides = tuple(map(substitute, self.strides))
+    new_offset = substitute(self.offset)
+    new_mask = tuple(tuple(map(substitute, x)) for x in self.mask) if self.mask is not None else None
+    return View.create(new_shape, new_strides, new_offset, new_mask), dict(v.unbind() for v in self.vars())
 
   @functools.lru_cache(maxsize=None)  # pylint: disable=method-cache-max-size-none
   def __add__(self, vm1:View) -> Optional[View]:


### PR DESCRIPTION
2 changes @chenyuxyz:
* v.unbind() is atomic, can be called twice to remove the `var_unbound_var` variable
* a function `substitute` (can also be a lambda) reduces some complexity here

One could argue that the 4  `new_...` variables don't have to be created now, but it is more readable to keep them.