### PR TITLE
Bugfix dont print get_kernal timings when DEBUG < 3

### DIFF
--- a/test/unit/test_realize.py
+++ b/test/unit/test_realize.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import patch
+from tinygrad.tensor import Tensor
+from tinygrad.ops import UOps, UOp
+from tinygrad.helpers import Context
+from tinygrad.engine.realize import get_kernel
+from tinygrad.device import Device
+
+class TestGetKernel(unittest.TestCase):
+  @patch("builtins.print")
+  def test_debug_print_trigger(self, mock_print):
+    t = Tensor.arange(10)
+    t = t + t * Tensor.rand(10)
+    with Context(DEBUG=1, BEAM=2):
+      # Generate the kernel and trigger the debug print
+      schedule_item = t.schedule()[-1]
+      kernel = get_kernel(Device[Device.DEFAULT].renderer, schedule_item.ast)
+      uops = kernel.linearize().uops
+      if uops:
+        sink = UOp(UOps.SINK, None, (uops[-1],))
+
+    for call in mock_print.ase:
+      self.assertNotIn("us", call[0][0])
+
+if __name__ == "__main__":
+  unittest.main(verbosity=2)

--- a/test/unit/test_realize.py
+++ b/test/unit/test_realize.py
@@ -17,7 +17,7 @@ class TestGetKernel(unittest.TestCase):
       kernel = get_kernel(Device[Device.DEFAULT].renderer, schedule_item.ast)
       uops = kernel.linearize().uops
       if uops:
-        sink = UOp(UOps.SINK, None, (uops[-1],))
+        UOp(UOps.SINK, None, (uops[-1],))
 
     for call in mock_print.ase:
       self.assertNotIn("us", call[0][0])

--- a/test/unit/test_realize.py
+++ b/test/unit/test_realize.py
@@ -6,6 +6,7 @@ from tinygrad.helpers import Context
 from tinygrad.engine.realize import get_kernel
 from tinygrad.device import Device
 
+
 class TestGetKernel(unittest.TestCase):
   @patch("builtins.print")
   def test_debug_print_trigger(self, mock_print):
@@ -21,6 +22,7 @@ class TestGetKernel(unittest.TestCase):
 
     for call in mock_print.ase:
       self.assertNotIn("us", call[0][0])
+
 
 if __name__ == "__main__":
   unittest.main(verbosity=2)

--- a/test/unit/test_realize.py
+++ b/test/unit/test_realize.py
@@ -13,7 +13,6 @@ class TestGetKernel(unittest.TestCase):
     t = Tensor.arange(10)
     t = t + t * Tensor.rand(10)
     with Context(DEBUG=1, BEAM=2):
-      # Generate the kernel and trigger the debug print
       schedule_item = t.schedule()[-1]
       kernel = get_kernel(Device[Device.DEFAULT].renderer, schedule_item.ast)
       uops = kernel.linearize().uops

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -15,12 +15,10 @@ from tinygrad.engine.schedule import ScheduleItem
 
 logkerns, logkerns_level = open(getenv("LOGKERNS", ""), "a") if getenv("LOGKERNS", "") else None, getenv("LOGKERNS_LEVEL", 1)
 def get_kernel(renderer:Renderer, ast:UOp) -> Kernel:
-  print("TEST==========")
   if DEBUG >= 5:
     print(ast)
   k = Kernel(ast, opts=renderer).required_optimizations()
   if not NOOPT:
-    print("<===================HERE")
     if not (used_tensor_cores:=k.apply_tensor_cores(getenv("TC", 1))): k.hand_coded_optimizations()
     if BEAM >= 1:
       from tinygrad.engine.search import beam_search, time_linearizer, bufs_from_lin

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -15,10 +15,12 @@ from tinygrad.engine.schedule import ScheduleItem
 
 logkerns, logkerns_level = open(getenv("LOGKERNS", ""), "a") if getenv("LOGKERNS", "") else None, getenv("LOGKERNS_LEVEL", 1)
 def get_kernel(renderer:Renderer, ast:UOp) -> Kernel:
+  print("TEST==========")
   if DEBUG >= 5:
     print(ast)
   k = Kernel(ast, opts=renderer).required_optimizations()
   if not NOOPT:
+    print("<===================HERE")
     if not (used_tensor_cores:=k.apply_tensor_cores(getenv("TC", 1))): k.hand_coded_optimizations()
     if BEAM >= 1:
       from tinygrad.engine.search import beam_search, time_linearizer, bufs_from_lin
@@ -34,7 +36,7 @@ def get_kernel(renderer:Renderer, ast:UOp) -> Kernel:
         lins: List[Tuple[str, Kernel]] = [(f"beam{BEAM.value}", k), (("tc" if used_tensor_cores else "hc"), k_opt)]
         if used_tensor_cores: lins.append(("hc", Kernel(ast, opts=renderer).hand_coded_optimizations()))
         timed = sorted([(nm, tk, time_linearizer(tk, rawbufs, allow_test_size=False, clear_l2=True)) for nm, tk in lins], key=lambda x: x[2])
-        if DEBUG >= 1: print("  <  ".join(f"{nm:6s} : {lin.colored_shape(30, dense=True)} : {tm*1e6:8.2f} us" for nm, lin, tm in timed))
+        if DEBUG >= 3: print("  <  ".join(f"{nm:6s} : {lin.colored_shape(30, dense=True)} : {tm*1e6:8.2f} us" for nm, lin, tm in timed))
         k = timed[0][1]
         if logkerns is not None and logkerns_level > 1: logkerns.writelines([f"{(lin.ast, lin.applied_opts)}\n" for (_,lin,_) in timed[1:]])
         if beam_compare == 2:


### PR DESCRIPTION
This implements the bugfix that @geohot did on pull request #6146 
Test is a regression test for the DEBUG level not being 1.