### PR TITLE
assert conv bw reduceops merge [compare_schedule]

### DIFF
--- a/test/external/process_replay/diff_schedule.py
+++ b/test/external/process_replay/diff_schedule.py
@@ -11,8 +11,10 @@ from tinygrad.engine.realize import CompiledRunner, lower_schedule_item
 
 def process_replay(outs:List[LazyBuffer], graph:DefaultDict[LBScheduleItem, List[LBScheduleItem]], in_degree:DefaultDict[LBScheduleItem, int]):
   # copy the reference module
+  ref_schedule = getenv("REF_COMMIT_HASH", "master")
   fp = __file__.replace("diff_schedule", "master_schedule")
-  if not os.path.isfile(fp): shutil.copyfile(fetch("https://raw.githubusercontent.com/tinygrad/tinygrad/master/tinygrad/engine/schedule.py"), fp)
+  if not os.path.isfile(fp):
+    shutil.copyfile(fetch(f"https://raw.githubusercontent.com/tinygrad/tinygrad/{ref_schedule}/tinygrad/engine/schedule.py"), fp)
   # create the reference graph
   ref_graph, ref_in_degree = importlib.import_module("test.external.process_replay.master_schedule")._graph_schedule(outs, set())
   # compare

--- a/test/external/process_replay/diff_schedule.py
+++ b/test/external/process_replay/diff_schedule.py
@@ -1,5 +1,5 @@
 # create a diff of two schedule graphs
-import shutil, importlib, uuid, os
+import shutil, importlib, uuid, os, logging
 from collections import defaultdict
 from typing import DefaultDict, List, Set, Tuple
 from test.external.process_replay.utils import print_diff
@@ -41,6 +41,7 @@ def diff_schedule(s:List[Tuple[DefaultDict[LBScheduleItem, List[LBScheduleItem]]
   return changed
 
 def print_si_diff(si0:ScheduleItem, si1:ScheduleItem):
+  logging.basicConfig(level=logging.INFO)
   ei0 = lower_schedule_item(si0)
   ei1 = lower_schedule_item(si1)
   assert isinstance(ei0.prg, CompiledRunner) and isinstance(ei1.prg, CompiledRunner)

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -4,6 +4,7 @@ import difflib, pickle, multiprocessing, os, logging, sqlite3, requests, io, zip
 from tabulate import tabulate
 from datetime import datetime
 from typing import Dict, List, cast
+from test.external.process_replay.utils import print_diff
 from tinygrad.codegen.kernel import Kernel
 from tinygrad.helpers import Context, ContextVar, colored, db_connection, VERSION, getenv, temp, tqdm
 
@@ -74,12 +75,9 @@ def print_ast_diff(offset:int):
   for row in cur.fetchall():
     buf, asts = pickle.loads(row[0])
     if len(asts) == 1:
-      print(f"{buf} was folded")
-      print(asts[0])
-    else:
-      diff = list(difflib.unified_diff(str(asts[0]).splitlines(), str(asts[1]).splitlines()))
-      unified_diff = "\n".join(colored(line, "red" if line.startswith("-") else "green" if line.startswith("+") else None) for line in diff)
-      print(unified_diff)
+      logging.info(f"{buf} was folded")
+      logging.info(asts[0])
+    else: print_diff(asts[0], asts[1])
 
 def download_artifact(run_id:str, name:str, dest:str):
   res = requests.get(f"{BASE_URL}/actions/runs/{run_id}/artifacts?name={name}", headers=GH_HEADERS)


### PR DESCRIPTION
kernel.py folds some already:
```
REF_COMMIT_HASH=b67d521a07d73f29e20200c124f4676285ac93d5 RUN_PROCESS_REPLAY=1 DEBUG=1 python3 test/test_schedule.py TestConvBW.test_fold_conv_relu_backward
```
![image](https://github.com/user-attachments/assets/f9d58e4f-8db5-4a7e-b371-8230d1f84f2f)

some beautiful_mnist kernels didn't fold before:
```
REF_COMMIT_HASH=b67d521a07d73f29e20200c124f4676285ac93d5 RUN_PROCESS_REPLAY=1 FUSE_CONV_BW=1 python3 examples/beautiful_mnist.py
```
![image](https://github.com/user-attachments/assets/d3ce73f4-644f-48db-9706-d3a40c220003)

and some kernels trigger other optimizations:

```
REF_COMMIT_HASH=b67d521a07d73f29e20200c124f4676285ac93d5 RUN_PROCESS_REPLAY=1 GPU=1 python3 test/external/external_test_opt.py TestOpt.test_expand_reduce_is_folded_on_different_axes
```

![image](https://github.com/user-attachments/assets/18162b77-d835-4685-a5f3-df87ab1acdfe)