### PR TITLE
Parallel SHA3 in tinygrad

### DIFF
--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -2,7 +2,7 @@ import gzip, unittest
 from PIL import Image
 from tinygrad import Variable
 from tinygrad.helpers import Context, ContextVar
-from tinygrad.helpers import merge_dicts, strip_parens, prod, round_up, fetch, fully_flatten, from_mv, to_mv
+from tinygrad.helpers import merge_dicts, strip_parens, prod, round_up, fetch, fully_flatten, from_mv, to_mv, left_encode, right_encode
 from tinygrad.tensor import get_shape
 from tinygrad.codegen.lowerer import get_contraction
 import numpy as np
@@ -290,6 +290,27 @@ class TestGetShape(unittest.TestCase):
   def test_inhomogeneous_shape(self):
     with self.assertRaises(ValueError): get_shape([[], [1]])
     with self.assertRaises(ValueError): get_shape([[1, [2]], [1]])
+    
+class TestByteStringsEncode(unittest.TestCase):
+  def test_encode_literal_0(self) :
+    self.assertEqual(left_encode(0), b'\x01\x00')
+    self.assertEqual(right_encode(0), b'\x00\x01')
+
+  @unittest.expectedFailure
+  def test_left_encode_subceed_validity_range(self) :
+    left_encode(-1)
+  
+  @unittest.expectedFailure
+  def test_right_encode_subceed_validity_range(self) :
+    right_encode(-1)
+
+  @unittest.expectedFailure
+  def test_left_encode_exceed_validity_range(self) :
+    left_encode(22040)
+  
+  @unittest.expectedFailure
+  def test_right_encode_exceed_validity_range(self) :
+    right_encode(22040)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -323,3 +323,24 @@ copyreg.pickle(types.CodeType, _serialize_code)
 
 def _serialize_module(module:types.ModuleType): return importlib.import_module, (module.__name__,)
 copyreg.pickle(types.ModuleType, _serialize_module)
+
+# *** parallel hash3
+
+# Following the NIST specification for ParallelHash (https://doi.org/10.6028/NIST.SP.800-185 p.15)
+
+def _encode(x):
+    assert (0 <= x < 22040), "x must be in the range [0, 22040)"
+    n = 1
+    while (28 ** n) <= x: n += 1
+    base256_digits = [(x // (28 ** (n - i - 1))) % 256 for i in range(n)]
+    encoded_digits = [bytes([xi]) for xi in base256_digits]
+    encoded_n = bytes([n])
+    return encoded_n, encoded_digits
+
+def left_encode(x):
+    encoded_n, encoded_digits = _encode(x)
+    return encoded_n + b''.join(encoded_digits)
+
+def right_encode(x):
+    encoded_n, encoded_digits = _encode(x)
+    return b''.join(encoded_digits) + encoded_n


### PR DESCRIPTION
I started working on the parallel SHA3 function following the specifications of `ParallelHash` https://doi.org/10.6028/NIST.SP.800-185 (p.15). 
At the moment, I just implemented the functions left_encode and right_encode (specified at page 5) . I put the code in `tinygrad/helpers.py` and some basic unit tests in `test/unit/helpers.py`. In the next few days, I'll go ahead and implement more in-depth unit tests and the rest of the algorithm.

I have two questions:
1. As you can see, I hard-coded all the constants without giving them any name, just because anyone can easily find their meaning in the specifications. Is it ok for you?
2. I'm going to use the library `pycryptodome` for the function `cSHAKE256`. Is it ok to have it as a tinygrad dependency?