### PR TITLE
[MLPerf] Prepare openimages dataset script

### DIFF
--- a/examples/mlperf/model_eval.py
+++ b/examples/mlperf/model_eval.py
@@ -94,11 +94,11 @@ def eval_retinanet():
     x /= input_std
     return x
 
-  from extra.datasets.openimages import openimages, iterate
+  from extra.datasets.openimages import download_dataset, iterate, BASEDIR
   from pycocotools.coco import COCO
   from pycocotools.cocoeval import COCOeval
   from contextlib import redirect_stdout
-  coco = COCO(openimages('validation'))
+  coco = COCO(download_dataset(base_dir:=getenv("BASE_DIR", BASEDIR), 'validation'))
   coco_eval = COCOeval(coco, iouType="bbox")
   coco_evalimgs, evaluated_imgs, ncats, narea = [], [], len(coco_eval.params.catIds), len(coco_eval.params.areaRng)
 
@@ -107,7 +107,7 @@ def eval_retinanet():
 
   n, bs = 0, 8
   st = time.perf_counter()
-  for x, targets in iterate(coco, bs):
+  for x, targets in iterate(coco, base_dir, bs):
     dat = Tensor(x.astype(np.float32))
     mt = time.perf_counter()
     if dat.shape[0] == bs:

--- a/examples/mlperf/model_eval.py
+++ b/examples/mlperf/model_eval.py
@@ -113,7 +113,7 @@ def eval_retinanet():
     if dat.shape[0] == bs:
       outs = mdlrun(dat).numpy()
     else:
-      mdlrun.jit_cache = None
+      mdlrun._jit_cache = []
       outs =  mdl(input_fixup(dat)).numpy()
     et = time.perf_counter()
     predictions = mdl.postprocess_detections(outs, input_size=dat.shape[1:3], orig_image_sizes=[t["image_size"] for t in targets])

--- a/extra/datasets/openimages.py
+++ b/extra/datasets/openimages.py
@@ -2,14 +2,13 @@ import sys
 import json
 import numpy as np
 from PIL import Image
-import pathlib
+from pathlib import Path
 import boto3, botocore
-from tinygrad.helpers import fetch
-from tqdm import tqdm
+from tinygrad.helpers import fetch, tqdm, getenv
 import pandas as pd
 import concurrent.futures
 
-BASEDIR = pathlib.Path(__file__).parent / "open-images-v6-mlperf"
+BASEDIR = Path(__file__).parent / "open-images-v6-mlperf"
 BUCKET_NAME = "open-images-dataset"
 TRAIN_BBOX_ANNOTATIONS_URL = "https://storage.googleapis.com/openimages/v6/oidv6-train-annotations-bbox.csv"
 VALIDATION_BBOX_ANNOTATIONS_URL = "https://storage.googleapis.com/openimages/v5/validation-annotations-bbox.csv"
@@ -55,17 +54,12 @@ MLPERF_CLASSES = ['Airplane', 'Antelope', 'Apple', 'Backpack', 'Balloon', 'Banan
 ]
 
 
-def openimages(subset: str):
+def openimages(base_dir:Path, subset:str, ann_file:Path):
   valid_subsets = ['train', 'validation']
   if subset not in valid_subsets:
     raise ValueError(f"{subset=} must be one of {valid_subsets}")
-
-  ann_file = BASEDIR / f"{subset}/labels/openimages-mlperf.json"
-
-  if not ann_file.is_file():
-    fetch_openimages(ann_file, subset)
-
-  return ann_file
+  
+  fetch_openimages(ann_file, base_dir, subset)
 
 # this slows down the conversion a lot!
 # maybe use https://raw.githubusercontent.com/scardine/image_size/master/get_image_size.py
