### PR TITLE
always run process replay with contextvars

### DIFF
--- a/test/external/process_replay/helpers.py
+++ b/test/external/process_replay/helpers.py
@@ -1,18 +1,17 @@
 from dataclasses import dataclass
 import traceback, subprocess
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 from tinygrad.helpers import ContextVar, getenv
 
 @dataclass(frozen=True)
 class ProcessReplayContext:
-  ctx_vars: Dict[str, int]
-  loc: str = ""
-  head_sha: str = ""
-  run_id: Optional[int] = None
-def get_process_replay_ctx() -> ProcessReplayContext:
+  loc: str
+  head_sha: str
+  run_id: Optional[int]
+def get_process_replay_ctx() -> Tuple[Dict, ProcessReplayContext]:
   stack = filter(lambda x: "tinygrad" in x.filename and not any(n in x.filename for n in ["engine/schedule.py", "engine/realize.py", \
       "codegen/kernel.py", "unittest"]), traceback.extract_stack()[:-1])
   loc = "\n".join(traceback.format_list(stack))
   try: head_sha = subprocess.check_output(["git", "rev-parse", "HEAD"]).strip().decode()
   except Exception: head_sha = ""
-  return ProcessReplayContext({k:v.value for k,v in ContextVar._cache.items()}, loc, head_sha, getenv("GITHUB_RUN_ID") or None)
+  return {k:v.value for k,v in ContextVar._cache.items()}, ProcessReplayContext(loc, head_sha, getenv("GITHUB_RUN_ID") or None)

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -5,8 +5,8 @@ from typing import Callable, List, Tuple, Union, cast
 from tinygrad.engine.schedule import ScheduleItemContext, full_ast_rewrite
 from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connection, getenv, tqdm
 from tinygrad.codegen.kernel import Kernel, Opt
-from tinygrad.ops import UOp
 from tinygrad.renderer import Renderer
+from tinygrad.ops import UOp
 from test.helpers import print_diff
 
 # *** process replay settings

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -28,8 +28,8 @@ if REF == "master": SKIP_PROCESS_REPLAY = True
 
 # *** recreators
 
-def recreate_sched(sink:UOp, ctx:ScheduleItemContext, _) -> UOp: return full_ast_rewrite(sink, ctx)
-def recreate_kernel(ast:UOp, opts:Renderer, applied_opts:List[Opt], name:str, _) -> str:
+def recreate_sched(sink:UOp, ctx:ScheduleItemContext) -> UOp: return full_ast_rewrite(sink, ctx)
+def recreate_kernel(ast:UOp, opts:Renderer, applied_opts:List[Opt], name:str) -> str:
   k = Kernel(ast, opts=opts)
   for opt in applied_opts: k.apply_opt(opt)
   # NOTE: replay with the captured renderer, not the one in master
@@ -52,7 +52,7 @@ def diff(offset:int, name:str, fxn:Callable) -> Union[Tuple[int, int], bool]:
       continue
     # try recreate
     try:
-      with Context(**{k:v for k,v in args[-2].items() if k in ContextVar._cache and k != "DEBUG"}): good = fxn(*args)
+      with Context(**{k:v for k,v in args[-2].items() if k in ContextVar._cache and k != "DEBUG"}): good = fxn(*args[:-2])
     except Exception as e:
       logging.warning(f"FAILED TO RECREATE KERNEL {e}")
       for x in args[:-1]: logging.info(x)

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -8,7 +8,6 @@ from tinygrad.codegen.kernel import Kernel, Opt
 from tinygrad.ops import UOp
 from tinygrad.renderer import Renderer
 from test.helpers import print_diff
-from test.external.process_replay.helpers import ProcessReplayContext
 
 # *** process replay settings
 
@@ -30,12 +29,11 @@ if REF == "master": SKIP_PROCESS_REPLAY = True
 # *** recreators
 
 def recreate_sched(sink:UOp, ctx:ScheduleItemContext, _) -> UOp: return full_ast_rewrite(sink, ctx)
-def recreate_kernel(ast:UOp, opts:Renderer, applied_opts:List[Opt], name:str, ctx:ProcessReplayContext, _) -> str:
-  with Context(**{k:v for k,v in ctx.ctx_vars.items() if k in ContextVar._cache and k != "DEBUG"}):
-    k = Kernel(ast, opts=opts)
-    for opt in applied_opts: k.apply_opt(opt)
-    # NOTE: replay with the captured renderer, not the one in master
-    return k.opts.render(name, cast(List,k.to_program().uops))
+def recreate_kernel(ast:UOp, opts:Renderer, applied_opts:List[Opt], name:str, _) -> str:
+  k = Kernel(ast, opts=opts)
+  for opt in applied_opts: k.apply_opt(opt)
+  # NOTE: replay with the captured renderer, not the one in master
+  return k.opts.render(name, cast(List,k.to_program().uops))
 
 # *** diff a "good" recreation against the generated version
 
@@ -53,7 +51,8 @@ def diff(offset:int, name:str, fxn:Callable) -> Union[Tuple[int, int], bool]:
       if ASSERT_DIFF: return True
       continue
     # try recreate
-    try: good = fxn(*args)
+    try:
+      with Context(**{k:v for k,v in args[-2].items() if k in ContextVar._cache and k != "DEBUG"}): good = fxn(*args)
     except Exception as e:
       logging.warning(f"FAILED TO RECREATE KERNEL {e}")
       for x in args[:-1]: logging.info(x)

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -727,7 +727,7 @@ class Kernel:
 
     if getenv("RUN_PROCESS_REPLAY"):
       from test.external.process_replay.helpers import get_process_replay_ctx
-      diskcache_put("kernel_process_replay", str(id(self)), (self.ast, self.opts, self.applied_opts, name, get_process_replay_ctx(), src))
+      diskcache_put("kernel_process_replay", str(id(self)), (self.ast, self.opts, self.applied_opts, name, *get_process_replay_ctx(), src))
 
     # group non-local bufs by the op type (LOAD or STORE) and the buffer arg. take the max access of that buffer in bytes
     # TODO: these max and min don't work on symbolic, and results are very wrong.

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -211,7 +211,7 @@ PROCESS_REPLAY_CAPTURE: List[Tuple[UOp, ScheduleItemContext, UOp]] = []
 if getenv("RUN_PROCESS_REPLAY"):
   @atexit.register
   def save_process_replay():
-    for base_sink,ctx,ret in PROCESS_REPLAY_CAPTURE: diskcache_put("schedule_process_replay", str(base_sink.key), (base_sink, ctx, ret))
+    for base_sink,ctx,ret in PROCESS_REPLAY_CAPTURE: diskcache_put("schedule_process_replay", str(base_sink.key), (base_sink, ctx, {}, ret))
 
 # **** Schedule creation and BFS toposort
 


### PR DESCRIPTION
towards sharing process replay with schedule and kernel. Once it's a generic helper schedule.py can use the context dict.