### PR TITLE
Don't create cast variable if one of it's parents is an IF

### DIFF
--- a/test/test_renderer_failures.py
+++ b/test/test_renderer_failures.py
@@ -12,19 +12,22 @@ from tinygrad.renderer import Program
 from tinygrad.tensor import Tensor, _to_np_dtype
 from tinygrad.lazy import LazyBuffer
 
-def _test_uop_result(inputs:List[Tensor], stores:List[UOp]):
+def _test_uop_result(inputs:List[Tensor], uops:List[UOp]):
   for x in inputs: x.realize()
-  assert all(x.op is UOps.STORE for x in stores)
-  # NOTE: we only toposort the stores
-  uops: List[UOp] = []
-  def _recursive_add(uop:UOp) -> List[UOp]: return flatten([_recursive_add(x) for x in uop.src])+[uop]
-  uops = dedup(flatten(_recursive_add(st) for st in stores))
   outbufs = [Buffer(Device.DEFAULT, 1, cast(DType,u.src[2].dtype)).allocate() for u in uops if u.op is UOps.STORE]
   inbufs = [cast(LazyBuffer,x.lazydata).base.buffer for x in inputs]
   src = Device[Device.DEFAULT].renderer.render("test", uops)
   ei = CompiledRunner(Program("test", src, Device.DEFAULT, uops=uops))
   ei.exec(outbufs+inbufs)
   return [np.frombuffer(x.as_buffer(), _to_np_dtype(x.dtype)) for x in outbufs]
+
+def _get_uops_from_stores(stores:List[UOp]) -> List[UOp]:
+  assert all(x.op is UOps.STORE for x in stores)
+  # NOTE: we only toposort the stores
+  uops: List[UOp] = []
+  def _recursive_add(uop:UOp) -> List[UOp]: return flatten([_recursive_add(x) for x in uop.src])+[uop]
+  uops = dedup(flatten(_recursive_add(st) for st in stores))
+  return uops
 
 @unittest.skipIf(not isinstance(Device[Device.DEFAULT].renderer, CStyleLanguage), "uops are for cstyle")
 class TestCStyleFailures(unittest.TestCase):
@@ -36,8 +39,28 @@ class TestCStyleFailures(unittest.TestCase):
     alu = ld.alu(BinaryOps.MAX, UOp.const(dtypes.int, dtypes.min(dtypes.int)))
     store = UOp.store(a, idx, alu)
     # CLANG doesn't use the max function
-    ret = _test_uop_result([Tensor([1])], [store])[0]
+    ret = _test_uop_result([Tensor([1])], _get_uops_from_stores([store]))[0]
     self.assertEqual(ret[0], 1)
+
+  # simplified version of test_padto_where_multireduce
+  def test_oos_fails(self):
+    g = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), 0)
+    c0 = UOp.const(dtypes.int, 0)
+    c4 = UOp.const(dtypes.int, 4)
+    acc0 = c4.alu(BinaryOps.ADD, c4)
+    r0 = UOp(UOps.RANGE, dtypes.int, (c0, c4), (1, 0, False))
+    alu0 = UOp(UOps.ALU, dtypes.int, (r0, acc0), BinaryOps.ADD)
+    phi0 = UOp(UOps.PHI, dtypes.int, (acc0, alu0))
+    cast0 = UOp(UOps.CAST, dtypes.int64, (acc0,))
+    er0 = UOp(UOps.ENDRANGE, None, (r0,))
+    gate0 = UOp(UOps.ALU, dtypes.bool, (acc0, c0), BinaryOps.CMPNE)
+    if0 = UOp(UOps.IF, None, (gate0, cast0))
+    store0 = UOp.store(g, c0, cast0)
+    eif0 = UOp(UOps.ENDIF, None, (if0,))
+
+    uops = [g, c0, c4, acc0, r0, alu0, phi0, cast0, er0, gate0, if0, store0, eif0]
+    ret = _test_uop_result([Tensor([1])], uops)[0]
+    self.assertEqual(ret[0], 14)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_renderer_failures.py
+++ b/test/test_renderer_failures.py
@@ -43,7 +43,7 @@ class TestCStyleFailures(unittest.TestCase):
     self.assertEqual(ret[0], 1)
 
   # simplified version of test_padto_where_multireduce
-  def test_oos_fails(self):
+  def test_cast_out_of_scope(self):
     g = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), 0)
     c0 = UOp.const(dtypes.int, 0)
     c4 = UOp.const(dtypes.int, 4)
@@ -54,6 +54,8 @@ class TestCStyleFailures(unittest.TestCase):
     cast0 = UOp(UOps.CAST, dtypes.int64, (acc0,))
     er0 = UOp(UOps.ENDRANGE, None, (r0,))
     gate0 = UOp(UOps.ALU, dtypes.bool, (acc0, c0), BinaryOps.CMPNE)
