### PR TITLE
Interpolate Multi Fix

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1965,7 +1965,7 @@ class Tensor:
     x, expand = self, list(self.shape)
     for i in range(-len(size), 0):
       scale = (self.shape[i] - int(align_corners)) / (size[i] - int(align_corners))
-      arr, reshape = Tensor.arange(size[i], dtype=dtypes.float32), [1] * self.ndim
+      arr, reshape = Tensor.arange(size[i], dtype=dtypes.float32, device=self.device), [1] * self.ndim
       index = (scale*arr if align_corners else (scale*(arr+0.5))-0.5).clip(0, self.shape[i]-1)
       reshape[i] = expand[i] = size[i]
       low, high, perc = [y.reshape(reshape).expand(expand) for y in (index.floor(), index.ceil(), index - index.floor())]


### PR DESCRIPTION
Calling `.interpolate()` on a Tensor across multiple devices throws an error:
```
AssertionError: all buffers must be MultiLazyBuffer (<MLB... >, <LB... >)
```
This is due to the `Tensor.arange` being created on the default device rather than matching the input. Relaying that device to the constructor fixes the issue.

A new `TestTensorOps` class was made in `test/test_multitensor.py` to unit test the running of tensor ops on both a single and multiple devices, checking for error-less running as well as discrepancies in the result.
