### PR TITLE
Check disk device before saving

### DIFF
--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -202,6 +202,14 @@ class TestSafetensors(unittest.TestCase):
       assert v.numpy().dtype == tensors[k].dtype
       np.testing.assert_allclose(v.numpy(), tensors[k])
 
+  @unittest.expectedFailure
+  def test_save_to_open_disk_device(self):
+    t1 = Tensor([1, 2, 3])
+    state_dict = get_state_dict(t1)
+    safe_save(state_dict, "model.safetensors")
+    state_dict2 = safe_load("model.safetensors")
+    safe_save(state_dict2, "model.safetensors")
+
 def helper_test_disk_tensor(fn, data, np_fxn, tinygrad_fxn=None):
   if tinygrad_fxn is None: tinygrad_fxn = np_fxn
   pathlib.Path(temp(fn)).unlink(missing_ok=True)

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -184,8 +184,8 @@ class Compiler:
     return lib
 
 class Compiled:
-  def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer], compiler:Optional[Compiler], runtime, graph=None, count=None):
-    self.dname, self.allocator, self.compiler, self.runtime, self.graph, self.count = device, allocator, compiler or Compiler(), runtime, graph, count
+  def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer], compiler:Optional[Compiler], runtime, graph=None, count:Optional[int]=None):
+      self.dname, self.allocator, self.compiler, self.runtime, self.graph, self.count = device, allocator, compiler or Compiler(), runtime, graph, count
     self.renderer = renderer or Renderer()
   def synchronize(self):
     """

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -184,8 +184,8 @@ class Compiler:
     return lib
 
 class Compiled:
-  def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer], compiler:Optional[Compiler], runtime, graph=None):
-    self.dname, self.allocator, self.compiler, self.runtime, self.graph = device, allocator, compiler or Compiler(), runtime, graph
+  def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer], compiler:Optional[Compiler], runtime, graph=None, count=None):
+    self.dname, self.allocator, self.compiler, self.runtime, self.graph, self.count = device, allocator, compiler or Compiler(), runtime, graph, count
     self.renderer = renderer or Renderer()
   def synchronize(self):
     """

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -185,7 +185,7 @@ class Compiler:
 
 class Compiled:
   def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer],
-               compiler:Optional[Compiler], runtime, graph=None, count:Optional[int]=None):
+               compiler:Optional[Compiler], runtime, graph=None, count=0):
     self.dname, self.allocator, self.compiler, self.runtime, self.graph, self.count = device, allocator, compiler or Compiler(), runtime, graph, count
     self.renderer = renderer or Renderer()
   def synchronize(self):

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -184,7 +184,7 @@ class Compiler:
     return lib
 
 class Compiled:
-  def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer], compiler:Optional[Compiler], runtime, graph=None, count=None):
+  def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer], compiler:Optional[Compiler], runtime, graph=None, count=0):
     self.dname, self.allocator, self.compiler, self.runtime, self.graph, self.count = device, allocator, compiler or Compiler(), runtime, graph, count
     self.renderer = renderer or Renderer()
   def synchronize(self):

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -185,7 +185,7 @@ class Compiler:
 
 class Compiled:
   def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer], compiler:Optional[Compiler], runtime, graph=None, count:Optional[int]=None):
