### PR TITLE
Llama 3.2 1B load from GGUF

### DIFF
--- a/extra/models/llama.py
+++ b/extra/models/llama.py
@@ -217,7 +217,7 @@ def convert_from_gguf(weights:Dict[str, Tensor], model: Transformer):
     "rope_freqs.weight": "rope_freqs.weight",
   }
   sd = {keymap[k]: v for k,v in weights.items()}
-  sd["output.weight"] = weights["token_embd.weight"].to(Device.DEFAULT)
+  sd["output.weight"] = weights["token_embd.weight"]
   return sd
 
 def fix_bf16(weights:Dict[Any, Tensor]):


### PR DESCRIPTION
#7180 

Some kv_data from the file isn't used, namely the model params which are hardcoded and the tokens which are copied from 8B. (Maybe you want that changed for this example?)