### PR TITLE
Fix ValueError in Yolo 8 example

### DIFF
--- a/examples/yolov8.py
+++ b/examples/yolov8.py
@@ -61,7 +61,7 @@ def compute_nms(boxes, scores, iou_threshold):
     if order.size == 1:
       break
     iou = box_iou(boxes[i][None, :], boxes[order[1:]])
-    inds = np.where(iou.squeeze() <= iou_threshold)[0]
+    inds = np.where(np.atleast_1d(iou.squeeze()) <= iou_threshold)[0]
     order = order[inds + 1]
   return np.array(keep)
 


### PR DESCRIPTION
Calling

    python3 examples/yolov8.py ./test/models/efficientnet/Chicken.jpg

used to result in this error

    ValueError: Calling nonzero on 0d arrays is not allowed.

Using np.atleast_1d makes sure we avoid a zero-dimension array.