### PR TITLE
Fix gpt2 example

### DIFF
--- a/examples/gpt2.py
+++ b/examples/gpt2.py
@@ -133,7 +133,6 @@ class GPT2:
         weights[k] = weights[k].T
     # lm head and wte are tied
     weights['lm_head.weight'] = weights['wte.weight']
-    model.lm_head.weight.realize()
 
     load_state_dict(model, weights)
 

--- a/examples/gpt2.py
+++ b/examples/gpt2.py
@@ -133,6 +133,7 @@ class GPT2:
         weights[k] = weights[k].T
     # lm head and wte are tied
     weights['lm_head.weight'] = weights['wte.weight']
+    model.lm_head.weight.realize()
 
     load_state_dict(model, weights)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -307,6 +307,14 @@ class TestJit(unittest.TestCase):
     assert len(res3) == 10, "All values should be different, rand works in jit."
     assert res3 != res2, "Jit rand is diff with diff seeds"
 
+  def test_jit_random_after_unrealized_random(self):
+    @TinyJit
+    def f(): return Tensor.rand()
+    Tensor.manual_seed(1234)
+    Tensor.rand()
+    res = [f().numpy() for _ in range(3)]
+    assert res[1] != res[2]
+
   def test_jit_realization_and_sampling(self):
     w = Tensor.eye(5)
 


### PR DESCRIPTION
gpt2 example gives different outputs with JIT since [c100f3d](https://github.com/tinygrad/tinygrad/commit/c100f3d40618ff7f19ded78eee89d8a0dc253135).

Outputs on master:
![master output](https://github.com/user-attachments/assets/413ea5f3-8aba-40a5-b9de-45625119e802)

Outputs with change:
![output after change](https://github.com/user-attachments/assets/a74000e3-67a7-4d1f-a1b3-ecf5ba74f7c5)


