### PR TITLE
add test for inconsistent behavior in float to int casting

### DIFF
--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -3,7 +3,7 @@ import unittest
 from tinygrad import Tensor, dtypes, Device
 import operator
 import numpy as np
-from hypothesis import given, strategies as strat, settings, HealthCheck
+from hypothesis import given, strategies as strat, settings
 from tinygrad.dtype import DType
 from tinygrad.helpers import CI, getenv
 from tinygrad.engine.schedule import create_schedule

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -174,7 +174,7 @@ class TestDTypeALU(unittest.TestCase):
   def test_int32_cast(self, a, dtype): universal_test_cast(a, dtypes.int32, dtype)
 
   @unittest.expectedFailure
-  def test_float_cast_to_int_failure(self):
+  def test_unsafe_cast_float_to_int_failure(self):
     val = float(dtypes.max(dtypes.int32) - 1)
     t1 = Tensor([val], dtype=dtypes.float32).cast(dtypes.int32)
     t2 = Tensor(val, dtype=dtypes.float32).cast(dtypes.int32)

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -3,7 +3,7 @@ import unittest
 from tinygrad import Tensor, dtypes, Device
 import operator
 import numpy as np
-from hypothesis import given, strategies as strat, settings
+from hypothesis import given, strategies as strat, settings, HealthCheck
 from tinygrad.dtype import DType
 from tinygrad.helpers import CI, getenv
 from tinygrad.engine.schedule import create_schedule
@@ -172,6 +172,13 @@ class TestDTypeALU(unittest.TestCase):
   @unittest.skip("broken. TODO: fix it")
   @given(ht.int32, strat.sampled_from(dtypes_float+dtypes_int+dtypes_bool))
   def test_int32_cast(self, a, dtype): universal_test_cast(a, dtypes.int32, dtype)
+
+  @unittest.expectedFailure
+  def test_float_cast_to_int_failure(self):
+    val = float(dtypes.max(dtypes.int32) - 1)
+    t1 = Tensor([val], dtype=dtypes.float32).cast(dtypes.int32)
+    t2 = Tensor(val, dtype=dtypes.float32).cast(dtypes.int32)
+    np.testing.assert_equal(t1.item(), t2.item())
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
this really tripped me out while I was doing float -> uint casting
thought I was going insane for a bit

should we treat this cast?

-------

`t1 = Tensor([2147483646.0], dtype=dtypes.float32).cast(dtypes.int32) -> 2147483647`

```
UOp(Ops.SINK, dtypes.void, arg=KernelInfo(local_dims=0, upcasted=0, dont_use_locals=False), src=(
  UOp(Ops.STORE, dtypes.void, arg=None, src=(
    UOp(Ops.DEFINE_GLOBAL, dtypes.int.ptr(), arg=0, src=()),
    x2:=UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(), strides=(), offset=0, mask=None, contiguous=True),)), src=()),
    UOp(Ops.CAST, dtypes.int, arg=None, src=(
      UOp(Ops.LOAD, dtypes.float, arg=None, src=(
        UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(), arg=1, src=()),
         x2,)),)),)),))
[]

void E_(int* restrict data0, float* restrict data1) {
  float val0 = *(data1+0);
  *(data0+0) = ((int)(val0));
}
```
--------


`t2 = Tensor(2147483646.0, dtype=dtypes.float32).cast(dtypes.int32) -> 2147483646`
`
```
UOp(Ops.SINK, dtypes.void, arg=KernelInfo(local_dims=0, upcasted=0, dont_use_locals=False), src=(
  UOp(Ops.STORE, dtypes.void, arg=None, src=(
    UOp(Ops.DEFINE_GLOBAL, dtypes.int.ptr(), arg=0, src=()),
    x2:=UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(), strides=(), offset=0, mask=None, contiguous=True),)), src=()),
    UOp(Ops.WHERE, dtypes.int, arg=None, src=(
      UOp(Ops.VALID, dtypes.bool, arg=None, src=(
         x2,)),
      UOp(Ops.CONST, dtypes.int, arg=2147483646, src=()),
      UOp(Ops.CONST, dtypes.int, arg=0, src=()),)),)),))
[]

void E_n1(int* restrict data0) {
  *(data0+0) = 2147483646;
}
```
---------

numpy with `RuntimeWarning: invalid value encountered in cast`
```
np.array([2147483646.0], dtype=np.float32).astype('int32').item() -> 2147483647
np.array(2147483646.0, dtype=np.float32).astype('int32').item() -> 2147483647
```
torch is 2147483647 too


