### PR TITLE
new viz fuzz tests, track multiple contexts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -346,9 +346,7 @@ jobs:
     - name: Fuzz Test models schedule
       run: FUZZ_SCHEDULE=1 FUZZ_SCHEDULE_MAX_PATHS=5 python -m pytest test/models/test_train.py test/models/test_end2end.py
     - name: Run VIZ=1 tests
-      run: |
-        PYTHONPATH="." TRACK_MATCH_STATS=2 METAL=1 python3 -m pytest viz/test_viz.py
-        PYTHONPATH="." FUZZ_VIZ=1 python3 -m pytest test/test_ops.py
+      run: PYTHONPATH="." TRACK_MATCH_STATS=2 METAL=1 python3 -m pytest viz/test_viz.py
     - name: Run TRANSCENDENTAL math
       run: TRANSCENDENTAL=2 python -m pytest -n=auto test/test_ops.py::TestOps::test_sin test/test_ops.py::TestOps::test_cos test/test_ops.py::TestOps::test_tan test/test_ops.py::TestOps::test_exp test/test_ops.py::TestOps::test_log --durations=20
     - name: Run process replay tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -346,7 +346,9 @@ jobs:
     - name: Fuzz Test models schedule
       run: FUZZ_SCHEDULE=1 FUZZ_SCHEDULE_MAX_PATHS=5 python -m pytest test/models/test_train.py test/models/test_end2end.py
     - name: Run VIZ=1 tests
-      run: PYTHONPATH="." TRACK_MATCH_STATS=2 METAL=1 python3 -m pytest viz/test_viz.py
+      run: |
+        PYTHONPATH="." TRACK_MATCH_STATS=2 METAL=1 python3 -m pytest viz/test_viz.py
+        PYTHONPATH="." FUZZ_VIZ=1 python3 -m pytest test/test_ops.py
     - name: Run TRANSCENDENTAL math
       run: TRANSCENDENTAL=2 python -m pytest -n=auto test/test_ops.py::TestOps::test_sin test/test_ops.py::TestOps::test_cos test/test_ops.py::TestOps::test_tan test/test_ops.py::TestOps::test_exp test/test_ops.py::TestOps::test_log --durations=20
     - name: Run process replay tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ env:
   # increment this when downloads substantially change to avoid the internet
   DOWNLOAD_CACHE_VERSION: '6'
   RUN_PROCESS_REPLAY: 1
+  FUZZ_VIZ: 1
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PYTHONPATH: .
 
@@ -348,7 +349,6 @@ jobs:
     - name: Run VIZ=1 tests
       run: |
         PYTHONPATH="." TRACK_MATCH_STATS=2 METAL=1 python3 -m pytest viz/test_viz.py
-        PYTHONPATH="." FUZZ_VIZ=1 python3 -m pytest -n=auto test/test_ops.py --durations=20
     - name: Run TRANSCENDENTAL math
       run: TRANSCENDENTAL=2 python -m pytest -n=auto test/test_ops.py::TestOps::test_sin test/test_ops.py::TestOps::test_cos test/test_ops.py::TestOps::test_tan test/test_ops.py::TestOps::test_exp test/test_ops.py::TestOps::test_log --durations=20
     - name: Run process replay tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -346,7 +346,9 @@ jobs:
     - name: Fuzz Test models schedule
       run: FUZZ_SCHEDULE=1 FUZZ_SCHEDULE_MAX_PATHS=5 python -m pytest test/models/test_train.py test/models/test_end2end.py
     - name: Run VIZ=1 tests
-      run: PYTHONPATH="." TRACK_MATCH_STATS=2 METAL=1 python3 -m pytest viz/test_viz.py
+      run: |
+        PYTHONPATH="." TRACK_MATCH_STATS=2 METAL=1 python3 -m pytest viz/test_viz.py
+        PYTHONPATH="." FUZZ_VIZ=1 python3 -m pytest -n=auto test/test_ops.py --durations=20
     - name: Run TRANSCENDENTAL math
       run: TRANSCENDENTAL=2 python -m pytest -n=auto test/test_ops.py::TestOps::test_sin test/test_ops.py::TestOps::test_cos test/test_ops.py::TestOps::test_tan test/test_ops.py::TestOps::test_exp test/test_ops.py::TestOps::test_log --durations=20
     - name: Run process replay tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ env:
   # increment this when downloads substantially change to avoid the internet
   DOWNLOAD_CACHE_VERSION: '6'
   RUN_PROCESS_REPLAY: 1
-  FUZZ_VIZ: 1
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PYTHONPATH: .
 
@@ -347,8 +346,7 @@ jobs:
     - name: Fuzz Test models schedule
       run: FUZZ_SCHEDULE=1 FUZZ_SCHEDULE_MAX_PATHS=5 python -m pytest test/models/test_train.py test/models/test_end2end.py
     - name: Run VIZ=1 tests
