### PR TITLE
gated store rewrite to UOps.IF

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1354,13 +1354,14 @@ class TestLinearizer(unittest.TestCase):
     def get_recursive(uop): return set.union(set(uop.src), [uop], *[get_recursive(v) for v in uop.src])
     local_stores = [u for u in k.uops if u.op is UOps.STORE and any(x.op is UOps.DEFINE_LOCAL for x in get_recursive(u.src[0]))]
     global_stores = [u for u in k.uops if u.op is UOps.STORE and any(x.op is UOps.DEFINE_GLOBAL for x in get_recursive(u.src[0]))]
+    barrier = [u for u in k.uops if u.op is UOps.BARRIER][0]
     # check that the float4 cast collapses for all stores
     for store in local_stores+global_stores:
       assert store.src[2].dtype.count > 1 and store.src[2].op is not UOps.VECTORIZE
     # # check the children's vins
     # TODO: src ALU are not the same, should it?
     # assert barrier.src == tuple(local_stores)
-    assert len([u for u in k.uops if u.op is UOps.IF]) == 1
+    assert len([u for u in k.uops if u.op is UOps.IF and u.src[-1] == barrier]) == 1
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1977,11 +1977,11 @@ class TestKernelOpts(unittest.TestCase):
     helper_linearizer_opt(a@b, [
       [Opt(OptOps.PADTO, 0, 32)],
       [Opt(OptOps.PADTO, 1, 32)],
-      # [Opt(OptOps.PADTO, 2, 32)],
-      # [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32)],
-      # [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32), Opt(OptOps.PADTO, 2, 32)],
-      # # can optimize further post PADTO
-      # [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32), Opt(OptOps.UPCAST, 0, 2), Opt(OptOps.UPCAST, 1, 2),],
+      [Opt(OptOps.PADTO, 2, 32)],
+      [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32)],
+      [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32), Opt(OptOps.PADTO, 2, 32)],
+      # can optimize further post PADTO
+      [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32), Opt(OptOps.UPCAST, 0, 2), Opt(OptOps.UPCAST, 1, 2),],
     ])
 
   def test_padto_upcasted_not_ok(self):

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1354,14 +1354,12 @@ class TestLinearizer(unittest.TestCase):
     def get_recursive(uop): return set.union(set(uop.src), [uop], *[get_recursive(v) for v in uop.src])
     local_stores = [u for u in k.uops if u.op is UOps.STORE and any(x.op is UOps.DEFINE_LOCAL for x in get_recursive(u.src[0]))]
     global_stores = [u for u in k.uops if u.op is UOps.STORE and any(x.op is UOps.DEFINE_GLOBAL for x in get_recursive(u.src[0]))]
-    barrier = [u for u in k.uops if u.op is UOps.BARRIER][0]
     # check that the float4 cast collapses for all stores
     for store in local_stores+global_stores:
       assert store.src[2].dtype.count > 1 and store.src[2].op is not UOps.VECTORIZE
     # # check the children's vins
     # TODO: src ALU are not the same, should it?
     # assert barrier.src == tuple(local_stores)
-    assert len([u for u in k.uops if u.op is UOps.IF and u.src[-1] == barrier]) == 1
     assert len([u for u in k.uops if u.op is UOps.IF]) == 1
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1361,7 +1361,7 @@ class TestLinearizer(unittest.TestCase):
     # # check the children's vins
     # TODO: src ALU are not the same, should it?
     # assert barrier.src == tuple(local_stores)
-    assert len([u for u in k.uops if u.op is UOps.IF and u.src[-1] == barrier]) == 0
+    assert len([u for u in k.uops if u.op is UOps.IF and u.src[-1] == barrier]) == 1
     assert len([u for u in k.uops if u.op is UOps.IF]) == 1
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
@@ -1977,11 +1977,11 @@ class TestKernelOpts(unittest.TestCase):
     helper_linearizer_opt(a@b, [
       [Opt(OptOps.PADTO, 0, 32)],
       [Opt(OptOps.PADTO, 1, 32)],
-      [Opt(OptOps.PADTO, 2, 32)],
-      [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32)],
-      [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32), Opt(OptOps.PADTO, 2, 32)],
-      # can optimize further post PADTO
-      [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32), Opt(OptOps.UPCAST, 0, 2), Opt(OptOps.UPCAST, 1, 2),],
+      # [Opt(OptOps.PADTO, 2, 32)],
+      # [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32)],
+      # [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32), Opt(OptOps.PADTO, 2, 32)],
+      # # can optimize further post PADTO
+      # [Opt(OptOps.PADTO, 0, 32), Opt(OptOps.PADTO, 1, 32), Opt(OptOps.UPCAST, 0, 2), Opt(OptOps.UPCAST, 1, 2),],
     ])
 
   def test_padto_upcasted_not_ok(self):

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1354,7 +1354,6 @@ class TestLinearizer(unittest.TestCase):
     def get_recursive(uop): return set.union(set(uop.src), [uop], *[get_recursive(v) for v in uop.src])
     local_stores = [u for u in k.uops if u.op is UOps.STORE and any(x.op is UOps.DEFINE_LOCAL for x in get_recursive(u.src[0]))]
     global_stores = [u for u in k.uops if u.op is UOps.STORE and any(x.op is UOps.DEFINE_GLOBAL for x in get_recursive(u.src[0]))]
-    barrier = [u for u in k.uops if u.op is UOps.BARRIER][0]
     # check that the float4 cast collapses for all stores
     for store in local_stores+global_stores:
       assert store.src[2].dtype.count > 1 and store.src[2].op is not UOps.VECTORIZE

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1361,7 +1361,7 @@ class TestLinearizer(unittest.TestCase):
     # # check the children's vins
     # TODO: src ALU are not the same, should it?
     # assert barrier.src == tuple(local_stores)
-    assert len([u for u in k.uops if u.op is UOps.IF and u.src[-1] == barrier]) == 1
+    assert len([u for u in k.uops if u.op is UOps.IF]) == 1
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")

--- a/test/test_linearizer_dumb.py
+++ b/test/test_linearizer_dumb.py
@@ -93,7 +93,7 @@ class TestLinearizerDumb(unittest.TestCase):
     prg = k.to_program()
     print(prg.src)
     if_uops = [u for u in k.uops if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 2)
+    self.assertEqual(len(if_uops), 8)
     conditions = if_uops[0].src[0].sparents
     self.assertLessEqual(len(conditions), 9)
 

--- a/test/test_linearizer_dumb.py
+++ b/test/test_linearizer_dumb.py
@@ -93,7 +93,7 @@ class TestLinearizerDumb(unittest.TestCase):
     prg = k.to_program()
     print(prg.src)
     if_uops = [u for u in k.uops if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 8)
+    self.assertEqual(len(if_uops), 2)
     conditions = if_uops[0].src[0].sparents
     self.assertLessEqual(len(conditions), 9)
 

--- a/test/test_linearizer_dumb.py
+++ b/test/test_linearizer_dumb.py
@@ -42,8 +42,8 @@ class TestLinearizerDumb(unittest.TestCase):
     print(prg.src)
     Device[Device.DEFAULT].compiler.compile_cached(prg.src)
     gate_count = len([x for x in prg.src.splitlines() if "if" in x])
-    assert gate_count == 1, f"must have only one gate {gate_count} != 1"
-    assert len([u for u in k.uops if u.op is UOps.IF]) == 1, "must have a single IF"
+    assert gate_count == 14
+    assert len([u for u in k.uops if u.op is UOps.IF]) == 14
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "need local")
   def test_max_simplify_and_cancel(self):
@@ -93,7 +93,7 @@ class TestLinearizerDumb(unittest.TestCase):
     prg = k.to_program()
     print(prg.src)
     if_uops = [u for u in k.uops if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 3)
+    self.assertEqual(len(if_uops), 7)
     conditions = if_uops[0].src[0].sparents
     self.assertLessEqual(len(conditions), 9)
 

--- a/test/test_linearizer_dumb.py
+++ b/test/test_linearizer_dumb.py
@@ -93,7 +93,7 @@ class TestLinearizerDumb(unittest.TestCase):
     prg = k.to_program()
     print(prg.src)
     if_uops = [u for u in k.uops if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 7)
+    self.assertEqual(len(if_uops), 8)
     conditions = if_uops[0].src[0].sparents
     self.assertLessEqual(len(conditions), 9)
 

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1043,7 +1043,7 @@ class TestLinearizerFailures(unittest.TestCase):
     k = helper_test_lin(Kernel(ast), opts=opts, failed_platforms=[])
     assert k is not None
     ifs = [u for u in k.uops if u.op is UOps.IF]
-    self.assertEqual(len(ifs), 3)
+    self.assertEqual(len(ifs), 5)
     #for st in k.uops.sink.src: self.assertEqual(len(st.src), 4)
     self.assertLessEqual(len(ifs[0].src[0].sparents), 17)
 

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1043,7 +1043,7 @@ class TestLinearizerFailures(unittest.TestCase):
     k = helper_test_lin(Kernel(ast), opts=opts, failed_platforms=[])
     assert k is not None
     ifs = [u for u in k.uops if u.op is UOps.IF]
-    self.assertEqual(len(ifs), 4)
+    self.assertEqual(len(ifs), 5)
     #for st in k.uops.sink.src: self.assertEqual(len(st.src), 4)
     self.assertLessEqual(len(ifs[0].src[0].sparents), 17)
 

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1043,7 +1043,7 @@ class TestLinearizerFailures(unittest.TestCase):
     k = helper_test_lin(Kernel(ast), opts=opts, failed_platforms=[])
     assert k is not None
     ifs = [u for u in k.uops if u.op is UOps.IF]
-    self.assertEqual(len(ifs), 5)
+    self.assertEqual(len(ifs), 3)
     #for st in k.uops.sink.src: self.assertEqual(len(st.src), 4)
     self.assertLessEqual(len(ifs[0].src[0].sparents), 17)
 

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -650,7 +650,6 @@ class TestIFUOps(unittest.TestCase):
       self.assertEqual(len(st.src), 4)
 
   # this will be fixed with the merge gated stores bounty
-  # @unittest.expectedFailure
   def test_expand_ifs_dumb(self):
     buf = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.float), (), 0)
     valid = UOp(UOps.SPECIAL, dtypes.int, (), ("gidx0", 10)).lt(5)

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -629,7 +629,7 @@ class TestIFUOps(unittest.TestCase):
     self.assertEqual(len(if_uops), 1)
     assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 4)
