### PR TITLE
early assert swizzle in kernel [pr]

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1642,9 +1642,8 @@ class TestIndexing(unittest.TestCase):
     r = r + ast_const(dtypes.int, 2, ())
     sink = UOp(Ops.SINK, dtypes.void, (UOp(Ops.STORE, dtypes.void, (bufs[0], ShapeTracker.from_shape(()).to_uop(), r)),))
     rsink = graph_rewrite(sink, view_right)
-    # NOTE: this AST is always correct in the entire lifecycle of graph_rewrite!
-    # with self.assertRaisesRegex(AssertionError, "implicit reshape"): verify_ast(sink)
-    verify_ast(sink)
+    # this AST first needs to swizzle, but it doesn't have implicit movementops
+    with self.assertRaisesRegex(AssertionError, "swizzle"): verify_ast(sink)
     verify_ast(rsink)
 
   def test_no_reshape_reduceop(self):

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1663,9 +1663,8 @@ class TestIndexing(unittest.TestCase):
     for _ in range(24): r = r + ast_const(dtypes.int, 2, ())
     sink = UOp(Ops.SINK, dtypes.void, (UOp(Ops.STORE, dtypes.void, (bufs[0], ShapeTracker.from_shape(()).to_uop(), r)),))
     rsink, et = timeit(graph_rewrite, sink, view_right)
-    # NOTE: this AST is always correct in the entire lifecycle of graph_rewrite!
-    # with self.assertRaisesRegex(AssertionError, "implicit reshape"): verify_ast(sink)
-    verify_ast(sink)
+    # this AST first needs to swizzle, but it doesn't have implicit movementops
+    with self.assertRaisesRegex(AssertionError, "swizzle"): verify_ast(sink)
     verify_ast(rsink)
     self.assertLessEqual(et, 1e3)
 

--- a/test/unit/test_verify_ast.py
+++ b/test/unit/test_verify_ast.py
@@ -81,5 +81,12 @@ class TestVerifyAST(unittest.TestCase):
     const_st = [st for u,st in uop_sts.items() if u.op is Ops.VALID][0]
     self.assertEqual(const_st, ShapeTracker.from_shape((1, 1)).expand((4, 4)))
 
+  def test_assert_swizzle(self):
+    buf = UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(), (), 0)
+    a = UOp(Ops.LOAD, dtypes.float, (buf, ShapeTracker.from_shape((32, 1)).to_uop()))
+    r = UOp(Ops.REDUCE_AXIS, dtypes.float, (a,), (ReduceOps.SUM, (0,)))
+    st = UOp.store(buf, ShapeTracker.from_shape((32, 1)).to_uop(), r.view(r.st.expand((32, 1)))+a)
+    with self.assertRaisesRegex(InvalidASTException, "swizzle"): helper_test_verify_ast(st)
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -745,7 +745,9 @@ def _assert_valid_uop(uop:UOp, st:ShapeTracker, sts:Dict[UOp, ShapeTracker]) -> 
   # only reduceuop is allowed to change shape, limited to turning n to 1
   if uop.op in {Ops.REDUCE_AXIS, Ops.WMMA}: st = ShapeTracker.from_shape(sts[uop.src[0]].reduce(uop.axis_arg))
   # movementops are pushed to VIEW
-  elif uop.op is Ops.VIEW: st = uop.arg
+  elif uop.op is Ops.VIEW:
+    assert len(uop.src) == 0, f"can't have swizzle in ast {uop}"
+    st = uop.arg
   # everything else inherits shape
   else:
     st = (src_sts:=[sts[x] for x in uop.src if x.has_st])[0]

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -746,7 +746,7 @@ def _assert_valid_uop(uop:UOp, st:ShapeTracker, sts:Dict[UOp, ShapeTracker]) -> 
   if uop.op in {Ops.REDUCE_AXIS, Ops.WMMA}: st = ShapeTracker.from_shape(sts[uop.src[0]].reduce(uop.axis_arg))
   # movementops are pushed to VIEW
   elif uop.op is Ops.VIEW:
-    assert len(uop.src) == 0, f"can't have swizzle in ast {uop}"
+    assert len(uop.src) == 0, f"can't swizzle in kernel yet {uop}"
     st = uop.arg
   # everything else inherits shape
   else:


### PR DESCRIPTION
In master, kernel.py's error for leftover swizzle is incomprehensible. This assert makes it easier to write big graph swizzle UPats.