### PR TITLE
Fix GPT2 with OpenCL backend.

### DIFF
--- a/test/test_ocl.py
+++ b/test/test_ocl.py
@@ -1,5 +1,7 @@
 import unittest
 from tinygrad import Device
+from tinygrad.device import Buffer
+from tinygrad.dtype import dtypes
 from tinygrad.helpers import CI
 from tinygrad.runtime.ops_gpu import CLDevice, CLAllocator, CLCompiler, CLProgram
 
@@ -18,3 +20,12 @@ class TestCLError(unittest.TestCase):
     with self.assertRaises(RuntimeError) as err:
       CLProgram(device, name="", lib=CLCompiler(device, "test").compile("__kernel void test(__global int* a) { a[0] = 1; }"))
     assert str(err.exception) == "OpenCL Error -46: CL_INVALID_KERNEL_NAME"
+
+  def test_unaligned_copy(self):
+    data = list(range(65))
+    unaligned = memoryview(bytearray(data))[1:]
+    buffer = Buffer("GPU", 64, dtypes.uint8).allocate()
+    buffer.copyin(unaligned)
+    result = memoryview(bytearray(len(data) - 1))
+    buffer.copyout(result)
+    assert unaligned == result, "Unaligned data copied in must be equal to data copied out."

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -74,6 +74,7 @@ class CLAllocator(LRUAllocator):
       check(cl.clEnqueueWriteImage(self.device.queue, dest[0], False, (ctypes.c_size_t * 3)(0,0,0),
                                    (ctypes.c_size_t * 3)(dest[1].image.shape[1],dest[1].image.shape[0],1), 0, 0, from_mv(src), 0, None, None))
     else:
+      if ctypes.addressof(ctypes.c_char.from_buffer(src)) % 16: src = memoryview(bytearray(src))
       check(cl.clEnqueueWriteBuffer(self.device.queue, dest[0], False, 0, len(src)*src.itemsize, from_mv(src), 0, None, None))
     self.device.pending_copyin.append(src)    # NOTE: these can't be freed until the GPU actually executes this command
   def copyout(self, dest:memoryview, src:Tuple[ctypes._CData, BufferOptions]):


### PR DESCRIPTION
Solves #3482. We sliced a memory-mapped file that lead to an awkward alignment. OpenCL, the backend used when GPU=1, did not give any errors and instead zero-padded the front of the buffer. This lead to corruption after copying from the GPU back to the CPU, which lead to bad weights and tokens. To fix this, we can simply reallocate the buffer on the heap if it is unaligned.

The alternative is to instead assert the alignment and give the user an error. However, this makes things much harder for the user for the dubious benefit of 1 less buffer copy. 

Tested on an M3 Mac:
```
$ GPU=1 python examples/gpt2.py --model_size=gpt2         
using GPU backend
using gpt2
ram used:  0.50 GB, lm_head.weight                                    : 100%|██████| 149/149 [00:00<00:00, 884.87it/s]
loaded weights in 168.56 ms, 0.65 GB loaded at 3.87 GB/s
100%|███████████████████████████████████████████████████████████████████████████████| 100/100 [00:01<00:00, 73.85it/s]
Generating text...
What is the answer to life, the universe, and everything?

The answer to life, the universe, and everything is to do with the question: "What is the answer to life, the universe, and everything?"

In the case of the object of my love, I am in the small world. I am in the big world. I am in the big world.

The question is: "What is the answer to life, the universe, and everything?"

The answer to life, the universe, and everything is to
```
