### PR TITLE
use int32 in tests where possible

### DIFF
--- a/test/test_fuzz_shape_ops.py
+++ b/test/test_fuzz_shape_ops.py
@@ -27,7 +27,7 @@ def st_shape(draw) -> tuple[int, ...]:
   return s
 
 def tensors_for_shape(s:tuple[int, ...]) -> tuple[torch.tensor, Tensor]:
-  x = np.arange(prod(s)).reshape(s)
+  x = np.arange(prod(s), dtype=np.int32).reshape(s)
   return torch.from_numpy(x), Tensor(x)
 
 def apply(tor, ten, tor_fn, ten_fn=None):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -66,7 +66,7 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn=None, atol=1e-6, rtol=1e-3, gra
 
 def prepare_test_op(low, high, shps, vals, forward_only=False):
   if shps is None:
-    ts = [torch.tensor(x, requires_grad=(not forward_only)) for x in vals]
+    ts = [(t:=torch.tensor(x, requires_grad=(not forward_only))).to(torch.int32 if not torch.is_floating_point(t) else None) for x in vals]
   else:
     np.random.seed(0)
     np_data = [np.random.uniform(low=low, high=high, size=size).astype(_to_np_dtype(dtypes.default_float)) for size in shps]

--- a/test/test_rearrange_einops.py
+++ b/test/test_rearrange_einops.py
@@ -164,7 +164,7 @@ class test_rearrange_ops(unittest.TestCase):
       ("a b c d e -> b (a c d) e", "a b ... e -> b (a ...) e"),
     ]
 
-    xnp = np.arange(2 * 3 * 4 * 5 * 6).reshape([2, 3, 4, 5, 6])
+    xnp = np.arange(2 * 3 * 4 * 5 * 6, dtype=np.int32).reshape([2, 3, 4, 5, 6])
     x = Tensor(xnp)
     for pattern in identity_patterns:
       assert np.array_equal(xnp, x.rearrange(pattern).numpy()), pattern
@@ -174,7 +174,7 @@ class test_rearrange_ops(unittest.TestCase):
 
   def test_rearrange_consistency(self):
     shape = [1, 2, 3, 5, 7, 11]
-    xnp = np.arange(np.prod(shape)).reshape(shape)
+    xnp = np.arange(np.prod(shape), dtype=np.int32).reshape(shape)
     x = Tensor(xnp)
     for pattern in [
       "a b c d e f -> a b c d e f",
@@ -205,7 +205,7 @@ class test_rearrange_ops(unittest.TestCase):
     result = temp.rearrange("(f d) c (e b) a -> a b c d e f", **sizes).numpy()
     assert np.array_equal(xnp, result)
 
-    x2 = np.arange(2 * 3 * 4).reshape([2, 3, 4])
+    x2 = np.arange(2 * 3 * 4, dtype=np.int32).reshape([2, 3, 4])
     result = Tensor(x2).rearrange("a b c -> b c a").numpy()
     assert x2[1, 2, 3] == result[2, 3, 1]
     assert x2[0, 1, 2] == result[1, 2, 0]
@@ -213,7 +213,7 @@ class test_rearrange_ops(unittest.TestCase):
   def test_rearrange_permutations(self):
     # tests random permutation of axes against two independent numpy ways
     for n_axes in range(1, 10):
-      x = np.arange(2**n_axes).reshape([2] * n_axes)
+      x = np.arange(2**n_axes, dtype=np.int32).reshape([2] * n_axes)
       permutation = np.random.permutation(n_axes)
       left_expression = " ".join("i" + str(axis) for axis in range(n_axes))
       right_expression = " ".join("i" + str(axis) for axis in permutation)
@@ -224,7 +224,7 @@ class test_rearrange_ops(unittest.TestCase):
         assert x[tuple(pick)] == result[tuple(pick[permutation])]
 
     for n_axes in range(1, 10):
-      x = np.arange(2**n_axes).reshape([2] * n_axes)
+      x = np.arange(2**n_axes, dtype=np.int32).reshape([2] * n_axes)
       permutation = np.random.permutation(n_axes)
       left_expression = " ".join("i" + str(axis) for axis in range(n_axes)[::-1])
       right_expression = " ".join("i" + str(axis) for axis in permutation[::-1])
@@ -310,7 +310,7 @@ class test_rearrange_parsing(unittest.TestCase):
       ("a b … e -> b (a …) e", "a b ... e -> b (a ...) e"),
     ]
 
