### PR TITLE
fix wrong directory access for bert vocab in mlperf/model_eval.py

### DIFF
--- a/examples/mlperf/model_eval.py
+++ b/examples/mlperf/model_eval.py
@@ -181,7 +181,7 @@ def eval_bert():
   from examples.mlperf.metrics import f1_score
   from transformers import BertTokenizer
 
-  tokenizer = BertTokenizer(str(Path(__file__).parents[2] / "weights/bert_vocab.txt"))
+  tokenizer = BertTokenizer(str(Path(__file__).parents[2] / "extra/weights/bert_vocab.txt"))
 
   c = 0
   f1 = 0.0


### PR DESCRIPTION
The Bert model in extra/models downloads the vocab in extra/weights, but model_eval.py searches for the vocab in the top tinygrad directory. Trivial but noticed it, so. 