### PR TITLE
perf: restore early stopping for _match [run_process_replay]

### DIFF
--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -43,13 +43,22 @@ def _match(uop:UOp, pat:UPat, store:Dict[str, UOp]) -> List[Dict[str, UOp]]:
   # only one if it's a tuple
   # try all permutations if it's a list
   # repeat if it's a UPat
-  res: List[Dict[str, UOp]] = []
   for vp in itertools.permutations(pat.src) if isinstance(pat.src,list) else ([pat.src] if isinstance(pat.src,tuple) else [(pat.src,)*len(uop.src)]):
     if len(uop.src) != len(vp) and (len(uop.src) not in pat.allow_len) and not pat.allow_any_len: return []
-    new_stores = [store.copy()]
-    for uu, vv in zip(uop.src, vp): new_stores = [rstore for nstore in new_stores for rstore in _match(uu, vv, nstore)]
-    res.extend(new_stores)
-  return res
+    new_store = store.copy()
+    for uu, vv in zip(uop.src, vp):
+      if not _match(uu, vv, new_store): break
+    else:  # all matched
+      store.update(new_store)
+      return [store]
+  return []
+
+# new_store = store.copy()
+# for uu, vv in zip(uop.src, vp):
+#   if not _match(uu, vv, new_store): break
+# else:
+#   store.update(new_store)
+#   break
 
 class PatternMatcher:
   def __init__(self, patterns:List[Tuple[Union[UPat, UOp], Callable]]):

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -53,13 +53,6 @@ def _match(uop:UOp, pat:UPat, store:Dict[str, UOp]) -> List[Dict[str, UOp]]:
       return [store]
   return []
 
-# new_store = store.copy()
-# for uu, vv in zip(uop.src, vp):
-#   if not _match(uu, vv, new_store): break
-# else:
-#   store.update(new_store)
-#   break
-
 class PatternMatcher:
   def __init__(self, patterns:List[Tuple[Union[UPat, UOp], Callable]]):
     self.patterns = patterns


### PR DESCRIPTION
main: 
`n:  669639  tm: 480.27ms  tot: 718.49ms uopgraph.py:37:_match`
branch: 
`n:  669639  tm: 437.15ms  tot: 651.15ms uopgraph.py:37:_match`