### PR TITLE
Construct c_ulong in blitCommandEncoder copy method

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -135,7 +135,8 @@ class MetalAllocator(LRUAllocator):
     dest_dev.synchronize()
     src_command_buffer = msg(src_dev.mtl_queue, "commandBuffer", restype=objc_instance)
     encoder = msg(src_command_buffer, "blitCommandEncoder", restype=objc_instance)
-    msg(encoder, "copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:", src.buf, ctypes.c_ulong(src.offset), dest.buf, ctypes.c_ulong(dest.offset), ctypes.c_ulong(sz))
+    msg(encoder, "copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:", src.buf, ctypes.c_ulong(src.offset),
+        dest.buf, ctypes.c_ulong(dest.offset), ctypes.c_ulong(sz))
     msg(encoder, "endEncoding")
     if src_dev != dest_dev:
       msg(src_command_buffer, "encodeSignalEvent:value:", src_dev.timeline_signal, src_dev.timeline_value)

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -135,7 +135,7 @@ class MetalAllocator(LRUAllocator):
     dest_dev.synchronize()
     src_command_buffer = msg(src_dev.mtl_queue, "commandBuffer", restype=objc_instance)
     encoder = msg(src_command_buffer, "blitCommandEncoder", restype=objc_instance)
-    msg(encoder, "copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:", src.buf, src.offset, dest.buf, dest.offset, sz)
+    msg(encoder, "copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:", src.buf, ctypes.c_ulong(src.offset), dest.buf, ctypes.c_ulong(dest.offset), ctypes.c_ulong(sz))
     msg(encoder, "endEncoding")
     if src_dev != dest_dev:
       msg(src_command_buffer, "encodeSignalEvent:value:", src_dev.timeline_signal, src_dev.timeline_value)


### PR DESCRIPTION
This method isn't run on CI so it wasn't caught, but running `METAL=1 pytest test/test_jit.py::TestJit::test_jitted_transfers`, or the following two examples, would cause the program to hang, because `copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:` expects NSUInteger (c_ulong) rather than NSInteger (the default c_int/c_long). Interestingly though other methods that expect NSUInteger didn't experience an error like this. 

- [A low level transfer example](https://gist.github.com/mesozoic-egg/530649deca9ef490eb7b0fbe3066d118)

Sharding example (intra device, just for demo):
```python

from tinygrad import Tensor, Device
import numpy as np

np.random.seed(0)
data = np.random.rand(10).astype(np.float32)

a = Tensor(data)
a = a.shard(['METAL:0', 'METAL:1'], axis=0)
a.realize()
```