### PR TITLE
Bitcast

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -241,29 +241,6 @@ class TestUint8DType(TestDType):
 
 @unittest.skipIf(Device.DEFAULT == "WEBGL", "No bitcast on WebGL")
 class TestBitCast(unittest.TestCase):
-  # def simple(self):
-  #   import tempfile, pathlib
-  #   _, tmp = tempfile.mkstemp()
-  #   a = Tensor(np.ones((3,40), np.float32), dtype=dtypes.float32, device=f"disk:{tmp}").bitcast(dtypes.int8).realize()
-  #   b = np.ones((3,40), np.float32).view(np.int8)
-  #   np.testing.assert_equal(a.numpy(), b)
-  #   pathlib.Path(tmp).unlink()
-  # def simple1(self):
-  #   a = Tensor(np.ones((3,40), np.float32), dtype=dtypes.float32).bitcast(dtypes.int8).realize()
-  #   b = np.ones((3,40), np.float32).view(np.int8)
-  #   np.testing.assert_equal(a.numpy(), b)
-  # def simple2(self):
-  #   a = Tensor(np.ones((3,40), np.float32), dtype=dtypes.float32).bitcast(dtypes.int16).realize()
-  #   b = np.ones((3,40), np.float32).view(np.int16)
-  #   np.testing.assert_equal(a.numpy(), b)
-  # def simple3(self):
-  #   from tinygrad.ops import MetaOps
-  #   a = Tensor.arange(12).reshape(4, 3).shrink(((1, 2), (1, 3))).contiguous().realize()
-  #   # assert isinstance(a.lazydata, LazyBuffer)
-  #   self.assertIs(a.lazydata.base.op, MetaOps.VIEW)
-  #   # a = Tensor.ones((3,40), dtype=dtypes.float32).bitcast(dtypes.int16).realize()
-  #   # b = np.ones((3,40), np.float32).view(np.int16)
-  #   # np.testing.assert_equal(a.numpy(), b)
   def test_fp32_to_uint8(self):
     _test_bitcast(Tensor([100000], dtype=dtypes.float32), dtypes.uint8)
     _test_bitcast(Tensor.randn((3,40), dtype=dtypes.float32), dtypes.uint8)

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -99,7 +99,7 @@ class TestDType(unittest.TestCase):
     if self.DTYPE == dtypes.bool: raise unittest.SkipTest("no bools in bitcast")
     list(map(
       lambda dtype:
-        _test_bitcast(Tensor(self.DATA, dtype=self.DTYPE), dtype) if dtype.itemsize == self.DTYPE.itemsize and dtype != dtypes.bool else None,
+        _test_bitcast(Tensor.ones((3,40), dtype=self.DTYPE).contiguous(), dtype) if dtype != dtypes.bool else None,
      get_available_cast_dtypes(self.DTYPE)
     ))
 

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -83,7 +83,7 @@ class Buffer:
     elif self._base is not None:
       self._base.ensure_allocated()
       assert hasattr(self.allocator, "offset"), "offset function required for view"
-      self._buf: Any = self.allocator.offset(self.base._buf, self.nbytes, self.offset)
+      self._buf = self.allocator.offset(self.base._buf, self.nbytes, self.offset)
     else:
       self._buf = self.allocator.alloc(self.nbytes, self.options)
       if not self.device.startswith("DISK"): GlobalCounters.mem_used += self.nbytes

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -107,8 +107,7 @@ class LazyBuffer:
     elif getenv("CAST_BEFORE_VIEW", 1) and dtype.itemsize <= self.dtype.itemsize and self != self.base:
       # TODO: applying this makes gpt2 slower
       return self.base.cast(dtype, bitcast)._view(self.st)
-    canView = self.st.consecutive and not self.is_unrealized_const()
-    cast_op: Union[MetaOps, UnaryOps] = (MetaOps.VIEW if canView and allow_buffer_view else UnaryOps.BITCAST) if bitcast else UnaryOps.CAST
+    cast_op: Union[MetaOps, UnaryOps] = (MetaOps.VIEW if allow_buffer_view else UnaryOps.BITCAST) if bitcast else UnaryOps.CAST
     return create_lazybuffer(self.device, ShapeTracker.from_shape(new_shape), dtype, cast_op, dtype, (self,))
 
   def is_unrealized_const(self): return self.base.realized is None and self.base.op is MetaOps.CONST and not isinstance(self.base.arg, Variable)

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -95,7 +95,7 @@ class LazyBuffer:
   def cast(self, dtype:DType, bitcast:bool=False, allow_buffer_view=True) -> LazyBuffer:
     if self.dtype == dtype: return self
     if self.device.startswith("DISK") and not bitcast: raise RuntimeError("attempted to cast disk buffer (bitcast only)")
-    if bitcast and not self.st.contiguous: raise RuntimeError("non-contiguous bitcast not supported")
+    if bitcast and not self.st.contiguous and not self.device.startswith("DISK"): raise RuntimeError("non-contiguous bitcast not supported")
     if self.is_unrealized_unmasked_const() and not bitcast:
       return create_lazybuffer(self.device, self.st, dtype, MetaOps.CONST, dtypes.as_const(self.base.arg, dtype))
     new_shape = self.shape

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -107,8 +107,9 @@ class LazyBuffer:
     elif getenv("CAST_BEFORE_VIEW", 1) and dtype.itemsize <= self.dtype.itemsize and self != self.base:
       # TODO: applying this makes gpt2 slower
       return self.base.cast(dtype, bitcast)._view(self.st)