-      run: |
-        PYTHONPATH="." TRACK_MATCH_STATS=2 METAL=1 python3 -m pytest viz/test_viz.py
+      run: PYTHONPATH="." TRACK_MATCH_STATS=2 METAL=1 python3 -m pytest viz/test_viz.py
     - name: Run TRANSCENDENTAL math
       run: TRANSCENDENTAL=2 python -m pytest -n=auto test/test_ops.py::TestOps::test_sin test/test_ops.py::TestOps::test_cos test/test_ops.py::TestOps::test_tan test/test_ops.py::TestOps::test_exp test/test_ops.py::TestOps::test_log --durations=20
     - name: Run process replay tests

--- a/viz/serve.py
+++ b/viz/serve.py
@@ -21,7 +21,7 @@ def reconstruct_graph(ctx:TrackedRewriteContext) -> Tuple[List[UOp], List[List[s
     new_sink = replace_uop(uops[-1], {**seen_replaces})
     # sanity check
     if new_sink is uops[-1]:
-      raise AssertionError(f"rewritten sink wasn't rewritten!")
+      raise AssertionError(f"rewritten sink wasn't rewritten! {i} {upat.location}")
     # update ret data
     changed_nodes.append([id(x) for x in rewritten.sparents if x.op is not UOps.CONST])
     diffs.append(list(difflib.unified_diff(str(first).splitlines(), str(rewritten).splitlines())))

--- a/viz/serve.py
+++ b/viz/serve.py
@@ -43,7 +43,7 @@ def uop_to_json(x:UOp) -> Dict[int, Tuple[str, str, List[int], str, str]]:
 
 def replace_uop(base:UOp, replaces:Dict[UOp, UOp]) -> UOp:
   if (found:=replaces.get(base)) is not None: return found
-  replaces[base] = ret = UOp(base.op, base.dtype, tuple(replace_uop(x, replaces) for x in base.src), base.arg)
+  replaces[base] = ret = base.replace(src=tuple(replace_uop(x, replaces) for x in base.src))
   return ret
 
 def load_kernels(contexts) -> DefaultDict[str, List[Tuple[GraphRewriteMetadata, TrackedRewriteContext]]]:

--- a/viz/serve.py
+++ b/viz/serve.py
@@ -15,12 +15,13 @@ def reconstruct_graph(ctx:TrackedRewriteContext) -> Tuple[List[UOp], List[List[s
   diffs: List[List[str]] = []
   changed_nodes: List[List[int]] = []
   seen_replaces: Dict[UOp, UOp] = {}
-  for i, (first, rewritten, _) in enumerate(ctx.rewrites):
+  for i, (first, rewritten, upat) in enumerate(ctx.rewrites):
     # first, rewrite this UOp with the current rewrite + all the seen rewrites before this
     seen_replaces[first] = rewritten
     new_sink = replace_uop(uops[-1], {**seen_replaces})
     # sanity check
-    assert new_sink is not uops[-1], f"rewritten sink wasn't rewritten! {i}\n{new_sink}\n{uops[-1]}"
+    if new_sink is uops[-1]:
+      raise AssertionError(f"rewritten sink wasn't rewritten!")
     # update ret data
     changed_nodes.append([id(x) for x in rewritten.sparents if x.op is not UOps.CONST])
     diffs.append(list(difflib.unified_diff(str(first).splitlines(), str(rewritten).splitlines())))

--- a/viz/test_viz.py
+++ b/viz/test_viz.py
@@ -7,7 +7,7 @@ from tinygrad import Tensor
 from tinygrad.engine.realize import lower_schedule
 from tinygrad.ops import TrackedRewriteContext, UOp, UOps, graph_rewrite, PatternMatcher, UPat, contexts, KernelInfo, BinaryOps
 from tinygrad.dtype import dtypes, PtrDType
-from tinygrad.helpers import CI, Context, all_same, DEBUG, colored, getenv
+from tinygrad.helpers import Context, all_same, DEBUG, colored, getenv
 from tinygrad.codegen.uopgraph import sym, devectorize, float4_folding
 from test.external.process_replay.helpers import print_diff
 from viz.serve import reconstruct_graph, uop_to_json, load_kernels
@@ -23,7 +23,7 @@ class TestViz(unittest.TestCase):
   def assert_valid_ctx(self, contexts:List[TrackedRewriteContext]):
     assert len(contexts) != 0
     for i,ctx in enumerate(contexts):
-      try: graphs,_,_ = reconstruct_graph(ctx.sink, ctx.rewrites)
+      try: graphs,_,_ = reconstruct_graph(ctx)
       except Exception as e:
         print(colored(f"failed to create graph for ctx {i}", "red"))
         raise e
@@ -70,7 +70,7 @@ class TestViz(unittest.TestCase):
     ])
     ret = graph_rewrite(sink, pm)
     if DEBUG >= 4: print_diff(sink, ret)
-    graphs,_,_ = reconstruct_graph(contexts[0].sink, contexts[0].rewrites)
+    graphs,_,_ = reconstruct_graph(contexts[0])
     assert graphs[-1].key == ret.key
     self.assert_valid_ctx(contexts)
 


### PR DESCRIPTION
VIZ needs a temp stack to keep track of graph_rewrite calls while doing another graph_rewrite.