### PR TITLE
fix small typo

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -165,7 +165,7 @@ from extra.datasets import fetch_mnist
 Now we have everything we need to start training our neural network.
 We will be training for 1000 steps with a batch size of 64.
 
-We use `with Tensor.train()` set the internal flag `Tensor.training` to `True` during training.
+We use `with Tensor.train()` to set the internal flag `Tensor.training` to `True` during training.
 Upon exit, the flag is restored to its previous value by the context manager.
 
 ```python


### PR DESCRIPTION
"We use with Tensor.train() set the internal flag" -> "We use with Tensor.train() *to* set the internal flag"