### PR TITLE
CLIP Batched Pooling

### DIFF
--- a/extra/models/clip.py
+++ b/extra/models/clip.py
@@ -372,7 +372,8 @@ class FrozenOpenClipEmbedder(Embedder):
 
     if self.return_pooled:
       x = self.model.ln_final(x)
-      pooled = x[:, tokens.argmax(axis=-1).numpy().item()] @ self.model.text_projection
+      index = tokens.argmax(axis=-1).reshape(-1,1,1).expand(x.shape[0],1,x.shape[-1])
+      pooled = x.gather(1, index).squeeze(1) @ self.model.text_projection
       return penultimate, pooled
     else:
       return penultimate


### PR DESCRIPTION
## Overview

Previous version only worked for batch_size=0 and had to call `.numpy()`

New version works with any batch size and doesn't rely on a `.numpy()` call

## Testing

```
PYTHONPATH=. NV=1 python examples/sdxl.py --seed 0
output validated with distance=0.00289628142490983
```
