### PR TITLE
nv fix timeline signal rollover on copy queue

### DIFF
--- a/test/test_hcq.py
+++ b/test/test_hcq.py
@@ -306,8 +306,7 @@ class TestHCQ(unittest.TestCase):
     assert (0.3 if CI else 2) <= gb_s <= 50
 
   def test_timeline_signal_rollover(self):
-    # NV 64bit, AMD 32bit
-    TestHCQ.d0.timeline_value = (1 << 64) - 20 if Device.DEFAULT == "NV" else (1 << 32) - 20 # close value to reset
+    TestHCQ.d0.timeline_value = (1 << 31) - 20 # close value to reset
     TestHCQ.d0.hw_compute_queue_t().signal(TestHCQ.d0.timeline_signal, TestHCQ.d0.timeline_value - 1).submit(TestHCQ.d0)
     TestHCQ.d0._wait_signal(TestHCQ.d0.timeline_signal, TestHCQ.d0.timeline_value - 1)
 

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -581,7 +581,7 @@ class NVDevice(HCQCompatCompiled):
     NVDevice._wait_signal(self.timeline_signal, self.timeline_value - 1)
     self.cmdq_wptr = 0
 
-    if self.timeline_value > (1 << 63): self._wrap_timeline_signal()
+    if self.timeline_value > (1 << 31): self._wrap_timeline_signal()
     if PROFILE: self._prof_process_events()
 
   def _new_gpu_fifo(self, gpfifo_area, ctxshare, channel_group, offset=0, entries=0x400) -> GPFifo:


### PR DESCRIPTION
Signaling on the copy queue uses 32bit signal, so limit timeline signal to 32bits then wrap. Test now check wait/signals on both queues