### PR TITLE
METAL raise RuntimeError with no compiler and bad src

### DIFF
--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -63,3 +63,15 @@ kernel void r_5(device int* data0, const device int* data1, uint3 gid [[threadgr
 """)
     MetalProgram(device, "r_5", compiled)
 
+  def test_bad_program_w_empty_compiler(self):
+    device = MetalDevice("metal")
+    compiler = Compiler(device)
+    # this does not raise
+    compiled = compiler.compile("""
+#include <metal_stdlib>
+kernel void r_5(device int* data0, const device int* data1, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]){
+  invalid codes;
+}
+""")
+    with self.assertRaises(RuntimeError):
+      MetalProgram(device, "r_5", compiled)

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -97,7 +97,8 @@ class MetalProgram:
       error_check(error_library_creation)
     else:
       # metal source. rely on OS caching
-      self.library = metal_src_to_library(self.device, lib.decode())
+      try: self.library = metal_src_to_library(self.device, lib.decode())
+      except CompileError as e: raise RuntimeError from e
     self.fxn = msg(self.library, "newFunctionWithName:", to_ns_str(name), restype=objc_instance)
     descriptor = msg(libobjc.objc_getClass(b"MTLComputePipelineDescriptor"), "new", restype=objc_instance)
     msg(descriptor, "setComputeFunction:", self.fxn)


### PR DESCRIPTION
fixed BEAM if src is invalid on METAL. it currently only accept RuntimeError in `_time_program`