### PR TITLE
Split SDXL Gen Fix

### DIFF
--- a/examples/sdxl.py
+++ b/examples/sdxl.py
@@ -303,7 +303,7 @@ class VanillaCFG(Guider):
 
 class SplitVanillaCFG(Guider):
   def __call__(self, denoiser, x:Tensor, s:Tensor, c:Dict, uc:Dict) -> Tensor:
-    x_u = denoiser(x, s, uc)
+    x_u = denoiser(x, s, uc).clone().realize()
     x_c = denoiser(x, s, c)
     x_pred = x_u + self.scale*(x_c - x_u)
     return x_pred


### PR DESCRIPTION
## Overview

Implements the fix when calling a JIT function 2 separate times before using the result.

This PR relies on the merging of #7154 and will be converted from draft to PR once that is done.

## Testing

Ran SDXL batched inference code and computed the CLIP score (higher is better).

Before
```
clip_score: 0.2597
```

After
```
clip_score: 0.3468
```
