### PR TITLE
restore process replay runs by their id

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -5,7 +5,7 @@ from tinygrad.codegen.kernel import Kernel
 from tinygrad.helpers import Context, ContextVar, colored, db_connection, VERSION, getenv, tqdm
 
 page_size = 100
-table_name = f"process_replay_{getenv('GITHUB_SHA', 'HEAD')}_{VERSION}"
+table_name = f"process_replay_{getenv('GITHUB_RUN_ID', 'HEAD')}_{VERSION}"
 
 def process_replay(offset:int):
   conn = db_connection()

--- a/test/external/process_replay/reset.py
+++ b/test/external/process_replay/reset.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 from tinygrad.helpers import db_connection, VERSION, getenv
 cur = db_connection()
-cur.execute(f"drop table if exists process_replay_{getenv('GITHUB_SHA', 'HEAD')}_{VERSION}")
+cur.execute(f"drop table if exists process_replay_{getenv('GITHUB_RUN_ID', 'HEAD')}_{VERSION}")

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -760,7 +760,7 @@ class Kernel:
     self.linearize()
     src = self.opts.render(name:=to_function_name(self.name), self.uops)
     if getenv("RUN_PROCESS_REPLAY"):
-      table_name = f"process_replay_{getenv('GITHUB_SHA', 'HEAD')}"
+      table_name = f"process_replay_{getenv('GITHUB_RUN_ID', 'HEAD')}"
       diskcache_put(table_name, id(self), (self.ast, self.opts, self.applied_opts, name, src, {k:v.value for k,v in ContextVar._cache.items()}))
     info = get_lazyop_info(self.ast.src[0])   # TODO: this should be removed
     ops, mem = flops_mem(self.uops.uops)


### PR DESCRIPTION
adding to repro this llama 3 8b failure: https://github.com/tinygrad/tinygrad/actions/runs/9920520242/job/27407496131#step:13:107
GITHUB_SHA isn't unique because runs can be manually retried.
