### PR TITLE
Fix bf16 tests using torch as reference value

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,7 @@ setup(name='tinygrad',
             "hypothesis",
             "nibabel",
             "bottle",
-            "ggml-python",
-            "ml_dtypes",
+            "ggml-python"
         ],
         'docs': [
             "mkdocs",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(name='tinygrad',
             "hypothesis",
             "nibabel",
             "bottle",
-            "ggml-python"
+            "ggml-python",
+            "ml_dtypes",
         ],
         'docs': [
             "mkdocs",

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -67,11 +67,11 @@ def universal_test(a, b, dtype, op):
   if not isinstance(op, tuple): op = (op, op, op)
   tensor_value = (op[0](Tensor([a], dtype=dtype), Tensor([b], dtype=dtype))).numpy()
   if dtype in torch_dtypes_map.keys():
-    compare_value = (op[2](torch.tensor([a], dtype=torch_dtypes_map[dtype]), torch.tensor([b], dtype=torch_dtypes_map[dtype]))).float().numpy()
+    reference_value = (op[2](torch.tensor([a], dtype=torch_dtypes_map[dtype]), torch.tensor([b], dtype=torch_dtypes_map[dtype]))).float().numpy()
   else:
-    compare_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)), np.array([b]).astype(_to_np_dtype(dtype)))
-  if dtype in (*dtypes_float, dtypes.bfloat16): np.testing.assert_allclose(tensor_value, compare_value, atol=1e-10)
-  else: np.testing.assert_equal(tensor_value, compare_value)
+    reference_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)), np.array([b]).astype(_to_np_dtype(dtype)))
+  if dtype in (*dtypes_float, dtypes.bfloat16): np.testing.assert_allclose(tensor_value, reference_value, atol=1e-10)
+  else: np.testing.assert_equal(tensor_value, reference_value)
 
 def universal_test_unary(a, dtype, op):
   if not isinstance(op, tuple): op = (op, op, op)
@@ -81,11 +81,11 @@ def universal_test_unary(a, dtype, op):
   run_schedule(sched)
   tensor_value = out.numpy()
   if dtype in torch_dtypes_map.keys():
-    compare_value = op[2](torch.tensor([a], dtype=torch_dtypes_map[dtype])).float().numpy()
+    reference_value = op[2](torch.tensor([a], dtype=torch_dtypes_map[dtype])).float().numpy()
   else:
-    compare_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)))
-  if dtype in (*dtypes_float, dtypes.bfloat16): np.testing.assert_allclose(tensor_value, compare_value, atol=1e-3, rtol=1e-2)
-  else: np.testing.assert_equal(tensor_value, compare_value)
+    reference_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)))
+  if dtype in (*dtypes_float, dtypes.bfloat16): np.testing.assert_allclose(tensor_value, reference_value, atol=1e-3, rtol=1e-2)
+  else: np.testing.assert_equal(tensor_value, reference_value)
   if op[0] != Tensor.reciprocal: # reciprocal is not supported in most backends
     op = [x for x in ast.parents if x.op is UOps.ALU and x.arg in UnaryOps][0]
     assert op.dtype == dtype

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -50,7 +50,7 @@ torch_dtypes_map = { dtypes.bfloat16: torch.bfloat16 }
 #binary_operations += [(Tensor.maximum, np.maximum)]
 
 # TODO: CI CUDA segfaults on sin
-if getenv("MOCKGPU") and Device.DEFAULT == "NV": unary_operations.remove((Tensor.sin, np.sin, torch.sin))
+if getenv("MOCKGPU") and Device.DEFAULT == "NV": unary_operations.remove((Tensor.sin, np.sin))
 
 class ht:
   float64 = strat.floats(width=64, allow_subnormal=False)

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -46,7 +46,7 @@ torch_dtypes_map = { dtypes.bfloat16: torch.bfloat16 }
 #binary_operations += [(Tensor.maximum, np.maximum)]
 
 # TODO: CI CUDA segfaults on sin
-if getenv("MOCKGPU") and Device.DEFAULT == "NV": unary_operations.remove((Tensor.sin, np.sin))
+if getenv("MOCKGPU") and Device.DEFAULT == "NV": unary_operations.remove((Tensor.sin, np.sin, torch.sin))
 
 class ht:
   float64 = strat.floats(width=64, allow_subnormal=False)

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -99,7 +99,7 @@ def universal_test_unary_torch(a, dtype, op):
   run_schedule(sched)
   tensor_value = out.numpy()
   reference_value = op[2](torch.tensor([a]).to(torch_dtypes_map[dtype])).item()
