### PR TITLE
Refactor code_for_op into pm rules [run_process_replay]

### DIFF
--- a/test/unit/test_simplify_valid_idx.py
+++ b/test/unit/test_simplify_valid_idx.py
@@ -26,7 +26,7 @@ def render(uop:UOp) -> str:
   uops = linearize_uop(full_graph_rewrite(uop.sink()))
   from tinygrad.renderer.cstyle import OpenCLRenderer
   class TestRenderer(OpenCLRenderer):
-    code_for_op = {**OpenCLRenderer.code_for_op, BinaryOps.IDIV: lambda a,b,dtype: f"({a}//{b})"}
+    code_for_op = {**OpenCLRenderer.code_for_op, (BinaryOps.IDIV, None): lambda a,b: f"({a}//{b})"}
   fxn = TestRenderer().render("", uops)
   # print(fxn)
   return fxn.split("val0 = ")[1].split(";")[0]

--- a/test/unit/test_simplify_valid_idx.py
+++ b/test/unit/test_simplify_valid_idx.py
@@ -26,7 +26,7 @@ def render(uop:UOp) -> str:
   uops = linearize_uop(full_graph_rewrite(uop.sink()))
   from tinygrad.renderer.cstyle import OpenCLRenderer
   class TestRenderer(OpenCLRenderer):
-    code_for_op = {**OpenCLRenderer.code_for_op, (BinaryOps.IDIV, None): lambda a,b: f"({a}//{b})"}
+    code_for_op = {**OpenCLRenderer.code_for_op, BinaryOps.IDIV: lambda a,b,dtype: f"({a}//{b})"}
   fxn = TestRenderer().render("", uops)
   # print(fxn)
   return fxn.split("val0 = ")[1].split(";")[0]

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -510,7 +510,8 @@ def full_graph_rewrite(sink:UOp, opts:Optional[Renderer]=None) -> UOp:
       sink = graph_rewrite(sink, sym+just_reduce)
       sink = graph_rewrite(sink, sym+(devectorize+float4_folding if opts is not None and opts.supports_float4 else devectorize))
       sink = graph_rewrite(sink, sym+reducer)
-      sink = graph_rewrite(sink, sym+get_extra_patterns(tuple(opts.code_for_op.keys()) if opts is not None else (), TRANSCENDENTAL>=2))
+      code_for_op_keys = tuple(key[0] if isinstance(key, tuple) else key for key in opts.code_for_op.keys()) if opts is not None else ()
+      sink = graph_rewrite(sink, sym+get_extra_patterns(code_for_op_keys, TRANSCENDENTAL>=2))
 
   if opts is not None and opts.extra_matcher is not None: sink = graph_rewrite(sink, opts.extra_matcher)
   return sink

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple, Dict, Callable, Any
+from typing import Optional, List, Tuple, Dict, Callable, Any, Union
 import functools
 from dataclasses import dataclass, field
 from tinygrad.helpers import to_function_name, dedup, prod
@@ -83,7 +83,7 @@ class Renderer:
   shared_max: int = 32768
   tensor_cores: List[TensorCore] = []
   extra_matcher: Any = None
-  code_for_op: Dict[Op, Callable] = {}
+  code_for_op: Dict[Union[Op, Tuple[Op,Optional[Tuple[DType, ...]]]], Callable] = {}
 
   def __reduce__(self): return self.__class__, ()
   def render(self, name:str, uops:List[UOp]) -> str: raise NotImplementedError("needs a renderer")

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -83,7 +83,7 @@ class Renderer:
   shared_max: int = 32768
   tensor_cores: List[TensorCore] = []
   extra_matcher: Any = None
-  code_for_op: Dict[Union[Op, Tuple[Op,Optional[Tuple[DType, ...]]]], Callable] = {}
+  code_for_op: Union[Dict[Op, Callable], Dict[Union[Op, Tuple[Op, Optional[Tuple[DType, ...]]]], Callable]] = {}
 
   def __reduce__(self): return self.__class__, ()
   def render(self, name:str, uops:List[UOp]) -> str: raise NotImplementedError("needs a renderer")

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -83,7 +83,7 @@ class Renderer:
   shared_max: int = 32768
   tensor_cores: List[TensorCore] = []
   extra_matcher: Any = None
