### PR TITLE
docs: addded JIT description to dos/env_vars.md

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -49,4 +49,4 @@ FLOAT16             | [1]        | use float16 for images instead of float32
 PTX                 | [1]        | enable the specialized [PTX](https://docs.nvidia.com/cuda/parallel-thread-execution/) assembler for Nvidia GPUs. If not set, defaults to generic CUDA codegen backend.
 PROFILE             | [1]        | enable output of [perfetto](https://ui.perfetto.dev/) compatible profile. This feature is supported in NV and AMD backends.
 VISIBLE_DEVICES     | [list[int]]| restricts the NV/AMD devices that are available. The format is a comma-separated list of identifiers (indexing starts with 0).
-JIT                 | [0-2]      | 0=disabled, 1=[jit enabled](/docs/quickstart.md#jit), 2=jit enabled but [splitting cache into batches is disabled for compatibility](https://github.com/tinygrad/tinygrad/issues/5408) |
+JIT                 | [0-2]      | 0=disabled, 1=[jit enabled](/docs/quickstart.md#jit), 2=jit enabled, but graphs are disabled |

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -49,3 +49,4 @@ FLOAT16             | [1]        | use float16 for images instead of float32
 PTX                 | [1]        | enable the specialized [PTX](https://docs.nvidia.com/cuda/parallel-thread-execution/) assembler for Nvidia GPUs. If not set, defaults to generic CUDA codegen backend.
 PROFILE             | [1]        | enable output of [perfetto](https://ui.perfetto.dev/) compatible profile. This feature is supported in NV and AMD backends.
 VISIBLE_DEVICES     | [list[int]]| restricts the NV/AMD devices that are available. The format is a comma-separated list of identifiers (indexing starts with 0).
+JIT                 | [0-2]      | 0=disabled, 1=[jit enabled](/docs/quickstart.md#jit), 2=jit enabled but [splitting cache into batches is disabled for compatibility](https://github.com/tinygrad/tinygrad/issues/5408) |


### PR DESCRIPTION
During the conversation here https://github.com/tinygrad/tinygrad/issues/5408 I realized that the JIT env var was not documented, so after a bit of digging in the codebase I added it. I hope I got value 2 right.