### PR TITLE
smaller test_llama_embedding + assert correctness

### DIFF
--- a/test/test_arange.py
+++ b/test/test_arange.py
@@ -1,7 +1,7 @@
 import unittest, contextlib
 import numpy as np
 from tinygrad import Tensor, GlobalCounters, dtypes, nn
-from tinygrad.helpers import Context, getenv
+from tinygrad.helpers import CI, Context, getenv
 from tinygrad.engine.realize import run_schedule
 from tinygrad.codegen.kernel import Opt, OptOps, Kernel, KernelOptError
 from tinygrad.engine.realize import CompiledRunner, ExecItem
@@ -143,12 +143,13 @@ class TestIndexing(unittest.TestCase):
   @unittest.skipIf(getenv("PTX"), "broken on ptx for some reason")
   def test_llama_embedding(self, noopt=1, op_limit=0):
     # llama3 is 128256
-    emb = nn.Embedding(32000, 4096)
+    emb = nn.Embedding(10, 3) if CI else nn.Embedding(32000, 4096)
     emb.weight.realize()
     with Context(NOOPT=noopt, FUSE_ARANGE=1):
       GlobalCounters.reset()
       emb(Tensor([1,2,3,4])).realize()
       self.assertLessEqual(GlobalCounters.global_ops, op_limit)
+      self.assertEqual(GlobalCounters.kernel_count, 2)
   # at least the arange is being fused
   def test_llama_embedding_opt(self): self.test_llama_embedding(0, 1736704000)
 

--- a/test/test_arange.py
+++ b/test/test_arange.py
@@ -143,13 +143,23 @@ class TestIndexing(unittest.TestCase):
   @unittest.skipIf(getenv("PTX"), "broken on ptx for some reason")
   def test_llama_embedding(self, noopt=1, op_limit=0):
     # llama3 is 128256
-    emb = nn.Embedding(10, 3) if CI else nn.Embedding(32000, 4096)
-    emb.weight.realize()
+    vocab_size, embed_size = (10, 3) if CI else (32000, 4096)
+    emb = nn.Embedding(vocab_size, embed_size)
+    emb_w = emb.weight.numpy()
+    x = Tensor([1,2,3,4])
     with Context(NOOPT=noopt, FUSE_ARANGE=1):
       GlobalCounters.reset()
-      emb(Tensor([1,2,3,4])).realize()
+      z = emb(x).realize()
       self.assertLessEqual(GlobalCounters.global_ops, op_limit)
       self.assertEqual(GlobalCounters.kernel_count, 2)
+    if getenv("CHECK", 1):
+      import torch
+      with torch.no_grad():
+        torch_emb = torch.nn.Embedding(vocab_size, embed_size).eval()
+        torch_emb.weight[:] = torch.tensor(emb_w, dtype=torch.float32)
+      torch_z = torch_emb(torch.tensor(x.numpy()))
+      # TODO: reshape to match torch, should we do this in nn?
+      np.testing.assert_allclose(z.numpy().reshape(4, 3), torch_z.detach().numpy(), atol=1e-8, rtol=1e-8)
   # at least the arange is being fused
   def test_llama_embedding_opt(self): self.test_llama_embedding(0, 1736704000)
 

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1471,8 +1471,8 @@ class TestIndexing(unittest.TestCase):
     from tinygrad.nn.datasets import mnist
     import torch
     _, Y_train, _, _ = mnist()
-    samples = Tensor.randint(getenv("BS", 512), high=6000)
-    yt = Tensor.randn(512, 10)
+    samples = Tensor.randint(BS:=getenv("BS", 512), high=cast(int,Y_train.shape[-1]))
+    yt = Tensor.randn(BS, 10)
     with Context(SPLIT_REDUCEOP=0):
       loss = yt.sparse_categorical_crossentropy(Y_train[samples])
       self.check_schedule(loss, 6)


### PR DESCRIPTION
these were the slowest tests:
```
============================= slowest 20 durations =============================
39.69s call     test/test_arange.py::TestIndexing::test_llama_embedding
38.18s call     test/test_arange.py::TestIndexing::test_llama_embedding_opt
30.09s call     test/test_schedule.py::TestIndexing::test_mnist_val
```