### PR TITLE
Added error message for alu of tensors on different devices, issue #7699

### DIFF
--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -182,7 +182,7 @@ class ExecItem:
     return et
 
 def lower_schedule_item(si:ScheduleItem) -> ExecItem:
-  assert len(set(x.device for x in si.bufs)) == 1 or si.ast.op is Ops.COPY
+  assert len(set(x.device for x in si.bufs)) == 1 or si.ast.op is Ops.COPY, f"schedule item buffers have to be on same device in order to be lowered"
   if si.ast.op is Ops.SINK:
     runner = get_runner(si.outputs[0].device, si.ast)
     return ExecItem(runner, [si.bufs[x] for x in runner.p.globals], si.metadata)

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -182,7 +182,7 @@ class ExecItem:
     return et
 
 def lower_schedule_item(si:ScheduleItem) -> ExecItem:
-  assert len(set(x.device for x in si.bufs)) == 1 or si.ast.op is Ops.COPY, f"schedule item buffers have to be on same device in order to be lowered"
+  assert len(set(x.device for x in si.bufs)) == 1 or si.ast.op is Ops.COPY, f"schedule item buffers have to be on same device in order to be lowered" # noqa: E501
   if si.ast.op is Ops.SINK:
     runner = get_runner(si.outputs[0].device, si.ast)
     return ExecItem(runner, [si.bufs[x] for x in runner.p.globals], si.metadata)


### PR DESCRIPTION
I added an error message in lower_schedule_item so it’s easier to debug if buffers aren’t on the same device, which should fix issue #7699 