### PR TITLE
Add Tensor.rearrange

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -6,6 +6,7 @@ from tinygrad.helpers import getenv, IMAGE, DEBUG, CI
 from tinygrad import Tensor, Device, dtypes
 from tinygrad.tensor import _to_np_dtype
 import functools
+import einops
 
 if CI:
   import warnings
@@ -1190,6 +1191,12 @@ class TestOps(unittest.TestCase):
     helper_test_op([(4,4)], lambda x: x[1:3][1:2])
     helper_test_op([(4,4)], lambda x: x[:, 1:2][0:1])
     helper_test_op([(4,4)], lambda x: x[:, 1:2][:, 0:1])
+
+  def test_rearrange(self):
+    helper_test_op([(7,5,10,9)], lambda x: einops.rearrange(x, 'b h w c -> (b h) w c'), lambda x: x.rearrange([[0, 1], 2, 3]))
+    helper_test_op([(7,5,10,9)], lambda x: einops.rearrange(x, 'b h w c -> h (b w) c'), lambda x: x.rearrange([1,[0,2],3]))
+    helper_test_op([(7,5,10,9)], lambda x: einops.rearrange(x, 'b h w c -> b c h w'), lambda x: x.rearrange([0,3,1,2]))
+    helper_test_op([(7,5,10,9)], lambda x: einops.rearrange(x, 'b h w c -> b (c h w)'), lambda x: x.rearrange([0,[3,1,2]]))
 
   def test_pad2d(self):
     helper_test_op([(3,3,3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4)), lambda x: x.pad2d(padding=(1,2,3,4)))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -494,6 +494,26 @@ class Tensor:
     return Tensor.full(argfix(*shape), 1.0, **kwargs)
 
   @staticmethod
+  def rearrange(self,axes):
+    order = []
+    shape = []
+    for i in range(len(axes)):
+        if(type(axes[i]) == int):
+            order.append(axes[i])
+            shape.append(self.shape[axes[i]])
+        else:
+            shape.append(self.shape[axes[i][0]])
+            order.append(axes[i][0])
+            for j in range(1,len(axes[i])):
+                shape[-1]*=self.shape[axes[i][j]]
+                order.append(axes[i][j])
+    for a in range(len(order)):
+        while(order[a] != a):
+            self = self.transpose(order[a],order[order[a]])
+            order[order[a]], order[a] = order[a], order[order[a]]
+    return self.reshape(*shape)
+
+  @staticmethod
   def arange(start, stop=None, step=1, **kwargs):
     """
     Returns a 1-D tensor of size `ceil((stop - start) / step)` with values from `[start, stop)`, with spacing between values given by `step`.


### PR DESCRIPTION
Todo

- add split functionality from https://einops.rocks/api/rearrange/ examples + tests
- validate inputs
- clean a lot
- remove einops import from test

Not sure if einops should be matched with the "b h w c" dimensions thing, I will change it to that style later unless told otherwise