+    # we want to have the IF come after the cast, but not actually dependent on it
+    # (i.e we don't want to have the cast have multiple deps and thus become a var inside the range loop)
     if0 = UOp(UOps.IF, None, (gate0, cast0))
     store0 = UOp.store(g, c0, cast0)
     eif0 = UOp(UOps.ENDIF, None, (if0,))

--- a/test/test_renderer_failures.py
+++ b/test/test_renderer_failures.py
@@ -43,7 +43,7 @@ class TestCStyleFailures(unittest.TestCase):
     self.assertEqual(ret[0], 1)
 
   # simplified version of test_padto_where_multireduce
-  def test_cast_to_half_out_of_scope(self):
+  def test_cast_half_out_of_scope(self):
     g = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), 0)
     c0 = UOp.const(dtypes.int, 0)
     c4 = UOp.const(dtypes.int, 4)
@@ -51,7 +51,7 @@ class TestCStyleFailures(unittest.TestCase):
     r0 = UOp(UOps.RANGE, dtypes.int, (c0, c4), (1, 0, False))
     alu0 = UOp(UOps.ALU, dtypes.int, (r0, acc0), BinaryOps.ADD)
     phi0 = UOp(UOps.PHI, dtypes.int, (acc0, alu0))
-    cast0 = UOp(UOps.CAST, dtypes.half, (acc0,))
+    cast0 = UOp(UOps.CAST, dtypes.float, (acc0,))
     er0 = UOp(UOps.ENDRANGE, None, (r0,))
     gate0 = UOp(UOps.ALU, dtypes.bool, (acc0, c0), BinaryOps.CMPNE)
     # we want to have the IF come after the cast, but not actually dependent on it
@@ -63,7 +63,7 @@ class TestCStyleFailures(unittest.TestCase):
     uops = [g, c0, c4, acc0, r0, alu0, phi0, cast0, er0, gate0, if0, store0, eif0]
     ret = _test_uop_result([Tensor([1])], uops)[0]
     # self.assertEqual(ret[0], np.int32(14).astype(np.int64))
-    self.assertAlmostEqual(ret[0], 8.3e-07) # 14 casted to half
+    self.assertAlmostEqual(ret[0], 2e-44) # 14 casted
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_renderer_failures.py
+++ b/test/test_renderer_failures.py
@@ -43,7 +43,7 @@ class TestCStyleFailures(unittest.TestCase):
     self.assertEqual(ret[0], 1)
 
   # simplified version of test_padto_where_multireduce
-  def test_cast_out_of_scope(self):
+  def test_cast_to_half_out_of_scope(self):
     g = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), (), 0)
     c0 = UOp.const(dtypes.int, 0)
     c4 = UOp.const(dtypes.int, 4)
@@ -51,7 +51,7 @@ class TestCStyleFailures(unittest.TestCase):
     r0 = UOp(UOps.RANGE, dtypes.int, (c0, c4), (1, 0, False))
     alu0 = UOp(UOps.ALU, dtypes.int, (r0, acc0), BinaryOps.ADD)
     phi0 = UOp(UOps.PHI, dtypes.int, (acc0, alu0))
-    cast0 = UOp(UOps.CAST, dtypes.bool, (acc0,))
+    cast0 = UOp(UOps.CAST, dtypes.half, (acc0,))
     er0 = UOp(UOps.ENDRANGE, None, (r0,))
     gate0 = UOp(UOps.ALU, dtypes.bool, (acc0, c0), BinaryOps.CMPNE)
     # we want to have the IF come after the cast, but not actually dependent on it
@@ -63,7 +63,7 @@ class TestCStyleFailures(unittest.TestCase):
     uops = [g, c0, c4, acc0, r0, alu0, phi0, cast0, er0, gate0, if0, store0, eif0]
     ret = _test_uop_result([Tensor([1])], uops)[0]
     # self.assertEqual(ret[0], np.int32(14).astype(np.int64))
-    self.assertAlmostEqual(ret[0], True) # 14 casted to float32
+    self.assertAlmostEqual(ret[0], 8.3e-07) # 14 casted to half
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_renderer_failures.py
+++ b/test/test_renderer_failures.py
@@ -51,7 +51,7 @@ class TestCStyleFailures(unittest.TestCase):
     r0 = UOp(UOps.RANGE, dtypes.int, (c0, c4), (1, 0, False))
     alu0 = UOp(UOps.ALU, dtypes.int, (r0, acc0), BinaryOps.ADD)
     phi0 = UOp(UOps.PHI, dtypes.int, (acc0, alu0))
-    cast0 = UOp(UOps.CAST, dtypes.float32, (acc0,))
+    cast0 = UOp(UOps.CAST, dtypes.bool, (acc0,))
     er0 = UOp(UOps.ENDRANGE, None, (r0,))
     gate0 = UOp(UOps.ALU, dtypes.bool, (acc0, c0), BinaryOps.CMPNE)
     # we want to have the IF come after the cast, but not actually dependent on it
