### PR TITLE
Hook memoryview via class instead of a function

### DIFF
--- a/extra/mockgpu/mockgpu.py
+++ b/extra/mockgpu/mockgpu.py
@@ -178,7 +178,7 @@ class TrackedMemoryView:
   def __len__(self): return len(self.mv)
   def __repr__(self): return repr(self.mv)
 
-def _memoryview(mem):
+def _memoryview(cls, mem):
   if isinstance(mem, int) or isinstance(mem, ctypes.Array):
     addr = ctypes.addressof(mem) if isinstance(mem, ctypes.Array) else mem
     for d in drivers:
@@ -196,7 +196,7 @@ install_hook(libc.lseek64, _lseek64)
 install_hook(libc.stat64, _stat64)
 install_hook(libc.fstat64, _fstat64)
 install_hook(libc.getdents64, _getdents64)
-builtins.memoryview = _memoryview # type: ignore
+builtins.memoryview = type("memoryview", (), {'__new__': _memoryview}) # type: ignore
 
 # rewrite autogen's libc mmaps functions.
 import tinygrad.runtime.autogen.libc as autogen_libc

--- a/test/testextra/test_mockgpu.py
+++ b/test/testextra/test_mockgpu.py
@@ -1,0 +1,13 @@
+from tinygrad.helpers import getenv
+import unittest, importlib
+
+@unittest.skipUnless(getenv("MOCKGPU"), 'Testing mockgpu')
+class TestMockGPU(unittest.TestCase):
+  # https://github.com/tinygrad/tinygrad/pull/7627
+  def test_import_typing_extensions(self):
+    import extra.mockgpu.mockgpu # noqa: F401  # pylint: disable=unused-import
+    import typing_extensions
+    importlib.reload(typing_extensions) # pytest imports typing_extension before mockgpu
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Python typing_extensions [assumes](https://github.com/python/typing_extensions/blob/9340ce7f4e5e89617e63ac30a00118934200a471/src/typing_extensions.py#L3428) builtin.memoryview is a class (3.11, couldn't reproduce on 3.12). When it isn't, everything [blows up](https://github.com/tinygrad/tinygrad/actions/runs/11763036338/job/32766560039#step:17:1755)

Submitting this as a separate PR because this was just triggered by #7615 and can probably be triggered by an unlucky import ordering as well