### PR TITLE
fix the reduceops cache breaking beautiful_mnist

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1464,7 +1464,7 @@ class TestIndexing(unittest.TestCase):
     Y = Tensor([1, 2]).realize()
     loss = X.sparse_categorical_crossentropy(Y)
     self.check_schedule(loss, 5)
-    np.testing.assert_allclose(loss.item(), 0.878309)
+    np.testing.assert_allclose(loss.item(), 0.878309, atol=1e-5, rtol=1e-6)
 
   def test_arange_fuse_grouped_children(self):
     X = Tensor.randn(4, 4).realize()

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1466,19 +1466,18 @@ class TestIndexing(unittest.TestCase):
     self.check_schedule(loss, 5)
     np.testing.assert_allclose(loss.item(), 0.878309, atol=1e-5, rtol=1e-6)
 
-  def test_sparse_categorical_crossentropy_alt(self):
+  def test_mnist_val(self):
     from tinygrad.nn.datasets import mnist
-    import torch
-    with Context(DEBUG=0):
-      X_train, Y_train, _, _ = mnist()
-      yt = Tensor.randn(512, 100).realize()
-      samples = Tensor.randint(getenv("BS", 512), high=X_train.shape[0]).realize()
-    y = Y_train[samples]
-    loss = yt.sparse_categorical_crossentropy(y)
-    self.check_schedule(loss, 8)
-    y_ref = torch.tensor(Y_train.numpy())[torch.tensor(samples.numpy())]
-    loss_ref = torch.nn.CrossEntropyLoss()(torch.tensor(yt.numpy()), y_ref)
-    np.testing.assert_allclose(loss.numpy(), loss_ref.numpy(), atol=1e-5, rtol=1e-6)
+    _, Y_train, _, _ = mnist()
+    samples = Tensor.randint(getenv("BS", 512), high=6000)
+    yt = Tensor.randn(512, 10)
+    with Context(SPLIT_REDUCEOP=0):
+      loss = yt.sparse_categorical_crossentropy(Y_train[samples])
+      self.check_schedule(loss, 6)
+      loss_fused = loss.numpy()
+    loss_ref = yt.sparse_categorical_crossentropy(Y_train[samples])
+    run_schedule(check_schedule(loss_ref, 9))
+    np.testing.assert_allclose(loss_fused, loss_ref.numpy(), atol=1e-6, rtol=1e-6)
 
   def test_arange_fuse_grouped_children(self):
     X = Tensor.randn(4, 4).realize()

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1458,5 +1458,12 @@ class TestIndexing(unittest.TestCase):
     xref[:, :2] = np.arange(8).reshape(4, 2)+y.numpy()
     np.testing.assert_equal(x.numpy(), xref)
 
+  def test_sparse_categorical_crossentropy_simple(self):
+    X = Tensor([[0, 2, 3], [1, 2, 3]]).realize()
+    Y = Tensor([1, 2]).realize()
+    loss = X.sparse_categorical_crossentropy(Y)
+    self.check_schedule(loss, 5)
+    np.testing.assert_allclose(loss.item(), 0.878309)
+
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -91,8 +91,8 @@ def _permute_reduce(input_st:ShapeTracker, axis:Tuple[int, ...]) -> Tuple[ShapeT
 
 def _recurse_reduceops(buf:LazyBuffer, st:ShapeTracker, realizes:Dict[LazyBuffer, None], outs:List[LazyBuffer],\
     reduce_info:Dict[Tuple[LazyBuffer, ShapeTracker], Tuple[ShapeTracker, Tuple[int, ...]]], cache) -> Optional[Tuple[LazyBuffer, ShapeTracker]]:
-  if buf.base.realized is not None or (buf.base in realizes and buf.base not in outs) or (buf, st) in cache: return None
-  cache.setdefault((buf, st))
+  if (buf, st) in cache: return cache[(buf, st)]
+  if buf.base.realized is not None or (buf.base in realizes and buf.base not in outs): return None
   if buf is not buf.base: st, buf = buf.st+st, buf.base
   input_st = ShapeTracker.from_shape(buf.srcs[0].shape) if buf.op in ReduceOps else st
   reduce_srcs = [r for x in buf.srcs if (r:=_recurse_reduceops(x, input_st, realizes, outs, reduce_info, cache)) is not None]
@@ -123,7 +123,7 @@ def _recurse_reduceops(buf:LazyBuffer, st:ShapeTracker, realizes:Dict[LazyBuffer
     st = st.reshape(reduce_st(input_st, axis))
     reduce_info[(buf, st)] = (input_st, axis)
     return (buf, st)
-  return top_reduce
+  return cache.setdefault((buf, st), top_reduce)
 
 def _lower_lazybuffer(outs:List[LazyBuffer], realizes:Dict[LazyBuffer, None]):
   """describe the computation for a LazyBuffer with LazyOp + inputs + var_vals"""


### PR DESCRIPTION
```
~/code/tinygrad> SPLIT_REDUCEOP=0 FUSE_ARANGE=1 python3 examples/beautiful_mnist.py
loss:   0.10 test_accuracy: 98.30%: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 70/70 [00:07<00:00,  9.40it/s]
```