### PR TITLE
compute ScheduleItem writable bufs [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -25,14 +25,15 @@ class ScheduleItem:
   ast: UOp
   bufs: Tuple[Buffer, ...]
   metadata: Tuple[Metadata, ...]
-  @functools.cached_property
+  @property
   def outputs(self) -> Tuple[Buffer, ...]:
     """Read/write or write only buffers in the schedule."""
-    return tuple(b for i,b in enumerate(self.bufs) if i in self.output_idxs())
-  @functools.cached_property
+    return tuple(b for i,b in enumerate(self.bufs) if i in self.output_idxs)
+  @property
   def inputs(self) -> Tuple[Buffer, ...]:
     """Read only buffers in the schedule."""
-    return tuple(b for i,b in enumerate(self.bufs) if i not in self.output_idxs())
+    return tuple(b for i,b in enumerate(self.bufs) if i not in self.output_idxs)
+  @functools.cached_property
   def output_idxs(self) -> Tuple[int, ...]: return tuple(x.src[0].arg for x in self.ast.src) if self.ast.op is UOps.SINK else (0,)
 
 @dataclass(frozen=True)

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -1,4 +1,4 @@
-import sys, atexit
+import sys, atexit, functools
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from typing import Callable, Set, Tuple, List, Dict, Optional, DefaultDict, cast
@@ -25,14 +25,15 @@ class ScheduleItem:
   ast: UOp
   bufs: Tuple[Buffer, ...]
   metadata: Tuple[Metadata, ...]
-  @property
+  @functools.cached_property
   def outputs(self) -> Tuple[Buffer, ...]:
     """Read/write or write only buffers in the schedule."""
-    return self.bufs[:len(self.ast.src)] if self.ast.op is UOps.SINK else self.bufs[0:1]
-  @property
+    return tuple(b for i,b in enumerate(self.bufs) if i in self.output_idxs())
+  @functools.cached_property
   def inputs(self) -> Tuple[Buffer, ...]:
     """Read only buffers in the schedule."""
-    return self.bufs[len(self.ast.src):] if self.ast.op is UOps.SINK else self.bufs[1:]
+    return tuple(b for i,b in enumerate(self.bufs) if i not in self.output_idxs())
+  def output_idxs(self) -> Tuple[int, ...]: return tuple(x.src[0].arg for x in self.ast.src) if self.ast.op is UOps.SINK else (0,)
 
 @dataclass(frozen=True)
 class LBScheduleItem:


### PR DESCRIPTION
This diff unblocks DFS buffer append order, eg ScheduleItem bufs in a multi output kernel: [out1, *inputs_to_out1, out2, *inputs_to_out2].