### PR TITLE
Fix "shape changing bitcast only supported on DISK"

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -242,8 +242,9 @@ class TestUint8DType(TestDType):
 @unittest.skipIf(Device.DEFAULT == "WEBGL", "No bitcast on WebGL")
 class TestBitCast(unittest.TestCase):
   def test_shape_change_bitcast(self):
+    _test_bitcast(Tensor([100000], dtype=dtypes.float32), dtypes.uint8, [0, 80, 195, 71])
     with self.assertRaises(RuntimeError):
-      _test_bitcast(Tensor([100000], dtype=dtypes.float32), dtypes.uint8, [100000])
+      _test_bitcast(Tensor([1, 2, 3, 4], dtype=dtypes.float32).reshape(2,2).transpose(), dtypes.uint8)
 
   def test_bitcast_float_to_int32(self):
     a = Tensor([1.,2,3])

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -98,7 +98,7 @@ class LazyBuffer:
       return create_lazybuffer(self.device, self.st, dtype, MetaOps.CONST, dtypes.as_const(self.base.arg, dtype))
     new_shape = self.shape
     if bitcast and self.dtype.itemsize != dtype.itemsize:
-      if not self.device.startswith("DISK"): raise RuntimeError("shape changing bitcast only supported on DISK right now")
+      if not self.st.contiguous: raise RuntimeError("must be contiguous for shape changing bitcast")
       if not all_int(new_shape): raise RuntimeError("shape changing bitcast with symbolic shape isn't supported yet")
       # https://pytorch.org/docs/stable/generated/torch.Tensor.view.html
       if not (new_shape[-1]*self.dtype.itemsize) % dtype.itemsize == 0: raise RuntimeError("unsupported size in bitcast")


### PR DESCRIPTION
Shape changing bitcasts seem to work fine on contiguous tensors so I just corrected the error message and added tests. I don't know if this is the desired fix.