### PR TITLE
usage summary in handcode opt

### DIFF
--- a/examples/handcode_bert_opt.py
+++ b/examples/handcode_bert_opt.py
@@ -1,4 +1,5 @@
 from typing import List
+from collections import defaultdict
 from examples.mlperf.helpers import get_mlperf_bert_model
 from tinygrad import Tensor, Device, dtypes, nn
 from tinygrad.codegen.linearizer import Linearizer
@@ -55,6 +56,7 @@ if __name__ == "__main__":
   # work with the schedule
   total_tm = 0
   running_gflops = 0
+  usage = {}
   for i,si in enumerate(sched):
     ops = sum(get_lazyop_info(ast).flops for ast in si.ast)
 
@@ -94,5 +96,10 @@ if __name__ == "__main__":
     tm, gflops, lin = sorted(choices, key=lambda x: x[0])[0]
     total_tm += tm
     running_gflops += gflops * tm
+    if (key := str([str(m) for m in si.metadata] if si.metadata is not None else None)) not in usage: usage[key] = (0, 0)
+    usage[key] = (usage[key][0] + tm, usage[key][1] + 1)
     print(f"*** {total_tm*1000:7.2f} ms : kernel {i:2d} {lin.name+' '*(37-ansilen(lin.name))} {str(lin.global_size):18s} {str(lin.local_size):12s} takes {tm*1000:7.2f} ms, {gflops:6.0f} GFLOPS {[str(m) for m in si.metadata] if si.metadata is not None else ''}")
   print(f"******* total {total_tm*1000:.2f} ms, {running_gflops/total_tm:6.0f} GFLOPS")
+  print("usage:")
+  for k in sorted(usage, key=lambda x: -usage[x][0])[:10]:
+    print(f"{usage[k][0]*1000:.2f} ms: {k} ({usage[k][1]} times)")

--- a/examples/handcode_resnet50_opt.py
+++ b/examples/handcode_resnet50_opt.py
@@ -1,5 +1,4 @@
 from typing import List
-from collections import defaultdict
 from extra.models.resnet import ResNet50
 from tinygrad import Tensor, nn
 from tinygrad.ops import LoadOps, get_lazyop_info

--- a/examples/handcode_resnet50_opt.py
+++ b/examples/handcode_resnet50_opt.py
@@ -1,4 +1,5 @@
 from typing import List
+from collections import defaultdict
 from extra.models.resnet import ResNet50
 from tinygrad import Tensor, nn
 from tinygrad.ops import LoadOps, get_lazyop_info
@@ -43,6 +44,7 @@ if __name__ == "__main__":
   # work with the schedule
   total_tm = 0
   running_gflops = 0
+  usage = {}
   for i,si in enumerate(sched):
     ops = sum(get_lazyop_info(ast).flops for ast in si.ast)
 
@@ -82,5 +84,10 @@ if __name__ == "__main__":
     tm, gflops, lin = sorted(choices, key=lambda x: x[0])[0]
     total_tm += tm
     running_gflops += gflops * tm
+    if (key := str([str(m) for m in si.metadata] if si.metadata is not None else None)) not in usage: usage[key] = (0, 0)
+    usage[key] = (usage[key][0] + tm, usage[key][1] + 1)
     print(f"*** {total_tm*1000:7.2f} ms : kernel {i:2d} {lin.name+' '*(37-ansilen(lin.name))} {str(lin.global_size):18s} {str(lin.local_size):12s} takes {tm*1000:7.2f} ms, {gflops:6.0f} GFLOPS {[str(m) for m in si.metadata] if si.metadata is not None else ''}")
   print(f"******* total {total_tm*1000:.2f} ms, {running_gflops/total_tm:6.0f} GFLOPS")
+  print("usage:")
+  for k in sorted(usage, key=lambda x: -usage[x][0])[:10]:
+    print(f"{usage[k][0]*1000:.2f} ms: {k} ({usage[k][1]} times)")


### PR DESCRIPTION
```
usage:
147.50 ms: ['conv2d bw'] (114 times)
126.90 ms: ['conv2d'] (53 times)
24.79 ms: ['relu bw', 'conv2d bw'] (16 times)
23.58 ms: ['relu bw', 'conv2d bw', '__add__'] (14 times)
17.34 ms: ['relu bw', 'batchnorm bw'] (26 times)
15.36 ms: ['__sub__', '__mul__ bw', '__add__', 'relu bw', 'batchnorm bw'] (17 times)
14.83 ms: ['__sub__', '__mul__ bw', '__add__', 'batchnorm bw'] (35 times)
14.40 ms: ['__sub__', 'batchnorm bw'] (35 times)
11.82 ms: ['__sub__', 'batchnorm', 'batchnorm bw'] (16 times)
11.72 ms: ['__sub__', 'relu bw', 'batchnorm bw'] (17 times)
```
