### PR TITLE
Fix tqdm MLPerf dataloader script

### DIFF
--- a/examples/mlperf/dataloader.py
+++ b/examples/mlperf/dataloader.py
@@ -363,16 +363,12 @@ if __name__ == "__main__":
     files = get_val_files() if val else get_train_files()
 
     if not preprocessed_dir.exists(): preprocess_dataset(files, preprocessed_dir, val)
-    with tqdm(total=len(files)) as pbar:
-      for x, _, _ in batch_load_unet3d(preprocessed_dir, val=val):
-        pbar.update(x.shape[0])
+    for x, _, _ in tqdm(batch_load_unet3d(preprocessed_dir, val=val), total=len(files) // 6): pass
 
   def load_resnet(val):
     from extra.datasets.imagenet import get_train_files, get_val_files
     files = get_val_files() if val else get_train_files()
-    with tqdm(total=len(files)) as pbar:
-      for x,y,c in batch_load_resnet(val=val):
-        pbar.update(x.shape[0])
+    for x, _, _ in tqdm(batch_load_resnet(val=val), total=len(files) // 64): pass
 
   load_fn_name = f"load_{getenv('MODEL', 'resnet')}"
   if load_fn_name in globals():

--- a/examples/mlperf/dataloader.py
+++ b/examples/mlperf/dataloader.py
@@ -363,12 +363,16 @@ if __name__ == "__main__":
     files = get_val_files() if val else get_train_files()
 
     if not preprocessed_dir.exists(): preprocess_dataset(files, preprocessed_dir, val)
-    for x, _, _ in tqdm(batch_load_unet3d(preprocessed_dir, val=val), total=len(files) // 6): pass
+    pbar = tqdm(range(len(files)))
+    for x, _, _ in batch_load_unet3d(preprocessed_dir, val=val):
+      pbar.update(x.shape[0])
 
   def load_resnet(val):
     from extra.datasets.imagenet import get_train_files, get_val_files
     files = get_val_files() if val else get_train_files()
-    for x, _, _ in tqdm(batch_load_resnet(val=val), total=len(files) // 64): pass
+    pbar = tqdm(range(len(files)))
+    for x, _, _ in batch_load_resnet(val=val):
+      pbar.update(x.shape[0])
 
   load_fn_name = f"load_{getenv('MODEL', 'resnet')}"
   if load_fn_name in globals():


### PR DESCRIPTION
# Overview
This fixes an issue where a tqdm context manager style isn't supported when this file got migrated over to use tinygrad's `tqdm` and throws the following error:
<img width="1004" alt="Screenshot 2024-11-12 at 05 50 14" src="https://github.com/user-attachments/assets/915195f5-b3ec-45c4-8d79-0e475772769f">

For now, this PR uses the iterative approach to update the progress bar.

Here is the result for UNet3D:
<img width="1008" alt="Screenshot 2024-11-12 at 05 54 29" src="https://github.com/user-attachments/assets/1b4304c0-5a58-454e-9dd8-7397f7716d9b">

And here is the result for ResNet:
<img width="1023" alt="Screenshot 2024-11-12 at 05 58 45" src="https://github.com/user-attachments/assets/5d963ec1-bbc6-4a32-a11d-55efbe7f991e">

# Notes
- I've also updated the `total` to be divided by the default batch sizes of these dataloaders so that it shows the proper progress bar length.
