### PR TITLE
test: replace lazycache with AST_REWRITE=1

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1739,8 +1739,14 @@ class TestScheduleRewrite(unittest.TestCase):
     expected_out = (a.numpy() + a.numpy().sum()).sum()
     np.testing.assert_equal(b.numpy(), expected_out)
 
-  def test_schedule_dedup(self):
-    a = Tensor.randn(32, 32)
+  def test_simple_dedup(self):
+    a = Tensor.randn(32, 32).realize()
+    b = Tensor.randn(32, 32).realize()
+    with Context(LAZYCACHE=0, AST_REWRITE=1):
+      c = a+b
+      d = a+b
+      s = Tensor.schedule(c, d)
+      self.assertEqual(len(s), 1)
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1739,5 +1739,8 @@ class TestScheduleRewrite(unittest.TestCase):
     expected_out = (a.numpy() + a.numpy().sum()).sum()
     np.testing.assert_equal(b.numpy(), expected_out)
 
+  def test_schedule_dedup(self):
+    a = Tensor.randn(32, 32)
+
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -110,7 +110,8 @@ GRAPH, GRAPHPATH, SAVE_SCHEDULE, RING = ContextVar("GRAPH", 0), getenv("GRAPHPAT
 MULTIOUTPUT, PROFILE, PROFILEPATH = ContextVar("MULTIOUTPUT", 1), ContextVar("PROFILE", 0), ContextVar("PROFILEPATH", temp("tinygrad_profile.json"))
 USE_TC, TC_OPT, TRANSCENDENTAL = ContextVar("TC", 1), ContextVar("TC_OPT", 0), ContextVar("TRANSCENDENTAL", 1)
 FUSE_ARANGE, FUSE_CONV_BW = ContextVar("FUSE_ARANGE", 0), ContextVar("FUSE_CONV_BW", 0)
-SPLIT_REDUCEOP, AST_REWRITE = ContextVar("SPLIT_REDUCEOP", 1), ContextVar("AST_REWRITE", 0)
+SPLIT_REDUCEOP, AST_REWRITE, LAZYCACHE = ContextVar("SPLIT_REDUCEOP", 1), ContextVar("AST_REWRITE", 0), ContextVar("LAZYCACHE", 1)
+
 
 @dataclass(frozen=True)
 class Metadata:

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Union, Optional, Any, Tuple, List, get_args
 from tinygrad.dtype import dtypes, DType, DTypeLike, ConstType, to_dtype
-from tinygrad.helpers import prod, getenv, all_int, all_same, DEBUG, _METADATA, Metadata, SPLIT_REDUCEOP
+from tinygrad.helpers import prod, getenv, all_int, all_same, DEBUG, _METADATA, Metadata, SPLIT_REDUCEOP, LAZYCACHE
 from tinygrad.ops import MetaOps, UnaryOps, BinaryOps, TernaryOps, ReduceOps, Op, exec_alu, python_alu, REDUCE_ALU, identity_element
 from tinygrad.shape.symbolic import sint, Variable
 from tinygrad.shape.shapetracker import ShapeTracker
@@ -10,7 +10,7 @@ from weakref import ref, ReferenceType, WeakValueDictionary
 
 lazycache: WeakValueDictionary[Any, LazyBuffer] = WeakValueDictionary()
 def create_lazybuffer(device:str, st:ShapeTracker, dtype:DTypeLike, op:Optional[Op]=None, arg:Any=None, srcs:Tuple[LazyBuffer, ...]=(),
-                      base:Optional[LazyBuffer]=None, enable_cache=bool(getenv("LAZYCACHE", 1))):
+                      base:Optional[LazyBuffer]=None, enable_cache=LAZYCACHE):
   if st.size == 0: op, arg, srcs, base = MetaOps.CONST, 0, (), None
   dtype = to_dtype(dtype)
   if op is MetaOps.CONST: arg, enable_cache = dtypes.as_const(arg, dtype) if not isinstance(arg, Variable) else arg, True


### PR DESCRIPTION
The goal is to dedup LazyBuffers across a single `create_schedule` call.
AST_REWRITE=1 dedups uops inside a single AST
But this doesn't dedup the asts across the schedule yet.