### PR TITLE
ops metadata map try 2, early fuse [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -176,12 +176,7 @@ to_si = PatternMatcher([
 
 # ** fusion
 
-def fuse_src(ctx:ScheduleItemContext, b:UOp, to_store:UOp, base:UOp) -> UOp:
-  if (lbuf:=ctx.lazybufs.get(b)) is not None and (metadata:=lbuf.metadata) is not None: ctx.metadata.add(metadata)
-  return to_store
-
 lazy = PatternMatcher([
-  (UPatSrc(), fuse_src),
   (UPat(Ops.BUFFER, name="b").view(name="v"), lambda ctx,b,v: UOp(Ops.PRELOAD if b in ctx.assigns else Ops.LOAD, v.dtype, (b, v.st.to_uop()))),
   (UPat(Ops.CONTIGUOUS, src=(UPat.var("x"),)), lambda ctx,x: x),
 ])

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -366,7 +366,7 @@ break_sched = PatternMatcher([
   # consts are always fused and generated
   (UPatSrc({Ops.CONST, Ops.BIND}), generate_valid),
   # everything else is a VIEW of BUFFER that either realizes or fuses
-  (UPatSrc(), lambda ctx,b,to_store,base: append_kernel(ctx, b, to_store, base) if b in ctx.realizes else None),
+  (UPatSrc(), lambda ctx,b,to_store,base: append_kernel(ctx, b, to_store, base) if b in ctx.realizes else to_store),
 ])
 
 @track_rewrites(named=True)


### PR DESCRIPTION
It's more correct this way. The logic for fold/fuse is isolated in break_sched. In master it's scattered between lazy and break_sched.

```
~/code/tinygrad (metadata_try_2) > SCHEDULE_ONLY=1 python3 test/external/external_benchmark_schedule.py
***** model tensor in     24.25 ms
***** model schedule in   81.25 ms
all 105.54 ms

~/code/tinygrad (master) > SCHEDULE_ONLY=1 python3 test/external/external_benchmark_schedule.py
***** model tensor in     24.54 ms
***** model schedule in   83.12 ms
all 107.70 ms
```