### PR TITLE
update test_arange test_llama_embedding_opt

### DIFF
--- a/test/test_arange.py
+++ b/test/test_arange.py
@@ -161,7 +161,7 @@ class TestIndexing(unittest.TestCase):
       # TODO: reshape to match torch, should we do this in nn?
       np.testing.assert_allclose(z.numpy().reshape(4, embed_size), torch_z.detach().numpy(), atol=1e-8, rtol=1e-8)
   # at least the arange is being fused
-  def test_llama_embedding_opt(self): self.test_llama_embedding(0, 1736704000)
+  def test_llama_embedding_opt(self): self.test_llama_embedding(0, 1_736_704_000 if CI else 3_801_088_000)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
non CI uses larger embedding, still same orders of magnitude