### PR TITLE
fix pad constant mode a symbolic amount

### DIFF
--- a/test/test_symbolic_shapetracker.py
+++ b/test/test_symbolic_shapetracker.py
@@ -229,5 +229,10 @@ class TestSymbolicPad(unittest.TestCase):
     st = t.lazydata.st
     print(st)
 
+  def test_pad_maybe_negative_symbolic(self):
+    v = Variable("v", 1, 10).bind(3)
+    t = Tensor.empty(5).pad(((0, 5-v),))
+    self.assertEqual(t.shape[0].render(), "((max((v+-10), -5)*-1)+max(((v*-1)+5), 0))")
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1068,7 +1068,7 @@ class Tensor(SimpleMathTrait):
     pads = tuple((smax(pB,0), smax(pA,0)) for pB,pA in pX)
     if mode == "constant":
       def _constant(x,px,v): return F.Pad.apply(x, arg=px) if v == 0 else F.Pad.apply(x, arg=px) + F.Pad.apply(Tensor.ones_like(x), arg=px).where(0,v)
-      return _constant(X, pX, value) if all(resolve(p >= 0) for p in flatten(pX)) else \
+      return _constant(X, pX, value) if all(resolve(p >= 0, False) for p in flatten(pX)) else \
              _constant(X.shrink(tuple((-smin(pB,0),smin(pA+s,s)) for (pB,pA),s in zip(pX, X.shape))), pads, value)
     assert all_int(self.shape), f"does not support symbolic shape {self.shape}"
     if mode == "circular":


### PR DESCRIPTION
default for resolve should be False, otherwise the unresolved case might skip the shrink