### PR TITLE
fix abstracions2 printout

### DIFF
--- a/docs/abstractions2.py
+++ b/docs/abstractions2.py
@@ -58,7 +58,7 @@ sink = LazyOp(MetaOps.KERNEL, (st_0,))
 # convert the computation to a "linearized" format (print the format)
 from tinygrad.engine.realize import get_kernel, CompiledRunner
 lin = get_kernel(Device[DEVICE].renderer, sink).linearize()
-for u in lin.uops: print(u)
+lin.uops.print()
 
 # compile a program (and print the source)
 fxn = CompiledRunner(lin.to_program())


### PR DESCRIPTION
restore known abstractions behaviour
```python
******** first, the runtime ***********
5
******** second, the Device ***********
   0 UOps.DEFINE_GLOBAL  : PtrDType(dtypes.int)      []                               (0, True)
   1 UOps.DEFINE_GLOBAL  : PtrDType(dtypes.int)      []                               (1, False)
   2 UOps.DEFINE_GLOBAL  : PtrDType(dtypes.int)      []                               (2, False)
   3 UOps.CONST          : dtypes.int                []                               0
   4 UOps.LOAD           : dtypes.int                [1, '0']                         None
   5 UOps.LOAD           : dtypes.int                [2, '0']                         None
   6 UOps.ALU            : dtypes.int                [4, 5]                           BinaryOps.ADD
   7 UOps.STORE          :                           [0, '0', 6]                      None
void E_(int* restrict data0, const int* restrict data1, const int* restrict data2) {
  int val0 = data1[0];
  int val1 = data2[0];
  data0[0] = (val0+val1);
}
******** third, the LazyBuffer ***********
MetaOps.KERNEL
 LazyOp(MetaOps.KERNEL, arg=None, src=(
   LazyOp(BufferOps.STORE, arg=MemBuffer(idx=0, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),))), src=(
     LazyOp(BinaryOps.ADD, arg=None, src=(
       LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=1, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),))), src=()),
       LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=2, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),))), src=()),)),)),))
******** fourth, the Tensor ***********
5
```