### PR TITLE
GGUF cleanup

### DIFF
--- a/examples/gpt2.py
+++ b/examples/gpt2.py
@@ -9,7 +9,7 @@ from tinygrad.dtype import dtypes
 from tinygrad.ops import UOp
 from tinygrad.helpers import Timing, DEBUG, JIT, getenv, fetch, colored, trange
 from tinygrad.nn import Embedding, Linear, LayerNorm
-from tinygrad.nn.state import load_gguf, torch_load, load_state_dict, get_state_dict
+from tinygrad.nn.state import gguf_load, torch_load, load_state_dict, get_state_dict
 
 MAX_CONTEXT = getenv("MAX_CONTEXT", 128)
 HALF = getenv("HALF")
@@ -150,7 +150,7 @@ class GPT2:
     q_type = model_size[len("gpt2_gguf_"):].upper()
     fn = fetch(f"https://huggingface.co/PrunaAI/gpt2-GGUF-smashed/resolve/main/gpt2.{q_type}.gguf?download=true")
     gguf_tensor = Tensor.empty(os.stat(fn).st_size, dtype=dtypes.uint8, device=f"disk:{fn}").to(Device.DEFAULT)
-    kv_data, state_dict = load_gguf(gguf_tensor)
+    kv_data, state_dict = gguf_load(gguf_tensor)
 
     gpt2_params = {
       "dim": kv_data["gpt2.embedding_length"], "n_heads": kv_data["gpt2.attention.head_count"],

--- a/examples/gpt2.py
+++ b/examples/gpt2.py
@@ -155,7 +155,7 @@ class GPT2:
     gpt2_params = {
       "dim": kv_data["gpt2.embedding_length"], "n_heads": kv_data["gpt2.attention.head_count"],
       "n_layers": kv_data["gpt2.block_count"], "norm_eps": kv_data["gpt2.attention.layer_norm_epsilon"],
-      "vocab_size": 50257, "max_seq_len": kv_data["gpt2.context_length"],
+      "vocab_size": VOCAB_SIZE, "max_seq_len": kv_data["gpt2.context_length"],
     }
     def _remap_gguf_key(key: str):
       replaces = [

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -5,7 +5,7 @@ import tarfile, ggml, ctypes
 import numpy as np
 from tinygrad import Tensor, Device, dtypes
 from tinygrad.dtype import DType
-from tinygrad.nn.state import safe_load, safe_save, get_state_dict, torch_load, tar_extract, ggml_data_to_tensor, load_gguf
+from tinygrad.nn.state import safe_load, safe_save, get_state_dict, torch_load, tar_extract, ggml_data_to_tensor, gguf_load
 from tinygrad.helpers import Timing, fetch, temp, CI
 from test.helpers import is_dtype_supported
 
@@ -514,7 +514,7 @@ class TestGGUF(unittest.TestCase):
     fp = fetch(url)
     model_size = os.stat(fp).st_size
     gguf_tensor = Tensor.empty(model_size, dtype=dtypes.uint8, device=f"disk:{fp}").to(Device.DEFAULT)
-    kv_data, tensors = load_gguf(gguf_tensor)
+    kv_data, tensors = gguf_load(gguf_tensor)
 
     gguf_params = ggml.gguf_init_params(ctx=self.ctx, no_alloc=False)
     gguf_ctx = ggml.gguf_init_from_file(str(fp).encode("utf8"), gguf_params)

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -228,6 +228,13 @@ def torch_load(fn:str) -> Dict[str, Tensor]:
       return TorchPickle(f).load()
 
 def ggml_data_to_tensor(t: Tensor, n: int, ggml_type: int):
+  """
+  Converts ggml tensor data to a tinygrad tensor.
+
+  Supported native types: float32 (id: 0), float16 (id: 1), int8 (id: 16), int16 (id: 17), int32 (id: 18)
+  Supported quantized types: Q4_0 (id: 2), Q4_1 (id: 3), Q6_K (id: 14), Q8_0 (id: 8)
+  """
+
   bc_dtype = { 0: dtypes.float32, 1: dtypes.float16, 16: dtypes.int8, 17: dtypes.int16, 18: dtypes.int32 }.get(ggml_type, None)
   if bc_dtype is not None: return t[:bc_dtype.itemsize * n].bitcast(bc_dtype)
 
@@ -248,7 +255,7 @@ def ggml_data_to_tensor(t: Tensor, n: int, ggml_type: int):
     d = blocks[:,-2:].bitcast(dtypes.float16).cast(dtypes.float32).expand((-1, 256))
     return d * (xl.bitwise_or(xh).bitcast(dtypes.int8) - 32).flatten(-2) * scales
 
-def load_gguf(tensor: Tensor) -> Tuple[Dict, Dict[str, Tensor]]:
+def gguf_load(tensor: Tensor) -> Tuple[Dict, Dict[str, Tensor]]:
   """
   Loads a gguf file from a tensor.
 


### PR DESCRIPTION
In reference to the last comments on #7046.

`ggml_data_to_tensor` does not return `None` if a type is not supported, it raises a `KeyError`. Mypy does not recognize this, which means that explicitly setting the return type to `Tensor` creates a mypy error.
Do we want to spend one line on an explicit error?
