### PR TITLE
update Tensor.eye api to match torch

### DIFF
--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -532,9 +532,9 @@ def EyeLike(x: Tensor, dtype=None, k=0):
   else: dtype = DTYPE_MAP[int(dtype)]
   dim = min(x.shape)
   if x.shape[0] == x.shape[1]:
-    return Tensor.eye(dim=dim, dtype=dtype)
+    return Tensor.eye(dim, dtype=dtype)
   padarg = tuple(None if d == dim else (k, d-dim-k) for d in x.shape)
-  return Tensor.eye(dim=dim, dtype=dtype).pad(padarg)
+  return Tensor.eye(dim, dtype=dtype).pad(padarg)
 
 def Upsample(X, scales, mode): return Resize(X=X, scales=scales, mode=mode)
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -129,6 +129,8 @@ class TestOps(unittest.TestCase):
 
   def test_eye(self):
     helper_test_op([], lambda: torch.eye(10), lambda: Tensor.eye(10), forward_only=True)
+    helper_test_op([], lambda: torch.eye(3, 5), lambda: Tensor.eye(3, 5), forward_only=True)
+    helper_test_op([], lambda: torch.eye(5, 3), lambda: Tensor.eye(5, 3), forward_only=True)
     helper_test_op([], lambda: torch.eye(1), lambda: Tensor.eye(1), forward_only=True)
     helper_test_op([], lambda: torch.eye(0), lambda: Tensor.eye(0), forward_only=True)
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -526,7 +526,7 @@ class Tensor:
     print(Tensor.eye(2, 4).numpy())
     ```
     """
-    return Tensor.ones((n,1),**kwargs).pad((None,(0,n))).flatten().shrink(((0,n*n),)).reshape(n, n)._slice((None, (0, n if m is None else m)))
+    return Tensor.ones((n,1),**kwargs).pad((None,(0,n))).flatten().shrink(((0,n*n),)).reshape(n,n)._slice((None,(0,n if m is None else m)))
 
   def full_like(self, fill_value:ConstType, **kwargs):
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -511,9 +511,9 @@ class Tensor:
     return (Tensor.full((math.ceil((stop-start)/step),), step, dtype=dtype, **kwargs)._cumsum() + (start - step)).cast(dtype)
 
   @staticmethod
-  def eye(dim:int, **kwargs):
+  def eye(n:int, m:Optional[int]=None, **kwargs):
     """
-    Creates an identity matrix of the given dimension.
+    Returns a 2-D tensor with `n` rows and `m` columns, with ones on the diagonal and zeros elsewhere.
 
     You can pass in `dtype` and `device` keyword arguments to control the data type and device of the tensor.
     Additionally, all other keyword arguments are passed to the constructor of the tensor.
@@ -521,8 +521,12 @@ class Tensor:
     ```python exec="true" source="above" session="tensor" result="python"
     print(Tensor.eye(3).numpy())
     ```
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    print(Tensor.eye(2, 4).numpy())
+    ```
     """
-    return Tensor.ones((dim,1),**kwargs).pad((None,(0,dim))).flatten().shrink(((0,dim*dim),)).reshape(dim, dim)
+    return Tensor.ones((n,1),**kwargs).pad((None,(0,n))).flatten().shrink(((0,n*n),)).reshape(n, n)._slice((None, (0, n if m is None else m)))
 
   def full_like(self, fill_value:ConstType, **kwargs):
     """


### PR DESCRIPTION
input is n for nrows and optional m for ncols