### PR TITLE
remove add in pad when padding with non-zero

### DIFF
--- a/test/external/external_test_opt.py
+++ b/test/external/external_test_opt.py
@@ -68,7 +68,7 @@ class TestInferenceMinKernels(unittest.TestCase):
     model = ResNet18()
     for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=_to_np_dtype(p.dtype)))
     img = Tensor.randn(1, 3, 224, 224)
-    with CLCache(23):
+    with CLCache(24):
       model.forward(img).realize()
 
   def test_vit(self):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1039,7 +1039,7 @@ class Tensor(SimpleMathTrait):  # pylint: disable=abstract-method
     pX = ((0,0),)*(self.ndim - len(padding)//2) + tuple(zip(padding[-2::-2], padding[::-2])) if flat else padding
     if len(pX) != self.ndim: raise ValueError(f"padding length is improper, {padding=} {self.ndim=}")
     X, pX = self, cast(Tuple[Tuple[sint, sint]], tuple((0,0) if p is None else p for p in pX))
-    def _constant(x,px,v): return F.Pad.apply(x, arg=px) if v == 0 else F.Pad.apply(x, arg=px) + F.Pad.apply(Tensor.ones_like(x), arg=px).where(0, v)
+    def _constant(x,px,v): return F.Pad.apply(x, arg=px) if v == 0 else F.Pad.apply(Tensor.ones_like(x), arg=px).where(F.Pad.apply(x, arg=px), v)
     # early return for symbolic with positive pads (no need to max)
     if all(resolve(p >= 0) for p in flatten(pX)): return _constant(X, pX, value)
     pads, shrinks = tuple((smax(pB,0), smax(pA,0)) for pB,pA in pX), tuple((-smin(pB,0),smin(pA+s,s)) for (pB,pA),s in zip(pX, self.shape))


### PR DESCRIPTION
this is simpler because shapetracker is shared

```
from tinygrad import Tensor
Tensor([1, 2, 3]).pad(((1, 1),), 4).realize()
```
with NOOPT=1

this
```
  int gidx0 = gid.x; /* 5 */
  bool alu0 = ((gidx0<4)&((gidx0<1)!=1));
  int val0 = (alu0?*(data1+(gidx0+-1)):0);
  *(data0+gidx0) = ((alu0?1:0)?val0:4);
```

master
```
  int gidx0 = gid.x; /* 5 */
  bool alu0 = ((gidx0<4)&((gidx0<1)!=1));
  int val0 = (alu0?*(data1+(gidx0+-1)):0);
  *(data0+gidx0) = (val0+((alu0?1:0)?0:4));
```

will find a way to rewrite with uop simplification, this should be
```
  *(data0+gidx0) = (alu0?*(data1+(gidx0+-1)):4);
```