### PR TITLE
Cleanup cstlye render_const [run_process_replay]

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -47,11 +47,10 @@ class CStyleLanguage(Renderer):
   def render_const(self, x:ConstType, dtype:DType) -> str:
     if math.isnan(x): val = "NAN"
     elif math.isinf(x): val = ("-" if x < 0 else "") + "INFINITY"
-    elif dtype.scalar() == dtypes.bool: val = "1" if x else "0"
-    elif dtype.scalar() == dtypes.float: val = f"{x}f"
-    elif dtype.scalar() == dtypes.uint64: val = f"{x}ULL"
+    elif dtype == dtypes.bool: val = "1" if x else "0"
+    elif dtype == dtypes.float: val = f"{x}f"
+    elif dtype == dtypes.uint64: val = f"{x}ULL"
     else: val = str(x)
-    if dtype.count > 1: return self.render_vectorize([val] * dtype.count, dtype)
     return (self.render_cast(val, dtype) if dtype not in [dtypes.float, dtypes.int, dtypes.bool] else val)
 
   # returns a str expression of the loaded value with the output type

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -45,6 +45,7 @@ class CStyleLanguage(Renderer):
 
   # returns a str expression of the const with the given type
   def render_const(self, x:ConstType, dtype:DType) -> str:
+    assert dtype.count == 1, "consts should be scalar, got {dtype}"
     if math.isnan(x): val = "NAN"
     elif math.isinf(x): val = ("-" if x < 0 else "") + "INFINITY"
     elif dtype == dtypes.bool: val = "1" if x else "0"


### PR DESCRIPTION
Simplifies cstyle `render_const` in the spirit of #5313. This change takes advantage of the fact that CONSTs are always scalar, and localizes the complexity of deciding when to apply casts and extra parentheses to CONSTs in ALUs, where CONSTs are used to construct expressions as opposed to being used for simple assignments (where type promotion is easy to reason about).

process_replay impact: less excessive casting and parens.

e.g.
![image](https://github.com/user-attachments/assets/ab50b8a9-0e94-49b6-9a37-d06c517fa7ce)