### PR TITLE
buf cnt limiting with graph_rewrite

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -73,7 +73,9 @@ def _test_buf_cnt(cnt:int, bufs_max:int, allowed:int):
   backup_renderer = Device[Device.DEFAULT].renderer
   r = CStyleLanguage()
   r.buf_max = bufs_max
-  alu = functools.reduce(lambda x,y: x+y, [Tensor.ones((1, 1)).contiguous().realize() for _ in range(cnt-1)])
+  loads = [Tensor.ones((1, 1)).contiguous().realize() for _ in range(cnt-1)]
+  Device[Device.DEFAULT].renderer = r
+  alu = functools.reduce(lambda x,y: x+y, loads)
   s = alu.schedule()
   assert len(s) == allowed
   Device[Device.DEFAULT].renderer = backup_renderer

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -4,11 +4,13 @@
 
 import unittest
 import numpy as np
+import functools
 from typing import List, Optional, Union, cast
 
 from tinygrad import nn, dtypes
 from tinygrad.device import Device
 from tinygrad.dtype import DType, PtrDType
+from tinygrad.renderer.cstyle import CStyleLanguage
 from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.shape.view import View
 from tinygrad.tensor import Tensor
@@ -66,6 +68,18 @@ def _test_conv2d(allowed:int, dtype:DType=dtypes.float, **kwargs):
     assert ref_img.grad is not None and ref_w.grad is not None and img.grad is not None and w.grad is not None
     np.testing.assert_allclose(img.grad.numpy(), ref_img.grad.detach().numpy(), atol=1e-6 if dtype == dtypes.float else 1e-2)
     np.testing.assert_allclose(w.grad.numpy(), ref_w.grad.detach().numpy(), atol=1e-6 if dtype == dtypes.float else 1e-2)
+
+def _test_buf_cnt(cnt:int, bufs_max:int, allowed:int):
+  backup_renderer = Device[Device.DEFAULT].renderer
+  r = CStyleLanguage()
+  r.buf_max = bufs_max
+  alu = functools.reduce(lambda x,y: x+y, [Tensor.ones((1, 1)).contiguous().realize() for _ in range(cnt-1)])
+  s = alu.schedule()
+  assert len(s) == allowed
+  Device[Device.DEFAULT].renderer = backup_renderer
+  run_schedule(s)
+  expected = functools.reduce(lambda x,y: x+y, [np.ones((1, 1)) for _ in range(cnt-1)])
+  np.testing.assert_equal(alu.numpy(), expected)
 
 class TestSchedule(unittest.TestCase):
   def test_basic_binop_fusion(self):
@@ -1299,6 +1313,12 @@ class TestSchedule(unittest.TestCase):
   @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
   @unittest.expectedFailure
   def test_conv2d_fused_ast_rewrite_half(self): _test_conv2d(7, FUSE_CONV_BW=1, AST_REWRITE=1, dtype=dtypes.half)
+
+  def test_buf_cnt_at_limit(self): _test_buf_cnt(5, bufs_max=5, allowed=1)
+  @unittest.expectedFailure
+  def test_buf_cnt_over_limit(self): _test_buf_cnt(7, bufs_max=5, allowed=2)
+  @unittest.expectedFailure
+  def test_buf_cnt_over_limit_alt(self): _test_buf_cnt(11, bufs_max=5, allowed=3)
 
 class TestIndexing(unittest.TestCase):
   def check_schedule(self, xt:Union[Tensor,List[Tensor]], cnt:int):

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -76,6 +76,7 @@ class Renderer:
   global_max: Optional[Tuple[int, ...]] = (0x8FFFFFFF,) * (3) # TODO: UOps.SPECIAL int32 indexes right now
   local_max: Optional[Tuple[int, ...]] = (0x8FFFFFFF,) * (3) # TODO: UOps.SPECIAL int32 indexes right now
   shared_max: int = 32768
+  buf_max: Optional[int] = None
   tensor_cores: List[TensorCore] = []
   extra_matcher: Any = None
   code_for_op: Dict[Op, Callable] = {}

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -264,6 +264,7 @@ class IntelRenderer(OpenCLRenderer):
 class MetalRenderer(CStyleLanguage):
   device = "METAL"
   shared_max = 32768
+  bufs_max = 32
   tensor_cores = [TensorCore(dims=(8,8,8), threads=[(0,2),(1,4),(0,2),(1,2)], dtype_in=di, dtype_out=do) for (di, do) in [(dtypes.float, dtypes.float), (dtypes.half, dtypes.float), (dtypes.half, dtypes.half)]] # noqa: E501
   def __init__(self): self.tensor_cores = MetalRenderer.tensor_cores if os.uname().machine == "arm64" else []
 


### PR DESCRIPTION
milestones:
- [ ] add base graph_rewrite rule
- [ ] split the ast into n sinks
- [ ] split `sink` into List[LBScheduleItem]
- [ ] refactor _lower_lazybuffer to return a List[LBScheduleItem]
- [ ] add these opts to the Metal renderer and enable the dm model test for METAL=1