### PR TITLE
update env_vars doc on VIZ link

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -47,4 +47,4 @@ PTX                 | [1]        | enable the specialized [PTX](https://docs.nvi
 PROFILE             | [1]        | enable output of [perfetto](https://ui.perfetto.dev/) compatible profile. This feature is supported in NV and AMD backends.
 VISIBLE_DEVICES     | [list[int]]| restricts the NV/AMD devices that are available. The format is a comma-separated list of identifiers (indexing starts with 0).
 JIT                 | [0-2]      | 0=disabled, 1=[jit enabled](quickstart.md#jit) (default), 2=jit enabled, but graphs are disabled
-VIZ                 | [1]        | 0=disabled, 1=[viz enabled](../tinygrad/viz/README)
+VIZ                 | [1]        | 0=disabled, 1=[viz enabled](https://github.com/tinygrad/tinygrad/tree/master/tinygrad/viz)


### PR DESCRIPTION
existing one throws 404 because mkdocs does not allow traverse above doc root (i think?). so for now just stick the github link to it