### PR TITLE
hcopts fail in fused arange kernel

### DIFF
--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -386,5 +386,34 @@ class TestLinearizerFailures(unittest.TestCase):
     opts = [Opt(op=OptOps.GROUP, axis=0, amt=0), Opt(op=OptOps.PADTO, axis=0, amt=32), Opt(op=OptOps.LOCAL, axis=0, amt=4), Opt(op=OptOps.UPCAST, axis=0, amt=4)]
     helper_test_lin(Kernel(ast), opts=opts, failed_platforms=[])
 
+  @unittest.expectedFailure
+  def test_failure_43(self):
+    ast = LazyOp(MetaOps.KERNEL, arg=None, src=(
+      LazyOp(BufferOps.STORE, arg=MemBuffer(idx=0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(2, 3, 1, 1, 1), strides=(3, 1, 0, 0, 0), offset=0, mask=None, contiguous=True),))), src=(
+        LazyOp(ReduceOps.SUM, arg=(2, 3), src=(
+          LazyOp(BinaryOps.MUL, arg=None, src=(
+            LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=1, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(2, 3, 2, 3, 1), strides=(0, 0, 3, 1, 0), offset=0, mask=None, contiguous=False),))), src=()),
+            LazyOp(UnaryOps.CAST, arg=dtypes.float, src=(
+              LazyOp(BinaryOps.MUL, arg=None, src=(
+                LazyOp(BinaryOps.CMPNE, arg=None, src=(
+                  LazyOp(BinaryOps.CMPNE, arg=None, src=(
+                    LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=2, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(2, 3, 2, 3, 1), strides=(0, 0, 0, 0, 0), offset=0, mask=None, contiguous=False),))), src=()),
+                    LazyOp(BinaryOps.ADD, arg=None, src=(
+                      LazyOp(ReduceOps.SUM, arg=(4,), src=(
+                        LazyOp(BufferOps.CONST, arg=ConstBuffer(val=1, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(3, 3), strides=(0, 0), offset=0, mask=((0, 3), (1, 3)), contiguous=False), View(shape=(2, 3, 2, 3, 2), strides=(0, 0, 1, 0, 4), offset=0, mask=None, contiguous=False)))), src=()),)),
+                      x12:=LazyOp(BufferOps.CONST, arg=ConstBuffer(val=-1, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(2, 3, 2, 3, 1), strides=(0, 0, 0, 0, 0), offset=0, mask=None, contiguous=False),))), src=()),)),)),
+                  x13:=LazyOp(BufferOps.CONST, arg=ConstBuffer(val=True, dtype=dtypes.bool, st=ShapeTracker(views=(View(shape=(2, 3, 2, 3, 1), strides=(0, 0, 0, 0, 0), offset=0, mask=None, contiguous=False),))), src=()),)),
+                LazyOp(BinaryOps.CMPNE, arg=None, src=(
+                  LazyOp(BinaryOps.CMPNE, arg=None, src=(
+                    LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=3, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(2, 3, 2, 3, 1), strides=(3, 1, 0, 0, 0), offset=0, mask=None, contiguous=False),))), src=()),
+                    LazyOp(BinaryOps.ADD, arg=None, src=(
+                      LazyOp(ReduceOps.SUM, arg=(4,), src=(
+                        LazyOp(BufferOps.CONST, arg=ConstBuffer(val=1, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(4, 5), strides=(0, 0), offset=0, mask=((0, 4), (2, 5)), contiguous=False), View(shape=(2, 3, 2, 3, 3), strides=(0, 0, 0, 1, 6), offset=0, mask=None, contiguous=False)))), src=()),)),
+                       x12,)),)),
+                   x13,)),)),)),)),)),)),))
+    # ValueError: size mismatched, can't reshape self.shape=(6, 2, 3, 3) -> new_shape=(6, 2, 3, 1, 2)
+    opts = [Opt(op=OptOps.UNROLL, axis=2, amt=0)]
+    helper_test_lin(Kernel(ast), opts=opts, failed_platforms=[])
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -387,7 +387,7 @@ class TestLinearizerFailures(unittest.TestCase):
     helper_test_lin(Kernel(ast), opts=opts, failed_platforms=[])
 
   @unittest.expectedFailure
-  def test_failure_43(self):
+  def test_failure_45(self):
     ast = LazyOp(MetaOps.KERNEL, arg=None, src=(
       LazyOp(BufferOps.STORE, arg=MemBuffer(idx=0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(2, 3, 1, 1, 1), strides=(3, 1, 0, 0, 0), offset=0, mask=None, contiguous=True),))), src=(
         LazyOp(ReduceOps.SUM, arg=(2, 3), src=(


### PR DESCRIPTION
This AST passes verify_lazyop and the NOOPT=1 kernel is ok.
hcopts tries to unroll these loops and it fails.

I'm trying to fuse 2 aranges (data3 and data5)
```
X = Tensor.randn(2, 3)
xt = X[Tensor([1]), Tensor([[0,0,0],[0,0,0]])]


kernel void r_6_2_3(device float* data0, const device float* data1, const device int* data2, const device int* data3, const device int* data4, const device int* data5, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int gidx0 = gid.x; /* 6 */
  int val0 = *(data2+0);
  int val1 = *(data4+gidx0);
  float acc0 = 0.0f;
  for (int ridx0 = 0; ridx0 < 2; ridx0++) {
    int val2 = *(data3+ridx0);
    for (int ridx1 = 0; ridx1 < 3; ridx1++) {
      float val3 = *(data1+(ridx0*3)+ridx1);
      int val4 = *(data5+ridx1);
      acc0 = (acc0+(val3*(float)(((!(val0!=val2))*(!(val1!=val4))))));
    }
  }
  *(data0+gidx0) = acc0;
}
```

If I fuse only Tensor.arange(2) or Tensor.arange(3) it works.
https://gist.github.com/Qazalin/1a58be84d83d844d7ab0c33f85c019ab