### PR TITLE
do not serialize MTL library

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -63,34 +63,11 @@ class MetalCompiler(Compiler):
     self.device = device
     super().__init__("compile_metal")
   def compile(self, src:str) -> bytes:
-    # if self.device is None:
-    #   # NOTE: if you run llvm-dis on "air" you can see the llvm bytecode
-    #   air = subprocess.check_output(['xcrun', '-sdk', 'macosx', 'metal', '-x', 'metal', '-c', '-', '-o', '-'], input=src.encode('utf-8'))
-    #   return subprocess.check_output(['xcrun', '-sdk', 'macosx', 'metallib', '-', '-o', '-'], input=air)
-    # options = msg(libobjc.objc_getClass(b"MTLCompileOptions"), "new", restype=objc_instance)
-    # msg(options, "setFastMathEnabled:", getenv("METAL_FAST_MATH"))
-    # compileError = objc_instance()
-    # library = msg(self.device.device, "newLibraryWithSource:options:error:", to_ns_str(src),
-    #               options, ctypes.byref(compileError), restype=objc_instance)
-    # error_check(compileError, CompileError)
-    # library_contents = msg(library, "libraryDataContents", restype=objc_instance)
-    # return ctypes.string_at(msg(library_contents, "bytes"), cast(int, msg(library_contents, "length", restype=ctypes.c_ulong)))
     return src.encode()
 
 class MetalProgram:
   def __init__(self, device:MetalDevice, name:str, lib:bytes):
     self.device, self.name, self.lib = device, name, lib
-    # if DEBUG >= 6:
-    #   with tempfile.NamedTemporaryFile(delete=True) as shader:
-    #     shader.write(lib)
-    #     shader.flush()
-    #     ret = os.system(f"cd {pathlib.Path(__file__).parents[2]}/extra/disassemblers/applegpu && python3 compiler_explorer.py {shader.name}")
-    #     if ret:
-    #       print("Error running disassembler: Make sure you have https://github.com/dougallj/applegpu cloned to tinygrad/extra/disassemblers/applegpu")
-    # assert lib[:4] == b"MTLB", "Invalid Metal library. Could be due to using conda. Try system python or METAL_XCODE=1 DISABLE_COMPILER_CACHE=1."
-    # data = libdispatch.dispatch_data_create(lib, len(lib), None, None)
-    # error_library_creation = objc_instance()
-    # self.library = msg(self.device.device, "newLibraryWithData:error:", data, ctypes.byref(error_library_creation), restype=objc_instance)
     options = msg(libobjc.objc_getClass(b"MTLCompileOptions"), "new", restype=objc_instance)
     msg(options, "setFastMathEnabled:", getenv("METAL_FAST_MATH"))
     compileError = objc_instance()

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -40,6 +40,7 @@ def msg(ptr: objc_id, selector: str, /, *args: Any, restype: type[T] = objc_id) 
   return sender(ptr, sel(selector), *args)
 
 def to_ns_str(s: str): return msg(libobjc.objc_getClass(b"NSString"), "stringWithUTF8String:", s.encode(), restype=objc_instance)
+def bytes_to_ns_str(b: bytes): return msg(libobjc.objc_getClass(b"NSString"), "stringWithUTF8String:", b, restype=objc_instance)
 
 def to_struct(*t: int, _type: type = ctypes.c_ulong):
   class Struct(ctypes.Structure): pass
@@ -62,34 +63,40 @@ class MetalCompiler(Compiler):
     self.device = device
     super().__init__("compile_metal")
   def compile(self, src:str) -> bytes:
