### PR TITLE
get buffer size just from Ops.BUFFER [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -397,7 +397,7 @@ def create_schedule_with_vars(outs:List[LazyBuffer]) -> Tuple[List[ScheduleItem]
   prescheduled: List[ScheduleItem] = []
   for store_uops in store_groups:
     ast, ast_ctx = full_ast_rewrite(UOp.sink(*(ctx.realizes[u] for u in store_uops)), ctx)
-    prescheduled.append(ScheduleItem(ast, tuple(b for u in ast_ctx.bufs if (b:=buffers[u]).size != 0),
+    prescheduled.append(ScheduleItem(ast, tuple(buffers[u] for u in ast_ctx.bufs if u.size != 0),
                                      tuple(ast_ctx.metadata), frozenset(x.buf_uop for x in ast_ctx.assign_preloads)))
   # do BFS
   schedule_targets = {out:si for si in prescheduled for out in si.outputs}

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -360,7 +360,10 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
       case Ops.BUFFER: return self.arg[1][0]
       case _: return self.src[0].device
   @property
+  def size(self) -> int: return self.buf_uop.arg[1][1]
+  @property
   def buf_uop(self) -> UOp:
+    if self.op is Ops.BUFFER: return self
     assert self.op in {*GroupOp.Buffer, Ops.ASSIGN, Ops.VIEW} and self.src[0].op is Ops.BUFFER, f"buf_uop called on {self.op}"
     return self.src[0]
 


### PR DESCRIPTION
at this point the only reason the scheduler imports Buffer is because ScheduleItem holds a list of Buffers.
When `LazyBuffer = UOp` there's a globally accessible map of UOps to their Buffers realize.py can directly access.