### PR TITLE
MCTS tweaks

### DIFF
--- a/extra/mcts_search.py
+++ b/extra/mcts_search.py
@@ -8,7 +8,7 @@ from tinygrad.engine.search import _ensure_buffer_alloc, get_kernel_actions, _tr
 class MCTSNode:
   def __init__(self, kernel, parent=None):
     self.kernel = kernel
-    self.t = 0
+    self.t = math.inf
     self.n = 0
     self.parent: Optional[MCTSNode] = parent
     self.children: Optional[List[MCTSNode]] = None
@@ -22,7 +22,7 @@ C = math.sqrt(2)
 def mcts_search(lin:Kernel, rawbufs:List[Buffer], amt:int) -> Kernel:
   # TODO: copied from BEAM
   key = {"ast": lin.ast.key, "amt": amt, "device": lin.opts.device, "suffix": lin.opts.suffix}
-  if not getenv("IGNORE_BEAM_CACHE") and CACHELEVEL >= 1 and (val:=diskcache_get("mcts_search", key)) is not None:
+  if not getenv("IGNORE_MCTS_CACHE") and CACHELEVEL >= 1 and (val:=diskcache_get("mcts_search", key)) is not None:
     ret = lin.copy()
     for o in val[len(lin.applied_opts):]: ret.apply_opt(o)
     return ret
@@ -45,7 +45,7 @@ def mcts_search(lin:Kernel, rawbufs:List[Buffer], amt:int) -> Kernel:
     node = root
     while node.children is not None and len(node.children) != 0:
       #if DEBUG>=2: print(f"{(node.t/node.n)/best_tm:6.2f} value {node.n:3d}", node.kernel.name)
-      ucb = sorted([(math.inf if child.n == 0 else ((child.t/child.n)/best_tm) + C*math.sqrt(math.log(node.n)/child.n), child)
+      ucb = sorted([(math.inf if child.n == 0 else -child.t/best_tm + C*math.sqrt(math.log(node.n)/child.n), child)
                     for child in node.children], key=lambda x: x[0], reverse=True) # pylint: disable=not-an-iterable
       node = ucb[0][1]
 
@@ -58,21 +58,21 @@ def mcts_search(lin:Kernel, rawbufs:List[Buffer], amt:int) -> Kernel:
     _, compile_ret = _compile_fn((0, node.kernel))
     if compile_ret is None:
       remove_node(node)
-      continue
+      tm = math.inf
+    else:
+      p, lib, _ = compile_ret
+      try: tm = statistics.median(_time_program(p, lib, var_vals, rawbufs, cnt=5, early_stop=best_tm*10/1e6))*1e6
+      except RuntimeError:
+        remove_node(node)
+        tm = math.inf
 
-    p, lib, _ = compile_ret
-    try: tm = statistics.median(_time_program(p, lib, var_vals, rawbufs, cnt=5, early_stop=best_tm*10/1e6))*1e6
-    except RuntimeError:
-      remove_node(node)
-      continue
-
-    if DEBUG>=2: print(f"\r{time.perf_counter() - st:7.2f}s: {tm:12.2f} us     best: {best_tm:12.2f} us @ {best_idx+1:4d}        {i+1:4d}/{amt:4d}         {node.kernel.colored_shape()}\033[K", end="")  # noqa: E501
     if tm < best_tm: best, best_idx, best_tm = node.kernel, i, tm
+    if DEBUG>=2: print(f"\r{time.perf_counter() - st:7.2f}s: {tm:12.2f} us     best: {best_tm:12.2f} us @ {best_idx+1:4d}        {i+1:4d}/{amt:4d}         {node.kernel.colored_shape()}\033[K", end="")  # noqa: E501
 
     # backprop
     bnode: Optional[MCTSNode] = node
     while bnode is not None:
-      bnode.t += -tm
+      if bnode.t > tm: bnode.t = tm
       bnode.n += 1
       bnode = bnode.parent
 


### PR DESCRIPTION
MCTS 500 is competitive with BEAM=8 on resnet on M1 Max.
- increment trial times even with compiled error and runtime error.
- use best time of children as the node value.