### PR TITLE
support for std_mean and cross_entropy

### DIFF
--- a/docs/tensor/ops.md
+++ b/docs/tensor/ops.md
@@ -8,6 +8,7 @@
 ::: tinygrad.Tensor.mean
 ::: tinygrad.Tensor.var
 ::: tinygrad.Tensor.std
+::: tinygrad.Tensor.std_mean
 ::: tinygrad.Tensor.softmax
 ::: tinygrad.Tensor.log_softmax
 ::: tinygrad.Tensor.logsumexp
@@ -40,3 +41,4 @@
 ::: tinygrad.Tensor.binary_crossentropy
 ::: tinygrad.Tensor.binary_crossentropy_logits
 ::: tinygrad.Tensor.sparse_categorical_crossentropy
+::: tinygrad.Tensor.cross_entropy

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2015,14 +2015,19 @@ class TestOps(unittest.TestCase):
     helper_test_op([(32,10), (32,10)], lambda x,y: torch.nn.functional.binary_cross_entropy(x.sigmoid(),torch.clip(y,0,1)),
                                        lambda x,y: x.binary_crossentropy_logits(y.clip(0,1)))
 
+  def test_cross_entropy(self):
+    helper_test_op([(32,10), (32,10)], lambda x,y: torch.nn.functional.cross_entropy(x, y),
+                                       lambda x,y: x.cross_entropy(y))
+    helper_test_op([(32,10), (32,10)], lambda x,y: torch.nn.functional.cross_entropy(x, torch.argmax(y, dim=1)),
+                                       lambda x,y: x.cross_entropy(y.argmax(axis=1)), forward_only=True)
   def test_cross_entropy_reductions(self):
     for r in ("mean", "sum", "none"):
-      helper_test_op([(32,10), (32,10)], lambda x,y: torch.nn.functional.cross_entropy(x, torch.clip(y,0,1), reduction=r),
-                                         lambda x,y: x.cross_entropy(y.clip(0,1), reduction=r))
+      helper_test_op([(32,10), (32,10)], lambda x,y: torch.nn.functional.cross_entropy(x, y, reduction=r),
+                                         lambda x,y: x.cross_entropy(y, axis=1, reduction=r))
   def test_cross_entropy_smoothing(self):
     for ls in (0., 0.3, 0.7, 1.):
-      helper_test_op([(32,10), (32,10)], lambda x,y: torch.nn.functional.cross_entropy(x, torch.clip(y,0,1), label_smoothing=ls),
-                                         lambda x,y: x.cross_entropy(y.clip(0,1), label_smoothing=ls))
+      helper_test_op([(32,10), (32,10)], lambda x,y: torch.nn.functional.cross_entropy(x, y, label_smoothing=ls),
+                                         lambda x,y: x.cross_entropy(y, label_smoothing=ls))
 
   def test_one_hot(self):
     data = [1, 2, 4]

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -988,7 +988,17 @@ class TestOps(unittest.TestCase):
   def test_std_keepdim(self):
     helper_test_op([(15, 25, 35)], lambda x: x.std(keepdim=True))
     helper_test_op([(15, 25, 35)], lambda x: x.std(0, keepdim=True, correction=0))
-
+  def test_std_mean(self):
+    helper_test_op([(15,25,35)], lambda x: torch.stack(torch.std_mean(x)),
+                                 lambda x: Tensor.stack(*x.std_mean()))
+    helper_test_op([(15,25,35)], lambda x: torch.stack(torch.std_mean(x, correction=5)),
+                                 lambda x: Tensor.stack(*x.std_mean(correction=5)))
+    helper_test_op([(15,25,35)], lambda x: torch.stack(torch.std_mean(x, keepdim=True, correction=0)),
+                                 lambda x: Tensor.stack(*x.std_mean(keepdim=True, correction=0)))
+    helper_test_op([(1,0,3,0,5)], lambda x: torch.stack(torch.std_mean(x, axis=(1,3))),
+                                  lambda x: Tensor.stack(*x.std_mean(axis=(1,3))))
+    helper_test_op([(3,4,5,6)], lambda x: torch.stack(torch.std_mean(x, axis=(1,2))),
+                                lambda x: Tensor.stack(*x.std_mean(axis=(1,2))))
   def test_softmax(self):
     # exceed per kernel buffer limit with backward
     forward_only = (Device.DEFAULT == "WEBGPU")
@@ -2004,6 +2014,15 @@ class TestOps(unittest.TestCase):
                                        lambda x,y: x.sigmoid().binary_crossentropy(y.clip(0,1)))
     helper_test_op([(32,10), (32,10)], lambda x,y: torch.nn.functional.binary_cross_entropy(x.sigmoid(),torch.clip(y,0,1)),
                                        lambda x,y: x.binary_crossentropy_logits(y.clip(0,1)))
