### PR TITLE
ConstLike type [pr]

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1139,4 +1139,4 @@ renderer = PatternMatcher([
 sint = Union[int, UOp]
 Variable = UOp
 
-ConstLike = ConstType|Variable|Tuple[ConstType, ...]
+ConstLike = Union[ConstType, Variable, Tuple[ConstType, ...]]


### PR DESCRIPTION
`ConstLike = ConstType|Variable|Tuple[ConstType, ...]`. fixed the wrong `Tuple[ConstType]`