### PR TITLE
fix cuda double disassemble

### DIFF
--- a/test/test_prints.py
+++ b/test/test_prints.py
@@ -1,0 +1,26 @@
+import unittest, contextlib, io
+from tinygrad import Tensor, Context, Device
+from tinygrad.engine.realize import method_cache
+from tinygrad.codegen.kernel import Kernel
+
+@unittest.skipIf(Device.DEFAULT != "CUDA", "test prints for cuda")
+class TestPrints(unittest.TestCase):
+  def test_cuda_print_debug_6(self):
+    db5_out = io.StringIO()
+    with contextlib.redirect_stdout(db5_out):
+      with Context(DEBUG=5):
+        Tensor.arange(0,6).realize()
+    method_cache.clear()
+    Kernel.kernel_cnt.clear()
+
+    db6_out = io.StringIO()
+    with contextlib.redirect_stdout(db6_out):
+      with Context(DEBUG=6):
+        Tensor.arange(0,6).realize()
+    
+    # get rif of trailing "\n" and final print with kernel time/flops/mem usage
+    str = db5_out.getvalue()[:-1].rpartition("\n")[0]
+    assert db6_out.getvalue().startswith(str), "DEBUG=6 output should start with DEBUG=5 output"
+
+if __name__ == "__main__":
+  unittest.main()

--- a/test/test_prints.py
+++ b/test/test_prints.py
@@ -7,31 +7,26 @@ def clear_cache():
   method_cache.clear()
   Kernel.kernel_cnt.clear()
 
+def print_debug(level:int) -> str:
+  clear_cache()
+  db_out = io.StringIO()
+  with contextlib.redirect_stdout(db_out):
+    with Context(DEBUG=level):
+      Tensor.ones(3).realize()
+  return db_out.getvalue()
+
 @unittest.skipIf(Device.DEFAULT != "CUDA", "test prints for cuda")
 class TestCUDAPrints(unittest.TestCase):
   def test_cuda_print_order_debug_6(self):
-    clear_cache()
-    db5_out = io.StringIO()
-    with contextlib.redirect_stdout(db5_out):
-      with Context(DEBUG=5):
-        Tensor.ones(3).realize()
-
-    clear_cache()
-    db6_out = io.StringIO()
-    with contextlib.redirect_stdout(db6_out):
-      with Context(DEBUG=6):
-        Tensor.ones(3).realize()
+    db5_str = print_debug(5)
+    db6_str = print_debug(6)
     # get rif of trailing "\n" and final print with kernel time/flops/mem usage
-    db5_str = db5_out.getvalue()[:-1].rpartition("\n")[0]
-    assert db6_out.getvalue().startswith(db5_str), "DEBUG=6 output should start with DEBUG=5 output"
+    db5_str = db5_str[:-1].rpartition("\n")[0]
+    assert db6_str.startswith(db5_str), "DEBUG=6 output should start with DEBUG=5 output"
 
   def test_cuda_disassemble(self):
-    clear_cache()
-    db6_out = io.StringIO()
-    with contextlib.redirect_stdout(db6_out):
-      with Context(DEBUG=6):
-        Tensor.ones(3).realize()
-    assert "returned non-zero exit status 1" not in db6_out.getvalue(), "failed disassembly from ptx"
+    db6_str = print_debug(6)
+    assert "returned non-zero exit status 1" not in db6_str, "failed disassembly from ptx"
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_prints.py
+++ b/test/test_prints.py
@@ -17,7 +17,7 @@ class TestPrints(unittest.TestCase):
     with contextlib.redirect_stdout(db6_out):
       with Context(DEBUG=6):
         Tensor.arange(0,6).realize()
-    
+
     # get rif of trailing "\n" and final print with kernel time/flops/mem usage
     str = db5_out.getvalue()[:-1].rpartition("\n")[0]
     assert db6_out.getvalue().startswith(str), "DEBUG=6 output should start with DEBUG=5 output"

--- a/test/test_prints.py
+++ b/test/test_prints.py
@@ -19,8 +19,8 @@ class TestPrints(unittest.TestCase):
         Tensor.arange(0,6).realize()
 
     # get rif of trailing "\n" and final print with kernel time/flops/mem usage
-    str = db5_out.getvalue()[:-1].rpartition("\n")[0]
-    assert db6_out.getvalue().startswith(str), "DEBUG=6 output should start with DEBUG=5 output"
+    db_str = db5_out.getvalue()[:-1].rpartition("\n")[0]
+    assert db6_out.getvalue().startswith(db_str), "DEBUG=6 output should start with DEBUG=5 output"
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_prints.py
+++ b/test/test_prints.py
@@ -9,8 +9,8 @@ def clear_cache():
 
 @unittest.skipIf(Device.DEFAULT != "CUDA", "test prints for cuda")
 class TestCUDAPrints(unittest.TestCase):
