### PR TITLE
optimize symbolic-related updates in graphs

### DIFF
--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -81,7 +81,7 @@ class GraphRunner(Runner):  # pylint: disable=abstract-method
     self.vars = sorted(var_vals.keys(), key=lambda v: v.expr)
     self.symbolic_dims = dedup([tuple(d) for ji in jit_cache if isinstance(ji.prg, CompiledRunner) and (d:=ji.prg.p.local_size) and not all_int(d)] +
                                [tuple(d) for ji in jit_cache if isinstance(ji.prg, CompiledRunner) and (d:=ji.prg.p.global_size) and not all_int(d)])
-    def sym_dim_idx(dim): return self.symbolic_dims.index(tuple(dim)) if dim is not None and tuple(dim) in self.symbolic_dims else None
+    def find_symbolic_dim(dim): return self.symbolic_dims.index(tuple(dim)) if dim is not None and tuple(dim) in self.symbolic_dims else None
 
     for j,ji in enumerate(jit_cache):
       op_estimate += ji.prg.op_estimate
@@ -90,8 +90,8 @@ class GraphRunner(Runner):  # pylint: disable=abstract-method
       if isinstance(ji.prg, CompiledRunner):
         if ji.prg.p.vars: self.var_vals_replace[j] = [self.vars.index(v) for v in ji.prg.p.vars]
 
-        gl_idx, lc_idx = sym_dim_idx(ji.prg.p.global_size), sym_dim_idx(ji.prg.p.local_size)
-        if gl_idx is not None or lc_idx is not None: self.launch_dims_replace[j] = (gl_idx, lc_idx)
+        global_dim_idx, local_dim_idx = find_symbolic_dim(ji.prg.p.global_size), find_symbolic_dim(ji.prg.p.local_size)
+        if global_dim_idx is not None or local_dim_idx is not None: self.launch_dims_replace[j] = (global_dim_idx, local_dim_idx)
 
     super().__init__(colored(f"<batched {len(self.jit_cache)}>", "cyan"), jit_cache[0].prg.dname.split(":")[0],
                      op_estimate, mem_estimate, lds_estimate)

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -96,12 +96,12 @@ class GraphRunner(Runner):  # pylint: disable=abstract-method
     super().__init__(colored(f"<batched {len(self.jit_cache)}>", "cyan"), jit_cache[0].prg.dname.split(":")[0],
                      op_estimate, mem_estimate, lds_estimate)
 
-  def replaced_vars(self, var_vals):
+  def updated_vars(self, var_vals):
     vals = [var_vals[v] for v in self.vars]
     for j, vidxs in self.var_vals_replace.items():
       for i, v in enumerate(vidxs): yield j, i, vals[v]
 
-  def replaced_launch_dims(self, var_vals):
+  def updated_launch_dims(self, var_vals):
     dims = [tuple(sym_infer(s, var_vals) for s in dim) for dim in self.symbolic_dims]
     for j, (gl, lc) in self.launch_dims_replace.items(): yield j, (dims[gl] if gl is not None else None), (dims[lc] if lc is not None else None)
 

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -71,9 +71,11 @@ class GraphRunner(Runner):  # pylint: disable=abstract-method
   def __init__(self, jit_cache: List[ExecItem], input_rawbuffers: List[Buffer], var_vals: Dict[Variable, int]):
     self.jit_cache = jit_cache
     self.input_replace = get_input_replace(jit_cache, input_rawbuffers)
+    self.launch_dims_replace = []
+    self.var_vals_replace = []
+
     self.symbolic_launch_dims = []
     self.jc_idx_with_updatable_launch_dims = []
-    self.jc_idx_with_updatable_launch_dims_2 = []
     self.jc_idx_with_updatable_var_vals = []
     op_estimate: sint = 0
     mem_estimate: sint = 0
