### PR TITLE
CI speed: Invalidate gpuocelot cache monthly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -437,15 +437,17 @@ jobs:
           sudo apt update -y || true
           sudo apt install -y --no-install-recommends git g++ cmake ninja-build llvm-15-dev zlib1g-dev libglew-dev \
             flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-toolkit-gcc libzstd-dev
+      - name: Get month for cache key
+        id: get-month
+        run: echo "month=$(date +'%Y%m')">> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache gpuocelot
         if: matrix.backend == 'ptx' || matrix.backend == 'triton' || matrix.backend == 'nv'
         id: cache-build
         uses: actions/cache@v4
-        env:
-          cache-name: cache-gpuocelot-build
         with:
           path: ${{ github.workspace }}/gpuocelot/ocelot
-          key: ubuntu22.04-gpuocelot-4524e34adb7eaccc6f71262f2e21d7052bb17c2f-rebuild-8
+          key: ubuntu22.04-gpuocelot-4524e34adb7eaccc6f71262f2e21d7052bb17c2f-rebuild-${{ steps.get-month.outputs.date }}
       - name: Clone/compile gpuocelot
         if: (matrix.backend == 'ptx' || matrix.backend == 'triton' || matrix.backend == 'nv') && steps.cache-build.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -445,9 +445,11 @@ jobs:
         if: matrix.backend == 'ptx' || matrix.backend == 'triton' || matrix.backend == 'nv'
         id: cache-build
         uses: actions/cache@v4
+        env:
+          cache-name: cache-gpuocelot-build
         with:
           path: ${{ github.workspace }}/gpuocelot/ocelot
-          key: ubuntu22.04-gpuocelot-4524e34adb7eaccc6f71262f2e21d7052bb17c2f-rebuild-${{ steps.get-month.outputs.date }}
+          key: ubuntu22.04-gpuocelot-4524e34adb7eaccc6f71262f2e21d7052bb17c2f-rebuild-${{ steps.get-month.outputs.month }}
       - name: Clone/compile gpuocelot
         if: (matrix.backend == 'ptx' || matrix.backend == 'triton' || matrix.backend == 'nv') && steps.cache-build.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -437,8 +437,8 @@ jobs:
           sudo apt update -y || true
           sudo apt install -y --no-install-recommends git g++ cmake ninja-build llvm-15-dev zlib1g-dev libglew-dev \
             flex bison libfl-dev libboost-thread-dev libboost-filesystem-dev nvidia-cuda-toolkit-gcc libzstd-dev
-      - name: Get month for cache key
-        id: get-month
+      - name: Store month for cache key
+        id: month
         run: echo "month=$(date +'%Y%m')">> $GITHUB_OUTPUT
         shell: bash
       - name: Cache gpuocelot
@@ -449,7 +449,7 @@ jobs:
           cache-name: cache-gpuocelot-build
         with:
           path: ${{ github.workspace }}/gpuocelot/ocelot
-          key: ubuntu22.04-gpuocelot-4524e34adb7eaccc6f71262f2e21d7052bb17c2f-rebuild-${{ steps.get-month.outputs.month }}
+          key: ubuntu22.04-gpuocelot-4524e34adb7eaccc6f71262f2e21d7052bb17c2f-rebuild-${{ steps.month.outputs.month }}
       - name: Clone/compile gpuocelot
         if: (matrix.backend == 'ptx' || matrix.backend == 'triton' || matrix.backend == 'nv') && steps.cache-build.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,7 +441,7 @@ jobs:
         id: month
         run: echo "month=$(date +'%Y%m')">> $GITHUB_OUTPUT
         shell: bash
-      - name: Cache gpuocelot
+      - name: Cache gpuocelot build (invalidated monthly)
         if: matrix.backend == 'ptx' || matrix.backend == 'triton' || matrix.backend == 'nv'
         id: cache-build
         uses: actions/cache@v4


### PR DESCRIPTION
Automatically invalidate the `gpuocelot` build cache at the beginning of each month.

The gpuocelot build cache went out of sync, resulting in a recompilation on each CI job (see the ninja warnings [here](https://github.com/tinygrad/tinygrad/actions/runs/11521503810/job/32075303745?pr=7305)).

```
ninja explain: CMakeFiles/gpuocelot_analysis.dir/src/analysis/DivergenceGraph.cpp.o is dirty
ninja explain: output CMakeFiles/gpuocelot_analysis.dir/src/analysis/DominatorTree.cpp.o older than most recent input /usr/include/linux/errno.h (1724981335987500422 vs 1727457702000000000)
```

The cache was not updated because the bad cache was hit every time (had a static cache key).

This PR removes ~1m30s of unnecessary work from the nv and ptx jobs. The nv job is the slowest unit test job.

Main:
<img width="192" alt="image" src="https://github.com/user-attachments/assets/fc2dbdca-cbc2-4e3a-bee0-c635cb6305df">

PR:
<img width="184" alt="image" src="https://github.com/user-attachments/assets/9f2dd68b-fe14-49df-93ee-c3856007b941">

