### PR TITLE
can push SWIZZLE through reduce both ways

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1723,7 +1723,6 @@ class TestScheduleRewrite(unittest.TestCase):
     change = tms[-1] / tms[0]
     assert change <= SZ, f"bad complexity, time increased by {change:4.2f}x while input only grew {SZ}x"
 
-  @unittest.skip("TODO: this can swizzle twice, once up to LOAD and then down to the STORE")
   def test_swizzle_rewrite(self):
     # graph rewrite
     sink = UOp(UOps.SINK, None, arg=None, src=(


### PR DESCRIPTION
This generalizes the new SWIZZLE to multi reduce fusion.

eg. here:

The first reduce (arange) applies the expand SWIZZLE, then we wrap it around a new SWIZZLE, describing a reshape:
```
 1  UOp(UOps.STORE, None, arg=None, src=(
 2    UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), arg=0, src=()),
 3    UOp(UOps.SHAPETRACKER, None, arg=ShapeTracker(views=(View(shape=(1, 1), strides=(0, 0), offset=0, mask=None, contiguous=True),)), src=()),
 4    UOp(UOps.REDUCE_AXIS, dtypes.int, arg=(BinaryOps.ADD, (0, 1)), src=(
 5      UOp(UOps.SWIZZLE, None, arg=ShapeTracker(views=(View(shape=(32, 32), strides=(32, 1), offset=0, mask=None, contiguous=True),)), src=(
 6        UOp(UOps.ALU, dtypes.int, arg=BinaryOps.ADD, src=(
 7          UOp(UOps.REDUCE_AXIS, dtypes.int, arg=(BinaryOps.ADD, (2, 3)), src=(
 8            UOp(UOps.LOAD, dtypes.int, arg=None, src=(
 9              x8:=UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), arg=1, src=()),
10              UOp(UOps.SHAPETRACKER, None, arg=ShapeTracker(views=(View(shape=(32, 32, 32, 32), strides=(0, 0, 32, 1), offset=0, mask=None, contiguous=False),)), src=()),)),)),
11          UOp(UOps.LOAD, dtypes.int, arg=None, src=(
12             x8,
13            UOp(UOps.SHAPETRACKER, None, arg=ShapeTracker(views=(View(shape=(32, 32, 1, 1), strides=(32, 1, 0, 0), offset=0, mask=None, contiguous=True),)), src=()),)),)),)),)),)
 ```
 
 This SWIZZLE pushes through the second REDUCE_AXIS, all the way up to the STORE:
 ```
  1  UOp(UOps.SINK, None, arg=None, src=(
 2    UOp(UOps.STORE, None, arg=None, src=(
 3      UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), arg=0, src=()),
 4      UOp(UOps.SHAPETRACKER, None, arg=ShapeTracker(views=(View(shape=(1, 1, 1, 1), strides=(0, 0, 0, 0), offset=0, mask=None, contiguous=True),)), src=()),
 5      UOp(UOps.REDUCE_AXIS, dtypes.int, arg=(BinaryOps.ADD, (0, 1)), src=(
 6        UOp(UOps.ALU, dtypes.int, arg=BinaryOps.ADD, src=(
 7          UOp(UOps.REDUCE_AXIS, dtypes.int, arg=(BinaryOps.ADD, (2, 3)), src=(
 8            UOp(UOps.LOAD, dtypes.int, arg=None, src=(
 9              x7:=UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.int), arg=1, src=()),
10              UOp(UOps.SHAPETRACKER, None, arg=ShapeTracker(views=(View(shape=(32, 32, 32, 32), strides=(0, 0, 32, 1), offset=0, mask=None, contiguous=False),)), src=()),)),)),
11          UOp(UOps.LOAD, dtypes.int, arg=None, src=(
12             x7,
13            UOp(UOps.SHAPETRACKER, None, arg=ShapeTracker(views=(View(shape=(32, 32, 1, 1), strides=(32, 1, 0, 0
```
 
 