### PR TITLE
add property to flag contig buffer uop [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -230,8 +230,7 @@ if getenv("RUN_PROCESS_REPLAY"):
 
 def uval(u:UOp) -> UOp:
   assert u.op is Ops.LOAD and len(u.src) == 3 and u.src[2].op is Ops.STORE, f"must be a LOAD of STORE {u}"
-  if (to_store:=u.src[2].src[2]).op is Ops.CONTIGUOUS and to_store.src[0].base.op is not Ops.LOAD: return to_store.src[0]
-  return to_store
+  return to_store.src[0] if (to_store:=u.src[2].src[2]).is_contiguous_base else to_store
 
 def recursive_group(tr:UOp, st:ShapeTracker, r:UOp, children:DefaultDict[UOp, Dict[UOp, None]], allbufs:Dict[UOp, UOp], realizes:Dict[UOp, UOp],
                      reduce_for_op:Dict[UOp, UOp], group:Dict[UOp, None], cache:Dict[Tuple[UOp, ShapeTracker], None]) -> None:
@@ -318,7 +317,7 @@ def group_realizes(children:DefaultDict[UOp, Dict[UOp, None]], allbufs:Dict[UOp,
 
   for rbuf in reduce_of_const:
     group = {tr:None for tr,rop in reduce_for_op.items() if rop is rbuf}
-    if any((tr_val:=allbufs[tr].src[2].src[2]).op is Ops.CONTIGUOUS and tr_val.src[0].op is not Ops.LOAD for tr in group): continue
+    if any(allbufs[tr].src[2].src[2].is_contiguous_base for tr in group): continue
     kernel_children = {c for tr in group for c in children[tr] if uval(allbufs[c]).op not in {Ops.COPY, Ops.BUFFER_VIEW}}
     if len(kernel_children) == 0: continue
     for tr in group: del realizes[tr]

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -339,6 +339,8 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
                                              UOp.const(dtype, end) if not isinstance(end, UOp) else end), arg=(idx, False))
   def r(self, op, axis): return UOp(Ops.REDUCE_AXIS, self.dtype, (self,), (op, axis))
   def assign(self, x:UOp): return UOp(Ops.ASSIGN, self.dtype, (self,x))
+  @property
+  def is_contiguous_base(self): return self.op is Ops.CONTIGUOUS and self.src[0].base.op is not Ops.LOAD
 
   # *** uop movement ops ***
 


### PR DESCRIPTION
The src[2].src[2] is still a mess, #7695 fixes that!

I first called this forced_realize to mirror lazy, but I think `is_contiguous_base` is more comprehensive.

`(Ops.CONTIGUOUS, src=(load_store.view(...)))` already expresses the contiguous pre load option.

This flags:
1. `(Ops.CONTIGUOUS, src=(op.view(...))` just swizzles then realize immediately. (rewrites to `(Ops.CONTIGUOUS, src=(op,))`)

2. early `(Ops.CONTIGUOUS, src=(op,))` is also fine, it's a user controlled immediate realize.