### PR TITLE
add UOps.BUFFER, delete Buffer in UOps.DEFINE_GLOBAL

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -43,7 +43,7 @@ class LBScheduleItem:
 
 @dataclass(frozen=True)
 class ScheduleItemContext:
-  bufs: Tuple[Buffer, ...]
+  bufs: Tuple[int, ...]
 
 # *** UOp with SWIZZLE (movementops) rewriting to UOp we can index ***
 
@@ -117,7 +117,7 @@ reduceop_fusor = PatternMatcher([
 ])
 
 enumerate_bufs = PatternMatcher([
-  (UPat(UOps.DEFINE_GLOBAL, name="x"), lambda ctx,x: x.replace(arg=ctx.bufs.index(x.arg)) if isinstance(x.arg, Buffer) else None),
+  (UPat(UOps.DEFINE_GLOBAL, name="x"), lambda ctx,x: x.replace(arg=ctx.bufs.index(int(x.arg))) if isinstance(x.arg, str) else None),
 ])
 
 def full_ast_rewrite(sink:UOp, ctx:ScheduleItemContext) -> UOp:
@@ -128,7 +128,7 @@ def full_ast_rewrite(sink:UOp, ctx:ScheduleItemContext) -> UOp:
 # *** List[LazyBuffer] lowering to ScheduleItem ***
 
 def _recursive_uop(buf:LazyBuffer, st:ShapeTracker, outputs:Tuple[LazyBuffer, ...], var_vals:Dict[Variable, int], inputs:List[LazyBuffer],
-                      bufs:Tuple[LazyBuffer, ...], assign_targets:Dict[LazyBuffer, LazyBuffer],
+                      bufs:Tuple[Buffer, ...], assign_targets:Dict[LazyBuffer, LazyBuffer],
                       cache:Dict[Tuple[LazyBuffer, ShapeTracker], UOp]) -> UOp:
   """recursively create a UOp"""
   if buf is not buf.base: st, buf = buf.st+st, buf.base
