### PR TITLE
skip test_failure_39 in CI

### DIFF
--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -324,6 +324,7 @@ class TestLinearizerFailures(unittest.TestCase):
     for axis in [0,1,3,4]:
       opts = [Opt(op=OptOps.TC, axis=axis, amt=2)]
       helper_test_lin(Kernel(ast), opts=opts, failed_platforms=[])
+  @unittest.skipIf(CI, "very slow, similar to test_failure_37")
   def test_failure_39(self):
     # beautiful mnist kernel number 127: 6 possible TC axis_choices (3 for axis_buf1 and 2 reduce) and all fail
     # fuzz: PYTHONPATH=. METAL=1 FUZZ_ALL_ACTIONS=1 DEPTH=1 FUZZ_NTH=127 DEBUG=2 python3 ./test/external/fuzz_linearizer.py --logfile /tmp/beautiful_mnist.kernels.txt


### PR DESCRIPTION
took more than 2 minutes in ci metal, it's basically the same as test_failure_37 but 20X bigger