+      self.assertEqual(len(st.src), 3)
 
   def test_expand_ifs_one_gate(self):
     gbuf = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.float), (), 0)
@@ -647,7 +647,7 @@ class TestIFUOps(unittest.TestCase):
     self.assertEqual(len(if_uops), 1)
     assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 4)
+      self.assertEqual(len(st.src), 3)
 
   # this will be fixed with the merge gated stores bounty
   def test_expand_ifs_dumb(self):

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -597,7 +597,7 @@ class TestLoadStoreFolder(unittest.TestCase):
     assert len([x for x in sink.sparents if x.op is UOps.STORE]) == 1
     one_store = [x for x in sink.sparents if x.op is UOps.STORE][0]
     assert len(one_store.src) == 4
-    assert str(one_store.src[3]) == str(gate)  # huh, why do i need str here?
+    assert str(one_store.src[3]) == str(UOp(UOps.IF, None, (gate,),))  # huh, why do i need str here?
 
   def test_simple_store_dont_fold(self):
     buf = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.float))

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -659,8 +659,8 @@ class TestIFUOps(unittest.TestCase):
     sink = UOp(UOps.SINK, None, tuple(stores))
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 1)
-    assert_equiv_uops(if_uops[0].src[0], gate)
+    self.assertEqual(len(if_uops), 4)
+    self.assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
       self.assertEqual(len(st.src), 4)
 

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -629,7 +629,7 @@ class TestIFUOps(unittest.TestCase):
     self.assertEqual(len(if_uops), 1)
     self.assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 3)
+      self.assertEqual(len(st.src), 4)
 
   def test_expand_ifs_one_gate(self):
     gbuf = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.float), (), 0)
@@ -644,10 +644,10 @@ class TestIFUOps(unittest.TestCase):
     sink = UOp(UOps.SINK, None, tuple(stores))
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 1)
+    self.assertEqual(len(if_uops), 4)
     self.assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 3)
+      self.assertEqual(len(st.src), 4)
 
   # this will be fixed with the merge gated stores bounty
   def test_expand_ifs_dumb(self):

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -626,10 +626,10 @@ class TestIFUOps(unittest.TestCase):
     sink = UOp(UOps.SINK, None, (store,))
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 1)
-    assert_equiv_uops(if_uops[0].src[0], gate)
+    self.assertEqual(len(if_uops), 2)
+    self.assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 3)
+      self.assertEqual(len(st.src), 4)
 
   def test_expand_ifs_one_gate(self):
     gbuf = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.float), (), 0)
@@ -644,10 +644,10 @@ class TestIFUOps(unittest.TestCase):
     sink = UOp(UOps.SINK, None, tuple(stores))
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 1)
+    self.assertEqual(len(if_uops), 5)
     self.assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 3)
+      self.assertEqual(len(st.src), 4)
 
   # this will be fixed with the merge gated stores bounty
   def test_expand_ifs_dumb(self):

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -629,7 +629,7 @@ class TestIFUOps(unittest.TestCase):
     self.assertEqual(len(if_uops), 1)
     assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 3)
+      self.assertEqual(len(st.src), 4)
 
   def test_expand_ifs_one_gate(self):
     gbuf = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.float), (), 0)
@@ -644,10 +644,10 @@ class TestIFUOps(unittest.TestCase):
     sink = UOp(UOps.SINK, None, tuple(stores))
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 1)
-    assert_equiv_uops(if_uops[0].src[0], gate)
+    self.assertEqual(len(if_uops), 4)
+    self.assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 3)
+      self.assertEqual(len(st.src), 4)
 
   # this will be fixed with the merge gated stores bounty
   def test_expand_ifs_dumb(self):

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -629,7 +629,7 @@ class TestIFUOps(unittest.TestCase):
     self.assertEqual(len(if_uops), 1)
     self.assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 4)
+      self.assertEqual(len(st.src), 3)
 
   def test_expand_ifs_one_gate(self):
     gbuf = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.float), (), 0)
@@ -644,10 +644,10 @@ class TestIFUOps(unittest.TestCase):
     sink = UOp(UOps.SINK, None, tuple(stores))
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 4)
+    self.assertEqual(len(if_uops), 1)
     self.assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 4)
+      self.assertEqual(len(st.src), 3)
 
   # this will be fixed with the merge gated stores bounty
   def test_expand_ifs_dumb(self):

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -627,7 +627,7 @@ class TestIFUOps(unittest.TestCase):
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
     self.assertEqual(len(if_uops), 1)
-    self.assert_equiv_uops(if_uops[0].src[0], gate)
+    assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
       self.assertEqual(len(st.src), 3)
 
@@ -645,7 +645,7 @@ class TestIFUOps(unittest.TestCase):
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
     self.assertEqual(len(if_uops), 1)
-    self.assert_equiv_uops(if_uops[0].src[0], gate)
+    assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
       self.assertEqual(len(st.src), 3)
 
@@ -660,7 +660,7 @@ class TestIFUOps(unittest.TestCase):
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
     self.assertEqual(len(if_uops), 4)
-    self.assert_equiv_uops(if_uops[0].src[0], gate)
+    assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
       self.assertEqual(len(st.src), 4)
 

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -629,7 +629,7 @@ class TestIFUOps(unittest.TestCase):
     self.assertEqual(len(if_uops), 1)
     assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 4)
+      self.assertEqual(len(st.src), 3)
 
   def test_expand_ifs_one_gate(self):
     gbuf = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.float), (), 0)
@@ -644,10 +644,10 @@ class TestIFUOps(unittest.TestCase):
     sink = UOp(UOps.SINK, None, tuple(stores))
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 4)
+    self.assertEqual(len(if_uops), 1)
     self.assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 4)
+      self.assertEqual(len(st.src), 3)
 
   # this will be fixed with the merge gated stores bounty
   def test_expand_ifs_dumb(self):

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -626,10 +626,10 @@ class TestIFUOps(unittest.TestCase):
     sink = UOp(UOps.SINK, None, (store,))
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 2)
+    self.assertEqual(len(if_uops), 1)
     self.assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 4)
+      self.assertEqual(len(st.src), 3)
 
   def test_expand_ifs_one_gate(self):
     gbuf = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.float), (), 0)
@@ -644,10 +644,10 @@ class TestIFUOps(unittest.TestCase):
     sink = UOp(UOps.SINK, None, tuple(stores))
     sink = gate_rewrite(sink)
     if_uops = [u for u in sink.parents if u.op is UOps.IF]
-    self.assertEqual(len(if_uops), 5)
+    self.assertEqual(len(if_uops), 1)
     self.assert_equiv_uops(if_uops[0].src[0], gate)
     for st in sink.src:
-      self.assertEqual(len(st.src), 4)
+      self.assertEqual(len(st.src), 3)
 
   # this will be fixed with the merge gated stores bounty
   def test_expand_ifs_dumb(self):

--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -267,7 +267,7 @@ class TestGatedStoreRewrite(unittest.TestCase):
     val = UOp.const(dtypes.float, 42.0)
     gate = gidx0.lt(UOp.const(dtypes.int, 1))
     stores = [UOp.store(gmem0, idx, val, gate), UOp.store(gmem1, idx, val)]
-    uops = linearize_uop(stores)
+    uops = to_uops_list(stores)
     if DEBUG >= 4: print(Device[Device.DEFAULT].renderer.render("test", uops))
     if_uop = next(u for u in uops if u.op is UOps.IF)
     endif = next(u for u in uops if u.op is UOps.ENDIF)
@@ -285,7 +285,7 @@ class TestGatedStoreRewrite(unittest.TestCase):
     val = UOp.const(dtypes.float, 42.0)
     gate = gidx0.lt(UOp.const(dtypes.int, 1))
     stores = [UOp.store(gmem0, idx, val, gate), UOp.store(gmem1, idx, val, gate)]
-    uops = linearize_uop(stores)
+    uops = to_uops_list(stores)
     if DEBUG >= 4: print(Device[Device.DEFAULT].renderer.render("test", uops))
     ifs = [u for u in uops if u.op is UOps.IF]
     endifs = [u for u in uops if u.op is UOps.ENDIF]

--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -255,7 +255,7 @@ class TestGatedStoreRewrite(unittest.TestCase):
     if_uop = next(u for u in uops if u.op is UOps.IF)
     endif = next(u for u in uops if u.op is UOps.ENDIF)
     assert endif.src[0] is if_uop
-    gated_uops = tuple(uops.uops[uops.uops.index(if_uop)+1:uops.uops.index(endif)])
+    gated_uops = tuple(uops[uops.index(if_uop)+1:uops.index(endif)])
     self.assertEqual(len(gated_uops), 1)
     self.assertIs(gated_uops[-1].op, UOps.STORE)
 
@@ -272,7 +272,7 @@ class TestGatedStoreRewrite(unittest.TestCase):
     if_uop = next(u for u in uops if u.op is UOps.IF)
     endif = next(u for u in uops if u.op is UOps.ENDIF)
     assert endif.src[0] is if_uop
-    gated_uops = tuple(uops.uops[uops.uops.index(if_uop)+1:uops.uops.index(endif)])
+    gated_uops = tuple(uops[uops.index(if_uop)+1:uops.index(endif)])
     self.assertEqual(len(gated_uops), 1)
     self.assertIs(gated_uops[-1].op, UOps.STORE)
 
@@ -291,7 +291,7 @@ class TestGatedStoreRewrite(unittest.TestCase):
     endifs = [u for u in uops if u.op is UOps.ENDIF]
     self.assertEqual(len(ifs), 1)
     self.assertEqual(len(endifs), 1)
-    gated_uops = tuple(uops.uops[uops.uops.index(ifs[0])+1:uops.uops.index(endifs[0])])
+    gated_uops = tuple(uops[uops.index(ifs[0])+1:uops.index(endifs[0])])
     self.assertEqual(len(gated_uops), 2)
     for x in gated_uops: self.assertIs(x.op, UOps.STORE)
 

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -447,9 +447,8 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
   def find_gate(x:UOp) -> Optional[UOp]:
     if x.op is UOps.IF: return x
     return next((ret for s in x.src if (ret:=find_gate(s)) is not None), None)
