### PR TITLE
split reduce op

### DIFF
--- a/stupidtest.py
+++ b/stupidtest.py
@@ -1,0 +1,5 @@
+from tinygrad import Tensor
+
+a = Tensor.rand(1, 5, 4, 255, 256).realize()
+a = a.sum()
+print(a.numpy())

--- a/stupidtest.py
+++ b/stupidtest.py
@@ -1,5 +1,0 @@
-from tinygrad import Tensor
-
-a = Tensor.rand(1, 5, 4, 255, 256).realize()
-a = a.sum()
-print(a.numpy())

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -146,19 +146,19 @@ class BufferXfer(BufferCopy):
 
 # **************** method cache ****************
 
-method_cache: Dict[Tuple[str, bytes, int, int, bool], CompiledRunner] = {}
-def get_runner(dname:str, ast:UOp) -> CompiledRunner:
+method_cache: Dict[Tuple[str, bytes, int, int, bool], List[CompiledRunner]] = {}
+def get_runners(dname:str, ast:UOp) -> List[CompiledRunner]:
   ckey = (dname, ast.key, BEAM.value, NOOPT.value, False)
   if cret:=method_cache.get(ckey): return cret
   bkey = (dname.split(":")[0], ast.key, BEAM.value, NOOPT.value, True)
   if bret:=method_cache.get(bkey):
-    method_cache[ckey] = ret = CompiledRunner(replace(bret.p, dname=dname), bret.lib)
+    method_cache[ckey] = ret = [CompiledRunner(replace(runner.p, dname=dname), runner.lib) for runner in bret]
   else:
-    prg: Program = get_kernel(Device[dname].renderer, ast).to_program()
+    prgs: List[Program] = [k.to_program() for k in get_kernel(Device[dname].renderer, ast).linearize()]
     if getenv("FUZZ_UOPS"):
       from test.external.fuzz_uops import UOpsFuzzerRunner
-      return UOpsFuzzerRunner(replace(prg, dname=dname))
-    method_cache[ckey] = method_cache[bkey] = ret = CompiledRunner(replace(prg, dname=dname))
+      return [UOpsFuzzerRunner(replace(p, dname=dname)) for p in prgs]
+    method_cache[ckey] = method_cache[bkey] = ret = [CompiledRunner(replace(p, dname=dname)) for p in prgs]
   return ret
 
 # **************** lowering functions ****************
@@ -186,26 +186,29 @@ class ExecItem:
       self.prg.first_run = False
     return et
 
-def lower_schedule_item(si:ScheduleItem) -> ExecItem:
+def lower_schedule_item(si:ScheduleItem) -> List[ExecItem]:
   assert len(set(x.device for x in si.bufs)) == 1 or (si.ast.op is UOps.EXT and si.ast.arg[0] is MetaOps.COPY)
   if si.ast.op is UOps.SINK:
-    runner = get_runner(si.outputs[0].device, si.ast)
+    runners = get_runners(si.outputs[0].device, si.ast)
+    return [ExecItem(r, [si.bufs[x] for x in r.p.globals], si.metadata) for r in runners]
     return ExecItem(runner, [si.bufs[x] for x in runner.p.globals], si.metadata)
   out, (op, arg) = si.outputs[0], si.ast.arg
   if op is MetaOps.COPY:
     kernel_type = BufferCopy
     if hasattr(Device[out.device].allocator, 'transfer') and out.device.split(":")[0] == si.inputs[0].device.split(":")[0]:
       kernel_type = BufferXfer
-    return ExecItem(kernel_type(arg, out.device, si.inputs[0].device), list(si.bufs))
-  if op is MetaOps.CUSTOM: return ExecItem(CustomOp(arg), list(si.bufs))
-  if op is MetaOps.EMPTY: return ExecItem(EmptyOp(out), list(si.bufs))
-  if op is MetaOps.VIEW: return ExecItem(ViewOp(out), list(si.bufs))
+    return [ExecItem(kernel_type(arg, out.device, si.inputs[0].device), list(si.bufs))]
+  if op is MetaOps.CUSTOM: return [ExecItem(CustomOp(arg), list(si.bufs))]
+  if op is MetaOps.EMPTY: return [ExecItem(EmptyOp(out), list(si.bufs))]
+  if op is MetaOps.VIEW: return [ExecItem(ViewOp(out), list(si.bufs))]
   raise RuntimeError(f"don't know how to lower {si.ast}")
 
 def lower_schedule(schedule:List[ScheduleItem]) -> Generator[ExecItem, None, None]:
   while len(schedule):
     si = schedule.pop(0)