-  clear_cache()
   def test_cuda_print_order_debug_6(self):
+    clear_cache()
     db5_out = io.StringIO()
     with contextlib.redirect_stdout(db5_out):
       with Context(DEBUG=5):

--- a/test/test_prints.py
+++ b/test/test_prints.py
@@ -31,7 +31,7 @@ class TestCUDAPrints(unittest.TestCase):
     with contextlib.redirect_stdout(db6_out):
       with Context(DEBUG=6):
         Tensor.ones(3).realize()
-    assert "Failed" not in db6_out.getvalue(), "failed disassembly from ptx"
+    assert "returned non-zero exit status 1" not in db6_out.getvalue(), "failed disassembly from ptx"
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_prints.py
+++ b/test/test_prints.py
@@ -3,24 +3,35 @@ from tinygrad import Tensor, Context, Device
 from tinygrad.engine.realize import method_cache
 from tinygrad.codegen.kernel import Kernel
 
+def clear_cache():
+  method_cache.clear()
+  Kernel.kernel_cnt.clear()
+
 @unittest.skipIf(Device.DEFAULT != "CUDA", "test prints for cuda")
-class TestPrints(unittest.TestCase):
-  def test_cuda_print_debug_6(self):
+class TestCUDAPrints(unittest.TestCase):
+  clear_cache()
+  def test_cuda_print_order_debug_6(self):
     db5_out = io.StringIO()
     with contextlib.redirect_stdout(db5_out):
       with Context(DEBUG=5):
-        Tensor.arange(0,6).realize()
-    method_cache.clear()
-    Kernel.kernel_cnt.clear()
+        Tensor.ones(3).realize()
 
+    clear_cache()
     db6_out = io.StringIO()
     with contextlib.redirect_stdout(db6_out):
       with Context(DEBUG=6):
-        Tensor.arange(0,6).realize()
-
+        Tensor.ones(3).realize()
     # get rif of trailing "\n" and final print with kernel time/flops/mem usage
-    db_str = db5_out.getvalue()[:-1].rpartition("\n")[0]
-    assert db6_out.getvalue().startswith(db_str), "DEBUG=6 output should start with DEBUG=5 output"
+    db5_str = db5_out.getvalue()[:-1].rpartition("\n")[0]
+    assert db6_out.getvalue().startswith(db5_str), "DEBUG=6 output should start with DEBUG=5 output"
+
+  def test_cuda_disassemble(self):
+    clear_cache()
+    db6_out = io.StringIO()
+    with contextlib.redirect_stdout(db6_out):
+      with Context(DEBUG=6):
+        Tensor.ones(3).realize()
+    assert "Failed" not in db6_out.getvalue(), "failed disassembly from ptx"
 
 if __name__ == "__main__":
   unittest.main()

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -79,8 +79,8 @@ class CompiledRunner(Runner):
     if DEBUG >= 4: print(p.src)
     self.p:Program = p
     self.lib:bytes = precompiled if precompiled is not None else Device[p.dname].compiler.compile_cached(p.src)
-    if DEBUG >= 6: Device[p.dname].compiler.disassemble(self.lib)
     self.clprg = Device[p.dname].runtime(p.function_name, self.lib)
+    if DEBUG >= 6: Device[p.dname].compiler.disassemble(self.lib)
     super().__init__(p.name, p.dname, p.op_estimate, p.mem_estimate, p.lds_estimate)
 
   def __reduce__(self): return self.__class__, (self.p, self.lib)

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -78,10 +78,10 @@ class CompiledRunner(Runner):
   def __init__(self, p:Program, precompiled:Optional[bytes]=None):
     if DEBUG >= 4: print(p.src)
     self.p:Program = p
-    self.lib:bytes = precompiled if precompiled is not None else Device[p.dname].compiler.compile_cached(p.src)
-    self.clprg = Device[p.dname].runtime(p.function_name, self.lib)
-    if DEBUG >= 6: Device[p.dname].compiler.disassemble(self.lib)
-    super().__init__(p.name, p.dname, p.op_estimate, p.mem_estimate, p.lds_estimate)
+    self.lib:bytes = precompiled if precompiled is not None else Device[p.device].compiler.compile_cached(p.src)
+    self.clprg = Device[p.device].runtime(p.function_name, self.lib)
+    if DEBUG >= 6: Device[p.device].compiler.disassemble(self.lib)
+    super().__init__(p.name, p.device, p.op_estimate, p.mem_estimate, p.lds_estimate)
 
   def __reduce__(self): return self.__class__, (self.p, self.lib)
 

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -40,7 +40,7 @@ class CUDAProgram:
     status = cuda.cuModuleLoadData(ctypes.byref(self.module), lib)
     if status != 0:
       del self.module