-  # different types are neccesary while ptx and llvm are not pm-like
+  # different types are necessary while ptx and llvm are not pm-like
   code_for_op: Union[Dict[Op, Callable], Dict[Union[Op, Tuple[Op, Optional[Tuple[DType, ...]]]], Callable]] = {}
 
   def __reduce__(self): return self.__class__, ()

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -83,6 +83,7 @@ class Renderer:
   shared_max: int = 32768
   tensor_cores: List[TensorCore] = []
   extra_matcher: Any = None
+  # different types are neccesary while ptx and llvm are not pm-like
   code_for_op: Union[Dict[Op, Callable], Dict[Union[Op, Tuple[Op, Optional[Tuple[DType, ...]]]], Callable]] = {}
 
   def __reduce__(self): return self.__class__, ()

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -83,7 +83,7 @@ class Renderer:
   shared_max: int = 32768
   tensor_cores: List[TensorCore] = []
   extra_matcher: Any = None
-  # different types are necessary while ptx and llvm are not pm-style
+  # different types are necessary while ptx and llvmir are not pm-style
   code_for_op: Union[Dict[Op, Callable], Dict[Union[Op, Tuple[Op, Optional[Tuple[DType, ...]]]], Callable]] = {}
 
   def __reduce__(self): return self.__class__, ()

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -83,7 +83,7 @@ class Renderer:
   shared_max: int = 32768
   tensor_cores: List[TensorCore] = []
   extra_matcher: Any = None
-  # different types are necessary while ptx and llvm are not pm-like
+  # different types are necessary while ptx and llvm are not pm-style
   code_for_op: Union[Dict[Op, Callable], Dict[Union[Op, Tuple[Op, Optional[Tuple[DType, ...]]]], Callable]] = {}
 
   def __reduce__(self): return self.__class__, ()

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -82,27 +82,13 @@ class CStyleLanguage(Renderer):
   type_map: Dict[DType, str] = {}
   infinity: str = "INFINITY"
   nan: str = "NAN"
-  code_for_op: Dict = {
-    (UnaryOps.SQRT, None): lambda x: f"sqrt({x})",
-    (UnaryOps.RECIP, None): lambda x: f"(1/{x})",
-    (UnaryOps.NEG, None): lambda x: f"-{x}",
-    (UnaryOps.EXP2, None): lambda x: f"exp2({x})",
-    (UnaryOps.LOG2, None): lambda x: f"log2({x})",
-    (UnaryOps.SIN, None): lambda x: f"sin({x})",
-    (BinaryOps.SHL, None): lambda a, b: f"({a}<<{b})",
-    (BinaryOps.SHR, None): lambda a, b: f"({a}>>{b})",
-    (BinaryOps.ADD, None): lambda a, b: f"({a}+{b})",
-    (BinaryOps.SUB, None): lambda a, b: f"({a}-{b})",
-    (BinaryOps.IDIV, None): lambda a, b: f"({a}/{b})",
-    (BinaryOps.MUL, None): lambda a, b: f"({a}*{b})",
-    (BinaryOps.MOD, None): lambda a, b: f"({a}%{b})",
-    (BinaryOps.CMPLT, None): lambda a, b: f"({a}<{b})",
-    (BinaryOps.CMPNE, None): lambda a, b: f"({a}!={b})",
-    (BinaryOps.XOR, None): lambda a, b: f"({a}^{b})",
-    (BinaryOps.AND, None): lambda a, b: f"({a}&{b})",
-    (BinaryOps.OR, None): lambda a, b: f"({a}|{b})",
-    (TernaryOps.WHERE, None): lambda a, b, c: f"({a}?{b}:{c})",
-  }
+  code_for_op: Dict = { (TernaryOps.WHERE,None): lambda a, b, c: f"({a}?{b}:{c})",
+    (UnaryOps.SQRT,None): lambda x: f"sqrt({x})", (BinaryOps.SHL,None): lambda a, b: f"({a}<<{b})", (BinaryOps.MOD,None): lambda a, b: f"({a}%{b})",
+    (UnaryOps.RECIP,None): lambda x: f"(1/{x})", (BinaryOps.SHR,None): lambda a, b: f"({a}>>{b})", (BinaryOps.CMPLT,None): lambda a, b: f"({a}<{b})",
+    (UnaryOps.NEG,None): lambda x: f"-{x}", (BinaryOps.ADD,None): lambda a, b: f"({a}+{b})", (BinaryOps.CMPNE,None): lambda a, b: f"({a}!={b})",
+    (UnaryOps.EXP2,None): lambda x: f"exp2({x})", (BinaryOps.SUB,None): lambda a, b: f"({a}-{b})", (BinaryOps.XOR,None): lambda a, b: f"({a}^{b})",
+    (UnaryOps.LOG2,None): lambda x: f"log2({x})", (BinaryOps.IDIV,None): lambda a, b: f"({a}/{b})", (BinaryOps.AND,None): lambda a, b: f"({a}&{b})",
+    (UnaryOps.SIN,None): lambda x: f"sin({x})",  (BinaryOps.MUL,None): lambda a, b: f"({a}*{b})", (BinaryOps.OR,None): lambda a, b: f"({a}|{b})" }
 
   string_rewrite = base_rewrite
   extra_matcher = extra_pm
