### PR TITLE
unset TRACK_MATCH_STATS while initing beam buffers [pr]

### DIFF
--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -38,7 +38,7 @@ def get_kernel(renderer:Renderer, ast:UOp) -> Kernel:
         if beam_compare == 2:
           from tinygrad import Tensor
           all_outs: List[List[Tensor]] = []
-          with Context(DEBUG=0, BEAM=0, CAPTURING=0):
+          with Context(DEBUG=0, BEAM=0, CAPTURING=0, TRACK_MATCH_STATS=0):
             rand_bufs = [Tensor.normal(buf.size, std=0.1, dtype=buf.dtype).data() if dtypes.is_float(buf.dtype) else \
                         (Tensor.randint(buf.size, low=0, high=2).cast(buf.dtype).data() if buf.dtype == dtypes.bool else \
                          Tensor.randint(buf.size, low=dtypes.min(buf.dtype), high=dtypes.max(buf.dtype), dtype=buf.dtype).data()) \
@@ -47,7 +47,7 @@ def get_kernel(renderer:Renderer, ast:UOp) -> Kernel:
             for buf,data in zip(rawbufs, rand_bufs): buf.ensure_allocated().copyin(data)
             time_linearizer(tk, rawbufs, allow_test_size=False, clear_l2=True, disable_cache=True)
             all_outs.append([Tensor(bytes(buf.as_buffer()), dtype=buf.dtype) for buf in rawbufs[:len(ast.src)]])
-          with Context(DEBUG=0, BEAM=0, CAPTURING=0):
+          with Context(DEBUG=0, BEAM=0, CAPTURING=0, TRACK_MATCH_STATS=0):
             for bufs in zip(*all_outs):
               for b in bufs[1:]:
                 if dtypes.is_float(bufs[0].dtype):

--- a/tinygrad/engine/search.py
+++ b/tinygrad/engine/search.py
@@ -47,7 +47,7 @@ def _time_program(p:ProgramSpec, lib:bytes, var_vals:Dict[Variable, int], rawbuf
     if clear_l2:
       if hasattr(dev:=Device[p.device], 'invalidate_caches'): dev.invalidate_caches()
       else:
-        with Context(DEBUG=0, BEAM=0, CAPTURING=0): Tensor.ones(1024,1024).contiguous().realize(do_update_stats=False)
+        with Context(DEBUG=0, BEAM=0, CAPTURING=0, TRACK_MATCH_STATS=0): Tensor.ones(1024,1024).contiguous().realize(do_update_stats=False)
     tms.append(cast(float, car(input_bufs, var_vals, wait=True))*factor)
     if early_stop is not None and early_stop < min(tms): break
   return tms


### PR DESCRIPTION
realized this after spending half an hour counting kernels in #7940.