### PR TITLE
Raise error when model architecture does not match state dict

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -612,5 +612,5 @@ class TestNN(unittest.TestCase):
     assert layer.bias_ih is None
 
 if __name__ == '__main__':
-
+  unittest.main()
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -613,4 +613,3 @@ class TestNN(unittest.TestCase):
 
 if __name__ == '__main__':
   unittest.main()
-

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7,7 +7,7 @@ from tinygrad.ops import Ops
 from tinygrad.helpers import CI, Context
 from tinygrad.nn import Conv1d, ConvTranspose1d, Conv2d, ConvTranspose2d, Linear, Embedding
 from tinygrad.nn import BatchNorm, LayerNorm, LayerNorm2d, GroupNorm, InstanceNorm, RMSNorm, LSTMCell
-from tinygrad.nn.state import safe_save, safe_load, get_state_dict, load_state_dict
+from tinygrad.nn.state import load_state_dict
 from tinygrad.engine.schedule import create_schedule
 from tinygrad.engine.realize import run_schedule
 from tinygrad.device import is_dtype_supported

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -573,9 +573,8 @@ class TestNN(unittest.TestCase):
     d1, d2 = 2, 4
     layer = Linear(d1, d1, bias=False)
     state_dict = {'weight': Tensor.randn(d2, d2)}
-    with self.assertRaises(ValueError) as cm:
+    with self.assertRaisesRegex(ValueError, r'Shape mismatch in layer `weight`: Expected shape \(2, 2\), but found \(4, 4\) in state dict.'):
       load_state_dict(layer, state_dict)
-    self.assertEqual(cm.exception, ValueError('Shape mismatch in layer `weight`: Expected shape (2, 2), but found (4, 4) in state dict.'))
 
   def test_lstm_cell(self):
     layer = LSTMCell(32, 16)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7,7 +7,7 @@ from tinygrad.ops import Ops
 from tinygrad.helpers import CI, Context
 from tinygrad.nn import Conv1d, ConvTranspose1d, Conv2d, ConvTranspose2d, Linear, Embedding
 from tinygrad.nn import BatchNorm, LayerNorm, LayerNorm2d, GroupNorm, InstanceNorm, RMSNorm, LSTMCell
-from tinygrad.nn.state import load_state_dict
+from tinygrad.nn.state import safe_save, safe_load, get_state_dict, load_state_dict
 from tinygrad.engine.schedule import create_schedule
 from tinygrad.engine.realize import run_schedule
 from tinygrad.device import is_dtype_supported
@@ -569,6 +569,14 @@ class TestNN(unittest.TestCase):
     np.testing.assert_allclose(layer.weight.numpy(), state_dict['weight'].numpy())
     np.testing.assert_allclose(layer.bias.numpy(), state_dict['bias'].numpy())
 
+  def test_load_state_dict_shape_mismatch(self):
+    d1, d2 = 2, 4
+    layer = Linear(d1, d1, bias=False)
+    state_dict = {'weight': Tensor.randn(d2, d2)}
+    with self.assertRaises(ValueError) as cm:
+      load_state_dict(layer, state_dict)
+    self.assertEqual(cm.exception, ValueError('Shape mismatch in layer `weight`: Expected shape (2, 2), but found (4, 4) in state dict.'))
+
   def test_lstm_cell(self):
     layer = LSTMCell(32, 16)
     with torch.no_grad():
@@ -604,4 +612,5 @@ class TestNN(unittest.TestCase):
     assert layer.bias_ih is None
 
 if __name__ == '__main__':
-  unittest.main()
+
+

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -123,6 +123,7 @@ def load_state_dict(model, state_dict:Dict[str, Tensor], strict=True, verbose=Tr
       if k not in state_dict and not strict:
         if DEBUG >= 1: print(f"WARNING: not loading {k}")
         continue
+      if v.lazydata.shape != state_dict[k].shape: raise ValueError(f'Shape mismatch in layer `{k}`: Expected shape {v.lazydata.shape}, but found {state_dict[k].shape} in state dict.')
       if isinstance((mlb:=v.lazydata), MultiLazyBuffer):
         if isinstance(state_dict[k].lazydata, MultiLazyBuffer): v.replace(state_dict[k]).realize()
         else: v.replace(state_dict[k].shard(mlb.device, mlb.axis)).realize()

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -123,7 +123,8 @@ def load_state_dict(model, state_dict:Dict[str, Tensor], strict=True, verbose=Tr
       if k not in state_dict and not strict:
         if DEBUG >= 1: print(f"WARNING: not loading {k}")
         continue
-      if v.lazydata.shape != state_dict[k].shape: raise ValueError(f'Shape mismatch in layer `{k}`: Expected shape {v.lazydata.shape}, but found {state_dict[k].shape} in state dict.')
+      if v.lazydata.shape != state_dict[k].shape:
+        raise ValueError(f'Shape mismatch in layer `{k}`: Expected shape {v.lazydata.shape}, but found {state_dict[k].shape} in state dict.')
       if isinstance((mlb:=v.lazydata), MultiLazyBuffer):
         if isinstance(state_dict[k].lazydata, MultiLazyBuffer): v.replace(state_dict[k]).realize()
         else: v.replace(state_dict[k].shard(mlb.device, mlb.axis)).realize()


### PR DESCRIPTION
Raise an error if the size of your tensors in the loaded model don't match the input model.

Mentioned in [discord](https://discord.com/channels/1068976834382925865/1069001075828469790/1307730523820658810).