### PR TITLE
Batched CLIP Score

### DIFF
--- a/extra/models/clip.py
+++ b/extra/models/clip.py
@@ -451,9 +451,9 @@ class OpenClipEncoder:
 
   def get_clip_score(self, tokens:Tensor, image:Tensor) -> Tensor:
     image_features: Tensor = self.visual(image)
-    image_features /= image_features.square().sum([-1,-2], keepdim=True).sqrt() # Frobenius Norm
+    image_features /= image_features.square().sum(-1, keepdim=True).sqrt() # Frobenius Norm
 
-    text_features = self.encode_tokens(tokens).squeeze(0)
-    text_features /= text_features.square().sum([-1,-2], keepdim=True).sqrt() # Frobenius Norm
+    text_features = self.encode_tokens(tokens)
+    text_features /= text_features.square().sum(-1, keepdim=True).sqrt() # Frobenius Norm
 
-    return image_features @ text_features.T
+    return (image_features * text_features).sum(axis=-1)


### PR DESCRIPTION
## Overview

The clip score computation was originally built and tested against single batch inputs and provides wrong answers for batch sizes >1

This PR fixes this code and produces consistent results with variable batch sizes

## Testing

Just image+caption 1: `score: [0.3593387]`
Just image+caption 2: `score: [0.39535367]`
Batched images+captions 1 & 2: `score: [0.35933858 0.39535385]`
