### PR TITLE
Fix blockDim.{x, y, z} and gridDim.{x, y, z} being zero

### DIFF
--- a/test/test_ops_nv.py
+++ b/test/test_ops_nv.py
@@ -9,11 +9,14 @@ from tinygrad.runtime.ops_nv import NVDevice
 
 MOCKGPU = getenv("MOCKGPU")
 
-@unittest.skipUnless(type(Device[Device.DEFAULT]) == NVDevice, "NV device required to run")
+@unittest.skipUnless(isinstance(Device[Device.DEFAULT], NVDevice), "NV device required to run")
 class TestOpsNV(unittest.TestCase):
   @unittest.skipIf(MOCKGPU, "Can't run on MOCKGPU for now due to constbuf[0] hack")
   def test_blockdim_non_zero(self):
-    program = Program("test_blockdim_nonzero","extern \"C\" __global__ void test_blockdim_nonzero(float *dst) {int idx = blockDim.x * blockIdx.x + threadIdx.x;dst[idx] = 1.0f;}","nv")
+    program = Program("test_blockdim_nonzero",
+                      "extern \"C\" __global__ void test_blockdim_nonzero(float *dst) {"
+                      "int idx = blockDim.x * blockIdx.x + threadIdx.x;dst[idx] = 1.0f;}",
+                      "nv")
     runner = CompiledRunner(program)
     N = 1024
     block_size = 256

--- a/test/test_ops_nv.py
+++ b/test/test_ops_nv.py
@@ -1,0 +1,32 @@
+import unittest
+
+from tinygrad import Device, dtypes
+from tinygrad.device import BufferOptions, Buffer
+from tinygrad.engine.realize import CompiledRunner
+from tinygrad.helpers import getenv, to_mv
+from tinygrad.renderer import Program
+from tinygrad.runtime.ops_nv import NVDevice
+
+MOCKGPU = getenv("MOCKGPU")
+
+@unittest.skipUnless(type(Device[Device.DEFAULT]) == NVDevice, "NV device required to run")
+class TestOpsNV(unittest.TestCase):
+  @unittest.skipIf(MOCKGPU, "Can't run on MOCKGPU for now due to constbuf[0] hack")
+  def test_blockdim_non_zero(self):
+    program = Program("test_blockdim_nonzero","extern \"C\" __global__ void test_blockdim_nonzero(float *dst) {int idx = blockDim.x * blockIdx.x + threadIdx.x;dst[idx] = 1.0f;}","nv")
+    runner = CompiledRunner(program)
+    N = 1024
+    block_size = 256
+    grid_size = N // block_size
+    dst_buf = Buffer(Device.DEFAULT, N, dtypes.float32, options=BufferOptions(cpu_access=True)).ensure_allocated()
+    runner.clprg(
+      dst_buf._buf,
+      global_size=(grid_size, 1, 1),
+      local_size=(block_size, 1, 1),
+      wait=True
+    )
+    dst_mv = to_mv(dst_buf._buf.va_addr, 4 * N).cast('f')
+    assert dst_mv.tolist() == ([1.0] * N)
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -147,6 +147,7 @@ class NVComputeQueue(NVCommandQueue, HWComputeQueue):
     self.cmd_idx_to_qmd[(cmd_idx := len(self) - 1)] = qmd = qmd_struct_t.from_address(qmd_addr) # Save qmd for later update
     self.cmd_idx_to_global_dims[cmd_idx] = to_mv(qmd_addr + nv_gpu.NVC6C0_QMDV03_00_CTA_RASTER_WIDTH[1] // 8, 12).cast('I')
     self.cmd_idx_to_local_dims[cmd_idx] = to_mv(qmd_addr + nv_gpu.NVC6C0_QMDV03_00_CTA_THREAD_DIMENSION0[1] // 8, 6).cast('H')
+    to_mv(args_state.ptr, 6 * 4).cast('I')[:] = array.array('I', [*local_size, *global_size])
 
     qmd.cta_raster_width, qmd.cta_raster_height, qmd.cta_raster_depth = global_size
     qmd.cta_thread_dimension0, qmd.cta_thread_dimension1, qmd.cta_thread_dimension2 = local_size


### PR DESCRIPTION
`ops_nv.py` does not correctly populate `blockDim.{x, y, z}` and `gridDim.{x, y, z}` in launched cuda kernels.

PTX `ntid.{x, y, z}` and `nctaid.{x, y, z}` register accesses get compiled into SASS `MOV`s loading from the first constant bank at offsets `0x0` to `0x14` (first `6*sizeof(int)` bytes)

eg.
`ntid.x` -> `MOV R2, c[0x0][0x0]`
`ntid.y` -> `MOV R2, c[0x0][0x4]`
...


Tinygrad seems to not rely on these being populated, as the values get inline-compiled into the kernel, but I suspect this fix is still needed to avoid future confusion, as it breaks cuda quite on a fundamental level.

# How to test
```cpp
extern "C" __global__ void write_float(float *dst) {
    int idx = blockDim.x * blockIdx.x + threadIdx.x;
    dst[idx] = 1.0f;
}
```

```console
nvcc -ptx -std=c++11 -arch sm_89 write_float.cu -o write_float.ptx
ptxas -arch sm_89 write_float.ptx -o write_float.cubin
```

```python
from tinygrad.device import BufferOptions
from tinygrad.helpers import to_mv
from tinygrad.runtime.ops_nv import NVProgram, NVDevice

if __name__ == '__main__':
    device = NVDevice("nv:0")

    with open("write_float.cubin", "rb") as f:
        simple_bytes = f.read()

    prog = NVProgram(
        device, "write_float",
        simple_bytes
    )

    dst_buf = device.allocator.alloc(size=4 * 1024, options=BufferOptions(cpu_access=True))

    dst_mv = to_mv(dst_buf.va_addr, 4 * 1024).cast('f')
    print(dst_mv[1])

    N = 1024
    block_size = 256
    grid_size = N // block_size

    prog(
        dst_buf,
        global_size=(grid_size, 1, 1),
        local_size=(block_size, 1, 1),
        wait=True
    )

    print(dst_mv.tolist())
```

## Expected results
The existing tinygrad implementation only populates `256` float values with `1.0` while the rest stay at `0.0`, as the `blockDim.x * blockIdx.x` expresion multiplies to `0` and thus does not allow for correct index calculation.

With the fix, all values should be correctly populated as `1.0`.