### PR TITLE
fix test warnings without affecting errors

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -8,6 +8,8 @@ from tinygrad import Device, Tensor, dtypes
 from tinygrad.tensor import _to_np_dtype
 from hypothesis import given, settings, strategies as strat
 from test.helpers import is_dtype_supported, rand_for_dtype
+import pytest
+pytestmark = pytest.mark.filterwarnings("ignore")
 
 settings.register_profile("my_profile", max_examples=200, deadline=None, derandomize=getenv("DERANDOMIZE_CI", False))
 settings.load_profile("my_profile")
@@ -71,7 +73,6 @@ class TestDType(unittest.TestCase):
   def test_to_np(self):
     _test_to_np(Tensor(self.DATA, dtype=self.DTYPE), _to_np_dtype(self.DTYPE), np.array(self.DATA, dtype=_to_np_dtype(self.DTYPE)))
 
-  @np.errstate(all='ignore')
   def test_casts_to(self): list(map(
     lambda dtype: _test_cast(Tensor(self.DATA, dtype=dtype), self.DTYPE),
     get_available_cast_dtypes(self.DTYPE)
@@ -421,7 +422,6 @@ class TestTypeSpec(unittest.TestCase):
       subprocess.run(['DEFAULT_FLOAT=TYPO python3 -c "from tinygrad import dtypes"'],
                       shell=True, check=True)
 
-  @np.errstate(all='ignore')
   def test_dtype_str_arg(self):
     n = np.random.normal(0, 1, (10, 10)).astype(np.float32)
     tested = 0

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -11,6 +11,8 @@ from tinygrad.engine.realize import run_schedule
 from tinygrad.ops import UnaryOps, UOps
 from tinygrad.tensor import _to_np_dtype
 from test.helpers import is_dtype_supported
+import pytest
+pytestmark = pytest.mark.filterwarnings("ignore")
 
 settings.register_profile("my_profile", max_examples=200, deadline=None, derandomize=getenv("DERANDOMIZE_CI", False))
 settings.load_profile("my_profile")
@@ -94,7 +96,6 @@ def universal_test_midcast(a, b, c, op1, op2, d1:DType, d2:DType):
   numpy_value = op2[1](op1[1](an, bn).astype(_to_np_dtype(d2)), cn)
   np.testing.assert_allclose(tensor_value, numpy_value, rtol=1e-6 if getenv("PTX") else 1e-7)
 
-@np.errstate(all='ignore')
 class TestDTypeALU(unittest.TestCase):
   @unittest.skipUnless(is_dtype_supported(dtypes.float64, Device.DEFAULT), f"no float64 on {Device.DEFAULT}")
   @given(ht.float64, ht.float64, strat.sampled_from(binary_operations))
@@ -192,7 +193,6 @@ class TestFromFuzzer(unittest.TestCase):
     _test_value(np.pi / 2)
      # worst case of ulp 1.5
     _test_value(np.pi * 2, unit=1.5)
-  @np.errstate(all='ignore')
   @given(strat.sampled_from(dtypes_float))
   def test_log2(self, dtype):
     if not is_dtype_supported(dtype): return


### PR DESCRIPTION
Re https://github.com/tinygrad/tinygrad/pull/7024#issuecomment-2421048032

`np.errstate(all='ignore')` was ignoring errors as well, which affected tests in CI.

This fix ensures that only warnings are ignored. Errors will be raised as usual (I tested this by deliberately changing tests locally).

Source for the fix: https://docs.pytest.org/en/stable/how-to/capture-warnings.html#pytest-mark-filterwarnings