### PR TITLE
Context manager support for tqdm

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -293,6 +293,8 @@ class tqdm:
       yield item
       self.update(1)
     self.update(close=True)
+  def __enter__(self): return self
+  def __exit__(self, *exc): self.update(close=True)
   def set_description(self, desc:str): self.desc = f"{desc}: " if desc else ""
   def update(self, n:int=0, close:bool=False):
     self.n, self.i = self.n+n, self.i+1

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -294,7 +294,7 @@ class tqdm:
       self.update(1)
     self.update(close=True)
   def __enter__(self): return self
-  def __exit__(self, *exc): self.update(close=True)
+  def __exit__(self, *_): self.update(close=True)
   def set_description(self, desc:str): self.desc = f"{desc}: " if desc else ""
   def update(self, n:int=0, close:bool=False):
     self.n, self.i = self.n+n, self.i+1


### PR DESCRIPTION
# Overview
This fixes an issue where a `tqdm` context manager style isn't supported. This causes an error when this file got migrated over to use tinygrad's `tqdm` and throws the following error:
<img width="1004" alt="Screenshot 2024-11-12 at 05 50 14" src="https://github.com/user-attachments/assets/915195f5-b3ec-45c4-8d79-0e475772769f">

This PR now adds support for context manager inside tinygrad's `tqdm`:
<img width="2054" alt="Screenshot 2024-11-18 at 12 50 37" src="https://github.com/user-attachments/assets/492d701e-92ec-4c5b-88cb-a264cbfdd693">