### PR TITLE
Link to tinygrad-tensor-puzzles in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ python3 -m pip install -e .
 
 After you have installed tinygrad, try the [MNIST tutorial](mnist.md)
 
-We also have [developer docs](developer/developer.md), and Di Zhu has created a [bunch of tutorials](https://mesozoic-egg.github.io/tinygrad-notes/) to help understand how tinygrad works.
+We also have [developer docs](developer/developer.md), and Di Zhu has created a [bunch of tutorials](https://mesozoic-egg.github.io/tinygrad-notes/) to help understand how tinygrad works. Additionally, check out [tinygrad-tensor-puzzles](https://github.com/obadakhalili/tinygrad-tensor-puzzles), an implementation of various tensor operations using tinygrad tensors.
 
 ## tinygrad Usage
 


### PR DESCRIPTION
I implemented [Sasha's Tensor Puzzles](https://github.com/srush/Tensor-Puzzles) using tinygrad, and saw that it could be useful to new users of tensor libraries. Thus, I thought I could link my solutions in tinygrad docs. I'm unsure how desired this is though, but here is a PR ..