### PR TITLE
Increase test tolerance for flaky probabilistic test

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -602,7 +602,7 @@ class TestMultiTensor(unittest.TestCase):
       output = X.dropout(0.5).numpy()
       unique, counts = np.unique(output, return_counts=True)
       assert set(unique) == {0, 2}, unique
-      assert 228 < counts[0] < 284, counts[0]
+      assert 200 < counts[0] < 312, counts[0]
 
   def test_dropout_on_uneven_shard_axis(self):
     with Tensor.train():


### PR DESCRIPTION
https://github.com/tinygrad/tinygrad/actions/runs/11724131309/job/32657333309?pr=7572#step:17:153
Failed on completely unrelated change. Is there a reason Tensor.manual_seed is not used?