-    try: yield lower_schedule_item(si)
+    #try: yield lower_schedule_item(si)
+    try:
+      for ei in lower_schedule_item(si): yield ei
     except Exception as e:
       if DEBUG >= 2:
         print(f"error lowering {si.ast.op}")

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -185,26 +185,6 @@ class LazyBuffer:
 
     return self._reduce_op(op, axis)
 
-    # TODO: can we split symbolic shape if the reduce axis is not symbolic?
-    if not SPLIT_REDUCEOP or not all_int(self.shape) or (0 in self.shape) or \
-      prod(self.shape) // prod(new_shape) < getenv("REDUCEOP_SPLIT_THRESHOLD", 32768):
-      return self._reduce_op(op, axis)
-
-    # if there are few globals, make some reduces into globals by splitting into two kernels
-    # cap output buffer to 2**22: heuristic number of global outputs to achieve max occupancy with enough locals+upcasts for gemm
-    #   ~2**10 should be enough if GROUP is used
-    # 256 split maximum should be "negligible reduce" for low prod(new_shape), 8 split minimum.
-    # split is moved to the end to provide maximum locality for the second phase reduce.
-    self_real_strides = self.st.real_strides(ignore_valid=True)
-    split_candidates = [(i, x) for i in axis for x in range(min(256,2**getenv("REDUCEOP_SPLIT_SIZE",22)//prod(new_shape)),8-1,-1)
-                        if self.shape[i] % x == 0 and self_real_strides[i] != 0]
-    if not split_candidates: return self._reduce_op(op, axis)
-    dim_to_split, divisor = split_candidates[0]
-    splitted_shape = self.shape[:dim_to_split] + (divisor,) + (self.shape[dim_to_split]//divisor,) + self.shape[dim_to_split+1:]
-    splitted = self.reshape(splitted_shape).permute(tuple([x for x in range(len(splitted_shape)) if x != dim_to_split]+[dim_to_split]))
-    if DEBUG >= 3: print(f"split {divisor}: {self.shape} -> {splitted.shape} -> {new_shape}")
-    return splitted._reduce_op(op, axis)._reduce_op(op, (len(new_shape),)).reshape(new_shape)  # reduce original axes, then split
-
   # *** movement ops ***
 
   def _view(self, new_st:ShapeTracker) -> LazyBuffer:

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -183,6 +183,8 @@ class LazyBuffer:
       if op is ReduceOps.PROD: return self.const(self.base.arg ** prod(self.shape[i] for i in axis), new_shape)
       if op is ReduceOps.MAX: return self.const(self.base.arg, new_shape)
 
+    return self._reduce_op(op, axis)
+
     # TODO: can we split symbolic shape if the reduce axis is not symbolic?
     if not SPLIT_REDUCEOP or not all_int(self.shape) or (0 in self.shape) or \
       prod(self.shape) // prod(new_shape) < getenv("REDUCEOP_SPLIT_THRESHOLD", 32768):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -257,7 +257,7 @@ BUFFER_UOPS = {UOps.LOAD, UOps.STORE, UOps.CONST}
 
 END_FOR_UOP = {UOps.IF:(UOps.STORE, UOps.ENDIF), UOps.RANGE:(UOps.PHI, UOps.ENDRANGE)}
 
-@dataclass(frozen=True, eq=False)
+@dataclass(eq=False)
 class UOp:
   op: UOps
   dtype: Optional[DType] = None
@@ -401,7 +401,7 @@ def get_location() -> Tuple[str, int]:
 @functools.lru_cache(None)
 def lines(fn): return open(fn).readlines()
 
-@dataclass(frozen=True, repr=False)  # reuse repr from UOp
+@dataclass(repr=False)  # reuse repr from UOp
 class NOp(UOp):
   name: Optional[str] = None
   src: Tuple[NOp, ...] = tuple()


### PR DESCRIPTION
Just saw #6369 maybe the sink injection should happen in the graph rewrite in linearize instead of in get_optimized_ast? The split could also be a pattern and graph rewrite returns a list of uops. I'm asking as the bounty specifically says to move split_reduceop into kernel.py