### PR TITLE
beautiful_mnist -4.3% kernels

### DIFF
--- a/examples/beautiful_mnist.py
+++ b/examples/beautiful_mnist.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
   def get_test_acc() -> Tensor: return (model(X_test).argmax(axis=1) == Y_test).mean()*100
 
   test_acc = float('nan')
-  for i in (t:=trange(70)):
+  for i in (t:=trange(getenv("STEPS", 70))):
     GlobalCounters.reset()   # NOTE: this makes it nice for DEBUG=2 timing
     loss = train_step()
     if i%10 == 9: test_acc = get_test_acc().item()

--- a/examples/beautiful_mnist.py
+++ b/examples/beautiful_mnist.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
   def get_test_acc() -> Tensor: return (model(X_test).argmax(axis=1) == Y_test).mean()*100
 
   test_acc = float('nan')
-  for i in (t:=trange(getenv("STEPS", 70))):
+  for i in (t:=trange(70)):
     GlobalCounters.reset()   # NOTE: this makes it nice for DEBUG=2 timing
     loss = train_step()
     if i%10 == 9: test_acc = get_test_acc().item()

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -209,7 +209,7 @@ class TestSchedule(unittest.TestCase):
 
   def test_fold_conv_batchnorm_optim(self):
     # this is too high
-    for optim, cnt in [(nn.optim.Adam, 19), (nn.optim.SGD, 17)]:
+    for optim, cnt in [(nn.optim.Adam, 18), (nn.optim.SGD, 16)]:
       with self.subTest(optim=optim.__name__):
         with Tensor.train():
           img = Tensor.ones(1,3,4,4)
@@ -256,7 +256,7 @@ class TestSchedule(unittest.TestCase):
         fw = bn(x).contiguous_backward().relu().contiguous()
         fw.sum().backward()
         # TODO: this is too many
-        check_schedule([x.grad, bn.weight.grad, bn.bias.grad, fw], 10)
+        check_schedule([x.grad, bn.weight.grad, bn.bias.grad, fw], 9)
 
   def test_fold_conv_relu(self):
     c1 = nn.Conv2d(3,16,3)
@@ -620,7 +620,7 @@ class TestSchedule(unittest.TestCase):
     out0 = a.sum() + b.sum() + 2
     out1 = a.sum() + b.sum() + 4
     # run_schedule(check_schedule([out0, out1], 1))
-    run_schedule(check_schedule([out0, out1], 4))
+    run_schedule(check_schedule([out0, out1], 2))
     np.testing.assert_allclose(out0.numpy(), a.numpy().sum()+b.numpy().sum()+2, atol=1e-4, rtol=1e-4)
     np.testing.assert_allclose(out1.numpy(), a.numpy().sum()+b.numpy().sum()+4, atol=1e-4, rtol=1e-4)
 
@@ -649,7 +649,7 @@ class TestSchedule(unittest.TestCase):
     out1 = b.max() + out0*2
     out2 = a.sum() + out1
     # run_schedule(check_schedule([out0, out1, out2], 1))
-    run_schedule(check_schedule([out0, out1, out2], 4))
+    run_schedule(check_schedule([out0, out1, out2], 3))
     np.testing.assert_allclose(out0.numpy(), out0_np:=a.numpy().sum()+4, atol=1e-4, rtol=1e-6)
     np.testing.assert_allclose(out1.numpy(), out1_np:=b.numpy().max() + out0_np*2, atol=1e-4, rtol=1e-6)
     np.testing.assert_allclose(out2.numpy(), a.numpy().sum() + out1_np, atol=1e-4, rtol=1e-6)
@@ -1096,7 +1096,7 @@ class TestSchedule(unittest.TestCase):
     c = a.sum() + 2
     d = (a.sum() - b.sum()) * 4
     # run_schedule(check_schedule([c, d], 1))
