### PR TITLE
remove __hash__ from Tensor [pr]

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -185,9 +185,6 @@ class Tensor:
   def __repr__(self):
     return f"<Tensor {self.lazydata!r} on {self.device} with grad {(self.grad.lazydata if self.grad is not None else None)!r}>"
 
-  # Python has a non moving GC, so this should be okay
-  def __hash__(self): return id(self)
-
   def __bool__(self): raise TypeError("__bool__ on Tensor is not defined")
 
   def __len__(self):


### PR DESCRIPTION
Oh, cause it has different equals. There should be a comment about this.

How does torch do this?