### PR TITLE
Fix typo in Runtime Overview docs

### DIFF
--- a/docs/runtime/overview.md
+++ b/docs/runtime/overview.md
@@ -36,7 +36,7 @@ The `Allocator` class is responsible for managing memory on the device. There is
 
 ### Program
 
-The `Program` class is created for each loaded program. It is responsible for compiling and executing the program on the device. As an exmaple, here is a `ClangProgram` implmentation which loads program and runs it.
+The `Program` class is created for each loaded program. It is responsible for compiling and executing the program on the device. As an example, here is a `ClangProgram` implementation which loads program and runs it.
 
 ::: tinygrad.runtime.ops_clang.ClangProgram
     options:


### PR DESCRIPTION
I was reading through the Runtime Overview docs section and came across some small typos.