### PR TITLE
WIP: autocast bf16 to float32 for clang

### DIFF
--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -575,7 +575,7 @@ def full_graph_rewrite(sink:UOp, opts:Optional[Renderer]=None) -> UOp:
       sink = graph_rewrite(sink, sym+reducer)
       sink = graph_rewrite(sink, sym+get_extra_patterns(tuple(opts.code_for_op.keys()) if opts is not None else (), TRANSCENDENTAL>=2))
 
-  if opts is not None and opts.extra_matcher is not None: sink = graph_rewrite(sink, folder+opts.extra_matcher)
+  if opts is not None and opts.extra_matcher is not None: sink = graph_rewrite(sink, opts.extra_matcher)
   return sink
 
 def linearize_uop(sink:UOp, skip_check:bool=not __debug__) -> List[UOp]:

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -575,7 +575,8 @@ def full_graph_rewrite(sink:UOp, opts:Optional[Renderer]=None) -> UOp:
       sink = graph_rewrite(sink, sym+reducer)
       sink = graph_rewrite(sink, sym+get_extra_patterns(tuple(opts.code_for_op.keys()) if opts is not None else (), TRANSCENDENTAL>=2))
 
-  if opts is not None and opts.extra_matcher is not None: sink = graph_rewrite(sink, opts.extra_matcher)
+  if opts is not None and opts.extra_matcher is not None:
+      sink = graph_rewrite(sink, folder+opts.extra_matcher)
   return sink
 
 def linearize_uop(sink:UOp, skip_check:bool=not __debug__) -> List[UOp]:

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -575,8 +575,7 @@ def full_graph_rewrite(sink:UOp, opts:Optional[Renderer]=None) -> UOp:
       sink = graph_rewrite(sink, sym+reducer)
       sink = graph_rewrite(sink, sym+get_extra_patterns(tuple(opts.code_for_op.keys()) if opts is not None else (), TRANSCENDENTAL>=2))
 
-  if opts is not None and opts.extra_matcher is not None:
-      sink = graph_rewrite(sink, folder+opts.extra_matcher)
+  if opts is not None and opts.extra_matcher is not None: sink = graph_rewrite(sink, folder+opts.extra_matcher)
   return sink
 
 def linearize_uop(sink:UOp, skip_check:bool=not __debug__) -> List[UOp]:

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -165,6 +165,22 @@ class CStyleLanguage(Renderer):
     # NOTE: this relies on bufs dict preserving order
     return self.render_kernel(name, kernel, list(bufs.values()), uops)
 
+<<<<<<< HEAD
+=======
+def _make_clang_dtype(self, dtype):
+  return f"typedef {self.render_dtype(dtype.scalar())} {self.render_dtype(dtype)} __attribute__((aligned({(sz:=dtype.itemsize)}),vector_size({sz})));"
+
+no_bfloat16 = PatternMatcher([
+    (UPat({UOps.DEFINE_GLOBAL}, dtype=PtrDType(dtypes.bfloat16), name="x"),
+     lambda x: UOp(x.op, PtrDType(dtypes.float32), x.src, x.arg)),
+    (UPat({UOps.CONST}, dtype=dtypes.bfloat16, name="x"),
+     lambda x: UOp(x.op, dtypes.float32, x.src, x.arg)),
+    (UPat({UOps.LOAD, UOps.STORE}, dtype=dtypes.bfloat16, name="x"),
+     lambda x: UOp(x.op, dtypes.float32, x.src, x.arg)),
+    ]
+)
+
+>>>>>>> f8d5e9a8 (get llama to build with clang)
 class ClangRenderer(CStyleLanguage):
   device = "CLANG"
   float4 = "(float4)"
@@ -172,6 +188,7 @@ class ClangRenderer(CStyleLanguage):
   global_max = None
   infinity = "__builtin_inff()"
   nan = '__builtin_nanf("")'
+  extra_matcher = no_bfloat16
 
   # language options
   buffer_suffix = " restrict"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -165,7 +165,6 @@ class CStyleLanguage(Renderer):
     # NOTE: this relies on bufs dict preserving order
     return self.render_kernel(name, kernel, list(bufs.values()), uops)
 