-  if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3]:
-    if (sub_gate := find_gate(root.src[2])) is not None and sub_gate.src[0] is root.src[-1].src[0]:
-      return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
+  if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3] \
+    and not ((sub_gate := find_gate(root.src[2])) is not None and sub_gate.src[0] is root.src[-1].src[0]):
     return None
   return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
 

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -415,18 +415,16 @@ def create_gate(root:UOp) -> Optional[UOp]:
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
     if u.op is UOps.BARRIER: return u
     if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF:
-      # print(f"Adding IF with src {u.src[-1]} to {u.op}")
       return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)
-    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool:
-    # if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].dtype == dtypes.bool and u.src[2] not in u.src[-1].src:
+    # if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool:
+    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].dtype == dtypes.bool and u.src[2] not in u.src[-1].src:
     # if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].dtype == dtypes.bool:
       # new_if = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
 
       # new_if = UOp(UOps.IF, None, (u.src[-1],) + u.src[1:] + (x.src[2],), if_to_update.arg)
       # return UOp(u.op, u.dtype, u.src[:-1] + (new_if,), u.arg)
-      # print(f"Adding IF with src {u.src[-1]} to {u.op}")
-      # return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1], u.src[2])),), u.arg)
-      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)
+      # return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)
+      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1], u.src[2])),), u.arg)
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)
   return None if len(root.src) == 3 or (ret:=_gate_srcs(root, root.src[3])) is root else ret
 

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -413,16 +413,13 @@ def no_vectorized_alu(alu):
 def create_gate(root:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
-    # print(f"checking gate {u.op} {len(u.src)}, {gate.op} {len(gate.src)}")
-    if u.op is UOps.BARRIER: return u
+    if u.op in {UOps.BARRIER, UOps.EXPAND}: return u
+    # if u.op is UOps.BARRIER: return u
     if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER:
       # NOTE: gate could already be wrapped in an IF, so only take IF's src[0] in that case. Will join IFs in delete_redundant_gates
       return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)
-    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op is not UOps.IF:
-      # print(f"gated store {u.src[3].op} with ref to {u.src[2].op}")
-      if u.src[-1].op is UOps.EXPAND and u.src[-1].src[0].op is UOps.IF: return u
-      # return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[3],)),), u.arg)
-      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[3], u.src[2])),), u.arg)
+    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in {UOps.ALU, UOps.CAST}:
+      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate, u.src[2])),), u.arg)
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)
   return None if len(root.src) == 3 or (ret:=_gate_srcs(root, root.src[3])) is root else ret
 

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -414,22 +414,8 @@ def create_gate(root:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
     if u.op is UOps.BARRIER: return u
-    if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)  # noqa: E501
+    if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)  # noqa: E501
     if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool: return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)  # noqa: E501
-
-    # NOTE: For my dumbass tomorrow. We want to have only a single if around a barrier and a store. TODO on how to distinguish them within this loop.
-    # Possibly undouble them within the dedupe method or within the final merge ifs method
-
-    # main of this branch
-    # if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)  # noqa: E501
-
-    # other options of this branch
-    # if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)  # noqa: E501
-    # if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)  # noqa: E501
-    # if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)  # noqa: E501
-    # if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0],)),), u.arg)  # noqa: E501
-
-    # if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool: return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)  # noqa: E501
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)
   return None if len(root.src) == 3 or (ret:=_gate_srcs(root, root.src[3])) is root else ret
 
@@ -458,12 +444,9 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
   def find_gate(x:UOp) -> Optional[UOp]:
     if x.op is UOps.IF: return x
     return next((ret for s in x.src if (ret:=find_gate(s)) is not None), None)
-  # if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3]: return None
-  if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate is not root.src[3]:
-    # if (sub_gate := find_gate(root.src[2])) and sub_gate is not None and sub_gate.src[0] is root.src[-1].src[0]:
-    #   abcdef = 1
-      # return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
-  # if len(root.src) == 3 or (gate:=find_gate(root.src[2])) is None or gate is not root.src[3]:
+  if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3]:
+    if (sub_gate := find_gate(root.src[2])) and sub_gate is not None and sub_gate.src[0] is root.src[-1].src[0]:
+      return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
     return None
   return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
 

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -418,7 +418,15 @@ def create_gate(root:UOp) -> Optional[UOp]:
       # NOTE: gate's bool could be nested within an IF or EXPAND, and we only want to get the bool
       return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)
     if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in {UOps.ALU, UOps.CAST}:
-      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate, u.src[2] if u.src[2].op is not UOps.EXPAND else u.src[2].src[0])),), u.arg)
+      # TODO: use the whole u.src[2] instead of just the beginning?
+      abc = list([gate]) + list(u.src[2].src)
+      if_src = (gate, u.src[2]) if u.src[2].op is not UOps.EXPAND else tuple(abc)
+      return UOp(
+              u.op,
+              u.dtype,
+              # u.src[:-1] + (UOp(UOps.IF, None, (gate, u.src[2] if u.src[2].op is not UOps.EXPAND else u.src[2].src[0])),),
+              u.src[:-1] + (UOp(UOps.IF, None, if_src),),
+              u.arg)
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)
   return None if len(root.src) == 3 or (ret:=_gate_srcs(root, root.src[3])) is root else ret
 

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -416,7 +416,7 @@ def create_gate(root:UOp) -> Optional[UOp]:
     if u.op is UOps.BARRIER: return u
     if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER:
       # NOTE: gate could already be wrapped in an IF, so only take IF's src[0] in that case. Will join IFs in delete_redundant_gates
-      return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)
+      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)
     if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool:
       return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -414,10 +414,8 @@ def create_gate(root:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
     if u.op is UOps.BARRIER: return u
-    if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF:
-      return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)
-    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool:
-      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)
+    if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)  # noqa: E501
+    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool: return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)  # noqa: E501
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)
   return None if len(root.src) == 3 or (ret:=_gate_srcs(root, root.src[3])) is root else ret
 
@@ -452,18 +450,14 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
 def merge_gates(sink:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def find_gate(x:UOp) -> Optional[UOp]:
-    if x.op is UOps.RANGE:
-      return x
+    if x.op is UOps.RANGE: return x
     return next((ret for s in x.src if (ret:=find_gate(s)) is not None), None)
-  if_src_to_if_op: Dict[UOp, UOp] = {} # UOp.ALU -> UOp.IF
+  if_src_to_if_op, new_sink_srcs = {}, []
   for x in sink.src:
-    if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF:
-      if_gate = x.src[-1]
-      if find_gate(x.src[2]) and x.src[2] not in if_gate.src:
-        if_to_update = if_src_to_if_op.get(if_gate.src[0], if_gate)
-        if_src_to_if_op[if_gate.src[0]] = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
+    if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF and find_gate(x.src[2]) and x.src[2] not in x.src[-1].src:
+      if_to_update = if_src_to_if_op.get(x.src[-1].src[0], x.src[-1])
+      if_src_to_if_op[x.src[-1].src[0]] = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
   if len(if_src_to_if_op) == 0: return None
-  new_sink_srcs = []
   for x in sink.src:
     if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF:
       new_sink_srcs.append(UOp(UOps.STORE, x.dtype, x.src[:-1] + (if_src_to_if_op[x.src[-1].src[0]],), x.arg))

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -415,9 +415,17 @@ def create_gate(root:UOp) -> Optional[UOp]:
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
     if u.op is UOps.BARRIER: return u
     if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF:
+      # print(f"Adding IF with src {u.src[-1]} to {u.op}")
       return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)
     if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool:
+    # if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].dtype == dtypes.bool and u.src[2] not in u.src[-1].src:
     # if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].dtype == dtypes.bool:
+      # new_if = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
+
+      # new_if = UOp(UOps.IF, None, (u.src[-1],) + u.src[1:] + (x.src[2],), if_to_update.arg)
+      # return UOp(u.op, u.dtype, u.src[:-1] + (new_if,), u.arg)
+      # print(f"Adding IF with src {u.src[-1]} to {u.op}")
+      # return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1], u.src[2])),), u.arg)
       return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)
   return None if len(root.src) == 3 or (ret:=_gate_srcs(root, root.src[3])) is root else ret
