### PR TITLE
hotfix: adjust test_backward_pass_diamond_model thresholds

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -141,7 +141,7 @@ class TestTinygrad(unittest.TestCase):
       return out.detach().numpy(), u.grad, v.grad, w.grad
 
     for x,y in zip(test_tinygrad(), test_pytorch()):
-      np.testing.assert_allclose(x, y, atol=1e-5)
+      np.testing.assert_allclose(x, y, atol=1e-5, rtol=1e-6)
 
   def test_nograd(self):
     x = Tensor(x_init, requires_grad=False)


### PR DESCRIPTION
was red 1 out of 4 times on M2 with and without NOOPT=1
![image](https://github.com/user-attachments/assets/a85713f7-9471-4266-bd2f-ca250578a1d4)
