### PR TITLE
match dataclass.replace in UOp.replace [run_process_replay]

### DIFF
--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -377,7 +377,6 @@ class TestUOpMethod(unittest.TestCase):
   def test_replace(self):
     x = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.void), (), 0)
     self.assertIs(x.replace(arg=None).arg, None)
-    x = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.void), (), 0)
     with self.assertRaises(AssertionError): x.replace(field="a")
 
 class TestUOpStr(unittest.TestCase):

--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, replace as dataclass_replace
 from typing import Optional, Tuple, Any, List
 import unittest, math
 import numpy as np
@@ -373,6 +374,19 @@ class TestUOpMethod(unittest.TestCase):
     self.assertEqual((gidx0*3).const_factor(), 3)
     self.assertEqual((gidx0*3+6).const_factor(), 3)
     self.assertEqual((gidx0*3+1).const_factor(), 1)
+
+  def test_replace(self):
+    x = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.void), (), 0)
+    @dataclass
+    class DUOp:
+      op: Any
+      dtype: Any
+      src: Any
+      arg: Any
+    xd = DUOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.void), (), 0)
+    assert dataclass_replace(xd, arg=None).arg is None
+    assert x.replace(arg=None).arg is None
+    #assert_equiv_uops(x.replace(arg=None), dataclass_replace(xd, arg=None))
 
 class TestUOpStr(unittest.TestCase):
   def test_uop_str(self):

--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass, replace as dataclass_replace
 from typing import Optional, Tuple, Any, List
 import unittest, math
 import numpy as np
@@ -377,16 +376,9 @@ class TestUOpMethod(unittest.TestCase):
 
   def test_replace(self):
     x = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.void), (), 0)
-    @dataclass
-    class DUOp:
-      op: Any
-      dtype: Any
-      src: Any
-      arg: Any
-    xd = DUOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.void), (), 0)
-    assert dataclass_replace(xd, arg=None).arg is None
-    assert x.replace(arg=None).arg is None
-    #assert_equiv_uops(x.replace(arg=None), dataclass_replace(xd, arg=None))
+    self.assertIs(x.replace(arg=None).arg, None)
+    x = UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.void), (), 0)
+    with self.assertRaises(AssertionError): x.replace(field="a")
 
 class TestUOpStr(unittest.TestCase):
   def test_uop_str(self):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -144,8 +144,9 @@ class UOp(MathTrait):
     #if op is UOps.ALU and arg not in (BinaryOps.CMPNE, BinaryOps.CMPLT, TernaryOps.WHERE): assert all_same([dtype] + [x.dtype for x in src])
     #if op is UOps.CAST: assert dtype.count == src[0].dtype.count, f"cast can't change vectorization {src[0].dtype} --> {dtype}"
     self.op, self.dtype, self.src, self.arg = op, dtype, src, arg
-  def replace(self, op: Optional[UOps]=None, dtype:Optional[DType]=None, src: Optional[Tuple[UOp,...]]=None, arg:Any=None):
-    return UOp(op or self.op, dtype or self.dtype, self.src if src is None else src, self.arg if arg is None else arg)
+  def replace(self, **kwargs) -> UOp:
+    for k in kwargs: assert k in self.__slots__, f"unkown replace arg, expected one of {self.__slots__}, got {k}"
+    return UOp(kwargs.get("op", self.op), kwargs.get("dtype", self.dtype), kwargs.get("src", self.src), kwargs.get("arg", self.arg))
   @property
   def has_st(self) -> bool: return self.op not in {UOps.DEFINE_LOCAL, UOps.DEFINE_GLOBAL, UOps.CONST, UOps.DEFINE_VAR}
   @functools.cached_property


### PR DESCRIPTION
explicit `arg=None` should change the arg.