### PR TITLE
Downgrade wgpu to prevent sd segfault

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name='tinygrad',
             "bottle",
             "ggml-python"
         ],
-        'webgpu': ["wgpu>=v0.19.0"],
+        'webgpu': ["wgpu==v0.18.1"],
         'docs': [
             "mkdocs",
             "mkdocs-material",

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -58,8 +58,8 @@ class WebGpuAllocator(Allocator):
 
 class WebGpuDevice(Compiled):
   def __init__(self, device:str):
-    adapter = wgpu.gpu.request_adapter_sync(power_preference="high-performance")
+    adapter = wgpu.gpu.request_adapter(power_preference="high-performance")
     timestamp_supported = wgpu.FeatureName.timestamp_query in adapter.features
-    wgpu_device = adapter.request_device_sync(required_features=[wgpu.FeatureName.timestamp_query] if timestamp_supported else [])
+    wgpu_device = adapter.request_device(required_features=[wgpu.FeatureName.timestamp_query] if timestamp_supported else [])
     super().__init__(device, WebGpuAllocator(wgpu_device), WGSLRenderer(), Compiler(),
                      functools.partial(WebGPUProgram, (wgpu_device, timestamp_supported)))


### PR DESCRIPTION
Starting with  `wgpu v0.19.0 `, stable diffusion segfaults with:

>  File "/Users/ahmedharmouche/Documents/tinygrad/tinygrad/runtime/ops_webgpu.py", line 56, in _copyout
>     buffer_data = self.dev.queue.read_buffer(src, 0)
>                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/ahmedharmouche/Documents/tinygrad/venv/lib/python3.12/site-packages/wgpu/backends/wgpu_native/_api.py", line 3427, in read_buffer
>     tmp_buffer._map("READ_NOSYNC").sync_wait()
>   File "/Users/ahmedharmouche/Documents/tinygrad/venv/lib/python3.12/site-packages/wgpu/backends/wgpu_native/_helpers.py", line 268, in sync_wait
>     return self.finish()
>            ^^^^^^^^^^^^^
>   File "/Users/ahmedharmouche/Documents/tinygrad/venv/lib/python3.12/site-packages/wgpu/backends/wgpu_native/_helpers.py", line 260, in finish
>     raise RuntimeError(f"Waiting for {self.title} timed out.")
> RuntimeError: Waiting for buffer.map timed out.
> zsh: segmentation fault  PYTHONPATH=. WEBGPU=1 python3 examples/stable_diffusion.py --seed 0 --steps 1

Downgrading to the latest version which works, which is `0.18.1`. Will report the bug in the wgpu repo.