### PR TITLE
Use Tensor.randint in test_embedding

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -425,14 +425,14 @@ class TestNN(unittest.TestCase):
       torch_layer.weight[:] = torch.tensor(layer.weight.numpy(), dtype=torch.float32)
 
     # test
-    x = Tensor(np.random.randint(0, vocab_size, (B, T)))
+    x = Tensor.randint(B, T, low=0, high=vocab_size)
     z = layer(x)
     torch_x = torch.tensor(x.numpy())
     torch_z = torch_layer(torch_x)
     np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=1e-8, rtol=1e-8)
 
     # test with empty input length
-    x = Tensor(np.random.randint(0, vocab_size, (B, 0)))
+    x = Tensor.randint(B, 0, low=0, high=vocab_size)
     z = layer(x)
     torch_x = torch.tensor(x.numpy())
     torch_z = torch_layer(torch_x)
@@ -444,7 +444,7 @@ class TestNN(unittest.TestCase):
       return layer(x).realize()
 
     for _ in range(3):
-      x = Tensor(np.random.randint(0, vocab_size, (B, T)))
+      x = Tensor.randint(B, T, low=0, high=vocab_size)
       z = layer_jit(x)
       torch_x = torch.tensor(x.numpy())
       torch_z = torch_layer(torch_x)


### PR DESCRIPTION
A little simpler and respects tinygrad defaults using int32 instead of int64.