### PR TITLE
Update evaluation_cases URL for kits19

### DIFF
--- a/extra/datasets/kits19.py
+++ b/extra/datasets/kits19.py
@@ -33,7 +33,7 @@ def get_train_files():
 
 @functools.lru_cache(None)
 def get_val_files():
-  data = fetch("https://raw.githubusercontent.com/mlcommons/training/master/image_segmentation/pytorch/evaluation_cases.txt").read_text()
+  data = fetch("https://raw.githubusercontent.com/mlcommons/training/master/retired_benchmarks/unet3d/pytorch/evaluation_cases.txt").read_text()
   return sorted([x for x in BASEDIR.iterdir() if x.stem.split("_")[-1] in data.split("\n")])
 
 def load_pair(file_path):


### PR DESCRIPTION
MLPerf made some recent changes (see [here](https://github.com/mlcommons/training/pull/756)) since UNet3D is a retired benchmark and they moved it inside of their `retired_benchmarks` subfolder. This PR updates it to that new location.