### PR TITLE
add failing test for second order derivatives

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -79,7 +79,7 @@ class TestTinygrad(unittest.TestCase):
       grad_W.sum().backward()
       second_grad_W = W.grad
       return second_grad_x, second_grad_W
-      
+
     def test_tinygrad():
       x = Tensor(x_init, requires_grad=True)
       W = Tensor(W_init, requires_grad=True)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -121,7 +121,7 @@ class TestTinygrad(unittest.TestCase):
       out = x.matmul(W).relu()
       out = torch.nn.functional.log_softmax(out, dim=1)
       out = out.mul(m).add(m)
-      out.backward(gradient)
+      out.backward(torch.tensor(gradient))
       return out.detach().numpy(), x.grad, W.grad
 
     for x,y in zip(test_tinygrad(), test_pytorch()):

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -59,6 +59,49 @@ class TestTinygrad(unittest.TestCase):
 
   @unittest.expectedFailure
   def test_second_order_backward_pass(self):
+    def test_pytorch():
+      x = torch.tensor(x_init, requires_grad=True)
+      W = torch.tensor(W_init, requires_grad=True)
+      m = torch.tensor(m_init)
+      # forward pass
+      out = x.matmul(W).relu()
+      out = torch.nn.functional.log_softmax(out, dim=1)
+      out = out.mul(m).add(m).sum()
+      # use retain graph so we can compute second order derivatives later
+      out.backward(retain_graph=True)
+      # save first-order gradients (dL/dx, dL/dW). they still contain graph information on how they were constructed wrt x and W
+      grad_x = x.grad
+      grad_W = W.grad
+      # zero gradients so second-order gradients are correct
+      x.grad = None
+      W.grad = None
+      # compute second-order gradients
+      grad_x.sum().backward(retain_graph=True)
+      second_grad_x = x.grad
+      grad_W.sum().backward()
+      second_grad_W = W.grad
+      return second_grad_x, second_grad_W
+
+    def test_tinygrad():
+      x = Tensor(x_init, requires_grad=True)
+      W = Tensor(W_init, requires_grad=True)
+      m = Tensor(m_init)
+      out = x.matmul(W).relu()
+      out = out.log_softmax()
+      out = out.mul(m).add(m).sum()
+      out.backward()
+      grad_x = x.grad
+      grad_W = W.grad
+      x.grad = None
+      W.grad = None
+      grad_x.sum().backward()
+      second_grad_x = x.grad
+      grad_W.sum().backward()
+      second_grad_W = W.grad
+      return second_grad_x.numpy(), second_grad_W.numpy()
+
+    for x,y in zip(test_tinygrad(), test_pytorch()):
+      np.testing.assert_allclose(x, y, atol=1e-5)
 
   # passing `gradient` to backward
   def test_backward_pass_vjp(self):

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -55,6 +55,52 @@ class TestTinygrad(unittest.TestCase):
     for x,y in zip(test_tinygrad(), test_pytorch()):
       np.testing.assert_allclose(x, y, atol=1e-5)
 
+  @unittest.expectedFailure
+  def test_second_order_backward_pass(self):
+    def test_pytorch():
+      x = torch.tensor(x_init, requires_grad=True)
+      W = torch.tensor(W_init, requires_grad=True)
+      m = torch.tensor(m_init)
+      # forward pass
+      out = x.matmul(W).relu()
+      out = torch.nn.functional.log_softmax(out, dim=1)
+      out = out.mul(m).add(m).sum()
+      # use retain graph so we can compute second order derivatives later
+      out.backward(retain_graph=True)
+      # save first-order gradients (dL/dx, dL/dW). they still contain graph information on how they were constructed wrt x and W
+      grad_x = x.grad
+      grad_W = W.grad
+      # zero gradients so second-order gradients are correct
+      x.grad = None
+      W.grad = None
+      # compute second-order gradients
+      grad_x.sum().backward(retain_graph=True)
+      second_grad_x = x.grad
+      grad_W.sum().backward()
+      second_grad_W = W.grad
+      return second_grad_x, second_grad_W
+      
+    def test_tinygrad():
+      x = Tensor(x_init, requires_grad=True)
+      W = Tensor(W_init, requires_grad=True)
+      m = Tensor(m_init)
+      out = x.matmul(W).relu()
+      out = out.log_softmax()
+      out = out.mul(m).add(m).sum()
+      out.backward()
+      grad_x = x.grad
+      grad_W = W.grad
+      x.grad = None
+      W.grad = None
+      grad_x.sum().backward()
+      second_grad_x = x.grad
+      grad_W.sum().backward()
+      second_grad_W = W.grad
+      return second_grad_x.numpy(), second_grad_W.numpy()
+
+    for x,y in zip(test_tinygrad(), test_pytorch()):
+      np.testing.assert_allclose(x, y, atol=1e-5)
+
   @unittest.skipIf(Device.DEFAULT == "WEBGPU", "this test uses more than 8 bufs which breaks webgpu") #TODO: remove after #1461
   def test_backward_pass_diamond_model(self):
     def test_tinygrad():

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -56,7 +56,6 @@ class TestTinygrad(unittest.TestCase):
     for x,y in zip(test_tinygrad(), test_pytorch()):
       np.testing.assert_allclose(x, y, atol=1e-5)
 
