### PR TITLE
viz prep refactor for tracked scope decorator [pr]

### DIFF
--- a/viz/serve.py
+++ b/viz/serve.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
   kernels = load_kernels(contexts)
   if getenv("FUZZ_VIZ"):
     for v in tqdm(kernels.values()):
-      for _,ctx in v: reconstruct_graph(ctx)
+      for _,ctx,_ in v: reconstruct_graph(ctx)
   print("*** loaded kernels")
   server = HTTPServer(('', 8000), Handler)
   st = time.perf_counter()

--- a/viz/serve.py
+++ b/viz/serve.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 from collections import defaultdict
-from typing import DefaultDict, Dict, List, Optional, Tuple
+from typing import Any, DefaultDict, Dict, List, Optional, Tuple
 import pickle, os, sys, time, threading, webbrowser, json, difflib, contextlib, multiprocessing, functools
 from dataclasses import asdict
 from urllib.parse import parse_qs, urlparse
 from http.server import HTTPServer, BaseHTTPRequestHandler
+from tinygrad.codegen.kernel import Kernel
 from tinygrad.helpers import getenv, to_function_name, tqdm
 from tinygrad.ops import TrackedRewriteContext, UOp, UOps, lines
 from tinygrad.engine.graph import uops_colors, word_wrap
@@ -47,17 +48,20 @@ def replace_uop(base:UOp, replaces:Dict[UOp, UOp]) -> UOp:
   replaces[base] = ret = base.replace(src=tuple(replace_uop(x, replaces) for x in base.src))
   return ret
 
-def load_kernels(contexts) -> DefaultDict[str, List[Tuple[GraphRewriteMetadata, TrackedRewriteContext]]]:
+def load_kernels(contexts:List[Tuple[Any, List[TrackedRewriteContext]]]) -> DefaultDict[str, List[Tuple[GraphRewriteMetadata, \
+    TrackedRewriteContext, Any]]]:
   kernels = defaultdict(list)
-  for ctx in contexts:
-    if ctx.sink.op is UOps.CONST: continue
-    name = to_function_name(ctx.kernel.name) if ctx.kernel is not None else None
-    upats = [(upat.location, upat.printable()) for _,_,upat in ctx.rewrites]
-    kernels[name].append((GraphRewriteMetadata(ctx.loc, lines(ctx.loc[0])[ctx.loc[1]-1].strip(), name, upats), ctx))
+  for k,rewrites in contexts:
+    if isinstance(k, Kernel): name = to_function_name(k.name)
+    else: name = None
+    for ctx in rewrites:
+      if ctx.sink.op is UOps.CONST: continue
+      upats = [(upat.location, upat.printable()) for _,_,upat in ctx.rewrites]
+      kernels[name].append((GraphRewriteMetadata(ctx.loc, lines(ctx.loc[0])[ctx.loc[1]-1].strip(), name, upats), ctx, k))
   return kernels
 
 @functools.lru_cache(None)
-def get_src(k) -> Optional[str]: return k.to_program().src if k else None
+def get_src(k) -> Optional[str]: return k.to_program().src if isinstance(k, Kernel) else None
 
 class Handler(BaseHTTPRequestHandler):
   def do_GET(self):
@@ -79,10 +83,10 @@ class Handler(BaseHTTPRequestHandler):
       self.end_headers()
       query = parse_qs(url.query)
       if (qkernel:=query.get("kernel")) is not None:
-        metadata, ctx = list(kernels.values())[int(qkernel[0])][int(query["idx"][0])]
+        metadata, ctx, k = list(kernels.values())[int(qkernel[0])][int(query["idx"][0])]
         graphs, diffs, changed_nodes = reconstruct_graph(ctx)
         ret = json.dumps(asdict(GraphRewriteDetails(**asdict(metadata), graphs=list(map(uop_to_json, graphs)),
-                                                    diffs=diffs, changed_nodes=changed_nodes, kernel_code=get_src(ctx.kernel)))).encode()
+                                                    diffs=diffs, changed_nodes=changed_nodes, kernel_code=get_src(k)))).encode()
       else: ret = json.dumps([list(map(lambda x:asdict(x[0]), v)) for v in kernels.values()]).encode()
     else:
       self.send_response(404)
@@ -102,7 +106,7 @@ def reloader():
 if __name__ == "__main__":
   multiprocessing.current_process().name = "VizProcess"    # disallow opening of devices
   print("*** viz is starting")
-  with open("/tmp/rewrites.pkl", "rb") as f: contexts: List[TrackedRewriteContext] = pickle.load(f)
+  with open("/tmp/rewrites.pkl", "rb") as f: contexts: List[Tuple[Any, List[TrackedRewriteContext]]] = pickle.load(f)
   print("*** unpickled saved rewrites")
   kernels = load_kernels(contexts)
   if getenv("FUZZ_VIZ"):


### PR DESCRIPTION
removes Kernel dep for type_checking. I think Any is fine here because we also wanna track ScheduleItem graphs.