### PR TITLE
Get readable error from wait_check in ops_metal

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -48,7 +48,7 @@ def to_struct(*t: int, _type: type = ctypes.c_ulong):
 
 def wait_check(cbuf: Any):
   msg(cbuf, "waitUntilCompleted")
-  if (error := cast(int, msg(cbuf, "error", restype=ctypes.c_ulong))) != 0: raise RuntimeError(error)
+  error_check(msg(cbuf, "error", restype=objc_instance))
 
 def elapsed_time(cbuf: objc_id):
   return cast(float, msg(cbuf, "GPUEndTime", restype=ctypes.c_double)) - cast(float, msg(cbuf, "GPUStartTime", restype=ctypes.c_double))


### PR DESCRIPTION
Before it would return an integer that doesn't help much in debugging:
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/af0db47e-99ce-49b0-8031-6968086bbfd5">



now there's a descriptive string

<img width="1241" alt="image" src="https://github.com/user-attachments/assets/c755f99c-6ec2-44df-9884-ee4a1b55b2e9">