-
   @unittest.expectedFailure
   def test_second_order_backward_pass(self):
     def test_pytorch():
@@ -115,55 +114,15 @@ class TestTinygrad(unittest.TestCase):
       out.backward(Tensor(gradient))
       return out.numpy(), x.grad.numpy(), W.grad.numpy()
 
-
     def test_pytorch():
       x = torch.tensor(x_init, requires_grad=True)
       W = torch.tensor(W_init, requires_grad=True)
       m = torch.tensor(m_init)
-
-      # forward pass
-      out = x.matmul(W).relu()
-      out = torch.nn.functional.log_softmax(out, dim=1)
-      out = out.mul(m).add(m).sum()
-      # use retain graph so we can compute second order derivatives later
-      out.backward(retain_graph=True)
-      # save first-order gradients (dL/dx, dL/dW). they still contain graph information on how they were constructed wrt x and W
-      grad_x = x.grad
-      grad_W = W.grad
-      # zero gradients so second-order gradients are correct
-      x.grad = None
-      W.grad = None
-      # compute second-order gradients
-      grad_x.sum().backward(retain_graph=True)
-      second_grad_x = x.grad
-      grad_W.sum().backward()
-      second_grad_W = W.grad
-      return second_grad_x, second_grad_W
-
-    def test_tinygrad():
-      x = Tensor(x_init, requires_grad=True)
-      W = Tensor(W_init, requires_grad=True)
-      m = Tensor(m_init)
-      out = x.matmul(W).relu()
-      out = out.log_softmax()
-      out = out.mul(m).add(m).sum()
-      out.backward()
-      grad_x = x.grad
-      grad_W = W.grad
-      x.grad = None
-      W.grad = None
-      grad_x.sum().backward()
-      second_grad_x = x.grad
-      grad_W.sum().backward()
-      second_grad_W = W.grad
-      return second_grad_x.numpy(), second_grad_W.numpy()
-
       out = x.matmul(W).relu()
       out = torch.nn.functional.log_softmax(out, dim=1)
       out = out.mul(m).add(m)
-      out.backward(torch.tensor(gradient))
+      out.backward(gradient)
       return out.detach().numpy(), x.grad, W.grad
-
 
     for x,y in zip(test_tinygrad(), test_pytorch()):
       np.testing.assert_allclose(x, y, atol=1e-5)

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -105,7 +105,7 @@ class AMDComputeQueue(HWComputeQueue):
     self._acquire_mem(gli=0, gl2=0)
 
     user_regs = [*data64_le(kernargs)]
-    if prg.kernel_code_properties & 0x2:
+    if prg.enable_dispatch_ptr:
       dp = hsa.hsa_kernel_dispatch_packet_t.from_address(dp_addr:=kernargs + prg.kernargs_segment_size)
       dp.workgroup_size_x, dp.workgroup_size_y, dp.workgroup_size_z = local_size[0], local_size[1], local_size[2]
       dp.grid_size_x, dp.grid_size_y, dp.grid_size_z = global_size[0]*local_size[0], global_size[1]*local_size[1], global_size[2]*local_size[2]
@@ -277,12 +277,14 @@ class AMDProgram(HCQProgram):
 
     self.rsrc1 = code.compute_pgm_rsrc1
     self.rsrc2 = code.compute_pgm_rsrc2 | (lds_size << 15)
-    self.kernel_code_properties = code.kernel_code_properties
     self.prog_addr = self.lib_gpu.va_addr + entry_point + code.kernel_code_entry_byte_offset
 
-    # If required, allocate space for the dispatch packet in the kernargs to pass it to the GPU.
-    args_alloc_sz = self.kernargs_segment_size + (ctypes.sizeof(hsa.hsa_kernel_dispatch_packet_t) if self.kernel_code_properties & 0x2 else 0)
-    super().__init__(self.device, self.name, kernargs_alloc_size=args_alloc_sz)
+    # Some programs use hsa_kernel_dispatch_packet_t to read workgroup sizes during execution.
+    # The packet is represented as a pointer and set up in SGPRs. Space for the packet is allocated as part of the kernel arguments.
+    self.enable_dispatch_ptr = code.kernel_code_properties & hsa.AMD_KERNEL_CODE_PROPERTIES_ENABLE_SGPR_DISPATCH_PTR
+    additional_alloc_sz = ctypes.sizeof(hsa.hsa_kernel_dispatch_packet_t) if self.enable_dispatch_ptr else 0
+
+    super().__init__(self.device, self.name, kernargs_alloc_size=self.kernargs_segment_size+additional_alloc_sz)
 
   def __del__(self):
     if hasattr(self, 'lib_gpu'): cast(AMDDevice, self.device)._gpu_free(self.lib_gpu)


### PR DESCRIPTION
As commented in https://github.com/tinygrad/tinygrad/pull/5701, the 'minimal' failing test case is a second order derivative. The main issue is that tinygrad does not keep computational graph for gradients, so gradients cannot be 'backpropagated' again. This means that, for Tinygrad, the gradient of W.grad wrt inputs(for example) is 'None'. Common uses for this includes directly computing second order derivatives or even what is mentioned in https://github.com/tinygrad/tinygrad/pull/5701.