### PR TITLE
simplify bitwise_not

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2994,7 +2994,7 @@ class Tensor(SimpleMathTrait):  # pylint: disable=abstract-method
     ```
     """
     if self.dtype != dtypes.bool and not dtypes.is_int(self.dtype): raise RuntimeError(f"{self.dtype} is not supported")
-    return self.logical_not() if self.dtype == dtypes.bool else self ^ ((1<<8*self.dtype.itemsize)-1)
+    return self.logical_not() if self.dtype == dtypes.bool else self ^ -1
 
   def lshift(self, x:int):
     """


### PR DESCRIPTION
Trying to understand the recently added `bitwise_not`, I found that this version also passes the test. However, I don't know if there's another reason for explicitly shifting by a dtype-dependent amount.