### PR TITLE
remove float division from idiv in python_alu

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -408,6 +408,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(), ()], lambda x,y: x/y)
   def test_div_int(self):
     helper_test_op(None, lambda x,y: x/y, Tensor.div, forward_only=True, vals=np.array([[5, 6, 7],[1, 2, 3]], dtype=np.int32))
+    helper_test_op(None, lambda x,y: x/y, Tensor.div, forward_only=True, vals=np.array([[18446744073709551612],[1]], dtype=np.uint64))
     helper_test_op(None, lambda x: x/2, lambda x: x/2, forward_only=True, vals=np.array([[3, 4, 5]], dtype=np.int32))
   def test_scalar_div(self):
     helper_test_op([(45,65)], lambda x: x/255)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -4,6 +4,7 @@ import torch
 from tinygrad.helpers import getenv, IMAGE, DEBUG, CI
 from tinygrad import Tensor, Device, dtypes
 from tinygrad.tensor import _to_np_dtype
+import functools
 
 if CI:
   import warnings
@@ -408,8 +409,11 @@ class TestOps(unittest.TestCase):
     helper_test_op([(), ()], lambda x,y: x/y)
   def test_div_int(self):
     helper_test_op(None, lambda x,y: x/y, Tensor.div, forward_only=True, vals=np.array([[5, 6, 7],[1, 2, 3]], dtype=np.int32))
-    helper_test_op(None, lambda x,y: x/y, Tensor.div, forward_only=True, vals=np.array([[18446744073709551612],[1]], dtype=np.uint64))
     helper_test_op(None, lambda x: x/2, lambda x: x/2, forward_only=True, vals=np.array([[3, 4, 5]], dtype=np.int32))
+    torch_idiv, tiny_idiv = functools.partial(torch.div, rounding_mode="trunc"), functools.partial(Tensor.div, upcast=False)
+    helper_test_op(None, torch_idiv, tiny_idiv, forward_only=True, vals=np.array([[5, -6, 7],[1, 2, 3]], dtype=np.int32))
+    x = Tensor(2**64 - 1, dtype=dtypes.uint64).div(1, upcast=False)
+    np.testing.assert_equal(x.numpy(), 2**64 - 1)
   def test_scalar_div(self):
     helper_test_op([(45,65)], lambda x: x/255)
     helper_test_op([(45,65)], lambda x: x/1)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -117,7 +117,8 @@ python_alu: Dict[Op, Callable]  = {
   BinaryOps.MUL: operator.mul, BinaryOps.ADD: operator.add,
   BinaryOps.XOR: operator.xor, BinaryOps.MAX: max, BinaryOps.CMPNE: operator.ne, BinaryOps.CMPLT: operator.lt,
   BinaryOps.OR: operator.or_, BinaryOps.AND: operator.and_,
-  BinaryOps.MOD: lambda x,y: abs(int(x))%abs(int(y))*(1,-1)[x<0], BinaryOps.IDIV: lambda x, y: int(x/y) if y != 0 else x*math.inf,
+  BinaryOps.MOD: lambda x,y: abs(int(x))%abs(int(y))*(1,-1)[x<0],
+  BinaryOps.IDIV: lambda x,y: (x // y) + (1 if (x < 0) != (y < 0) and x % y != 0 else 0) if y != 0 else x*math.inf,
   TernaryOps.MULACC: lambda x,y,z: (x*y)+z,
   TernaryOps.WHERE: lambda x,y,z: y if x else z}
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -118,7 +118,7 @@ python_alu: Dict[Op, Callable]  = {
   BinaryOps.XOR: operator.xor, BinaryOps.MAX: max, BinaryOps.CMPNE: operator.ne, BinaryOps.CMPLT: operator.lt,
   BinaryOps.OR: operator.or_, BinaryOps.AND: operator.and_,
   BinaryOps.MOD: lambda x,y: abs(int(x))%abs(int(y))*(1,-1)[x<0],
-  BinaryOps.IDIV: lambda x,y: (x // y) + (1 if (x < 0) != (y < 0) and x % y != 0 else 0) if y != 0 else x*math.inf,
+  BinaryOps.IDIV: lambda x,y: abs(x)//abs(y)*(1,-1)[x*y<0] if y != 0 else x*math.inf,
   TernaryOps.MULACC: lambda x,y,z: (x*y)+z,
   TernaryOps.WHERE: lambda x,y,z: y if x else z}
 

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -50,6 +50,7 @@ class CStyleLanguage(Renderer):
     elif math.isinf(x): val = ("-" if x < 0 else "") + "INFINITY"
     elif dtype.scalar() == dtypes.bool: val = "1" if x else "0"
     elif dtype.scalar() == dtypes.float: val = f"{x}f"
+    elif dtypes.is_unsigned(dtype): val = f"{x}U"
     else: val = str(x)
     if dtype.count > 1: return self.render_vectorize([val] * dtype.count, dtype)
     return (self.render_cast(val, dtype) if dtype not in [dtypes.float, dtypes.int, dtypes.bool] else val)

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -50,7 +50,7 @@ class CStyleLanguage(Renderer):
     elif math.isinf(x): val = ("-" if x < 0 else "") + "INFINITY"
     elif dtype.scalar() == dtypes.bool: val = "1" if x else "0"
     elif dtype.scalar() == dtypes.float: val = f"{x}f"
-    elif dtypes.is_unsigned(dtype): val = f"{x}U"
+    elif dtype.scalar() == dtypes.uint64: val = f"{x}ULL"
     else: val = str(x)
     if dtype.count > 1: return self.render_vectorize([val] * dtype.count, dtype)
     return (self.render_cast(val, dtype) if dtype not in [dtypes.float, dtypes.int, dtypes.bool] else val)


### PR DESCRIPTION
Currently python_alu uses int(x/y) for integer division. This does not work for very large integers as the float casting is not precise enough. This pr replaces that with x//y, along with the required logic to make it truncate towards 0.

```python
print(Tensor([18446744073709551612,], dtype=dtypes.uint64, device='PYTHON').div(Tensor([1,], dtype=dtypes.uint64, device='PYTHON'), upcast=False).numpy())
```

```sh
[0] #main
[18446744073709551612] #this pr