-    canView = self.st.consecutive and not self.is_unrealized_const()
-    cast_op: Union[MetaOps, UnaryOps] = (MetaOps.VIEW if canView and allow_buffer_view else UnaryOps.BITCAST) if bitcast else UnaryOps.CAST
+    canView = self.st.consecutive and not self.is_unrealized_const() and allow_buffer_view
+    if not canView: raise RuntimeError("attempting to render bitcast")
+    cast_op: Union[MetaOps, UnaryOps] = MetaOps.VIEW if bitcast else UnaryOps.CAST
     return create_lazybuffer(self.device, ShapeTracker.from_shape(new_shape), dtype, cast_op, dtype, (self,))
 
   def is_unrealized_const(self): return self.base.realized is None and self.base.op is MetaOps.CONST and not isinstance(self.base.arg, Variable)

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -108,8 +108,7 @@ class LazyBuffer:
       # TODO: applying this makes gpt2 slower
       return self.base.cast(dtype, bitcast)._view(self.st)
     canView = self.st.consecutive and not self.is_unrealized_const()
-    if not canView: raise RuntimeError("attempting to render bitcast")
-    cast_op: Union[MetaOps, UnaryOps] = (MetaOps.VIEW if allow_buffer_view else UnaryOps.BITCAST) if bitcast else UnaryOps.CAST
+    cast_op: Union[MetaOps, UnaryOps] = (MetaOps.VIEW if canView and allow_buffer_view else UnaryOps.BITCAST) if bitcast else UnaryOps.CAST
     return create_lazybuffer(self.device, ShapeTracker.from_shape(new_shape), dtype, cast_op, dtype, (self,))
 
   def is_unrealized_const(self): return self.base.realized is None and self.base.op is MetaOps.CONST and not isinstance(self.base.arg, Variable)

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -107,7 +107,7 @@ class LazyBuffer:
     elif getenv("CAST_BEFORE_VIEW", 1) and dtype.itemsize <= self.dtype.itemsize and self != self.base:
       # TODO: applying this makes gpt2 slower
       return self.base.cast(dtype, bitcast)._view(self.st)
-    cast_op: Union[MetaOps, UnaryOps] = (MetaOps.VIEW if allow_buffer_view else UnaryOps.BITCAST) if bitcast else UnaryOps.CAST
+    cast_op: Union[MetaOps, UnaryOps] = (MetaOps.VIEW if not self.is_unrealized_const() and allow_buffer_view else UnaryOps.BITCAST) if bitcast else UnaryOps.CAST
     return create_lazybuffer(self.device, ShapeTracker.from_shape(new_shape), dtype, cast_op, dtype, (self,))
 
   def is_unrealized_const(self): return self.base.realized is None and self.base.op is MetaOps.CONST and not isinstance(self.base.arg, Variable)

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -107,7 +107,8 @@ class LazyBuffer:
     elif getenv("CAST_BEFORE_VIEW", 1) and dtype.itemsize <= self.dtype.itemsize and self != self.base:
       # TODO: applying this makes gpt2 slower
       return self.base.cast(dtype, bitcast)._view(self.st)
-    cast_op: Union[MetaOps, UnaryOps] = (MetaOps.VIEW if not self.is_unrealized_const() and allow_buffer_view else UnaryOps.BITCAST) if bitcast else UnaryOps.CAST
+    if bitcast: cast_op: Union[MetaOps, UnaryOps] = MetaOps.VIEW if not self.is_unrealized_const() and allow_buffer_view else UnaryOps.BITCAST
+    else: cast_op = UnaryOps.CAST
     return create_lazybuffer(self.device, ShapeTracker.from_shape(new_shape), dtype, cast_op, dtype, (self,))
 
   def is_unrealized_const(self): return self.base.realized is None and self.base.op is MetaOps.CONST and not isinstance(self.base.arg, Variable)

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -107,9 +107,9 @@ class LazyBuffer:
     elif getenv("CAST_BEFORE_VIEW", 1) and dtype.itemsize <= self.dtype.itemsize and self != self.base:
       # TODO: applying this makes gpt2 slower
       return self.base.cast(dtype, bitcast)._view(self.st)
-    canView = self.st.consecutive and not self.is_unrealized_const() and allow_buffer_view
+    canView = self.st.consecutive and not self.is_unrealized_const()
     if not canView: raise RuntimeError("attempting to render bitcast")
-    cast_op: Union[MetaOps, UnaryOps] = MetaOps.VIEW if bitcast else UnaryOps.CAST
+    cast_op: Union[MetaOps, UnaryOps] = (MetaOps.VIEW if allow_buffer_view else UnaryOps.BITCAST) if bitcast else UnaryOps.CAST
     return create_lazybuffer(self.device, ShapeTracker.from_shape(new_shape), dtype, cast_op, dtype, (self,))
 
   def is_unrealized_const(self): return self.base.realized is None and self.base.op is MetaOps.CONST and not isinstance(self.base.arg, Variable)


### PR DESCRIPTION
This uses MetaOps.VIEW to create a buffer object of new dtype with the same ```_buf``` buffer. This way generates no kernel code. Is this the desired behavior?