### PR TITLE
fix advanced setitem with 1 in shape

### DIFF
--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -93,7 +93,7 @@ class TestSetitem(unittest.TestCase):
     t = Tensor([1,2,3,4])
     t[[1,1]] = Tensor([1,0])
     np.testing.assert_allclose(t.numpy(), [1,0,3,4])
-  
+
   def test_setitem_with_1_in_shape(self):
     t = Tensor([[1],[2],[3]])
     t[[0,0]] = Tensor([[1],[2]])

--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -93,6 +93,11 @@ class TestSetitem(unittest.TestCase):
     t = Tensor([1,2,3,4])
     t[[1,1]] = Tensor([1,0])
     np.testing.assert_allclose(t.numpy(), [1,0,3,4])
+  
+  def test_setitem_with_1_in_shape(self):
+    t = Tensor([[1],[2],[3]])
+    t[[0,0]] = Tensor([[1],[2]])
+    np.testing.assert_allclose(t.numpy(), [[2],[2],[3]])
 
   def test_fancy_setitem(self):
     t = Tensor.zeros(6,6).contiguous()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1195,8 +1195,10 @@ class Tensor(SimpleMathTrait):  # pylint: disable=abstract-method
         # apply mask to vb(broadcasted) and reduce such that if mask contains repeated indices the last one remains
         vb = vb * mask
         for dim in axis: mask, vb = functools.reduce(lambda x,y: (x[0]|y[0], y[0].where(y[1], x[1])), zip(mask.split(1, dim), vb.split(1, dim)))
-        # select from vb for each True element in mask else select from self, squeeze to remove extra dims from reduce
-        ret = mask.squeeze().where(vb.squeeze(), self)
+        # remove extra dims from reduce
+        for dim in reversed(axis): mask, vb = mask.squeeze(dim), vb.squeeze(dim)
+        # select from vb for each True element in mask else select from self
+        ret = mask.where(vb, self)
 
     return ret
 


### PR DESCRIPTION
chenyu pointed out the issue where if shape contained a 1. This fixes that. This way it only removes the dims from the reduce axis instead of removing all dims with 1.