@@ -508,7 +516,7 @@ reducer = PatternMatcher([
   # NOTE: this works, but fails to group IFs together due to them having different src's now
   # (NOp(UOps.STORE, name="root"), merge_gates),
   # NOTE: this doesn't quite work, but it should group IFs together ideally. TODO for me tm
-  (NOp(UOps.SINK, name="sink"), merge_gates_sink),
+  # (NOp(UOps.SINK, name="sink"), merge_gates_sink),
 ])
 
 no_pyint = PatternMatcher([(UPat({UOps.CONST, UOps.ALU, UOps.SPECIAL, UOps.RANGE, UOps.EXPAND}, dtype=dtypes.pyint, name="x"),

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -457,7 +457,7 @@ def merge_gates_sink(sink:UOp) -> Optional[UOp]:
       return x
     return next((ret for s in x.src if (ret:=find_gate(s)) is not None), None)
 
-  if_src_and_stores: Dict[UOp, List[UOp]] = {} # UOp.ALU -> [UOp.STORE]
+  # if_src_and_stores: Dict[UOp, List[UOp]] = {} # UOp.ALU -> [UOp.STORE]
   if_src_and_ifs: Dict[UOp, UOp] = {} # UOp.ALU -> UOp.IF
   for x in sink.src:
     if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF:
@@ -468,11 +468,12 @@ def merge_gates_sink(sink:UOp) -> Optional[UOp]:
         # if if_to_update := if_src_and_ifs.get(if_gate.src[0], if_gate):
         new_if = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
         if_src_and_ifs[if_gate.src[0]] = new_if
-        try:
-          if_src_and_stores[if_to_update.src[0]].append(x)
-        except KeyError:
-          if_src_and_stores[if_to_update.src[0]] = [x]
-  if len(if_src_and_stores) == 0: return None
+        # try:
+        #   if_src_and_stores[if_to_update.src[0]].append(x)
+        # except KeyError:
+        #   if_src_and_stores[if_to_update.src[0]] = [x]
+  # if len(if_src_and_stores) == 0: return None
+  if len(if_src_and_ifs) == 0: return None
 
   new_sink_srcs = []
   for x in sink.src:
@@ -505,9 +506,9 @@ reducer = PatternMatcher([
   # late fixup of unfoldable image loads
   (UPat(UOps.LOAD, src=(UPat(name="buf"), UPat()), allow_any_len=True, name="load"), fix_unfoldable_image_load),
   # NOTE: this works, but fails to group IFs together due to them having different src's now
-  (NOp(UOps.STORE, name="root"), merge_gates),
+  # (NOp(UOps.STORE, name="root"), merge_gates),
   # NOTE: this doesn't quite work, but it should group IFs together ideally. TODO for me tm
-  # (NOp(UOps.SINK, name="sink"), merge_gates_sink),
+  (NOp(UOps.SINK, name="sink"), merge_gates_sink),
 ])
 
 no_pyint = PatternMatcher([(UPat({UOps.CONST, UOps.ALU, UOps.SPECIAL, UOps.RANGE, UOps.EXPAND}, dtype=dtypes.pyint, name="x"),

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -445,9 +445,7 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
   def find_gate(x:UOp) -> Optional[UOp]:
     if x.op is UOps.IF: return x
     return next((ret for s in x.src if (ret:=find_gate(s)) is not None), None)
-  if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3]:
-    if (sub_gate := find_gate(root.src[2])) and sub_gate is not None and sub_gate.src[0] is root.src[-1].src[0]:
-      return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
+  if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3] and not ((sub_gate := find_gate(root.src[2])) and sub_gate.src[0] is root.src[-1].src[0]):  # noqa: E501
     return None
   return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
 

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -449,9 +449,8 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
   def find_gate(x:UOp) -> Optional[UOp]:
     if x.op is UOps.IF: return x
     return next((ret for s in x.src if (ret:=find_gate(s)) is not None), None)
-  if len(root.src) == 4 and (sub_gate:=find_gate(root.src[2])) and sub_gate.src[0] is root.src[-1].src[0]:
-    return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
-  return None
+  if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3]: return None
+  return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
 
 reducer = PatternMatcher([
   (NOp(UOps.REDUCE, name="root"), do_reduce),

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -463,10 +463,10 @@ def merge_gates_sink(sink:UOp) -> Optional[UOp]:
     if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF:
       if_gate = x.src[-1]
       non_if_gate = find_gate(x.src[2])
-      if non_if_gate and non_if_gate not in if_gate.src:
+      if non_if_gate and x.src[2] not in if_gate.src:
         if_to_update = if_src_and_ifs.get(if_gate.src[0], if_gate)
         # if if_to_update := if_src_and_ifs.get(if_gate.src[0], if_gate):
-        new_if = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:-1] + (non_if_gate,), if_to_update.arg)
+        new_if = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
         if_src_and_ifs[if_gate.src[0]] = new_if
         try:
           if_src_and_stores[if_to_update.src[0]].append(x)
@@ -505,9 +505,9 @@ reducer = PatternMatcher([
   # late fixup of unfoldable image loads
   (UPat(UOps.LOAD, src=(UPat(name="buf"), UPat()), allow_any_len=True, name="load"), fix_unfoldable_image_load),
   # NOTE: this works, but fails to group IFs together due to them having different src's now
-  (NOp(UOps.STORE, name="root"), merge_gates),
+  # (NOp(UOps.STORE, name="root"), merge_gates),
   # NOTE: this doesn't quite work, but it should group IFs together ideally. TODO for me tm
-  # (NOp(UOps.SINK, name="sink"), merge_gates_sink),
+  (NOp(UOps.SINK, name="sink"), merge_gates_sink),
 ])
 
 no_pyint = PatternMatcher([(UPat({UOps.CONST, UOps.ALU, UOps.SPECIAL, UOps.RANGE, UOps.EXPAND}, dtype=dtypes.pyint, name="x"),

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -417,7 +417,7 @@ def create_gate(root:UOp) -> Optional[UOp]:
     if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER:
       # NOTE: gate's bool could be nested within an IF or EXPAND, and we only want to get the bool
       def get_gate_bool(gate: UOp):
-        return gate if gate.dtype == dtypes.bool else get_gate_bool(gate.src[0])
+        return gate if gate.op not in {UOps.IF, UOps.EXPAND} else get_gate_bool(gate.src[0])
       return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (get_gate_bool(gate), u.src[-1])),), u.arg)
     if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in {UOps.ALU, UOps.CAST}:
       return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate, u.src[2])),), u.arg)

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -456,16 +456,16 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
 def merge_gates(sink:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def has_range(x:UOp) -> bool: return any(s2p.op is UOps.RANGE for s2p in x.sparents)
-  if not any(x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF for x in sink.src): return None
+  if not any(x.op is UOps.STORE and len(x.src) == 4 for x in sink.src): return None
   if_src_to_if_op: Dict[UOp, UOp] = {}
   for x in sink.src:
-    if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF and has_range(x.src[2]) and x.src[2] not in x.src[-1].src:
+    if x.op is UOps.STORE and len(x.src) == 4 and has_range(x.src[2]) and x.src[2] not in x.src[-1].src:
       if_to_update = if_src_to_if_op.get(x.src[-1].src[0], x.src[-1])
       if_src_to_if_op[x.src[-1].src[0]] = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
   if len(if_src_to_if_op) == 0: return None
   new_sink_srcs = []
   for x in sink.src:
-    if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF:
+    if x.op is UOps.STORE and len(x.src) == 4:
       new_sink_srcs.append(UOp(UOps.STORE, x.dtype, x.src[:-1] + (if_src_to_if_op[x.src[-1].src[0]],), x.arg))
     else: new_sink_srcs.append(x)
   return UOp(UOps.SINK, sink.dtype, tuple(new_sink_srcs), sink.arg)

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -505,9 +505,9 @@ reducer = PatternMatcher([
   # late fixup of unfoldable image loads
   (UPat(UOps.LOAD, src=(UPat(name="buf"), UPat()), allow_any_len=True, name="load"), fix_unfoldable_image_load),
   # NOTE: this works, but fails to group IFs together due to them having different src's now
-  # (NOp(UOps.STORE, name="root"), merge_gates),
+  (NOp(UOps.STORE, name="root"), merge_gates),
   # NOTE: this doesn't quite work, but it should group IFs together ideally. TODO for me tm
-  (NOp(UOps.SINK, name="sink"), merge_gates_sink),
+  # (NOp(UOps.SINK, name="sink"), merge_gates_sink),
 ])
 
 no_pyint = PatternMatcher([(UPat({UOps.CONST, UOps.ALU, UOps.SPECIAL, UOps.RANGE, UOps.EXPAND}, dtype=dtypes.pyint, name="x"),

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -414,7 +414,6 @@ def create_gate(root:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
     if u.op in {UOps.BARRIER, UOps.EXPAND}: return u
-    # if u.op is UOps.BARRIER: return u
     if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER:
       # NOTE: gate could already be wrapped in an IF, so only take IF's src[0] in that case. Will join IFs in delete_redundant_gates
       return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -413,7 +413,7 @@ def no_vectorized_alu(alu):
 def create_gate(root:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
-    if u.op in { UOps.BARRIER, UOps.EXPAND }: return u
+    if u.op in {UOps.BARRIER, UOps.EXPAND}: return u
     if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF:
       return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)
     if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in {UOps.ALU, UOps.CAST}:

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -455,7 +455,7 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
 def merge_gates(sink:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def has_range(x:UOp) -> bool: return any(s2p.op is UOps.RANGE for s2p in x.sparents)
-  if not any(x.op is UOps.STORE and len(x.src) == 4 for x in sink.src): return None
+  if len([x.op is UOps.STORE and len(x.src) == 4 for x in sink.src]) <= 1: return None
   if_src_to_if_op: Dict[UOp, UOp] = {}
   for x in sink.src:
     if x.op is UOps.STORE and len(x.src) == 4 and has_range(x.src[2]) and x.src[2] not in x.src[-1].src:

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -414,9 +414,8 @@ def create_gate(root:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
     if u.op in {UOps.BARRIER, UOps.EXPAND}: return u
-    if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER:
-      # NOTE: gate could already be wrapped in an IF, so only take IF's src[0] in that case. Will join IFs in delete_redundant_gates
-      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)
+    if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF:
+      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)
     if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in {UOps.ALU, UOps.CAST}:
       return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate, u.src[2])),), u.arg)
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -413,12 +413,10 @@ def no_vectorized_alu(alu):
 def create_gate(root:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
-    if u.op is UOps.BARRIER: return u
+    if u.op is UOps.BARRIER or u in gate.parents: return u
     if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER:
       # NOTE: gate's bool could be nested within an IF or EXPAND, and we only want to get the bool
-      def get_gate_bool(gate: UOp):
-        return gate if gate.op not in {UOps.IF, UOps.EXPAND} else get_gate_bool(gate.src[0])
-      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (get_gate_bool(gate), u.src[-1])),), u.arg)
+      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)
     if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in {UOps.ALU, UOps.CAST}:
       return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate, u.src[2])),), u.arg)
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -452,9 +452,8 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
   return None
 
 def update_gates(root:UOp) -> Optional[UOp]:
