### PR TITLE
failing test for View.__add__ RecursionError

### DIFF
--- a/test/test_symbolic_ops.py
+++ b/test/test_symbolic_ops.py
@@ -1,7 +1,6 @@
 import unittest
 from tinygrad import Variable
 from tinygrad.helpers import getenv
-from tinygrad.shape.view import View
 from tinygrad.tensor import Tensor
 from examples.gpt2 import Attention
 import numpy as np
@@ -189,12 +188,6 @@ class TestSymbolicOps(unittest.TestCase):
           expected = a.var(axis).numpy()
           symbolic = a.reshape(vi, vj).var(axis).reshape(expected.shape).numpy()
           np.testing.assert_allclose(symbolic, expected, atol=1e-6, rtol=1e-6)
-
-  @unittest.expectedFailure # passes in 0.9.2
-  def test_merge_view(self):
-    vm2 = View(shape=(Variable('j', 1, 10),), strides=(0,), offset=0, mask=None, contiguous=False)
-    vm1 = View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True)
-    vm2.__add__(vm1)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_symbolic_ops.py
+++ b/test/test_symbolic_ops.py
@@ -1,6 +1,7 @@
 import unittest
 from tinygrad import Variable
 from tinygrad.helpers import getenv
+from tinygrad.shape.view import View
 from tinygrad.tensor import Tensor
 from examples.gpt2 import Attention
 import numpy as np
@@ -188,6 +189,12 @@ class TestSymbolicOps(unittest.TestCase):
           expected = a.var(axis).numpy()
           symbolic = a.reshape(vi, vj).var(axis).reshape(expected.shape).numpy()
           np.testing.assert_allclose(symbolic, expected, atol=1e-6, rtol=1e-6)
+
+  @unittest.expectedFailure # passes in 0.9.2
+  def test_merge_view(self):
+    vm2 = View(shape=(Variable('j', 1, 10),), strides=(0,), offset=0, mask=None, contiguous=False)
+    vm1 = View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True)
+    vm2.__add__(vm1)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -28,6 +28,12 @@ class TestSymbolic(unittest.TestCase):
     st = ShapeTracker(views=(View(shape=(3, (Variable('i', 1, 10)+Variable('j', 1, 10))), strides=(Variable('i', 1, 10), 1), offset=0, mask=((0, 3), (0, Variable('i', 1, 10))), contiguous=False),))   # noqa: E501
     self.assertEqual(st.real_strides(), (Variable('i', 1, 10), None))
 
+  @unittest.expectedFailure # passes in 0.9.2
+  def test_merge_view_recursion_err(self):
+    vm2 = View(shape=(Variable('j', 1, 10),), strides=(0,), offset=0, mask=None, contiguous=False)
+    vm1 = View(shape=(1,), strides=(0,), offset=0, mask=None, contiguous=True)
+    vm2.__add__(vm1)
+
   def test_cat_dim0_strides(self):
     i = Variable("i", 1, 5).bind(3)
     j = Variable("j", 1, 5).bind(3)


### PR DESCRIPTION
I hit this while writing fusion UPats in big graph #7556.
No asserts pre symbolic deletion `518c022c29104d79c7a50ec41af5b7e6404da317g`.