-  np.testing.assert_allclose(tensor_value, reference_value, atol=1e-3, rtol=1e-2)
+  np.testing.assert_allclose(tensor_value, reference_value, atol=1e-4, rtol=3e-2)
   if op[0] != Tensor.reciprocal: # reciprocal is not supported in most backends
     op = [x for x in ast.parents if x.op is UOps.ALU and x.arg in UnaryOps][0]
     assert op.dtype == dtype

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -67,7 +67,7 @@ def universal_test(a, b, dtype, op):
   if not isinstance(op, tuple): op = (op, op, op)
   tensor_value = (op[0](Tensor([a], dtype=dtype), Tensor([b], dtype=dtype))).numpy()
   if dtype in torch_dtypes_map.keys():
-    reference_value = op[2](torch.tensor([a]).to(torch_dtypes_map[dtype]), torch.tensor([b]).to(torch_dtypes_map[dtype])).float().numpy()
+    reference_value = op[2](torch.tensor([a]).to(torch_dtypes_map[dtype]), torch.tensor([b]).to(torch_dtypes_map[dtype])).item()
   else:
     reference_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)), np.array([b]).astype(_to_np_dtype(dtype)))
 
@@ -81,7 +81,7 @@ def universal_test_unary(a, dtype, op):
   ast = sched[-1].ast
   run_schedule(sched)
   tensor_value = out.numpy()
-  if dtype in torch_dtypes_map.keys(): reference_value = op[2](torch.tensor([a]).to(torch_dtypes_map[dtype])).float().numpy()
+  if dtype in torch_dtypes_map.keys(): reference_value = op[2](torch.tensor([a]).to(torch_dtypes_map[dtype])).item()
   else: reference_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)))
 
   if dtype in (*dtypes_float, dtypes.bfloat16): np.testing.assert_allclose(tensor_value, reference_value, atol=1e-3, rtol=1e-2)

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -67,9 +67,10 @@ def universal_test(a, b, dtype, op):
   if not isinstance(op, tuple): op = (op, op, op)
   tensor_value = (op[0](Tensor([a], dtype=dtype), Tensor([b], dtype=dtype))).numpy()
   if dtype in torch_dtypes_map.keys():
-    reference_value = (op[2](torch.tensor([a], dtype=torch_dtypes_map[dtype]), torch.tensor([b], dtype=torch_dtypes_map[dtype]))).float().numpy()
+    reference_value = op[2](torch.tensor([a]).to(torch_dtypes_map[dtype]), torch.tensor([b]).to(torch_dtypes_map[dtype])).float().numpy()
   else:
     reference_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)), np.array([b]).astype(_to_np_dtype(dtype)))
+
   if dtype in (*dtypes_float, dtypes.bfloat16): np.testing.assert_allclose(tensor_value, reference_value, atol=1e-10)
   else: np.testing.assert_equal(tensor_value, reference_value)
 
@@ -80,10 +81,9 @@ def universal_test_unary(a, dtype, op):
   ast = sched[-1].ast
   run_schedule(sched)
   tensor_value = out.numpy()
-  if dtype in torch_dtypes_map.keys():
-    reference_value = op[2](torch.tensor([a], dtype=torch_dtypes_map[dtype])).float().numpy()
-  else:
-    reference_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)))
+  if dtype in torch_dtypes_map.keys(): reference_value = op[2](torch.tensor([a]).to(torch_dtypes_map[dtype])).float().numpy()
+  else: reference_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)))
+
   if dtype in (*dtypes_float, dtypes.bfloat16): np.testing.assert_allclose(tensor_value, reference_value, atol=1e-3, rtol=1e-2)
   else: np.testing.assert_equal(tensor_value, reference_value)
   if op[0] != Tensor.reciprocal: # reciprocal is not supported in most backends

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -130,6 +130,7 @@ class TestDTypeALU(unittest.TestCase):
   @given(ht.float16, ht.float16, strat.sampled_from(binary_operations))
   def test_float16(self, a, b, op): universal_test(a, b, dtypes.float16, op)
 