-    if self.device is None:
-      # NOTE: if you run llvm-dis on "air" you can see the llvm bytecode
-      air = subprocess.check_output(['xcrun', '-sdk', 'macosx', 'metal', '-x', 'metal', '-c', '-', '-o', '-'], input=src.encode('utf-8'))
-      return subprocess.check_output(['xcrun', '-sdk', 'macosx', 'metallib', '-', '-o', '-'], input=air)
-    options = msg(libobjc.objc_getClass(b"MTLCompileOptions"), "new", restype=objc_instance)
-    msg(options, "setFastMathEnabled:", getenv("METAL_FAST_MATH"))
-    compileError = objc_instance()
-    library = msg(self.device.device, "newLibraryWithSource:options:error:", to_ns_str(src),
-                  options, ctypes.byref(compileError), restype=objc_instance)
-    error_check(compileError, CompileError)
-    library_contents = msg(library, "libraryDataContents", restype=objc_instance)
-    return ctypes.string_at(msg(library_contents, "bytes"), cast(int, msg(library_contents, "length", restype=ctypes.c_ulong)))
+    # if self.device is None:
+    #   # NOTE: if you run llvm-dis on "air" you can see the llvm bytecode
+    #   air = subprocess.check_output(['xcrun', '-sdk', 'macosx', 'metal', '-x', 'metal', '-c', '-', '-o', '-'], input=src.encode('utf-8'))
+    #   return subprocess.check_output(['xcrun', '-sdk', 'macosx', 'metallib', '-', '-o', '-'], input=air)
+    # options = msg(libobjc.objc_getClass(b"MTLCompileOptions"), "new", restype=objc_instance)
+    # msg(options, "setFastMathEnabled:", getenv("METAL_FAST_MATH"))
+    # compileError = objc_instance()
+    # library = msg(self.device.device, "newLibraryWithSource:options:error:", to_ns_str(src),
+    #               options, ctypes.byref(compileError), restype=objc_instance)
+    # error_check(compileError, CompileError)
+    # library_contents = msg(library, "libraryDataContents", restype=objc_instance)
+    # return ctypes.string_at(msg(library_contents, "bytes"), cast(int, msg(library_contents, "length", restype=ctypes.c_ulong)))
+    return src.encode()
 
 class MetalProgram:
   def __init__(self, device:MetalDevice, name:str, lib:bytes):
     self.device, self.name, self.lib = device, name, lib
-    if DEBUG >= 6:
-      with tempfile.NamedTemporaryFile(delete=True) as shader:
-        shader.write(lib)
-        shader.flush()
-        ret = os.system(f"cd {pathlib.Path(__file__).parents[2]}/extra/disassemblers/applegpu && python3 compiler_explorer.py {shader.name}")
-        if ret:
-          print("Error running disassembler: Make sure you have https://github.com/dougallj/applegpu cloned to tinygrad/extra/disassemblers/applegpu")
-    assert lib[:4] == b"MTLB", "Invalid Metal library. Could be due to using conda. Try system python or METAL_XCODE=1 DISABLE_COMPILER_CACHE=1."
-    data = libdispatch.dispatch_data_create(lib, len(lib), None, None)
-    error_library_creation = objc_instance()
-    self.library = msg(self.device.device, "newLibraryWithData:error:", data, ctypes.byref(error_library_creation), restype=objc_instance)
-    error_check(error_library_creation)
+    # if DEBUG >= 6:
+    #   with tempfile.NamedTemporaryFile(delete=True) as shader:
+    #     shader.write(lib)
+    #     shader.flush()
+    #     ret = os.system(f"cd {pathlib.Path(__file__).parents[2]}/extra/disassemblers/applegpu && python3 compiler_explorer.py {shader.name}")
+    #     if ret:
+    #       print("Error running disassembler: Make sure you have https://github.com/dougallj/applegpu cloned to tinygrad/extra/disassemblers/applegpu")
+    # assert lib[:4] == b"MTLB", "Invalid Metal library. Could be due to using conda. Try system python or METAL_XCODE=1 DISABLE_COMPILER_CACHE=1."
+    # data = libdispatch.dispatch_data_create(lib, len(lib), None, None)
+    # error_library_creation = objc_instance()
+    # self.library = msg(self.device.device, "newLibraryWithData:error:", data, ctypes.byref(error_library_creation), restype=objc_instance)
+    options = msg(libobjc.objc_getClass(b"MTLCompileOptions"), "new", restype=objc_instance)
+    msg(options, "setFastMathEnabled:", getenv("METAL_FAST_MATH"))
+    compileError = objc_instance()
+    self.library = msg(self.device.device, "newLibraryWithSource:options:error:", bytes_to_ns_str(lib),
+                  options, ctypes.byref(compileError), restype=objc_instance)
+    error_check(compileError)
     self.fxn = msg(self.library, "newFunctionWithName:", to_ns_str(name), restype=objc_instance)
     descriptor = msg(libobjc.objc_getClass(b"MTLComputePipelineDescriptor"), "new", restype=objc_instance)
     msg(descriptor, "setComputeFunction:", self.fxn)


### PR DESCRIPTION
not the best fix. I think with JIT and IndirectCommandBuffer, serializing the IR of MTLLibrary may not be necessary?