### PR TITLE
Improve error message if clang is not installed

### DIFF
--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -12,7 +12,7 @@ class ClangCompiler(Compiler):
                                '-o', str(output_file.name)], input=src.encode('utf-8'))
         return pathlib.Path(output_file.name).read_bytes()
     except FileNotFoundError as e:
-      if shutil.which('clang'): raise Exception('clang not installed')
+      if not shutil.which('clang'): raise Exception('clang not installed')
       else: raise e
 
 class ClangProgram:

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -1,4 +1,4 @@
-import ctypes, subprocess, pathlib, tempfile
+import ctypes, subprocess, pathlib, tempfile, shutil
 from tinygrad.device import Compiled, Compiler, MallocAllocator
 from tinygrad.helpers import cpu_time_execution, DEBUG, cpu_objdump
 from tinygrad.renderer.cstyle import ClangRenderer
@@ -24,5 +24,6 @@ class ClangProgram:
 
 class ClangDevice(Compiled):
   def __init__(self, device:str):
+    assert shutil.which('clang') is not None, 'clang not installed'
     from tinygrad.runtime.graph.clang import ClangGraph
     super().__init__(device, MallocAllocator, ClangRenderer(), ClangCompiler("compile_clang"), ClangProgram, ClangGraph)


### PR DESCRIPTION
Current error message is `FileNotFoundError: [Errno 2] No such file or directory: 'clang'` 