### PR TITLE
add get_available_backends()

### DIFF
--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -37,6 +37,7 @@ class _Device:
           return device
       except Exception: pass
     raise RuntimeError("no usable devices")
+  def get_available_backends(self) -> List[str]: return self._devices
 Device = _Device()
 
 # **************** Buffer + Allocators ****************


### PR DESCRIPTION
`python -c "from tinygrad import Device; print(Device.get_available_backends())"`
['DSP', 'LLVM', 'PYTHON', 'CUDA', 'NV', 'QCOM', 'CLANG', 'METAL', 'NPY', 'AMD', 'DISK', 'HIP', 'GPU']

ref https://github.com/tinygrad/tinygrad/issues/6689#issuecomment-2370459624