### PR TITLE
test: try outputing DEFINE_VAR in the scheduler

### DIFF
--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -93,7 +93,10 @@ class IndependentLowerer:
       idx, valid = x.st_arg.to_indexed_uops(self.ridxs if x.op is UOps.LOAD and x.src[0].op is UOps.DEFINE_LOCAL else self.idxs)
       # TODO: check has_valid in UPat, not here
       has_valid = valid.op is not UOps.CONST or valid.arg is not True
-      if x.op is UOps.CONST: return valid.where(UOp.const(x.dtype, x.arg), UOp.const(x.dtype, 0))
+      if x.op in {UOps.CONST, UOps.DEFINE_VAR}:
+        # TODO: should vmin vmax end up with a valid.where too?
+        new_src = tuple(self.to_uop(y) for y in x.src[1:])
+        return valid.where(replace(x, src=new_src), UOp.const(x.dtype, 0))
       buf = x.src[0]
       if x.op is UOps.LOAD:
         barrier = (UOp(UOps.BARRIER, None, (self.to_uop(x.src[2]),)),) if x.src[0].op is UOps.DEFINE_LOCAL else ()

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -67,7 +67,8 @@ def _recursive_uop(buf:LazyBuffer, st:ShapeTracker, outputs:Tuple[LazyBuffer, ..
       if isinstance(val:=buf.arg, Variable):
         val, var_val = val.unbind()
         var_vals[val] = var_val
-      else: assert isinstance(val, get_args(ConstType)), f"cannot create ConstBuffer with value {val}"
+        return UOp(UOps.DEFINE_VAR, dtype, (unbound_st.to_uop(),), val)
+      assert isinstance(val, get_args(ConstType)), f"cannot create ConstBuffer with value {val}"
       return UOp(UOps.CONST, dtype, (unbound_st.to_uop(),), val)
     # otherwise, it's a load and we add it to the inputs
     if buf in assign_targets and not (unbound_st.contiguous or (len(unbound_st.views) == 1 and unbound_st.views[0].mask is not None and \

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -92,7 +92,7 @@ class UOps(Enum):
   # these two are not graph nodes
   ENDRANGE = auto(); ENDIF = auto() # noqa: E702
 
-BUFFER_UOPS = {UOps.LOAD, UOps.STORE, UOps.CONST}
+BUFFER_UOPS = {UOps.LOAD, UOps.STORE, UOps.CONST, UOps.DEFINE_VAR}
 
 END_FOR_UOP = {UOps.IF:(UOps.STORE, UOps.ENDIF), UOps.RANGE:(UOps.PHI, UOps.ENDRANGE)}
 
@@ -120,7 +120,7 @@ class UOp:
   @property
   def st_arg(self) -> ShapeTracker:
     assert self.op in BUFFER_UOPS, f"st_arg called on {self.op}"
-    ret = self.src[0 if self.op is UOps.CONST else 1]
+    ret = self.src[0 if self.op in {UOps.CONST, UOps.DEFINE_VAR} else 1]
     assert ret.op is UOps.SHAPETRACKER, f"st_arg trying to return {ret}"
     return ret.arg
   def ufix(self, x): return self.const(x) if not isinstance(x, UOp) else x


### PR DESCRIPTION
currently DEFINE_VAR is only a low-level uop, rewritten in the Lowerer. Would it make sense for the scheduler to output DEFINE_VAR in the Variable code path?
I don't think DEFINE_VAR's min/max have the typical valid.where on their ShapeTrackers.