### PR TITLE
fuzz uops is simpler with List[UOp] [run_process_replay]

### DIFF
--- a/test/external/fuzz_uops.py
+++ b/test/external/fuzz_uops.py
@@ -12,7 +12,7 @@ from tinygrad.shape.symbolic import Variable
 from tinygrad.tensor import _to_np_dtype
 from test.external.fuzz_schedule import FUZZ_SCHEDULE_MAX_PATHS, find_all_toposorts
 
-def fuzz_uops(uops:UOpGraph) -> List[Tuple[UOp, ...]]:
+def fuzz_uops(uops:List[UOp]) -> List[Tuple[UOp, ...]]:
   blocks: List[List[UOp]] = [[]]
   for u in uops:
     if u.op in END_FOR_UOP: blocks.append([u])
@@ -38,24 +38,25 @@ def fuzz_uops(uops:UOpGraph) -> List[Tuple[UOp, ...]]:
 
 class UOpsFuzzerRunner(CompiledRunner):
   def __call__(self, rawbufs:List[Buffer], var_vals:Dict[Variable, int], wait=False):
-    assert self.p.uops is not None and len(self.p.uops._fuzz_paths) >= 1
+    assert self.p.uops is not None
+    fuzz_paths = fuzz_uops(self.p.uops)
     init_rawbufs, init_name = {x:x.as_buffer() for x in rawbufs}, self.p.function_name
-    init_globals = {i[0]:buf for i, buf in zip(self.p.globals, rawbufs)}
-    if DEBUG >= 1: print(colored(f"fuzzing {len(self.p.uops._fuzz_paths)} uop permutations for {init_name}", "yellow"))
+    init_globals = {i:buf for i, buf in zip(self.p.globals, rawbufs)}
+    if DEBUG >= 1: print(colored(f"fuzzing {len(fuzz_paths)} uop permutations for {init_name}", "yellow"))
 
     super().__call__(rawbufs, var_vals, wait)
     ground_truth = {x:np.frombuffer(x.as_buffer(), _to_np_dtype(x.dtype)) for x in rawbufs}
 
-    for i, path in enumerate(self.p.uops._fuzz_paths):
+    for i, path in enumerate(fuzz_paths):
       # setup prg
       uops = UOpGraph([])
       uops._uops = list(path)
       if DEBUG >= 5: uops.print()
-      self.p = replace(self.p, name=(name:=f"{init_name}fuzz{i}"), src=Device[self.p.dname].renderer.render(name, uops), uops=uops)
+      self.p = replace(self.p, name=(name:=f"{init_name}fuzz{i}"), src=Device[self.p.dname].renderer.render(name, uops.uops), uops=uops.uops)
       if DEBUG >= 4: print(self.p.src)
       self.lib = Device[self.p.dname].compiler.compile_cached(self.p.src)
       self.clprg = Device[self.p.dname].runtime(name, self.lib)
-      for x in (rawbufs:=[init_globals[i[0]] for i in self.p.globals]): x.copyin(init_rawbufs[x])
+      for x in (rawbufs:=[init_globals[i] for i in self.p.globals]): x.copyin(init_rawbufs[x])
       # verify
       super().__call__(rawbufs, var_vals, wait)
       for i, x in enumerate(rawbufs):

--- a/test/external/fuzz_uops.py
+++ b/test/external/fuzz_uops.py
@@ -41,7 +41,7 @@ class UOpsFuzzerRunner(CompiledRunner):
     assert self.p.uops is not None
     fuzz_paths = fuzz_uops(self.p.uops)
     init_rawbufs, init_name = {x:x.as_buffer() for x in rawbufs}, self.p.function_name
-    init_globals = {i:buf for i, buf in zip(self.p.globals, rawbufs)}
+    init_globals = dict(zip(self.p.globals, rawbufs))
     if DEBUG >= 1: print(colored(f"fuzzing {len(fuzz_paths)} uop permutations for {init_name}", "yellow"))
 
     super().__call__(rawbufs, var_vals, wait)

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -567,9 +567,4 @@ class UOpGraph:
 
     # strip the SINK
     self._uops = self._uops[:-1]
-
-    if getenv("FUZZ_UOPS"):
-      from test.external.fuzz_uops import fuzz_uops
-      self._fuzz_paths = fuzz_uops(self)
-
     return self

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -158,7 +158,7 @@ def get_runner(dname:str, ast:LazyOp) -> CompiledRunner:
     method_cache[ckey] = ret = CompiledRunner(replace(bret.p, dname=dname), bret.lib)
   else:
     prg: Program = get_kernel(Device[dname].renderer, ast).to_program()
-    if hasattr(prg.uops, "_fuzz_paths"):
+    if getenv("FUZZ_UOPS"):
       from test.external.fuzz_uops import UOpsFuzzerRunner
       return UOpsFuzzerRunner(replace(prg, dname=dname))
     method_cache[ckey] = method_cache[bkey] = ret = CompiledRunner(replace(prg, dname=dname))


### PR DESCRIPTION
FUZZ_UOPS=1 creates the fuzz paths at runtime instead of compile time. This is fine because `get_runner` is behind a cache.