### PR TITLE
autocast bfloat16 to float32 for llama on clang

### DIFF
--- a/examples/llama3.py
+++ b/examples/llama3.py
@@ -3,7 +3,7 @@ from typing import List
 import json, argparse, random, time
 import tiktoken
 from tiktoken.load import load_tiktoken_bpe
-from models.llama import Transformer, convert_from_huggingface, fix_bf16
+from extra.models.llama import Transformer, convert_from_huggingface, fix_bf16
 from tinygrad.nn.state import safe_load, torch_load, load_state_dict, get_parameters
 from tinygrad import Tensor, dtypes, nn, Context, Device, GlobalCounters
 from tinygrad.helpers import Profiling, Timing, DEBUG, colored, fetch, tqdm

--- a/examples/llama3.py
+++ b/examples/llama3.py
@@ -3,7 +3,7 @@ from typing import List
 import json, argparse, random, time
 import tiktoken
 from tiktoken.load import load_tiktoken_bpe
-from extra.models.llama import Transformer, convert_from_huggingface, fix_bf16
+from models.llama import Transformer, convert_from_huggingface, fix_bf16
 from tinygrad.nn.state import safe_load, torch_load, load_state_dict, get_parameters
 from tinygrad import Tensor, dtypes, nn, Context, Device, GlobalCounters
 from tinygrad.helpers import Profiling, Timing, DEBUG, colored, fetch, tqdm

--- a/extra/models/llama.py
+++ b/extra/models/llama.py
@@ -206,8 +206,11 @@ def convert_from_huggingface(weights:Dict[str, Tensor], model: Transformer, n_he
   return sd
 
 def fix_bf16(weights:Dict[Any, Tensor]):
-  if getenv("SUPPORT_BF16", 1):
+  if Device.DEFAULT == "CLANG":
     # TODO: without casting to float16, 70B llama OOM on tinybox.
-    return {k:v.cast(dtypes.float16) if v.dtype == dtypes.bfloat16 else v for k,v in weights.items()}
+    return {
+      k: (v.llvm_bf16_cast(dtypes.float32).to(v.device) if v.dtype == dtypes.bfloat16 else v) 
+      for k, v in weights.items()
+    }
   # TODO: check if device supports bf16
-  return {k:v.llvm_bf16_cast(dtypes.half).to(v.device) if v.dtype == dtypes.bfloat16 else v for k,v in weights.items()}
+  return {k:v.cast(dtypes.float16) if v.dtype == dtypes.bfloat16 else v for k,v in weights.items()}


### PR DESCRIPTION
#6909 and #6905 
The predefined function fix_bf16 was not working correctly.
I was able to load the weights and run examples/llama3.py.