### PR TITLE
Remove Ops.ALU

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -953,7 +953,7 @@ class TestLinearizer(unittest.TestCase):
     k = Kernel(create_schedule([r.lazydata])[-1].ast)
     k.upcast()
     k.linearize()
-    num_ops = len([uop for uop in k.uops if uop.op is Ops.ALU])
+    num_ops = len([uop for uop in k.uops if uop.op in GroupOp.ALU])
     assert num_ops <= 1, "more alu uops than needed"
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.supports_float4, "test requires float4")
@@ -998,7 +998,7 @@ class TestLinearizer(unittest.TestCase):
     k = Kernel(create_schedule([r.lazydata])[-1].ast)
     k.upcast()
     k.linearize()
-    num_ops = len([uop for uop in k.uops if uop.op is Ops.ALU])
+    num_ops = len([uop for uop in k.uops if uop.op in GroupOp.ALU])
     assert num_ops == 0, "more alu uops than needed"
 
   def test_sum_acc_dtype(self):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -136,7 +136,6 @@ class Ops(FastEnum):
   LOAD = auto()
 
   # math ops
-  ALU = auto()
   WMMA = auto()
 
   # BinaryOps


### PR DESCRIPTION
`Ops.ALU` is not used anymore, which used to be arg, is now op.
There were two occurrences in tests that still referenced `Ops.ALU`, I replaced them with `GroupOp.ALU`