### PR TITLE
Add shl and shr to llvmir

### DIFF
--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -143,15 +143,10 @@ def get_late_rewrite_patterns(ops):
   # rewrite MUL/IDIV to SHL+SHR
   if BinaryOps.SHL in ops and BinaryOps.SHR in ops:
     pat += [
-    # *** enforce type alignment for shl and shr ***
-    (UPat.var("x") << UPat.var("y"), lambda x, y: x << y.cast(x.dtype) if x.dtype != y.dtype else None),
-    (UPat.var("x") >> UPat.var("y"), lambda x, y: x >> y.cast(x.dtype) if x.dtype != y.dtype else None),
-    # *** (x  * (2**y)) -> shl(x,y) ***
     (UPat(UOps.ALU, arg=BinaryOps.MUL, dtype=dtypes.ints, src=[UPat.cvar("const"), UPat.var("mul")]), lambda mul, const:
-      UOp(UOps.ALU, mul.dtype, (mul, UOp.const(dtypes.int, powers_of_two[const.arg])), BinaryOps.SHL) if const.arg in powers_of_two else None),
-    # *** (x // (2**y)) -> shr(x,y) ***
+      mul << powers_of_two[const.arg] if const.arg in powers_of_two else None), # (x  * (2**y)) -> shl(x,y)
     (UPat(UOps.ALU, arg=BinaryOps.IDIV, src=(UPat.var("div"), UPat.cvar("const"))), lambda div, const:
-      UOp(UOps.ALU, div.dtype, (div, UOp.const(dtypes.int, powers_of_two[const.arg])), BinaryOps.SHR) if const.arg in powers_of_two else None)]
+      div >> powers_of_two[const.arg] if const.arg in powers_of_two else None)] # (x // (2**y)) -> shr(x,y)
   if UnaryOps.NEG in ops:
     pat += [(UPat.var('x')*-1, lambda x: x.alu(UnaryOps.NEG))]
     if BinaryOps.SUB in ops: pat += [(UPat.var('x')+UPat.var('y').alu(UnaryOps.NEG), lambda x,y: x.alu(BinaryOps.SUB, y))]

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -143,7 +143,7 @@ def get_late_rewrite_patterns(ops):
   # rewrite MUL/IDIV to SHL+SHR
   if BinaryOps.SHL in ops and BinaryOps.SHR in ops:
     pat += [
-    # *** enforce type alignment for shl ad shr ***
+    # *** enforce type alignment for shl and shr ***
     (UPat.var("x") << UPat.var("y"), lambda x, y: x << y.cast(x.dtype) if x.dtype != y.dtype else None),
     (UPat.var("x") >> UPat.var("y"), lambda x, y: x >> y.cast(x.dtype) if x.dtype != y.dtype else None),
     # *** (x  * (2**y)) -> shl(x,y) ***

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -789,7 +789,7 @@ spec = PatternMatcher([
   (UPat(UOps.ALU, dtype=dtypes.bool, src=(UPat(name="x"), UPat(name="y")), arg=BinaryOps.CMPNE), lambda x,y: x.dtype == y.dtype),
   # and SHL/SHR, the shift distance is an int
   (UPat(UOps.ALU, src=(UPat(name="x"), UPat()), name="alu", arg=BinaryOps.SHL), lambda alu,x: alu.dtype == x.dtype),
-  (UPat(UOps.ALU, src=(UPat(name="x"), UPat(name="y")), name="alu", arg=BinaryOps.SHR), lambda alu,x,y: alu.dtype == x.dtype == y.dtype),
+  (UPat(UOps.ALU, src=(UPat(name="x"), UPat()), name="alu", arg=BinaryOps.SHR), lambda alu,x: alu.dtype == x.dtype),
   (UPat(UOps.ALU, arg=BinaryOps.IDIV, name="x"), lambda x: None if dtypes.is_int(x.dtype) else False),
   (UPat(UOps.ALU, name="x"), lambda x: all(x.dtype == y.dtype for y in x.src)),
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -788,7 +788,7 @@ spec = PatternMatcher([
   (UPat(UOps.ALU, dtype=dtypes.bool, src=(UPat(name="x"), UPat(name="y")), arg=BinaryOps.CMPLT), lambda x,y: x.dtype == y.dtype),
   (UPat(UOps.ALU, dtype=dtypes.bool, src=(UPat(name="x"), UPat(name="y")), arg=BinaryOps.CMPNE), lambda x,y: x.dtype == y.dtype),
   # and SHL/SHR, the shift distance is an int
-  (UPat(UOps.ALU, src=(UPat(name="x"), UPat(name="y")), name="alu", arg=BinaryOps.SHL), lambda alu,x,y: alu.dtype == x.dtype == y.dtype),
+  (UPat(UOps.ALU, src=(UPat(name="x"), UPat()), name="alu", arg=BinaryOps.SHL), lambda alu,x: alu.dtype == x.dtype),
   (UPat(UOps.ALU, src=(UPat(name="x"), UPat(name="y")), name="alu", arg=BinaryOps.SHR), lambda alu,x,y: alu.dtype == x.dtype == y.dtype),
   (UPat(UOps.ALU, arg=BinaryOps.IDIV, name="x"), lambda x: None if dtypes.is_int(x.dtype) else False),
   (UPat(UOps.ALU, name="x"), lambda x: all(x.dtype == y.dtype for y in x.src)),

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -788,8 +788,8 @@ spec = PatternMatcher([
   (UPat(UOps.ALU, dtype=dtypes.bool, src=(UPat(name="x"), UPat(name="y")), arg=BinaryOps.CMPLT), lambda x,y: x.dtype == y.dtype),
   (UPat(UOps.ALU, dtype=dtypes.bool, src=(UPat(name="x"), UPat(name="y")), arg=BinaryOps.CMPNE), lambda x,y: x.dtype == y.dtype),
   # and SHL/SHR, the shift distance is an int
-  (UPat(UOps.ALU, src=(UPat(name="x"), UPat()), name="alu", arg=BinaryOps.SHL), lambda alu,x: alu.dtype == x.dtype),
-  (UPat(UOps.ALU, src=(UPat(name="x"), UPat()), name="alu", arg=BinaryOps.SHR), lambda alu,x: alu.dtype == x.dtype),
+  (UPat(UOps.ALU, src=(UPat(name="x"), UPat(name="y")), name="alu", arg=BinaryOps.SHL), lambda alu,x,y: alu.dtype == x.dtype == y.dtype),
+  (UPat(UOps.ALU, src=(UPat(name="x"), UPat(name="y")), name="alu", arg=BinaryOps.SHR), lambda alu,x,y: alu.dtype == x.dtype == y.dtype),
   (UPat(UOps.ALU, arg=BinaryOps.IDIV, name="x"), lambda x: None if dtypes.is_int(x.dtype) else False),
   (UPat(UOps.ALU, name="x"), lambda x: all(x.dtype == y.dtype for y in x.src)),
 

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -63,7 +63,7 @@ class LLVMRenderer(Renderer):
     BinaryOps.MAX: lambda builder, x, y, dtype: builder.select(builder.icmp_unsigned(">", x, y) if is_bool_or_unsigned(dtype) else builder.icmp_signed(">", x, y) if dtypes.is_int(dtype) else builder.fcmp_unordered(">", x, y, flags=MFLAGS), x, y),  # noqa: E501
     BinaryOps.MOD: lambda builder, x, y, dtype: builder.urem(x, y) if is_bool_or_unsigned(dtype) else builder.srem(x, y) if dtypes.is_int(dtype) else builder.frem(x, y),  # noqa: E501
     BinaryOps.XOR: lambda builder, x, y, dtype: builder.xor(x, y), BinaryOps.AND: lambda builder, x, y, dtype: builder.and_(x, y), BinaryOps.OR: lambda builder, x, y, dtype: builder.or_(x, y), # noqa: E501
-    BinaryOps.SHL: lambda builder, x, y, dtype: builder.shl(x,y), BinaryOps.SHR: lambda builder, x, y, dtype: builder.lshr(x,y) if dtypes.is_unsigned(dtype) else builder.ashr(x,y), # noqa: E501
+    BinaryOps.SHL: lambda builder, x, y, dtype: builder.shl(x, y), BinaryOps.SHR: lambda builder, x, y, dtype: builder.lshr(x, y) if dtypes.is_unsigned(dtype) else builder.ashr(x, y), # noqa: E501
     TernaryOps.WHERE: lambda builder, x, y, z, dtype: builder.select(x, y, z)}
 
   def render(self, name:str, uops:List[UOp]) -> str:

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -1,7 +1,7 @@
 from typing import Dict, Callable, List, Optional
 from llvmlite import ir
 from tinygrad.dtype import DType, PtrDType, dtypes
-from tinygrad.ops import Op, UnaryOps, BinaryOps, TernaryOps, UOps, UOp, PatternMatcher, UPat
+from tinygrad.ops import Op, UnaryOps, BinaryOps, TernaryOps, UOps, UOp
 from tinygrad.renderer import Renderer
 
 MFLAGS = ('nsz', 'arcp', 'contract', 'afn', 'reassoc') # All from fast math, but nnan and ninf
@@ -65,10 +65,6 @@ class LLVMRenderer(Renderer):
     BinaryOps.XOR: lambda builder, x, y, dtype: builder.xor(x, y), BinaryOps.AND: lambda builder, x, y, dtype: builder.and_(x, y), BinaryOps.OR: lambda builder, x, y, dtype: builder.or_(x, y), # noqa: E501
     BinaryOps.SHL: lambda builder, x, y, dtype: builder.shl(x,y), BinaryOps.SHR: lambda builder, x, y, dtype: builder.lshr(x,y) if dtypes.is_unsigned(dtype) else builder.ashr(x,y), # noqa: E501
     TernaryOps.WHERE: lambda builder, x, y, z, dtype: builder.select(x, y, z)}
-  extra_matcher = PatternMatcher([
-    (UPat(UOps.ALU, arg=BinaryOps.SHL, src=(UPat.var("x"), UPat.var("y"))), lambda x, y: x << y.cast(x.dtype) if x.dtype != y.dtype else None),
-    (UPat(UOps.ALU, arg=BinaryOps.SHR, src=(UPat.var("x"), UPat.var("y"))), lambda x, y: x >> y.cast(x.dtype) if x.dtype != y.dtype else None),
-  ])
 
   def render(self, name:str, uops:List[UOp]) -> str:
     # all llvm stuff goes into a module

--- a/tinygrad/renderer/ptx.py
+++ b/tinygrad/renderer/ptx.py
@@ -49,6 +49,7 @@ ptx_matcher = PatternMatcher([
   # load/store use pointer arithmetic, and the cast does nothing
   (UPat(UOps.INDEX, src=(UPat.var("buf"), UPat.var("idx"))), lambda buf,idx: buf.cast(dtypes.int64) + idx.cast(dtypes.int64)*buf.dtype.itemsize),
   (UPat(UOps.CAST, name="x"), lambda x: x.src[0] if isinstance(x.dtype, PtrDType) else None),
+  (UPat() << UPat.var("y"), lambda y: y.cast(dtypes.uint32) if y.dtype != dtypes.uint32 else None),
 ])
 
 class PTXRenderer(Renderer):

--- a/tinygrad/renderer/ptx.py
+++ b/tinygrad/renderer/ptx.py
@@ -49,8 +49,9 @@ ptx_matcher = PatternMatcher([
   # load/store use pointer arithmetic, and the cast does nothing
   (UPat(UOps.INDEX, src=(UPat.var("buf"), UPat.var("idx"))), lambda buf,idx: buf.cast(dtypes.int64) + idx.cast(dtypes.int64)*buf.dtype.itemsize),
   (UPat(UOps.CAST, name="x"), lambda x: x.src[0] if isinstance(x.dtype, PtrDType) else None),
-  (UPat.var("x") << UPat.var("y"), lambda x,y: UOp(UOps.ALU,x.dtype,(x,y.cast(dtypes.uint32)),BinaryOps.SHL) if y.dtype != dtypes.uint32 else None),
-  (UPat.var("x") >> UPat.var("y"), lambda x,y: UOp(UOps.ALU,x.dtype,(x,y.cast(dtypes.uint32)),BinaryOps.SHR) if y.dtype != dtypes.uint32 else None),
+  # ptx shr and shl instructions require y to be uint
+  (UPat.var("x") << UPat.var("y"), lambda x,y: UOp(UOps.ALU, x.dtype, (x,y.cast(dtypes.uint)), BinaryOps.SHL) if y.dtype != dtypes.uint else None),
+  (UPat.var("x") >> UPat.var("y"), lambda x,y: UOp(UOps.ALU, x.dtype, (x,y.cast(dtypes.uint)), BinaryOps.SHR) if y.dtype != dtypes.uint else None),
 ])
 
 class PTXRenderer(Renderer):

--- a/tinygrad/renderer/ptx.py
+++ b/tinygrad/renderer/ptx.py
@@ -49,7 +49,7 @@ ptx_matcher = PatternMatcher([
   # load/store use pointer arithmetic, and the cast does nothing
   (UPat(UOps.INDEX, src=(UPat.var("buf"), UPat.var("idx"))), lambda buf,idx: buf.cast(dtypes.int64) + idx.cast(dtypes.int64)*buf.dtype.itemsize),
   (UPat(UOps.CAST, name="x"), lambda x: x.src[0] if isinstance(x.dtype, PtrDType) else None),
-  (UPat() << UPat.var("y"), lambda y: y.cast(dtypes.uint32) if y.dtype != dtypes.uint32 else None),
+  (UPat.var("x") << UPat.var("y"), lambda x,y: x << y.cast(dtypes.uint32) if y.dtype != dtypes.uint32 else None),
 ])
 
 class PTXRenderer(Renderer):

--- a/tinygrad/renderer/ptx.py
+++ b/tinygrad/renderer/ptx.py
@@ -49,7 +49,8 @@ ptx_matcher = PatternMatcher([
   # load/store use pointer arithmetic, and the cast does nothing
   (UPat(UOps.INDEX, src=(UPat.var("buf"), UPat.var("idx"))), lambda buf,idx: buf.cast(dtypes.int64) + idx.cast(dtypes.int64)*buf.dtype.itemsize),
   (UPat(UOps.CAST, name="x"), lambda x: x.src[0] if isinstance(x.dtype, PtrDType) else None),
-  (UPat.var("x") << UPat.var("y"), lambda x,y: x << y.cast(dtypes.uint32) if y.dtype != dtypes.uint32 else None),
+  (UPat.var("x") << UPat.var("y"), lambda x,y: UOp(UOps.ALU,x.dtype,(x,y.cast(dtypes.uint32)),BinaryOps.SHL) if y.dtype != dtypes.uint32 else None),
+  (UPat.var("x") >> UPat.var("y"), lambda x,y: UOp(UOps.ALU,x.dtype,(x,y.cast(dtypes.uint32)),BinaryOps.SHR) if y.dtype != dtypes.uint32 else None),
 ])
 
 class PTXRenderer(Renderer):


### PR DESCRIPTION
Saw chenyu pr on shl and shr refactor of transcendental and most of llvm tests failed due to the lack of support of those op in the backend. I don't know if it was removed or never added to the backend for some specific reason but I believe it is worth having support for them in llvm backend.