### PR TITLE
Fix: direct use of MTLCompilerService

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -95,7 +95,7 @@ class MetalCompiler(Compiler):
       options = msg(libobjc.objc_getClass(b"MTLCompileOptions"), "new", restype=objc_instance)
       fast_math_enabled = getenv("METAL_FAST_MATH")
       if fast_math_enabled is not None:
-          msg(options, "setFastMathEnabled:", fast_math_enabled.lower() == 'true')
+        msg(options, "setFastMathEnabled:", getenv("METAL_FAST_MATH"))
       compiler_service = MetalCompilerService()
       lib = compiler_service.compile(src, options)
     assert lib[:4] == b"MTLB", "Invalid Metal library. Using conda? Corrupt XCode?"

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -70,18 +70,14 @@ class MetalCompilerService:
 
   def compile(self, src: str, options: Optional[objc_instance] = None) -> bytes:
     compile_error = objc_instance()
-    library = msg(self.compiler_service, "newLibraryWithSource:options:error:", 
-                  to_ns_str(src), options, ctypes.byref(compile_error), restype=objc_instance)
-    
+    library = msg(self.compiler_service, "newLibraryWithSource:options:error:", to_ns_str(src), options, ctypes.byref(compile_error), restype=objc_instance)
     error_check(compile_error, CompileError)
-    
     library_contents = msg(library, "libraryDataContents", restype=objc_instance)
-    lib = ctypes.string_at(msg(library_contents, "bytes"), 
-                            cast(int, msg(library_contents, "length", restype=ctypes.c_ulong)))
-    
+    lib = ctypes.string_at(msg(library_contents, "bytes"), cast(int, msg(library_contents, "length", restype=ctypes.c_ulong)))
+
     if not lib.startswith(b"MTLB"):
-        print("Library contents (first 64 bytes):", lib[:64])
-        raise AssertionError("Invalid Metal library.")
+      print("Library contents (first 64 bytes):", lib[:64])
+      raise AssertionError("Invalid Metal library.")
     
     return lib
 

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -65,34 +65,37 @@ def metal_src_to_library(device:MetalDevice, src:str) -> objc_instance:
   return library
 
 class MetalCompilerService:
-    def __init__(self):
-        self.compiler_service = msg(libobjc.objc_getClass(b"MTLCompilerService"), "sharedService", restype=objc_instance)
+  def __init__(self):
+    self.compiler_service = msg(libobjc.objc_getClass(b"MTLCompilerService"), "sharedService", restype=objc_instance)
 
-    def compile(self, src: str, options: Optional[objc_instance] = None) -> bytes:
-        compile_error = objc_instance()
-        library = msg(self.compiler_service, "newLibraryWithSource:options:error:", to_ns_str(src), options, 
-                      ctypes.byref(compile_error), restype=objc_instance)
-        error_check(compile_error, CompileError)
-        
-        library_contents = msg(library, "libraryDataContents", restype=objc_instance)
-        lib = ctypes.string_at(msg(library_contents, "bytes"), cast(int, msg(library_contents, "length", restype=ctypes.c_ulong)))
-        
-        assert lib[:4] == b"MTLB", "Invalid Metal library."
-        return lib
+  def compile(self, src: str, options: Optional[objc_instance] = None) -> bytes:
+    compile_error = objc_instance()
+    library = msg(self.compiler_service, "newLibraryWithSource:options:error:", 
+                  to_ns_str(src), options, ctypes.byref(compile_error), restype=objc_instance)
+    
+    error_check(compile_error, CompileError)
+    
+    library_contents = msg(library, "libraryDataContents", restype=objc_instance)
+    lib = ctypes.string_at(msg(library_contents, "bytes"), 
+                            cast(int, msg(library_contents, "length", restype=ctypes.c_ulong)))
+    
+    if not lib.startswith(b"MTLB"):
+        print("Library contents (first 64 bytes):", lib[:64])
+        raise AssertionError("Invalid Metal library.")
+    
+    return lib
 
 class MetalCompiler(Compiler):
   def __init__(self, device:Optional[MetalDevice]=None):
     self.device = device
     super().__init__("compile_metal_xcode" if self.device is None else "compile_metal")
-    
   def compile(self, src: str) -> bytes:
-      options = msg(libobjc.objc_getClass(b"MTLCompileOptions"), "new", restype=objc_instance)
-      msg(options, "setFastMathEnabled:", getenv("METAL_FAST_MATH"))
+    options = msg(libobjc.objc_getClass(b"MTLCompileOptions"), "new", restype=objc_instance)
+    msg(options, "setFastMathEnabled:", getenv("METAL_FAST_MATH"))
 
-      compiler_service = MetalCompilerService()
-      lib = compiler_service.compile(src, options)
-      return lib
-             
+    compiler_service = MetalCompilerService()
+    lib = compiler_service.compile(src, options)
+    return lib        
   def disassemble(self, lib:bytes):
     with tempfile.NamedTemporaryFile(delete=True) as shader:
       shader.write(lib)


### PR DESCRIPTION
Utilizing the Metal framework's compiler service directly for compiling shaders and managing  GPU-based computations on Apple devices.