### PR TITLE
FSDP in tinygrad

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -74,6 +74,14 @@ def get_contraction(old_shape:Tuple[sint, ...], new_shape:Tuple[sint, ...]) -> O
   except ValueError: return None
   return [list(range(st,ed)) for st,ed in zip([0]+split[:-1], split[:-1]+[len(old_shape)])]
 
+def get_bounds(devices:Tuple[str, ...], axis_shape:int, axis:Optional[int], splits:Optional[Tuple[int, ...]]=None, pads:Optional[bool]=False):
+  if splits is None:
+    sz = round_up(axis_shape, len(devices)) // len(devices)
+    splits = tuple([max(0, min(sz, axis_shape - sz*i)) for i in range(len(devices))])
+  assert sum(splits) == axis_shape, "specified splits do not sum up to axis shape"
+  boundaries = tuple(itertools.accumulate(splits))
+  return tuple(zip((0,) + boundaries, boundaries)) if not pads else tuple(zip((0,) + boundaries, [axis_shape-b for b in boundaries]))
+
 @functools.lru_cache(maxsize=None)
 def to_function_name(s:str): return ''.join([c if c in (string.ascii_letters+string.digits+'_') else f'{ord(c):02X}' for c in ansistrip(s)])
 @functools.lru_cache(maxsize=None)

--- a/tinygrad/multi.py
+++ b/tinygrad/multi.py
@@ -42,6 +42,14 @@ def all_reduce(op: ReduceOps, lbs: List[LazyBuffer]) -> List[LazyBuffer]:
   pads = [((s,dim-e),) for s,e in chunks]
   return [functools.reduce(lambda x,y: x.e(BinaryOps.ADD, y), [c.pad(pads[i]) for i,c in enumerate(lb_c)]).reshape(lbs[0].shape) for lb_c in chunked]
 
+def all_gather(lbs:List[LazyBuffer], axis:int, pads:Tuple[Tuple[int, int], ...]) -> List[LazyBuffer]:
+  n_lbs, chunked = len(lbs), [[lbs[i] if i == j else None for i in range(n_lbs)] for j in range(n_lbs)]
+  for step in range(n_lbs - 1):
+    for i in range(n_lbs):
+      s, r = (i+step-1)%n_lbs, (i+step)%n_lbs
+      chunked[r][i] = chunked[s][i].copy_to_device(chunked[r][r].device, force=True)
+  return [functools.reduce(lambda x,y: x.e(BinaryOps.ADD, y), [c.pad(tuple(pads[i] + c.shape[1::])) for i,c in enumerate(lb)]) for lb in chunked]
+
 def to_sharded(lbs:List[LazyBuffer], axis:int, bounds: Tuple[Tuple[int, int], ...]) -> List[LazyBuffer]:
   if DEBUG >= 3 and lbs[0].shape[axis] % len(lbs) != 0: print(f"multi axis uneven: {lbs[0].shape=} {axis=} {len(lbs)=}, bounds={bounds}")
   return [lb.shrink(tuple((0,s) if a != axis else bound for a,s in enumerate(lb.shape))) for i, (bound, lb) in enumerate(zip(bounds, lbs))]


### PR DESCRIPTION
Initial attempt at FSDP. Still thinking about how I want the API to look, currently you put the FSDP decorator in front of the neural network layer definition you want to shard (ex. in front of your transformer block class). I want it to work such that you can shard your batch across devices in a totally seamless manner and have the gradient all-reduction just work alongside FSDP. Currently far from finished.