### PR TITLE
track running stats bug (BatchNorm)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -75,8 +75,8 @@ class TestNN(unittest.TestCase):
 
   def test_batchnorm3d(self): self.test_batchnorm2d(threed=True)
   def test_batchnorm3d_training(self): self.test_batchnorm2d(training=True, threed=True)
-  def test_batchnorm3d_tracking(self): self.test_batchnorm2d(tracking=True, threed=True)
-  def test_batchnorm3d_training_and_tracking(self): self.test_batchnorm2d(training=True, tracking=True, threed=True)
+  def test_batchnorm3d_tracking(self): self.test_batchnorm2d(track_running_stats=True, threed=True)
+  def test_batchnorm3d_training_and_tracking(self): self.test_batchnorm2d(training=True, track_running_stats=True, threed=True)
 
   def test_batchnorm_axis(self):
     sz = (2, 4, 3, 2, 2)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -195,7 +195,7 @@ class TestSchedule(unittest.TestCase):
       c1 = nn.Conv2d(3,32,3)
       bn = nn.BatchNorm2d(32, track_running_stats=False)
       out = bn(c1(img)).relu()
-      check_schedule(out, 1, [c1.weight, c1.bias])
+      check_schedule(out, 4, [c1.weight, c1.bias])
 
   def test_fold_conv_batchnorm(self):
     with Tensor.train():

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -35,30 +35,28 @@ class BatchNorm:
     if affine: self.weight, self.bias = Tensor.ones(sz), Tensor.zeros(sz)
     else: self.weight, self.bias = None, None
 
-    self.running_mean, self.running_var = Tensor.zeros(sz, requires_grad=False), Tensor.ones(sz, requires_grad=False)
     self.num_batches_tracked = Tensor.zeros(1, requires_grad=False)
+    if track_running_stats: self.running_mean, self.running_var = Tensor.zeros(sz, requires_grad=False), Tensor.ones(sz, requires_grad=False)
+
+  def calc_stats(self, x:Tensor) -> Tuple[Tensor, Tensor]:
+    shape_mask = [1, -1, *([1]*(x.ndim-2))]
+    if self.track_running_stats and not Tensor.training: return self.running_mean, self.running_var.reshape(shape=shape_mask).expand(x.shape)
+    # This requires two full memory accesses to x
+    # https://github.com/pytorch/pytorch/blob/c618dc13d2aa23625cb0d7ada694137532a4fa33/aten/src/ATen/native/cuda/Normalization.cuh
+    # There's "online" algorithms that fix this, like https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_Online_algorithm
+    batch_mean = x.mean(axis=(reduce_axes:=tuple(x for x in range(x.ndim) if x != 1)))
+    y = (x - batch_mean.detach().reshape(shape=shape_mask))  # d(var)/d(mean) = 0
+    batch_var = (y*y).mean(axis=reduce_axes)
+    return batch_mean, batch_var
 
   def __call__(self, x:Tensor):
-    shape_mask = [1, -1, *([1]*(x.ndim-2))]
-    if Tensor.training:
-      # This requires two full memory accesses to x
-      # https://github.com/pytorch/pytorch/blob/c618dc13d2aa23625cb0d7ada694137532a4fa33/aten/src/ATen/native/cuda/Normalization.cuh
-      # There's "online" algorithms that fix this, like https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_Online_algorithm
-      batch_mean = x.mean(axis=(reduce_axes:=tuple(x for x in range(x.ndim) if x != 1)))
-      y = (x - batch_mean.detach().reshape(shape=shape_mask))  # d(var)/d(mean) = 0
-      batch_var = (y*y).mean(axis=reduce_axes)
-      batch_invstd = batch_var.add(self.eps).pow(-0.5)
-
-      # NOTE: wow, this is done alldef test_batchnorm3d(self): self.test_batchnorm2d(threed=True) throughout training in most PyTorch models
-      if self.track_running_stats:
-        self.running_mean.assign((1-self.momentum) * self.running_mean + self.momentum * batch_mean.detach())
-        self.running_var.assign((1-self.momentum) * self.running_var + self.momentum * prod(y.shape)/(prod(y.shape)-y.shape[1]) * batch_var.detach())
-        self.num_batches_tracked += 1
-    else:
-      batch_mean = self.running_mean
-      # NOTE: this can be precomputed for static inference. we expand it here so it fuses
-      batch_invstd = self.running_var.reshape(shape=shape_mask).expand(x.shape).add(self.eps).rsqrt()
-    return x.batchnorm(self.weight, self.bias, batch_mean, batch_invstd)
+    mean, var = self.calc_stats(x)
+    # NOTE: wow, this is done all throughout training in most PyTorch models
+    if self.track_running_stats and Tensor.training:
+      self.running_mean.assign((1-self.momentum) * self.running_mean + self.momentum * mean.detach())
+      self.running_var.assign((1-self.momentum) * self.running_var + self.momentum * prod(x.shape)/(prod(x.shape)-x.shape[1]) * var.detach())
+      self.num_batches_tracked += 1
+    return x.batchnorm(self.weight, self.bias, mean, var.add(self.eps).rsqrt())
 BatchNorm2d = BatchNorm3d = BatchNorm
 
 def Conv1d(in_channels, out_channels, kernel_size, stride=1, padding=0, dilation=1, groups=1, bias=True):

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -49,7 +49,7 @@ class BatchNorm:
       batch_var = (y*y).mean(axis=reduce_axes)
       batch_invstd = batch_var.add(self.eps).pow(-0.5)
 
-      # NOTE: wow, this is done all throughout training in most PyTorch models
+      # NOTE: wow, this is done alldef test_batchnorm3d(self): self.test_batchnorm2d(threed=True) throughout training in most PyTorch models
       if self.track_running_stats:
         self.running_mean.assign((1-self.momentum) * self.running_mean + self.momentum * batch_mean.detach())
         self.running_var.assign((1-self.momentum) * self.running_var + self.momentum * prod(y.shape)/(prod(y.shape)-y.shape[1]) * batch_var.detach())


### PR DESCRIPTION
This PR builds upon #6146

## Changes to Tests (`test/`)
- Altered `test_batchnorm2d` to use valid variance values (i.e. non-negative values).
- Altered `test_batchnorm2d` to only assign and test the running stats when `track_running_stats=True`
- The PyTorch Batch now properly sets `track_running_stats`
- Also possible combinations of parameters for `test_batchnorm2d` are tried (though probs not needed).
- To mimic pytorch, `test_fold_conv_batchnorm_notrain()` is updated to allow 4 kernels.

## Changes to BatchNorm (`tinygrad.nn.__init__.py__`)
- The tracked stats are used if in eval mode (i.e. Tensor.training == False).
- `calc_stats()` is added.
- Variable names are changed to reflect their usage more accurately.