-    xnp = np.arange(2 * 3 * 4 * 5 * 6).reshape([2, 3, 4, 5, 6])
+    xnp = np.arange(2 * 3 * 4 * 5 * 6, dtype=np.int32).reshape([2, 3, 4, 5, 6])
     x = Tensor(xnp)
 
     for pattern1, pattern2 in equivalent_rearrange_patterns:

--- a/test/test_uops_stats.py
+++ b/test/test_uops_stats.py
@@ -17,48 +17,48 @@ def get_stats(x:Tensor):
 
 class TestMemoryCount(unittest.TestCase):
   def test_add(self):
-    a = Tensor.empty(1024, 1024, dtype=dtypes.uint8)
-    b = Tensor.empty(1024, 1024, dtype=dtypes.uint8)
+    a = Tensor.empty(1024, 1024, dtype=dtypes.uint32)
+    b = Tensor.empty(1024, 1024, dtype=dtypes.uint32)
     _, mem = get_stats(a+b)
-    self.assertEqual(mem, 1024*1024*3)  # 2 reads + 1 write
+    self.assertEqual(mem, 1024*1024*3*4)  # 2 reads + 1 write
 
   def test_add_const(self):
-    a = Tensor.empty(1024, 1024, dtype=dtypes.uint8)
+    a = Tensor.empty(1024, 1024, dtype=dtypes.uint32)
     _, mem = get_stats(a+3)
-    self.assertEqual(mem, 1024*1024*2)  # 1 read + 1 write
+    self.assertEqual(mem, 1024*1024*2*4)  # 1 read + 1 write
 
   def test_add_slice(self):
-    a = Tensor.empty(1024, 1024, dtype=dtypes.uint8)[:512]
+    a = Tensor.empty(1024, 1024, dtype=dtypes.uint32)[:512]
     _, mem = get_stats(a+3)
-    self.assertEqual(mem, 512*1024*2)  # 1 read + 1 write
+    self.assertEqual(mem, 512*1024*2*4)  # 1 read + 1 write
 
   def test_expanded(self):
-    a = Tensor.empty(1024, 1, dtype=dtypes.uint8).expand(1024, 1024)
-    b = Tensor.empty(1024, 1024, dtype=dtypes.uint8)
+    a = Tensor.empty(1024, 1, dtype=dtypes.uint32).expand(1024, 1024)
+    b = Tensor.empty(1024, 1024, dtype=dtypes.uint32)
     _, mem = get_stats(a+b)
-    self.assertEqual(mem, 1024*1024*2 + 1024)  # 1 full read + 1 lil read + 1 write
+    self.assertEqual(mem, 1024*1024*2*4 + 1024*4)  # 1 full read + 1 lil read + 1 write
 
   def test_both_expanded(self):
     # TODO: this probably should be a full write
-    a = Tensor.empty(1024, 1, dtype=dtypes.uint8).expand(1024, 1024)
-    b = Tensor.empty(1024, 1, dtype=dtypes.uint8).expand(1024, 1024)
+    a = Tensor.empty(1024, 1, dtype=dtypes.uint32).expand(1024, 1024)
+    b = Tensor.empty(1024, 1, dtype=dtypes.uint32).expand(1024, 1024)
     _, mem = get_stats(a+b)
-    self.assertEqual(mem, 1024*1024 + 2*1024)  # 2 lil reads + 1 write
+    self.assertEqual(mem, 1024*1024*4 + 2*1024*4)  # 2 lil reads + 1 write
 
   def test_self_add(self):
-    a = Tensor.empty(1024, 1024, dtype=dtypes.uint8)
+    a = Tensor.empty(1024, 1024, dtype=dtypes.uint32)
     _, mem = get_stats(a+a)
-    self.assertEqual(mem, 1024*1024*2)  # 1 read + 1 write
+    self.assertEqual(mem, 1024*1024*2*4)  # 1 read + 1 write
 
   def test_self_add_transposed(self):
-    a = Tensor.empty(1024, 1024, dtype=dtypes.uint8)
+    a = Tensor.empty(1024, 1024, dtype=dtypes.uint32)
     _, mem = get_stats(a+a.T)