+
+  def test_cross_entropy_reductions(self):
+    for r in ("mean", "sum", "none"):
+      helper_test_op([(32,10), (32,10)], lambda x,y: torch.nn.functional.cross_entropy(x, torch.clip(y,0,1), reduction=r),
+                                         lambda x,y: x.cross_entropy(y.clip(0,1), reduction=r))
+  def test_cross_entropy_smoothing(self):
+    for ls in (0., 0.3, 0.7, 1.):
+      helper_test_op([(32,10), (32,10)], lambda x,y: torch.nn.functional.cross_entropy(x, torch.clip(y,0,1), label_smoothing=ls),
+                                         lambda x,y: x.cross_entropy(y.clip(0,1), label_smoothing=ls))
 
   def test_one_hot(self):
     data = [1, 2, 4]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1517,6 +1517,31 @@ class Tensor:
     """
     return self.var(axis, keepdim, correction).sqrt()
 
+  def std_mean(self, axis:Optional[Union[int, Sequence[int]]]=None, keepdim=False, correction=1):
+    """
+    Calculates the standard deviation and mean over the dimensions specified by dim.
+    Syntactic sugar around `Tensor.std` and `Tensor.mean` to match `torch.std_mean`.
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    Tensor.manual_seed(42)
+    t = Tensor.normal(2, 3, mean=2.5, std=0.5)
+    print(t.numpy())
+    ```
+    ```python exec="true" source="above" session="tensor" result="python"
+    std, mean = t.std_mean()
+    print(std.numpy(), mean.numpy())
+    ```
+    ```python exec="true" source="above" session="tensor" result="python"
+    std, mean = t.std_mean(axis=0)
+    print(std.numpy(), mean.numpy())
+    ```
+    ```python exec="true" source="above" session="tensor" result="python"
+    std, mean = t.std_mean(axis=1)
+    print(std.numpy(), mean.numpy())
+    ```
+    """
+    return self.std(axis, keepdim, correction), self.mean(axis, keepdim)
+
   def _softmax(self, axis):
     m = self - self.max(axis=axis, keepdim=True)
     e = m.exp()
@@ -3007,6 +3032,25 @@ class Tensor:
     y = ((y_counter == Y.flatten().reshape(-1, 1)) * loss_mask.reshape(-1, 1)).reshape(*Y.shape, self.shape[-1])
     smoothing = label_smoothing * (log_probs.mean(-1) * loss_mask).sum()
     return -((1 - label_smoothing) * (log_probs * y).sum() + smoothing) / loss_mask.sum()
+
+  def cross_entropy(self, y:Tensor, reduction:str='mean', label_smoothing:float=0.0) -> Tensor:
+    """
+    Compute the cross entropy loss between input logits and target.
+
+    See: https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor([[-1, 2, -3], [1, -2, 3]])
+    Y = Tensor([1, 2])
+    print(t.cross_entropy(Y).item())
+    ```
+    """
+    assert 0.0 <= label_smoothing <= 1.0, "label_smoothing must be in [0.0, 1.0]"
+    assert reduction in ("mean", "sum", "none"), "reduction must be one of ['mean', 'sum', 'none']"
+    y = (1 - label_smoothing)*y + label_smoothing / cast(int, y.shape[1])
+    ret = -self.log_softmax(axis=1).mul(y).sum(axis=1)
+    do_reduction: Dict[str, Callable[[Tensor], Tensor]] = {"mean": Tensor.mean, "sum": Tensor.sum, "none": lambda x: x}
+    return do_reduction[reduction](ret)
 
   # ***** Tensor Properties *****
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3054,7 +3054,7 @@ class Tensor:
     """
     assert 0.0 <= label_smoothing <= 1.0, "label_smoothing must be in [0.0, 1.0]"
     assert reduction in ("mean", "sum", "none"), "reduction must be one of ['mean', 'sum', 'none']"
-    y = y.one_hot(num_classes=self.shape[1]) if y.ndim < 2 else y
+    y = y.one_hot(num_classes=cast(int, self.shape[1])) if y.ndim < 2 else y
     y = (1 - label_smoothing)*y + label_smoothing / cast(int, y.shape[1])
     ret = -self.log_softmax(axis=1).mul(y).sum(axis=1)
     do_reduction: Dict[str, Callable[[Tensor], Tensor]] = {"mean": Tensor.mean, "sum": Tensor.sum, "none": lambda x: x}

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3037,16 +3037,24 @@ class Tensor:
     """
     Compute the cross entropy loss between input logits and target.
 
-    See: https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html
+    NOTE: `self` are logits and `Y` are the target labels or class probabilities.
+
+    See: https://pytorch.org/docs/stable/generated/torch.nn.functional.cross_entropy.html
 
     ```python exec="true" source="above" session="tensor" result="python"
     t = Tensor([[-1, 2, -3], [1, -2, 3]])
     Y = Tensor([1, 2])
     print(t.cross_entropy(Y).item())
     ```
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor([[-1, 2, -3], [1, -2, 3]])
+    Y = Tensor([1, 2])
+    print(t.cross_entropy(Y, reduction='none').numpy())
+    ```
     """
     assert 0.0 <= label_smoothing <= 1.0, "label_smoothing must be in [0.0, 1.0]"
     assert reduction in ("mean", "sum", "none"), "reduction must be one of ['mean', 'sum', 'none']"
+    y = y.one_hot(num_classes=self.shape[1]) if y.ndim < 2 else y
     y = (1 - label_smoothing)*y + label_smoothing / cast(int, y.shape[1])
     ret = -self.log_softmax(axis=1).mul(y).sum(axis=1)
     do_reduction: Dict[str, Callable[[Tensor], Tensor]] = {"mean": Tensor.mean, "sum": Tensor.sum, "none": lambda x: x}


### PR DESCRIPTION
- Added `std_mean` and `cross_entropy` to the tensor class.
- Added tests for both methods.

With respect to the code in https://github.com/tinygrad/tinygrad/pull/6146, I also added `asserts` to `cross_entropy` and examples in the documentation for both functions.

I am not sure whether the tests for `std_mean` should be expanded.