### PR TITLE
perf: cached_property on early reject is slow

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -442,7 +442,7 @@ class UPat:
     self.allowed_len: int = 0 if allow_any_len or isinstance(src, UPat) or src is None else len(src)
     self.location = location or get_location()
 
-  @property
+  @functools.cached_property
   def early_reject(self) -> Set[Tuple[UOps, Any]]:
     if self.custom_early_reject is not None: return self.custom_early_reject
     upat_match = [self.in_src] if isinstance(self.in_src, UPat) else ([] if self.in_src is None else self.src[0])

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -442,7 +442,7 @@ class UPat:
     self.allowed_len: int = 0 if allow_any_len or isinstance(src, UPat) or src is None else len(src)
     self.location = location or get_location()
 
-  @functools.cached_property
+  @property
   def early_reject(self) -> Set[Tuple[UOps, Any]]:
     if self.custom_early_reject is not None: return self.custom_early_reject
     upat_match = [self.in_src] if isinstance(self.in_src, UPat) else ([] if self.in_src is None else self.src[0])


### PR DESCRIPTION
`PROFILE=0 python -O test/external/external_benchmark_schedule.py` best out of 5

Master
```
***** model tensor in     17.41 ms
***** model schedule in    7.25 ms
***** model opts(53) in   29.08 ms
***** model lower in       6.35 ms
***** model rewrite in   477.46 ms
***** model linearize in 127.28 ms
14964
all 668.97 ms
```

Branch
```
***** model tensor in     17.48 ms
***** model schedule in    7.28 ms
***** model opts(53) in   28.40 ms
***** model lower in       6.30 ms
***** model rewrite in   454.29 ms
***** model linearize in 121.87 ms
14964
all 639.66 ms
```