### PR TITLE
even simpler PatternMatcher gc test

### DIFF
--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -4,7 +4,6 @@ import unittest
 import numpy as np
 from tinygrad.device import Buffer
 from tinygrad.dtype import PtrDType, dtypes
-from tinygrad.engine.realize import run_schedule
 from tinygrad.ops import PatternMatcher, UOp, UOps, UPat
 from tinygrad.tensor import Tensor
 
@@ -41,27 +40,6 @@ class TestGC(unittest.TestCase):
     assert (tensors_allocated() == 5)
     del b
     assert (tensors_allocated() == 3)
-
-  def test_schedule_gc(self):
-    init = bufs_allocated()
-    x = Tensor.ones(256).contiguous().realize()
-    y = Tensor.ones(5, 5).contiguous()
-    y.schedule()
-    del x
-    del y
-    self.assertEqual(bufs_allocated()-init, 0)
-
-  def test_schedule_gc_with_inputs(self):
-    init = bufs_allocated()
-    x = Tensor.ones(256).contiguous().realize()
-    y = x+Tensor.ones(256).contiguous()
-    ys = y.schedule()
-    del x
-    run_schedule(ys)
-    np.testing.assert_equal(y.numpy(), np.full((256,), 2))
-    self.assertEqual(bufs_allocated()-init, 1)
-    del y
-    self.assertEqual(bufs_allocated()-init, 0)
 
   @unittest.expectedFailure
   def test_pattern_matcher_gc(self):

--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -51,13 +51,9 @@ class TestGC(unittest.TestCase):
     ])
     ret = matcher.rewrite(uop)
     del uop
+    del buf
     assert ret.arg == 0
-    try:
-      self.assertEqual(bufs_allocated()-init, 0)
-    except AssertionError as e:
-      print(f"{buf} wasn't gced, refs:")
-      print(gc.get_referrers(buf))
-      raise e
+    self.assertEqual(bufs_allocated()-init, 0)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This is because the gc doesn't cleanup pdict after rewrite.

When DEFINE_GLBOAL arg is Buffer, it'll hold on to that Buffer forever.