-    run_schedule(check_schedule([c, d], 3))
+    run_schedule(check_schedule([c, d], 2))
     np.testing.assert_allclose(c.numpy(), a.numpy().sum()+2, atol=1e-4, rtol=1e-4)
     np.testing.assert_allclose(d.numpy(), (a.numpy().sum() - b.numpy().sum()) * 4, atol=1e-4, rtol=1e-4)
 

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1140,7 +1140,7 @@ class TestSchedule(unittest.TestCase):
     e = c * d
     f = (b - d).sum() - e
     # run_schedule(check_schedule([c, d, e, f], 1))
-    run_schedule(check_schedule([c, d, e, f], 2))
+    run_schedule(check_schedule([c, d, e, f], 3))
     np.testing.assert_allclose(c.numpy(), c_np:=a.numpy().sum()+2, atol=1e-4, rtol=1e-4)
     np.testing.assert_allclose(d.numpy(), d_np:=a.numpy().sum()*2, atol=1e-4, rtol=1e-4)
     np.testing.assert_allclose(e.numpy(), e_np:=c_np*d_np, atol=1e-4, rtol=1e-4)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1028,7 +1028,7 @@ class TestSchedule(unittest.TestCase):
     b = Tensor.empty(4, 4)
     r = a.sum(2) + b
     d = r.T * 4
-    e = r * d
+    e = r + d
     schedule = check_schedule([d, e], 3)
     assert schedule[0].ast.src[0].src[0].op is BinaryOps.ADD
 
@@ -1140,7 +1140,7 @@ class TestSchedule(unittest.TestCase):
     e = c * d
     f = (b - d).sum() - e
     # run_schedule(check_schedule([c, d, e, f], 1))
-    run_schedule(check_schedule([c, d, e, f], 3))
+    run_schedule(check_schedule([c, d, e, f], 2))
     np.testing.assert_allclose(c.numpy(), c_np:=a.numpy().sum()+2, atol=1e-4, rtol=1e-4)
     np.testing.assert_allclose(d.numpy(), d_np:=a.numpy().sum()*2, atol=1e-4, rtol=1e-4)
     np.testing.assert_allclose(e.numpy(), e_np:=c_np*d_np, atol=1e-4, rtol=1e-4)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1028,7 +1028,7 @@ class TestSchedule(unittest.TestCase):
     b = Tensor.empty(4, 4)
     r = a.sum(2) + b
     d = r.T * 4
