### PR TITLE
Addition of nll_loss and cross_entropy to tensor.py

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1971,6 +1971,19 @@ class TestOps(unittest.TestCase):
     helper_test_op([], lambda: torch.nn.functional.one_hot(torch.tensor(data), 8).type(torch.int32),
                        lambda: Tensor(data).one_hot(8), forward_only=True)
 
+  def test_nll_loss(self):
+    helper_test_op([(4, 4), (4)], lambda x,y: torch.nn.functional.nll_loss(x,torch.clip(y, 0).type(torch.long), reduction = 'mean'),
+                                  lambda x,y: x.nll_loss(y.clip(0).cast(dtypes.long)), forward_only=True)
+
+  def test_cross_entropy(self):
+    helper_test_op([(4, 4), (4)], lambda x,y: torch.nn.functional.cross_entropy(x,torch.clip(y, 0).type(torch.long), reduction = 'mean'),
+                                       lambda x,y: x.cross_entropy(y.clip(0,1)), forward_only=True)
+
+    # helper_test_op(None,
+    #                lambda data, target: torch_cross_entropy(data, target),
+    #                lambda data, target: Tensor(data.cross_entropy(target).numpy()),
+    #                forward_only=True, vals = [np.random.randn(3, 5), [1, 0, 4]])
+
   def test_masked_fill(self):
     helper_test_op([(32,10)], lambda x: x.masked_fill((x>0.1).detach(), -math.inf))
     helper_test_op([(32,10)], lambda x: x.masked_fill((x<0.1).detach(), -math.inf))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2856,6 +2856,15 @@ class Tensor:
     """
     return (self[..., None] == Tensor.arange(num_classes, requires_grad=False, device=self.device)).where(1, 0)
 
+  def nll_loss(self, target:Tensor) -> Tensor:
+    """
+    Returns the nll_loss for self with target.
+    """
+    return -self.gather(1, target.view(1, target.shape[0]).T).mean()
+
+  def cross_entropy(self, target:Tensor) -> Tensor:
+    return self.log_softmax().nll_loss(target).mean()
+
   def scaled_dot_product_attention(self, key:Tensor, value:Tensor, attn_mask:Optional[Tensor]=None,
                                    dropout_p:float=0.0, is_causal:bool=False) -> Tensor:
     """


### PR DESCRIPTION
* tensor: added nll_loss and cross_entropy
* test_ops: added test for nll_loss and test for cross_entropy
* 
This PR adds negative_log_likelihood and cross_entropy to Tensor. #3891 and #5247 

Eg:
For `negative_log_likelihood`,
```py
import tinygrad
data = tinygrad.Tensor([[1, 2, 4]])
target = [2]
print(data.nll_loss(target).numpy())
```

For `cross_entropy`,
```py
import tinygrad
data = tinygrad.Tensor([[1, 2, 4]])
target = [2]
print(data.cross_entropy(target).numpy())
```


======= Issues to Resolve =======
The issue to resolve lies within the `test/test_ops.py` where the test fails for the added functions (`test_nll_loss` and `test_cross_entropy`) when `forward_only` is set to `False`. The error returned is that there is no grad available in the Tensor.

The returned values from the implemented loss functions matches that of `torch`.

Conversation to refer to: https://discord.com/channels/1068976834382925865/1070745817025106080/1266685261618872350  

Logs: https://gist.github.com/nighteous/2992fc80703f8e15a55d44b3455d9620