@@ -137,7 +137,7 @@ def _recursive_uop(buf:LazyBuffer, st:ShapeTracker, outputs:Tuple[LazyBuffer, ..
   dtype = buf.dtype.base if isinstance(buf.dtype, ImageDType) else buf.dtype
 
   # buffer ops define ShapeTracker
-  if buf in bufs and buf not in outputs:
+  if buf.buffer in bufs and buf not in outputs:
     unbound_st, st_var_vals = st.simplify().unbind()
     var_vals.update(st_var_vals)
     # if it's a const, we generate it
@@ -154,7 +154,7 @@ def _recursive_uop(buf:LazyBuffer, st:ShapeTracker, outputs:Tuple[LazyBuffer, ..
       raise RuntimeError("self operand of augmented assign must be contiguous.\nhelp: consider using .contiguous():\n"
                            +colored("   - a += a.T\n", "red")+colored("   + a += a.T.contiguous()", "green"))
     if buf not in assign_targets and buf not in inputs: inputs.append(buf)
-    return UOp(UOps.LOAD, dtype, (UOp.define_global(buf.dtype, buf.buffer), unbound_st.to_uop()))
+    return UOp(UOps.LOAD, dtype, (UOp.define_global(buf.dtype, str(bufs.index(buf.buffer))), unbound_st.to_uop()))
 
   # reduce ops change ShapeTracker
   if buf.op in ReduceOps:
@@ -171,7 +171,7 @@ def _recursive_uop(buf:LazyBuffer, st:ShapeTracker, outputs:Tuple[LazyBuffer, ..
   if buf.op is UnaryOps.BITCAST: return cache.setdefault((buf, st), UOp(UOps.BITCAST, dtype, in_uops))
   return cache.setdefault((buf, st), UOp(UOps.ALU, dtype, in_uops, buf.op))
 
-def _lower_lazybuffer(outs:List[LazyBuffer], bufs:Tuple[LazyBuffer, ...]) -> Tuple[LBScheduleItem, Dict[Variable, int]]:
+def _lower_lazybuffer(outs:List[LazyBuffer], bufs:Tuple[Buffer, ...]) -> Tuple[LBScheduleItem, Dict[Variable, int]]:
   """describe the computation for a LazyBuffer with UOp + inputs + var_vals"""
   if (out:=outs[0]).op in {MetaOps.CUSTOM, MetaOps.COPY, MetaOps.EMPTY, MetaOps.VIEW}:
     return LBScheduleItem(UOp(UOps.EXT, out.dtype, (), (out.op, out.arg)), (out,)+tuple(x.base for x in out.srcs)), {}
@@ -188,8 +188,8 @@ def _lower_lazybuffer(outs:List[LazyBuffer], bufs:Tuple[LazyBuffer, ...]) -> Tup
       output_st = out.arg[0]
     output_st, vv = output_st.simplify().unbind()
     var_vals.update(vv)
-    ast.append(UOp(UOps.STORE, dtypes.void, (UOp.define_global(out.dtype, out.buffer), output_st.to_uop(), src)))
-  sink = full_ast_rewrite(ast[0].sink(*ast[1:]), ScheduleItemContext(bufs=tuple(x.buffer for x in outs+inputs)))
+    ast.append(UOp(UOps.STORE, dtypes.void, (UOp.define_global(out.dtype, str(bufs.index(out.buffer))), output_st.to_uop(), src)))
+  sink = full_ast_rewrite(ast[0].sink(*ast[1:]), ScheduleItemContext(bufs=tuple(dedup(bufs.index(x.buffer) for x in outs+inputs))))
   return LBScheduleItem(sink, tuple(outs+inputs), tuple(dedup([x[0].metadata for x in cache if x[0].metadata and x[0] not in inputs]))), var_vals
 
 # *** DAG creation: decide which LazyBuffers should realize ***
@@ -273,7 +273,7 @@ def _get_isolated_children(r:LazyBuffer, reduce_for_op:Dict[LazyBuffer, LazyBuff
 
 def _get_output_groups(outs:List[LazyBuffer]) -> \
   Tuple[DefaultDict[LazyBuffer, List[LazyBuffer]],  # these are the output groups
-        Tuple[LazyBuffer, ...],                     # these are all the realizes in the graph
+        Tuple[Buffer, ...],                         # these are all the realizes in the graph
         Dict[LazyBuffer, LazyBuffer]]:              # these are the buffers we ASSIGN to in this schedule
   """find all the realizes in the graph, group the output LazyBuffers into kernels."""
   # start by just realizing the buffers passed in
@@ -363,7 +363,7 @@ def _get_output_groups(outs:List[LazyBuffer]) -> \
         assert not hasattr(buf.buffer, '_buf'), "can't fixup allocated buffer"
         buf.buffer.dtype = dtypes.float32
         buf.buffer.options = None
-  return output_groups, tuple(realizes), assign_targets
+  return output_groups, tuple(dedup(x.buffer for x in realizes)), assign_targets
 
 SCHEDULES: List[Tuple[DefaultDict[LBScheduleItem, List[LBScheduleItem]], DefaultDict[LBScheduleItem, int]]] = []
 def _graph_schedule(outs:List[LazyBuffer]) -> \

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -94,6 +94,7 @@ class UOps(FastEnum):
   SHAPETRACKER = auto()
   SWIZZLE = auto()
   DEFINE_GLOBAL = auto()
+  BUFFER = auto()
   DEFINE_VAR = auto()
   DEFINE_LOCAL = auto()
   DEFINE_ACC = auto()
@@ -148,7 +149,7 @@ class UOp(MathTrait):
     for k in kwargs: assert k in self.__slots__, f"unkown replace arg, expected one of {self.__slots__}, got {k}"
     return UOp(kwargs.get("op", self.op), kwargs.get("dtype", self.dtype), kwargs.get("src", self.src), kwargs.get("arg", self.arg))
   @property
-  def has_st(self) -> bool: return self.op not in {UOps.DEFINE_LOCAL, UOps.DEFINE_GLOBAL, UOps.CONST, UOps.DEFINE_VAR}
+  def has_st(self) -> bool: return self.op not in {UOps.DEFINE_LOCAL, UOps.DEFINE_GLOBAL, UOps.BUFFER, UOps.CONST, UOps.DEFINE_VAR}
   @functools.cached_property
   def st(self) -> Optional[ShapeTracker]:
     if not self.has_st: return None

--- a/viz/serve.py
+++ b/viz/serve.py
@@ -99,7 +99,7 @@ def load_kernels(contexts:List[TrackedRewriteContext]) -> List[KernelRet]:
   code = ""
   for ctx in contexts:
     if ctx.loc[0].split("/")[-1] == "schedule.py":
-      si_ctx = ScheduleItemContext(bufs=tuple(x.arg for x in ctx.sink.sparents if x.op is UOps.DEFINE_GLOBAL))
+      si_ctx = ScheduleItemContext(bufs=tuple(int(x.arg) for x in ctx.sink.sparents if x.op is UOps.DEFINE_GLOBAL))
       with Context(TRACK_MATCH_STATS=0): kernel_name, code = (prg:=get_runner(Device.DEFAULT, full_ast_rewrite(ctx.sink, si_ctx)).p).name, prg.src
     elif ctx.kernel_name is not None: kernel_name, code = ctx.kernel_name, ""
     if ret.get(k:=to_function_name(kernel_name)) is None: ret[k] = KernelRet(k, code, {})

--- a/viz/serve.py
+++ b/viz/serve.py
@@ -99,7 +99,7 @@ def load_kernels(contexts:List[TrackedRewriteContext]) -> List[KernelRet]:
   code = ""
   for ctx in contexts:
     if ctx.loc[0].split("/")[-1] == "schedule.py":
-      si_ctx = ScheduleItemContext(bufs=tuple(int(x.arg) for x in ctx.sink.sparents if x.op is UOps.DEFINE_GLOBAL))
+      si_ctx = ScheduleItemContext(bufs=tuple(x.arg for x in ctx.sink.sparents if x.op is UOps.BUFFER))
       with Context(TRACK_MATCH_STATS=0): kernel_name, code = (prg:=get_runner(Device.DEFAULT, full_ast_rewrite(ctx.sink, si_ctx)).p).name, prg.src
     elif ctx.kernel_name is not None: kernel_name, code = ctx.kernel_name, ""
     if ret.get(k:=to_function_name(kernel_name)) is None: ret[k] = KernelRet(k, code, {})


### PR DESCRIPTION
The big graph creates UOps.BUFFER, where arg is the index in the big graph.

The small graph rewrites UOps.BUFFER to UOps.DEFINE_GLOBAL, where arg is from 0-n.

This makes decoupling compute scheduling from data scheduling (https://github.com/tinygrad/tinygrad/issues/6784) possible.

![image](https://github.com/user-attachments/assets/a0496c12-2e29-4cd8-9f7d-ca3b8d9bf992)

