### PR TITLE
include seen rewrites in VIZ

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -340,7 +340,7 @@ jobs:
     - name: Fuzz Test models schedule
       run: FUZZ_SCHEDULE=1 FUZZ_SCHEDULE_MAX_PATHS=5 python -m pytest test/models/test_train.py test/models/test_end2end.py
     - name: Run VIZ=1 tests
-      run: PYTHONPATH="." TRACK_MATCH_STATS=2 METAL=1 python3 -m pytest viz/test_viz.py
+      run: PYTHONPATH="." RUN_PROCESS_REPLAY=0 TRACK_MATCH_STATS=2 METAL=1 python3 -m pytest viz/test_viz.py
     - name: Run TRANSCENDENTAL math
       run: TRANSCENDENTAL=2 python -m pytest -n=auto test/test_ops.py::TestOps::test_sin test/test_ops.py::TestOps::test_cos test/test_ops.py::TestOps::test_tan test/test_ops.py::TestOps::test_exp test/test_ops.py::TestOps::test_log --durations=20
     - name: Run process replay tests

--- a/viz/serve.py
+++ b/viz/serve.py
@@ -53,7 +53,7 @@ def create_graph(ctx:TrackedRewriteContext) -> UOpRet:
     # first, rewrite this UOp with the current rewrite + all the seen rewrites before this
     new_sink = replace_uop(uops[-1], first, rewritten, {**seen_replaces})
     # sanity check
-    assert new_sink is not uops[-1], f"rewritten sink wasn't rewritten! {i} {new_sink}"
+    assert new_sink is not uops[-1], f"rewritten sink wasn't rewritten! {i}\n{new_sink}\n{uops[-1]}"
     # update ret data
     diffs.append((pattern, list(difflib.unified_diff(str(first).splitlines(), str(rewritten).splitlines()))))
     graphs.append((new_sink, uops[-1], rewritten, first))

--- a/viz/test_viz.py
+++ b/viz/test_viz.py
@@ -11,7 +11,6 @@ from tinygrad.codegen.uopgraph import constant_folder, devectorize, float4_foldi
 from test.external.process_replay.helpers import print_diff
 from viz.serve import create_graph
 
-@unittest.skip("TODO: some of these graph_rewrites don't display a diff in VIZ=1")
 class TestViz(unittest.TestCase):
   def tearDown(self) -> None:
     from tinygrad.ops import contexts


### PR DESCRIPTION
VIZ was showing wrong graphs because some of the patterns aren't re-tracked in the TRACK_MATCH_STATS=2 context and hit the cache. This fixes the tests in test_viz.