### PR TITLE
respect TRACEMETA=0

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -4,7 +4,7 @@ import torch
 import unittest, copy, mmap, random, math, array
 from tinygrad import Tensor, Device, dtypes
 from tinygrad.engine.schedule import create_schedule
-from tinygrad.helpers import getenv, temp, CI, _METADATA, mv_address
+from tinygrad.helpers import getenv, temp, CI, _METADATA, mv_address, Context
 from extra.gradcheck import numerical_jacobian, jacobian, gradcheck
 from hypothesis import given, settings, strategies as strat
 from test.helpers import is_dtype_supported
@@ -759,6 +759,14 @@ class TestTensorMetadata(unittest.TestCase):
     assert s[-1].metadata[1].name == "sigmoid"
     assert s[-1].metadata[1].backward
     assert s[-1].metadata[2].name == "relu"
+
+  def test_respects_tracemeta_0(self):
+    _METADATA.set(None)
+    with Context(TRACEMETA=0):
+      x = Tensor.rand(3, requires_grad=True)
+      y = Tensor.rand(3, requires_grad=True)
+      out = (x.relu() * y.sigmoid()).sum()
+    assert out.lazydata.metadata is None
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3521,7 +3521,7 @@ if IMAGE:
 
 def _metadata_wrapper(fn):
   def _wrapper(*args, **kwargs):
-    if _METADATA.get() is not None: return fn(*args, **kwargs)
+    if _METADATA.get() is not None or not TRACEMETA: return fn(*args, **kwargs)
 
     if TRACEMETA >= 2:
       caller_frame = sys._getframe(frame := 1)


### PR DESCRIPTION
### What this is
Makes it so that TRACEMETA=0 context var is respected in a Context() environment.

### Why it's good
fixes https://github.com/tinygrad/tinygrad/issues/6918

### Testing
Added unit test