### PR TITLE
derivative of softmax is indepedent of max

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -882,7 +882,7 @@ class TestSchedule(unittest.TestCase):
     Tensor.manual_seed(0)
     x = Tensor.randn(4, 12, 64, 64, requires_grad=True).realize()
     x.softmax().sum().backward()
-    run_schedule(check_schedule(x.grad, 6))
+    run_schedule(check_schedule(x.grad, 4))
 
   # changed by: multireduce spec
   def test_layernorm_onelayer_fusion(self):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1681,7 +1681,7 @@ class Tensor:
 
   def _softmax(self, axis, dtype:Optional[DTypeLike]=None):
     x = self.cast(dtype) if dtype is not None else self
-    m = x - x.max(axis=axis, keepdim=True)
+    m = x - x.max(axis=axis, keepdim=True).detach()
     e = m.exp()
     return m, e, e.sum(axis=axis, keepdim=True)
 


### PR DESCRIPTION
two less kernels per softmax backward. testing on bert seems to be 3% faster

209 -> 213 tflops
<https://wandb.ai/chenyuxyz/MLPerf-BERT/runs/ed4m45ph/overview>