### PR TITLE
Ops.key: no need for functools here

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -76,7 +76,7 @@ class UOp:
   def __lt__(self, x:UOp): return self.cmp_tuple < x.cmp_tuple
   @functools.cached_property
   def key(self) -> bytes:
-    return hashlib.sha256(functools.reduce(lambda x,y: x+y, [s.key for s in self.src], str((self.op, self.dtype, self.arg)).encode())).digest()
+    return hashlib.sha256(str((self.op, self.dtype, self.arg)).encode() + b"".join([s.key for s in self.src])).digest()
   def __repr__(self): return pretty_print(self, lambda x: f"{type(self).__name__}({x.op}, {x.dtype}, arg={x.argstr()}, src=(%s))")
   def argstr(self):
     return f'({", ".join(map(str, self.arg))})' if self.op is UOps.REDUCE_AXIS else repr(self.arg) if isinstance(self.arg, Variable) else self.arg


### PR DESCRIPTION
No major speed impact, but a bit simpler.

`JIT=0 kernprof -lv examples/llama.py --gen 1 --prompt "Hello." --count 10 --temperature 0 --timing`

```
Total time: 0.416079 s
File: /Users/rvd/src/rvd/tinygrad/tinygrad/ops.py
Function: key at line 77

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    77                                             @functools.cached_property
    78                                             @profile
    79                                             def key(self) -> bytes:
    80    225149     416079.0      1.8    100.0      return hashlib.sha256(functools.reduce(lambda x,y: x+y, [s.key for s in self.src], str((self.op, self.dtype, self.arg)).encode())).digest()
```

```
Total time: 0.394044 s
File: /Users/rvd/src/rvd/tinygrad/tinygrad/ops.py
Function: key at line 77

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    77                                             @functools.cached_property
    78                                             @profile
    79                                             def key(self) -> bytes:
    80    225149     394044.0      1.8    100.0      return hashlib.sha256(str((self.op, self.dtype, self.arg)).encode() + b"".join([s.key for s in self.src])).digest()
```