### PR TITLE
temp: disable process replay on metal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -326,11 +326,12 @@ jobs:
       run: FUZZ_SCHEDULE=1 FUZZ_SCHEDULE_MAX_PATHS=5 python -m pytest test/models/test_train.py test/models/test_end2end.py
     - name: Run TRANSCENDENTAL math
       run: TRANSCENDENTAL=2 python -m pytest -n=auto test/test_ops.py::TestOps::test_sin test/test_ops.py::TestOps::test_cos test/test_ops.py::TestOps::test_tan test/test_ops.py::TestOps::test_exp test/test_ops.py::TestOps::test_log --durations=20
-    - name: Run process replay tests
-      run: |
-        export PR_TITLE=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
-        export COMMIT_MESSAGE=$(git show -s --format=%B ${{ github.event.pull_request.head.sha }})
-        cp test/external/process_replay/process_replay.py ./process_replay.py && git fetch origin master && git -c advice.detachedHead=false checkout origin/master && PYTHONPATH=. python3 process_replay.py
+      # TODO: this is timing out
+      #- name: Run process replay tests
+      #run: |
+      #  export PR_TITLE=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
+      #  export COMMIT_MESSAGE=$(git show -s --format=%B ${{ github.event.pull_request.head.sha }})
+      #  cp test/external/process_replay/process_replay.py ./process_replay.py && git fetch origin master && git -c advice.detachedHead=false checkout origin/master && PYTHONPATH=. python3 process_replay.py
 
 #  testwebgl:
 #    name: WebGL Tests


### PR DESCRIPTION
I'll take ownership of putting this back.
https://github.com/tinygrad/tinygrad/commit/6e3eb50fd172d7599e9a0aaea88b772460bd3a15 took 1 minute https://github.com/tinygrad/tinygrad/actions/runs/10361803011/job/28682742416#step:18:21

https://github.com/tinygrad/tinygrad/commit/18192079a9f49de43d059157067f8b29fcec9db9 and everything after it times out https://github.com/tinygrad/tinygrad/actions/runs/10364239612/job/28706053434#step:18:1

METAL tests also went from taking 5 minutes to 8.