### PR TITLE
simpler & faster UOp key

### DIFF
--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -146,7 +146,7 @@ class BufferXfer(BufferCopy):
 
 # **************** method cache ****************
 
-method_cache: Dict[Tuple[str, bytes, int, int, bool], CompiledRunner] = {}
+method_cache: Dict[Tuple[str, int, int, int, bool], CompiledRunner] = {}
 def get_runner(dname:str, ast:UOp) -> CompiledRunner:
   ckey = (dname, ast.key, BEAM.value, NOOPT.value, False)
   if cret:=method_cache.get(ckey): return cret

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Any, DefaultDict, List, Optional, Set, Union, Tuple, Dict, Callable, cast, TYPE_CHECKING, Sequence
-import sys, time, math, operator, ctypes, struct, functools, hashlib, itertools
+import sys, time, math, operator, ctypes, struct, functools, itertools
 from collections import defaultdict
 from enum import Enum, auto
 from dataclasses import dataclass, field
@@ -72,8 +72,8 @@ class UOp:
             self.arg.value, self.dtype, self.src)
   def __lt__(self, x:UOp): return self.cmp_tuple < x.cmp_tuple
   @functools.cached_property
-  def key(self) -> bytes:
-    return hashlib.sha256(functools.reduce(lambda x,y: x+y, [s.key for s in self.src], str((self.op, self.dtype, self.arg)).encode())).digest()
+  def key(self) -> int:
+    return hash((tuple(s.key for s in self.src), self.op, self.dtype, self.arg))
   def __repr__(self): return pretty_print(self, lambda x: f"{type(self).__name__}({x.op}, {x.dtype}, arg={x.argstr()}, src=(%s))")
   def argstr(self):
     return f'({", ".join(map(str, self.arg))})' if self.op is UOps.REDUCE_AXIS else repr(self.arg) if isinstance(self.arg, Variable) else self.arg


### PR DESCRIPTION
This potentially could just use the builtin `hash` function. Does not need to be a cached property anymore either.

`python -O test/external/external_test_speed_llama.py`

master
```
codegen(0)      mean runtime:  169.99ms, runs:   231.78,  143.90,  157.94,  146.22,  170.13
codegen(1)      mean runtime:  160.19ms, runs:   212.01,  142.28,  144.54,  153.92,  148.23
methodcache     mean runtime:  122.26ms, runs:   130.98,  117.75,  118.34,  126.58,  117.65
profile         mean runtime:  358.61ms, runs:   362.39,  356.50,  364.70,  353.77,  355.69
```

branch
```
codegen(0)      mean runtime:  150.76ms, runs:   208.69,  128.98,  138.77,  135.32,  142.07
codegen(1)      mean runtime:  144.40ms, runs:   191.80,  128.79,  138.18,  130.26,  132.98
methodcache     mean runtime:  107.44ms, runs:   118.65,  102.11,  102.56,  111.41,  102.46
profile         mean runtime:  334.07ms, runs:   335.63,  327.87,  327.13,  342.77,  336.98
```