### PR TITLE
test conv schedules are identical (they aren't!) [pr]

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -15,7 +15,7 @@ from tinygrad.shape.view import View
 from tinygrad.tensor import Tensor
 from tinygrad.ops import BinaryOps, MetaOps, UOp, UnaryOps, UOps
 from tinygrad.ops import graph_rewrite
-from tinygrad.helpers import AST_REWRITE, CI, DEBUG, FUSE_ARANGE, GlobalCounters, dedup, flatten, getenv, SPLIT_REDUCEOP, unwrap, prod
+from tinygrad.helpers import AST_REWRITE, CI, DEBUG, FUSE_ARANGE, GlobalCounters, flatten, getenv, SPLIT_REDUCEOP, unwrap, prod
 from tinygrad.codegen.kernel import Kernel, verify_ast
 from tinygrad.engine.schedule import BUF_LIMIT, create_schedule, reduceop_fusor, st_fixup
 from tinygrad.engine.realize import CompiledRunner, run_schedule


### PR DESCRIPTION
This was true before https://github.com/tinygrad/tinygrad/pull/6116
Now it fails because of rand's implicit Tensor copy cache:
![image](https://github.com/user-attachments/assets/3221d34d-599b-4ffb-9ecb-55517f621713)
