### PR TITLE
Speedup np conversion 2x

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -241,7 +241,7 @@ class Tensor:
   def _data(self) -> memoryview:
     if 0 in self.shape: return memoryview(bytearray(0))
     # NOTE: this realizes on the object from as_buffer being a Python object
-    cpu = self.cast(self.dtype.scalar()).contiguous().to("CLANG").realize()
+    cpu = self.cast(self.dtype.scalar()).contiguous().realize()
     buf = cast(Buffer, cast(LazyBuffer, cpu.lazydata).base.realized)
     if self.device != "CLANG": buf.options = BufferOptions(nolru=True)
     return buf.as_buffer(allow_zero_copy=True if self.device != "CLANG" else False)


### PR DESCRIPTION
```
from tinygrad import Tensor, dtypes
import numpy as np
import time

nbt = time.perf_counter()
arr_np = np.ones((36, 120128,250)).astype(np.float32)
net = time.perf_counter()
arr_tens = Tensor(arr_np, dtype=dtypes.float32).realize()
tbt = time.perf_counter()
arr_tens = arr_tens.numpy()
tet = time.perf_counter()
print(f'NP: {net-nbt} TENS: {tet-tbt}')

np.testing.assert_equal(arr_np, arr_tens)
```