@@ -199,9 +185,7 @@ class ClangRenderer(CStyleLanguage):
   type_map = {dtypes.bool:"_Bool", dtypes.half:"__fp16"}
   code_for_op = {
     **({(op, dtype): v for (op, dtype), v in CStyleLanguage.code_for_op.items() if op not in (UnaryOps.EXP2, UnaryOps.SIN, UnaryOps.LOG2)}),
-    (UnaryOps.SQRT, (dtypes.float64,)): lambda x: f"__builtin_sqrtl({x})",
-    (UnaryOps.SQRT, None): lambda x: f"__builtin_sqrtf({x})",
-  }
+    (UnaryOps.SQRT, (dtypes.float64,)): lambda x: f"__builtin_sqrtl({x})", (UnaryOps.SQRT, None): lambda x: f"__builtin_sqrtf({x})" }
 
   if AMX:
     tensor_cores = [TensorCore(dims=(sz,sz,1), threads=[], reduce_axes=[], upcast_axes=([(1,sz)],[(0,sz)],[(1,sz),(0,sz)]), dtype_in=dt, dtype_out=dt)
@@ -336,14 +320,9 @@ class CUDARenderer(CStyleLanguage):
   float4 = "make_float4"
   code_for_workitem = {"g": lambda x: f"blockIdx.{chr(120+int(x))}", "l": lambda x: f"threadIdx.{chr(120+int(x))}",
                        "i": lambda x: f"(blockIdx.{chr(120+int(x))}*blockDim.{chr(120+int(x))}+threadIdx.{chr(120+int(x))})"}
-  code_for_op = {
-    **CStyleLanguage.code_for_op,
-    (UnaryOps.RECIP, (dtypes.half, dtypes.bfloat16)): lambda x: f"hrcp({x})",
-    (UnaryOps.SQRT, (dtypes.half, dtypes.bfloat16)): lambda x: f"hsqrt({x})",
-    (UnaryOps.SIN, (dtypes.half, dtypes.bfloat16)): lambda x: f"hsin({x})",
-    (UnaryOps.LOG2, (dtypes.half, dtypes.bfloat16)): lambda x: f"hlog2({x})",
-    (UnaryOps.EXP2, (dtypes.half, dtypes.bfloat16)): lambda x: f"hexp2({x})",
-  }
+  code_for_op = { **CStyleLanguage.code_for_op, (UnaryOps.RECIP, (dtypes.half, dtypes.bfloat16)): lambda x: f"hrcp({x})",
+    (UnaryOps.SQRT, (dtypes.half,dtypes.bfloat16)): lambda x: f"hsqrt({x})", (UnaryOps.SIN, (dtypes.half,dtypes.bfloat16)): lambda x: f"hsin({x})",
+    (UnaryOps.LOG2, (dtypes.half,dtypes.bfloat16)): lambda x: f"hlog2({x})", (UnaryOps.EXP2, (dtypes.half,dtypes.bfloat16)): lambda x: f"hexp2({x})" }
   type_map = {dtypes.bfloat16: "nv_bfloat16"}
 
   def render_vector_prefix(self, dt:DType) -> str:
@@ -408,21 +387,13 @@ class AMDRenderer(CStyleLanguage):
   kernel_prefix += '\nextern "C" __attribute__((global))'
   code_for_workitem = {"g": lambda x: f"__ockl_get_group_id({x})", "l": lambda x: f"__ockl_get_local_id({x})",
                        "i": lambda x: f"(__ockl_get_group_id({x})*__ockl_get_local_size({x})+__ockl_get_local_id({x}))"}
-  code_for_op = {
-    **CStyleLanguage.code_for_op,
-    (UnaryOps.SQRT, (dtypes.half,)): lambda x: f"__ocml_sqrt_f16({x})",
-    (UnaryOps.SQRT, (dtypes.double,)): lambda x: f"__ocml_sqrt_f64({x})",
-    (UnaryOps.LOG2, (dtypes.half,)): lambda x: f"__ocml_log2_f16({x})",
-    (UnaryOps.LOG2, (dtypes.double,)): lambda x: f"__ocml_log2_f64({x})",
-    (UnaryOps.EXP2, (dtypes.half,)): lambda x: f"__ocml_exp2_f16({x})",
-    (UnaryOps.EXP2, (dtypes.double,)): lambda x: f"__ocml_exp2_f64({x})",
-    (UnaryOps.SIN, (dtypes.half,)): lambda x: f"__ocml_sin_f16({x})",
-    (UnaryOps.SIN, (dtypes.double,)): lambda x: f"__ocml_sin_f64({x})",
-    (UnaryOps.SQRT, None): lambda x: f"__ocml_sqrt_f32({x})",
-    (UnaryOps.LOG2, None): lambda x: f"__ocml_log2_f32({x})",
-    (UnaryOps.EXP2, None): lambda x: f"__ocml_exp2_f32({x})",
-    (UnaryOps.SIN, None): lambda x: f"__ocml_sin_f32({x})",
-  }
+  code_for_op = { **CStyleLanguage.code_for_op,
+    (UnaryOps.SQRT, (dtypes.half,)): lambda x: f"__ocml_sqrt_f16({x})", (UnaryOps.SQRT, (dtypes.double,)): lambda x: f"__ocml_sqrt_f64({x})",
+    (UnaryOps.LOG2, (dtypes.half,)): lambda x: f"__ocml_log2_f16({x})", (UnaryOps.LOG2, (dtypes.double,)): lambda x: f"__ocml_log2_f64({x})",
+    (UnaryOps.EXP2, (dtypes.half,)): lambda x: f"__ocml_exp2_f16({x})", (UnaryOps.EXP2, (dtypes.double,)): lambda x: f"__ocml_exp2_f64({x})",
+    (UnaryOps.SIN, (dtypes.half,)): lambda x: f"__ocml_sin_f16({x})", (UnaryOps.SIN, (dtypes.double,)): lambda x: f"__ocml_sin_f64({x})",
+    (UnaryOps.SQRT, None): lambda x: f"__ocml_sqrt_f32({x})", (UnaryOps.LOG2, None): lambda x: f"__ocml_log2_f32({x})",
+    (UnaryOps.EXP2, None): lambda x: f"__ocml_exp2_f32({x})", (UnaryOps.SIN, None): lambda x: f"__ocml_sin_f32({x})" }
   smem_prefix = "__attribute__((shared))"
   barrier = '__builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup");' + '__builtin_amdgcn_s_barrier();' + \
             '__builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup");'
@@ -477,14 +448,9 @@ class DSPRenderer(ClangRenderer):
   buffer_suffix = " restrict __attribute__((align_value(128)))"
   kernel_prefix = "__attribute__((noinline)) "
   type_map = { **ClangRenderer.type_map, dtypes.uint64: "unsigned long long", dtypes.int64: "long long" }
-  code_for_op = {
-    **ClangRenderer.code_for_op,
-    (UnaryOps.SIN, None): lambda x: f"__builtin_sin({x})",
-    (UnaryOps.LOG2, (dtypes.float64,)): lambda x: f"__builtin_log2l({x})",
-    (UnaryOps.LOG2, None): lambda x: f"__builtin_log2f({x})",
-    (UnaryOps.EXP2, (dtypes.float64,)): lambda x: f"__builtin_exp2l({x})",
-    (UnaryOps.EXP2, None): lambda x: f"__builtin_exp2f({x})",
-  }
+  code_for_op = { **ClangRenderer.code_for_op, (UnaryOps.SIN, None): lambda x: f"__builtin_sin({x})",
+    (UnaryOps.LOG2, (dtypes.float64,)): lambda x: f"__builtin_log2l({x})", (UnaryOps.LOG2, None): lambda x: f"__builtin_log2f({x})",
+    (UnaryOps.EXP2, (dtypes.float64,)): lambda x: f"__builtin_exp2l({x})", (UnaryOps.EXP2, None): lambda x: f"__builtin_exp2f({x})" }
 
   def render_kernel(self, function_name:str, kernel:List[str], bufs:List[Tuple[str,Tuple[DType,bool]]], uops:List[UOp], prefix=None) -> str:
     ret = super().render_kernel(function_name, kernel, bufs, uops, prefix)

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -110,27 +110,15 @@ class CStyleLanguage(Renderer):
       return (self.smem_prefix if dt.local else self.buffer_prefix) + self.render_dtype(dt.base) + ("*" if isinstance(dt, PtrDType) else "")
     return self.type_map.get(scalar:=dt.scalar(), scalar.name) + (str(dt.count) if (dt.count) > 1 else "")
 
-  # @functools.cached_property
-  # def alu_rewrite_2(self) -> PatternMatcher:
-  #   # sorts dtyped items first
-  #   sorted_code_for_op = sorted(self.code_for_op.items(), key=lambda item: item[0][1] is None)
-
-  #   # render_alu=alu_code_for_op is a hack to avoid closure on pattern matcher
-  #   return PatternMatcher([*[(UPat(UOps.ALU, arg=op, dtype=dtype, name="x"), lambda r,x,render_alu=alu_code_for_op:
-  #     render_alu(*[strip_parens(r[v]) if v.arg==x.arg and x.arg in {BinaryOps.ADD, BinaryOps.MUL, BinaryOps.XOR} else r[v] for v in x.src]))
-  #     for (op, dtype), alu_code_for_op in sorted_code_for_op]])
-
   @functools.cached_property
   def alu_rewrite(self) -> PatternMatcher:
     # sorts dtyped items first
     sorted_code_for_op = sorted(self.code_for_op.items(), key=lambda item: item[0][1] is None)
 
-    # functools.partial is neccessary to avoid closure on pattern matcher
-    def func(r, x, render_alu):
-      return render_alu(*[strip_parens(r[v]) if v.arg == x.arg and x.arg in (BinaryOps.ADD,BinaryOps.MUL,BinaryOps.XOR) else r[v] for v in x.src])
-
-    return PatternMatcher([(UPat(UOps.ALU, arg=op, dtype=dtype, name="x"), functools.partial(func, render_alu=alu_code_for_op))
-      for (op, dtype), alu_code_for_op in sorted_code_for_op])
+    # render_alu=alu_code_for_op is a hack to avoid closure on pattern matcher
+    return PatternMatcher([*[(UPat(UOps.ALU, arg=op, dtype=dtype, name="x"), lambda r,x,render_alu=alu_code_for_op:
+      render_alu(*[strip_parens(r[v]) if v.arg==x.arg and x.arg in {BinaryOps.ADD, BinaryOps.MUL, BinaryOps.XOR} else r[v] for v in x.src]))
+      for (op, dtype), alu_code_for_op in sorted_code_for_op]])
 
   def __getitem__(self, key): return self.r[key]  # hacky helper
   def render(self, name:str, uops:List[UOp]) -> str:


### PR DESCRIPTION
Alternative `alu_rewrite` with functools.partial to avoid closure won't work due to how `deconstruct_function` in ops works. And wrapper function wouldn't avoid closure. I know it's kind of a hacky solution but is the best way I could find to create a separate rule for every op and dtype.

render_rewrite patterns for CLANG
<img width="1877" alt="image" src="https://github.com/user-attachments/assets/d115b625-9c10-4108-b62b-4232ab427186">

