### PR TITLE
metal bf16 tc support [pr]

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -41,7 +41,7 @@ def helper_tc_allclose(n:int, m:int, k:int, dtype_in:DType, dtype_out:DType, axi
   assert len([x for x in k.applied_opts if x.op is OptOps.TC]) == 1, "tensor core opt not included"
   np_c = np_a @ np_b
   if dtype_out == dtypes.half: tc_atol, tc_rtol = 1e-2, 1e-3
-  elif dtype_in == dtypes.bfloat16: tc_atol, tc_rtol = 1e-2, 3e-3
+  elif dtype_in == dtypes.bfloat16: tc_atol, tc_rtol = 1e-2, 1e-2
   else: tc_atol, tc_rtol = 5e-3, 1e-4
   np.testing.assert_allclose(np_c, out, atol=tc_atol, rtol=tc_rtol)
 
@@ -1036,14 +1036,16 @@ class TestLinearizer(unittest.TestCase):
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test requires tensor cores")
   def test_tensor_cores(self):
     for tc in Device[Device.DEFAULT].renderer.tensor_cores:
-      if (getenv("EMULATE_CUDA") or getenv("EMULATE_INTEL")) and (tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16): continue
+      if (getenv("EMULATE_CUDA") or getenv("EMULATE_INTEL") or getenv("EMULATE_METAL")) and tc.dtype_in == dtypes.bfloat16: continue
+      if CI and Device.DEFAULT == "METAL" and tc.dtype_in == dtypes.bfloat16: continue
       # for AMX, tc.dims[2] == 1 so reduceop is None thus tensor_cores are not triggered
       helper_tc_allclose(tc.dims[0], tc.dims[1], 2 if AMX else tc.dims[2], tc.dtype_in, tc.dtype_out, axis=0, tc_opt=0)
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test requires tensor cores")
   def test_tensor_cores_padded(self):
     for tc in Device[Device.DEFAULT].renderer.tensor_cores:
-      if getenv("EMULATE_CUDA") and (tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16): continue
+      if (getenv("EMULATE_CUDA") or getenv("EMULATE_METAL")) and tc.dtype_in == dtypes.bfloat16: continue
+      if CI and Device.DEFAULT == "METAL" and tc.dtype_in == dtypes.bfloat16: continue
       pad = 1
 
       # check that TC is triggered for TC_OPT=2

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -41,7 +41,7 @@ def helper_tc_allclose(n:int, m:int, k:int, dtype_in:DType, dtype_out:DType, axi
   assert len([x for x in k.applied_opts if x.op is OptOps.TC]) == 1, "tensor core opt not included"
   np_c = np_a @ np_b
   if dtype_out == dtypes.half: tc_atol, tc_rtol = 1e-2, 1e-3
-  elif dtype_in == dtypes.bfloat16: tc_atol, tc_rtol = 1e-2, 1e-2
+  elif dtype_out == dtypes.bfloat16: tc_atol, tc_rtol = 1e-2, 1e-2
   else: tc_atol, tc_rtol = 5e-3, 1e-4
   np.testing.assert_allclose(np_c, out, atol=tc_atol, rtol=tc_rtol)
 

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1036,16 +1036,17 @@ class TestLinearizer(unittest.TestCase):
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test requires tensor cores")
   def test_tensor_cores(self):
     for tc in Device[Device.DEFAULT].renderer.tensor_cores:
-      if (getenv("EMULATE_CUDA") or getenv("EMULATE_INTEL") or getenv("EMULATE_METAL")) and tc.dtype_in == dtypes.bfloat16: continue
-      if CI and Device.DEFAULT == "METAL" and tc.dtype_in == dtypes.bfloat16: continue
+      if (getenv("EMULATE_CUDA") or getenv("EMULATE_INTEL") or getenv("EMULATE_METAL")) and \
+        tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16: continue
+      if CI and Device.DEFAULT == "METAL" and tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16: continue
       # for AMX, tc.dims[2] == 1 so reduceop is None thus tensor_cores are not triggered
       helper_tc_allclose(tc.dims[0], tc.dims[1], 2 if AMX else tc.dims[2], tc.dtype_in, tc.dtype_out, axis=0, tc_opt=0)
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test requires tensor cores")
   def test_tensor_cores_padded(self):
     for tc in Device[Device.DEFAULT].renderer.tensor_cores:
-      if (getenv("EMULATE_CUDA") or getenv("EMULATE_METAL")) and tc.dtype_in == dtypes.bfloat16: continue
-      if CI and Device.DEFAULT == "METAL" and tc.dtype_in == dtypes.bfloat16: continue
+      if (getenv("EMULATE_CUDA") or getenv("EMULATE_METAL")) and tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16: continue
+      if CI and Device.DEFAULT == "METAL" and tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16: continue
       pad = 1
 
       # check that TC is triggered for TC_OPT=2

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1037,16 +1037,16 @@ class TestLinearizer(unittest.TestCase):
   def test_tensor_cores(self):
     for tc in Device[Device.DEFAULT].renderer.tensor_cores:
       if (getenv("EMULATE_CUDA") or getenv("EMULATE_INTEL") or getenv("EMULATE_METAL")) and \
-        tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16: continue
-      if CI and Device.DEFAULT == "METAL" and tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16: continue
+        (tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16): continue
+      if CI and Device.DEFAULT == "METAL" and (tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16): continue
       # for AMX, tc.dims[2] == 1 so reduceop is None thus tensor_cores are not triggered
       helper_tc_allclose(tc.dims[0], tc.dims[1], 2 if AMX else tc.dims[2], tc.dtype_in, tc.dtype_out, axis=0, tc_opt=0)
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test requires tensor cores")
   def test_tensor_cores_padded(self):
     for tc in Device[Device.DEFAULT].renderer.tensor_cores:
-      if (getenv("EMULATE_CUDA") or getenv("EMULATE_METAL")) and tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16: continue
-      if CI and Device.DEFAULT == "METAL" and tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16: continue
+      if (getenv("EMULATE_CUDA") or getenv("EMULATE_METAL")) and (tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16): continue
+      if CI and Device.DEFAULT == "METAL" and (tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16): continue
       pad = 1
 
       # check that TC is triggered for TC_OPT=2

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -249,7 +249,8 @@ class MetalRenderer(CStyleLanguage):
   shared_max = 32768
   tensor_cores = [TensorCore(dims=(8,8,8),threads=[(0,2),(1,4),(0,2),(1,2)],expanded_shape=(2,2,2,2),upcast_axes=([(1,2)],[(1,2)],[(1,2)]),
     st1_pattern=(((1,1),(0,1),(1,0),(0,3)),((0,0),(0,2),(1,3),(1,2))),st2_pattern=(((0,0),(1,1),(1,2),(0,2),(1,0)),((0,1),(0,3),(1,3))),
-    dtype_in=di,dtype_out=do,reduce_axes=[(0,8)]) for di,do in [(dtypes.float,dtypes.float),(dtypes.half,dtypes.float),(dtypes.half,dtypes.half)]]
+    dtype_in=di,dtype_out=do,reduce_axes=[(0,8)]) for di,do in [(dtypes.float,dtypes.float),(dtypes.half,dtypes.float),(dtypes.half,dtypes.half),
+                                                                (dtypes.bfloat16, dtypes.float),(dtypes.bfloat16, dtypes.bfloat16)]]
   def __init__(self): self.tensor_cores = MetalRenderer.tensor_cores if hasattr(os, 'uname') and os.uname().machine == "arm64" else []
 
   # language options

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -250,7 +250,7 @@ class MetalRenderer(CStyleLanguage):
   tensor_cores = [TensorCore(dims=(8,8,8),threads=[(0,2),(1,4),(0,2),(1,2)],expanded_shape=(2,2,2,2),upcast_axes=([(1,2)],[(1,2)],[(1,2)]),
     st1_pattern=(((1,1),(0,1),(1,0),(0,3)),((0,0),(0,2),(1,3),(1,2))),st2_pattern=(((0,0),(1,1),(1,2),(0,2),(1,0)),((0,1),(0,3),(1,3))),
     dtype_in=di,dtype_out=do,reduce_axes=[(0,8)]) for di,do in [(dtypes.float,dtypes.float),(dtypes.half,dtypes.float),(dtypes.half,dtypes.half),
-                                                                (dtypes.bfloat16, dtypes.float),(dtypes.bfloat16, dtypes.bfloat16)]]
+                                                                (dtypes.bfloat16,dtypes.float),(dtypes.bfloat16,dtypes.bfloat16)]]
   def __init__(self): self.tensor_cores = MetalRenderer.tensor_cores if hasattr(os, 'uname') and os.uname().machine == "arm64" else []
 
   # language options


