### PR TITLE
less flaky benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Run 10 CIFAR training steps
       run: JIT=1 STEPS=10 python3.11 examples/hlb_cifar10.py | tee train_cifar.txt
     - name: Run 10 CIFAR training steps w HALF
-      run: JIT=1 STEPS=10 DEFAULT_FLOAT=HALF python3.11 examples/hlb_cifar10.py | tee train_cifar_half.txt
+      run: JIT=2 STEPS=10 DEFAULT_FLOAT=HALF python3.11 examples/hlb_cifar10.py | tee train_cifar_half.txt
     #- name: Run 10 CIFAR training steps w BF16
     #  run: STEPS=10 DEFAULT_FLOAT=BFLOAT16 python3.11 examples/hlb_cifar10.py | tee train_cifar_bf16.txt
     - name: Run 10 CIFAR training steps w winograd

--- a/test/external/speed_v_theoretical.py
+++ b/test/external/speed_v_theoretical.py
@@ -83,7 +83,7 @@ class TestKernelSpeed(unittest.TestCase):
   # TODO: smaller ones has other overhead in synchronize
   # def test_gemm_1024(self): self._test_matmul(1024, nv_tflops=8, amd_tflops=7)
   # def test_gemm_2048(self): self._test_matmul(2048, nv_tflops=50, amd_tflops=30)
-  def test_gemm_4096(self): self._test_matmul(4096, nv_tflops=100, amd_tflops=70)
+  def test_gemm_4096(self): self._test_matmul(4096, nv_tflops=95, amd_tflops=70)
   def test_gemm_8192(self): self._test_matmul(8192, nv_tflops=130, amd_tflops=70)
 
   def test_gemv_16384_4096(self): self._test_matmul(16384, 4096, 1, nv_gbs=430, amd_gbs=400)


### PR DESCRIPTION
JIT=2 for metal cifar with HALF, and lower tflops for nv test_gemm_4096. failures in https://github.com/tinygrad/tinygrad/actions/runs/11980239535/job/33404098428?pr=7830