-    e = r + d
+    e = r * d
     schedule = check_schedule([d, e], 3)
     assert schedule[0].ast.src[0].src[0].op is BinaryOps.ADD
 

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -204,10 +204,9 @@ def _recursive_group(tr:LazyBuffer, st:ShapeTracker, r:LazyBuffer, children:Defa
     _recursive_group(tr_next, st+st_childs[0].st, r, children, realizes, reduce_for_op, group, cache)
 
 def _get_inputs(buf:LazyBuffer, r:LazyBuffer, realizes:Dict[LazyBuffer, None], cache, first=True) -> Set[LazyBuffer]:
-  if buf.realized is not None or buf.op is MetaOps.CONST or buf in cache: return set()
-  cache.add(buf)
+  if buf.realized is not None or buf.op is MetaOps.CONST or buf in cache: return cache.get(buf, set())
   if not first and (buf in realizes or buf is r): return set((buf,))
-  return set.union(set(), *iter(_get_inputs(x.base, r, realizes, cache, False) for x in buf.srcs))
+  return cache.setdefault(buf, set.union(set(), *iter(_get_inputs(x.base, r, realizes, cache, False) for x in buf.srcs)))
 
 def _get_isolated_children(r:LazyBuffer, reduce_for_op:Dict[LazyBuffer, LazyBuffer], children:DefaultDict[LazyBuffer, Dict[LazyBuffer, None]],\
     realizes:Dict[LazyBuffer, None], group:Dict[LazyBuffer, None], forced_realize:bool) -> Dict[LazyBuffer, None]:

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -218,8 +218,9 @@ def _get_isolated_children(r:LazyBuffer, reduce_for_op:Dict[LazyBuffer, LazyBuff
     if not first and (buf in realizes or buf is r): return set((buf,))
     return set.union(set(), *iter(_get_recursive_parents(x.base, False) for x in buf.srcs))
   if not is_complete:
-    return {}
-    #return {tr:None for tr in group if tr is not r and len(_get_recursive_parents(tr)) == 1}
+    new_group = {tr:None for tr in group if tr is not r and len(_get_recursive_parents(tr)) == 1}
+    if new_group: realizes[r] = None
+    return new_group
   # search descendants of the reduceop that can cleanly group
   descendants: Dict[LazyBuffer, None] = {}
   for tr in group: _recursive_group(tr, tr.st, tr, children, realizes, reduce_for_op, descendants, cache=set())

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -203,9 +203,9 @@ def _recursive_group(tr:LazyBuffer, st:ShapeTracker, r:LazyBuffer, children:Defa
       return
     _recursive_group(tr_next, st+st_childs[0].st, r, children, realizes, reduce_for_op, group, cache)
 
-def _get_inputs(buf:LazyBuffer, r:LazyBuffer, realizes:Dict[LazyBuffer, None], cache, first=True) -> Set[LazyBuffer]:
+def _get_inputs(buf:LazyBuffer, r:LazyBuffer, realizes:Dict[LazyBuffer, None], cache:Dict[LazyBuffer, Set[LazyBuffer]], first=True) -> Set[LazyBuffer]:
   if buf.realized is not None or buf.op is MetaOps.CONST or buf in cache: return cache.get(buf, set())
-  if not first and (buf in realizes or buf is r): return set((buf,))
+  if not first and (buf in realizes or buf is r): cache.setdefault(buf, set((buf,)))
   return cache.setdefault(buf, set.union(set(), *iter(_get_inputs(x.base, r, realizes, cache, False) for x in buf.srcs)))
 
 def _get_isolated_children(r:LazyBuffer, reduce_for_op:Dict[LazyBuffer, LazyBuffer], children:DefaultDict[LazyBuffer, Dict[LazyBuffer, None]],\
@@ -218,7 +218,7 @@ def _get_isolated_children(r:LazyBuffer, reduce_for_op:Dict[LazyBuffer, LazyBuff
     if p.op in ReduceOps: is_complete = False
     rc_parents.extend(x.base for x in p.srcs if x.base.realized is None and x.base is not r)
   if not is_complete:
-    new_group = {tr:None for tr in group if tr is not r and len(_get_inputs(tr, r, realizes, set())) == 1}
+    new_group = {tr:None for tr in group if tr is not r and len(_get_inputs(tr, r, realizes, {})) == 1}
     # if it can only group some children, we have to realize the reduceop
     if new_group: realizes[r] = None
     return new_group


### PR DESCRIPTION
(this is independent from savings in FUSE_CONV_BW=1 and indexing #5590)

this branch:
```
~/code/tinygrad> DEBUG=1 python3 examples/beautiful_mnist.py
memory reduced from 897.18 MB -> 781.91 MB, 52 -> 37 bufs
opened device CLANG from pid:26625
loss:   2.60 test_accuracy:   nan%:  33%|██████████████████████████████████████                                                                            | 1/3 [00:13<00:27,  0.07it/s]scheduled 85 kernels
memory reduced from 903.62 MB -> 781.58 MB, 41 -> 23 bufs
JIT captured 88 kernels with 0 inputs
loss:   1.20 test_accuracy:   nan%: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:41<00:00,  0.07it/s]
```

master:
```
~/code/tinygrad> DEBUG=1 python3 examples/beautiful_mnist.py
memory reduced from 897.18 MB -> 781.91 MB, 52 -> 37 bufs
opened device CLANG from pid:26974
loss:   2.49 test_accuracy:   nan%:  33%|██████████████████████████████████████                                                                            | 1/3 [00:13<00:26,  0.08it/s]scheduled 89 kernels
memory reduced from 903.62 MB -> 781.58 MB, 41 -> 23 bufs
JIT captured 92 kernels with 0 inputs
loss:   1.10 test_accuracy:   nan%: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:39<00:00,  0.08it/s]