### PR TITLE
dfs append_bufs

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -22,9 +22,9 @@ def helper_realized_ast(r:Union[Tensor, List[Tensor]]) -> Tuple[UOp, List[Buffer
   s = create_schedule([x.lazydata for x in r])
   run_schedule(s[:-1])  # run all kernels except the last one
   # now all input LazyBuffers buffers in s[-1] should be realized
-  # allocate an output buffer
-  output_buffers = [Buffer((out).device, out.size, out.dtype).allocate() for out in s[-1].outputs]
-  return s[-1].ast, output_buffers+list(s[-1].inputs)
+  # create fresh buffers for the output buffer
+  bufs = [Buffer((x).device, x.size, x.dtype).allocate() if x in s[-1].outputs else x for x in s[-1].bufs]
+  return s[-1].ast, bufs
 
 def helper_tc_allclose(n:int, m:int, k:int, dtype_in:DType, dtype_out:DType, axis:int=0, tc_opt:int=0):
   a, b = Tensor.rand(m, k, dtype=dtype_in), Tensor.rand(k, n, dtype=dtype_in)
@@ -1781,7 +1781,7 @@ def reset_bufs(bufs:List[Buffer]):
 def _helper_linearizer_opt_ast(realized_ast:UOp, real_bufs:List[Buffer], opts=[],
                                apply_tc=False, atol=1e-4, rtol=1e-4, color_sizes=[], wanna_output=[]) -> List[Kernel]:
   lins: List[Kernel] = []
-  outbufs = real_bufs[:len(realized_ast.src)]
+  outbufs = [real_bufs[x.src[0].arg] for x in realized_ast.src]
 
   def get_prg(k:Kernel): return CompiledRunner(replace(k.to_program(), dname=Device.DEFAULT))
 

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -40,6 +40,7 @@ class ScheduleItem:
 class LBScheduleItem:
   ast: UOp
   bufs: Tuple[LazyBuffer, ...]
+  ubufs: Tuple[UOp, ...]
   metadata: Tuple[Metadata, ...]
   @property
   def outputs(self) -> Tuple[LazyBuffer, ...]: return self.bufs[:len(self.ast.src)] if self.ast.op is UOps.SINK else self.bufs[0:1]
@@ -132,7 +133,7 @@ view_right = merge_views+PatternMatcher([
 class ScheduleItemContext:
   var_vals: Dict[Variable, int]
   sts: Set[ShapeTracker]
-  bufs: Tuple[int, ...]
+  bufs: List[UOp]
 
 def _append_st_vars(ctx:ScheduleItemContext, x:UOp) -> Optional[UOp]:
   if (st:=unwrap(x.st)) in ctx.sts: return None
@@ -142,7 +143,8 @@ def _append_st_vars(ctx:ScheduleItemContext, x:UOp) -> Optional[UOp]:
   return st.to_uop() if st != x.st else None
 
 def _append_buf(ctx:ScheduleItemContext, x:UOp) -> UOp:
-  return UOp(UOps.DEFINE_GLOBAL, x.dtype, (), ctx.bufs.index(x.arg[0]))
+  ctx.bufs.append(x)
+  return UOp(UOps.DEFINE_GLOBAL, x.dtype, (), len(ctx.bufs)-1)
 
 to_si = PatternMatcher([
   (UPat(UOps.BUFFER, name="x"), _append_buf),
@@ -195,14 +197,14 @@ def _lower_lazybuffer(outs:List[LazyBuffer], buf_uops:Dict[Buffer, UOp], var_val
   metadata: Dict[UOp, Metadata] = {}
   sink = UOp(UOps.SINK, src=tuple(UOp.store(buf_uops[out.buffer], ShapeTracker.from_shape(out.shape).to_uop(),
                                             to_uop(out, outs, inputs, buf_uops, metadata, cache)) for out in outs))
-  sink = full_ast_rewrite(sink, ScheduleItemContext(var_vals, set(), tuple(buf_uops[x.buffer].arg[0] for x in outs+inputs)))
+  sink = full_ast_rewrite(sink, ctx:=ScheduleItemContext(var_vals, set(), []))
   # we also allow masked views. if it has a single view and it's equal when you shrink a contig, it's fine
   if len(assign_targets:=[x.src[0] for x in sink.sparents if x.op is UOps.ASSIGN]) != 0:
     if not all((s:=x.st_arg).contiguous or (len(s.views) == 1 and (m:=s.views[0].mask) is not None \
         and ShapeTracker.from_shape(s.shape).shrink(m) == s.shrink(m)) for x in sink.sparents if x.op is UOps.LOAD and x.src[0] in assign_targets):
       raise RuntimeError("self operand of augmented assign must be contiguous.\nhelp: consider using .contiguous():\n"
                          +colored("   - a += a.T\n", "red")+colored("   + a += a.T.contiguous()", "green"))
-  return LBScheduleItem(sink, tuple(outs+inputs), tuple(dedup(metadata.values())))
+  return LBScheduleItem(sink, tuple(outs+inputs), tuple(ctx.bufs), tuple(dedup(metadata.values())))
 
 # *** DAG creation: decide which LazyBuffers should realize ***
 
@@ -411,7 +413,7 @@ def create_schedule_with_vars(outs:List[LazyBuffer]) -> Tuple[List[ScheduleItem]
   schedule: List[ScheduleItem] = []
   while queue:
     lsi = queue.popleft()
-    schedule.append(si:=ScheduleItem(lsi.ast, tuple(x.buffer for x in lsi.bufs if x.size != 0), lsi.metadata))
+    schedule.append(si:=ScheduleItem(lsi.ast, tuple(b for u in lsi.ubufs if (b:=uop_bufs[u]).size != 0), lsi.metadata))
     for b in si.outputs: del lazybufs_to_realize[b].srcs  # can only schedule once
     if (m:=BUF_LIMIT.get(device:=si.outputs[0].device)) and len(si.bufs) >= m:
       if DEBUG >= 3: print(si)


### PR DESCRIPTION
This diff switches the append order for ScheduleItem Buffers from BFS to DFS order.

For example, a Multi-output kernel in this order will look like:
WRITE 0, READ 1, WRITE 2

vs BFS:

WRITE 0, WRITE 1, READ 2


eg: ScheduleItem.bufs for `test/test_linearizer.py TestKernelOpts.test_padto_where_multioutput`
```diff
- (<buf real:False device:CLANG size:289 dtype:dtypes.int offset:0>, <buf real:False device:CLANG size:289 dtype:dtypes.int offset:0>, <buf real:True device:CLANG size:83521 dtype:dtypes.float offset:0>)
+ (<buf real:False device:CLANG size:289 dtype:dtypes.int offset:0>, <buf real:True device:CLANG size:83521 dtype:dtypes.float offset:0>, <buf real:False device:CLANG size:289 dtype:dtypes.int offset:0>)
```

DFS order invalidates using `len(outputs)` to slice writable buffers. I updated everything I could test in https://github.com/tinygrad/tinygrad/pull/7234. This offset logic in ops_dsp might also need to update.
https://github.com/tinygrad/tinygrad/blob/aeeb917b6ea7ee7f1e3672e72acce0ac4643be08/tinygrad/runtime/ops_dsp.py#L150