### PR TITLE
test_kernel_cache_in_action: fix test

### DIFF
--- a/test/test_kernel_cache.py
+++ b/test/test_kernel_cache.py
@@ -8,20 +8,22 @@ class TestKernelCache(unittest.TestCase):
     if Device.DEFAULT not in ["CLANG"]:
       self.skipTest("No custom kernel cache is implemented")
 
-    a = Tensor.rand(4,4)
-    b = Tensor.rand(4,4)
-    x = a + b
+    unique_const = 0.6765677269
+    a = Tensor.rand(4,4).realize()
+    b = Tensor.rand(4,4).realize()
+    x = a + b + unique_const
     x.realize()
 
+    a1 = Tensor.rand(4,4).realize()
+    b1 = Tensor.rand(4,4).realize()
     orig_compile_func = Device['CLANG'].compiler
     Device['CLANG'].compiler = None # making it not callable
 
-    a1 = Tensor.rand(4,4)
-    b1 = Tensor.rand(4,4)
-    x1 = a1 + b1
-    x1.realize() # Same kernel should be from cache.
-
-    Device['CLANG'].compiler = orig_compile_func
+    try:
+      x1 = a1 + b1 + unique_const
+      x1.realize() # Same kernel should be from cache.
+    finally:
+      Device['CLANG'].compiler = orig_compile_func
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/tinygrad/tinygrad/commit/c100f3d40618ff7f19ded78eee89d8a0dc253135.

```
self = <tinygrad.engine.realize.CompiledRunner object at 0xfffedac82a80>
p = Program(name='E_\x1b[34m4194304\x1b[0m\x1b[90m_\x1b[0m\x1b[33m4\x1b[0m\x1b[90m\x1b[0m', src='typedef float float4 __at...))], mem_estimate=134217728, global_size=None, local_size=None, vars=[], globals=[0, 1], outs=[0], _ran_post_init=True)
precompiled = None

    def __init__(self, p:Program, precompiled:Optional[bytes]=None):
      if DEBUG >= 4: print(p.src)
      self.p:Program = p
>     self.lib:bytes = precompiled if precompiled is not None else Device[p.dname].compiler.compile_cached(p.src)
E     AttributeError: 'NoneType' object has no attribute 'compile_cached'

tinygrad/engine/realize.py:81: AttributeError
```

Full log: https://paste.glepage.com/raw/bear-cobra-spider
