### PR TITLE
hotfix ctypes.c_ulong(size) for metal _alloc

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -135,7 +135,8 @@ class MetalAllocator(LRUAllocator):
     super().__init__()
   def _alloc(self, size:int, options) -> MetalBuffer:
     # Buffer is explicitly released in _free() rather than garbage collected via reference count
-    ret = msg(self.dev.sysdevice, "newBufferWithLength:options:", size, MTLResourceOptions.MTLResourceStorageModeShared, restype=objc_id)
+    ret = msg(self.dev.sysdevice, "newBufferWithLength:options:", ctypes.c_ulong(size), MTLResourceOptions.MTLResourceStorageModeShared,
+              restype=objc_id)
     if ret.value is None: raise MemoryError(f"Metal OOM while allocating {size=}")
     return MetalBuffer(ret, size)
   def _free(self, opaque:MetalBuffer, options): msg(opaque.buf, "release")


### PR DESCRIPTION
fix `Tensor.ones(1000, 1000, 1000).contiguous().realize()` on METAL

on master it raises error
```
  File "/Users/chenyu/code/tinygrad/tinygrad/runtime/ops_metal.py", line 139, in _alloc
    if ret.value is None: raise MemoryError(f"Metal OOM while allocating {size=}")
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
MemoryError: Metal OOM while allocating size=4000000000
```