### PR TITLE
Use MTLCompiler directly

### DIFF
--- a/test/external/external_metal_compile_fail.py
+++ b/test/external/external_metal_compile_fail.py
@@ -225,6 +225,6 @@ from tinygrad.runtime.ops_metal import MetalDevice, MetalCompiler, MetalProgram
 
 if __name__ == "__main__":
   dev = MetalDevice("METAL")
-  lib = MetalCompiler(dev).compile(src)
+  lib = MetalCompiler().compile(src)
   prg = MetalProgram(dev, "r_64_32_8_16_4_6_6_4", lib)
 

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -10,14 +10,12 @@ class TestMetal(unittest.TestCase):
       device.allocator.alloc(10000000000000000000)
 
   def test_compile_error(self):
-    device = MetalDevice("metal")
-    compiler = MetalCompiler(device)
+    compiler = MetalCompiler()
     with self.assertRaises(CompileError):
       compiler.compile("this is not valid metal")
 
   def test_compile_success(self):
-    device = MetalDevice("metal")
-    compiler = MetalCompiler(device)
+    compiler = MetalCompiler()
     ret = compiler.compile("""
 #include <metal_stdlib>
   using namespace metal;
@@ -41,7 +39,7 @@ class TestMetal(unittest.TestCase):
 
   def test_failed_newLibraryWithData(self):
     device = MetalDevice("metal")
-    compiler = MetalCompiler(device)
+    compiler = MetalCompiler()
     compiled = compiler.compile("""
 #include <metal_stdlib>
 kernel void r_5(device int* data0, const device int* data1, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]){


### PR DESCRIPTION
MTLCompilerService is just a wrapper around MTLCompiler dylib that shares llvm instance between processes. All it does is dlopen on appropriate MTLCompiler version and forwards the rest of the request to it

I've also commited a bunch of tools and two scripts to compile via xpc and via MTLCompiler directly that i wrote for exploring all of this to extra in case they will be needed for something else. (i've looked at other accepted PRs and they commit extra/ stuff together with tinygrad/ even when tinygrad/ stuff doesn't depend on extra/ so i did the same here)