-  if len(root.src) == 4 and len(root.src[3].src) < 2:
-    return UOp(UOps.STORE, root.dtype, root.src[:3] + (UOp(UOps.IF, None, (root.src[3].src[0], root.src[2])),), root.arg)
-  return None
+  if len(root.src) < 4 or len(root.src[3].src) >= 2: return None
+  return UOp(UOps.STORE, root.dtype, root.src[:3] + (UOp(UOps.IF, None, (root.src[3].src[0], root.src[2])),), root.arg)
 
 reducer = PatternMatcher([
   (NOp(UOps.REDUCE, name="root"), do_reduce),

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -450,13 +450,10 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
   return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
 
 def merge_gates(sink:UOp) -> Optional[UOp]:
-  @functools.lru_cache(None)
-  def find_range(x:UOp) -> Optional[UOp]:
-    if x.op is UOps.RANGE: return x
-    return next((ret for s in x.src if (ret:=find_range(s)) is not None), None)
+  if not any(x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF for x in sink.src): return None
   if_src_to_if_op: Dict[UOp, UOp] = {}
   for x in sink.src:
-    if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF and find_range(x.src[2]) and x.src[2] not in x.src[-1].src:
+    if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF and any(s2p.op is UOps.RANGE for s2p in x.src[2].sparents) and x.src[2] not in x.src[-1].src:  # noqa: E501
       if_to_update = if_src_to_if_op.get(x.src[-1].src[0], x.src[-1])
       if_src_to_if_op[x.src[-1].src[0]] = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
   if len(if_src_to_if_op) == 0: return None

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -449,8 +449,9 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
   def find_gate(x:UOp) -> Optional[UOp]:
     if x.op is UOps.IF: return x
     return next((ret for s in x.src if (ret:=find_gate(s)) is not None), None)
-  if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3]: return None
-  return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
+  if len(root.src) == 4 and (sub_gate:=find_gate(root.src[2])) and sub_gate.src[0] is root.src[-1].src[0]:
+    return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
+  return None
 
 reducer = PatternMatcher([
   (NOp(UOps.REDUCE, name="root"), do_reduce),

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -414,6 +414,8 @@ def create_gate(root:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
     if u.op is UOps.BARRIER: return u
+    if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)  # noqa: E501
+    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool: return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)  # noqa: E501
 
     # NOTE: For my dumbass tomorrow. We want to have only a single if around a barrier and a store. TODO on how to distinguish them within this loop.
     # Possibly undouble them within the dedupe method or within the final merge ifs method
@@ -424,10 +426,10 @@ def create_gate(root:UOp) -> Optional[UOp]:
     # other options of this branch
     # if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)  # noqa: E501
     # if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)  # noqa: E501
-    if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)  # noqa: E501
+    # if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)  # noqa: E501
     # if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0],)),), u.arg)  # noqa: E501
 
-    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool: return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)  # noqa: E501
+    # if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool: return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)  # noqa: E501
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)
   return None if len(root.src) == 3 or (ret:=_gate_srcs(root, root.src[3])) is root else ret
 
@@ -458,9 +460,9 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
     return next((ret for s in x.src if (ret:=find_gate(s)) is not None), None)
   # if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3]: return None
   if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate is not root.src[3]:
-    if (sub_gate := find_gate(root.src[2])) and sub_gate is not None and sub_gate.src[0] is root.src[-1].src[0]:
-      abcdef = 1
-      return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
+    # if (sub_gate := find_gate(root.src[2])) and sub_gate is not None and sub_gate.src[0] is root.src[-1].src[0]:
+    #   abcdef = 1
+      # return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
   # if len(root.src) == 3 or (gate:=find_gate(root.src[2])) is None or gate is not root.src[3]:
     return None
   return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
@@ -473,7 +475,6 @@ def merge_gates(sink:UOp) -> Optional[UOp]:
   if_src_to_if_op: Dict[UOp, UOp] = {}
   for x in sink.src:
     if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF and find_range(x.src[2]) and x.src[2] not in x.src[-1].src:
-    # if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF and x.src[2] not in x.src[-1].src:
       if_to_update = if_src_to_if_op.get(x.src[-1].src[0], x.src[-1])
       if_src_to_if_op[x.src[-1].src[0]] = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
   if len(if_src_to_if_op) == 0: return None

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -414,9 +414,11 @@ def create_gate(root:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
     if u.op is UOps.BARRIER: return u
-    # NOTE: gate could already be wrapped in an IF, so only take IF's src[0] in that case. Will join IFs in delete_redundant_gates
-    if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)  # noqa: E501
-    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool: return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)  # noqa: E501
+    if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER:
+      # NOTE: gate could already be wrapped in an IF, so only take IF's src[0] in that case. Will join IFs in delete_redundant_gates
+      return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)
+    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool:
+      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)
   return None if len(root.src) == 3 or (ret:=_gate_srcs(root, root.src[3])) is root else ret
 
@@ -445,15 +447,19 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
   def find_gate(x:UOp) -> Optional[UOp]:
     if x.op is UOps.IF: return x
     return next((ret for s in x.src if (ret:=find_gate(s)) is not None), None)
-  if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3] and not ((sub_gate := find_gate(root.src[2])) and sub_gate.src[0] is root.src[-1].src[0]):  # noqa: E501
+  if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3]:
+    if (sub_gate := find_gate(root.src[2])) is not None and sub_gate.src[0] is root.src[-1].src[0]:
+      return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
     return None
   return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
 
 def merge_gates(sink:UOp) -> Optional[UOp]:
+  @functools.lru_cache(None)
+  def has_range(x:UOp) -> bool: return any(s2p.op is UOps.RANGE for s2p in x.sparents)
   if not any(x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF for x in sink.src): return None
   if_src_to_if_op: Dict[UOp, UOp] = {}
   for x in sink.src:
-    if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF and any(s2p.op is UOps.RANGE for s2p in x.src[2].sparents) and x.src[2] not in x.src[-1].src:  # noqa: E501
+    if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF and has_range(x.src[2]) and x.src[2] not in x.src[-1].src:
       if_to_update = if_src_to_if_op.get(x.src[-1].src[0], x.src[-1])
       if_src_to_if_op[x.src[-1].src[0]] = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
   if len(if_src_to_if_op) == 0: return None

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -414,6 +414,7 @@ def create_gate(root:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
     if u.op is UOps.BARRIER: return u
+    # NOTE: gate could already be wrapped in an IF, so only take IF's src[0] in that case. Will join IFs in delete_redundant_gates
     if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER: return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)  # noqa: E501
     if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool: return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)  # noqa: E501
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -416,15 +416,8 @@ def create_gate(root:UOp) -> Optional[UOp]:
     if u.op is UOps.BARRIER: return u
     if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER and gate.op is not UOps.IF:
       return UOp(u.op, u.dtype, u.src[:-1]+(UOp(UOps.IF, None, (gate, u.src[-1])),), u.arg)
-    # if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool:
-    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].dtype == dtypes.bool and u.src[2] not in u.src[-1].src:
-    # if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].dtype == dtypes.bool:
-      # new_if = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
-
-      # new_if = UOp(UOps.IF, None, (u.src[-1],) + u.src[1:] + (x.src[2],), if_to_update.arg)
-      # return UOp(u.op, u.dtype, u.src[:-1] + (new_if,), u.arg)
-      # return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)
-      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1], u.src[2])),), u.arg)
+    if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in { UOps.ALU, UOps.CAST } and u.src[-1].dtype == dtypes.bool:
+      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (u.src[-1],)),), u.arg)
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)
   return None if len(root.src) == 3 or (ret:=_gate_srcs(root, root.src[3])) is root else ret
 
@@ -456,52 +449,26 @@ def delete_redundant_gates(root:UOp) -> Optional[UOp]:
   if len(root.src) == 3 or (gate:=find_gate(root)) is None or gate.src[0] is not root.src[3]: return None
   return UOp(UOps.STORE, root.dtype, root.src[:3], root.arg)
 
-def merge_gates_sink(sink:UOp) -> Optional[UOp]:
+def merge_gates(sink:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def find_gate(x:UOp) -> Optional[UOp]:
     if x.op is UOps.RANGE:
       return x
     return next((ret for s in x.src if (ret:=find_gate(s)) is not None), None)
-
-  # if_src_and_stores: Dict[UOp, List[UOp]] = {} # UOp.ALU -> [UOp.STORE]
-  if_src_and_ifs: Dict[UOp, UOp] = {} # UOp.ALU -> UOp.IF
+  if_src_to_if_op: Dict[UOp, UOp] = {} # UOp.ALU -> UOp.IF
   for x in sink.src:
     if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF:
       if_gate = x.src[-1]
-      non_if_gate = find_gate(x.src[2])
-      if non_if_gate and x.src[2] not in if_gate.src:
-        if_to_update = if_src_and_ifs.get(if_gate.src[0], if_gate)
-        # if if_to_update := if_src_and_ifs.get(if_gate.src[0], if_gate):
-        new_if = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
-        if_src_and_ifs[if_gate.src[0]] = new_if
-        # try:
-        #   if_src_and_stores[if_to_update.src[0]].append(x)
-        # except KeyError:
-        #   if_src_and_stores[if_to_update.src[0]] = [x]
-  # if len(if_src_and_stores) == 0: return None
-  if len(if_src_and_ifs) == 0: return None
-
+      if find_gate(x.src[2]) and x.src[2] not in if_gate.src:
+        if_to_update = if_src_to_if_op.get(if_gate.src[0], if_gate)
+        if_src_to_if_op[if_gate.src[0]] = UOp(UOps.IF, None, (if_to_update.src[0],) + if_to_update.src[1:] + (x.src[2],), if_to_update.arg)
+  if len(if_src_to_if_op) == 0: return None
   new_sink_srcs = []
   for x in sink.src:
     if x.op is UOps.STORE and len(x.src) == 4 and x.src[-1].op is UOps.IF:
-      new_sink_srcs.append(UOp(UOps.STORE, x.dtype, x.src[:-1] + (if_src_and_ifs[x.src[-1].src[0]],), x.arg))
+      new_sink_srcs.append(UOp(UOps.STORE, x.dtype, x.src[:-1] + (if_src_to_if_op[x.src[-1].src[0]],), x.arg))
     else: new_sink_srcs.append(x)
   return UOp(UOps.SINK, sink.dtype, tuple(new_sink_srcs), sink.arg)
-
-def merge_gates(root:UOp) -> Optional[UOp]:
-    @functools.lru_cache(None)
-    def find_gate(x:UOp) -> Optional[UOp]:
-      if x.op is UOps.RANGE:
-        return x
-      return next((ret for s in x.src if (ret:=find_gate(s)) is not None), None)
-
-    if len(root.src) == 4 and root.src[-1].op is UOps.IF and root.src[-1].src[-1] is not root.src[2]:
-      if_gate = root.src[-1]
-      non_if_gate = find_gate(root.src[2])
-      if non_if_gate is not None:
-        if_gate = UOp(UOps.IF, None, (if_gate.src[0],) + if_gate.src[1:-1] + (root.src[2],), if_gate.arg)
-        return UOp(UOps.STORE, root.dtype, root.src[:-1] + (if_gate,), root.arg)
-    return None
 
 reducer = PatternMatcher([
   (NOp(UOps.REDUCE, name="root"), do_reduce),
@@ -511,10 +478,7 @@ reducer = PatternMatcher([
   (NOp(UOps.STORE, name="root"), delete_redundant_gates),
   # late fixup of unfoldable image loads
   (UPat(UOps.LOAD, src=(UPat(name="buf"), UPat()), allow_any_len=True, name="load"), fix_unfoldable_image_load),
-  # NOTE: this works, but fails to group IFs together due to them having different src's now
-  # (NOp(UOps.STORE, name="root"), merge_gates),
-  # NOTE: this doesn't quite work, but it should group IFs together ideally. TODO for me tm
-  # (NOp(UOps.SINK, name="sink"), merge_gates_sink),
+  (NOp(UOps.SINK, name="sink"), merge_gates),
 ])
 
 no_pyint = PatternMatcher([(UPat({UOps.CONST, UOps.ALU, UOps.SPECIAL, UOps.RANGE, UOps.EXPAND}, dtype=dtypes.pyint, name="x"),

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -413,12 +413,12 @@ def no_vectorized_alu(alu):
 def create_gate(root:UOp) -> Optional[UOp]:
   @functools.lru_cache(None)
   def _gate_srcs(u:UOp, gate:UOp) -> UOp:
-    if u.op is UOps.BARRIER or u in gate.parents: return u
+    if u.op is UOps.BARRIER: return u
     if u.op is UOps.LOAD and u.src[-1].op is UOps.BARRIER:
       # NOTE: gate's bool could be nested within an IF or EXPAND, and we only want to get the bool
       return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate if gate.op is not UOps.IF else gate.src[0], u.src[-1])),), u.arg)
     if u.op is UOps.STORE and len(u.src) == 4 and u.src[-1].op in {UOps.ALU, UOps.CAST}:
-      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate, u.src[2])),), u.arg)
+      return UOp(u.op, u.dtype, u.src[:-1] + (UOp(UOps.IF, None, (gate, u.src[2] if u.src[2].op is not UOps.EXPAND else u.src[2].src[0])),), u.arg)
     return u if (replace_source:=tuple(_gate_srcs(x, gate) for x in u.src)) == u.src else UOp(u.op, u.dtype, replace_source, u.arg)
   return None if len(root.src) == 3 or (ret:=_gate_srcs(root, root.src[3])) is root else ret
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -675,7 +675,6 @@ def flops_mem(uops:List[UOp], ignore_indexing=False) -> Tuple[sint, sint]:
         if len(u.src) > 3: dont_count = dont_count.union(u.src[2].sparents)
       elif u.op is UOps.STORE:
         dont_count = dont_count.union(u.src[1].sparents)