@@ -76,7 +70,7 @@ def export_to_coco(class_map, annotations, image_list, dataset_path, output_path
   cats = [{"id": i, "name": c, "supercategory": None} for i, c in enumerate(classes)]
   categories_map = pd.DataFrame([(i, c) for i, c in enumerate(classes)], columns=["category_id", "category_name"])
   class_map = class_map.merge(categories_map, left_on="DisplayName", right_on="category_name", how="inner")
-  annotations = annotations[np.isin(annotations["ImageID"], image_list)]
+  annotations = annotations[annotations["ImageID"].isin(image_list)]
   annotations = annotations.merge(class_map, on="LabelName", how="inner")
   annotations["image_id"] = pd.factorize(annotations["ImageID"].tolist())[0]
   annotations[["height", "width"]] = annotations.apply(lambda x: extract_dims(dataset_path / f"{x['ImageID']}.jpg"), axis=1, result_type="expand")
@@ -102,8 +96,8 @@ def export_to_coco(class_map, annotations, image_list, dataset_path, output_path
     json.dump(coco_annotations, fp)
 
 def get_image_list(class_map, annotations, classes=MLPERF_CLASSES):
-  labels = class_map[np.isin(class_map["DisplayName"], classes)]["LabelName"]
-  image_ids = annotations[np.isin(annotations["LabelName"], labels)]["ImageID"].unique()
+  labels = class_map[class_map["DisplayName"].isin(classes)]["LabelName"]
+  image_ids = annotations[annotations["LabelName"].isin(labels)]["ImageID"].unique()
   return image_ids
 
 def download_image(bucket, subset, image_id, data_dir):
@@ -112,10 +106,10 @@ def download_image(bucket, subset, image_id, data_dir):
   except botocore.exceptions.ClientError as exception:
     sys.exit(f"ERROR when downloading image `validation/{image_id}`: {str(exception)}")
 
-def fetch_openimages(output_fn, subset: str):
+def fetch_openimages(output_fn:str, base_dir:Path, subset:str):
   bucket = boto3.resource("s3", config=botocore.config.Config(signature_version=botocore.UNSIGNED)).Bucket(BUCKET_NAME)
 
-  annotations_dir, data_dir = BASEDIR / "annotations", BASEDIR / f"{subset}/data"
+  annotations_dir, data_dir = base_dir / "annotations", base_dir / f"{subset}/data"
   annotations_dir.mkdir(parents=True, exist_ok=True)
   data_dir.mkdir(parents=True, exist_ok=True)
 
@@ -143,8 +137,8 @@ def fetch_openimages(output_fn, subset: str):
   print("Converting annotations to COCO format...")
   export_to_coco(class_map, annotations, image_list, data_dir, output_fn, subset)
 
-def image_load(subset, fn):
-  img_folder = BASEDIR / f"{subset}/data"
+def image_load(base_dir, subset, fn):
+  img_folder = base_dir / f"{subset}/data"
   img = Image.open(img_folder / fn).convert('RGB')
   import torchvision.transforms.functional as F
   ret = F.resize(img, size=(800, 800))
@@ -164,18 +158,28 @@ def prepare_target(annotations, img_id, img_size):
   classes = classes[keep]
   return {"boxes": boxes, "labels": classes, "image_id": img_id, "image_size": img_size}
 
-def iterate(coco, bs=8):
+def iterate(coco, base_dir, bs=8):
   image_ids = sorted(coco.imgs.keys())
   for i in range(0, len(image_ids), bs):
     X, targets  = [], []
     for img_id in image_ids[i:i+bs]:
       img_dict = coco.loadImgs(img_id)[0]
-      x, original_size = image_load(img_dict['subset'], img_dict["file_name"])
+      x, original_size = image_load(base_dir, img_dict['subset'], img_dict["file_name"])
       X.append(x)
       annotations = coco.loadAnns(coco.getAnnIds(img_id))
       targets.append(prepare_target(annotations, img_id, original_size))
     yield np.array(X), targets
 
+def download_dataset(base_dir:Path, subset:str) -> Path:
+  if (ann_file:=base_dir / f"{subset}/labels/openimages-mlperf.json").is_file(): print(f"{subset} dataset is already available")
+  else:
+    print(f"Downloading {subset} dataset...")
+    openimages(base_dir, subset, ann_file)
+    print("Done")
+
+  return ann_file
+
+
 if __name__ == "__main__":
-  openimages("validation")
-  openimages("train")
+  download_dataset(base_dir:=getenv("BASE_DIR", BASEDIR), "train")
+  download_dataset(base_dir, "validation")

--- a/extra/datasets/openimages.py
+++ b/extra/datasets/openimages.py
@@ -58,7 +58,7 @@ def openimages(base_dir:Path, subset:str, ann_file:Path):
   valid_subsets = ['train', 'validation']
   if subset not in valid_subsets:
     raise ValueError(f"{subset=} must be one of {valid_subsets}")
-  
+
   fetch_openimages(ann_file, base_dir, subset)
 
 # this slows down the conversion a lot!

--- a/extra/datasets/openimages.py
+++ b/extra/datasets/openimages.py
@@ -70,7 +70,7 @@ def export_to_coco(class_map, annotations, image_list, dataset_path, output_path
   cats = [{"id": i, "name": c, "supercategory": None} for i, c in enumerate(classes)]
   categories_map = pd.DataFrame([(i, c) for i, c in enumerate(classes)], columns=["category_id", "category_name"])
   class_map = class_map.merge(categories_map, left_on="DisplayName", right_on="category_name", how="inner")
-  annotations = annotations[annotations["ImageID"].isin(image_list)]
+  annotations = annotations[np.isin(annotations["ImageID"], image_list)]
   annotations = annotations.merge(class_map, on="LabelName", how="inner")
   annotations["image_id"] = pd.factorize(annotations["ImageID"].tolist())[0]
   annotations[["height", "width"]] = annotations.apply(lambda x: extract_dims(dataset_path / f"{x['ImageID']}.jpg"), axis=1, result_type="expand")
@@ -96,8 +96,8 @@ def export_to_coco(class_map, annotations, image_list, dataset_path, output_path
     json.dump(coco_annotations, fp)
 
 def get_image_list(class_map, annotations, classes=MLPERF_CLASSES):
-  labels = class_map[class_map["DisplayName"].isin(classes)]["LabelName"]
-  image_ids = annotations[annotations["LabelName"].isin(labels)]["ImageID"].unique()
+  labels = class_map[np.isin(class_map["DisplayName"], classes)]["LabelName"]
+  image_ids = annotations[np.isin(annotations["LabelName"], labels)]["ImageID"].unique()
   return image_ids
 
 def download_image(bucket, subset, image_id, data_dir):


### PR DESCRIPTION
**Overview**
This PR adds support for an optional `BASE_DIR` env. variable to place the openimages dataset at a specific location. In addition, it performs basic checks to see if a specific dataset type is already available from the `BASE_DIR` location.

The download script usage is as follows:
```python
BASE_DIR=<path> python3 extra/datasets/openimages.py
```

By default, it will download __both__ training and validation sets.

**Remaining task(s)**
- [x] Verify `MODEL=retinanet python3 examples/mlperf/model_eval.py` produces the same result as before:
<img width="594" alt="Screenshot 2024-09-26 at 18 00 54" src="https://github.com/user-attachments/assets/5d1c8581-0ec8-4f07-97d8-659900322dfb">
