### PR TITLE
move colorize_float to helpers.py

### DIFF
--- a/test/external/speed_compare_cuda_nv.py
+++ b/test/external/speed_compare_cuda_nv.py
@@ -1,18 +1,11 @@
 from tinygrad import Device, dtypes
-from tinygrad.helpers import getenv, colored
+from tinygrad.helpers import getenv, colorize_float
 from extra.optimization.helpers import load_worlds, ast_str_to_lin
 from test.external.fuzz_linearizer import get_fuzz_rawbufs
 from tinygrad.engine.search import bufs_from_lin
 from tinygrad.engine.realize import CompiledRunner
 from tinygrad.tensor import _to_np_dtype
 import numpy as np
-
-# move to helpers?
-def colorize_float(x):
-  ret = f"{x:7.2f}x"
-  if x < 0.75: return colored(ret, 'green')
-  elif x > 1.15: return colored(ret, 'red')
-  else: return colored(ret, 'yellow')
 
 if __name__ == "__main__":
   ast_strs = load_worlds(filter_reduce=False, filter_novariable=True)

--- a/test/external/speed_compare_cuda_ptx.py
+++ b/test/external/speed_compare_cuda_ptx.py
@@ -1,17 +1,10 @@
 import itertools
 from tinygrad import Device
 from tinygrad.engine.realize import CompiledRunner
-from tinygrad.helpers import getenv, colored
+from tinygrad.helpers import getenv, colorize_float
 from extra.optimization.helpers import load_worlds, ast_str_to_lin
 from tinygrad.engine.search import bufs_from_lin
 from tinygrad.runtime.ops_cuda import PTXCompiler, PTXRenderer, CUDACompiler
-
-# move to helpers?
-def colorize_float(x):
-  ret = f"{x:7.2f}x"
-  if x < 0.75: return colored(ret, 'green')
-  elif x > 1.15: return colored(ret, 'red')
-  else: return colored(ret, 'yellow')
 
 if __name__ == "__main__":
   ast_strs = load_worlds(filter_reduce=False, filter_novariable=True)

--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -11,7 +11,7 @@ import numpy as np
 np.set_printoptions(linewidth=160)
 from tinygrad import Tensor, Device, GlobalCounters, TinyJit
 from tinygrad.nn import Conv2d
-from tinygrad.helpers import colored, getenv, CI
+from tinygrad.helpers import colorize_float, getenv, CI
 
 IN_CHANS = [int(x) for x in getenv("IN_CHANS", "4,16,64").split(",")]
 
@@ -25,15 +25,6 @@ elif str(torch_device) == "cuda":
   def sync(): torch.cuda.synchronize()
 else:
   def sync(): pass
-
-def colorize_float(x):
-  ret = f"{x:7.2f}x"
-  if x < 0.75:
-    return colored(ret, 'green')
-  elif x > 1.15:
-    return colored(ret, 'red')
-  else:
-    return colored(ret, 'yellow')
 
 save_ops, save_mem = 0, 0
 CNT = getenv("CNT", 8)

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -26,6 +26,7 @@ def argsort(x): return type(x)(sorted(range(len(x)), key=x.__getitem__)) # https
 def all_same(items:List[T]): return all(x == items[0] for x in items)
 def all_int(t: Sequence[Any]) -> TypeGuard[Tuple[int, ...]]: return all(isinstance(s, int) for s in t)
 def colored(st, color:Optional[str], background=False): return f"\u001b[{10*background+60*(color.upper() == color)+30+['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'].index(color.lower())}m{st}\u001b[0m" if color is not None else st  # replace the termcolor library with one line  # noqa: E501
+def colorize_float(x: float): return colored(f"{x:7.2f}x", 'green' if x < 0.75 else 'red' if x > 1.15 else 'yellow')
 def ansistrip(s:str): return re.sub('\x1b\\[(K|.*?m)', '', s)
 def ansilen(s:str): return len(ansistrip(s))
 def make_pair(x:Union[int, Tuple[int, ...]], cnt=2) -> Tuple[int, ...]: return (x,)*cnt if isinstance(x, int) else x


### PR DESCRIPTION
Moved `colorize_float` (used in speed tests) to `helpers.py`.

as per
https://github.com/tinygrad/tinygrad/blob/e21910367768fe034e7b9876d10e694b4cc743f6/test/external/speed_compare_cuda_ptx.py#L9-L10
Let me know if I should make a seperate PR to update all references to it, or keep working in this one.