### PR DESCRIPTION
### CI bf16 support

I had to skip bf16 tensor core support for Metal since CI doesn’t support it, even though it worked perfectly in my local setup. The tests failed with the error message below.

I'm currently working on bf16 support using uop-casting to simulate bf16 when the target lacks native support. I’ve encountered this issue before, and it’s confusing that bf16 is used in some pr kernels, even though CI skips all bf16 tests for Metal. I’m not sure why bf16 appears in some pr kernels despite this. (Still working on this)

``` python
# this function in test->helpers and is used for skipping tests when the dtype is not supported

def is_dtype_supported(dtype: DType, device: str = Device.DEFAULT):
  if dtype == dtypes.bfloat16:
    # NOTE: this requires bf16 buffer support
    return device in {"AMD"} or (device in {"CUDA", "NV"} and not CI and not getenv("PTX"))
```

```
FAILED test/test_linearizer.py::TestLinearizer::test_tensor_cores - 
tinygrad.device.CompileError: program_source:4:3: error: use of undeclared identifier 'bfloat'; 
did you mean 'float'?

  bfloat precast0 = (bfloat)(1.0f);
  ^~~~~~
  float
program_source:4:22: error: use of undeclared identifier 'bfloat'; did you mean 'float'?
  bfloat precast0 = (bfloat)(1.0f);
                     ^~~~~~
                     float
```

