### PR TITLE
Barrier consecutive load-store

### DIFF
--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -458,7 +458,7 @@ def create_gate(root:UOp) -> Optional[UOp]:
 
 def bar_load_store(root:UOp, buf:UOp, idx, val) -> Optional[UOp]:
   @functools.lru_cache(None)
-  def _bar_load(u:UOp) -> UOp:
+  def _bar_load(u:UOp) -> List[UOp]:
     if u.op is UOps.LOAD and u.src[0] is buf and u.src[2].op not in {UOps.IF}: return [u]
     if u.op is UOps.BARRIER or u.op is UOps.LOAD: return []
     return [l for x in u.src for l in _bar_load(x)]

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -584,7 +584,7 @@ def linearize_uop(sink_in:Union[UOp, List[UOp]], opts:Optional[Renderer]=None, s
     if DEBUG >= 7: print(f"{p:5d}",x)
     if x in scope_children: scope_end[x] = x
     if domain is not None and x.op is UOps.STORE and domain.op is UOps.LOAD and x.src[0] is domain.src[0]:
-      if not any(x in ss for _,ss in scope_children.items()): self.uops.append(UOp(UOps.BARRIER, None, (domain,)))
+      if not any(x in ss for _,ss in scope_children.items()): _uops.append(UOp(UOps.BARRIER, None, (domain,)))
     if (x.op in {UOps.LOAD, UOps.STORE} and x.src[0].op is UOps.DEFINE_LOCAL) or x.op is UOps.BARRIER: domain = x
     if x.op is UOps.DEFINE_ACC:
       idx = min([_uops.index(l) for l in x.src if l.op is UOps.RANGE])

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -315,7 +315,7 @@ def type_verify(uops):
     if uop is UOps.GEP: assert dtype == src[0].dtype.scalar(), f"GEP of {src[0].dtype=} should be {src[0].dtype.scalar()} != {dtype}"
     if uop is UOps.STORE:
       assert dtype is None, f"{uop} dtype must be None, got {dtype}"
-      if len(src) == 4: assert src[3].dtype == dtypes.bool, f"gate dtype mismatch {src[3].dtype} != {dtypes.bool}"
+      if len(src) == 4: assert src[3].dtype == dtypes.bool or src[3].op is UOps.BARRIER, f"gate dtype mismatch {src[3].dtype} != {dtypes.bool}"
     if uop is UOps.ALU:
       if arg in UnaryOps: assert dtype == src[0].dtype, f"{arg} dtype mismatch {dtype=} != {src[0].dtype=}"
       elif arg in {BinaryOps.CMPLT, BinaryOps.CMPNE}:

--- a/tinygrad/renderer/assembly.py
+++ b/tinygrad/renderer/assembly.py
@@ -191,7 +191,7 @@ class PTXRenderer(Renderer):
         assert src[1].op is UOps.CONST, f"store isn't const {u}"
         mem_type = '.shared' if src[0].op is UOps.DEFINE_LOCAL or any(x.op is UOps.DEFINE_LOCAL for x in src[0].parents) else '.global'
         if src[2].dtype.count > 1:
-          kk((f"@{r[src[3]]} " if len(src)>3 else "") + \
+          kk((f"@{r[src[3]]} " if len(src)>3 and src[3].op is not UOps.BARRIER else "") + \
               f"st{mem_type}.v{src[2].dtype.count}.{self.mem_types[src[2].dtype.scalar()]} [{r[src[0]]}+{src[1].arg}], {{{', '.join(r[src[2]])}}};")
         else:
           kk(*self.render_store(r[src[0]], r[src[2]], src[2].dtype, gate=r[src[3]] if len(src)>3 else None, ss=mem_type, offset=src[1].arg))

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -127,7 +127,7 @@ class CStyleLanguage(Renderer):
         # mark DEFINE_GLOBAL buf as writable
         if src[0].op is UOps.DEFINE_GLOBAL: bufs[src[0]] = (bufs[src[0]][0], (bufs[src[0]][1][0], True))
         rendered_store = self.render_store(r[src[0]], src[0].dtype, r[src[2]], src[2].dtype, strip_parens(r[src[1]]), src[0].op is UOps.DEFINE_LOCAL)
-        kk(f"if ({r[src[3]]}) {{ {rendered_store} }}" if len(src) > 3 else rendered_store)
+        kk(f"if ({r[src[3]]}) {{ {rendered_store} }}" if len(src) > 3 and src[3].op is not UOps.BARRIER else rendered_store)
       else:
         assert dtype is not None, f"None dtype for uop {uop}"
         if uop is UOps.RANGE:


### PR DESCRIPTION
Pre-req for multireduce

This adds a few lines to uopgraph that will insert barriers in the event of consecutive load-stores to the same local buffer

This is needed for multireduce to prevent writing to a local buffer, before every thread loads the result of the previous group reduce. This lets us use only one local buffer.
Ex:
```
  ...
  temp1[lidx1] = acc0; // store result of first reduce
  barrier(CLK_LOCAL_MEM_FENCE); // barrier prevents the grouped reduce from starting before every thread stores their reduce
  if (alu0) {
    float acc1 = 0.0f;
    for (int ridx1 = 0; ridx1 < 16; ridx1++) { /* first grouped reduce */ }
    temp1[0] = acc1;
  }
  barrier(CLK_LOCAL_MEM_FENCE); // barrier prevents threads from loading the result of the grouped reduce before it's finished
  float val2 = temp1[0];
  float acc2 = 0.0f;
  for (int ridx2 = 0; ridx2 < 2; ridx2++) { /* second reduce */ }
  barrier(CLK_LOCAL_MEM_FENCE); // PR adds a barrier here, prevents threads from storing their second reduce
                                // before every thread has loaded the result of the grouped reduce
  temp1[lidx0] = acc2;
  barrier(CLK_LOCAL_MEM_FENCE); // barrier before second grouped reduce
  if (alu0) {
```

* doesn't apply within `UOps.IF` because we can't gate barriers