### PR TITLE
failure test case for pool ops

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1818,12 +1818,12 @@ class TestOps(unittest.TestCase):
           lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=ksz),
           lambda x: Tensor.avg_pool2d(x, kernel_size=ksz), rtol=1e-5)
 
-  # TODO: fix
+  # TODO fix edge case
   @unittest.expectedFailure
   def test_avgpool2d_failure(self):
-    helper_test_op([(1,1,32,32)],
-      lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=(1,2), padding=(0,1), stride=(5,1), count_include_pad=False),
-      lambda x: Tensor.avg_pool2d(x, kernel_size=(1,2), padding=(0,1), stride=(5,1), count_include_pad=False), rtol=1e-5)
+    helper_test_op([(1,1,8,8)],
+      lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=(1,2), padding=(0,1), stride=(5,1)),
+      lambda x: Tensor.avg_pool2d(x, kernel_size=(1,2), padding=(0,1), stride=(5,1)), rtol=1e-5)
 
   def test_avgpool2d_padding(self):
     shape = (32,2,111,28)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1818,6 +1818,13 @@ class TestOps(unittest.TestCase):
           lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=ksz),
           lambda x: Tensor.avg_pool2d(x, kernel_size=ksz), rtol=1e-5)
 
+  # TODO: fix
+  @unittest.expectedFailure
+  def test_avgpool2d_failure(self):
+    helper_test_op([(1,1,32,32)],
+      lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=(1,2), padding=(0,1), stride=(5,1), count_include_pad=False),
+      lambda x: Tensor.avg_pool2d(x, kernel_size=(1,2), padding=(0,1), stride=(5,1), count_include_pad=False), rtol=1e-5)
+
   def test_avgpool2d_padding(self):
     shape = (32,2,111,28)
     for ksz in [(2,2), (3,3), 2, 3, (3,2)]:


### PR DESCRIPTION
Currently trying to find a way to have `ceil_mode` fit nicely in code
spammed some tests (fuzzed?) for our pools and found a failure case that should pass

exact error is 
`AssertionError: invalid shrink ((0, 1), (0, 1), (0, 1), (0, 10), (0, 2), (0, 9)) for (1, 1, 1, 9, 2, 11)`
raised by the `shrink` from this in `_pool`
```
      # handle stride
      xup = xup.shrink(
        tuple(noop_ + flatten(((0,k), (0,o*s)) for k,o,s in zip(k_, o_, s_)))).reshape(noop_ + flatten((k,o,s) for k,o,s in zip(k_, o_, s_)))
```

real output should be
```
In [48]: torch.nn.functional.avg_pool2d(x, kernel_size=(1,2), padding=(0,1), stride=(5,1), count_include_pad=False).shape
Out[48]: torch.Size([1, 1, 2, 9])
```

I'll think about this a bit more and see if there's a clever way to have both this fixed and ceil_mode added.