### PR TITLE
fix test_schedule conv2d bug

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1634,7 +1634,7 @@ class TestOps(unittest.TestCase):
     self.helper_test_exception([(1,1,6,7), (6,1,3,3)],
                                lambda x,w:torch.nn.functional.conv2d(x,w,dilation=3),
                                lambda x,w: Tensor.conv2d(x,w,dilation=3), expected=(RuntimeError, AssertionError))
-    # regression test for ____
+    # regression test for https://github.com/tinygrad/tinygrad/pull/7549/
     self.helper_test_exception([(2,16,2,2), (32,16,3,3)], lambda x,w:torch.nn.functional.conv2d(x,w), lambda x,w: Tensor.conv2d(x,w),
                                expected=(RuntimeError, AssertionError))
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1629,6 +1629,15 @@ class TestOps(unittest.TestCase):
   def test_conv2d_bs_1_cin_1(self): self._test_conv2d(bs=1, cin=1)
   def test_conv2d_bs_4_cin_1(self): self._test_conv2d(bs=4, cin=1)
 
+  def test_conv2d_errors(self):
+    # kernel size cannot be larger than input size
+    self.helper_test_exception([(1,1,6,7), (6,1,3,3)],
+                               lambda x,w:torch.nn.functional.conv2d(x,w,dilation=3),
+                               lambda x,w: Tensor.conv2d(x,w,dilation=3), expected=(RuntimeError, AssertionError))
+    # regression test for ____
+    self.helper_test_exception([(2,16,2,2), (32,16,3,3)], lambda x,w:torch.nn.functional.conv2d(x,w), lambda x,w: Tensor.conv2d(x,w),
+                               expected=(RuntimeError, AssertionError))
+
   def test_large_input_conv2d(self):
     bs = 4
     cin = 16

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -932,7 +932,7 @@ class TestSchedule(unittest.TestCase):
     with Tensor.train():
       img = Tensor.empty(2,3,4,4)
       c1 = nn.Conv2d(3,16,3,bias=False)
-      c2 = nn.Conv2d(16,32,3,bias=False)
+      c2 = nn.Conv2d(16,32,2,bias=False)
       _realize_weights([c1, c2])
       opt = nn.optim.Adam(nn.state.get_parameters([c1, c2]), lr=1e-4)
       opt.zero_grad()
@@ -953,23 +953,23 @@ class TestSchedule(unittest.TestCase):
     with Tensor.train():
       img = Tensor.empty(2,3,4,4)
       c1 = nn.Conv2d(3,16,3,bias=False)
-      c2 = nn.Conv2d(16,32,3,bias=False)
+      c2 = nn.Conv2d(16,32,2,bias=False)
       _realize_weights([c1, c2])
       opt = nn.optim.SGD(nn.state.get_parameters([c1, c2]))
       opt.zero_grad()
       c2(c1(img).relu()).relu().sum().backward()
-      check_schedule(opt.schedule_step(), 6)
+      check_schedule(opt.schedule_step(), 8)
 
   def test_fold_2convs_sgd_nesterov_momentum_wd(self):
     with Tensor.train():
       img = Tensor.empty(2,3,4,4)
       c1 = nn.Conv2d(3,16,3,bias=False)
-      c2 = nn.Conv2d(16,32,3,bias=False)
+      c2 = nn.Conv2d(16,32,2,bias=False)
       _realize_weights([c1, c2])
       opt = nn.optim.SGD(nn.state.get_parameters([c1, c2]), nesterov=True, momentum=0.9, weight_decay=0.1)
       opt.zero_grad()
       c2(c1(img).relu()).relu().sum().backward()
-      check_schedule(opt.schedule_step(), 8)
+      check_schedule(opt.schedule_step(), 10)
 
   def test_sgd_4convs_fuse(self):
     with Tensor.train():

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1945,7 +1945,7 @@ class Tensor(SimpleMathTrait):  # pylint: disable=abstract-method
     s_, d_ = make_tuple(stride, len(k_)), make_tuple(dilation, len(k_))
     assert len(k_) == len(s_) == len(d_), f"stride/dilation mismatch kernel:{k_} stride:{s_} dilation:{d_}"
     noop_, i_ = [None] * len(self.shape[:-len(k_)]), self.shape[-len(k_):]
-    assert all(d*(k-1)+1 <= i for k,d,i in zip(k_, d_, i_)), "kernel size cannot be greater than actual input size"
+    assert all(resolve(d*(k-1)+1 <= i) for k,d,i in zip(k_, d_, i_)), "kernel size cannot be greater than actual input size"
     o_ = [ceildiv(i - d * (k-1), s) for i,d,k,s in zip(i_, d_, k_, s_)]
     if any(resolve(k > s) for k,s in zip(k_, s_)) or any(d != 1 for d in d_):
       # repeats such that we don't need padding

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1945,6 +1945,7 @@ class Tensor(SimpleMathTrait):  # pylint: disable=abstract-method
     s_, d_ = make_tuple(stride, len(k_)), make_tuple(dilation, len(k_))
     assert len(k_) == len(s_) == len(d_), f"stride/dilation mismatch kernel:{k_} stride:{s_} dilation:{d_}"
     noop_, i_ = [None] * len(self.shape[:-len(k_)]), self.shape[-len(k_):]
+    assert all(d*(k-1)+1 <= i for k,d,i in zip(k_, d_, i_)), "kernel size cannot be greater than actual input size"
     o_ = [ceildiv(i - d * (k-1), s) for i,d,k,s in zip(i_, d_, k_, s_)]
     if any(resolve(k > s) for k,s in zip(k_, s_)) or any(d != 1 for d in d_):
       # repeats such that we don't need padding


### PR DESCRIPTION
wrote a fix for the pool edge case but hit problems in `test_schedule`

it turns out that the 3 tests in `test_schedule` was doing conv with input shape `[2,2]` and weight shape `[3,3]` and was passing. 
Torch raises error for this `RuntimeError: Calculated padded input size per channel: (2 x 2). Kernel size: (3 x 3). Kernel size can't be greater than actual input size`
so I changed the weight shape, and kernel count increased....
I'm not sure whats suppose to fuse and what's not suppose to fuse.
also not sure if decreasing the weight shape is even the right test...