### PR TITLE
perf: shapetracker ideas

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -16,7 +16,7 @@ def prod(x:Iterable[T]) -> Union[T,int]: return functools.reduce(operator.mul, x
 OSX = platform.system() == "Darwin"
 CI = os.getenv("CI", "") != ""
 
-def dedup(x:Iterable[T]): return list(dict.fromkeys(x))   # retains list order
+def dedup(x:Iterable[T]): return  x if len(x:=list(x)) < 2 else list(dict.fromkeys(x))   # retains list order
 def argfix(*x):
   if x and x[0].__class__ in (tuple, list):
     if len(x) != 1: raise ValueError(f"bad arg {x}")

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -35,8 +35,7 @@ def _uop_view(view:View, idxs:List[UOp], vexpr:UOp) -> Tuple[UOp, UOp]:
 
 @functools.lru_cache(None)
 def simplify(views: Tuple[View, ...]) -> Tuple[View, ...]:
-  if len(views) >= 2 and (new_view := views[-2] + views[-1]) is not None:
-    return simplify(views[:-2] + (new_view,))
+  if len(views) >= 2 and (new_view:=views[-2]+views[-1]) is not None: return simplify(views[:-2]+(new_view,))
   return views
 
 @dataclass(frozen=True)

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -34,7 +34,7 @@ def _uop_view(view:View, idxs:List[UOp], vexpr:UOp) -> Tuple[UOp, UOp]:
   return iexpr, vexpr
 
 @functools.lru_cache(None)
-def simplify(views: Tuple[View]) -> Tuple[View]:
+def simplify(views: Tuple[View, ...]) -> Tuple[View, ...]:
   if len(views) >= 2 and (new_view := views[-2] + views[-1]) is not None:
     return simplify(views[:-2] + (new_view,))
   return views


### PR DESCRIPTION
* There's some speed to be gained by caching the ShapeTracker methods. At least the `from_shape` constructor could be cached, and potentially the expensive `to_uop`. Can't remember why the methods on `View` are cached but these are not. I remember @chenyuxyz being against these caches, is that still true?
* `helpers.dedup` can be slightly faster
* `simplify` can be a method on a tuple of views to avoid the attribute access
* another idea I was playing with is always simplifying a ShapeTracker by default at creation - this would remove all the `.simplify()` calls everywhere and make everything slightly faster. Does require some more test changes and unfreezing this class. Is there a disadvantage to always creating the simplest possible ShapeTracker?

```
branch
codegen(0)      mean runtime:  150.75ms, runs:   210.53,  136.65,  147.76,  137.14,  149.83,  139.14,  152.27,  139.84,  140.35,  154.04
codegen(1)      mean runtime:  147.18ms, runs:   174.25,  144.43,  136.43,  137.34,  147.91,  141.09,  141.42,  153.37,  141.22,  154.36
methodcache     mean runtime:  122.41ms, runs:   125.91,  119.35,  119.13,  119.09,  131.57,  119.15,  119.23,  119.14,  120.19,  131.38


master
codegen(0)      mean runtime:  169.47ms, runs:   226.37,  153.18,  162.98,  162.70,  157.86,  178.46,  160.46,  160.34,  172.33,  160.01
codegen(1)      mean runtime:  167.10ms, runs:   208.59,  153.06,  164.46,  155.22,  169.36,  158.57,  169.01,  159.96,  160.52,  172.29
methodcache     mean runtime:  135.29ms, runs:   137.65,  131.36,  142.92,  130.56,  132.31,  130.83,  143.11,  130.59,  131.57,  142.05


branch
***** model tensor in     17.94 ms
***** model schedule in   10.39 ms
***** model opts(53) in   58.26 ms
***** model lower in       4.91 ms
***** model rewrite in   348.15 ms
***** model linearize in  93.87 ms
14967
all 536.02 ms


master
***** model tensor in     18.37 ms
***** model schedule in   10.75 ms
***** model opts(53) in   67.47 ms
***** model lower in       4.56 ms
***** model rewrite in   352.19 ms
***** model linearize in  92.99 ms
14967
all 549.11 ms
```