@@ -84,21 +86,30 @@ class GraphRunner(Runner):  # pylint: disable=abstract-method
       lds_estimate += ji.prg.lds_estimate
       if isinstance(ji.prg, CompiledRunner):
         if ji.prg.p.vars: self.jc_idx_with_updatable_var_vals.append(j)
-        if ji.prg.p.global_size and not all_int(ji.prg.p.global_size): self.symblic_launch_dims.append(ji.prg.p.global_size)
-        if ji.prg.p.local_size and not all_int(ji.prg.p.local_size): self.symblic_launch_dims.append(ji.prg.p.local_size)
 
-    self.symbolic_launch_dims = list(set(self.symblic_launch_dims)) # TODO: dedup
-    for j,ji in enumerate(jit_cache):
-      if not isinstance(ji.prg, CompiledRunner): continue
-      g_resolve_idx, l_resolve_idx = self.symblic_launch_dims.index(ji.prg.p.global_size), self.symblic_launch_dims.index(ji.prg.p.local_size)
-      if g_resolve_idx > 0 or l_resolve_idx > 0: self.jc_idx_with_updatable_launch_dims_2.append((j, g_resolve_idx, l_resolve_idx))
+        gs, ls = tuple(ji.prg.p.global_size), tuple(ji.prg.p.local_size)
+        if gs and not all_int(gs): self.symbolic_launch_dims.append(gs)
+        if ls and not all_int(ls): self.symbolic_launch_dims.append(ls)
 
     self.vars = sorted(var_vals.keys(), key=lambda v: v.expr)
+    self.symbolic_launch_dims = list(set(self.symbolic_launch_dims)) # TODO: dedup
+
+    for j,ji in enumerate(jit_cache):
+      if not isinstance(ji.prg, CompiledRunner): continue
+      if ji.prg.p.vars: self.var_vals_replace.append((j, [self.vars.index(v) for v in ji.prg.p.vars]))
+
+      gs, ls = tuple(ji.prg.p.global_size), tuple(ji.prg.p.local_size)
+      g_resolve_idx = self.symbolic_launch_dims.index(gs) if gs in self.symbolic_launch_dims else None
+      l_resolve_idx = self.symbolic_launch_dims.index(ls) if ls in self.symbolic_launch_dims else None
+      if g_resolve_idx is not None or l_resolve_idx is not None: self.launch_dims_replace.append((j, g_resolve_idx, l_resolve_idx))
+
+
     # self.symblic_launch_dims = []
     super().__init__(colored(f"<batched {len(self.jit_cache)}>", "cyan"), jit_cache[0].prg.dname.split(":")[0],
                      op_estimate, mem_estimate, lds_estimate)
 
-  def _resolve_symbolic_launch_dims(self, var_vals) -> List: return [tuple(sym_infer(d, var_vals) for s in ld) for ld in self.symblic_launch_dims]
+  def _resolve_symbolic_vars(self, var_vals) -> List: return [var_vals[v] for v in self.vars]
+  def _resolve_symbolic_launch_dims(self, var_vals) -> List: return [tuple(sym_infer(s, var_vals) for s in ld) for ld in self.symbolic_launch_dims]
 
 class MultiGraphRunner(GraphRunner):  # pylint: disable=abstract-method
   def __init__(self, jit_cache: List[ExecItem], input_rawbuffers: List[Buffer], var_vals: Dict[Variable, int]):

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -97,13 +97,13 @@ class GraphRunner(Runner):  # pylint: disable=abstract-method
                      op_estimate, mem_estimate, lds_estimate)
 
   def replaced_vars(self, var_vals):
-    res_v = [var_vals[v] for v in self.vars]
+    vals = [var_vals[v] for v in self.vars]
     for j, vidxs in self.var_vals_replace.items():
-      for i, v in enumerate(vidxs): yield j, i, res_v[v]
+      for i, v in enumerate(vidxs): yield j, i, vals[v]
 
   def replaced_launch_dims(self, var_vals):
