### PR TITLE
use cummax in logcumsumexp

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1780,8 +1780,8 @@ class Tensor:
     print(t.logcumsumexp(axis=1).numpy())
     ```
     """
-    m = self.max(axis=axis, keepdim=True)
-    return (self - m).exp().cumsum(axis=axis).log() + m
+    cm = self.cumsum(axis=axis).maximum(self)
+    return (self - cm).exp().cumsum(axis=axis).log() + cm
 
   def argmax(self, axis=None, keepdim=False):
     """


### PR DESCRIPTION
#6937

```before
 ACTUAL: array([-inf, 100.], dtype=float32)
 DESIRED: array([  0., 100.], dtype=float32)
```

```after
Max absolute difference among violations: 0.69314575
Max relative difference among violations: 0.00693146
 ACTUAL: array([  0.      , 100.693146], dtype=float32)
 DESIRED: array([  0., 100.], dtype=float32)
 ```

cutting a pr now to fix the underflow immediately by using `cummax` from a `.cumsum().maximize()` in LCSE.
introduces some instability with exp(100). looking into this.