### PR TITLE
get fusion ready for lazy.py deletion [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -267,14 +267,16 @@ def group_realizes(big_graph:UOp, realizes:Dict[UOp, UOp]) -> Tuple[List[List[UO
   allbufs: Dict[UOp, UOp] = {}
   double_reduces: Dict[UOp, None] = {}
   assigns: Set[UOp] = set()
-  for uop in big_graph.parents:
-    if not is_scheduled(uop): continue
+  q: List[UOp] = list(big_graph.src)
+  while q:
+    uop = q.pop()
     allbufs[ubuf:=uop.buf_uop] = uop
     if (op:=uval(uop)).op is Ops.ASSIGN: assigns.add(ubuf)
     for x in op.src:
       if is_scheduled(x.base):
         children[x.base.buf_uop][ubuf] = None
         if FUSE_CONV_BW and op.op is Ops.REDUCE_AXIS and uval(x.base).op is op.op and x.base is not x: double_reduces[ubuf] = None
+        q.append(x.base)
   # find all reduces, and pair them to a elementwise op. if they can't be cleanly paired, force realize the reduce (or a contig child)
   reduce_for_op: Dict[UOp, UOp] = {}
   reduce_of_const: List[UOp] = []

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -367,7 +367,7 @@ break_sched = PatternMatcher([(UPatSrc(), lambda ctx,b,to_store,base: realize(ct
 
 @track_rewrites(named=True)
 def create_schedule_with_vars(outs:List[LazyBuffer]) -> Tuple[List[ScheduleItem], Dict[Variable, int]]:
-  if len(outs:=dedup(x.base for x in outs if x.realized is None and x.base.op is not Ops.CONST)) == 0: return [], {}
+  if len(outs:=dedup(x.base for x in outs if not x.base.is_realized and x.base.op is not Ops.CONST)) == 0: return [], {}
   for out in outs: out.forced_realize = True
   # create the big graph
   ctx = ScheduleContext()

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -268,11 +268,13 @@ def group_realizes(big_graph:UOp, realizes:Dict[UOp, UOp]) -> Tuple[List[List[UO
   double_reduces: Dict[UOp, None] = {}
   assigns: Set[UOp] = set()
   q: List[UOp] = list(big_graph.src)
+  seen: Set[UOp] = set()
   while q:
-    uop = q.pop()
+    seen.add(uop:=q.pop())
     allbufs[ubuf:=uop.buf_uop] = uop
     if (op:=uval(uop)).op is Ops.ASSIGN: assigns.add(ubuf)
     for x in op.src:
+      if x.base in seen: continue
       if is_scheduled(x.base):
         children[x.base.buf_uop][ubuf] = None
         if FUSE_CONV_BW and op.op is Ops.REDUCE_AXIS and uval(x.base).op is op.op and x.base is not x: double_reduces[ubuf] = None


### PR DESCRIPTION
This is the base branch for the lazy removal. It slows down master's scheduler:
```
~/code/tinygrad (move_children) > SCHEDULE_ONLY=1 python3 test/external/external_benchmark_schedule.py
***** model tensor in     23.71 ms
***** model schedule in  168.19 ms
all 191.95 ms
~/code/tinygrad (move_children) > gm
Switched to branch 'master'
~/code/tinygrad (master) > SCHEDULE_ONLY=1 python3 test/external/external_benchmark_schedule.py
***** model tensor in     23.67 ms
***** model schedule in   93.36 ms
all 117.08 ms
```
since it adds a second recursion. With the `LazyBuffer = UOp` diff this becomes one pass.


----
update:
yay queue is fast
```
~/code/tinygrad (move_children) > SCHEDULE_ONLY=1 python3 test/external/external_benchmark_schedule.py
***** model tensor in     24.34 ms
***** model schedule in   92.97 ms
all 117.35 ms
```