### PR TITLE
start benchmarking ast graph rewrite

### DIFF
--- a/test/external/external_benchmark_ast.py
+++ b/test/external/external_benchmark_ast.py
@@ -1,0 +1,52 @@
+import time
+import plotly.graph_objects as go
+from typing import Dict, List, Tuple
+from extra.models.resnet import ResNet50
+from tinygrad import Tensor
+from tinygrad.codegen.kernel import Kernel
+from tinygrad.helpers import Context, getenv, to_function_name
+from tinygrad.engine.schedule import _get_output_groups, _lower_lazybuffer
+from tinygrad.ops import UOps
+
+if __name__ == "__main__":
+  mdl = ResNet50()
+  img = Tensor.empty(64, 3, 224, 224)
+  out = mdl(img)
+  output_groups, realizes, _ = _get_output_groups(out.lazydata.lbs, set())
+
+  kernels: List[str] = []
+  no_rewrite: List[float] = []
+  for k,v in output_groups.items():
+    st = time.perf_counter_ns()
+    lsi = _lower_lazybuffer(v, realizes)
+    et = time.perf_counter_ns() - st
+    if lsi.ast.op is UOps.EXT: continue
+    no_rewrite.append(et*1e-6)
+    kernels.append(Kernel(lsi.ast).name)
+
+  rewrite: List[float] = []
+  with Context(AST_REWRITE=1):
+    for k,v in output_groups.items():
+      st = time.perf_counter_ns()
+      lsi = _lower_lazybuffer(v, realizes)
+      et = time.perf_counter_ns() - st
+      if lsi.ast.op is UOps.EXT: continue
+      rewrite.append(et*1e-6)
+
+  assert len(rewrite) == len(no_rewrite) == len(kernels)
+
+  data: Dict[str, Tuple[float, float]] = {k:(rewrite[i], no_rewrite[i]) for i,k in enumerate(kernels)}
+  slowest_kernels = list(sorted(data.items(), reverse=False, key=lambda x:((x[1][1]-x[1][0])/x[1][1])*100))
+  print("slowest ast rewrites:")
+  for k,tms in slowest_kernels[:10]:
+    print(f"{k:10s}   {tms[1]:4.2f} ms -> {tms[0]:4.2f} ms")
+
+  if getenv("GRAPH_TIMING"):
+    sample = slowest_kernels[:20]
+    x = [to_function_name(x) for x,_ in sample]
+    y1, y2 = [x[1][0] for x in sample], [x[1][1] for x in sample]
+    fig = go.Figure(data=[go.Bar(name="no graph_rewrite", x=x, y=y2, marker=dict(color="#524eed", line=dict(color='rgba(0,0,0,0)'))),
+                          go.Bar(name="graph_rewrite", x=x, y=y1, marker=dict(color="#6fcf97", line=dict(color='rgba(0,0,0,0)')))])
+    fig.update_layout(barmode="group", paper_bgcolor="black", plot_bgcolor="black",
+                      font={"color":"white"}, yaxis={"gridcolor":"rgba(255, 255, 255, 0.3)"})
+    fig.show()

--- a/test/external/external_benchmark_ast.py
+++ b/test/external/external_benchmark_ast.py
@@ -45,7 +45,8 @@ if __name__ == "__main__":
   print("slowest ast rewrites:")
   for k,pct in slowest_kernels[:10]:
     _, no_rw, rw, outs = kernel_tms[k]
-    print(f"{names[k]:10s}   {no_rw:4.2f} ms -> {rw:4.2f} ms {pct:4.2f}% {outs}")
+    print(f"{names[k]:10s}   {no_rw:4.2f} ms -> {rw:4.2f} ms {pct:4.2f}%")
+  with open("/tmp/kernel_tms", "wb") as f: pickle.dump(kernel_tms, f)
 
   if getenv("GRAPH_TIMING"):
     sample = slowest_kernels[:20]

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -13,8 +13,6 @@ from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.device import Buffer
 from tinygrad.shape.view import View, strides_for_shape
 
-from line_profiler import profile
-
 # creation can recurse a lot
 sys.setrecursionlimit(10000)
 
