### PR TITLE
Fix vectorized dtype rendering bug in CLANG

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -62,7 +62,7 @@ class CStyleLanguage(Renderer):
     if self.uses_vload and buf_dtype.scalar() == dtypes.float16 and output_dtype.scalar() != dtypes.float16:
       return f"vload_half{'' if output_dtype.count == 1 else str(output_dtype.count)}(0, {buf_name}+{idx})"
     if output_dtype.count > 1:
-      return f"*(({self.smem_prefix if local and self.smem_prefix_for_cast else self.buffer_prefix}{self.render_dtype(buf_dtype)}{output_dtype.count}*)({buf_name}+{idx}))"  # noqa: E501
+      return f"*(({self.smem_prefix if local and self.smem_prefix_for_cast else self.buffer_prefix}{self.render_dtype(output_dtype)}*)({buf_name}+{idx}))"  # noqa: E501
     return f"*({buf_name}+{idx})" if self.uses_ptr_arithmetic else f"{buf_name}[{idx}]"
 
   def get_kernel_modifier(self, uops:List[UOp]) -> str: return ""
@@ -85,11 +85,12 @@ class CStyleLanguage(Renderer):
       return f"vstore_half{'' if var_dtype.count == 1 else str(var_dtype.count)}({var_name}, 0, {buf_name}+{idx});"
     if var_dtype.count > 1:
       prefix = self.smem_prefix if local and self.smem_prefix_for_cast else self.buffer_prefix
-      return f"*(({prefix}{self.render_dtype(buf_dtype)}{var_dtype.count}*)({buf_name}+{idx})) = {var_name};"
+      return f"*(({prefix}{self.render_dtype(var_dtype)}*)({buf_name}+{idx})) = {var_name};"
     return f"*({buf_name}+{idx}) = {var_name};" if self.uses_ptr_arithmetic else f"{buf_name}[{idx}] = {var_name};"
 
   def render_local(self, name:str, dtype:DType, size:int): return self.smem_align + self.smem_prefix + f"{self.render_dtype(dtype)} {name}[{size}];"
-  def render_dtype(self, var_dtype:DType) -> str: return self.type_map.get(var_dtype, var_dtype.name)
+  def render_dtype(self, var_dtype:DType) -> str:
+    return self.type_map.get(scalar:=var_dtype.scalar(), scalar.name) + str(count) if (count:=var_dtype.count) > 1 else ""
 
   def render(self, name:str, uops:List[UOp]) -> str:
     kernel = []

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -90,7 +90,7 @@ class CStyleLanguage(Renderer):
 
   def render_local(self, name:str, dtype:DType, size:int): return self.smem_align + self.smem_prefix + f"{self.render_dtype(dtype)} {name}[{size}];"
   def render_dtype(self, var_dtype:DType) -> str:
-    return self.type_map.get(scalar:=var_dtype.scalar(), scalar.name) + (str(count) if (count:=var_dtype.count) > 1 else "")
+    return self.type_map.get(scalar:=var_dtype.scalar(), scalar.name) + (str(var_dtype.count) if (var_dtype.count) > 1 else "")
 
   def render(self, name:str, uops:List[UOp]) -> str:
     kernel = []

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -90,7 +90,7 @@ class CStyleLanguage(Renderer):
 
   def render_local(self, name:str, dtype:DType, size:int): return self.smem_align + self.smem_prefix + f"{self.render_dtype(dtype)} {name}[{size}];"
   def render_dtype(self, var_dtype:DType) -> str:
-    return self.type_map.get(scalar:=var_dtype.scalar(), scalar.name) + str(count) if (count:=var_dtype.count) > 1 else ""
+    return self.type_map.get(scalar:=var_dtype.scalar(), scalar.name) + (str(count) if (count:=var_dtype.count) > 1 else "")
 
   def render(self, name:str, uops:List[UOp]) -> str:
     kernel = []


### PR DESCRIPTION
Fix bug where vectorized dtypes would render differently

Now, self.render_dtype is in charge of rendering vectorized correctly

### Before fix

CLANG has the following type_map: `type_map = {dtypes.bool:"_Bool", dtypes.half:"__fp16"}`

for half4 render_cast and render_vectorized would render `half4`
``` python
# returns a str expression of the casted xs with the given type
def render_cast(self, x:str, var_dtype:DType, bitcast=False) -> str:
  if bitcast: return f"(*(({self.buffer_prefix}{self.render_dtype(var_dtype)}*)&{x}))"
  return f"({self.render_dtype(var_dtype)})({x})"

# returns a str expression of the vectorized xs with the given type
def render_vectorize(self, x:List[str], var_dtype:DType) -> str:
  assert len(x) == var_dtype.count, f"cast is wrong size {len(x)} != {var_dtype.count}"
  assert self.float4 is not None, "vectorized cast is not supported on this platform"
  return f"{self.float4.replace('float4', self.render_dtype(var_dtype))}({','.join(x)})"
```

but render_store and render_load would render `__fp164`:
``` python
# returns a str expression of the loaded value with the output type
def render_load(self, output_dtype, buf_name, buf_dtype, idx, local=False) -> str:
  [...]
  if output_dtype.count > 1:
    return f"*(({self.smem_prefix if local and self.smem_prefix_for_cast else self.buffer_prefix}{self.render_dtype(buf_dtype)}{output_dtype.count}*)({buf_name}+{idx}))" 

# returns a str statement that does the store
def render_store(self, buf_name:str, buf_dtype:DType, var_name:str, var_dtype:DType, idx:str, local=False) -> str:
  [...]
  if var_dtype.count > 1:
    prefix = self.smem_prefix if local and self.smem_prefix_for_cast else self.buffer_prefix
    return f"*(({prefix}{self.render_dtype(buf_dtype)}{var_dtype.count}*)({buf_name}+{idx})) = {var_name};"
```

### After fix

vectorized dtypes are renderer correctly as `(mapped_dtype + count)`, example: `__fp164`:

```python
def render_dtype(self, var_dtype:DType) -> str:
  return self.type_map.get(scalar:=var_dtype.scalar(), scalar.name) + (str(var_dtype.count) if (var_dtype.count) > 1 else "")
```