-      ptx_disassemble(lib, device.arch)
+      ptx_disassemble(lib, dev.arch)
       raise RuntimeError(f"module load failed with status code {status}: {cuda.cudaError_enum__enumvalues[status]}")
     check(cuda.cuModuleGetFunction(ctypes.byref(prg := cuda.CUfunction()), self.module, name.encode("utf-8")))
     self.prg = prg

--- a/tinygrad/runtime/support/compiler_cuda.py
+++ b/tinygrad/runtime/support/compiler_cuda.py
@@ -63,7 +63,7 @@ class CUDACompiler(Compiler):
 class NVCompiler(CUDACompiler):
   def __init__(self, arch:str): super().__init__(arch, cache_key="nv")
   def compile(self, src:str) -> bytes: return self._compile_program(src, nvrtc.nvrtcGetCUBIN, nvrtc.nvrtcGetCUBINSize)
-  def disassemble(self, lib: bytes): cubin_disassemble(lib)
+  def disassemble(self, lib:bytes): cubin_disassemble(lib)
 
 class PTXCompiler(CUDACompiler):
   def __init__(self, arch:str, cache_key="ptx"): super().__init__(arch, cache_key=cache_key)

--- a/tinygrad/runtime/support/compiler_cuda.py
+++ b/tinygrad/runtime/support/compiler_cuda.py
@@ -30,13 +30,20 @@ def pretty_ptx(s):
   s = re.sub(r'(\.)(version|target|address_size|visible|entry)', lambda m:m[1]+colored(m[2], "magenta"), s, flags=re.M) # derivatives
   return s
 
-def cuda_disassemble(lib, arch):
+def ptx_disassemble(lib, arch):
   try:
     fn = (pathlib.Path(tempfile.gettempdir()) / f"tinycuda_{hashlib.md5(lib).hexdigest()}").as_posix()
     with open(fn + ".ptx", "wb") as f: f.write(lib)
     subprocess.run(["ptxas", f"-arch={arch}", "-o", fn, fn+".ptx"], check=True)
     print(subprocess.check_output(['nvdisasm', fn]).decode('utf-8'))
   except Exception as e: print("Failed to generate SASS", str(e), "Make sure your PATH contains ptxas/nvdisasm binary of compatible version.")
+
+def cubin_disassemble(lib):
+  try:
+    fn = (pathlib.Path(tempfile.gettempdir()) / f"tinycuda_{hashlib.md5(lib).hexdigest()}").as_posix()
+    with open(fn + ".cubin", "wb") as f: f.write(lib)
+    print(subprocess.check_output(["nvdisasm", fn+".cubin"]).decode('utf-8'))
+  except Exception as e: print("Failed to disasm cubin:", str(e), "Make sure your PATH contains nvdisasm binary of compatible version.")
 
 class CUDACompiler(Compiler):
   def __init__(self, arch:str, cache_key:str="cuda"):
@@ -51,16 +58,12 @@ class CUDACompiler(Compiler):
     nvrtc_check(nvrtc.nvrtcDestroyProgram(ctypes.byref(prog)))
     return data
   def compile(self, src:str) -> bytes: return self._compile_program(src, nvrtc.nvrtcGetPTX, nvrtc.nvrtcGetPTXSize)
-  def disassemble(self, lib:bytes):
-    try:
-      fn = (pathlib.Path(tempfile.gettempdir()) / f"tinycuda_{hashlib.md5(lib).hexdigest()}").as_posix()
-      with open(fn + ".cubin", "wb") as f: f.write(lib)
-      print(subprocess.check_output(["nvdisasm", fn+".cubin"]).decode('utf-8'))
-    except Exception as e: print("Failed to disasm cubin:", str(e), "Make sure your PATH contains nvdisasm binary of compatible version.")
+  def disassemble(self, lib:bytes): ptx_disassemble(lib, self.arch)
 
 class NVCompiler(CUDACompiler):
   def __init__(self, arch:str): super().__init__(arch, cache_key="nv")
   def compile(self, src:str) -> bytes: return self._compile_program(src, nvrtc.nvrtcGetCUBIN, nvrtc.nvrtcGetCUBINSize)
+  def disassemble(self, lib: bytes): cubin_disassemble(lib)
 
 class PTXCompiler(CUDACompiler):
   def __init__(self, arch:str, cache_key="ptx"): super().__init__(arch, cache_key=cache_key)


### PR DESCRIPTION
currently the print order with CUDA=1 DEBUG>=6 is:
src -> fail cubin disassembly -> pretty ptx -> assemble ptx and disassemble cubin

with this pr:
src -> pretty ptx -> assemble ptx and disassemble cubin

NV=1 is unaffected:
src -> disassemble cubin