### PR TITLE
fold bitwise noops

### DIFF
--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -317,6 +317,9 @@ constant_folder = PatternMatcher([
   ((NOp.var("x") + NOp.var("y")) * NOp.cvar("c"), lambda x,y,c: x*c+y*c if dtypes.is_int(x.dtype) else None),
   # x!=0 -> (bool)x
   (NOp.var("x").ne(0), lambda x: x.cast(dtypes.bool)),
+  # bitwise noops
+  ((NOp.var("x") & NOp.var("x")), lambda x: x),
+  ((NOp.var("x") | NOp.var("x")), lambda x: x),
   # TODO: can do the invert of this (flip alt/load) when we fix double ops
   (NOp.store(NOp.var("buf"), NOp.var("idx"), NOp.var("gate").where(NOp.var("alt"), NOp.load(NOp.var("buf"), NOp.var("idx")))),
    lambda buf, idx, gate, alt: UOp.store(buf, idx, alt, gate)),


### PR DESCRIPTION
from `8269a721cd6f5c6030ce120e1139095d7ba117eb`

process replay:
![image](https://github.com/user-attachments/assets/b4edbd12-6a7b-46a8-9ba7-6e2662b603a8)