### PR TITLE
fix Tensor(MultiLazyBuffer) with different dtype should fail

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -51,6 +51,15 @@ class TestMultiTensor(unittest.TestCase):
       assert lb.shape == (128,)
     (X + X).realize()
 
+  def test_tensor_from_multi(self):
+    X = Tensor([1, 2], dtype=dtypes.int).shard_(devices_2, 0)
+    Y = Tensor(X.lazydata)
+    self.assertEqual(Y.device, Device.DEFAULT)
+    np.testing.assert_equal(X.numpy(), Y.numpy())
+
+    with self.assertRaises(AssertionError):
+      _ = Tensor(X.lazydata, dtype=dtypes.float)
+
   def test_sharded_arange(self):
     sharded_arange = Tensor.arange(1000).shard(devices_2, 0)
     sharded_arange.realize()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -133,7 +133,7 @@ class Tensor(SimpleMathTrait):  # pylint: disable=abstract-method
     self._ctx: Optional[Function] = None
 
     # create a LazyBuffer from the different types of inputs
-    if isinstance(data, LazyBuffer): assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
+    if isinstance(data, (LazyBuffer, MultiLazyBuffer)): assert dtype is None or dtype==data.dtype, "dtype doesn't match, and casting isn't supported"
     elif isinstance(data, get_args(ConstType)): data = _metaop(Ops.CONST, tuple(), dtype or dtypes.from_py(data), device, data)
     elif isinstance(data, UOp):
       assert data.op is Ops.BIND and data.src[0].op is Ops.DEFINE_VAR and data.src[1].op is Ops.CONST, f"can't create tensor from UOp {data}"


### PR DESCRIPTION
similar to Tensor(LazyBuffer) as we don't cast implicitly