### PR TITLE
assert a schedule double realize

### DIFF
--- a/test/test_assign.py
+++ b/test/test_assign.py
@@ -2,6 +2,7 @@
 import unittest
 import numpy as np
 from tinygrad import dtypes, Tensor, TinyJit, GlobalCounters, Variable
+from tinygrad.engine.schedule import create_schedule
 
 N = 200  # has to be bigger than the cache to fail
 
@@ -166,6 +167,15 @@ class TestAssign(unittest.TestCase):
     a += 1
     a += 1
     np.testing.assert_allclose(a.numpy(), 3)
+
+  # NOTE: this is similar to the resnet failure
+  @unittest.expectedFailure
+  def test_double_assign_alt(self):
+    a = Tensor.ones(4).contiguous().realize()
+    b = Tensor([1, 2, 3, 4]).realize().lazydata
+    a1 = a.lazydata.assign(b)
+    a2 = a.lazydata.assign(b)
+    create_schedule([a1, a2])
 
   def test_crossover_assign(self):
     a = Tensor.full((4,), 2).contiguous().realize()

--- a/test/test_assign.py
+++ b/test/test_assign.py
@@ -169,13 +169,14 @@ class TestAssign(unittest.TestCase):
     np.testing.assert_allclose(a.numpy(), 3)
 
   # NOTE: this is similar to the resnet failure
-  @unittest.expectedFailure
+  #@unittest.expectedFailure
   def test_double_assign_alt(self):
     a = Tensor.ones(4).contiguous().realize()
     b = Tensor([1, 2, 3, 4]).realize().lazydata
     a1 = a.lazydata.assign(b)
     a2 = a.lazydata.assign(b)
-    create_schedule([a1, a2])
+    sched = create_schedule([a1, a2])
+    self.assertEqual(len(sched), 1)
 
   def test_crossover_assign(self):
     a = Tensor.full((4,), 2).contiguous().realize()

--- a/test/test_assign.py
+++ b/test/test_assign.py
@@ -169,15 +169,13 @@ class TestAssign(unittest.TestCase):
     np.testing.assert_allclose(a.numpy(), 3)
 
   # NOTE: this is similar to the resnet failure
-  #@unittest.expectedFailure
+  @unittest.expectedFailure
   def test_double_assign_alt(self):
     a = Tensor.ones(4).contiguous().realize()
     b = Tensor([1, 2, 3, 4]).realize().lazydata
     a1 = a.lazydata.assign(b)
     a2 = a.lazydata.assign(b)
-    assert a1 is a2
-    sched = create_schedule([a1, a2])
-    assert len(sched) == 1
+    create_schedule([a1, a2])
 
   def test_crossover_assign(self):
     a = Tensor.full((4,), 2).contiguous().realize()

--- a/test/test_assign.py
+++ b/test/test_assign.py
@@ -169,13 +169,15 @@ class TestAssign(unittest.TestCase):
     np.testing.assert_allclose(a.numpy(), 3)
 
   # NOTE: this is similar to the resnet failure
-  @unittest.expectedFailure
+  #@unittest.expectedFailure
   def test_double_assign_alt(self):
     a = Tensor.ones(4).contiguous().realize()
     b = Tensor([1, 2, 3, 4]).realize().lazydata
     a1 = a.lazydata.assign(b)
     a2 = a.lazydata.assign(b)
-    create_schedule([a1, a2])
+    assert a1 is a2
+    sched = create_schedule([a1, a2])
+    assert len(sched) == 1
 
   def test_crossover_assign(self):
     a = Tensor.full((4,), 2).contiguous().realize()

--- a/tinygrad/engine/lazy.py
+++ b/tinygrad/engine/lazy.py
@@ -80,7 +80,8 @@ class LazyBuffer(MathTrait):
 
   def assign(self, x:LazyBuffer) -> LazyBuffer:
     assert x.size == self.size, f"assign target must have same size {self.size=} != {x.size=}"
-    return LazyBuffer.metaop(MetaOps.ASSIGN, self.shape, self.dtype, self.device, arg=() if self.st.contiguous else (self.st,), src=(self.base, x))
+    return LazyBuffer.metaop(MetaOps.ASSIGN, self.shape, self.dtype, self.device, arg=() if self.st.contiguous else (self.st,),
+                             src=(self.base, x), enable_cache=True)
 
   def can_view(self):
     return (self.st.consecutive and not self.is_unrealized_const() and not isinstance(self.dtype, ImageDType) and

--- a/tinygrad/engine/lazy.py
+++ b/tinygrad/engine/lazy.py
@@ -80,7 +80,7 @@ class LazyBuffer(MathTrait):
 
   def assign(self, x:LazyBuffer) -> LazyBuffer:
     assert x.size == self.size, f"assign target must have same size {self.size=} != {x.size=}"
-    return LazyBuffer.metaop(MetaOps.ASSIGN, self.shape, self.dtype, self.device, arg=() if self.st.contiguous else (self.st,), src=(self.base, x))
+    return LazyBuffer.metaop(MetaOps.ASSIGN, self.shape, self.dtype, self.device, arg=() if self.st.contiguous else (self.st,), src=(self.base, x), enable_cache=True)
 
   def can_view(self):
     return (self.st.consecutive and not self.is_unrealized_const() and not isinstance(self.dtype, ImageDType) and

--- a/tinygrad/engine/lazy.py
+++ b/tinygrad/engine/lazy.py
@@ -80,7 +80,7 @@ class LazyBuffer(MathTrait):
 
   def assign(self, x:LazyBuffer) -> LazyBuffer:
     assert x.size == self.size, f"assign target must have same size {self.size=} != {x.size=}"
-    return LazyBuffer.metaop(MetaOps.ASSIGN, self.shape, self.dtype, self.device, arg=() if self.st.contiguous else (self.st,), src=(self.base, x), enable_cache=True)
+    return LazyBuffer.metaop(MetaOps.ASSIGN, self.shape, self.dtype, self.device, arg=() if self.st.contiguous else (self.st,), src=(self.base, x))
 
   def can_view(self):
     return (self.st.consecutive and not self.is_unrealized_const() and not isinstance(self.dtype, ImageDType) and


### PR DESCRIPTION
This bug blocks big graph progress. Found this in #7170 - The resnet code hangs for a Buffer reuse post-assign in the optimizer step:
![image](https://github.com/user-attachments/assets/87a13000-7090-42fb-a44f-fcd4bc71e788)

I think Tensor should always guarantee that once a lazybuffer is assigned to it can't get reassigned to that exact LazyBuffer.