### PR TITLE
Add passing tests for shape changing bitcasts for non-disk tensors

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -245,21 +245,17 @@ def _test_bitcasted(t: Tensor, dt: DType, expected):
 @unittest.skipIf(Device.DEFAULT == "WEBGL", "No bitcast on WebGL")
 class TestBitCast(unittest.TestCase):
   def test_shape_change_bitcast(self):
-    # _test_bitcast(Tensor([100000], dtype=dtypes.float32), dtypes.uint8)
-    t = Tensor.empty((128, 128), dtype=dtypes.uint8, device="CLANG") # uint8
-    # all zeroes
+    t = Tensor.empty((128, 128), dtype=dtypes.uint8) # uint8
     _test_bitcasted(t, dtypes.float16, 0.0)
     _test_bitcasted(t, dtypes.uint16, 0)
     _test_bitcasted(t, dtypes.float32, 0.0)
     _test_bitcasted(t, dtypes.uint32, 0)
-    # pi in float16 stored via int16
-    t.bitcast(dtypes.uint16).realize().assign(Tensor.full((128, 64), 0x4248, dtype=dtypes.uint16, device="CLANG")).realize()
+    t.bitcast(dtypes.uint16).realize().assign(Tensor.full((128, 64), 0x4248, dtype=dtypes.uint16)).realize()
     _test_bitcasted(t, dtypes.float16, 3.140625)
     _test_bitcasted(t, dtypes.float32, 50.064727)
     _test_bitcasted(t, dtypes.uint16, 0x4248)
     _test_bitcasted(t, dtypes.uint32, 0x42484248)
-    # pi in float32 stored via float32
-    t.bitcast(dtypes.float32).realize().assign(Tensor.full((128, 32), 3.1415927, dtype=dtypes.float32, device="CLANG")).realize()
+    t.bitcast(dtypes.float32).realize().assign(Tensor.full((128, 32), 3.1415927, dtype=dtypes.float32)).realize()
     _test_bitcasted(t, dtypes.float32, 3.1415927)
     _test_bitcasted(t, dtypes.uint32, 0x40490FDB)
 

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -98,7 +98,6 @@ class LazyBuffer:
       return create_lazybuffer(self.device, self.st, dtype, MetaOps.CONST, dtypes.as_const(self.base.arg, dtype))
     new_shape = self.shape
     if bitcast and self.dtype.itemsize != dtype.itemsize:
-      if not self.device.startswith("DISK"): raise RuntimeError("shape changing bitcast only supported on DISK right now")
       if not all_int(new_shape): raise RuntimeError("shape changing bitcast with symbolic shape isn't supported yet")
       # https://pytorch.org/docs/stable/generated/torch.Tensor.view.html
       if not (new_shape[-1]*self.dtype.itemsize) % dtype.itemsize == 0: raise RuntimeError("unsupported size in bitcast")


### PR DESCRIPTION
After investigating, shape changing bitcasts work for non-disk tensors unless the data is non-contiguous. Non-contiguous shape changing bitcasts are not allowed in torch. Is this something we want? The only difference between disk and non-disk is when using assign as disk uses contiguous to force_realize where as non disk will not force realize.