@@ -142,22 +140,14 @@ def get_output_st(uop:UOp, uop_sts:Dict[UOp, ShapeTracker]) -> Optional[ShapeTra
   uop_sts[uop] = st = ShapeTracker.from_shape(src_sts[0].reduce(uop.arg[1])) if uop.op is UOps.REDUCE_AXIS else src_sts[0]
   return st
 
-
-@profile
 def st_fixup(u:UOp, apply_to_st:Callable[[ShapeTracker], ShapeTracker], uop_sts:Dict[UOp, ShapeTracker], cache:Dict[UOp, UOp]) -> UOp:
   if (n:=cache.get(u)): return n
-  if (st:=uop_sts.get(u)):
-    new_st = apply_to_st(st) # this reshape is taking 25.2% of the time?
-    if st == new_st: return u
+  if (st:=uop_sts.get(u)) and st == apply_to_st(st): return u
   if u.op is UOps.SHAPETRACKER:
     new_st = apply_to_st(u.arg)
-    if u.arg == new_st: return u
-    #return replace(u, arg=new_st)
-    return UOp(UOps.SHAPETRACKER, arg=new_st) # without dataclass.replace went from 32.0 to 10.0...
+    return u if u.arg == new_st else replace(u, arg=new_st)
   new_srcs = tuple(st_fixup(x, apply_to_st, uop_sts, cache) for x in u.src)
-  # 43.0 -> 12.0
-  cache[u] = ret = u if new_srcs == u.src else UOp(u.op, u.dtype, new_srcs, u.arg)
-  #cache[u] = ret = u if new_srcs == u.src else replace(u, src=new_srcs)
+  cache[u] = ret = u if new_srcs == u.src else replace(u, src=new_srcs)
   return ret
 
 def permute_reduce(input_st:ShapeTracker, axis:Tuple[int, ...]) -> Tuple[ShapeTracker, Tuple[sint, ...]]:
@@ -187,7 +177,6 @@ def apply_swizzle(root:UOp, rsrc:UOp, swizzle:UOp) -> UOp:
   new_input_st, new_axis = swizzle_reduceop(unwrap(get_output_st(rsrc, uop_sts)), swizzle.arg, root.arg[1])
   return replace(root, src=(st_fixup(rsrc, lambda _:new_input_st, uop_sts, {}),), arg=(root.arg[0], new_axis))
 
-#@profile
 def push_reduceop_shape(root:UOp) -> Optional[UOp]:
   reduceops = [x for x in root.parents if x.op is UOps.REDUCE_AXIS]
   if len(reduceops) == 0: return None

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -110,7 +110,7 @@ GRAPH, GRAPHPATH, SAVE_SCHEDULE, RING = ContextVar("GRAPH", 0), getenv("GRAPHPAT
 MULTIOUTPUT, PROFILE, PROFILEPATH = ContextVar("MULTIOUTPUT", 1), ContextVar("PROFILE", 0), ContextVar("PROFILEPATH", temp("tinygrad_profile.json"))
 USE_TC, TC_OPT, TRANSCENDENTAL = ContextVar("TC", 1), ContextVar("TC_OPT", 0), ContextVar("TRANSCENDENTAL", 1)
 FUSE_ARANGE, FUSE_CONV_BW = ContextVar("FUSE_ARANGE", 0), ContextVar("FUSE_CONV_BW", 0)
-SPLIT_REDUCEOP, ARANGE_DIFF = ContextVar("SPLIT_REDUCEOP", 1), ContextVar("ARANGE_DIFF", 0)
+SPLIT_REDUCEOP, AST_REWRITE = ContextVar("SPLIT_REDUCEOP", 1), ContextVar("AST_REWRITE", 0)
 
 @dataclass(frozen=True)
 class Metadata:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -327,6 +327,7 @@ if TRACK_MATCH_STATS:
     ret = [0,0,0.0,0.0]
     for k,v in sorted(list(match_stats.items()), key=lambda x: x[1][2]):
       loc_str = f"{k.location[0].split('/')[-1]}:{k.location[1]}"
+      if getenv("SCHEDULE_ONLY") and "schedule" not in loc_str: continue
       print(f"{v[0]:6d} / {v[1]:7d} -- {v[3]*1000.:9.2f} / {v[2]*1000.:9.2f} ms -- {loc_str:15s}", k.printable())
       ret = [x+y for x,y in zip(ret, v)]
     print(f"{ret[0]:6d} / {ret[1]:7d} -- {ret[3]*1000.:9.2f} / {ret[2]*1000.:9.2f} ms -- TOTAL")

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -327,7 +327,6 @@ if TRACK_MATCH_STATS:
     ret = [0,0,0.0,0.0]
     for k,v in sorted(list(match_stats.items()), key=lambda x: x[1][2]):
       loc_str = f"{k.location[0].split('/')[-1]}:{k.location[1]}"
-      if getenv("SCHEDULE_ONLY") and "schedule" not in loc_str: continue
       print(f"{v[0]:6d} / {v[1]:7d} -- {v[3]*1000.:9.2f} / {v[2]*1000.:9.2f} ms -- {loc_str:15s}", k.printable())
       ret = [x+y for x,y in zip(ret, v)]
     print(f"{ret[0]:6d} / {ret[1]:7d} -- {ret[3]*1000.:9.2f} / {ret[2]*1000.:9.2f} ms -- TOTAL")


### PR DESCRIPTION
Some reduceop kerenls take far longer than others:
![newplot](https://github.com/user-attachments/assets/7b7b08e4-f761-42b0-9d16-3f678c4f8f18)

This diff has some infra to isolate ScheduleItems.