-    res_v = [tuple(sym_infer(s, var_vals) for s in dim) for dim in self.symbolic_dims]
-    for j, (gd, ld) in self.launch_dims_replace.items(): yield j, (res_v[gd] if gd is not None else None), (res_v[ld] if ld is not None else None)
+    dims = [tuple(sym_infer(s, var_vals) for s in dim) for dim in self.symbolic_dims]
+    for j, (gl, lc) in self.launch_dims_replace.items(): yield j, (dims[gl] if gl is not None else None), (dims[lc] if lc is not None else None)
 
 class MultiGraphRunner(GraphRunner):  # pylint: disable=abstract-method
   def __init__(self, jit_cache: List[ExecItem], input_rawbuffers: List[Buffer], var_vals: Dict[Variable, int]):

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -81,7 +81,7 @@ class GraphRunner(Runner):  # pylint: disable=abstract-method
     self.vars = sorted(var_vals.keys(), key=lambda v: v.expr)
     self.symbolic_dims = dedup([tuple(d) for ji in jit_cache if isinstance(ji.prg, CompiledRunner) and (d:=ji.prg.p.local_size) and not all_int(d)] +
                                [tuple(d) for ji in jit_cache if isinstance(ji.prg, CompiledRunner) and (d:=ji.prg.p.global_size) and not all_int(d)])
-    def sym_dim_idx(dim): return self.symbolic_dims.index(tuple(dim)) if tuple(dim) in self.symbolic_dims and dim is not None else None
+    def sym_dim_idx(dim): return self.symbolic_dims.index(tuple(dim)) if dim is not None and tuple(dim) in self.symbolic_dims else None
 
     for j,ji in enumerate(jit_cache):
       op_estimate += ji.prg.op_estimate

--- a/tinygrad/runtime/graph/cuda.py
+++ b/tinygrad/runtime/graph/cuda.py
@@ -33,7 +33,7 @@ class CUDAGraph(MultiGraphRunner):
         kern_params = cuda.CUDA_KERNEL_NODE_PARAMS(ji.prg.clprg.prg, *global_size, *local_size, 0, None, vargs)
         check(cuda.cuGraphAddKernelNode(ctypes.byref(new_node), self.graph, c_deps, len(deps), ctypes.byref(kern_params)))
 
-        if j in self.jc_idx_with_updatable_launch_dims or j in self.jc_idx_with_updatable_var_vals or j in self.jc_idx_with_updatable_rawbufs:
+        if j in self.launch_dims_replace or j in self.var_vals_replace or j in self.jc_idx_with_updatable_rawbufs:
           self.updatable_nodes[j] = (new_node, kern_params, c_args, False)
       elif isinstance(ji.prg, BufferXfer):
         dest, src = [cast(Buffer, x) for x in ji.bufs[0:2]]

--- a/tinygrad/runtime/graph/cuda.py
+++ b/tinygrad/runtime/graph/cuda.py
@@ -63,7 +63,7 @@ class CUDAGraph(MultiGraphRunner):
     # Update launch dims in the kern_params struct.
     for j, global_dims, local_dims in self.updated_launch_dims(var_vals):
       prg = cast(CompiledRunner, self.jit_cache[j].prg)
-      node, local_size, global_size, = self.updatable_nodes[j][1], global_dims or prg.p.global_size, local_dims or prg.p.local_size
+      node, global_size, local_size = self.updatable_nodes[j][1], global_dims or prg.p.global_size, local_dims or prg.p.local_size
       node.blockDimX, node.blockDimY, node.blockDimZ, node.gridDimX, node.gridDimY, node.gridDimZ = *local_size, *global_size # type: ignore[misc]
 
     # Update graph nodes with the updated structs.

