### PR TITLE
viz rewrite part 1 [pr]

### DIFF
--- a/viz/index.html
+++ b/viz/index.html
@@ -250,7 +250,7 @@
       const p = Object.assign(document.createElement("p"), {id: `kernel-${k[0].kernel_name}`, innerText: k[0].kernel_name, style: "cursor: pointer;"});
       kernelUl.appendChild(p)
       k.forEach((u, j) => {
-        const rwUl = Object.assign(document.createElement("ul"), { innerText: `${toPath(u.loc)}`, key: `uop-rewrite-${j}`, className: (j === currentUOp && i == currentKernel) ? "active" : "" })
+        const rwUl = Object.assign(document.createElement("ul"), { innerText: `${toPath(u.loc)} - ${u.upats.length}`, key: `uop-rewrite-${j}`, className: (j === currentUOp && i == currentKernel) ? "active" : "" })
         rwUl.style.display = i === currentKernel && expandKernel ? "block" : "none";
         rwUl.onclick = (e) => {
           e.stopPropagation();

--- a/viz/index.html
+++ b/viz/index.html
@@ -225,6 +225,10 @@
     }
     document.querySelector('.status').textContent = active ? `` : `Connection to localhost:8000 failed, is VIZ=1 running?`;
   }
+  function toPath(loc) {
+    const [fp, lineno] = loc;
+    return `${fp.split("/").pop()}:${lineno}`
+  }
   var ret = {};
   var cache = {};
   var kernels = null;
@@ -243,10 +247,10 @@
     kernelList.innerHTML = "";
     kernels.forEach((k, i) => {
       kernelUl = Object.assign(document.createElement("ul"), { key: `kernel-${i}`, className: i === currentKernel ? "active" : "", style: "overflow-x: auto; cursor: initial;" });
-      const p = Object.assign(document.createElement("p"), {id: `kernel-${k.name}`, innerText: k.name, style: "cursor: pointer;"});
+      const p = Object.assign(document.createElement("p"), {id: `kernel-${k[0].kernel_name}`, innerText: k[0].kernel_name, style: "cursor: pointer;"});
       kernelUl.appendChild(p)
-      k.ctxs.forEach((u, j) => {
-        const rwUl = Object.assign(document.createElement("ul"), { innerText: `${u.filename} - ${u.match_count} - ${u.matcher_name}`, key: `uop-rewrite-${j}`, className: (j === currentUOp && i == currentKernel) ? "active" : "" })
+      k.forEach((u, j) => {
+        const rwUl = Object.assign(document.createElement("ul"), { innerText: `${toPath(u.loc)}`, key: `uop-rewrite-${j}`, className: (j === currentUOp && i == currentKernel) ? "active" : "" })
         rwUl.style.display = i === currentKernel && expandKernel ? "block" : "none";
         rwUl.onclick = (e) => {
           e.stopPropagation();
@@ -277,15 +281,15 @@
       ret = cache[cacheKey];
     }
     else {
-      ret = await (await fetch(`/graph?kernel_idx=${currentKernel}&uop_idx=${currentUOp}`)).json();
+      ret = await (await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}`)).json();
       cache[cacheKey] = ret;
     }
-    renderGraph(ret[0].graphs[currentRewrite], ret[0].additions[currentRewrite]);
+    renderGraph(ret.graphs[currentRewrite], ret.changed_nodes[currentRewrite]);
     // ***** RHS metadata
     const metadata = document.querySelector(".container.metadata");
     metadata.innerHTML = "";
-    metadata.appendChild(Object.assign(document.createElement("pre"), { textContent: ret[0].loc.filename }));
-    const pre = Object.assign(document.createElement("pre"), { innerHTML: `<code>${DOMPurify.sanitize(ret[0].loc.code)}</code>`, className: "wrap code-block language-python" });
+    metadata.appendChild(Object.assign(document.createElement("pre"), { textContent: toPath(ret.loc) }));
+    const pre = Object.assign(document.createElement("pre"), { innerHTML: `<code>${DOMPurify.sanitize(ret.code_line)}</code>`, className: "wrap code-block language-python" });
     metadata.appendChild(pre);
     hljs.highlightElement(pre);
     // ** resizer
@@ -319,29 +323,24 @@
       metadata.style.userSelect = "initial";
     }
     // ** code blocks
-    ret[0].extra[currentRewrite].forEach((e, i) => {
-      if (e.length == 0) return;
-      const pre = Object.assign(document.createElement("pre"), { innerHTML: `<code>${DOMPurify.sanitize(e)}</code>`, className: "code-block language-python" });
-      hljs.highlightElement(pre);
-      metadata.appendChild(pre);
-    })
-    if (kernels[currentKernel].code !== "") {
-      const code = kernels[currentKernel].code.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+    if (ret.kernel_code !== "") {
+      const code = kernels[currentKernel][0].kernel_code.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
       const pre = Object.assign(document.createElement("pre"), { innerHTML: `<code>${DOMPurify.sanitize(code)}</code>`, className: "code-block language-cpp" });
       hljs.highlightElement(pre);
       metadata.appendChild(pre);
     }
     // ** rewrite list
-    if (ret[0].graphs.length > 1) {
+    if (ret.graphs.length > 1) {
       const rewriteList = Object.assign(document.createElement("div"), { className: "rewrite-list" })
       metadata.appendChild(rewriteList);
-      ret[0].graphs.forEach((rw, i) => {
+      ret.graphs.forEach((rw, i) => {
         gUl = Object.assign(document.createElement("ul"), { innerText: i, key: `rewrite-${i}` });
         rewriteList.appendChild(gUl);
         if (i === currentRewrite) {
           gUl.classList.add("active");
           if (i !== 0) {
-            const [pattern, loc, diff] = ret[0].diffs[i-1];
+            const diff = ret.diffs[i-1];
+            const [loc, pattern] = ret.upats[i-1];
             const parts = loc.join(":").split("/");
             const div = Object.assign(document.createElement("div"), { className: "rewrite-container" });
             link = Object.assign(document.createElement("a"), { textContent: parts[parts.length-1]+"\n\n", href: "vscode://file"+parts.join("/"), style: "font-family: monospace; margin: 4px 0;" })
@@ -364,7 +363,7 @@
         });
       })
     } else {
-      metadata.appendChild(Object.assign(document.createElement("p"), { textContent: `No rewrites in ${ret[0].loc.filename}.` }));
+      metadata.appendChild(Object.assign(document.createElement("p"), { textContent: `No rewrites in ${toPath(ret.loc)}.` }));
     }
   }
   document.addEventListener("keydown", async function(event) {
@@ -401,7 +400,7 @@
     if (event.key == "ArrowDown") {
       event.preventDefault()
       currentRewrite = 0;
-      const totalUOps = kernels[currentKernel].ctxs.length-1;
+      const totalUOps = kernels[currentKernel].length-1;
       currentUOp = Math.min(totalUOps, currentUOp+1)
       main()
     }
@@ -413,7 +412,7 @@
     }
     if (event.key == "ArrowRight") {
       event.preventDefault()
-      const totalRewrites = ret[0].graphs.length-1;
+      const totalRewrites = ret.graphs.length-1;
       currentRewrite = Math.min(totalRewrites, currentRewrite+1)
       main()
     }

--- a/viz/serve.py
+++ b/viz/serve.py
@@ -99,8 +99,9 @@ if __name__ == "__main__":
   multiprocessing.current_process().name = "VizProcess"    # disallow opening of devices
   print("*** viz is starting")
   with open("/tmp/rewrites.pkl", "rb") as f: contexts: List[TrackedRewriteContext] = pickle.load(f)
-  kernels = load_kernels(contexts)
   print("*** unpickled saved rewrites")
+  kernels = load_kernels(contexts)
+  print("*** loaded kernels")
   server = HTTPServer(('', 8000), Handler)
   st = time.perf_counter()
   reloader_thread = threading.Thread(target=reloader)

--- a/viz/serve.py
+++ b/viz/serve.py
@@ -1,59 +1,31 @@
 #!/usr/bin/env python3
-from __future__ import annotations
-from typing import Dict, List, Optional, Tuple
-import pickle, os, sys, time, threading, webbrowser, json, difflib, contextlib, re, multiprocessing
-from dataclasses import dataclass, asdict
+from collections import defaultdict
+from typing import DefaultDict, Dict, List, Tuple
+import pickle, os, sys, time, threading, webbrowser, json, difflib, contextlib, multiprocessing
+from dataclasses import asdict
 from urllib.parse import parse_qs, urlparse
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from tinygrad.helpers import getenv, to_function_name
-from tinygrad.ops import TrackedRewriteContext, UOp, UOps, lines
+from tinygrad.helpers import getenv
+from tinygrad.ops import TrackedRewriteContext, UOp, UOps, UPat, lines
 from tinygrad.engine.graph import uops_colors, word_wrap
+from viz.spec import GraphRewriteDetails, GraphRewriteMetadata
 
-# **** /graph - detailed UOp + rewrites
-
-@dataclass(frozen=True)
-class RewriteLocation:
-  filename: str
-  code: str
-  matcher_name: Optional[str]
-  match_count: int
-  @staticmethod
-  def from_ctx(ctx:TrackedRewriteContext) -> RewriteLocation:
-    fp, lineno = ctx.loc
-    p = r"graph_rewrite\([^,]+,\s*([^>]+)\)"
-    match = re.search(p, code:=lines(fp)[lineno-1].strip())
-    return RewriteLocation(f"{fp.split('/')[-1]}:{lineno}", code, match.group(1).split(",")[0] if match is not None else None,
-                           len(ctx.rewrites))
-  def to_json(self): return asdict(self)
-
-@dataclass(frozen=True)
-class UOpRet:
-  loc: RewriteLocation
-  graphs: List[UOp]                                        # snapshot of the entire AST after each rewrite
-  diffs: List[Tuple[str, Tuple[str, int], List[str]]]      # the diffs for each rewrite
-  extra: List[List[str]]                                   # these become code blocks in the UI
-  additions: List[List[int]]
-  @staticmethod
-  def from_ctx(ctx:TrackedRewriteContext) -> UOpRet:
-    uops: List[UOp] = [ctx.sink]
-    diffs: List[Tuple[str, Tuple[str, int], List[str]]] = []
-    extra: List[List[str]] = [[str(ctx.sink)]]
-    additions: List[List[int]] = [[]]
-    seen_replaces: Dict[bytes, UOp] = {}
-    for i, (first, rewritten, pattern) in enumerate(ctx.rewrites):
-      # first, rewrite this UOp with the current rewrite + all the seen rewrites before this
-      seen_replaces[first.key] = rewritten
-      new_sink = replace_uop(uops[-1], {**seen_replaces})
-      # sanity check
-      assert new_sink is not uops[-1], f"rewritten sink wasn't rewritten! {i}\n{new_sink}\n{uops[-1]}"
-      # update ret data
-      additions.append([id(x) for x in rewritten.sparents if x.op is not UOps.CONST])
-      diffs.append((pattern.printable(), pattern.location, list(difflib.unified_diff(str(first).splitlines(), str(rewritten).splitlines()))))
-      uops.append(new_sink)
-      extra.append([str(new_sink)])
-    return UOpRet(RewriteLocation.from_ctx(ctx), uops, diffs, extra, additions)
-  def to_json(self) -> Dict:
-    return {**asdict(self), "loc":self.loc.to_json(), "graphs": list(map(uop_to_json, self.graphs))}
+def reconstruct_graph(sink:UOp, rewrites:List[Tuple[UOp, UOp, UPat]]) -> Tuple[List[UOp], List[List[str]], List[List[int]]]:
+  uops: List[UOp] = [sink]
+  diffs: List[List[str]] = []
+  changed_nodes: List[List[int]] = [[]]
+  seen_replaces: Dict[bytes, UOp] = {}
+  for i, (first, rewritten, _) in enumerate(rewrites):
+    # first, rewrite this UOp with the current rewrite + all the seen rewrites before this
+    seen_replaces[first.key] = rewritten
+    new_sink = replace_uop(uops[-1], {**seen_replaces})
+    # sanity check
+    assert new_sink is not uops[-1], f"rewritten sink wasn't rewritten! {i}\n{new_sink}\n{uops[-1]}"
+    # update ret data
+    changed_nodes.append([id(x) for x in rewritten.sparents if x.op is not UOps.CONST])
+    diffs.append(list(difflib.unified_diff(str(first).splitlines(), str(rewritten).splitlines())))
+    uops.append(new_sink)
+  return uops, diffs, changed_nodes
 
 def uop_to_json(x:UOp) -> Dict[int, Tuple[str, str, List[int], str, str]]:
   assert isinstance(x, UOp)
@@ -75,23 +47,13 @@ def replace_uop(base:UOp, replaces:Dict[bytes, UOp]) -> UOp:
   replaces[base.key] = ret = UOp(base.op, base.dtype, new_srcs, base.arg) if new_srcs != base.src else base
   return ret
 
-# **** /kernels - Overview of the kernel
-
-@dataclass(frozen=True)
-class KernelRet:
-  name: str
-  code: str
-  ctxs: List[TrackedRewriteContext]
-  def to_json(self) -> Dict: return {"name":self.name, "code":self.code, "ctxs":[RewriteLocation.from_ctx(x).to_json() for x in self.ctxs]}
-
-def load_kernels(contexts:List[TrackedRewriteContext]) -> List[KernelRet]:
-  ret: Dict[str, KernelRet] = {}
+def load_kernels(contexts) -> DefaultDict[str, List[Tuple[GraphRewriteMetadata, List[Tuple[UOp, UOp, UPat]], UOp]]]:
+  kernels = defaultdict(list)
   for ctx in contexts:
-    name = ctx.kernel.name if ctx.kernel is not None else "UNPARENTED"
-    if ret.get(k:=to_function_name(name)) is None:
-      ret[k] = KernelRet(k, ctx.kernel.to_program().src if ctx.kernel is not None else "", [])
-    ret[k].ctxs.append(ctx)
-  return list(ret.values())
+    name, code = ((p:=ctx.kernel.to_program()).function_name, p.src) if ctx.kernel is not None else ("UNPARENTED", "")
+    upats = [(upat.location, upat.printable()) for _,_,upat in ctx.rewrites]
+    kernels[name].append((GraphRewriteMetadata(ctx.loc, lines(ctx.loc[0])[ctx.loc[1]-1].strip(), name, code, upats), ctx.rewrites, ctx.sink))
+  return kernels
 
 class Handler(BaseHTTPRequestHandler):
   def do_GET(self):
@@ -111,15 +73,13 @@ class Handler(BaseHTTPRequestHandler):
       self.send_response(200)
       self.send_header("Content-type", "application/json")
       self.end_headers()
-      ret = json.dumps([x.to_json() for x in kernels]).encode()
-    elif url.path == "/graph":
       query = parse_qs(url.query)
-      self.send_response(200)
-      self.send_header("Content-type", "application/json")
-      self.end_headers()
-      k = kernels[int(query["kernel_idx"][0])]
-      g = UOpRet.from_ctx(k.ctxs[int(query["uop_idx"][0])])
-      ret = json.dumps((g.to_json(), [x.loc for x in k.ctxs])).encode()
+      if (qkernel:=query.get("kernel")) is not None:
+        metadata, rewrites, sink = list(kernels.values())[int(qkernel[0])][int(query["idx"][0])]
+        graphs, diffs, changed_nodes = reconstruct_graph(sink, rewrites)
+        ret = json.dumps(asdict(GraphRewriteDetails(**asdict(metadata), graphs=list(map(uop_to_json, graphs)),
+                                                    diffs=diffs, changed_nodes=changed_nodes))).encode()
+      else: ret = json.dumps([list(map(lambda x:asdict(x[0]), v)) for v in kernels.values()]).encode()
     else:
       self.send_response(404)
       ret = b""
@@ -139,9 +99,8 @@ if __name__ == "__main__":
   multiprocessing.current_process().name = "VizProcess"    # disallow opening of devices
   print("*** viz is starting")
   with open("/tmp/rewrites.pkl", "rb") as f: contexts: List[TrackedRewriteContext] = pickle.load(f)
-  print("*** unpickled saved rewrites")
   kernels = load_kernels(contexts)
-  print("*** loaded kernels")
+  print("*** unpickled saved rewrites")
   server = HTTPServer(('', 8000), Handler)
   st = time.perf_counter()
   reloader_thread = threading.Thread(target=reloader)

--- a/viz/spec.py
+++ b/viz/spec.py
@@ -9,18 +9,18 @@ class GraphRewriteMetadata:
   code_line: str
   """The Python line calling graph_rewrite"""
   kernel_name: Optional[str]
-  """The kernel instance calling graph_rewrite"""
+  """The kernel calling graph_rewrite"""
   kernel_code: Optional[str]
-  """The final code rendered by the kernel instance connected with this graph_rewrite"""
+  """The program after all rewrites"""
   upats: List[Tuple[Tuple[str, int], str]]
-  """List of all the UPats that matched and returned a not none value."""
+  """List of all the applied UPats."""
 
 @dataclass(frozen=True)
 class GraphRewriteDetails(GraphRewriteMetadata):
   """Full details about a single call to graph_rewrite"""
   graphs: List[Dict[int, Tuple[str, str, List[int], str, str]]]
-  """Sink at every stage of graph_rewrite"""
+  """Sink at every step of graph_rewrite"""
   diffs: List[List[str]]
   """.diff style before and after of the rewritten UOp child"""
   changed_nodes: List[List[int]]
-  """Nodes that changed at every stage of graph_rewrite"""
+  """Nodes that changed at every step of graph_rewrite"""

--- a/viz/spec.py
+++ b/viz/spec.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+from tinygrad.ops import UOp
+
+@dataclass(frozen=True)
+class GraphRewriteMetadata:
+  """Specifies metadata about a single call to graph_rewrite"""
+  loc: Tuple[str, int]
+  """File_path, Lineno"""
+  code_line: str
+  """The python line calling graph_rewrite"""
+  kernel_name: Optional[str]
+  """The kernel instance calling graph_rewrite"""
+  kernel_code: Optional[str]
+  """The final code rendered by the kernel instance connected with this graph_rewrite"""
+  rewrite_count: int
+  """Total number of rewrites on the sink"""
+
+@dataclass(frozen=True)
+class GraphRewriteFullInfo:
+  """
+  Full details about a single call to graph_rewrite
+  NOTE: this is slower to get because it reconstructs the entire graph after every rewrite
+  """
+  graphs: List[UOp]
+  """Snapshot of the SINK at every stage of graph_rewrite"""
+  upats: List[Tuple[Tuple[str, int], str]]
+  """List of all the UPats that matched and returned a not none value."""
+  diffs: List[str]
+  """.diff style before and after of the rewritten UOp child"""
+  metadata: GraphRewriteMetadata

--- a/viz/spec.py
+++ b/viz/spec.py
@@ -13,7 +13,7 @@ class GraphRewriteMetadata:
   kernel_code: Optional[str]
   """The program after all rewrites"""
   upats: List[Tuple[Tuple[str, int], str]]
-  """List of all the applied UPats."""
+  """List of all the applied UPats"""
 
 @dataclass(frozen=True)
 class GraphRewriteDetails(GraphRewriteMetadata):

--- a/viz/spec.py
+++ b/viz/spec.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-from tinygrad.ops import UOp
+from typing import Dict, List, Optional, Tuple
 
 @dataclass(frozen=True)
 class GraphRewriteMetadata:
@@ -8,24 +7,20 @@ class GraphRewriteMetadata:
   loc: Tuple[str, int]
   """File_path, Lineno"""
   code_line: str
-  """The python line calling graph_rewrite"""
+  """The Python line calling graph_rewrite"""
   kernel_name: Optional[str]
   """The kernel instance calling graph_rewrite"""
   kernel_code: Optional[str]
   """The final code rendered by the kernel instance connected with this graph_rewrite"""
-  rewrite_count: int
-  """Total number of rewrites on the sink"""
-
-@dataclass(frozen=True)
-class GraphRewriteFullInfo:
-  """
-  Full details about a single call to graph_rewrite
-  NOTE: this is slower to get because it reconstructs the entire graph after every rewrite
-  """
-  graphs: List[UOp]
-  """Snapshot of the SINK at every stage of graph_rewrite"""
   upats: List[Tuple[Tuple[str, int], str]]
   """List of all the UPats that matched and returned a not none value."""
-  diffs: List[str]
+
+@dataclass(frozen=True)
+class GraphRewriteDetails(GraphRewriteMetadata):
+  """Full details about a single call to graph_rewrite"""
+  graphs: List[Dict[int, Tuple[str, str, List[int], str, str]]]
+  """Sink at every stage of graph_rewrite"""
+  diffs: List[List[str]]
   """.diff style before and after of the rewritten UOp child"""
-  metadata: GraphRewriteMetadata
+  changed_nodes: List[List[int]]
+  """Nodes that changed at every stage of graph_rewrite"""


### PR DESCRIPTION
prereq for moving VIZ into core.

wins:
1. The VIZ server has 40 less lines.
2. spec.py, documented typed jsonable API responses.
![image](https://github.com/user-attachments/assets/1000059b-a65a-40aa-91b8-0d1505cc7e86)


