### PR TITLE
Add support and tests for "nearest" mode in interpolate

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1770,6 +1770,12 @@ class TestOps(unittest.TestCase):
       lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=(111,28)),
       lambda x: Tensor.avg_pool2d(x, kernel_size=(111,28)), rtol=1e-5)
 
+  def test_interpolate_nearest(self):
+    for in_sz, out_sz in [((52,),(29,)), ((29,),(52,))]:
+      helper_test_op([(2,3)+in_sz],
+          lambda x: torch.nn.functional.interpolate(x, size=out_sz, mode="nearest"),
+          lambda x: Tensor.interpolate(x, size=out_sz, mode="nearest"))
+
   def test_interpolate_linear(self):
     for in_sz, out_sz in [((52,),(29,)), ((29,),(52,))]:
       helper_test_op([(2,3)+in_sz],

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2071,7 +2071,7 @@ class Tensor:
       scale = (self.shape[i] - int(align_corners)) / (size[i] - int(align_corners))
       arr, reshape = Tensor.arange(size[i], dtype=dtypes.float32, device=self.device), [1] * self.ndim
       if mode == "nearest":
-        index = ((scale*arr) if align_corners else (scale*(arr+0.5)- 0.5)).round().clip(0, self.shape[i] - 1)
+        index = ((scale*(arr+0.5)- 0.5)).round().clip(0, self.shape[i] - 1)
         reshape[i] = expand[i] = size[i]
         x = x.gather(i, index.reshape(reshape).expand(expand))
       elif mode == "linear":

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2071,7 +2071,7 @@ class Tensor:
       scale = (self.shape[i] - int(align_corners)) / (size[i] - int(align_corners))
       arr, reshape = Tensor.arange(size[i], dtype=dtypes.float32, device=self.device), [1] * self.ndim
       if mode == "nearest":
-        index = ((scale*(arr+0.5)- 0.5)).round().clip(0, self.shape[i] - 1)
+        index = (scale * arr).floor().clip(0, self.shape[i] - 1)
         reshape[i] = expand[i] = size[i]
         x = x.gather(i, index.reshape(reshape).expand(expand))
       elif mode == "linear":

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2050,7 +2050,7 @@ class Tensor:
     """
     Downsamples or Upsamples to the input `size`, accepts 0 to N batch dimensions.
 
-    The interpolation algorithm is selected with `mode` which currently only supports `linear`.
+    The interpolation algorithm is selected with `mode` which currently only supports `linear` and 'nearest'.
     To run `bilinear` or `trilinear`, pass in a 2D or 3D size.
 
     ```python exec="true" source="above" session="tensor" result="python"
@@ -2060,17 +2060,25 @@ class Tensor:
     ```python exec="true" source="above" session="tensor" result="python"
     print(t.interpolate(size=(2,3), mode="linear").numpy())
     ```
+    ```python exec="true" source="above" session="tensor" result="python"
+    print(t.interpolate(size=(2,3), mode="nearest").numpy())
+    ```
     """
     assert isinstance(size, (tuple,list)) and all_int(size) and 0 < len(size) <= self.ndim, f"invalid {size=}"
-    assert mode == "linear", "only supports linear interpolate"
+    assert mode in ["linear", "nearest"], "only supports linear and nearest interpolate"
     x, expand = self, list(self.shape)
     for i in range(-len(size), 0):
       scale = (self.shape[i] - int(align_corners)) / (size[i] - int(align_corners))
       arr, reshape = Tensor.arange(size[i], dtype=dtypes.float32, device=self.device), [1] * self.ndim
-      index = (scale*arr if align_corners else (scale*(arr+0.5))-0.5).clip(0, self.shape[i]-1)
-      reshape[i] = expand[i] = size[i]
-      low, high, perc = [y.reshape(reshape).expand(expand) for y in (index.floor(), index.ceil(), index - index.floor())]
-      x = x.gather(i, low).lerp(x.gather(i, high), perc)
+      if mode == "nearest":
+        index = ((scale*arr) if align_corners else (scale*(arr+0.5)- 0.5)).round().clip(0, self.shape[i] - 1)
+        reshape[i] = expand[i] = size[i]
+        x = x.gather(i, index.reshape(reshape).expand(expand))
+      elif mode == "linear":
+        index = (scale*arr if align_corners else (scale*(arr+0.5))-0.5).clip(0, self.shape[i]-1)
+        reshape[i] = expand[i] = size[i]
+        low, high, perc = [y.reshape(reshape).expand(expand) for y in (index.floor(), index.ceil(), index - index.floor())]
+        x = x.gather(i, low).lerp(x.gather(i, high), perc)
     return x.cast(self.dtype)
 
   # ***** unary ops *****


### PR DESCRIPTION
Adds "nearest" mode to the `interpolate` function using the `round` function, referencing https://pytorch.org/docs/stable/generated/torch.nn.functional.interpolate.html

However, I have also discovered that there are "nearest" and "nearest exactly" modes that were added afterward in PyTorch (https://github.com/pytorch/pytorch/issues/34808). Should then these both be added?