### PR TITLE
perf: skip type verify with -O

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -587,6 +587,7 @@ def uop_alu_resolve(u:UOp) -> sint:
 # ***** uop type spec *****
 
 def type_verify(uops):
+  if not __debug__: return  # python -O sets __debug__ to False
   for u in uops:
     uop, arg, src, dtype = u.op, u.arg, u.src, u.dtype
     if uop is UOps.DEFINE_LOCAL: assert isinstance(dtype, PtrDType), f"invalid dtype for local buffer {dtype}"


### PR DESCRIPTION
`type_verify` is full of asserts. These get removed with `-O`, but all the if statements are still be executed, which is more than 10% of the linearize.

Using the fact that `__debug__` is set to false with `-O` we can skip everything here. (The other option would be to use the `PYTHONOPTIMIZE` value.)


`PROFILE=0 python -O test/external/external_benchmark_schedule.py` best out of 5

Master
```
***** model tensor in     17.15 ms
***** model schedule in    7.27 ms
***** model opts(53) in   28.97 ms
***** model lower in       6.32 ms
***** model rewrite in   478.40 ms
***** model linearize in 121.98 ms <--
14964
```

Branch
```
***** model tensor in     17.75 ms
***** model schedule in    7.23 ms
***** model opts(53) in   28.43 ms
***** model lower in       6.16 ms
***** model rewrite in   479.67 ms
***** model linearize in 108.13 ms <--
14964
all 651.34 ms
```