+  # use torch as reference as numpy does not support bfloat16
   @unittest.skipUnless(is_dtype_supported(dtypes.bfloat16, Device.DEFAULT), f"no bfloat16 on {Device.DEFAULT}")
   @given(ht.bfloat16, ht.bfloat16, strat.sampled_from(binary_operations))
   def test_bfloat16(self, a, b, op): universal_test_torch(a, b, dtypes.bfloat16, op)
@@ -141,6 +142,7 @@ class TestDTypeALU(unittest.TestCase):
   @given(ht.float16, strat.sampled_from(unary_operations))
   def test_float16_unary(self, a, op): universal_test_unary(a, dtypes.float16, op)
 
+  # use torch as reference as numpy does not support bfloat16
   @unittest.skipUnless(is_dtype_supported(dtypes.bfloat16, Device.DEFAULT), f"no bfloat16 on {Device.DEFAULT}")
   @given(ht.bfloat16, strat.sampled_from(unary_operations))
   def test_bfloat16_unary(self, a, op): universal_test_unary_torch(a, dtypes.bfloat16, op)

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -28,8 +28,8 @@ binary_operations = [operator.add, operator.sub, operator.mul, operator.lt, oper
 if Device.DEFAULT == "LLVM":
   binary_operations.remove(operator.lt)
 
-integer_binary_operations = binary_operations + [(Tensor.xor, np.bitwise_xor, torch.bitwise_xor), 
-                                                 (Tensor.bitwise_and, np.bitwise_and, torch.bitwise_and), 
+integer_binary_operations = binary_operations + [(Tensor.xor, np.bitwise_xor, torch.bitwise_xor),
+                                                 (Tensor.bitwise_and, np.bitwise_and, torch.bitwise_and),
                                                  (Tensor.bitwise_or, np.bitwise_or, torch.bitwise_or)]
 unary_operations = [(Tensor.exp, np.exp, torch.exp), (Tensor.log, np.log, torch.log), (Tensor.sin, np.sin, torch.sin),
                     (Tensor.sqrt, np.sqrt, torch.sqrt), (Tensor.reciprocal, np.reciprocal, torch.reciprocal)]

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -52,7 +52,7 @@ class ht:
   float64 = strat.floats(width=64, allow_subnormal=False)
   float32 = strat.floats(width=32, allow_subnormal=False)
   float16 = strat.floats(width=16, allow_subnormal=False)
-  bfloat16 = strat.floats(width=16, allow_subnormal=False)
+  bfloat16 = strat.floats(width=32, allow_subnormal=False).map(lambda x: torch.tensor([x]).to(torch.bfloat16).item())
   uint8 = strat.integers(0, 255)
   uint16 = strat.integers(0, 65535)
   uint32 = strat.integers(0, 2**32-1)
@@ -73,7 +73,7 @@ def universal_test(a, b, dtype, op):
 def universal_test_torch(a, b, dtype, op):
   if not isinstance(op, tuple): op = (op, op, op)
   tensor_value = (op[0](Tensor([a], dtype=dtype), Tensor([b], dtype=dtype))).numpy()
-  reference_value = op[2](torch.tensor([a]).to(torch_dtypes_map[dtype]), torch.tensor([b]).to(torch_dtypes_map[dtype])).item()
+  reference_value = op[2](torch.tensor([a], dtype=torch_dtypes_map[dtype]), torch.tensor([b], dtype=torch_dtypes_map[dtype])).item()
   np.testing.assert_allclose(tensor_value, reference_value, atol=1e-10)
 
 def universal_test_unary(a, dtype, op):
@@ -98,7 +98,7 @@ def universal_test_unary_torch(a, dtype, op):
   ast = sched[-1].ast
   run_schedule(sched)
   tensor_value = out.numpy()
-  reference_value = op[2](torch.tensor([a]).to(torch_dtypes_map[dtype])).item()
+  reference_value = op[2](torch.tensor([a], dtype=torch_dtypes_map[dtype])).item()
   np.testing.assert_allclose(tensor_value, reference_value, atol=1e-4, rtol=3e-2)
   if op[0] != Tensor.reciprocal: # reciprocal is not supported in most backends
     op = [x for x in ast.parents if x.op is UOps.ALU and x.arg in UnaryOps][0]


### PR DESCRIPTION
Enables much stricter tolerance (same as for other floats) now in binary operations.
Makes it easier adding other types only supported in torch in the future.

`.float().numpy()` float casting before numpy call is required.