--- a/tinygrad/runtime/graph/cuda.py
+++ b/tinygrad/runtime/graph/cuda.py
@@ -58,10 +58,10 @@ class CUDAGraph(MultiGraphRunner):
         elif i == 1: self.updatable_nodes[j][1].srcDevice = input_rawbuffers[input_idx]._buf
 
     # Update var_vals in the c_args struct.
-    for j, i, v in self.replaced_vars(var_vals): setattr(self.updatable_nodes[j][2], f'v{i}', v)
+    for j, i, v in self.updated_vars(var_vals): setattr(self.updatable_nodes[j][2], f'v{i}', v)
 
     # Update launch dims in the kern_params struct.
-    for j, global_dims, local_dims in self.replaced_launch_dims(var_vals):
+    for j, global_dims, local_dims in self.updated_launch_dims(var_vals):
       prg = cast(CompiledRunner, self.jit_cache[j].prg)
       node, local_size, global_size, = self.updatable_nodes[j][1], global_dims or prg.p.global_size, local_dims or prg.p.local_size
       node.blockDimX, node.blockDimY, node.blockDimZ, node.gridDimX, node.gridDimY, node.gridDimZ = *local_size, *global_size # type: ignore[misc]

--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -137,13 +137,16 @@ class HCQGraph(MultiGraphRunner):
       else: self.op_cmd_idx[j][0].update_copy(self.op_cmd_idx[j][1], **{('dest' if i == 0 else 'src'): input_rawbuffers[input_idx]._buf.va_addr})
 
     # Update var_vals
-    for j in self.jc_idx_with_updatable_var_vals:
-      for i,v in enumerate(cast(CompiledRunner, self.jit_cache[j].prg).p.vars): self.ji_args_vars[j][i] = var_vals[v]
+    vals = self._resolve_symbolic_vars(var_vals)
+    for j, vidxs in self.var_vals_replace:
+      for i,v in enumerate(vidxs): self.ji_args_vars[j][i] = vals[v]
+    # for j in self.jc_idx_with_updatable_var_vals:
+    #   for i,v in enumerate(cast(CompiledRunner, self.jit_cache[j].prg).p.vars): self.ji_args_vars[j][i] = var_vals[v]
 
     launch_dims = self._resolve_symbolic_launch_dims(var_vals)
-    for j,gd,ld in self.jc_idx_with_updatable_launch_dims_2:
+    for j,gd,ld in self.launch_dims_replace:
       queue, cmd_ptr = self.op_cmd_idx[j]
-      queue.update_exec(cmd_ptr, launch_dims[gd] if gd >= 0 else None, launch_dims[ld] if ld >= 0 else None)
+      queue.update_exec(cmd_ptr, launch_dims[gd] if gd is not None else None, launch_dims[ld] if ld is not None else None)
 
     for dev in self.devices:
       comp_queue, copy_queue, need_sig_upd = self.comp_queues[dev], self.copy_queues[dev], dev.timeline_signal != self.last_timeline[dev][0]

--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -138,15 +138,13 @@ class HCQGraph(MultiGraphRunner):
 
     # Update var_vals
     vals = self._resolve_symbolic_vars(var_vals)
-    for j, vidxs in self.var_vals_replace:
-      for i,v in enumerate(vidxs): self.ji_args_vars[j][i] = vals[v]
-    # for j in self.jc_idx_with_updatable_var_vals:
-    #   for i,v in enumerate(cast(CompiledRunner, self.jit_cache[j].prg).p.vars): self.ji_args_vars[j][i] = var_vals[v]
+    for j, vidxs in self.var_vals_replace.items():
+      for i, v in enumerate(vidxs): self.ji_args_vars[j][i] = vals[v]
 
     launch_dims = self._resolve_symbolic_launch_dims(var_vals)
-    for j,gd,ld in self.launch_dims_replace:
+    for j, (gd, ld) in self.launch_dims_replace.items():
       queue, cmd_ptr = self.op_cmd_idx[j]