### Tolerance
(below the acc_bfloat16 kernel is the precision error for 4096x4096 matmul)
Changed tolerance from `3e-3` to `1e-2` as with the old value of r-tol, test_tensor_core_padded fails with
```
E           AssertionError: 
E           Not equal to tolerance rtol=0.003, atol=0.01
E           
E           Mismatched elements: 1 / 81 (1.23%)
E           Max absolute difference among violations: 0.02124023
E           Max relative difference among violations: 0.00650419
E            ACTUAL: array([[3.720032, 2.469727, 3.070618, 2.715088, 2.364197, 1.527222,
E                   2.63031 , 3.244385, 3.556702],
E                  [2.592651, 2.362549, 2.000488, 1.94342 , 2.192993, 1.627441,...
E            DESIRED: array([[3.71875 , 2.46875 , 3.0625  , 2.703125, 2.359375, 1.53125 ,
E                   2.625   , 3.265625, 3.546875],
E                  [2.59375 , 2.359375, 1.992188, 1.929688, 2.1875  , 1.640625,...
```

### Kernels

<details>
<summary>simple_matmul kernel acc_bf16</summary>

``` c
#include <metal_stdlib>
using namespace metal;
bfloat2 __WMMA_8_8_8___bf16___bf16(bfloat2 m, bfloat2 n, bfloat2 o) {
  simdgroup_bfloat8x8 a,b,c; a.thread_elements()[0] = m.x; a.thread_elements()[1] = m.y; b.thread_elements()[0] = n.x;
  b.thread_elements()[1] = n.y; c.thread_elements()[0] = o.x; c.thread_elements()[1] = o.y; simdgroup_multiply_accumulate(c, a, b, c);
  return bfloat2(c.thread_elements()[0], c.thread_elements()[1]);
}
kernel void r_128_32_2_4_2_2_4_512_8_2_4_4(device bfloat* data0, device bfloat* data1, device bfloat* data2, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int gidx0 = gid.x; /* 32 */
  int gidx1 = gid.y; /* 128 */
  int lidx0 = lid.x; /* 16 */
  int lidx1 = lid.y; /* 2 */
  int lidx2 = lid.z; /* 4 */
  bfloat cast0 = (bfloat)(0.0f);
  int alu0 = (gidx0<<7);
  int alu1 = (gidx1<<17);
  int alu2 = (lidx1<<14);
  int alu3 = (lidx2<<5);
  int alu4 = ((lidx0>>3)<<2);
  int alu5 = ((lidx0&1)<<1);
  int alu6 = (((lidx0>>1)&3)<<12);
  int alu7 = (alu0+alu1+alu5+alu6+alu4+alu2+alu3);
  bfloat acc0 = cast0;
  bfloat acc1 = cast0;
  bfloat acc2 = cast0;
  bfloat acc3 = cast0;
  bfloat acc4 = cast0;
  bfloat acc5 = cast0;
  bfloat acc6 = cast0;
  bfloat acc7 = cast0;
  bfloat acc8 = cast0;
  bfloat acc9 = cast0;
  bfloat acc10 = cast0;
  bfloat acc11 = cast0;
  bfloat acc12 = cast0;
  bfloat acc13 = cast0;
  bfloat acc14 = cast0;
  bfloat acc15 = cast0;
  bfloat acc16 = cast0;
  bfloat acc17 = cast0;
  bfloat acc18 = cast0;
  bfloat acc19 = cast0;
  bfloat acc20 = cast0;
  bfloat acc21 = cast0;
  bfloat acc22 = cast0;
  bfloat acc23 = cast0;
  bfloat acc24 = cast0;
  bfloat acc25 = cast0;
  bfloat acc26 = cast0;
  bfloat acc27 = cast0;
  bfloat acc28 = cast0;
  bfloat acc29 = cast0;
  bfloat acc30 = cast0;
  bfloat acc31 = cast0;
  for (int ridx0 = 0; ridx0 < 512; ridx0++) {
    int alu8 = (alu1+alu5+alu6+alu4+alu2+(ridx0<<3));
    int alu9 = (alu0+alu5+alu6+alu4+alu2+alu3+(ridx0<<15));
    bfloat val0 = *(data1+alu8+1);
    bfloat val1 = *(data1+alu8+32768);
    bfloat val2 = *(data1+alu8+32769);
    bfloat2 cast1 = bfloat2(val1,val2);
    bfloat val3 = *(data1+alu8+65536);
    bfloat val4 = *(data1+alu8+65537);
    bfloat2 cast2 = bfloat2(val3,val4);
    bfloat val5 = *(data1+alu8+98304);
    bfloat val6 = *(data1+alu8+98305);
    bfloat2 cast3 = bfloat2(val5,val6);
    bfloat val7 = *(data1+alu8);
    bfloat2 cast4 = bfloat2(val7,val0);
    bfloat val8 = *(data2+alu9+1);
    bfloat val9 = *(data2+alu9+8);
    bfloat val10 = *(data2+alu9+9);
    bfloat2 cast5 = bfloat2(val9,val10);
    bfloat2 wmma0 = __WMMA_8_8_8___bf16___bf16(cast1, cast5, bfloat2(acc10,acc11));
    bfloat2 wmma1 = __WMMA_8_8_8___bf16___bf16(cast2, cast5, bfloat2(acc18,acc19));
    bfloat2 wmma2 = __WMMA_8_8_8___bf16___bf16(cast3, cast5, bfloat2(acc26,acc27));
    bfloat2 wmma3 = __WMMA_8_8_8___bf16___bf16(cast4, cast5, bfloat2(acc2,acc3));
    acc2 = wmma3.x;
    acc3 = wmma3.y;
    acc10 = wmma0.x;
    acc11 = wmma0.y;
    acc18 = wmma1.x;
    acc19 = wmma1.y;
    acc26 = wmma2.x;
    acc27 = wmma2.y;
    bfloat val11 = *(data2+alu9+16);
    bfloat val12 = *(data2+alu9+17);
    bfloat2 cast6 = bfloat2(val11,val12);
    bfloat2 wmma4 = __WMMA_8_8_8___bf16___bf16(cast1, cast6, bfloat2(acc12,acc13));
    bfloat2 wmma5 = __WMMA_8_8_8___bf16___bf16(cast2, cast6, bfloat2(acc20,acc21));
    bfloat2 wmma6 = __WMMA_8_8_8___bf16___bf16(cast3, cast6, bfloat2(acc28,acc29));
    bfloat2 wmma7 = __WMMA_8_8_8___bf16___bf16(cast4, cast6, bfloat2(acc4,acc5));
    acc4 = wmma7.x;
    acc5 = wmma7.y;
    acc12 = wmma4.x;
    acc13 = wmma4.y;
    acc20 = wmma5.x;
    acc21 = wmma5.y;
    acc28 = wmma6.x;
    acc29 = wmma6.y;
    bfloat val13 = *(data2+alu9+24);
    bfloat val14 = *(data2+alu9+25);
    bfloat2 cast7 = bfloat2(val13,val14);
    bfloat2 wmma8 = __WMMA_8_8_8___bf16___bf16(cast1, cast7, bfloat2(acc14,acc15));
    bfloat2 wmma9 = __WMMA_8_8_8___bf16___bf16(cast2, cast7, bfloat2(acc22,acc23));
    bfloat2 wmma10 = __WMMA_8_8_8___bf16___bf16(cast3, cast7, bfloat2(acc30,acc31));
    bfloat2 wmma11 = __WMMA_8_8_8___bf16___bf16(cast4, cast7, bfloat2(acc6,acc7));
    acc6 = wmma11.x;
    acc7 = wmma11.y;
    acc14 = wmma8.x;
    acc15 = wmma8.y;
    acc22 = wmma9.x;
    acc23 = wmma9.y;
    acc30 = wmma10.x;
    acc31 = wmma10.y;
    bfloat val15 = *(data2+alu9);
    bfloat2 cast8 = bfloat2(val15,val8);
    bfloat2 wmma12 = __WMMA_8_8_8___bf16___bf16(cast1, cast8, bfloat2(acc8,acc9));
    bfloat2 wmma13 = __WMMA_8_8_8___bf16___bf16(cast2, cast8, bfloat2(acc16,acc17));
    bfloat2 wmma14 = __WMMA_8_8_8___bf16___bf16(cast3, cast8, bfloat2(acc24,acc25));
    bfloat2 wmma15 = __WMMA_8_8_8___bf16___bf16(cast4, cast8, bfloat2(acc0,acc1));
    acc0 = wmma15.x;
    acc1 = wmma15.y;
    acc8 = wmma12.x;
    acc9 = wmma12.y;
    acc16 = wmma13.x;
    acc17 = wmma13.y;
    acc24 = wmma14.x;
    acc25 = wmma14.y;
  }
  *(data0+alu7+1) = acc1;
  *(data0+alu7+8) = acc2;
  *(data0+alu7+9) = acc3;
  *(data0+alu7+16) = acc4;
  *(data0+alu7+17) = acc5;
  *(data0+alu7+24) = acc6;
  *(data0+alu7+25) = acc7;
  *(data0+alu7+32768) = acc8;
  *(data0+alu7+32769) = acc9;
  *(data0+alu7+32776) = acc10;
  *(data0+alu7+32777) = acc11;
  *(data0+alu7+32784) = acc12;
  *(data0+alu7+32785) = acc13;
  *(data0+alu7+32792) = acc14;
  *(data0+alu7+32793) = acc15;
  *(data0+alu7+65536) = acc16;
  *(data0+alu7+65537) = acc17;
  *(data0+alu7+65544) = acc18;
  *(data0+alu7+65545) = acc19;
  *(data0+alu7+65552) = acc20;
  *(data0+alu7+65553) = acc21;
  *(data0+alu7+65560) = acc22;
  *(data0+alu7+65561) = acc23;
  *(data0+alu7+98304) = acc24;
  *(data0+alu7+98305) = acc25;
  *(data0+alu7+98312) = acc26;
  *(data0+alu7+98313) = acc27;
  *(data0+alu7+98320) = acc28;
  *(data0+alu7+98321) = acc29;
  *(data0+alu7+98328) = acc30;
  *(data0+alu7+98329) = acc31;
  *(data0+alu7) = acc0;
}
```
has the following precision error for 4096x4096
```
AssertionError: 
Not equal to tolerance rtol=0.03, atol=0.0001

Mismatched elements: 8276880 / 16777216 (49.3%)
Max absolute difference among violations: 169.47229
Max relative difference among violations: 0.17553304
 ACTUAL: array([[ 972.,  996., 1024., ...,  984.,  996., 1004.],
       [ 976.,  948.,  968., ...,  960.,  988.,  968.],
       [ 980.,  984.,  984., ...,  960.,  976.,  984.],...
 DESIRED: array([[1004.77045, 1012.2803 , 1038.5452 , ..., 1021.4076 , 1031.8147 ,
        1024.8218 ],
       [ 988.3465 ,  982.401  , 1008.8924 , ...,  995.7263 , 1011.1098 ,...
```
</details>