@@ -63,7 +63,7 @@ class TestCStyleFailures(unittest.TestCase):
     uops = [g, c0, c4, acc0, r0, alu0, phi0, cast0, er0, gate0, if0, store0, eif0]
     ret = _test_uop_result([Tensor([1])], uops)[0]
     # self.assertEqual(ret[0], np.int32(14).astype(np.int64))
-    self.assertAlmostEqual(ret[0], 2e-44) # 14 casted to float32
+    self.assertAlmostEqual(ret[0], True) # 14 casted to float32
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_renderer_failures.py
+++ b/test/test_renderer_failures.py
@@ -62,7 +62,7 @@ class TestCStyleFailures(unittest.TestCase):
 
     uops = [g, c0, c4, acc0, r0, alu0, phi0, cast0, er0, gate0, if0, store0, eif0]
     ret = _test_uop_result([Tensor([1])], uops)[0]
-    self.assertEqual(ret[0], 14)
+    self.assertEqual(ret[0], np.int32(14).astype(np.int64))
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_renderer_failures.py
+++ b/test/test_renderer_failures.py
@@ -51,7 +51,7 @@ class TestCStyleFailures(unittest.TestCase):
     r0 = UOp(UOps.RANGE, dtypes.int, (c0, c4), (1, 0, False))
     alu0 = UOp(UOps.ALU, dtypes.int, (r0, acc0), BinaryOps.ADD)
     phi0 = UOp(UOps.PHI, dtypes.int, (acc0, alu0))
-    cast0 = UOp(UOps.CAST, dtypes.int64, (acc0,))
+    cast0 = UOp(UOps.CAST, dtypes.float16, (acc0,))
     er0 = UOp(UOps.ENDRANGE, None, (r0,))
     gate0 = UOp(UOps.ALU, dtypes.bool, (acc0, c0), BinaryOps.CMPNE)
     # we want to have the IF come after the cast, but not actually dependent on it
@@ -62,7 +62,8 @@ class TestCStyleFailures(unittest.TestCase):
 
     uops = [g, c0, c4, acc0, r0, alu0, phi0, cast0, er0, gate0, if0, store0, eif0]
     ret = _test_uop_result([Tensor([1])], uops)[0]
-    self.assertEqual(ret[0], np.int32(14).astype(np.int64))
+    # self.assertEqual(ret[0], np.int32(14).astype(np.int64))
+    self.assertAlmostEqual(ret[0], 8.3e-07)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_renderer_failures.py
+++ b/test/test_renderer_failures.py
@@ -51,7 +51,7 @@ class TestCStyleFailures(unittest.TestCase):
     r0 = UOp(UOps.RANGE, dtypes.int, (c0, c4), (1, 0, False))
     alu0 = UOp(UOps.ALU, dtypes.int, (r0, acc0), BinaryOps.ADD)
     phi0 = UOp(UOps.PHI, dtypes.int, (acc0, alu0))
-    cast0 = UOp(UOps.CAST, dtypes.float16, (acc0,))
+    cast0 = UOp(UOps.CAST, dtypes.float32, (acc0,))
     er0 = UOp(UOps.ENDRANGE, None, (r0,))
     gate0 = UOp(UOps.ALU, dtypes.bool, (acc0, c0), BinaryOps.CMPNE)
     # we want to have the IF come after the cast, but not actually dependent on it
@@ -63,7 +63,7 @@ class TestCStyleFailures(unittest.TestCase):
     uops = [g, c0, c4, acc0, r0, alu0, phi0, cast0, er0, gate0, if0, store0, eif0]
     ret = _test_uop_result([Tensor([1])], uops)[0]
     # self.assertEqual(ret[0], np.int32(14).astype(np.int64))
-    self.assertAlmostEqual(ret[0], 8.3e-07)
+    self.assertAlmostEqual(ret[0], 2e-44) # 14 casted to float32
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -41,7 +41,7 @@ class CStyleLanguage(Renderer):
 
   # returns a str expression of the vectorized xs with the given type
   def render_vectorize(self, x:List[str], var_dtype:DType) -> str:
-    assert len(x) == var_dtype.count, f"cast is wrong size {len(x)} != {var_dtype.count} ({x=}) ({var_dtype=})"
+    assert len(x) == var_dtype.count, f"cast is wrong size {len(x)} != {var_dtype.count}"
     assert self.float4 is not None, "vectorized cast is not supported on this platform"
     return f"{self.float4.replace('float4', self.render_dtype(var_dtype))}" + (f"{{{','.join(x)}}}" if self.device == "CLANG" else f"({','.join(x)})")
 


### PR DESCRIPTION
In relation to [this PR](https://github.com/tinygrad/tinygrad/pull/5976) and specifically [this comment](https://github.com/tinygrad/tinygrad/pull/5976#discussion_r1714155701).

In order to have IFs come after CASTs (and other UOps), we want to include those UOps as srcs of the IF, but not actually cause the UOps to be created as vars or other changes. Thus we exclude them from the count of parents when deciding on whether to create a var or not.

AMD tests failing [but they supposedly work on a real chip](https://github.com/tinygrad/tinygrad/pull/5976#issuecomment-2284641826)