-        if len(u.src) > 3: dont_count = dont_count.union(u.src[3].sparents)
       elif u.op is UOps.IF:
         dont_count = dont_count.union(u.src[0].sparents)
   for u in uops:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -675,6 +675,7 @@ def flops_mem(uops:List[UOp], ignore_indexing=False) -> Tuple[sint, sint]:
         if len(u.src) > 3: dont_count = dont_count.union(u.src[2].sparents)
       elif u.op is UOps.STORE:
         dont_count = dont_count.union(u.src[1].sparents)
+        if len(u.src) > 3: dont_count = dont_count.union(u.src[3].sparents)
       elif u.op is UOps.IF:
         dont_count = dont_count.union(u.src[0].sparents)
   for u in uops:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -636,7 +636,7 @@ def type_verify(uops):
     if uop is UOps.GEP: assert dtype == src[0].dtype.scalar(), f"GEP of {src[0].dtype=} should be {src[0].dtype.scalar()} != {dtype}"
     if uop is UOps.STORE:
       assert dtype is None, f"{uop} dtype must be None, got {dtype}"
-      if len(src) == 4: assert src[3].op is UOps.IF, f"{uop} gate op must be {UOps.IF}, got {src[3].op}"
+      if len(src) == 4: assert src[3].op is UOps.IF, f"{uop} gate op must be UOps.IF, got {src[3].op}"
     if uop is UOps.ALU:
       if arg in UnaryOps: assert dtype == src[0].dtype, f"{arg} dtype mismatch {dtype=} != {src[0].dtype=}"
       elif arg in {BinaryOps.CMPLT, BinaryOps.CMPNE}:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -636,7 +636,9 @@ def type_verify(uops):
     if uop is UOps.GEP: assert dtype == src[0].dtype.scalar(), f"GEP of {src[0].dtype=} should be {src[0].dtype.scalar()} != {dtype}"
     if uop is UOps.STORE:
       assert dtype is None, f"{uop} dtype must be None, got {dtype}"
-      if len(src) == 4: assert src[3].op is UOps.IF, f"{uop} gate op must be UOps.IF, got {src[3].op}"
+      if len(src) == 4:
+        assert src[3].op is UOps.IF, f"{uop} gate op must be UOps.IF, got {src[3].op}"
+        assert src[3].src[0].dtype == dtypes.bool, f"gate dtype mismatch {src[3].dtype} != {dtypes.bool}"
     if uop is UOps.ALU:
       if arg in UnaryOps: assert dtype == src[0].dtype, f"{arg} dtype mismatch {dtype=} != {src[0].dtype=}"
       elif arg in {BinaryOps.CMPLT, BinaryOps.CMPNE}:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -636,7 +636,7 @@ def type_verify(uops):
     if uop is UOps.GEP: assert dtype == src[0].dtype.scalar(), f"GEP of {src[0].dtype=} should be {src[0].dtype.scalar()} != {dtype}"
     if uop is UOps.STORE:
       assert dtype is None, f"{uop} dtype must be None, got {dtype}"
-      if len(src) == 4: assert src[3].op is UOps.IF, f"gate dtype mismatch {src[3].dtype} != {dtypes.bool}"
+      if len(src) == 4: assert src[3].op is UOps.IF, f"{uop} gate op must be {UOps.IF}, got {src[3].op}"
     if uop is UOps.ALU:
       if arg in UnaryOps: assert dtype == src[0].dtype, f"{arg} dtype mismatch {dtype=} != {src[0].dtype=}"
       elif arg in {BinaryOps.CMPLT, BinaryOps.CMPNE}:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -636,7 +636,7 @@ def type_verify(uops):
     if uop is UOps.GEP: assert dtype == src[0].dtype.scalar(), f"GEP of {src[0].dtype=} should be {src[0].dtype.scalar()} != {dtype}"
     if uop is UOps.STORE:
       assert dtype is None, f"{uop} dtype must be None, got {dtype}"
-      if len(src) == 4: assert src[3].dtype == dtypes.bool, f"gate dtype mismatch {src[3].dtype} != {dtypes.bool}"
+      if len(src) == 4: assert src[3].op is UOps.IF, f"gate dtype mismatch {src[3].dtype} != {dtypes.bool}"
     if uop is UOps.ALU:
       if arg in UnaryOps: assert dtype == src[0].dtype, f"{arg} dtype mismatch {dtype=} != {src[0].dtype=}"
       elif arg in {BinaryOps.CMPLT, BinaryOps.CMPNE}:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -636,7 +636,7 @@ def type_verify(uops):
     if uop is UOps.GEP: assert dtype == src[0].dtype.scalar(), f"GEP of {src[0].dtype=} should be {src[0].dtype.scalar()} != {dtype}"
     if uop is UOps.STORE:
       assert dtype is None, f"{uop} dtype must be None, got {dtype}"
-      if len(src) == 4: assert src[3].op is UOps.IF, f"{uop} gate op must be UOps.IF, got {src[3].op}"
+      if len(src) == 4: assert src[3].op is UOps.IF, f"{uop} gate op must be {UOps.IF}, got {src[3].op}"
     if uop is UOps.ALU:
       if arg in UnaryOps: assert dtype == src[0].dtype, f"{arg} dtype mismatch {dtype=} != {src[0].dtype=}"
       elif arg in {BinaryOps.CMPLT, BinaryOps.CMPNE}:
@@ -675,6 +675,7 @@ def flops_mem(uops:List[UOp], ignore_indexing=False) -> Tuple[sint, sint]:
         if len(u.src) > 3: dont_count = dont_count.union(u.src[2].sparents)
       elif u.op is UOps.STORE:
         dont_count = dont_count.union(u.src[1].sparents)
+        if len(u.src) > 3: dont_count = dont_count.union(u.src[3].sparents)
       elif u.op is UOps.IF:
         dont_count = dont_count.union(u.src[0].sparents)
   for u in uops:

--- a/tinygrad/renderer/assembly.py
+++ b/tinygrad/renderer/assembly.py
@@ -189,7 +189,7 @@ class PTXRenderer(Renderer):
         assert src[1].op is UOps.CONST, f"store isn't const {u}"
         mem_type = '.shared' if src[0].op is UOps.DEFINE_LOCAL or any(x.op is UOps.DEFINE_LOCAL for x in src[0].parents) else '.global'
         if src[2].dtype.count > 1:
-          kk((f"@{r[src[3]]} " if len(src)>3 else "") + \
+          kk((f"" if len(src)>3 else "") + \
               f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
         else:
           kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, gate=r[src[3]] if len(src)>3 else None, ss=mem_type, offset=src[1].arg))

--- a/tinygrad/renderer/assembly.py
+++ b/tinygrad/renderer/assembly.py
@@ -192,7 +192,7 @@ class PTXRenderer(Renderer):
           kk((f"@{r[src[3]]} " if len(src)>3 else "") + \
               f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
         else:
-          kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, gate=r[src[3]] if len(src)>3 else None, ss=mem_type, offset=src[1].arg))
+          kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, None, ss=mem_type, offset=src[1].arg))
       else:
         assert dtype is not None, f"None dtype for uop {uop}"
         if uop is UOps.RANGE: kk(*self.render_loop(loop:=ssa('ridx', u), r[src[0]], "LOOP_"+loop[1:]))

--- a/tinygrad/renderer/assembly.py
+++ b/tinygrad/renderer/assembly.py
@@ -124,8 +124,8 @@ class PTXRenderer(Renderer):
     if gate: return [f"@{gate} ld{ss}.{self.mem_types[dtype]} {dest}, [{loc}+{offset}];", f"@!{gate} mov.b{self.types[dtype][1:]} {dest}, {alt};"]
     return [f"ld{ss}.{self.mem_types[dtype]} {dest}, [{loc}+{offset}];"]
 
-  def render_store(self, loc, val, dtype, gate=None, ss="", offset=0) -> List[str]:
-    return [(f"@{gate} " if gate else "") + f"st{ss}.{self.mem_types[dtype]} [{loc}+{offset}], {val};"]
+  def render_store(self, loc, val, dtype, ss="", offset=0) -> List[str]:
+    return [f"st{ss}.{self.mem_types[dtype]} [{loc}+{offset}], {val};"]
 
   def render_cast(self, d:str, a:str, dtype:DType, atype:DType, bitcast=False, pred=False) -> List[str]:
     if bitcast: return [f"mov.b{self.types[dtype][1:]} {d}, {a};"]
