### PR TITLE
adding viz to env_vars docs

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -47,3 +47,4 @@ PTX                 | [1]        | enable the specialized [PTX](https://docs.nvi
 PROFILE             | [1]        | enable output of [perfetto](https://ui.perfetto.dev/) compatible profile. This feature is supported in NV and AMD backends.
 VISIBLE_DEVICES     | [list[int]]| restricts the NV/AMD devices that are available. The format is a comma-separated list of identifiers (indexing starts with 0).
 JIT                 | [0-2]      | 0=disabled, 1=[jit enabled](quickstart.md#jit) (default), 2=jit enabled, but graphs are disabled
+VIZ                 | [1]        | 0=disabled, 1=[viz enabled](../tinygrad/viz/README)


### PR DESCRIPTION
I asked in Nov 11 stream if VIZ should be added to env_vars.md and George agreed.

One thing I noticed is /tinygrad/viz/README isn't currently a .md extension. Not sure if that's intended.