### PR TITLE
to_uop one path for all ops part 1

### DIFF
--- a/test/test_lazybuffer.py
+++ b/test/test_lazybuffer.py
@@ -88,7 +88,6 @@ class TestLazyBuffer(unittest.TestCase):
     self.assertEqual(len(sched), 1)
     self.assertIs(sched[0].ast.op, Ops.EMPTY)
     run_schedule(sched)
-    np.testing.assert_equal(empty.numpy(), [0])
 
 class TestReduceOp(unittest.TestCase):
   def test_no_split_reduce_kernel(self):

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -74,12 +74,10 @@ def to_uop(buf:LazyBuffer, ctx:ScheduleContext, children:DefaultDict[UOp, Dict[U
   if buf.is_realized(): return UOp(Ops.VIEW, dtype, (ubuf,), buf.st)
   # everything else needs sources
   src = tuple(to_uop(x, ctx, children, allbufs, double_reduces, cache) for x in buf.srcs)
-  if buf.op in {Ops.REDUCE_AXIS, Ops.CONTIGUOUS}: ret = UOp(buf.op, dtype, src, buf.arg)
-  elif buf.op is Ops.ASSIGN:
+  if buf.op is Ops.ASSIGN:
     ctx.assigns.add(ubuf)
     ret = UOp(Ops.ASSIGN, dtype, (ubuf, src[1]), buf.arg)
-  elif buf.op in GroupOp.Meta: ret = UOp(buf.op, dtype, src, buf.arg)
-  else: ret = UOp(cast(Ops, buf.op), dtype, src)
+  else: ret = UOp(cast(Ops, buf.op), dtype, src, None if buf.op in {Ops.CAST, Ops.BITCAST} else buf.arg)
   if buf.forced_realize: ret = UOp(Ops.CONTIGUOUS, dtype, (ret,))
   cache[buf] = ret = UOp(Ops.VIEW, dtype, (ubuf, ret), buf.st)
   if buf.metadata is not None: ctx.ubuf_metadata[ubuf] = buf.metadata

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -63,7 +63,7 @@ def to_uop(buf:LazyBuffer, ctx:ScheduleContext, children:DefaultDict[UOp, Dict[U
     buf.dtype = buf.buffer.dtype = buf.dtype.base
     assert not buf.is_realized(), "can't fixup allocated buffer"
     buf.buffer.options = None
-  dtype = buf.dtype.base if isinstance(buf.dtype, ImageDType) and buf.op not in GroupOp.Meta else buf.dtype
+  dtype = buf.dtype if buf.op in GroupOp.Meta else buf.dtype.base
   # consts are always fused and generated
   if buf.op is Ops.CONST:
     if isinstance(val:=buf.arg, UOp): ctx.var_vals.update([val.unbind()])
@@ -79,7 +79,7 @@ def to_uop(buf:LazyBuffer, ctx:ScheduleContext, children:DefaultDict[UOp, Dict[U
     ret = UOp(Ops.ASSIGN, dtype, (ubuf, src[1]), buf.arg)
   else: ret = UOp(cast(Ops, buf.op), dtype, src, None if buf.op in {Ops.CAST, Ops.BITCAST} else buf.arg)
   if buf.forced_realize: ret = UOp(Ops.CONTIGUOUS, dtype, (ret,))
-  cache[buf] = ret = UOp(Ops.VIEW, dtype, (ubuf, ret), buf.st)
+  cache[buf] = ret = UOp(Ops.VIEW, dtype.base, (ubuf, ret), buf.st)
   if buf.metadata is not None: ctx.ubuf_metadata[ubuf] = buf.metadata
   ctx.lazybufs[b] = buf
   # things for fuse.py


### PR DESCRIPTION
keeping it as you _could_ call .contiguous on a metaop, like:
![image](https://github.com/user-attachments/assets/92cbf689-3a52-40c0-8de6-49ab5ed60fb5)

This can be an instant rule in UOp's metaop method.