### PR TITLE
allow selecting UPat files in TRACK_MATCH_STATS [run_process_replay]

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -735,6 +735,7 @@ if TRACK_MATCH_STATS:
     ret = [0,0,0.0,0.0]
     for k,v in sorted(list(match_stats.items()), key=lambda x: x[1][2]):
       loc_str = f"{k.location[0].split('/')[-1]}:{k.location[1]}"
+      if getenv("UPAT_FILE", loc_str) not in loc_str: continue
       print(f"{v[0]:6d} / {v[1]:7d} -- {v[3]*1000.:9.2f} / {v[2]*1000.:9.2f} ms -- {loc_str:15s}", k.printable())
       ret = [x+y for x,y in zip(ret, v)]
     print(f"{ret[0]:6d} / {ret[1]:7d} -- {ret[3]*1000.:9.2f} / {ret[2]*1000.:9.2f} ms -- TOTAL")


### PR DESCRIPTION
```
TRACK_MATCH_STATS=1 SCHEDULE_ONLY=1 AST_REWRITE=1 UPAT_FILE=schedule python3 test/external/external_benchmark_schedule.py
```