### PR TITLE
allow benchmarking forward only

### DIFF
--- a/test/external/external_benchmark_schedule.py
+++ b/test/external/external_benchmark_schedule.py
@@ -8,19 +8,21 @@ if __name__ == "__main__":
   img = Tensor.empty(64, 3, 224, 224)
 
   PROFILE = getenv("PROFILE", 1)
+  FORWARD_ONLY = getenv("FORWARD_ONLY", 0)
 
   with Profiling(PROFILE):
     with Timing("***** model forward in "):
       out = mdl(img)
 
-  with Profiling(PROFILE):
-    with Timing("***** model schedule in "):
-      sched = out.schedule()
+  if not FORWARD_ONLY:
+    with Profiling(PROFILE):
+      with Timing("***** model schedule in "):
+        sched = out.schedule()
 
-  # snakeviz /tmp/schedule.prof
-  with Profiling(PROFILE, fn="/tmp/schedule.prof"):
-    with Timing("***** model lower in "):
-      eis = list(lower_schedule(sched))
+    # snakeviz /tmp/schedule.prof
+    with Profiling(PROFILE, fn="/tmp/schedule.prof"):
+      with Timing("***** model lower in "):
+        eis = list(lower_schedule(sched))
 
   # random makes this slow
   #with Profiling(PROFILE):


### PR DESCRIPTION
Run with `hyperfine`:

```bash
FORWARD_ONLY=1 PROFILE=0 hyperfine "python3 test/external/external_benchmark_schedule.py" --show-output --warmup 1
```
