### PR TITLE
Fix missing final rewrite in viz

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -68,7 +68,10 @@ def uop_to_json(x:UOp) -> Dict[int, Tuple[str, str, List[int], str, str]]:
   return graph
 def _replace_uop(base:UOp, replaces:Dict[UOp, UOp]) -> UOp:
   if (found:=replaces.get(base)) is not None: return found
-  replaces[base] = ret = base.replace(src=tuple(_replace_uop(x, replaces) for x in base.src))
+  ret = base.replace(src=tuple(_replace_uop(x, replaces) for x in base.src))
+  if (final := replaces.get(ret)) is not None:
+      return final
+  replaces[base] = ret
   return ret
 @functools.lru_cache(None)
 def _prg(k:Optional[Kernel]) -> Optional[str]:


### PR DESCRIPTION
In `_replace_uop` in `viz/serve.py`, master assumes rewriting `base` requires only rewriting its `src`s, however this is not true with matches from `(UPat(Ops.SINK, name="root")` and similar.

Fixes visible EXPAND nodes after the final expander rewrite in `uopgraph.py`.