-
 class ClangRenderer(CStyleLanguage):
   device = "CLANG"
   float4 = "(float4)"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -165,15 +165,6 @@ class CStyleLanguage(Renderer):
     # NOTE: this relies on bufs dict preserving order
     return self.render_kernel(name, kernel, list(bufs.values()), uops)
 
-no_bfloat16 = PatternMatcher([
-    (UPat({UOps.DEFINE_GLOBAL}, dtype=PtrDType(dtypes.bfloat16), name="x"),
-     lambda x: UOp(x.op, PtrDType(dtypes.float32), x.src, x.arg)),
-    (UPat({UOps.CONST}, dtype=dtypes.bfloat16, name="x"),
-     lambda x: UOp(x.op, dtypes.float32, x.src, x.arg)),
-    (UPat({UOps.LOAD, UOps.STORE}, dtype=dtypes.bfloat16, name="x"),
-     lambda x: UOp(x.op, dtypes.float32, x.src, x.arg)),
-    ]
-)
 
 class ClangRenderer(CStyleLanguage):
   device = "CLANG"
@@ -182,7 +173,14 @@ class ClangRenderer(CStyleLanguage):
   global_max = None
   infinity = "__builtin_inff()"
   nan = '__builtin_nanf("")'
-  extra_matcher = no_bfloat16
+  extra_matcher = PatternMatcher([
+    (UPat({UOps.DEFINE_GLOBAL}, dtype=PtrDType(dtypes.bfloat16), name="x"),
+     lambda x: UOp(x.op, PtrDType(dtypes.float32), x.src, x.arg)),
+    (UPat({UOps.CONST}, dtype=dtypes.bfloat16, name="x"),
+     lambda x: UOp(x.op, dtypes.float32, x.src, x.arg)),
+    (UPat({UOps.LOAD, UOps.STORE}, dtype=dtypes.bfloat16, name="x"),
+     lambda x: UOp(x.op, dtypes.float32, x.src, x.arg)),
+  ])
 
   # language options
   buffer_suffix = " restrict"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -165,11 +165,6 @@ class CStyleLanguage(Renderer):
     # NOTE: this relies on bufs dict preserving order
     return self.render_kernel(name, kernel, list(bufs.values()), uops)
 
-<<<<<<< HEAD
-=======
-def _make_clang_dtype(self, dtype):
-  return f"typedef {self.render_dtype(dtype.scalar())} {self.render_dtype(dtype)} __attribute__((aligned({(sz:=dtype.itemsize)}),vector_size({sz})));"
-
 no_bfloat16 = PatternMatcher([
     (UPat({UOps.DEFINE_GLOBAL}, dtype=PtrDType(dtypes.bfloat16), name="x"),
      lambda x: UOp(x.op, PtrDType(dtypes.float32), x.src, x.arg)),
@@ -180,7 +175,6 @@ no_bfloat16 = PatternMatcher([
     ]
 )
 
->>>>>>> f8d5e9a8 (get llama to build with clang)
 class ClangRenderer(CStyleLanguage):
   device = "CLANG"
   float4 = "(float4)"

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -12,7 +12,7 @@ class ClangCompiler(Compiler):
   def compile(self, src:str) -> bytes:
     # TODO: remove file write. sadly clang doesn't like the use of /dev/stdout here
     with tempfile.NamedTemporaryFile(delete=True) as output_file:
-      subprocess.check_output(['clang', '-shared', *self.args, '-O2', '-Wall', '-Werror', '-x', 'c', '-fPIC', '-ffreestanding', '-nostdlib',
+      subprocess.check_output(['clang', '-shared', *self.args, '-O2', '-Wall', '-Werror', '-x', 'c', '-fPIC', '-ffreestanding', '-nostdlib', '-lsystem',
                                '-', '-o', str(output_file.name)], input=src.encode('utf-8'))
       return pathlib.Path(output_file.name).read_bytes()
 


### PR DESCRIPTION
I hooked the rewriter using the `extra_matcher` field of the renderer (mimicking PTX). The rewrite rules are not correct (does not perform the shift), will fix soon. I was able to compile and run the llama example.

#6909 

PS: just noticed bfloat autocasting for metal after rebase, will refactor my change