### PR TITLE
feat: allow passing gradient to .backward() to compute vjp

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -16,6 +16,7 @@ U_init = np.random.randn(3,3).astype(np.float32)
 V_init = np.random.randn(3,3).astype(np.float32)
 W_init = np.random.randn(3,3).astype(np.float32)
 m_init = np.random.randn(1,3).astype(np.float32)
+gradient = np.random.randn(1,3).astype(np.float32)
 
 class TestTinygrad(unittest.TestCase):
   def test_zerodim_initialization(self):
@@ -55,6 +56,31 @@ class TestTinygrad(unittest.TestCase):
     for x,y in zip(test_tinygrad(), test_pytorch()):
       np.testing.assert_allclose(x, y, atol=1e-5)
 
+  # passing `gradient` to backward
+  def test_backward_pass_vjp(self):
+    def test_tinygrad():
+      x = Tensor(x_init, requires_grad=True)
+      W = Tensor(W_init, requires_grad=True)
+      m = Tensor(m_init)
+      out = x.dot(W).relu()
+      out = out.log_softmax()
+      out = out.mul(m).add(m)
+      out.backward(gradient)
+      return out.numpy(), x.grad.numpy(), W.grad.numpy()
+
+    def test_pytorch():
+      x = torch.tensor(x_init, requires_grad=True)
+      W = torch.tensor(W_init, requires_grad=True)
+      m = torch.tensor(m_init)
+      out = x.matmul(W).relu()
+      out = torch.nn.functional.log_softmax(out, dim=1)
+      out = out.mul(m).add(m)
+      out.backward(gradient)
+      return out.detach().numpy(), x.grad, W.grad
+
+    for x,y in zip(test_tinygrad(), test_pytorch()):
+      np.testing.assert_allclose(x, y, atol=1e-5)
+  
   @unittest.skipIf(Device.DEFAULT == "WEBGPU", "this test uses more than 8 bufs which breaks webgpu") #TODO: remove after #1461
   def test_backward_pass_diamond_model(self):
     def test_tinygrad():

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -65,7 +65,7 @@ class TestTinygrad(unittest.TestCase):
       out = x.dot(W).relu()
       out = out.log_softmax()
       out = out.mul(m).add(m)
-      out.backward(gradient)
+      out.backward(Tensor(gradient))
       return out.numpy(), x.grad.numpy(), W.grad.numpy()
 
     def test_pytorch():
@@ -75,12 +75,12 @@ class TestTinygrad(unittest.TestCase):
       out = x.matmul(W).relu()
       out = torch.nn.functional.log_softmax(out, dim=1)
       out = out.mul(m).add(m)
-      out.backward(gradient)
+      out.backward(torch.tensor(gradient))
       return out.detach().numpy(), x.grad, W.grad
 
     for x,y in zip(test_tinygrad(), test_pytorch()):
       np.testing.assert_allclose(x, y, atol=1e-5)
-  
+
   @unittest.skipIf(Device.DEFAULT == "WEBGPU", "this test uses more than 8 bufs which breaks webgpu") #TODO: remove after #1461
   def test_backward_pass_diamond_model(self):
     def test_tinygrad():

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -727,7 +727,7 @@ class Tensor:
   def backward(self, gradient:Optional[Tensor]=None) -> Tensor:
     """
     Propagates the gradient of a tensor backwards through the computation graph.
-    Must be called on a scalar tensor or the `gradient` argument must be provided.
+    If the 'gradient' argument is not provided, the tensor must be a scalar, and the gradient is implicitly set to 1.0.
 
     ```python exec="true" source="above" session="tensor" result="python"
     t = Tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
@@ -735,11 +735,14 @@ class Tensor:
     print(t.grad.numpy())
     ```
     """
-    assert self.shape == tuple() or gradient is not None, "backward must be called on a scalar tensor or with the gradient argument"
-    assert gradient is None or gradient.shape == self.shape, f"gradient shape must match tensor shape, {gradient.shape!r} != {self.shape!r}"
-    # fill in the first grad with one. don't use Tensor.ones because we don't need contiguous
-    # this is "implicit gradient creation"
-    self.grad = Tensor(1.0, dtype=self.dtype, device=self.device, requires_grad=False) if gradient is None else gradient
+    if gradient is None: 
+      assert self.shape == tuple(), "when no gradient is provided, backward must be called on a scalar tensor"
+      # fill in the first grad with one. don't use Tensor.ones because we don't need contiguous
+      # this is "implicit gradient creation"
+      gradient = Tensor(1.0, dtype=self.dtype, device=self.device, requires_grad=False)
+
+    assert self.shape == gradient.shape, f"grad shape must match tensor shape, {gradient.shape!r} != {self.shape!r}"
+    self.grad = gradient
 
     for t0 in reversed(self._deepwalk()):
       if t0.grad is None: raise RuntimeError(f"tensor {t0} has no grad")

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -735,7 +735,7 @@ class Tensor:
     print(t.grad.numpy())
     ```
     """
-    if gradient is None: 
+    if gradient is None:
       assert self.shape == tuple(), "when no gradient is provided, backward must be called on a scalar tensor"
       # fill in the first grad with one. don't use Tensor.ones because we don't need contiguous
       # this is "implicit gradient creation"


### PR DESCRIPTION
This allows the user to pass a `gradient` parameter to Tensor.backward. The API is similar to the one in PyTorch: if the tensor is not a scalar, then gradient must be passed. If it is scalar and it is not passed, it is assumed to be 1.0.
This means that backward can generalize to vector-jacobian products (can be seen as a 'generalization' of the gradient).