### PR TITLE
Diff arange timings

### DIFF
--- a/test/external/process_replay/diff_schedule.py
+++ b/test/external/process_replay/diff_schedule.py
@@ -2,30 +2,35 @@
 import difflib #, ocdiff
 from collections import defaultdict
 from typing import DefaultDict, List, Set, Tuple
-from tinygrad.device import Device
+from tinygrad.engine.schedule import ScheduleItem
 from tinygrad.helpers import colored
 from tinygrad.lazy import LazyBuffer
 from tinygrad.ops import LazyOp
-from tinygrad.engine.realize import get_kernel
-
-def render(ast:LazyOp) -> str:
-  k = get_kernel(Device[Device.DEFAULT].renderer, ast)
-  return k.to_program().src
+from tinygrad.engine.realize import lower_schedule_item
 
 def diff_schedule(s):
-  ast_for_buf: DefaultDict[LazyBuffer, List[LazyOp]] = defaultdict(list)
+  si_for_buf: DefaultDict[LazyBuffer, List[ScheduleItem]] = defaultdict(list)
   for _,prescheduled in s:
     for ps in prescheduled.values():
-      for buf in ps[0]: ast_for_buf[buf].append(ps[1])
+      for buf in ps[0]: si_for_buf[buf].append(ScheduleItem(ps[1], tuple(x.buffer for x in ps[0]+ps[2] if x.size != 0), ps[4]))
   changed = 0
   seen_diff: Set[Tuple[LazyOp, LazyOp]] = set()
-  for buf, ast in ast_for_buf.items():
-    if len(set(ast)) == 1: continue
-    if (ast[0], ast[1]) in seen_diff: continue
-    seen_diff.add((ast[0], ast[1]))
+  for buf, si in si_for_buf.items():
+    asts = [x.ast for x in si]
+    if len(set(asts)) == 1: continue
+    if (asts[0], asts[1]) in seen_diff: continue
+    seen_diff.add((asts[0], asts[1]))
     changed += 1
     #print(ocdiff.console_diff(render(ast[0]), render(ast[1])))
-    diff = list(difflib.unified_diff(render(ast[0]).splitlines(), render(ast[1]).splitlines()))
+    ei0 = lower_schedule_item(si[0])
+    ei1 = lower_schedule_item(si[1])
+    diff = list(difflib.unified_diff(ei0.prg.p.src.splitlines(), ei1.prg.p.src.splitlines()))
     unified_diff = "\n".join(colored(line, "red" if line.startswith("-") else "green" if line.startswith("+") else None) for line in diff)
     print(unified_diff)
+    tm0 = ei0.run(wait=True)
+    tm1 = ei1.run(wait=True)
+    assert tm0 is not None and tm1 is not None
+    tm_diff = ((tm0 - tm1) / tm0) * 100
+    if tm_diff > 0: print(colored(f"{tm_diff:.2f}% faster", "green"))
+    else: print(colored(f"{tm_diff:,.2f}% slower", "red"))
   print(f"{changed} unique kernel{'s' if changed>1 else ''} changed")

--- a/test/external/process_replay/diff_schedule.py
+++ b/test/external/process_replay/diff_schedule.py
@@ -3,7 +3,7 @@ import difflib #, ocdiff
 from collections import defaultdict
 from typing import DefaultDict, List, Set, Tuple
 from tinygrad.engine.schedule import ScheduleItem
-from tinygrad.helpers import colored
+from tinygrad.helpers import Context, colored
 from tinygrad.lazy import LazyBuffer
 from tinygrad.ops import LazyOp
 from tinygrad.engine.realize import lower_schedule_item
@@ -27,8 +27,9 @@ def diff_schedule(s):
     diff = list(difflib.unified_diff(ei0.prg.p.src.splitlines(), ei1.prg.p.src.splitlines()))
     unified_diff = "\n".join(colored(line, "red" if line.startswith("-") else "green" if line.startswith("+") else None) for line in diff)
     print(unified_diff)
-    tm0 = ei0.run(wait=True)
-    tm1 = ei1.run(wait=True)
+    with Context(DEBUG=2):
+      tm0 = ei0.run(wait=True)
+      tm1 = ei1.run(wait=True)
     assert tm0 is not None and tm1 is not None
     tm_diff = ((tm0 - tm1) / tm0) * 100
     if tm_diff > 0: print(colored(f"{tm_diff:.2f}% faster", "green"))


### PR DESCRIPTION
runs both versions as ExecItems:
![image](https://github.com/user-attachments/assets/65bd0201-8aa8-462f-8660-57deaa0e6e21)
