### PR TITLE
instant rewrite in uop metaclass [pr]

### DIFF
--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -166,6 +166,13 @@ class TestGraphRewrite(unittest.TestCase):
     self.assertEqual(nout.src[1].op, UOps.CONST)
     self.assertEqual(nout.src[1].arg, 3.0)
 
+  def test_instant_is_instant(self):
+    a = UOp.variable('a', 0, 1)
+    self.assertIs(a+0, a)
+    self.assertIs(0+a, a)
+    self.assertIs(a*0, a.const_like(0))
+    self.assertIs(a*1, a)
+
   def test_commutative_work(self):
     a = UOp.variable('a', 0, 1)
     b = UOp.variable('b', 0, 1)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -195,7 +195,9 @@ class UOpMetaClass(type):
     if op is UOps.ALU and arg in COMMUTATIVE and (src[0] is not src[1] and src[1].tuplize < src[0].tuplize and src[0].op is not UOps.NOOP):
       src = src[::-1]
     if (ret:=UOpMetaClass.ucache.get(key:=(op, dtype, src, arg), None)) is not None: return ret
-    UOpMetaClass.ucache[key] = ret = super().__call__(op, dtype, src, arg)
+    ret = super().__call__(op, dtype, src, arg)
+    while (nret:=instant.rewrite(ret)) is not None: ret = nret
+    UOpMetaClass.ucache[key] = ret
     return ret
 
 class UOp(MathTrait, metaclass=UOpMetaClass):


### PR DESCRIPTION
Do we want this? There's arguments both ways, I lean toward yes, but it seems slower.

We need PatternMatcher compiler. And for that we need lines.