### PR TITLE
early UOp const + maskless view

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -619,13 +619,13 @@ class TestMultiTensor(unittest.TestCase):
         assert ast.op is UOps.STORE
         assert ast.src[2].arg is BinaryOps.ADD
         assert ast.src[2].src[0].op is UOps.LOAD
-        assert ast.src[2].src[1].src[1].op is UOps.CONST and ast.src[2].src[1].src[1].arg == 1
+        assert ast.src[2].src[1].op is UOps.CONST and ast.src[2].src[1].arg == 1
       t = 2 * t
       for si in t.schedule():
         ast = si.ast.src[0]
         assert ast.op is UOps.STORE
         assert ast.src[2].arg is BinaryOps.MUL
-        assert ast.src[2].src[0].src[1].op is UOps.CONST and ast.src[2].src[0].src[1].arg == 2
+        assert ast.src[2].src[0].op is UOps.CONST and ast.src[2].src[0].arg == 2
         assert ast.src[2].src[1].op is UOps.LOAD
       t = t + t.full_like(3)
       for si in t.schedule():
@@ -633,7 +633,7 @@ class TestMultiTensor(unittest.TestCase):
         assert ast.op is UOps.STORE
         assert ast.src[2].arg is BinaryOps.ADD
         assert ast.src[2].src[0].op is UOps.LOAD
-        assert ast.src[2].src[1].src[1].op is UOps.CONST and ast.src[2].src[1].src[1].arg == 3
+        assert ast.src[2].src[1].op is UOps.CONST and ast.src[2].src[1].arg == 3
 
   def test_shard_memory(self):
     devices = (d0, d1, d2, d3)

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -109,7 +109,7 @@ def merge_double_reduce(root:UOp, first_reduce:UOp) -> UOp:
 
 reduceop_fusor = PatternMatcher([
   # const + maskless swizzle = const
-  (UPat(UOps.VIEW, src=(UPat.cvar("x"),), name="view"),
+  (UPat(UOps.VIEW, src=(UPat((UOps.CONST, UOps.DEFINE_VAR), name="x"),), name="view"),
    lambda view,x: x if all(v.mask is None for v in view.st.views) else UOp(UOps.VALID, dtypes.bool, (view.st.to_uop(),)).where(x, x.const_like(0))),
   # push a SWIZZLE up to LOAD, through a reduce (eg. expands)
   (UPat(UOps.VIEW, src=(UPat(UOps.REDUCE_AXIS, name="reduceop"),), name="swizzle"), push_swizzle_up_through_reduce),

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -109,8 +109,8 @@ def merge_double_reduce(root:UOp, first_reduce:UOp) -> UOp:
 
 reduceop_fusor = PatternMatcher([
   # const + maskless swizzle = const
-  (UPat(UOps.VIEW, src=(UPat((UOps.CONST, UOps.DEFINE_VAR), name="x"),), name="view"),
-   lambda view,x: x if all(v.mask is None for v in view.st.views) else UOp(UOps.VALID, dtypes.bool, (view.st.to_uop(),)).where(x, x.const_like(0))),
+  (UPat(UOps.VIEW, src=(UPat((UOps.CONST, UOps.DEFINE_VAR), name="x"),), name="view"), lambda view,x: x if all(v.mask is None for v in view.st.views)
+   and not any(isinstance(s, UOp) for s in view.st.shape) else UOp(UOps.VALID, dtypes.bool, (view.st.to_uop(),)).where(x, x.const_like(0))),
   # push a SWIZZLE up to LOAD, through a reduce (eg. expands)
   (UPat(UOps.VIEW, src=(UPat(UOps.REDUCE_AXIS, name="reduceop"),), name="swizzle"), push_swizzle_up_through_reduce),
   # push a SWIZZLE down to STORE, through a reduce (ONLY reshapes)

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -2,7 +2,7 @@ import sys, pickle, atexit
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from typing import Callable, Tuple, List, Dict, Optional, DefaultDict, cast
-from tinygrad.ops import REDUCE_ALU, UNSAFE_PAD_OPS, MetaOps, ReduceOps, TernaryOps, UnaryOps, UOp, UOps, PatternMatcher, UPat, resolve, \
+from tinygrad.ops import REDUCE_ALU, UNSAFE_PAD_OPS, MetaOps, ReduceOps, UnaryOps, UOp, UOps, PatternMatcher, UPat, resolve, \
     graph_rewrite, track_rewrites
 from tinygrad.helpers import GRAPH, DEBUG, MULTIOUTPUT, SAVE_SCHEDULE, FUSE_CONV_BW, FUSE_ARANGE, GlobalCounters, Metadata, all_same, \
     colored, diskcache_put, prod, dedup, all_int, merge_dicts, getenv, unwrap

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -196,7 +196,7 @@ class UOp(MathTrait):
     if (self.op, self.dtype, self.src, self.arg) == new_args: return self
     return UOp(*new_args)
   @property
-  def has_st(self) -> bool: return self.op not in {UOps.DEFINE_LOCAL, UOps.DEFINE_GLOBAL, UOps.BUFFER, UOps.CONST, UOps.DEFINE_VAR}
+  def has_st(self) -> bool: return self.op is UOps.VIEW or any(x.has_st for x in self.src)
   @functools.cached_property
   def st(self) -> Optional[ShapeTracker]:
     if not self.has_st: return None


### PR DESCRIPTION
I don't think we can fold this VALID though:
```
UOp(UOps.SINK, dtypes.void, arg=KernelInfo(local_dims=0, upcasted=0, dont_use_locals=False), src=(
  UOp(UOps.STORE, dtypes.void, arg=None, src=(
    UOp(UOps.DEFINE_GLOBAL, PtrDType(dtypes.float), arg=0, src=()),
    UOp(UOps.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True),)), src=()),
    UOp(UOps.REDUCE_AXIS, dtypes.float, arg=(BinaryOps.ADD, (0,)), src=(
      UOp(UOps.ALU, dtypes.float, arg=TernaryOps.WHERE, src=(
        UOp(UOps.VALID, dtypes.bool, arg=None, src=(
          UOp(UOps.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(Variable(UOps.DEFINE_VAR, dtypes.int, arg=('i', 1, 10), src=()),), strides=(0,), offset=0, mask=None, contiguous=False),)), src=()),)),
        UOp(UOps.CONST, dtypes.float, arg=1.0, src=()),
        UOp(UOps.CONST, dtypes.float, arg=0.0, src=()),)),)),)),))
```