### PR TITLE
don't offset if reading whole buffer [run_process_replay]

### DIFF
--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -81,8 +81,10 @@ class Buffer:
     self.allocator = Device[self.device].allocator
     if self._base is not None:
       self._base.ensure_allocated()
-      assert hasattr(self.allocator, "offset"), "offset function required for view"
-      self._buf: Any = self.allocator.offset(self.base._buf, self.nbytes, self.offset)
+      if self.offset == 0 and self.nbytes == self._base.nbytes: self._buf: Any = self._base._buf # view whole buffer
+      else:
+        assert hasattr(self.allocator, "offset"), "offset function required for view"
+        self._buf = self.allocator.offset(self.base._buf, self.nbytes, self.offset)
     else:
       self._buf = opaque if opaque is not None else self.allocator.alloc(self.nbytes, self.options)
       if not self.device.startswith("DISK"): GlobalCounters.mem_used += self.nbytes


### PR DESCRIPTION
If you put a print statement in the if and run ```test/unit/test_disk_tensor.py TestRawDiskBuffer```, it hits. The bitcast I proposed follows this