### PR TITLE
Refactor render_kernel for NV [run_process_replay]

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -271,7 +271,7 @@ _nms = "xyzwabcdefghijkl"
 def _make_cuda_dtype(self, dtype):
   vec, scalar = self.render_dtype(dtype), self.render_dtype(dtype.scalar()),
   elems, header = ', '.join(_nms[:dtype.count]), ', '.join([f"{scalar} {x}" for x in _nms[:dtype.count]])
-  return f"struct __align__({dtype.itemsize}) {vec} {{ {scalar} {elems}; }}; __device__ {vec} make_{vec}({header}) {{ {vec} r={{{elems}}}; return r; }}"
+  return f"struct __align__({dtype.itemsize}) {vec} {{ {scalar} {elems}; }}; __device__ {vec} make_{vec}({header}) {{ {vec} r={{{elems}}}; return r; }}" # noqa:E501
 
 class CUDARenderer(CStyleLanguage):
   device = "CUDA"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -269,8 +269,9 @@ code_for_op_half = {UnaryOps.RECIP: lambda x,dtype: f"hrcp({x})" if dtype in (dt
 
 _nms = "xyzwabcdefghijkl"
 def _make_cuda_dtype(self, dtype):
-  vec, elems, header = self.render_dtype(dtype), ', '.join(_nms[:dtype.count()]), ', '.join([f"{self.render_dtype(dtype.scalar())} {x}" for x in _nms[:dtype.count()]]) # noqa:E501
-  return f"struct __align__({dtype.size()}) {vec} {{ {self.render_dtype(dtype.scalar())} {elems}; }}; __device__ {vec} make_{vec}({header}) {{ {vec} r={{{elems}}}; return r; }}" # noqa:E501
+  vec, scalar = self.render_dtype(dtype), self.render_dtype(dtype.scalar()),
+  elems, header = ', '.join(_nms[:dtype.count()]), ', '.join([f"{scalar} {x}" for x in _nms[:dtype.count()]])
+  return f"struct __align__({dtype.size()}) {vec} {{ {scalar} {elems}; }}; __device__ {vec} make_{vec}({header}) {{ {vec} r={{{elems}}}; return r; }}"
 
 class CUDARenderer(CStyleLanguage):
   device = "CUDA"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -305,8 +305,10 @@ class CUDARenderer(CStyleLanguage):
     # if any(uop.dtype == dtypes.bfloat16 for uop in uops):
     #   prefix += ["#include <cuda_bf16.h>"] + [_make_cuda_dtype("nv_bfloat16", x, x*2) for x in [4, 8]]
 
+    prefix += [f"#include <cuda_{dt_map[dtype]}>.h" for dtype in dedup(uop.dtype for uop in uops if uop.dtype in (dtypes.half, dtypes.bfloat16))]
+
     for dtype in dedup(uop.dtype for uop in uops if uop.dtype.scalar() in (dtypes.half, dtypes.bfloat16) and uop.dtype.count>1):
-      prefix += [f"#include <cuda_{dt_map[dtype.scalar()]}>.h"] + [_make_cuda_dtype(self, dtype)]
+      prefix += [_make_cuda_dtype(self, dtype)]
 
     # TODO: this has to be way better to generate for arbitrary M,N,K: use arg[1] for MNK, use arg[4] for vec sizes, encode register packing
     for arg in dedup([uop.arg for uop in uops if uop.op is UOps.WMMA]):

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -268,10 +268,10 @@ code_for_op_half = {UnaryOps.RECIP: lambda x,dtype: f"hrcp({x})" if dtype in (dt
                     UnaryOps.EXP2: lambda x,dtype: f"hexp2({x})" if dtype in (dtypes.half, dtypes.bfloat16) else f"exp2({x})",}
 
 _nms = "xyzwabcdefghijkl"
-def _make_cuda_dtype(self, dtype):
-  vec, scalar = self.render_dtype(dtype), self.render_dtype(dtype.scalar()),
-  elems, header = ', '.join(_nms[:dtype.count]), ', '.join([f"{scalar} {x}" for x in _nms[:dtype.count]])
-  return f"struct __align__({dtype.itemsize}) {vec} {{ {scalar} {elems}; }}; __device__ {vec} make_{vec}({header}) {{ {vec} r={{{elems}}}; return r; }}" # noqa:E501
+def _make_cuda_dtype(renderer: CStyleLanguage, dtype: DType) -> str:
+  vec, scal = renderer.render_dtype(dtype), renderer.render_dtype(dtype.scalar()),
+  elems, header = ', '.join(_nms[:dtype.count]), ', '.join([f"{scal} {x}" for x in _nms[:dtype.count]])
+  return f"struct __align__({dtype.itemsize}) {vec} {{ {scal} {elems}; }}; __device__ {vec} make_{vec}({header}) {{ {vec} r={{{elems}}}; return r; }}"
 
 class CUDARenderer(CStyleLanguage):
   device = "CUDA"
@@ -296,12 +296,15 @@ class CUDARenderer(CStyleLanguage):
     # TODO: why is dtypes.bfloat16.name == "__bf16"? would be easier not override dtypes.name
     prefix = ["#define INFINITY (__int_as_float(0x7f800000))","#define NAN (__int_as_float(0x7fffffff))"]
 
-    for dtype in dedup(uop.dtype for uop in uops if uop.dtype is not None and uop.dtype.scalar() in (dtypes.half, dtypes.bfloat16)):
-      prefix += [f"#include <cuda_{'fp' if dtype == dtypes.half else 'bf'}16.h>"] if dtype.count == 1 else [_make_cuda_dtype(self, dtype)]
+    # for dtype in dedup(uop.dtype for uop in uops if uop.dtype is not None and uop.dtype.scalar() in (dtypes.half, dtypes.bfloat16)):
+    #   prefix += [f"#include <cuda_{'fp' if dtype == dtypes.half else 'bf'}16.h>"] if dtype.count == 1 else [_make_cuda_dtype(self, dtype)]
+
+    for dtype in dedup(uop.dtype for uop in uops if uop.dtype is not None and uop.dtype in (dtypes.half, dtypes.bfloat16)):
+      prefix += [f"#include <cuda_{'fp' if dtype == dtypes.half else 'bf'}16.h>"] + [_make_cuda_dtype(self, dtype.vec(sz)) for sz in [4, 8]]
 
     # TODO: this has to be way better to generate for arbitrary M,N,K: use arg[1] for MNK, use arg[4] for vec sizes, encode register packing
+    dt_map = { dtypes.float: "f32", dtypes.half: "f16", dtypes.bfloat16: "bf16" }
     for arg in dedup([uop.arg for uop in uops if uop.op is UOps.WMMA]):
-      dt_map = { dtypes.float: "f32", dtypes.half: "f16", dtypes.bfloat16: "bf16" }
       fn, ti, to, ci, co = arg[0], self.render_dtype(arg[2]), self.render_dtype(arg[3]), dt_map[arg[2]], dt_map[arg[3]]
       prefix.append(f"""__device__ {to}4 __{fn}({ti}8 a, {ti}4 b, {to}4 c) {{ int *a_pk = (int *) (&a), *b_pk = (int *) (&b);
 asm( "mma.sync.aligned.m16n8k16.row.col.{co}.{ci}.{ci}.{co} {{ %0, %1, %2, %3 }}, {{ %4, %5, %6, %7 }}, {{ %8, %9 }}, {{ %0, %1, %2, %3 }};"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -296,6 +296,10 @@ class CUDARenderer(CStyleLanguage):
     if any(uop.dtype == dtypes.bfloat16 for uop in uops):
       prefix += ["#include <cuda_bf16.h>"] + [_make_cuda_dtype("nv_bfloat16", x, x*2) for x in [4, 8]]
 
+    for uop in uops:
+      if uop.dtype == dtypes.half: prefix += ["#include <cuda_fp16.h>"] + [_make_cuda_dtype("half", x, x*2) for x in [4, 8]]
+      if uop.dtype == dtypes.bfloat16: prefix += ["#include <cuda_bf16.h>"] + [_make_cuda_dtype("nv_bfloat16", x, x*2) for x in [4, 8]]
+
     # TODO: this has to be way better to generate for arbitrary M,N,K: use arg[1] for MNK, use arg[4] for vec sizes, encode register packing
     for arg in dedup([uop.arg for uop in uops if uop.op is UOps.WMMA]):
       fn, ti, to, ci, co = arg[0], dt_map[arg[2]][0], dt_map[arg[3]][0], dt_map[arg[2]][1], dt_map[arg[3]][1]

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -295,7 +295,7 @@ class CUDARenderer(CStyleLanguage):
   def render_kernel(self, function_name, kernel, bufs, uops, prefix=None):
     # TODO: why is dtypes.bfloat16.name == "__bf16"? would be easier not override dtypes.name
     # TODO: refactor to render_dtype here
-    dt_map = { dtypes.float: ("float","f32"), dtypes.half: ("half","f16"), dtypes.bfloat16: ("nv_bfloat16","bf16"), }
+    dt_map = { dtypes.float: "f32", dtypes.half: "f16", dtypes.bfloat16: "bf16" }
 
     prefix = ["#define INFINITY (__int_as_float(0x7f800000))","#define NAN (__int_as_float(0x7fffffff))"]
 
@@ -305,12 +305,12 @@ class CUDARenderer(CStyleLanguage):
     # if any(uop.dtype == dtypes.bfloat16 for uop in uops):
     #   prefix += ["#include <cuda_bf16.h>"] + [_make_cuda_dtype("nv_bfloat16", x, x*2) for x in [4, 8]]
 
-    for dtype in dedup(uop.dtype for uop in uops if uop.dtype in (dtypes.half, dtypes.bfloat16) and uop.dtype.count>1):
-      prefix += [f"#include <cuda_{dt_map[dtype]}>.h"] + [_make_cuda_dtype(self, dtype)]
+    for dtype in dedup(uop.dtype for uop in uops if uop.dtype.scalar() in (dtypes.half, dtypes.bfloat16) and uop.dtype.count>1):
+      prefix += [f"#include <cuda_{dt_map[dtype.scalar()]}>.h"] + [_make_cuda_dtype(self, dtype)]
 
     # TODO: this has to be way better to generate for arbitrary M,N,K: use arg[1] for MNK, use arg[4] for vec sizes, encode register packing
     for arg in dedup([uop.arg for uop in uops if uop.op is UOps.WMMA]):
-      fn, ti, to, ci, co = arg[0], dt_map[arg[2]][0], dt_map[arg[3]][0], dt_map[arg[2]][1], dt_map[arg[3]][1]
+      fn, ti, to, ci, co = arg[0], self.render_dtype(arg[2]), self.render_dtype(arg[3]), dt_map[arg[2]], dt_map[arg[3]]
       prefix.append(f"""__device__ {to}4 __{fn}({ti}8 a, {ti}4 b, {to}4 c) {{ int *a_pk = (int *) (&a), *b_pk = (int *) (&b);
 asm( "mma.sync.aligned.m16n8k16.row.col.{co}.{ci}.{ci}.{co} {{ %0, %1, %2, %3 }}, {{ %4, %5, %6, %7 }}, {{ %8, %9 }}, {{ %0, %1, %2, %3 }};"
   : "+f"(c.x), "+f"(c.y), "+f"(c.z), "+f"(c.w) : "r"(a_pk[0]), "r"(a_pk[1]), "r"(a_pk[2]),  "r"(a_pk[3]), "r"(b_pk[0]), "r"(b_pk[1]) );

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -296,9 +296,6 @@ class CUDARenderer(CStyleLanguage):
     # TODO: why is dtypes.bfloat16.name == "__bf16"? would be easier not override dtypes.name
     prefix = ["#define INFINITY (__int_as_float(0x7f800000))","#define NAN (__int_as_float(0x7fffffff))"]
 
-    # for dtype in dedup(uop.dtype for uop in uops if uop.dtype is not None and uop.dtype.scalar() in (dtypes.half, dtypes.bfloat16)):
-    #   prefix += [f"#include <cuda_{'fp' if dtype == dtypes.half else 'bf'}16.h>"] if dtype.count == 1 else [_make_cuda_dtype(self, dtype)]
-
     for dtype in dedup(uop.dtype for uop in uops if uop.dtype is not None and uop.dtype in (dtypes.half, dtypes.bfloat16)):
       prefix += [f"#include <cuda_{'fp' if dtype == dtypes.half else 'bf'}16.h>"] + [_make_cuda_dtype(self, dtype.vec(sz)) for sz in [4, 8]]
 


### PR DESCRIPTION
It's failing process_replay because it is no longer rendering the vectorization structs if there are not used. Before, if there was type half or bfloat present, the vectorization structs would render automatically.

**kernel failing process_replay**

```c
#define INFINITY (__int_as_float(0x7f800000))
#define NAN (__int_as_float(0x7fffffff))
#include <cuda_fp16.h>
extern "C" __global__ void __launch_bounds__(1) r_4096_32000_32000n1(half* data0, const int* data1, const half* data2) {
  int gidx0 = blockIdx.x; /* 4096 */
  int val0 = data1[0];
  float acc0 = 0.0f;
  for (int ridx0 = 0; ridx0 < 32000; ridx0++) {
    half val1 = data2[gidx0+(ridx0*4096)];
    acc0 = (acc0+(float)(((half)((!(ridx0!=val0)))*val1)));
  }
  data0[gidx0] = (half)(acc0);
}
```

``` diff
 #define INFINITY (__int_as_float(0x7f800000))
 #define NAN (__int_as_float(0x7fffffff))
 #include <cuda_fp16.h>
-struct __align__(8) half4 { half x, y, z, w; }; __device__ half4 make_half4(half x, half y, half z, half w) { half4 r={x, y, z, w}; return r; }
-struct __align__(16) half8 { half x, y, z, w, a, b, c, d; }; __device__ half8 make_half8(half x, half y, half z, half w, half a, half b, half c, half d) { half8 r={x, y, z, w, a, b, c, d}; return r; }
 extern "C" __global__ void __launch_bounds__(1) r_4096_32000_32000(half* data0, const int* data1, const half* data2) {
   int gidx0 = blockIdx.x; /* 4096 */
   int val0 = data1[0];
Process Process-16:
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/runner/work/tinygrad/tinygrad/process_replay.py", line 69, in diff_kernel
    if ASSERT_DIFF: raise e
```