<details>
<summary>simple_matmul kernel acc_float</summary>

``` c
#include <metal_stdlib>
using namespace metal;
float2 __WMMA_8_8_8___bf16_float(bfloat2 m, bfloat2 n, float2 o) {
  simdgroup_float8x8 a,b,c; a.thread_elements()[0] = m.x; a.thread_elements()[1] = m.y; b.thread_elements()[0] = n.x;
  b.thread_elements()[1] = n.y; c.thread_elements()[0] = o.x; c.thread_elements()[1] = o.y; simdgroup_multiply_accumulate(c, a, b, c);
  return float2(c.thread_elements()[0], c.thread_elements()[1]);
}
kernel void r_128_32_2_4_2_2_4_512_8_2_4_4(device bfloat* data0, device bfloat* data1, device bfloat* data2, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int gidx0 = gid.x; /* 32 */
  int gidx1 = gid.y; /* 128 */
  int lidx0 = lid.x; /* 16 */
  int lidx1 = lid.y; /* 2 */
  int lidx2 = lid.z; /* 4 */
  int alu0 = (gidx0<<7);
  int alu1 = (gidx1<<17);
  int alu2 = (lidx1<<14);
  int alu3 = (lidx2<<5);
  int alu4 = ((lidx0>>3)<<2);
  int alu5 = ((lidx0&1)<<1);
  int alu6 = (((lidx0>>1)&3)<<12);
  int alu7 = (alu0+alu1+alu5+alu6+alu4+alu2+alu3);
  float acc0 = 0.0f;
  float acc1 = 0.0f;
  float acc2 = 0.0f;
  float acc3 = 0.0f;
  float acc4 = 0.0f;
  float acc5 = 0.0f;
  float acc6 = 0.0f;
  float acc7 = 0.0f;
  float acc8 = 0.0f;
  float acc9 = 0.0f;
  float acc10 = 0.0f;
  float acc11 = 0.0f;
  float acc12 = 0.0f;
  float acc13 = 0.0f;
  float acc14 = 0.0f;
  float acc15 = 0.0f;
  float acc16 = 0.0f;
  float acc17 = 0.0f;
  float acc18 = 0.0f;
  float acc19 = 0.0f;
  float acc20 = 0.0f;
  float acc21 = 0.0f;
  float acc22 = 0.0f;
  float acc23 = 0.0f;
  float acc24 = 0.0f;
  float acc25 = 0.0f;
  float acc26 = 0.0f;
  float acc27 = 0.0f;
  float acc28 = 0.0f;
  float acc29 = 0.0f;
  float acc30 = 0.0f;
  float acc31 = 0.0f;
  for (int ridx0 = 0; ridx0 < 512; ridx0++) {
    int alu8 = (alu1+alu5+alu6+alu4+alu2+(ridx0<<3));
    int alu9 = (alu0+alu5+alu6+alu4+alu2+alu3+(ridx0<<15));
    bfloat val0 = *(data1+alu8+1);
    bfloat val1 = *(data1+alu8+32768);
    bfloat val2 = *(data1+alu8+32769);
    bfloat2 cast0 = bfloat2(val1,val2);
    bfloat val3 = *(data1+alu8+65536);
    bfloat val4 = *(data1+alu8+65537);
    bfloat2 cast1 = bfloat2(val3,val4);
    bfloat val5 = *(data1+alu8+98304);
    bfloat val6 = *(data1+alu8+98305);
    bfloat2 cast2 = bfloat2(val5,val6);
    bfloat val7 = *(data1+alu8);
    bfloat2 cast3 = bfloat2(val7,val0);
    bfloat val8 = *(data2+alu9+1);
    bfloat val9 = *(data2+alu9+8);
    bfloat val10 = *(data2+alu9+9);
    bfloat2 cast4 = bfloat2(val9,val10);
    float2 wmma0 = __WMMA_8_8_8___bf16_float(cast0, cast4, float2(acc10,acc11));
    float2 wmma1 = __WMMA_8_8_8___bf16_float(cast1, cast4, float2(acc18,acc19));
    float2 wmma2 = __WMMA_8_8_8___bf16_float(cast2, cast4, float2(acc26,acc27));
    float2 wmma3 = __WMMA_8_8_8___bf16_float(cast3, cast4, float2(acc2,acc3));
    acc2 = wmma3.x;
    acc3 = wmma3.y;
    acc10 = wmma0.x;
    acc11 = wmma0.y;
    acc18 = wmma1.x;
    acc19 = wmma1.y;
    acc26 = wmma2.x;
    acc27 = wmma2.y;
    bfloat val11 = *(data2+alu9+16);
    bfloat val12 = *(data2+alu9+17);
    bfloat2 cast5 = bfloat2(val11,val12);
    float2 wmma4 = __WMMA_8_8_8___bf16_float(cast0, cast5, float2(acc12,acc13));
    float2 wmma5 = __WMMA_8_8_8___bf16_float(cast1, cast5, float2(acc20,acc21));
    float2 wmma6 = __WMMA_8_8_8___bf16_float(cast2, cast5, float2(acc28,acc29));
    float2 wmma7 = __WMMA_8_8_8___bf16_float(cast3, cast5, float2(acc4,acc5));
    acc4 = wmma7.x;
    acc5 = wmma7.y;
    acc12 = wmma4.x;
    acc13 = wmma4.y;
    acc20 = wmma5.x;
    acc21 = wmma5.y;
    acc28 = wmma6.x;
    acc29 = wmma6.y;
    bfloat val13 = *(data2+alu9+24);
    bfloat val14 = *(data2+alu9+25);
    bfloat2 cast6 = bfloat2(val13,val14);
    float2 wmma8 = __WMMA_8_8_8___bf16_float(cast0, cast6, float2(acc14,acc15));
    float2 wmma9 = __WMMA_8_8_8___bf16_float(cast1, cast6, float2(acc22,acc23));
    float2 wmma10 = __WMMA_8_8_8___bf16_float(cast2, cast6, float2(acc30,acc31));
    float2 wmma11 = __WMMA_8_8_8___bf16_float(cast3, cast6, float2(acc6,acc7));
    acc6 = wmma11.x;
    acc7 = wmma11.y;
    acc14 = wmma8.x;
    acc15 = wmma8.y;
    acc22 = wmma9.x;
    acc23 = wmma9.y;
    acc30 = wmma10.x;
    acc31 = wmma10.y;
    bfloat val15 = *(data2+alu9);
    bfloat2 cast7 = bfloat2(val15,val8);
    float2 wmma12 = __WMMA_8_8_8___bf16_float(cast0, cast7, float2(acc8,acc9));
    float2 wmma13 = __WMMA_8_8_8___bf16_float(cast1, cast7, float2(acc16,acc17));
    float2 wmma14 = __WMMA_8_8_8___bf16_float(cast2, cast7, float2(acc24,acc25));
    float2 wmma15 = __WMMA_8_8_8___bf16_float(cast3, cast7, float2(acc0,acc1));
    acc0 = wmma15.x;
    acc1 = wmma15.y;
    acc8 = wmma12.x;
    acc9 = wmma12.y;
    acc16 = wmma13.x;
    acc17 = wmma13.y;
    acc24 = wmma14.x;
    acc25 = wmma14.y;
  }
  *(data0+alu7+1) = (bfloat)(acc1);
  *(data0+alu7+8) = (bfloat)(acc2);
  *(data0+alu7+9) = (bfloat)(acc3);
  *(data0+alu7+16) = (bfloat)(acc4);
  *(data0+alu7+17) = (bfloat)(acc5);
  *(data0+alu7+24) = (bfloat)(acc6);
  *(data0+alu7+25) = (bfloat)(acc7);
  *(data0+alu7+32768) = (bfloat)(acc8);
  *(data0+alu7+32769) = (bfloat)(acc9);
  *(data0+alu7+32776) = (bfloat)(acc10);
  *(data0+alu7+32777) = (bfloat)(acc11);
  *(data0+alu7+32784) = (bfloat)(acc12);
  *(data0+alu7+32785) = (bfloat)(acc13);
  *(data0+alu7+32792) = (bfloat)(acc14);
  *(data0+alu7+32793) = (bfloat)(acc15);
  *(data0+alu7+65536) = (bfloat)(acc16);
  *(data0+alu7+65537) = (bfloat)(acc17);
  *(data0+alu7+65544) = (bfloat)(acc18);
  *(data0+alu7+65545) = (bfloat)(acc19);
  *(data0+alu7+65552) = (bfloat)(acc20);
  *(data0+alu7+65553) = (bfloat)(acc21);
  *(data0+alu7+65560) = (bfloat)(acc22);
  *(data0+alu7+65561) = (bfloat)(acc23);
  *(data0+alu7+98304) = (bfloat)(acc24);
  *(data0+alu7+98305) = (bfloat)(acc25);
  *(data0+alu7+98312) = (bfloat)(acc26);
  *(data0+alu7+98313) = (bfloat)(acc27);
  *(data0+alu7+98320) = (bfloat)(acc28);
  *(data0+alu7+98321) = (bfloat)(acc29);
  *(data0+alu7+98328) = (bfloat)(acc30);
  *(data0+alu7+98329) = (bfloat)(acc31);
  *(data0+alu7) = (bfloat)(acc0);
}
```
</details>


