### PR TITLE
increase tolerance on test_jitted_view [pr]

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -429,7 +429,7 @@ class TestJit(unittest.TestCase):
     for _ in range(5):
       a = Tensor.randn(10, 1000, device=d0).realize()
       xc = jf(a)
-      np.testing.assert_allclose((a.numpy().sum(axis=(1,)) + 5).view(np.int32), xc.numpy(), atol=1e-4, rtol=1e-5)
+      np.testing.assert_allclose((a.numpy().sum(axis=(1,)) + 5).view(np.int32), xc.numpy(), atol=1e-4, rtol=5e-5)
 
   def test_jit_output_clone(self):
     @TinyJit


### PR DESCRIPTION
rtol=1e-5 => rtol=5e-5

This test just failed on CI on master

https://github.com/ignaciosica/tinygrad/actions/runs/12097851268/job/33733678176#step:11:169
<img width="1429" alt="image" src="https://github.com/user-attachments/assets/017ca1f9-c3af-4378-9b89-c7c7cf82c614">
