### PR TITLE
make UOp.range arg a tuple [pr]

### DIFF
--- a/test/unit/test_shapetracker.py
+++ b/test/unit/test_shapetracker.py
@@ -862,5 +862,17 @@ class TestConsecutive(unittest.TestCase):
     # consecutive if sliced into size 1
     assert self.ones[0, 0].lazydata.st.consecutive
 
+class TestRender(unittest.TestCase):
+  def test_render(self):
+    st = ShapeTracker.from_shape((2, 3))
+    idx, valid = st.to_indexed_uops()
+    self.assertEqual(idx.render(), "((ridx0*3)+ridx1)")
+    self.assertEqual(valid.render(), "True")
+
+    st = st.pad(((0, 1), (0, 0)))
+    idx, valid = st.to_indexed_uops()
+    self.assertEqual(idx.render(), "((ridx0*3)+ridx1)")
+    self.assertEqual(valid.render(), "(ridx0<2)")
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -343,7 +343,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
   @staticmethod
   def range(dtype:DType, start:ConstType|UOp, end:ConstType|UOp, idx:int):
     return UOp(Ops.RANGE, dtype=dtype, src=(UOp.const(dtype, start) if not isinstance(start, UOp) else start,
-                                             UOp.const(dtype, end) if not isinstance(end, UOp) else end), arg=idx)
+                                             UOp.const(dtype, end) if not isinstance(end, UOp) else end), arg=(idx, False))
   def r(self, op, axis): return UOp(Ops.REDUCE_AXIS, self.dtype, (self,), (REDUCE_ALU[op] if op in GroupOp.Reduce else op, axis))
   def assign(self, x:UOp): return UOp(Ops.ASSIGN, self.dtype, (self,x))
 


### PR DESCRIPTION
so render works on output of ShapeTracker.to_indexed_uops