### PR TITLE
move attention upcast

### DIFF
--- a/test/unit/test_attention.py
+++ b/test/unit/test_attention.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import unittest
+from tinygrad import Tensor, dtypes
+from tinygrad.engine.schedule import create_schedule
+
+class TestAttention(unittest.TestCase):
+  def test_half_intermediate_dtypes(self):
+    q = Tensor.empty(1, 64, 128, dtype=dtypes.half).realize()
+    k = Tensor.empty(1, 64, 128, dtype=dtypes.half).realize()
+    v = Tensor.empty(1, 64, 128, dtype=dtypes.half).realize()
+    attn = q.scaled_dot_product_attention(k, v)
+
+    sched = create_schedule(attn.lazydata.lbs)
+    # TODO: make attention 1 kernel
+    self.assertEqual(len(sched), 5)
+    # store in half after after matmul
+    for buf in sched[0].outputs: self.assertEqual(buf.dtype, dtypes.half)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3356,7 +3356,7 @@ class Tensor(SimpleMathTrait):
     assert all_int(self.shape), f"does not support symbolic shape {self.shape}"
     if is_causal: attn_mask = Tensor.ones(self.shape[-2], key.shape[-2], requires_grad=False, device=self.device).tril(0).cast(dtypes.bool)
     if attn_mask is not None and attn_mask.dtype == dtypes.bool: attn_mask = (attn_mask == 0).where(-float("inf"), 0)
-    qk = self.matmul(key.transpose(-2,-1), acc_dtype=least_upper_dtype(self.dtype, key.dtype, dtypes.float32)) / math.sqrt(self.shape[-1])
+    qk = (self.matmul(key.transpose(-2,-1)) / math.sqrt(self.shape[-1])).cast(least_upper_dtype(self.dtype, key.dtype, dtypes.float32))
     return ((qk+attn_mask) if attn_mask is not None else qk).softmax(-1).cast(self.dtype).dropout(dropout_p) @ value
 
   def _do_reduction(self, reduction:ReductionStr="mean") -> Tensor:


### PR DESCRIPTION
still upcast before softmax, but faster because intermediate buffer can be stored in half (as long as qk is within half range).