### PR TITLE
push swizzle through dim change

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1364,11 +1364,10 @@ class TestIndexing(unittest.TestCase):
     self.check_schedule(xt, 3)
     np.testing.assert_equal(xt.numpy(), (np.arange(16).reshape(4, 4))[[1, 2], [1, 2]])
 
-  @unittest.expectedFailure
   def test_advanced_indexing(self):
     X = Tensor.arange(10)+1
     xt = X[[0]]
-    self.check_schedule(xt, 3)
+    self.check_schedule(xt, 2)
     np.testing.assert_equal(xt.numpy(), (np.arange(10)+1)[[0]])
 
   @unittest.expectedFailure

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -89,10 +89,8 @@ def push_swizzle_down_through_reduce(root:UOp, swizzle:UOp) -> UOp:
   output_shape = swizzle_st.reduce(axis)
   assert swizzle_st.contiguous, "can't push a non contiguous SWIZZLE down to STORE"
   assert prod(swizzle_st.shape) == prod(pre.shape), "can't push expands down to STORE"
-  #print(output_shape, pre.shape)
-  axis = tuple(0 if s == u else 1 for s,u in zip(pre.shape, output_shape))
-  #print(tuple((s, u) for s,u in zip(pre.shape, output_shape)), axis, root.arg[1])
-  return UOp(UOps.REDUCE_AXIS, root.dtype, swizzle.src, (op, axis)).swizzle(ShapeTracker.from_shape(output_shape))
+  new_axis = tuple(i for i,(s,u) in enumerate(zip(pre.shape, output_shape)) if s != u)
+  return UOp(UOps.REDUCE_AXIS, root.dtype, swizzle.src, (op, new_axis)).swizzle(ShapeTracker.from_shape(output_shape))
 
 def push_swizzle_down_through_elementwise(root:UOp) -> Optional[UOp]:
   swizzles = [x for x in root.src if x.op is UOps.SWIZZLE]

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -84,12 +84,12 @@ def push_swizzle_up_through_reduce(swizzle:UOp, reduceop:UOp) -> Optional[UOp]:
              (reduceop.arg[0], new_axis)).swizzle(ShapeTracker.from_shape(swizzle_st.shape))
 
 def push_swizzle_down_through_reduce(root:UOp, swizzle:UOp) -> UOp:
-  swizzle_st, pre = unwrap(swizzle.st), unwrap(swizzle.src[0].st)
+  swizzle_st, src_st = unwrap(swizzle.st), unwrap(swizzle.src[0].st)
+  assert swizzle_st.contiguous, "can't push a non contiguous SWIZZLE down to STORE"
+  assert prod(swizzle_st.shape) == prod(src_st.shape), "can't push expands down to STORE"
   op, axis = root.arg
   output_shape = swizzle_st.reduce(axis)
-  assert swizzle_st.contiguous, "can't push a non contiguous SWIZZLE down to STORE"
-  assert prod(swizzle_st.shape) == prod(pre.shape), "can't push expands down to STORE"
-  new_axis = tuple(i for i,(s,u) in enumerate(zip(pre.shape, output_shape)) if s != u)
+  new_axis = tuple(i for i,(s,u) in enumerate(zip(src_st.shape, output_shape)) if s != u)
   return UOp(UOps.REDUCE_AXIS, root.dtype, swizzle.src, (op, new_axis)).swizzle(ShapeTracker.from_shape(output_shape))
 
 def push_swizzle_down_through_elementwise(root:UOp) -> Optional[UOp]:


### PR DESCRIPTION
src has a SWIZZLE that reshapes the reduceop:
![image](https://github.com/user-attachments/assets/010a3030-b2d1-4a70-9407-6c3561224a75)
when it's pushed all the way up to the second REDUCE_AXIS:
![image](https://github.com/user-attachments/assets/68b83841-38c1-46da-8db4-2449aff1b894)

it should reduce on the new dims:
```diff
-UOp(UOps.REDUCE_AXIS, dtypes.int, arg=(BinaryOps.ADD, (1,)), src=(
-  UOp(UOps.SWIZZLE, dtypes.int, arg=ShapeTracker(views=(View(shape=(1, 10), strides=(0, 1), offset=0, mask=None, contiguous=True),)), src=(
+UOp(UOps.SWIZZLE, dtypes.int, arg=ShapeTracker(views=(View(shape=(1, 1), strides=(0, 0), offset=0, mask=None, contiguous=True),)), src=(
+  UOp(UOps.REDUCE_AXIS, dtypes.int, arg=(BinaryOps.ADD, (0,)), src=(
     UOp(UOps.ALU, dtypes.int, arg=BinaryOps.MUL, src=(
       UOp(UOps.ALU, dtypes.int, arg=BinaryOps.ADD, src=(
         x3:=UOp(UOps.ALU, dtypes.int, arg=BinaryOps.ADD, src=(
```

master rewrites this to:
```diff
-UOp(UOps.REDUCE_AXIS, dtypes.int, arg=(BinaryOps.ADD, (1,)), src=(
-  UOp(UOps.SWIZZLE, dtypes.int, arg=ShapeTracker(views=(View(shape=(1, 10), strides=(0, 1), offset=0, mask=None, contiguous=True),)), src=(
+UOp(UOps.SWIZZLE, dtypes.int, arg=ShapeTracker(views=(View(shape=(1, 1), strides=(0, 0), offset=0, mask=None, contiguous=True),)), src=(
+  UOp(UOps.REDUCE_AXIS, dtypes.int, arg=(BinaryOps.ADD, (1,)), src=(
     UOp(UOps.ALU, dtypes.int, arg=BinaryOps.MUL, src=(
       UOp(UOps.ALU, dtypes.int, arg=BinaryOps.ADD, src=(
         x3:=UOp(UOps.ALU, dtypes.int, arg=BinaryOps.ADD, src=(
 ```