### PR TITLE
[BUGFIX] Tensor([]).data()

### DIFF
--- a/test/test_tensor_data.py
+++ b/test/test_tensor_data.py
@@ -24,6 +24,13 @@ class TestTensorData(unittest.TestCase):
     assert dat[0] == 1
     assert dat[1] == 2
 
+  def test_data_empty(self):
+    a = Tensor([], dtype=dtypes.int32)
+    dat = a.data()
+    assert dat.itemsize == 4
+    assert list(dat) == []
+    assert dat.shape == (0,)
+
   def test_data_uint8(self):
     a = Tensor([1,2,3,4], dtype=dtypes.uint8)
     dat = a.data()

--- a/test/test_tensor_data.py
+++ b/test/test_tensor_data.py
@@ -31,6 +31,13 @@ class TestTensorData(unittest.TestCase):
     assert list(dat) == []
     assert dat.shape == (0,)
 
+  def test_data_empty_multi_dim(self):
+    a = Tensor([], dtype=dtypes.int32).reshape(0, 2)
+    dat = a.data()
+    assert dat.itemsize == 4
+    assert list(dat) == []
+    assert dat.shape == (0,)
+
   def test_data_uint8(self):
     a = Tensor([1,2,3,4], dtype=dtypes.uint8)
     dat = a.data()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -273,7 +273,7 @@ class Tensor(SimpleMathTrait):
     """
     assert self.dtype.fmt is not None, f"no fmt dtype for {self.dtype}"
     assert all_int(self.shape), f"no data if shape is symbolic, {self.shape=}"
-    return self._data().cast(self.dtype.fmt, self.shape)
+    return self._data().cast(self.dtype.fmt) if 0 in self.shape else self._data().cast(self.dtype.fmt, self.shape)
 
   def item(self) -> ConstType:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -273,7 +273,7 @@ class Tensor(SimpleMathTrait):
     """
     assert self.dtype.fmt is not None, f"no fmt dtype for {self.dtype}"
     assert all_int(self.shape), f"no data if shape is symbolic, {self.shape=}"
-    return self._data().cast(self.dtype.fmt) if self.shape == (0,) else self._data().cast(self.dtype.fmt, self.shape)
+    return self._data().cast(self.dtype.fmt) if 0 in self.shape else self._data().cast(self.dtype.fmt, self.shape)
 
   def item(self) -> ConstType:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -273,7 +273,7 @@ class Tensor(SimpleMathTrait):
     """
     assert self.dtype.fmt is not None, f"no fmt dtype for {self.dtype}"
     assert all_int(self.shape), f"no data if shape is symbolic, {self.shape=}"
-    return self._data().cast(self.dtype.fmt) if 0 in self.shape else self._data().cast(self.dtype.fmt, self.shape)
+    return self._data().cast(self.dtype.fmt) if self.shape == (0,) else self._data().cast(self.dtype.fmt, self.shape)
 
   def item(self) -> ConstType:
     """


### PR DESCRIPTION
Right now `memoryview` raises an error if `data` is called on a Tensor with `0 in Tensor.shape`. This is because `memoryview` does not allow casting to a shape that includes a 0.

```
TypeError: memoryview: cannot cast view with zeros in shape or strides
```

I have added a test for this and a fix for `Tensor.shape == (0,)`.

There still is a problem with `Tensor([]).reshape(0, 2).data()`. Since casting is not allowed I do not see how to make the shapes match in that case.