### PR TITLE
revert patterns that break resnet BEAM

### DIFF
--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -419,5 +419,26 @@ class TestLinearizerFailures(unittest.TestCase):
     opts = [Opt(op=OptOps.UNROLL, axis=2, amt=0)]
     helper_test_lin(Kernel(ast), opts=opts, failed_platforms=[])
 
+  def test_failure_46(self):
+    ast = LazyOp(MetaOps.KERNEL, arg=None, src=(
+      LazyOp(BufferOps.STORE, arg=MemBuffer(idx=0, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(512, 1), strides=(1, 0), offset=0, mask=None, contiguous=True),))), src=(
+        LazyOp(BinaryOps.MUL, arg=None, src=(
+          LazyOp(ReduceOps.SUM, arg=(1,), src=(
+            LazyOp(UnaryOps.NEG, arg=None, src=(
+              LazyOp(BinaryOps.MUL, arg=None, src=(
+                LazyOp(UnaryOps.CAST, arg=dtypes.float, src=(
+                  LazyOp(BinaryOps.MUL, arg=None, src=(
+                    LazyOp(BinaryOps.CMPNE, arg=None, src=(
+                      LazyOp(BinaryOps.CMPNE, arg=None, src=(
+                        LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=1, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(512, 10), strides=(0, 1), offset=0, mask=None, contiguous=False),))), src=()),
+                        LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=2, dtype=dtypes.int, st=ShapeTracker(views=(View(shape=(512, 10), strides=(1, 0), offset=0, mask=None, contiguous=False),))), src=()),)),
+                      LazyOp(BufferOps.CONST, arg=ConstBuffer(val=True, dtype=dtypes.bool, st=ShapeTracker(views=(View(shape=(512, 10), strides=(0, 0), offset=0, mask=None, contiguous=False),))), src=()),)),
+                    LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=3, dtype=dtypes.bool, st=ShapeTracker(views=(View(shape=(512, 10), strides=(1, 0), offset=0, mask=None, contiguous=False),))), src=()),)),)),
+                LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=4, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(512, 10), strides=(0, 0), offset=0, mask=None, contiguous=False),))), src=()),)),)),)),
+          LazyOp(UnaryOps.RECIP, arg=None, src=(
+            LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=5, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(512, 1), strides=(1, 0), offset=0, mask=None, contiguous=True),))), src=()),)),)),)),))
+    opts = [Opt(op=OptOps.UPCAST, axis=0, amt=2), Opt(op=OptOps.LOCAL, axis=0, amt=32)]
+    helper_test_lin(Kernel(ast), opts=opts, failed_platforms=[])
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -437,7 +437,7 @@ class TestLinearizerFailures(unittest.TestCase):
                 LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=4, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(512, 10), strides=(0, 0), offset=0, mask=None, contiguous=False),))), src=()),)),)),)),
           LazyOp(UnaryOps.RECIP, arg=None, src=(
             LazyOp(BufferOps.LOAD, arg=MemBuffer(idx=5, dtype=dtypes.float, st=ShapeTracker(views=(View(shape=(512, 1), strides=(1, 0), offset=0, mask=None, contiguous=True),))), src=()),)),)),)),))
-    opts = [Opt(op=OptOps.UPCAST, axis=0, amt=2), Opt(op=OptOps.LOCAL, axis=0, amt=32)]
+    opts = [Opt(op=OptOps.UPCAST, axis=0, amt=2)]
     helper_test_lin(Kernel(ast), opts=opts, failed_platforms=[])
 
 if __name__ == '__main__':

