### PR TITLE
Revert "remove one more UOp mod pattern"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,7 +227,7 @@ jobs:
         name: Test UOP_IS_SYMBOLIC
         run: |
           PYTHONPATH=. UOP_IS_SYMBOLIC=1 GPU=1 python3 -m pytest -n=auto test/test_ops.py -k "conv and not (test_padded_conv3d or test_conv2d_bs_4_cin_3 or test_conv2d or test_conv2d_bs_4_cin_1 or test_strided_conv_transpose2d)" --durations=20
-          PYTHONPATH=. UOP_IS_SYMBOLIC=1 python -m pytest -rA test/test_linearizer_failures.py::TestLinearizerFailures::test_failure_40 test/test_linearizer_failures.py::TestLinearizerFailures::test_failure_47 --durations=20
+          PYTHONPATH=. UOP_IS_SYMBOLIC=1 python -m pytest -rA test/test_linearizer_failures.py::TestLinearizerFailures::test_failure_47 --durations=20
       - if: ${{ matrix.task == 'onnx' }}
         name: Run handcode_opt
         run: PYTHONPATH=. MODEL=resnet GPU=1 DEBUG=1 BS=4 HALF=0 python3 examples/handcode_opt.py

--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -215,8 +215,7 @@ class TestSymbolic(unittest.TestCase):
 
   def test_mod_to_sub(self):
     # This is mod reduction
-    # TODO: fix expression
-    self.helper_test_variable((1+Variable("a",1,2))%2, 0, 1, {"(-1+a)", "((a+1)%2)"})
+    self.helper_test_variable((1+Variable("a",1,2))%2, 0, 1, {"(-1+a)", "(a+(-1))"})
 
   def test_sum_div_const(self):
     self.helper_test_variable(Node.sum([Variable("a", 0, 7)*4, NumNode(3)]) // 4, 0, 7, "a")

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -237,7 +237,8 @@ constant_folder = PatternMatcher([
    x*(c0.arg//g)//(c1.arg//g) if c0.arg > 0 and c1.arg > 0 and (g:=math.gcd(c0.arg,c1.arg)) > 1 and g > x2.vmax.arg and x2.vmin.arg >= 0 else None),
   # ** mod **
   # mod folding and mod reduction
-  (NOp.var('x') % NOp.cvar('c'), lambda x,c: x if 0 <= x.vmin.arg <= x.vmax.arg < c.arg else None),
+  (NOp.var('x') % NOp.cvar('c'), lambda x,c: x if 0 <= x.vmin.arg <= x.vmax.arg < c.arg else \
+    (x-(x.vmin.arg//c.arg)*c.arg)%c if 0 < c.arg <= x.vmin.arg else None),
   # mul mod
   ((NOp.cvar('c0')*NOp.var('x')) % NOp.cvar('c1'), lambda x,c0,c1:\
    x*(c0.arg%c1.arg)%c1 if 0 < c1.arg <= c0.arg else (x%(c1.arg//c0.arg))*c0 if c1.arg%c0.arg == 0 else None),


### PR DESCRIPTION
Reverts tinygrad/tinygrad#5865

the pattern is correct and test passes with int64 for alu, so we need more rules not less