### PR TITLE
ull literal support and test

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -270,7 +270,7 @@ class TestInt64DType(TestDType): DTYPE = dtypes.int64
 class TestUint64DType(TestDType):
   DTYPE = dtypes.uint64
   def test_uint64_load(self):
-    assert Tensor(2**64 - 1, dtype=dtypes.uint64) == 2**64 - 1
+    assert Tensor(2**64 - 1, dtype=dtypes.uint64).numpy() == 2**64 - 1
 
 class TestBoolDType(TestDType): DTYPE = dtypes.bool
 

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -267,7 +267,10 @@ class TestInt32DType(TestDType): DTYPE = dtypes.int32
 class TestUint32DType(TestDType): DTYPE = dtypes.uint32
 
 class TestInt64DType(TestDType): DTYPE = dtypes.int64
-class TestUint64DType(TestDType): DTYPE = dtypes.uint64
+class TestUint64DType(TestDType):
+  DTYPE = dtypes.uint64
+  def test_uint64_load(self):
+    assert Tensor(2**64 - 1, dtype=dtypes.uint64) == 2**64 - 1
 
 class TestBoolDType(TestDType): DTYPE = dtypes.bool
 

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -50,6 +50,7 @@ class CStyleLanguage(Renderer):
     elif math.isinf(x): val = ("-" if x < 0 else "") + "INFINITY"
     elif dtype.scalar() == dtypes.bool: val = "1" if x else "0"
     elif dtype.scalar() == dtypes.float: val = f"{x}f"
+    elif dtype.scalar() == dtypes.uint64: val = f"{x}ULL"
     else: val = str(x)
     if dtype.count > 1: return self.render_vectorize([val] * dtype.count, dtype)
     return (self.render_cast(val, dtype) if dtype not in [dtypes.float, dtypes.int, dtypes.bool] else val)


### PR DESCRIPTION
CLANG requires suffix ULL for unsigned long long literals. This pr adds that suffix and a test for this.

```python
print(Tensor(2**64 - 1, dtype=dtypes.uint64).numpy())
```

Main:
``` sh
<stdin>:2:30: error: integer literal is too large to be represented in a signed integer type, interpreting as unsigned [-Werror,-Wimplicitly-unsigned-literal]
  data0[0] = (unsigned long)(18446744073709551615);
```

This PR:
```sh
18446744073709551615