-      queue.update_exec(cmd_ptr, launch_dims[gd] if gd is not None else None, launch_dims[ld] if ld is not None else None)
+      queue.update_exec(cmd_ptr, launch_dims.get(gd), launch_dims.get(ld))
 
     for dev in self.devices:
       comp_queue, copy_queue, need_sig_upd = self.comp_queues[dev], self.copy_queues[dev], dev.timeline_signal != self.last_timeline[dev][0]

--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -137,10 +137,10 @@ class HCQGraph(MultiGraphRunner):
       else: self.op_cmd_idx[j][0].update_copy(self.op_cmd_idx[j][1], **{('dest' if i == 0 else 'src'): input_rawbuffers[input_idx]._buf.va_addr})
 
     # Update var_vals
-    for j, i, v in self.replaced_vars(var_vals): self.ji_args_vars[j][i] = v
+    for j, i, v in self.updated_vars(var_vals): self.ji_args_vars[j][i] = v
 
     # Update launch dims
-    for j, global_dims, local_dims in self.replaced_launch_dims(var_vals):
+    for j, global_dims, local_dims in self.updated_launch_dims(var_vals):
       queue, cmd_ptr = self.op_cmd_idx[j]
       queue.update_exec(cmd_ptr, global_dims, local_dims)
 

--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -120,8 +120,6 @@ class HCQGraph(MultiGraphRunner):
       if hasattr(self.copy_queues[dev], 'bind') and self.last_ji[self.copy_queues[dev]] is not None: self.copy_queues[dev].bind(dev)
 
   def __call__(self, input_rawbuffers: List[Buffer], var_vals: Dict[Variable, int], wait=False) -> Optional[float]:
-    # resolved_launch_dims, resolved_vals = self._resolve_symbolic_replace()
-
     # Wait and restore signals
     self.kickoff_value += 1
     for dev in self.devices: self.last_timeline[dev][0].wait(self.last_timeline[dev][1])

--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -140,9 +140,10 @@ class HCQGraph(MultiGraphRunner):
     for j in self.jc_idx_with_updatable_var_vals:
       for i,v in enumerate(cast(CompiledRunner, self.jit_cache[j].prg).p.vars): self.ji_args_vars[j][i] = var_vals[v]
 
-    for j in self.jc_idx_with_updatable_launch_dims:
+    launch_dims = self._resolve_symbolic_launch_dims(var_vals)
+    for j,gd,ld in self.jc_idx_with_updatable_launch_dims_2:
       queue, cmd_ptr = self.op_cmd_idx[j]
-      queue.update_exec(cmd_ptr, *cast(CompiledRunner, self.jit_cache[j].prg).p.launch_dims(var_vals))
+      queue.update_exec(cmd_ptr, launch_dims[gd] if gd >= 0 else None, launch_dims[ld] if ld >= 0 else None)
 
     for dev in self.devices:
       comp_queue, copy_queue, need_sig_upd = self.comp_queues[dev], self.copy_queues[dev], dev.timeline_signal != self.last_timeline[dev][0]

--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -146,21 +146,6 @@ class HCQGraph(MultiGraphRunner):
       queue, cmd_ptr = self.op_cmd_idx[j]
       queue.update_exec(cmd_ptr, global_dims, local_dims)
 
-    # Update launch dims
-    # for j, (global_replace_idx, local_replace_idx) in self.launch_dims_replace.items():
-    #   queue, cmd_ptr = self.op_cmd_idx[j]
-    #   queue.update_exec(cmd_ptr, resolved_launch_dims.get(global_replace_idx), resolved_launch_dims.get(local_replace_idx))
-
-    # Update var_vals
-    # vals = self._resolve_symbolic_vars(var_vals)
-    # for j, vidxs in self.var_vals_replace.items():
-    #   for i, v in enumerate(vidxs): self.ji_args_vars[j][i] = vals[v]
-
-    # launch_dims = self._resolve_symbolic_launch_dims(var_vals)
-    # for j, (gd, ld) in self.launch_dims_replace.items():
-    #   queue, cmd_ptr = self.op_cmd_idx[j]
-    #   queue.update_exec(cmd_ptr, launch_dims.get(gd), launch_dims.get(ld))
-
     for dev in self.devices:
       comp_queue, copy_queue, need_sig_upd = self.comp_queues[dev], self.copy_queues[dev], dev.timeline_signal != self.last_timeline[dev][0]
       comp_queue.update_wait(1, dev.timeline_signal if need_sig_upd else None, dev.timeline_value - 1) \

