### PR TITLE
Make self.fd Optional.

### DIFF
--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -125,11 +125,11 @@ class BufferCopy(Runner):
     else: name = f"{type(self).__name__[6:].lower()} {total_sz:8d}, {dest_device[:7]:>7s} <- {src_device[:7]:7s}"
     super().__init__(colored(name, "yellow"), dest_device, 0, total_sz)
   def copy(self, dest, src):
-    is_disk = src.device.startswith("DISK")
-    disk_supports_fast_copyout = is_disk and hasattr(src.allocator.device, 'io_uring') and getattr(src.allocator.device, 'fd', None) is not None
-    if is_disk and hasattr(dest.allocator, 'copy_from_disk') and disk_supports_fast_copyout and src.nbytes >= 4096:
+    disk_supports_fast_copyout = src.device.startswith("DISK") and hasattr(src.allocator.device, 'io_uring') and \
+      getattr(src.allocator.device, 'fd', None) is not None
+    if src.device.startswith("DISK") and hasattr(dest.allocator, 'copy_from_disk') and disk_supports_fast_copyout and src.nbytes >= 4096:
       dest.allocator.copy_from_disk(dest._buf, src._buf, src.nbytes)
-    elif is_disk and hasattr(dest.allocator, 'as_buffer'):
+    elif src.device.startswith("DISK") and hasattr(dest.allocator, 'as_buffer'):
       # fast(ish) path, uses readinto in diskbuffers
       src.allocator.copyout(dest.allocator.as_buffer(dest._buf), src._buf)
     else:


### PR DESCRIPTION
Right now, `self.fd` is sometimes in `DiskDevice`. This messes up mypy/pylint, because those tools work poorly with attributes that are added and removed dynamically. Hence, we make it an `Optional` field instead.

Necessary for my fix for #6294.