### PR TITLE
hotfix: ASSERT_PROCESS_REPLAY sometimes doesn't exist

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -8,6 +8,7 @@ page_size = 100
 table_name = f"process_replay_{getenv('GITHUB_RUN_ID', 'HEAD')}_{VERSION}"
 
 def process_replay(offset:int):
+  ASSERT_PROCESS_REPLAY = (k:="[run_process_replay]") in os.getenv("COMMIT_MESSAGE", k) or k in os.getenv("PR_TITLE", k)
   conn = db_connection()
   cur = conn.cursor()
   cur.execute(f"SELECT val FROM '{table_name}' LIMIT ? OFFSET ?", (page_size, offset))
@@ -40,8 +41,6 @@ def process_replay(offset:int):
   cur.close()
 
 if __name__ == "__main__":
-  ASSERT_PROCESS_REPLAY = (k:="[run_process_replay]") in os.getenv("COMMIT_MESSAGE", k) or k in os.getenv("PR_TITLE", k)
-  print(f"asserting kernel diff = {ASSERT_PROCESS_REPLAY}")
   conn = db_connection()
   cur = conn.cursor()
   row_count = cur.execute(f"select count(*) from '{table_name}'").fetchone()[0]


### PR DESCRIPTION
resolves https://github.com/tinygrad/tinygrad/actions/runs/9921751542/job/27410052371?pr=5455
It's ok if each process resolves this independently.