--- a/tinygrad/runtime/graph/metal.py
+++ b/tinygrad/runtime/graph/metal.py
@@ -56,7 +56,7 @@ class MetalGraph(GraphRunner):
       self.icb.indirectComputeCommandAtIndex_(j).setKernelBuffer_offset_atIndex_(input_rawbuffers[input_idx]._buf.buf,
                                                                                  input_rawbuffers[input_idx]._buf.offset, i)
 
-    for j, global_dims, local_dims in self.replaced_launch_dims(var_vals):
+    for j, global_dims, local_dims in self.updated_launch_dims(var_vals):
       prg = cast(CompiledRunner, self.jit_cache[j].prg)
       global_size, local_size = global_dims or prg.p.global_size, local_dims or prg.p.local_size
       self.icb.indirectComputeCommandAtIndex_(j).concurrentDispatchThreadgroups_threadsPerThreadgroup_(Metal.MTLSize(*global_size),

--- a/tinygrad/runtime/graph/metal.py
+++ b/tinygrad/runtime/graph/metal.py
@@ -26,7 +26,6 @@ class MetalGraph(GraphRunner):
     if len(self.vars): self.int_buf = self.device.allocator.alloc(len(self.vars)*dtypes.int32.itemsize)
     all_resources = [self.int_buf.buf] if len(self.vars) else []
 
-    launch_dims = self._resolve_symbolic_launch_dims(var_vals)
     for j,ji in enumerate(self.jit_cache):
       prg: CompiledRunner = cast(CompiledRunner, ji.prg)
       descriptor = Metal.MTLComputePipelineDescriptor.new()

--- a/tinygrad/runtime/graph/metal.py
+++ b/tinygrad/runtime/graph/metal.py
@@ -57,7 +57,8 @@ class MetalGraph(GraphRunner):
                                                                                  input_rawbuffers[input_idx]._buf.offset, i)
 
     for j, global_dims, local_dims in self.replaced_launch_dims(var_vals):
-      global_size, local_size = global_dims or self.jit_cache[j].prg.p.global_size, local_dims or self.jit_cache[j].prg.p.local_size
+      prg = cast(CompiledRunner, self.jit_cache[j].prg)
+      global_size, local_size = global_dims or prg.p.global_size, local_dims or prg.p.local_size
       self.icb.indirectComputeCommandAtIndex_(j).concurrentDispatchThreadgroups_threadsPerThreadgroup_(Metal.MTLSize(*global_size),
                                                                                                        Metal.MTLSize(*local_size))
     for j, var in enumerate(self.vars): self.int_buf_view[j] = var_vals[var]


### PR DESCRIPTION
llama 8b 6gpus:

```
enqueue in   2.01 ms
total   6.99 ms, 143.01 tok/s, 3084.66 GB/s, param 2299.00 GB/s
```
vs
```
enqueue in   4.65 ms
total   7.85 ms, 127.42 tok/s, 2748.32 GB/s, param 2048.32 GB/s
```

llama 8b 4gpus:
```
enqueue in   1.39 ms
total   7.28 ms, 137.34 tok/s, 2696.59 GB/s, param 2207.06 GB/s
```
vs
```
enqueue in   3.14 ms
total   7.30 ms, 136.99 tok/s, 2689.75 GB/s, param 2201.46 GB/s
```