--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -342,17 +342,18 @@ class TestSymbolic(unittest.TestCase):
     self.helper_test_variable((-gidx*8-lidx+1002)//-4 + 250, 0, 250, "(((((-gidx)*8)+(-lidx)+1002)//(-4))+250)")
 
   # NOTE: tests are not correct in symbolic
-  def test_div_neg_then_neg(self):
-    # taken from arange opts
-    lidx0 = Variable("lidx0", 0, 7)
-    lidx1 = Variable("lidx1", 0, 7)
-    alu2 = -lidx0-lidx1
-    self.helper_test_variable((((alu2+14)//(-32))+4), 4, 4, "4")
-    self.helper_test_variable(-(((alu2+14)//(-32))+4), -4, -4, "(-4)")
-    self.helper_test_variable((((alu2+134)//(-32))+4), 0, 1, "((((-lidx0)+(-lidx1)+134)//(-32))+4)")
-    self.helper_test_variable((((alu2+142)//(-32))+4), 0, 0, "0")
-    self.helper_test_variable((((alu2+150)//(-32))+4), 0, 0, "0")
-    self.helper_test_variable((((alu2+158)//(-32))+4), 0, 0, "0")
+  # TODO: fix
+  # def test_div_neg_then_neg(self):
+  #   # taken from arange opts
+  #   lidx0 = Variable("lidx0", 0, 7)
+  #   lidx1 = Variable("lidx1", 0, 7)
+  #   alu2 = -lidx0-lidx1
+  #   self.helper_test_variable((((alu2+14)//(-32))+4), 4, 4, "4")
+  #   self.helper_test_variable(-(((alu2+14)//(-32))+4), -4, -4, "(-4)")
+  #   self.helper_test_variable((((alu2+134)//(-32))+4), 0, 1, "((((-lidx0)+(-lidx1)+134)//(-32))+4)")
+  #   self.helper_test_variable((((alu2+142)//(-32))+4), 0, 0, "0")
+  #   self.helper_test_variable((((alu2+150)//(-32))+4), 0, 0, "0")
+  #   self.helper_test_variable((((alu2+158)//(-32))+4), 0, 0, "0")
 
 @unittest.skip("not supported on uops yet")
 class TestSymbolicNumeric(unittest.TestCase):

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -209,7 +209,11 @@ constant_folder = PatternMatcher([
   # NOTE: this can be wrong for loaded NaN
   (NOp.var('x') * 0, lambda x: x.const(float('nan') if isinstance(x.arg, float) and (math.isnan(x.arg) or math.isinf(x.arg)) else 0)),
   (NOp.var('x') - NOp.var('x'), lambda x: x.const(0)),   # x-x -> 0
-  (UPat(op=UOps.ALU, name='x'), lambda x: x.const(x.vmin.arg) if x.op is not UOps.CONST and x.vmin.arg == x.vmax.arg else None),
+  # TODO: this breaks resnet training
+  # (UPat(op=UOps.ALU, name='x'), lambda x: x.const(x.vmin.arg) if x.op is not UOps.CONST and x.vmin.arg == x.vmax.arg else None),
+  # lt folding
+  (NOp.var('x').lt(NOp.var('y')),
+   lambda x,y: NOp.const(dtypes.bool, True) if x.vmax.arg < y.vmin.arg else NOp.const(dtypes.bool, False) if x.vmin.arg >= y.vmax.arg else None),
   # c0*x<c1 for positive int c0,c1
   ((NOp.cvar('c0',dtypes.int)*NOp.var('x')).lt(NOp.cvar('c1',dtypes.int)),
    lambda x,c0,c1: x.lt(math.ceil(c1.arg/c0.arg)) if c0.arg > 0 and c1.arg > 0 else None),
@@ -243,6 +247,8 @@ constant_folder = PatternMatcher([
   (((NOp.var('x') * NOp.cvar('c0')) % NOp.cvar('c1')) % NOp.cvar('c0'), lambda x,c0,c1: x.const(0)),
   # -(x+y) -> -x + -y
   #(-(NOp.var("x") + NOp.var("y")), lambda x,y: (-x)+(-y)),
+  # x%1 -> 0
+  (NOp.var("x") % NOp.const(None, 1), lambda x: x.const(0)),
   # (x*c0)+(x*c1) -> x*(c0+c1)
   (NOp.var("x") * NOp.cvar("c0") + NOp.var("x") * NOp.cvar("c1"), lambda x,c0,c1: x*exec_alu(BinaryOps.ADD, x.dtype, [c0.arg, c1.arg])),
   # (x*c0)+(y*c0) -> (x+y)*c0


### PR DESCRIPTION
BEAM generated wrong kernel for resnet due to these new patterns.
will merge this if resnet training looks good and working on root causing the adding more tests