### PR TITLE
Clip Device Fix

### DIFF
--- a/extra/models/clip.py
+++ b/extra/models/clip.py
@@ -440,7 +440,7 @@ class OpenClipEncoder:
       top = (h - SIZE) // 2
       image = image.crop((0, SIZE, top, top+SIZE))
 
-    x = Tensor(np.array(image.convert('RGB')))
+    x = Tensor(np.array(image.convert('RGB')), device=self.std.device)
     x = x.permute(2, 0, 1).cast(dtypes.float32) / 255.0
     return (x - self.mean) / self.std
 


### PR DESCRIPTION
## Overview

CLIP was creating a tensor internally without defining a device and then multiplying by weights, which caused issues when the CLIP model was on a non-default device.

Passing in the device of one of the weights fixes this.

## Testing

Ran the code changes in a full SDXL mlperf run where the CLIP model was on `NV:2` instead of the default `NV`.