-      self.dname, self.allocator, self.compiler, self.runtime, self.graph, self.count = device, allocator, compiler or Compiler(), runtime, graph, count
+    self.dname, self.allocator, self.compiler, self.runtime, self.graph, self.count = device, allocator, compiler or Compiler(), runtime, graph, count
     self.renderer = renderer or Renderer()
   def synchronize(self):
     """

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -184,8 +184,7 @@ class Compiler:
     return lib
 
 class Compiled:
-  def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer],
-               compiler:Optional[Compiler], runtime, graph=None, count=0):
+  def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer], compiler:Optional[Compiler], runtime, graph=None, count=None):
     self.dname, self.allocator, self.compiler, self.runtime, self.graph, self.count = device, allocator, compiler or Compiler(), runtime, graph, count
     self.renderer = renderer or Renderer()
   def synchronize(self):

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -184,7 +184,8 @@ class Compiler:
     return lib
 
 class Compiled:
-  def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer], compiler:Optional[Compiler], runtime, graph=None, count:Optional[int]=None):
+  def __init__(self, device:str, allocator:Allocator, renderer:Optional[Renderer],
+               compiler:Optional[Compiler], runtime, graph=None, count:Optional[int]=None):
     self.dname, self.allocator, self.compiler, self.runtime, self.graph, self.count = device, allocator, compiler or Compiler(), runtime, graph, count
     self.renderer = renderer or Renderer()
   def synchronize(self):

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -5,6 +5,7 @@ from tinygrad.dtype import dtypes
 from tinygrad.helpers import prod, argsort, DEBUG, Timing, CI, unwrap, GlobalCounters, tqdm
 from tinygrad.shape.view import strides_for_shape
 from tinygrad.multi import MultiLazyBuffer
+from tinygrad.device import Device
 
 safe_dtypes = {"BOOL":dtypes.bool, "I8":dtypes.int8, "U8":dtypes.uint8, "I16":dtypes.int16, "U16":dtypes.uint16, "I32":dtypes.int, "U32":dtypes.uint,
                "I64":dtypes.int64, "U64":dtypes.uint64, "F16":dtypes.float16, "BF16":dtypes.bfloat16, "F32":dtypes.float32, "F64":dtypes.float64}
@@ -51,6 +52,7 @@ def safe_save(tensors:Dict[str, Tensor], fn:str, metadata:Optional[Dict[str, Any
     offset += v.nbytes()
   j = json.dumps(headers, separators=(',', ':'))
   j += "\x20"*((8-len(j)%8)%8)
+  assert Device[f"disk:{fn}"].allocator.device.count == 0, f"Different tensors have disk device 'disk:{fn}' open"
   pathlib.Path(fn).unlink(missing_ok=True)
   t = Tensor.empty(8+len(j)+offset, dtype=dtypes.uint8, device=f"disk:{fn}")
   t[0:8].bitcast(dtypes.int64).assign([len(j)])

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -52,7 +52,7 @@ def safe_save(tensors:Dict[str, Tensor], fn:str, metadata:Optional[Dict[str, Any
     offset += v.nbytes()
   j = json.dumps(headers, separators=(',', ':'))
   j += "\x20"*((8-len(j)%8)%8)
-  assert Device[f"disk:{fn}"].allocator.device.count == 0, f"Different tensors have disk device 'disk:{fn}' open"
+  assert Device[f"disk:{fn}"].count == 0, f"Different tensors have disk device 'disk:{fn}' open"
   pathlib.Path(fn).unlink(missing_ok=True)
   t = Tensor.empty(8+len(j)+offset, dtype=dtypes.uint8, device=f"disk:{fn}")
   t[0:8].bitcast(dtypes.int64).assign([len(j)])

--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -72,8 +72,7 @@ class DiskDevice(Compiled):
     if not DiskDevice._tried_io_uring_init: self._iouring_setup()
 
     self.size: Optional[int] = None
-    self.count = 0
-    super().__init__(device, DiskAllocator(self), None, None, None)
+    super().__init__(device, DiskAllocator(self), None, None, None, 0)
   def _might_open(self, size):
     self.count += 1
     assert self.size is None or size <= self.size, f"can't reopen Disk tensor with larger size, opened with {self.size}, tried to open with {size}"


### PR DESCRIPTION
Reopening #6307 . Compiled has a count added which is usually a parent class for different devices. count will be used by DiskDevice(and incremented where needed by `_might_open` function) and is added to avoid mypy errors(since class _Device's `__getitem__` has a type annotation of returning Compiled).

Open to comments/suggestions if there is a better way to deal with this. 