### PR TITLE
mask out writable bufs in runtime access_resources

### DIFF
--- a/extra/backends/hsa_graph.py
+++ b/extra/backends/hsa_graph.py
@@ -70,7 +70,7 @@ class HSAGraph(MultiGraphRunner):
 
     for j,ji in enumerate(self.jit_cache):
       if isinstance(ji.prg, CompiledRunner):
-        wait_signals = self.access_resources(ji.bufs[(outs:=ji.prg.p.outcount):], ji.bufs[:outs], new_dependency=j, sync_with_aql_packets=False)
+        wait_signals = self.access_resources(ji.bufs, ji.prg.p.outs, new_dependency=j, sync_with_aql_packets=False)
         for i in range(0, len(wait_signals), 5):
           self.virt_aql_queues[ji.prg.device].submit_barrier(wait_signals[i:i+5])
         self.packets[j] = hsa.hsa_kernel_dispatch_packet_t.from_address(self.virt_aql_queues[ji.prg.device].write_addr)
@@ -84,7 +84,7 @@ class HSAGraph(MultiGraphRunner):
         dest_dev, src_dev = cast(HSADevice, Device[dest.device]), cast(HSADevice, Device[src.device])
         sync_signal = self.alloc_signal(reset_on_start=True, wait_on=[dest_dev, src_dev])
 
-        wait_signals = self.access_resources(read=[src], write=[dest], new_dependency=sync_signal, sync_with_aql_packets=True)
+        wait_signals = self.access_resources([dest, src], write=[0], new_dependency=sync_signal, sync_with_aql_packets=True)
         self.transfers.append([dest._buf, dest_dev.agent, src._buf, src_dev.agent, dest.nbytes, len(wait_signals),
                               (hsa.hsa_signal_t*len(wait_signals))(*wait_signals), sync_signal, hsa.HSA_AMD_SDMA_ENGINE_0, True])
         self.ji_to_transfer[j] = len(self.transfers) - 1
@@ -164,8 +164,8 @@ class HSAGraph(MultiGraphRunner):
       return packet.completion_signal
     return None
 
-  def access_resources(self, read, write, new_dependency, sync_with_aql_packets=False):
-    rdeps = self._access_resources(read, write, new_dependency)
+  def access_resources(self, rawbufs, write, new_dependency, sync_with_aql_packets=False):
+    rdeps = self._access_resources(rawbufs, write, new_dependency)
     wait_signals = [self.dependency_as_signal(dep, sync_with_aql_packets=sync_with_aql_packets) for dep in rdeps]
-    if sync_with_aql_packets: wait_signals += [self.kickoff_signals[cast(HSADevice, Device[rawbuf.device])] for rawbuf in read+write]
+    if sync_with_aql_packets: wait_signals += [self.kickoff_signals[cast(HSADevice, Device[rawbuf.device])] for rawbuf in rawbufs]
     return dedup_signals(wait_signals)

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -54,8 +54,7 @@ def helper_test_graphs(graph_impl, graphs, runs=RUN_CNT):
   out_buffers = set()
   for graph in graphs:
     for ji in graph:
-      writable_buffers = ji.prg.p.outcount if isinstance(ji.prg, CompiledRunner) else 1
-      out_buffers.update(ji.bufs[:writable_buffers])
+      out_buffers.update([ji.bufs[i] for i in (ji.prg.p.outs if isinstance(ji.prg, CompiledRunner) else [0])])
       bufs += ji.bufs
       reg_ji.append(ji)
   bufs = dedup(bufs)

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -62,9 +62,6 @@ class Program:
   @functools.cached_property
   def _ops_lds(self) -> Tuple[sint, sint]: return (0,0) if self.uops is None else flops_mem(self.uops, ignore_indexing=True)
 
-  @property
-  def outcount(self) -> int: return len(self.outs)
-
   @functools.cached_property
   def function_name(self) -> str: return to_function_name(self.name)
 

--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -56,7 +56,7 @@ class HCQGraph(MultiGraphRunner):
       out_signal = self.signals.setdefault(enqueue_queue, enqueue_dev.signal_t(value=0))
 
       # Get dependencies based on input and output buffers.
-      rdeps = self._access_resources(ji.bufs[(wb:=ji.prg.p.outcount if is_exec_prg else 1):], ji.bufs[:wb], (enqueue_queue, j + 1)) #type:ignore
+      rdeps = self._access_resources(ji.bufs, ji.prg.p.outs if is_exec_prg else [0], (enqueue_queue, j + 1)) #type:ignore
 
       # Update dependencies to include previous kernel in queue. This is required for timeline signals.
       opt_deps, deps = [], rdeps + ([(enqueue_queue, prev_ji + 1)] if (prev_ji:=last_j[enqueue_queue]) is not None else [])


### PR DESCRIPTION
This diff removes the use of `outcount` to slice mutable bufs in runtime/*, which assumed writable bufs are always first (BFS order).

[Big graph appends bufs in DFS order,](https://github.com/tinygrad/tinygrad/pull/7224) so a kernel can look like:
STORE 0, LOAD 1, STORE 2, LOAD 3 - output mask: [0, 2].