### PR TITLE
Suppress warnings in transcendental tests.

### DIFF
--- a/test/test_transcendental.py
+++ b/test/test_transcendental.py
@@ -19,8 +19,7 @@ class TestTranscendentalMath(unittest.TestCase):
     if op[0] == Tensor.sin:
       # TODO: reduction does not work  # 536870912.125  # 2914593.01171875  # 134217728.03125  # 230581075.65625  # 139216373.71875
       if abs(x) > 100_000_000: return
-
-    with Context(TRANSCENDENTAL=2):
+    with Context(TRANSCENDENTAL=2), np.errstate(all='ignore'):
       np.testing.assert_allclose(op[0](Tensor([x], dtype=dtypes.float64)).numpy(),
                                  op[1](np.array([x], dtype=_to_np_dtype(dtypes.float64))),
                                  atol=3e-2, rtol=1e-5)  # sin can have bigger atol for very big x
@@ -28,7 +27,7 @@ class TestTranscendentalMath(unittest.TestCase):
   @unittest.skipIf(getenv("MOCKGPU") and Device.DEFAULT == "NV", "crashed")
   @given(ht.float32, strat.sampled_from([(Tensor.exp, np.exp), (Tensor.log, np.log), (Tensor.sin, np.sin)]))
   def test_float32(self, x, op):
-    with Context(TRANSCENDENTAL=2):
+    with Context(TRANSCENDENTAL=2), np.errstate(all='ignore'):
       np.testing.assert_allclose(op[0](Tensor([x], dtype=dtypes.float32)).numpy(),
                                  op[1](np.array([x], dtype=_to_np_dtype(dtypes.float32))),
                                  atol=2e-5, rtol=1e-5)
@@ -36,7 +35,7 @@ class TestTranscendentalMath(unittest.TestCase):
   @unittest.skipUnless(is_dtype_supported(dtypes.float16, Device.DEFAULT), f"no float16 on {Device.DEFAULT}")
   @given(ht.float16, strat.sampled_from([(Tensor.exp, np.exp), (Tensor.log, np.log), (Tensor.sin, np.sin)]))
   def test_float16(self, x, op):
-    with Context(TRANSCENDENTAL=2):
+    with Context(TRANSCENDENTAL=2), np.errstate(all='ignore'):
       np.testing.assert_allclose(op[0](Tensor([x], dtype=dtypes.float16)).numpy(),
                                  op[1](np.array([x], dtype=_to_np_dtype(dtypes.float16))),
                                  atol=1e-2, rtol=5e-3)  # exp can have bigger rtol


### PR DESCRIPTION
Right now, CI has several warnings like: 
```
test/test_transcendental.py::TestTranscendentalMath::test_float16
  /Users/runner/work/tinygrad/tinygrad/test/test_transcendental.py:41: RuntimeWarning: divide by zero encountered in log
    op[1](np.array([x], dtype=_to_np_dtype(dtypes.float16))),
```
when testing transcendental functions. This is because these functions have relatively limited domains and our testing library sometimes generates wacky inputs, as it should. We still want to confirm we match numpy's behavior in these cases, so I think we should suppress these errors. 