### PR TITLE
move image dtype fixup [pr]

### DIFF
--- a/tinygrad/engine/fuse.py
+++ b/tinygrad/engine/fuse.py
@@ -165,15 +165,4 @@ def get_realizes(outs:List[LazyBuffer]) -> Tuple[List[List[Buffer]], Dict[Buffer
         raise RuntimeError(f"can't double realize in one schedule, Buffer is realizing both {dup} and {buf}")
       lazybufs_to_realize[buf.buffer] = buf
       output_groups[reduce_for_op.get(buf, buf)].append(buf.buffer)
-
-      # make things that can't be images not images
-      if isinstance(buf.dtype, ImageDType) and (prod(buf.shape) != prod(buf.dtype.shape) or
-                                                not any(buf.shape[x]%4 == 0 for x in buf.st.unit_stride_axes())):
-        if DEBUG >= 2: print(f"forcing image {buf.dtype} with shape {buf.shape} to float32")
-        buf.dtype = dtypes.float32
-        # hack the underlying buffer too
-        if buf.base is buf:
-          assert not hasattr(buf.buffer, '_buf'), "can't fixup allocated buffer"
-          buf.buffer.dtype = dtypes.float32
-          buf.buffer.options = None
   return list(output_groups.values()), lazybufs_to_realize, assign_targets


### PR DESCRIPTION
prereq for #7443 - This hack is very annoying. Maybe it should be a graph_rewrite rule when `LazyBuffer = UOp`