### PR TITLE
optional shard kvcache for llama

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -227,7 +227,9 @@ class LLaMa:
       if isinstance(device, tuple):
         for k,v in nn.state.get_state_dict(model).items():
           if 'scale' in k: v.shard_(device, axis=None)  # from quantized
-          elif '.attention.' in k: v.shard_(device, axis=-1)
+          elif '.attention.' in k:
+            if getenv("SHARD_KVCACHE") and ('.wq.' in k or '.wk.' in k or '.wv.' in k): v.shard_(device, axis=0)
+            else: v.shard_(device, axis=-1)
           elif '.feed_forward.w1.' in k: v.shard_(device, axis=0)
           elif '.feed_forward.w3.' in k: v.shard_(device, axis=0)
           elif '.feed_forward.' in k: v.shard_(device, axis=-1)

--- a/extra/models/llama.py
+++ b/extra/models/llama.py
@@ -65,7 +65,7 @@ class Attention:
       self.cache_kv = Tensor.zeros(2, bsz, self.max_context, self.n_kv_heads, self.head_dim, dtype=x.dtype).contiguous().realize()
       if isinstance(x.device, tuple):
         # TODO: instead of specifying how to shard, it can follow how xk and xv are being sharded
-        self.cache_kv.shard_((x.device), axis=None).realize()
+        self.cache_kv.shard_((x.device), axis=3 if getenv("SHARD_KVCACHE") else None).realize()
 
     # update the cache
     assert xk.dtype == xv.dtype == self.cache_kv.dtype, f"{xk.dtype=}, {xv.dtype=}, {self.cache_kv.dtype=}"


### PR DESCRIPTION
only for 8 % devices == 0! (wait for more uneven splits / reshard support)