### PR TITLE
simplify valid in real_strides

### DIFF
--- a/test/unit/test_shapetracker.py
+++ b/test/unit/test_shapetracker.py
@@ -153,7 +153,6 @@ class TestRealStrides(unittest.TestCase):
     ))
     self.assertEqual(st.real_strides(), (896, 0, None, 56, None))
 
-  @unittest.expectedFailure  # FIXME
   def test_5(self):
     # test/test_ops.py::TestOps::test_conv2d
     st = ShapeTracker((

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -992,10 +992,15 @@ def uop_given_valid(valid:UOp, uop:UOp) -> Optional[UOp]:
 
   return uop
 
+def order(v: UOp, valids:List[UOp]):
+  try: return sum(parse_valid(v)[0] in other.parents for other in valids)
+  except ValueError: return 0
+
 def simplify_valid(valid:UOp) -> Optional[UOp]:
   ret:List[UOp] = []
   something_changed = False
-  for stmt in split_uop(valid, BinaryOps.AND):
+  valids = list(split_uop(valid, Ops.AND))
+  for stmt in sorted(valids, key=lambda v: order(v, valids), reverse=True):
     ret.append(newstmt if ret and (newstmt:=uop_given_valid(functools.reduce(operator.and_, ret), stmt)) is not None else stmt)
     if ret[-1] is not stmt: something_changed = True
   return functools.reduce(operator.and_, ret) if something_changed else None

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -5,7 +5,7 @@ from typing import Tuple, List, Optional, Dict, Set
 from tinygrad.helpers import merge_dicts, getenv
 from tinygrad.shape.view import View, strides_for_shape
 from tinygrad.dtype import dtypes
-from tinygrad.ops import UOp, Ops, BinaryOps, graph_rewrite, split_uop, symbolic_flat, Variable, sint, uop_given_valid
+from tinygrad.ops import UOp, Ops, BinaryOps, graph_rewrite, split_uop, symbolic_flat, Variable, sint, uop_given_valid, simplify_valid
 
 @dataclass(frozen=True, order=True)
 class ShapeTracker:
@@ -74,6 +74,7 @@ class ShapeTracker:
     if len(self.views) == 1 and self.views[-1].mask is None: return self.views[-1].strides
     ret: List[Optional[sint]] = [None] * len(self.shape)
     idx, valid = (graph_rewrite(u, symbolic_flat) for u in self.to_indexed_uops())
+    if (newvalid:=simplify_valid(valid)) is not None: valid = newvalid
     if (newidx:=uop_given_valid(valid, idx)) is not None: idx = newidx
     for c in split_uop(idx, BinaryOps.ADD):
       if c.op is Ops.RANGE: ret[c.arg[0]] = 1


### PR DESCRIPTION
also valid order matters. it changed because AND is commutative.