### PR TITLE
proposal: add UOps.PRELOAD

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -148,6 +148,7 @@ append_bufs = PatternMatcher([(UPat(UOps.BUFFER, name="x"), _append_buf),])
 
 to_ast = PatternMatcher([
   (UPat(UOps.CONTIGUOUS, src=(UPat.var("x"),)), lambda x: x),
+  (UPat(UOps.PRELOAD, name="root"), lambda root: root.replace(op=UOps.LOAD)),
   (UPat(UOps.SINK, src=(UPat.store(UPat(), UPat(), UPat(tuple(METAOPS.values()), name="x")),)), lambda x: x),
 ])
 
@@ -175,7 +176,7 @@ def to_uop(buf:LazyBuffer, outputs:List[LazyBuffer], inputs:List[LazyBuffer], bu
   dtype = buf.dtype.base if isinstance(buf.dtype, ImageDType) else buf.dtype
   if (ubuf:=buf_uops.get(buf.buffer)) is not None and buf not in outputs:
     if not any(x.buffer is buf.buffer for x in outputs) and buf not in inputs: inputs.append(buf)
-    return UOp.load(ubuf, buf.st.to_uop(), dtype=dtype)
+    return UOp(UOps.PRELOAD if buf.is_realized() else UOps.LOAD, dtype, (ubuf, buf.st.to_uop()))
   src = tuple(to_uop(x, outputs, inputs, buf_uops, metadata, cache) for x in buf.srcs)
   if buf.op in ReduceOps: ret = src[0].r(buf.op, buf.arg)
   elif buf.op is MetaOps.CONTIGUOUS: ret = UOp(UOps.CONTIGUOUS, dtype, src)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -103,6 +103,7 @@ class UOps(FastEnum):
   # uops that aren't rendered
   SINK = auto()
   CONTIGUOUS = auto()
+  PRELOAD = auto()
 
   # metaops
   COPY = auto()
@@ -152,7 +153,7 @@ class UOps(FastEnum):
   ENDRANGE = auto()
   ENDIF = auto()
 
-BUFFER_UOPS = {UOps.LOAD, UOps.STORE, UOps.VALID}
+BUFFER_UOPS = {UOps.LOAD, UOps.PRELOAD, UOps.STORE, UOps.VALID}
 COMMUTATIVE = {BinaryOps.ADD, BinaryOps.MUL, BinaryOps.MAX, BinaryOps.CMPNE, BinaryOps.XOR, BinaryOps.AND, BinaryOps.OR}
 END_FOR_UOP = {UOps.IF:(UOps.STORE, UOps.ENDIF), UOps.RANGE:(UOps.ASSIGN, UOps.ENDRANGE)}
 


### PR DESCRIPTION
This unblocks UOps.ASSIGN work for big graph #7044 milestones 2 and 3.

Given a big graph with two LOADs:

BUFFER 32 -> LOAD
BUFFER 32 -> ASSIGN -> STORE -> LOAD

The small graphs (ASTs) become:

BUFFER 32 -> PRELOAD
BUFFER 32 -> LOAD

The scheduler can differentiate pre and post ASSIGN Buffer read and toposort correctly.