### PR TITLE
early assert cyclic read [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -202,7 +202,7 @@ def _lower_lazybuffer(outs:List[LazyBuffer], buf_uops:Dict[Buffer, UOp], uop_buf
   # assert cyclic dependency
   for b,reads in itertools.groupby((x for x in sink.sparents if x.op in {UOps.PRELOAD, UOps.LOAD}), key=lambda x:x.src[0]):
     if not all_same([x.op for x in reads]):
-      raise RuntimeError(f"detected cycle in kernel.\nhelp: consider using .contiguous() to load the pre-assign version of {uop_bufs[b]}.")
+      raise RuntimeError(f"cycle detected in kernel.\nhelp: consider using .contiguous() to load the pre-assign version of {uop_bufs[b]}.")
   sink = full_ast_rewrite(sink, ctx:=ScheduleItemContext(var_vals))
   # we also allow masked views. if it has a single view and it's equal when you shrink a contig, it's fine
   if len(assign_targets:=[x.src[0] for x in sink.sparents if x.op is UOps.ASSIGN]) != 0:


### PR DESCRIPTION
PRELOAD makes this much easier to detect and give an actionable next step for that specific kernel.

VIZ of `TestAssign.test_assign_diamond_contiguous_cycle`
![image](https://github.com/user-attachments/assets/c6f285a8-61f7-4634-998f-8c8cb88ccac2)

prev error message:
```
  File "schedule.py", line 433, in create_schedule_with_vars
RuntimeError: cycle detected in graph, prescheduled 3 but only scheduled 0
```
this branch:
```
  File "schedule.py", line 205, in _lower_lazybuffer
RuntimeError: cycle detected in kernel.
help: consider using .contiguous() to load the pre-assign version of <buf real:True device:METAL size:4 dtype:dtypes.float offset:0>.
```

I think with embedded metadata in UOp this can get better too.