-    self.assertEqual(mem, 1024*1024*2)  # 1 read + 1 write
+    self.assertEqual(mem, 1024*1024*2*4)  # 1 read + 1 write
 
   def test_self_add_assign(self):
-    a = Tensor.empty(1024, 1024, dtype=dtypes.uint8).realize()
+    a = Tensor.empty(1024, 1024, dtype=dtypes.uint32).realize()
     _, mem = get_stats(a.assign(a+a))
-    self.assertEqual(mem, 1024*1024*2)  # 1 read + 1 write
+    self.assertEqual(mem, 1024*1024*2*4)  # 1 read + 1 write
 
 class TestUOpsStats(unittest.TestCase):
   @unittest.skipIf(getenv("PTX"), "wrong in PTX")

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -60,8 +60,8 @@ class TestRawDiskBuffer(unittest.TestCase):
     _test_bitcasted(t, dtypes.uint16, 0)
     _test_bitcasted(t, dtypes.float32, 0.0)
     _test_bitcasted(t, dtypes.uint32, 0)
-    # pi in float16 stored via int16
-    t.bitcast(dtypes.uint16).assign(Tensor.full((128, 64), 0x4248, dtype=dtypes.uint16)).realize()
+    # pi in float16 stored via int32
+    t.bitcast(dtypes.uint32).assign(Tensor.full((128, 64), 0x42484248, dtype=dtypes.uint32)).realize()
     _test_bitcasted(t, dtypes.float16, 3.140625)
     _test_bitcasted(t, dtypes.float32, 50.064727)
     _test_bitcasted(t, dtypes.uint16, 0x4248)
@@ -317,10 +317,10 @@ class TestDiskTensor(unittest.TestCase):
   def test_copy_from_disk_offset(self):
     fn = pathlib.Path(temp("dt_copy_from_disk_offset"))
     fn.unlink(missing_ok=True)
-    fn.write_bytes(bytes(range(256))*1024)
+    fn.write_bytes(bytes(range(256))*1024*4)
 
     for off in [314, 991, 2048, 4096]:
-      t = Tensor.empty(256*1024, device=f"disk:{temp('dt_copy_from_disk_offset')}", dtype=dtypes.uint8)[off:]
+      t = Tensor.empty(256*1024*4, device=f"disk:{temp('dt_copy_from_disk_offset')}", dtype=dtypes.uint32)[off:]
       on_dev = t.to(Device.DEFAULT).realize()
       np.testing.assert_equal(on_dev.numpy(), t.numpy())
 
@@ -329,10 +329,10 @@ class TestDiskTensor(unittest.TestCase):
 
     fn = pathlib.Path(temp("dt_copy_from_disk_huge"))
     fn.unlink(missing_ok=True)
-    fn.write_bytes(bytes(range(256))*1024*256)
+    fn.write_bytes(bytes(range(256))*1024*256*4)
 
     for off in [0, 551]:
-      t = Tensor.empty(256*1024*256, device=f"disk:{temp('dt_copy_from_disk_huge')}", dtype=dtypes.uint8)[off:]
+      t = Tensor.empty(256*1024*256, device=f"disk:{temp('dt_copy_from_disk_huge')}", dtype=dtypes.uint32)[off:]
       on_dev = t.to(Device.DEFAULT).realize()
       np.testing.assert_equal(on_dev.numpy(), t.numpy())
 

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -61,7 +61,7 @@ class TestRawDiskBuffer(unittest.TestCase):
     _test_bitcasted(t, dtypes.float32, 0.0)
     _test_bitcasted(t, dtypes.uint32, 0)
     # pi in float16 stored via int32
-    t.bitcast(dtypes.uint32).assign(Tensor.full((128, 64), 0x42484248, dtype=dtypes.uint32)).realize()
+    t.bitcast(dtypes.uint32).assign(Tensor.full((128, 32), 0x42484248, dtype=dtypes.uint32)).realize()
     _test_bitcasted(t, dtypes.float16, 3.140625)
     _test_bitcasted(t, dtypes.float32, 50.064727)
     _test_bitcasted(t, dtypes.uint16, 0x4248)


### PR DESCRIPTION
I don't like changing int8 to int32 but we won't be able to run these tests on webgpu without changing it. The rest of the changes avoid implicitly creating long tensors due to numpy/torch initialization which we do in most places already.