### PR TITLE
Fix tensor saving and loading twice.

### DIFF
--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -107,6 +107,9 @@ class TestSafetensors(unittest.TestCase):
         assert f.read() == g.read()
     ret2 = safe_load(temp("real.safetensors_alt"))
     for k,v in tensors.items(): np.testing.assert_array_equal(ret2[k].numpy(), v.numpy())
+    safe_save(ret2, temp("real.safetensors_alt2"))
+    ret3 = safe_load(temp("real.safetensors_alt2"))
+    for k,v in tensors.items(): np.testing.assert_array_equal(ret3[k].numpy(), v.numpy())
 
   def test_real_safetensors_open(self):
     fn = temp("real_safe")


### PR DESCRIPTION
Solves #6294. See [this comment](https://github.com/tinygrad/tinygrad/issues/6294#issuecomment-2382370590) for the details. TLDR; disk devices keep around unlinked files and don't create new files.

This is my first contribution, so there may be a few rough edges. Namely, mypy has poor data flow analysis for `Optional`, so I used sentinel values instead. And no, it doesn't make sense for `self.fd` to be 0 since `mmap`ing stdin will give an error. Also, don't know if multiple assignment is ok here.

I reproduced the given script and got it working. I also added a unit test for this edge case.

Only 1 new line of code + 3 lines of test code.
