### PR TITLE
typedef bf16 amd

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -412,7 +412,7 @@ class AMDRenderer(CStyleLanguage):
     prefix = ["#define INFINITY (__builtin_inff())","#define NAN (__builtin_nanf(\"\"))","typedef long unsigned int size_t;","#define half _Float16"]
 
     used_dtypes = uops_to_dtypes(uops)
-    if any(dt.scalar() == dtypes.bfloat16 for dt in used_dtypes): prefix.append("struct hip_bfloat16 { unsigned short data; };")
+    if any(dt.scalar() == dtypes.bfloat16 for dt in used_dtypes): prefix.append("typedef unsigned short hip_bfloat16;")
     prefix += [self.render_vector_prefix(dt) for dt in used_dtypes if dt.count > 1]
 
     for arg in dedup([uop.arg for uop in uops if uop.op is Ops.WMMA]): # TODO: handle TCs f32_bf16 and bf16_bf16 w/ wrapper


### PR DESCRIPTION
Working on bf16 tc support for amd. 
Using typedef instead of struct fixes vectorization for bf16.

Won't open bf16 tc pull request until I can properly test in tiny10. Progress here (ignaciosica/tinygrad#84))

process_replay has the following diff
```diff
-struct hip_bfloat16 { unsigned short data; };
+typedef unsigned short hip_bfloat16;
```