### PR TITLE
test: simpler verify_ast

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -775,10 +775,8 @@ class Kernel:
 # the living definition of intermediate UOps
 
 def _assert_valid_uop(uop:UOp, st:ShapeTracker, sts:Dict[UOp, ShapeTracker]) -> None:
-  if uop in sts: return
+  if uop in sts or uop.st is None: return
   op, _, src, arg = uop.op, uop.dtype, uop.src, uop.arg
-  # NOTE: UOps.DEFINE_GLOBAL and UOps.DEFINE_LOCAL don't have shape
-  if op in {UOps.DEFINE_LOCAL, UOps.DEFINE_GLOBAL}: return
   # restore globals from the two stage reduce
   if op is UOps.LOAD and src[0].op is UOps.DEFINE_LOCAL:
     _assert_valid_uop(local_reduce:=src[2].src[2], uop.st_arg, sts)
@@ -793,8 +791,8 @@ def _assert_valid_uop(uop:UOp, st:ShapeTracker, sts:Dict[UOp, ShapeTracker]) -> 
     # movementops are pushed to the edges with SHAPETRACKER
     # elementwise inherits shape
     st = arg if op is UOps.SHAPETRACKER else sts[src[uop.st_loc if op in BUFFER_UOPS else -1]]
-    for x in (src[1:] if op in BUFFER_UOPS else src):
-      if sts[x].shape != st.shape:
+    for x in src:
+      if x.st is not None and sts[x].shape != st.shape:
         if prod(sts[x].shape) == prod(st.shape): raise AssertionError(f"found implicit reshape {x.op} {op} {sts[x].shape} != {st.shape}")
         raise AssertionError(f"found implicit expand {x.op} {sts[x].shape} != {op} {st.shape} {prod(sts[x].shape)} != {prod(st.shape)}")
   sts[uop] = st

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -401,8 +401,7 @@ class UOp(MathTrait):
   @functools.cached_property
   def full_shape(self) -> Tuple[sint, ...]:
     if self.op is UOps.SHAPETRACKER: return self.arg.shape
-    # NOTE: UOps.DEFINE_GLOBAL and UOps.DEFINE_LOCAL don't have shape
-    return tuple(max(x) for x in zip(*[x.full_shape for x in self.src if x.op not in {UOps.DEFINE_GLOBAL, UOps.DEFINE_LOCAL}]))
+    return tuple(max(x) for x in zip(*[x.full_shape for x in self.src if x.st is not None]))
   def vars(self) -> Set[UOp]: return set([x for x in self.sparents if x.op is UOps.DEFINE_VAR])
   def variables(self) -> List[Variable]:
     st_vars: List[Set[Variable]] = [x.st_arg.vars() for x in self.sparents if x.op in BUFFER_UOPS]


### PR DESCRIPTION
need to figure out the global dims restoring in local reduce.
like this is OK but UOp.st doesn't know it.

```
AssertionError: UOp parents must have the same shape UOp(UOps.ALU, dtypes.int, arg=BinaryOps.ADD, src=(
  UOp(UOps.REDUCE_AXIS, dtypes.int, arg=(BinaryOps.ADD, (1,)), src=(
    UOp(UOps.LOAD, dtypes.int, arg=None, src=(
      x2:=UOp(UOps.DEFINE_LOCAL, PtrDType(dtypes.int), arg=('temp1', 16), src=()),
      x3:=UOp(UOps.SHAPETRACKER, None, arg=ShapeTracker(views=(View(shape=(1, 16, 1), strides=(0, 1, 0), offset=0, mask=None, contiguous=True),)), src=()),
      UOp(UOps.STORE, None, arg=None, src=(
         x2,
         x3,
        UOp(UOps.REDUCE_AXIS, dtypes.int, arg=(BinaryOps.ADD, (2,)), src=(
          UOp(UOps.CONST, dtypes.int, arg=1, src=(
            UOp(UOps.SHAPETRACKER, None, arg=ShapeTracker(views=(View(shape=(257, 511), strides=(0, 0), offset=0, mask=((0, 257), (255, 511)), contiguous=False), View(shape=(256, 16, 16), strides=(1, 8192, 512), offset=0, mask=None, contiguous=False))), src=()),)),)),)),)),)),
  UOp(UOps.CONST, dtypes.int, arg=-1, src=(
    UOp(UOps.SHAPETRACKER, None, arg=ShapeTracker(views=(View(shape=(256, 1, 1), strides=(0, 0, 0), offset=0, mask=None, contiguous=False),)), src=()),)),))
```

asserts since shapes are: `[(1, 1, 1), (256, 1, 1)]`