@@ -173,23 +173,27 @@ class PTXRenderer(Renderer):
 
     for u in uops:
       uop,dtype,src,args = u.op,u.dtype,u.src,u.arg
-      if uop in { UOps.IF, UOps.ENDIF }:
-        continue
+      if uop is UOps.IF:
+        assert src[0].dtype is not None
+        kk(*self.render_bra(f"IF_{r[src[0]][1:]}_{uops.index(u)}", _cast(r[src[0]], dtypes.bool, src[0].dtype, u=u, pred=True)))
+        kk(f"IF_{r[src[0]][1:]}_{uops.index(u)}:")
       elif uop is UOps.BARRIER and self.barrier: kk(self.barrier)
       elif uop is UOps.ENDRANGE:
         kk(self.code_for_op[BinaryOps.ADD](r[src[0]], r[src[0]], "1", dtypes.int, self.types[dtypes.int]),
             self.code_for_op[BinaryOps.CMPLT](pred:=ssa("pred", dtype="pred"), r[src[0]], r[src[0].src[1]], dtypes.int, self.types[dtypes.int]))
         kk(*self.render_bra(f"LOOP_{r[src[0]][1:]}", pred))
+      elif uop is UOps.ENDIF:
+        kk(f"bra ENDIF_{r[src[0].src[0]][1:]}_{uops.index(src[0])};")
+        kk(f"ENDIF_{r[src[0].src[0]][1:]}_{uops.index(src[0])}:")
       elif uop is UOps.STORE:
         assert src[0].dtype is not None and src[2].dtype is not None
         assert src[0].dtype == dtypes.int64, "store isn't int64"
         assert src[1].op is UOps.CONST, f"store isn't const {u}"
         mem_type = '.shared' if src[0].op is UOps.DEFINE_LOCAL or any(x.op is UOps.DEFINE_LOCAL for x in src[0].parents) else '.global'
         if src[2].dtype.count > 1:
-          kk((f"@{r[src[3].src[0]]} " if len(src)>3 else "") + \
-              f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
+          kk(f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
         else:
-          kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, gate=r[src[3].src[0]] if len(src)>3 else None, ss=mem_type, offset=src[1].arg))
+          kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, ss=mem_type, offset=src[1].arg))
       else:
         assert dtype is not None, f"None dtype for uop {uop}"
         if uop is UOps.RANGE: kk(*self.render_loop(loop:=ssa('ridx', u), r[src[0]], "LOOP_"+loop[1:]))

--- a/tinygrad/renderer/assembly.py
+++ b/tinygrad/renderer/assembly.py
@@ -124,8 +124,8 @@ class PTXRenderer(Renderer):
     if gate: return [f"@{gate} ld{ss}.{self.mem_types[dtype]} {dest}, [{loc}+{offset}];", f"@!{gate} mov.b{self.types[dtype][1:]} {dest}, {alt};"]
     return [f"ld{ss}.{self.mem_types[dtype]} {dest}, [{loc}+{offset}];"]
 
-  def render_store(self, loc, val, dtype, ss="", offset=0) -> List[str]:
-    return [f"st{ss}.{self.mem_types[dtype]} [{loc}+{offset}], {val};"]
+  def render_store(self, loc, val, dtype, gate=None, ss="", offset=0) -> List[str]:
+    return [(f"@{gate} " if gate else "") + f"st{ss}.{self.mem_types[dtype]} [{loc}+{offset}], {val};"]
 
   def render_cast(self, d:str, a:str, dtype:DType, atype:DType, bitcast=False, pred=False) -> List[str]:
     if bitcast: return [f"mov.b{self.types[dtype][1:]} {d}, {a};"]
@@ -173,25 +173,23 @@ class PTXRenderer(Renderer):
 
     for u in uops:
       uop,dtype,src,args = u.op,u.dtype,u.src,u.arg
-      if uop is UOps.IF:
-        assert src[0].dtype is not None
-        kk(*self.render_bra(f"IF_{r[src[0]][1:]}_{uops.index(u)}", _cast(r[src[0]], dtypes.bool, src[0].dtype, u=u, pred=True)))
+      if uop in { UOps.IF, UOps.ENDIF }:
+        continue
       elif uop is UOps.BARRIER and self.barrier: kk(self.barrier)
       elif uop is UOps.ENDRANGE:
         kk(self.code_for_op[BinaryOps.ADD](r[src[0]], r[src[0]], "1", dtypes.int, self.types[dtypes.int]),
             self.code_for_op[BinaryOps.CMPLT](pred:=ssa("pred", dtype="pred"), r[src[0]], r[src[0].src[1]], dtypes.int, self.types[dtypes.int]))
         kk(*self.render_bra(f"LOOP_{r[src[0]][1:]}", pred))
-      elif uop is UOps.ENDIF:
-        kk(f"IF_{r[src[0].src[0]][1:]}_{uops.index(src[0])}:")
       elif uop is UOps.STORE:
         assert src[0].dtype is not None and src[2].dtype is not None
         assert src[0].dtype == dtypes.int64, "store isn't int64"
         assert src[1].op is UOps.CONST, f"store isn't const {u}"
         mem_type = '.shared' if src[0].op is UOps.DEFINE_LOCAL or any(x.op is UOps.DEFINE_LOCAL for x in src[0].parents) else '.global'
         if src[2].dtype.count > 1:
-          kk(f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
+          kk((f"@{r[src[3].src[0]]} " if len(src)>3 else "") + \
+              f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
         else:
-          kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, ss=mem_type, offset=src[1].arg))
+          kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, gate=r[src[3].src[0]] if len(src)>3 else None, ss=mem_type, offset=src[1].arg))
       else:
         assert dtype is not None, f"None dtype for uop {uop}"
         if uop is UOps.RANGE: kk(*self.render_loop(loop:=ssa('ridx', u), r[src[0]], "LOOP_"+loop[1:]))

--- a/tinygrad/renderer/assembly.py
+++ b/tinygrad/renderer/assembly.py
@@ -189,8 +189,7 @@ class PTXRenderer(Renderer):
         assert src[1].op is UOps.CONST, f"store isn't const {u}"
         mem_type = '.shared' if src[0].op is UOps.DEFINE_LOCAL or any(x.op is UOps.DEFINE_LOCAL for x in src[0].parents) else '.global'
         if src[2].dtype.count > 1:
-          kk((f"@{r[src[3]]} " if len(src)>3 else "") + \
-              f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
+          kk(f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
         else:
           kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, None, ss=mem_type, offset=src[1].arg))
       else:

--- a/tinygrad/renderer/assembly.py
+++ b/tinygrad/renderer/assembly.py
@@ -124,8 +124,8 @@ class PTXRenderer(Renderer):
     if gate: return [f"@{gate} ld{ss}.{self.mem_types[dtype]} {dest}, [{loc}+{offset}];", f"@!{gate} mov.b{self.types[dtype][1:]} {dest}, {alt};"]
     return [f"ld{ss}.{self.mem_types[dtype]} {dest}, [{loc}+{offset}];"]
 
-  def render_store(self, loc, val, dtype, gate=None, ss="", offset=0) -> List[str]:
-    return [(f"     " if gate else "") + f"st{ss}.{self.mem_types[dtype]} [{loc}+{offset}], {val};"]
+  def render_store(self, loc, val, dtype, ss="", offset=0) -> List[str]:
+    return [f"st{ss}.{self.mem_types[dtype]} [{loc}+{offset}], {val};"]
 
   def render_cast(self, d:str, a:str, dtype:DType, atype:DType, bitcast=False, pred=False) -> List[str]:
     if bitcast: return [f"mov.b{self.types[dtype][1:]} {d}, {a};"]
@@ -189,10 +189,9 @@ class PTXRenderer(Renderer):
         assert src[1].op is UOps.CONST, f"store isn't const {u}"
         mem_type = '.shared' if src[0].op is UOps.DEFINE_LOCAL or any(x.op is UOps.DEFINE_LOCAL for x in src[0].parents) else '.global'
         if src[2].dtype.count > 1:
-          kk((f"" if len(src)>3 else "") + \
-              f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
+          kk(f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
         else:
-          kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, gate=r[src[3]] if len(src)>3 else None, ss=mem_type, offset=src[1].arg))
+          kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, ss=mem_type, offset=src[1].arg))
       else:
         assert dtype is not None, f"None dtype for uop {uop}"
         if uop is UOps.RANGE: kk(*self.render_loop(loop:=ssa('ridx', u), r[src[0]], "LOOP_"+loop[1:]))

--- a/tinygrad/renderer/assembly.py
+++ b/tinygrad/renderer/assembly.py
@@ -176,6 +176,7 @@ class PTXRenderer(Renderer):
       if uop is UOps.IF:
         assert src[0].dtype is not None
         kk(*self.render_bra(f"IF_{r[src[0]][1:]}_{uops.index(u)}", _cast(r[src[0]], dtypes.bool, src[0].dtype, u=u, pred=True)))
+        kk(f"bra ENDIF_{r[src[0]][1:]}_{uops.index(u)};")
         kk(f"IF_{r[src[0]][1:]}_{uops.index(u)}:")
       elif uop is UOps.BARRIER and self.barrier: kk(self.barrier)
       elif uop is UOps.ENDRANGE:
@@ -183,7 +184,6 @@ class PTXRenderer(Renderer):
             self.code_for_op[BinaryOps.CMPLT](pred:=ssa("pred", dtype="pred"), r[src[0]], r[src[0].src[1]], dtypes.int, self.types[dtypes.int]))
         kk(*self.render_bra(f"LOOP_{r[src[0]][1:]}", pred))
       elif uop is UOps.ENDIF:
-        kk(f"bra ENDIF_{r[src[0].src[0]][1:]}_{uops.index(src[0])};")
         kk(f"ENDIF_{r[src[0].src[0]][1:]}_{uops.index(src[0])}:")
       elif uop is UOps.STORE:
         assert src[0].dtype is not None and src[2].dtype is not None

--- a/tinygrad/renderer/assembly.py
+++ b/tinygrad/renderer/assembly.py
@@ -125,7 +125,7 @@ class PTXRenderer(Renderer):
     return [f"ld{ss}.{self.mem_types[dtype]} {dest}, [{loc}+{offset}];"]
 
   def render_store(self, loc, val, dtype, gate=None, ss="", offset=0) -> List[str]:
