### PR TITLE
Upgrade mypy to 1.13.0. [pr]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='tinygrad',
         'triton': ["triton-nightly>=2.1.0.dev20231014192330"],
         'linting': [
             "pylint",
-            "mypy==1.12.1",
+            "mypy==1.13.0",
             "typing-extensions",
             "pre-commit",
             "ruff",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='tinygrad',
         'triton': ["triton-nightly>=2.1.0.dev20231014192330"],
         'linting': [
             "pylint",
-            "mypy==1.11.2",
+            "mypy==1.12.1",
             "typing-extensions",
             "pre-commit",
             "ruff",

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
-from typing import Final, Optional, ClassVar, Set, Tuple, Dict, Union, Callable
+from typing import Final, Optional, ClassVar, Set, Tuple, Dict, Union, Callable, Literal
 import math, struct, ctypes, functools
 from dataclasses import dataclass
 from tinygrad.helpers import getenv
 
 ConstType = Union[float, int, bool]
 
+DTypeFmtType = Literal['e', '@e', 'f', '@f', 'd', '@d', '?', 'b', 'B', '@b', '@B', 'h', 'H',
+                       '@h', '@H', 'i', 'I', '@i', '@I', 'l', 'L', '@l', '@L', 'q', 'Q', '@q', '@Q', 'P', '@P']
+
 @dataclass(frozen=True, order=True)
 class DType:
   priority: int  # this determines when things get upcasted
   itemsize: int
   name: str
-  fmt: Optional[str]
+  fmt: Optional[DTypeFmtType]
   count: int
   def __repr__(self): return f"dtypes.{INVERSE_DTYPES_DICT[self.scalar().name]}"+(f".vec({self.count})" if self.count > 1 else "")
   def vec(self, sz:int):

--- a/tinygrad/multi.py
+++ b/tinygrad/multi.py
@@ -109,9 +109,11 @@ class MultiLazyBuffer(MathTrait):
     new_real = [all(transposed) for transposed in zip(*[mlb.real for mlb in msrcs])] if not_all_real else self.real
     assert any(new_real), "output contains no real lb"
     for mlb in msrcs:
-      if (mlb.axis == axis and (mlb.axis is None or mlb.bounds == bounds)) or not_all_real: srcs.append(mlb.lbs)
-      elif mlb.axis is None and axis is not None: srcs.append(to_sharded(mlb.lbs, axis, bounds))
-      else: srcs.append(to_sharded([mlb.copy_to_device(lb.device) for lb in mlb.lbs], axis, bounds))
+      if axis is None or ((mlb.axis == axis and mlb.bounds == bounds) or not_all_real): srcs.append(mlb.lbs)
+      else:
+        assert bounds is not None
+        if mlb.axis is None: srcs.append(to_sharded(mlb.lbs, axis, bounds))
+        else: srcs.append(to_sharded([mlb.copy_to_device(lb.device) for lb in mlb.lbs], axis, bounds))
     new_real_lbs:Dict[int,LazyBuffer] = {i:lsrcs[0].alu(op, *lsrcs[1:]) for i,(lsrcs,r) in enumerate(zip(zip(*srcs), new_real)) if r}
     # NOTE: const dtype should match real
     real_dtype = next(iter(new_real_lbs.values())).dtype

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -258,7 +258,8 @@ class LayerNorm:
   def __init__(self, normalized_shape:Union[int, Tuple[int, ...]], eps=1e-5, elementwise_affine=True):
     self.normalized_shape: Tuple[int, ...] = (normalized_shape,) if isinstance(normalized_shape, int) else tuple(normalized_shape)
     self.axis, self.eps, self.elementwise_affine = tuple(-1-i for i in range(len(self.normalized_shape))), eps, elementwise_affine
-    self.weight, self.bias = (Tensor.ones(*self.normalized_shape), Tensor.zeros(*self.normalized_shape)) if elementwise_affine else (None, None)
+    self.weight:Optional[Tensor] = Tensor.ones(*self.normalized_shape) if elementwise_affine else None
+    self.bias:Optional[Tensor] = Tensor.zeros(*self.normalized_shape) if elementwise_affine else None
 
   def __call__(self, x:Tensor) -> Tensor:
     assert self.normalized_shape == x.shape[-len(self.normalized_shape):], f"last dimensions of {x.shape} must match {self.normalized_shape}"
@@ -340,7 +341,8 @@ class LSTMCell:
     stdv = 1.0 / math.sqrt(hidden_size)
     self.weight_ih = Tensor.uniform(hidden_size*4, input_size, low=-stdv, high=stdv)
     self.weight_hh = Tensor.uniform(hidden_size*4, hidden_size, low=-stdv, high=stdv)
-    self.bias_ih, self.bias_hh = (Tensor.zeros(hidden_size*4), Tensor.zeros(hidden_size*4)) if bias else (None, None)
+    self.bias_ih:Optional[Tensor] = Tensor.zeros(hidden_size*4) if bias else None
+    self.bias_hh:Optional[Tensor] = Tensor.zeros(hidden_size*4) if bias else None
 
   def __call__(self, x:Tensor, hc:Optional[Tuple[Tensor, Tensor]]=None) -> Tuple[Tensor, Tensor]:
     if hc is None: hc = (Tensor.zeros(x.size(0), self.weight_hh.size(1), dtype=x.dtype, device=x.device),)*2

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -16,6 +16,7 @@ def safe_load_metadata(fn:Union[Tensor,str]) -> Tuple[Tensor, int, Any]:
   """
   t = fn if isinstance(fn, Tensor) else Tensor.empty(os.stat(fn).st_size, dtype=dtypes.uint8, device=f"disk:{fn}")
   json_len = t[0:8].bitcast(dtypes.int64).item()
+  assert isinstance(json_len, int)
   return t, json_len, json.loads(t[8:8+json_len].data().tobytes())
 
 def safe_load(fn:Union[Tensor,str]) -> Dict[str, Tensor]:

--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -1,5 +1,5 @@
 import collections, time
-from typing import List, Any, Dict, cast, Optional, Tuple, Set, Union
+from typing import List, Any, Dict, cast, Optional, Tuple, Set
 from tinygrad.helpers import round_up, PROFILE, memsize_to_str
 from tinygrad.runtime.support.hcq import HCQCompiled, HCQAllocator, HCQSignal, HCQBuffer, HWCommandQueue, HWComputeQueue, HWCopyQueue, HCQArgsState
 from tinygrad.device import Buffer, BufferOptions, Compiled, Device
@@ -57,7 +57,7 @@ class HCQGraph(MultiGraphRunner):
       else: enqueue_dev = ji.prg.device
       assert isinstance(enqueue_dev, HCQCompiled), "not instance of HCQCompiled"
       assert enqueue_dev.hw_copy_queue_t is not None, 'no hw copy queue'
-      enqueue_queue:Union[HWComputeQueue, HWCopyQueue, HWCommandQueue]
+      enqueue_queue:HWCommandQueue
       enqueue_queue = self.comp_queues[enqueue_dev] if is_exec_prg else self.copy_queues.setdefault(enqueue_dev, enqueue_dev.hw_copy_queue_t())
       out_signal = self.signals.setdefault(enqueue_queue, enqueue_dev.signal_t(value=0))
 

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -3,7 +3,7 @@
 # works to test the tensor cores, and all the uops in general
 # this is the (living) definition of uops
 from typing import Tuple, List, Optional, Any, Dict
-import pickle, base64, itertools, time, struct, sys
+import pickle, base64, itertools, time, struct
 from tinygrad.dtype import DType, dtypes, ImageDType, truncate
 from tinygrad.helpers import all_same, getenv, flatten
 from tinygrad.device import Compiled, Compiler, Allocator
@@ -74,13 +74,11 @@ class PythonProgram:
         dl[i] = dtype
         if uop is UOps.DEFINE_GLOBAL:
           assert dtype.fmt is not None
-          if sys.version_info[1] < 12: assert dtype.fmt != 'e' and dtype.fmt != '@e'
-          ul[i] = [pbufs.pop(0).cast(dtype.fmt)] * warp_size
+          ul[i] = [pbufs.pop(0).cast(dtype.fmt)] * warp_size # type: ignore
         elif uop is UOps.DEFINE_LOCAL:
           assert dtype.fmt is not None
-          if sys.version_info[1] < 12: assert dtype.fmt != 'e' and dtype.fmt != '@e'
           lbuf = memoryview(bytearray(arg[1]*dtype.itemsize))
-          ul[i] = [lbuf.cast(dtype.fmt)] * warp_size
+          ul[i] = [lbuf.cast(dtype.fmt)] * warp_size # type: ignore
         elif uop is UOps.DEFINE_VAR:
           ul[i] = [pvals.pop(0)] * warp_size
         elif uop is UOps.SPECIAL:

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -3,7 +3,7 @@
 # works to test the tensor cores, and all the uops in general
 # this is the (living) definition of uops
 from typing import Tuple, List, Optional, Any, Dict
-import pickle, base64, itertools, time, struct
+import pickle, base64, itertools, time, struct, sys
 from tinygrad.dtype import DType, dtypes, ImageDType, truncate
 from tinygrad.helpers import all_same, getenv, flatten
 from tinygrad.device import Compiled, Compiler, Allocator
@@ -74,9 +74,11 @@ class PythonProgram:
         dl[i] = dtype
         if uop is UOps.DEFINE_GLOBAL:
           assert dtype.fmt is not None
+          if sys.version_info[1] < 12: assert dtype.fmt != 'e' and dtype.fmt != '@e'
           ul[i] = [pbufs.pop(0).cast(dtype.fmt)] * warp_size
         elif uop is UOps.DEFINE_LOCAL:
           assert dtype.fmt is not None
+          if sys.version_info[1] < 12: assert dtype.fmt != 'e' and dtype.fmt != '@e'
           lbuf = memoryview(bytearray(arg[1]*dtype.itemsize))
           ul[i] = [lbuf.cast(dtype.fmt)] * warp_size
         elif uop is UOps.DEFINE_VAR:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -278,8 +278,9 @@ class Tensor:
     ```
     """
     assert self.dtype.fmt is not None, f"no fmt dtype for {self.dtype}"
+    if sys.version_info[1] < 12: assert self.dtype.fmt != 'e' and self.dtype.fmt != '@e', "half is only supported for python >= 3.12"
     assert all_int(self.shape), f"no data if shape is symbolic, {self.shape=}"
-    return self._data().cast(self.dtype.fmt, self.shape)
+    return self._data().cast(self.dtype.fmt, self.shape) # type: ignore
 
   def item(self) -> ConstType:
     """
@@ -291,6 +292,7 @@ class Tensor:
     ```
     """
     assert self.dtype.fmt is not None, f"no fmt dtype for {self.dtype}"
+    if sys.version_info[1] < 12: assert self.dtype.fmt != 'e' and self.dtype.fmt != '@e', "half is only supported for python >= 3.12"
     assert self.numel() == 1, "must have one element for item"
     return self._data().cast(self.dtype.fmt)[0]
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -278,7 +278,6 @@ class Tensor:
     ```
     """
     assert self.dtype.fmt is not None, f"no fmt dtype for {self.dtype}"
-    if sys.version_info[1] < 12: assert self.dtype.fmt != 'e' and self.dtype.fmt != '@e', "half is only supported for python >= 3.12"
     assert all_int(self.shape), f"no data if shape is symbolic, {self.shape=}"
     return self._data().cast(self.dtype.fmt, self.shape) # type: ignore
 
@@ -292,9 +291,8 @@ class Tensor:
     ```
     """
     assert self.dtype.fmt is not None, f"no fmt dtype for {self.dtype}"
-    if sys.version_info[1] < 12: assert self.dtype.fmt != 'e' and self.dtype.fmt != '@e', "half is only supported for python >= 3.12"
     assert self.numel() == 1, "must have one element for item"
-    return self._data().cast(self.dtype.fmt)[0]
+    return self._data().cast(self.dtype.fmt)[0] # type: ignore
 
   # TODO: should be Tensor.tolist() -> Union[List[ConstType], ConstType]. The List is Sequence because mypy expects memoryview.tolist() -> list[int]
   # src: https://github.com/python/mypy/blob/release-1.6/mypy/typeshed/stdlib/builtins.pyi#L803


### PR DESCRIPTION
Upgrades mypy to 1.12.1 #7176

\# type: ignore was added to Tensor.data because mypy is inferring
memoryview[int] as the return type but the exact type of a memoryview
can't be declared in python to fix this inference