### PR TITLE
Add gunzip to fetch with assorted tests

### DIFF
--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -161,6 +161,12 @@ class TestFetch(unittest.TestCase):
       assert pimg.size == (77, 77), pimg.size
     assert img.parent.name == "images"
 
+  def test_fetch_gzip(self):
+    import gzip
+    with self.assertRaises(gzip.BadGzipFile): fetch("https://github.com/tinygrad/tinygrad/raw/master/docs/logo_tiny_light.svg", allow_caching=False, gunzip=True)
+    assert fetch("https://github.com/tinygrad/tinygrad/raw/c8cd6e725c7d67fde03aa9dbdecd316909a8bdfc/extra/datasets/sops.gz", allow_caching=False).stat().st_size == 488441 # default is gunzip=False
+    assert fetch("https://github.com/tinygrad/tinygrad/raw/c8cd6e725c7d67fde03aa9dbdecd316909a8bdfc/extra/datasets/sops.gz", allow_caching=False, gunzip=True).stat().st_size == 21064045
+
 class TestFullyFlatten(unittest.TestCase):
   def test_fully_flatten(self):
     self.assertEqual(fully_flatten([[1, 3], [1, 2]]), [1, 3, 1, 2])

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -163,9 +163,9 @@ class TestFetch(unittest.TestCase):
 
   def test_fetch_gzip(self):
     import gzip
-    with self.assertRaises(gzip.BadGzipFile): fetch("https://github.com/tinygrad/tinygrad/raw/master/docs/logo_tiny_light.svg", allow_caching=False, gunzip=True)
-    assert fetch("https://github.com/tinygrad/tinygrad/raw/c8cd6e725c7d67fde03aa9dbdecd316909a8bdfc/extra/datasets/sops.gz", allow_caching=False).stat().st_size == 488441 # default is gunzip=False
-    assert fetch("https://github.com/tinygrad/tinygrad/raw/c8cd6e725c7d67fde03aa9dbdecd316909a8bdfc/extra/datasets/sops.gz", allow_caching=False, gunzip=True).stat().st_size == 21064045
+    with self.assertRaises(gzip.BadGzipFile): fetch("https://t.ly/CYWNi", allow_caching=False, gunzip=True)
+    assert fetch("https://t.ly/UuuTd", allow_caching=False).stat().st_size == 488441 # default is gunzip=False
+    assert fetch("https://t.ly/UuuTd", allow_caching=False, gunzip=True).stat().st_size == 21064045
 
 class TestFullyFlatten(unittest.TestCase):
   def test_fully_flatten(self):

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import os, functools, platform, time, re, contextlib, operator, hashlib, pickle, sqlite3, tempfile, pathlib, string, ctypes, sys
-import itertools, urllib.request, subprocess, shutil, math, json, contextvars
+import itertools, urllib.request, subprocess, shutil, math, json, contextvars, gzip
 from dataclasses import dataclass
 from typing import Dict, Tuple, Union, List, ClassVar, Optional, Iterable, Any, TypeVar, TYPE_CHECKING, Callable, Sequence
 if TYPE_CHECKING:  # TODO: remove this and import TypeGuard from typing once minimum python supported version is 3.10
@@ -262,19 +262,22 @@ def diskcache(func):
 
 # *** http support ***
 
-def fetch(url:str, name:Optional[Union[pathlib.Path, str]]=None, subdir:Optional[str]=None,
+def fetch(url:str, name:Optional[Union[pathlib.Path, str]]=None, subdir:Optional[str]=None, gunzip=False,
           allow_caching=not getenv("DISABLE_HTTP_CACHE")) -> pathlib.Path:
   if url.startswith(("/", ".")): return pathlib.Path(url)
   if name is not None and (isinstance(name, pathlib.Path) or '/' in name): fp = pathlib.Path(name)
-  else: fp = pathlib.Path(_cache_dir) / "tinygrad" / "downloads" / (subdir or "") / (name or hashlib.md5(url.encode('utf-8')).hexdigest())
+  else:
+    fp = pathlib.Path(_cache_dir) / "tinygrad" / "downloads" / (subdir or "") / \
+      ((name or hashlib.md5(url.encode('utf-8')).hexdigest()) + (".gunzip" if gunzip else ""))
   if not fp.is_file() or not allow_caching:
     with urllib.request.urlopen(url, timeout=10) as r:
       assert r.status == 200
       total_length = int(r.headers.get('content-length', 0))
       progress_bar = tqdm(total=total_length, unit='B', unit_scale=True, desc=f"{url}", disable=CI)
       (path := fp.parent).mkdir(parents=True, exist_ok=True)
+      readfile = gzip.GzipFile(fileobj=r) if gunzip else r
       with tempfile.NamedTemporaryFile(dir=path, delete=False) as f:
-        while chunk := r.read(16384): progress_bar.update(f.write(chunk))
+        while chunk := readfile.read(16384): progress_bar.update(f.write(chunk))
         f.close()
         progress_bar.update(close=True)
         if (file_size:=os.stat(f.name).st_size) < total_length: raise RuntimeError(f"fetch size incomplete, {file_size} < {total_length}")


### PR DESCRIPTION
Add gunzip to fetch with assorted tests (not a gzip file, default behaviour of fetch, correct size of output for a valid file)