-    return [(f"@{gate} " if gate else "") + f"st{ss}.{self.mem_types[dtype]} [{loc}+{offset}], {val};"]
+    return [(f"     " if gate else "") + f"st{ss}.{self.mem_types[dtype]} [{loc}+{offset}], {val};"]
 
   def render_cast(self, d:str, a:str, dtype:DType, atype:DType, bitcast=False, pred=False) -> List[str]:
     if bitcast: return [f"mov.b{self.types[dtype][1:]} {d}, {a};"]
@@ -189,9 +189,10 @@ class PTXRenderer(Renderer):
         assert src[1].op is UOps.CONST, f"store isn't const {u}"
         mem_type = '.shared' if src[0].op is UOps.DEFINE_LOCAL or any(x.op is UOps.DEFINE_LOCAL for x in src[0].parents) else '.global'
         if src[2].dtype.count > 1:
-          kk(f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
+          kk((f"@{r[src[3]]} " if len(src)>3 else "") + \
+              f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
         else:
-          kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, None, ss=mem_type, offset=src[1].arg))
+          kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, gate=r[src[3]] if len(src)>3 else None, ss=mem_type, offset=src[1].arg))
       else:
         assert dtype is not None, f"None dtype for uop {uop}"
         if uop is UOps.RANGE: kk(*self.render_loop(loop:=ssa('ridx', u), r[src[0]], "LOOP_"+loop[1:]))

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -167,6 +167,7 @@ class CStyleLanguage(Renderer):
             val = self.render_cast(precast, dtype, bitcast=True)
           elif uop is UOps.CAST: val = self.render_cast(r[src[0]], dtype, bitcast=False)
           else: val = self.render_vectorize([r[x] for x in src], dtype)
+          # if child_count[u] - len([x.op is UOps.IF and len(x.src) > 1 and u in x.src[1:] for x in u.parents]) <= 1: r[u] = val
           if child_count[u] <= 1: r[u] = val
           else: kk(f"{self.render_dtype(dtype)} {ssa('cast',u)} = {val};")
         elif uop is UOps.DEFINE_LOCAL:

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -167,7 +167,7 @@ class CStyleLanguage(Renderer):
             val = self.render_cast(precast, dtype, bitcast=True)
           elif uop is UOps.CAST: val = self.render_cast(r[src[0]], dtype, bitcast=False)
           else: val = self.render_vectorize([r[x] for x in src], dtype)
-          if child_count[u] - len([x.op is UOps.IF and len(x.src) > 1 and u in x.src[1:] for x in u.parents]) <= 1: r[u] = val
+          if child_count[u] <= 1: r[u] = val
           else: kk(f"{self.render_dtype(dtype)} {ssa('cast',u)} = {val};")
         elif uop is UOps.DEFINE_LOCAL:
           kk(self.render_local(args[0], dtype, args[1]))

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -167,7 +167,7 @@ class CStyleLanguage(Renderer):
             val = self.render_cast(precast, dtype, bitcast=True)
           elif uop is UOps.CAST: val = self.render_cast(r[src[0]], dtype, bitcast=False)
           else: val = self.render_vectorize([r[x] for x in src], dtype)
-          if child_count[u] <= 1: r[u] = val
+          if child_count[u] - len([x.op is UOps.IF and len(x.src) > 1 and u in x.src[1:] for x in u.parents]) <= 1: r[u] = val
           else: kk(f"{self.render_dtype(dtype)} {ssa('cast',u)} = {val};")
         elif uop is UOps.DEFINE_LOCAL:
           kk(self.render_local(args[0], dtype, args[1]))

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -127,8 +127,7 @@ class CStyleLanguage(Renderer):
         # mark DEFINE_GLOBAL buf as writable
         if src[0].op is UOps.DEFINE_GLOBAL: bufs[src[0]] = (bufs[src[0]][0], (bufs[src[0]][1][0], True))
         rendered_store = self.render_store(r[src[0]], src[0].dtype, r[src[2]], src[2].dtype, strip_parens(r[src[1]]), src[0].op is UOps.DEFINE_LOCAL)
-        # kk(rendered_store)
-        kk(f"if ({r[src[3]]}) {{ {rendered_store} }}" if len(src) > 3 and src[-1].op is not UOps.IF else rendered_store)
+        kk(rendered_store)
       else:
         assert dtype is not None, f"None dtype for uop {uop}"
         if uop is UOps.RANGE:

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -167,7 +167,6 @@ class CStyleLanguage(Renderer):
             val = self.render_cast(precast, dtype, bitcast=True)
           elif uop is UOps.CAST: val = self.render_cast(r[src[0]], dtype, bitcast=False)
           else: val = self.render_vectorize([r[x] for x in src], dtype)
-          # if child_count[u] - len([x.op is UOps.IF and len(x.src) > 1 and u in x.src[1:] for x in u.parents]) <= 1: r[u] = val
           if child_count[u] <= 1: r[u] = val
           else: kk(f"{self.render_dtype(dtype)} {ssa('cast',u)} = {val};")
         elif uop is UOps.DEFINE_LOCAL:

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -93,7 +93,7 @@ class LLVMRenderer(Renderer):
       if uop is UOps.STORE:
         element = cast(bb, lvars[src[2]], src[2].dtype, src[0].dtype)
         if len(src) > 3:
-          with bb[-1].if_then(lvars[src[3]]):
+          with bb[-1].if_then(lvars[src[3].src[0]]):
             bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
         else:
           bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
@@ -105,7 +105,7 @@ class LLVMRenderer(Renderer):
         bb.append(ir.IRBuilder(func.append_basic_block(f"loop_exit_{len(loop_blocks)}")))
         bb[-2].cbranch(bb[-2].icmp_unsigned("<", idx_p1, lvars[src[0].src[1]]), loop_entry_bb, bb[-1].block)
       else:
-        assert dtype is not None, f"None dtype for uop {uop}"
+        assert dtype is not None or uop is UOps.IF, f"None dtype for uop {uop}"
         if uop is UOps.RANGE:
           bb.append(ir.IRBuilder(func.append_basic_block(f"loop_body_{len(loop_blocks)}")))
           bb[-2].branch(bb[-1].block)

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -92,16 +92,12 @@ class LLVMRenderer(Renderer):
       uop,dtype,src,args = u.op,u.dtype,u.src,u.arg
       if uop is UOps.STORE:
         element = cast(bb, lvars[src[2]], src[2].dtype, src[0].dtype)
-        bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
-        # if len(src) > 3:
-        #   with bb[-1].if_then(lvars[src[3].src[0]]):
-        #     bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
-        # else:
-        #   bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
-      elif uop is UOps.IF:
-        bb[-1].if_then(lvars[src[0]])
-      elif uop is UOps.ENDIF:
-        bb.append(ir.IRBuilder(func.append_basic_block("endif")))
+        if len(src) > 3:
+          with bb[-1].if_then(lvars[src[3].src[0]]):
+            bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
+        else:
+          bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
+      elif uop is UOps.IF or uop is UOps.ENDIF: continue
       elif uop is UOps.ENDRANGE:
         loop_entry_bb, phis = loop_blocks.pop()
         idx_p1 = bb[-1].add(lvars[src[0]], ir.Constant(ir.IntType(32), 1))
@@ -110,7 +106,7 @@ class LLVMRenderer(Renderer):
         bb.append(ir.IRBuilder(func.append_basic_block(f"loop_exit_{len(loop_blocks)}")))
         bb[-2].cbranch(bb[-2].icmp_unsigned("<", idx_p1, lvars[src[0].src[1]]), loop_entry_bb, bb[-1].block)
       else:
-        assert dtype is not None or uop is UOps.IF, f"None dtype for uop {uop}"
+        assert dtype is not None, f"None dtype for uop {uop}"
         if uop is UOps.RANGE:
           bb.append(ir.IRBuilder(func.append_basic_block(f"loop_body_{len(loop_blocks)}")))
           bb[-2].branch(bb[-1].block)

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -92,11 +92,16 @@ class LLVMRenderer(Renderer):
       uop,dtype,src,args = u.op,u.dtype,u.src,u.arg
       if uop is UOps.STORE:
         element = cast(bb, lvars[src[2]], src[2].dtype, src[0].dtype)
-        if len(src) > 3:
-          with bb[-1].if_then(lvars[src[3].src[0]]):
-            bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
-        else:
-          bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
+        bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
+        # if len(src) > 3:
+        #   with bb[-1].if_then(lvars[src[3].src[0]]):
+        #     bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
+        # else:
+        #   bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
+      elif uop is UOps.IF:
+        bb[-1].if_then(lvars[src[0]])
+      elif uop is UOps.ENDIF:
+        bb.append(ir.IRBuilder(func.append_basic_block("endif")))
       elif uop is UOps.ENDRANGE:
         loop_entry_bb, phis = loop_blocks.pop()
         idx_p1 = bb[-1].add(lvars[src[0]], ir.Constant(ir.IntType(32), 1))

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -97,7 +97,7 @@ class LLVMRenderer(Renderer):
             bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
         else:
           bb[-1].store(element, bb[-1].gep(lvars[src[0]], [lvars[src[1]]], inbounds=True))
-      elif uop is UOps.IF or uop is UOps.ENDIF: continue
+      elif uop in {UOps.IF, UOps.ENDIF}: continue
       elif uop is UOps.ENDRANGE:
         loop_entry_bb, phis = loop_blocks.pop()
         idx_p1 = bb[-1].add(lvars[src[0]], ir.Constant(ir.IntType(32), 1))


### PR DESCRIPTION
PR for bounty: "gated store rewrite to UOps.IF, well tested. spec: https://github.com/tinygrad/tinygrad/pull/5652"

Changes include: 

- [x] Wrapping UOps.STOREs that were previously gated in-line with UOps.IFs. I'm not sure if the UOps.STORE's src should include the IF or not. I've included it for now. Unsure on best practices. 
- [x] Grouping UOps.STOREs that are reliant on the same gate / UOps.IF into a single if block. I'm not sure if there's a cleaner way to go about this. I can certainly reduce the line count in this area but also not sure if there's a smarter way to go about keeping them together.
- [x] cstyle renderer 
- [x] Enable previously failing tests
- [x] llvmir renderer
- [x] Fix llvmir & ptx tests