### PR TITLE
reverse global dim order

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -516,6 +516,8 @@ class Kernel:
 
   def hand_coded_optimizations(self):
     self.required_optimizations()
+    # reverse global order
+    self.reshape_and_permute(None, tuple(range(self.global_dims))[::-1] + tuple(range(self.global_dims, self.shape_len)))
 
     # should use matvec - TODO: adjust/tune based on the wide vs tall/large vs small mat
     MV_BLOCKSIZE, MV_THREADS_PER_ROW, MV_ROWS_PER_THREAD = getenv("MV_BLOCKSIZE", 4), getenv("MV_THREADS_PER_ROW", 8), getenv("MV_ROWS_PER_THREAD", 4)


### PR DESCRIPTION
this is the old linearizer bahavior and a lot faster for resnet kernels with > 3 global dim. eventually we want to search this