### PR TITLE
resnet training kernels 1793 -> 1551

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -29,7 +29,7 @@ def check_schedule(t:Union[Tensor, List[Tensor]], allowed:int, to_prerealize:Opt
   sched = create_schedule(flatten([r.lazydata.lbs for r in t]), seen)
   if filter_sink: sched = [s for s in sched if s.ast.op is MetaOps.KERNEL]
   if len(sched) != allowed: print(f"SCHEDULE ISSUE, expecting {allowed} got {len(sched)}")
-  if len(sched) != allowed or DEBUG >= 3:
+  if DEBUG >= 3:
     for i, s in enumerate(sched):
       print("kernel", i+1)
       print(s.ast)

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -356,7 +356,7 @@ def create_schedule_with_vars(outs:List[LazyBuffer], seen:Optional[Set[LazyBuffe
   if any(degree != 0 for degree in in_degree.values()) or len(prescheduled) != len(schedule):
     raise RuntimeError(f"cycle detected in graph, prescheduled {len(prescheduled)} but only scheduled {len(schedule)}")
   if DEBUG >= 1 and len(schedule) >= 10: print(f"scheduled {len(schedule)} kernels")
-  #if len(schedule) > 1000: exit(0)
+  if len(schedule) > getenv("EXIT_SCHEDULE", 0): exit(0)
   return schedule, var_vals
 
 def create_schedule(outs:List[LazyBuffer], seen:Optional[Set[LazyBuffer]]=None) -> List[ScheduleItem]:

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -209,7 +209,7 @@ def _get_isolated_children(r:LazyBuffer, group:Dict[LazyBuffer, None]) -> Dict[L
     if (p:=rc_parents.pop()) in cache: continue
     cache.add(p)
     # max one reduceop per kernel
-    if p.op in ReduceOps or p.st.size != r.st.size: return {}
+    if p.op in ReduceOps or p.st.size > r.st.size: return {}
     rc_parents.extend(x.base for x in p.srcs if x.base.realized is None and x.base is not r)
   return group
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -162,7 +162,7 @@ def verify_lazyop(ast:LazyOp) -> Dict[LazyOp, ShapeTracker]:
       st = op.arg.st if op.op in BufferOps else sts[op.src[0]]
       for x in op.src:
         if sts[x].shape != st.shape:
-          if prod(sts[x].shape) == prod(st.shape): raise AssertionError(f"found implicit reshape {x.op} {op.op} {sts[x].shape} != {sts[x].shape}")
+          if prod(sts[x].shape) == prod(st.shape): raise AssertionError(f"found implicit reshape {x.op} {op.op} {sts[x].shape} != {st.shape}")
           raise AssertionError(f"found implicit expand {x.op} {sts[x].shape} != {op.op} {sts[x].shape} {prod(sts[x].shape)} != {prod(st.shape)}")
     sts[op] = st
   for i, out in enumerate(ast.src):


### PR DESCRIPTION
building up on https://github.com/tinygrad/tinygrad/pull/5679 and https://github.com/tinygrad/tinygrad/pull/5680, this diff gives:

|            | master          | compare         | %   |
|-------------------|-----------------|-----------------|------------|
| kernel count      | 1801            | 1551            | -13.9%    |
| ms python         | 4931.56         | 5064.36         | 2.69%      |
| epoch global_mem  | 702145776021690 | 701635561677050 | -0.07%     |

