### PR TITLE
Add xavier alias for glorot

### DIFF
--- a/docs/tensor/creation.md
+++ b/docs/tensor/creation.md
@@ -28,3 +28,4 @@
 ::: tinygrad.Tensor.glorot_uniform
 ::: tinygrad.Tensor.kaiming_uniform
 ::: tinygrad.Tensor.kaiming_normal
+::: tinygrad.Tensor.xavier_uniform

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -109,7 +109,8 @@ class TestOps(unittest.TestCase):
       Tensor.normal,
       Tensor.uniform,
       Tensor.scaled_uniform,
-      Tensor.glorot_uniform
+      Tensor.glorot_uniform,
+      Tensor.xavier_uniform
     ]
 
     for method in creation_methods:

--- a/test/test_randomness.py
+++ b/test/test_randomness.py
@@ -266,6 +266,11 @@ class TestRandomness(unittest.TestCase):
     self.assertTrue(equal_distribution(Tensor.glorot_uniform, lambda x: torch.nn.init.xavier_uniform_(torch.empty(x)),
                                                               lambda x: np.random.uniform(-1, 1, size=x) * math.sqrt(6 / (x[0] + math.prod(x[1:])))))
 
+  def test_xavier_uniform(self):
+    self.assertFalse(normal_test(Tensor.xavier_uniform))
+    self.assertTrue(equal_distribution(Tensor.xavier_uniform, lambda x: torch.nn.init.xavier_uniform_(torch.empty(x)),
+                                                              lambda x: np.random.uniform(-1, 1, size=x) * math.sqrt(6 / (x[0] + math.prod(x[1:])))))
+
   def test_kaiming_uniform(self):
     for shape in [(256, 128, 3, 3), (80, 44), (3, 55, 35)]:
       self.assertTrue(equal_distribution(Tensor.kaiming_uniform, lambda x: torch.nn.init.kaiming_uniform_(torch.empty(x)), shape=shape))

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -219,7 +219,7 @@ class TestTinygrad(unittest.TestCase):
     self.assertFalse(gradcheck(tiny_func, tiny_x, eps = 1e-5))
 
   def test_random_fns_are_deterministic_with_seed(self):
-    for random_fn in [Tensor.randn, Tensor.normal, Tensor.uniform, Tensor.scaled_uniform, Tensor.glorot_uniform, Tensor.kaiming_normal]:
+    for random_fn in [Tensor.randn, Tensor.normal, Tensor.uniform, Tensor.scaled_uniform, Tensor.glorot_uniform, Tensor.kaiming_normal, Tensor.xavier_uniform]: # noqa: E501
       with self.subTest(msg=f"Tensor.{random_fn.__name__}"):
         Tensor.manual_seed(1337)
         a = random_fn(10,10).realize()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -815,6 +815,14 @@ class Tensor(SimpleMathTrait):  # pylint: disable=abstract-method
     """
     return Tensor.uniform(*shape, low=-1.0, high=1.0, **kwargs).mul((6/(argfix(*shape)[0]+prod(argfix(*shape)[1:])))**0.5)
 
+  # https://pytorch.org/docs/stable/_modules/torch/nn/init.html#xavier_uniform_
+  @staticmethod
+  def xavier_uniform(*shape, **kwargs) -> Tensor:
+    """
+    Alias for `Tensor.glorot_uniform`.
+    """
+    return Tensor.glorot_uniform(*shape, **kwargs)
+
   # https://pytorch.org/docs/stable/_modules/torch/nn/init.html#kaiming_uniform_
   @staticmethod
   def kaiming_uniform(*shape, a:float = 0.01, **kwargs) -> Tensor:


### PR DESCRIPTION
Added Xavier alias for Glorot uniform.

https://pytorch.org/docs/stable/nn.init.html#torch.nn.init.xavier_uniform_
^It's listed in PyTorch as an alias for the Glorot uniform.

Additionally:
1. Added the doc to the Tensor creation
2. Added tests / ran tests with no failures

Happy to modify it if need-be, checked all the search results for `glorot_uniform` in the repo, only other mentions of it were in the `examples/` folder but didn't seem appropriate to needlessly change names.

Also, the E501 edit seemed valid to not add an additional line needlessly