### PR TITLE
assert pyint in linearize_uop [run_process_replay]

### DIFF
--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -601,6 +601,7 @@ def linearize_uop(sink:UOp, skip_check:bool=not __debug__) -> List[UOp]:
       type_verify(_uops)
       assert _uops[-1].op is UOps.SINK, f"didn't end with SINK, ended with {_uops[-1]}"
       assert len(bad_ops) == 0, f"bad UOps left in list: {bad_ops}"
+      assert not any(x.dtype == dtypes.pyint for x in _uops), "can't return UOp with pyint"
       # TODO: this should be enabled, and the valid clause should be removed
       # NOTE: multiple identical stores to DEFINE_LOCAL is okay
       # NOTE: for PTX you have to propogate through some the calculations to determine if it is a store to DEFINE_LOCAL


### PR DESCRIPTION
master renders things like:
![Screenshot 2024-09-15 at 15 46 03](https://github.com/user-attachments/assets/62bd5cc3-da17-4fb0-814a-009ad4ea1ae5)

I think no_pyint is a part of the contract between linearize_uop and full_graph_rewrite, kinda like no EXPAND.