### PR TITLE
test fused precompute_freqs_cis

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -9,7 +9,7 @@ from tinygrad import nn, dtypes
 from tinygrad.device import Device
 from tinygrad.tensor import Tensor
 from tinygrad.ops import BinaryOps, MetaOps, ReduceOps, UnaryOps, verify_lazyop
-from tinygrad.helpers import DEBUG, FUSE_ARANGE, flatten, getenv
+from tinygrad.helpers import CI, DEBUG, FUSE_ARANGE, flatten, getenv
 from tinygrad.codegen.kernel import Kernel
 from tinygrad.engine.schedule import create_schedule
 from tinygrad.engine.realize import run_schedule
@@ -1412,7 +1412,7 @@ class TestIndexing(unittest.TestCase):
 
   @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
   def test_precompute_freqs_cis(self):
-    args = {"dim":128, "end":8192, "theta":10000, "dtype":dtypes.half}
+    args = {"dim":32 if CI else 128, "end":2048 if CI else 8192, "theta":10000, "dtype":dtypes.half}
     fused = precompute_freqs_cis(**args)
     self.check_schedule(fused, 1)
     ref = precompute_freqs_cis(**args)


### PR DESCRIPTION

![freqs](https://github.com/user-attachments/assets/2f14ed77-db14-4398-8a87-7e0308abcd22)

becomes 1 kernel. But this is slower, can we fold it?
![image](https://github.com/user-attachments/assets/e5f124c1-8698-48c9-b6dd-6408b5b50537)