### PR TITLE
fp16 conv2d numerical inaccuracy

### DIFF
--- a/test/test_numerical_accuracy.py
+++ b/test/test_numerical_accuracy.py
@@ -6,9 +6,9 @@ from tinygrad.device import Device, is_dtype_supported
 
 class TestNumericalAccuracy(unittest.TestCase):
   # TODO: blocker for true onnx fp16
-  @unittest.skipIf(not is_dtype_supported(dtypes.half, Device.DEFAULT) or Device.DEFAULT == "CLANG", "non-cpu backends fail")
+  @unittest.skipIf(not is_dtype_supported(dtypes.half) or Device.DEFAULT == "CLANG", "non-clang backends fail")
   @unittest.expectedFailure
-  def test_conv2d_fp16(self):
+  def test_conv2d_fp16_default(self):
     x,w,b = np.random.randn(1, 12, 128, 128), np.random.randn(32, 12, 3, 3), np.random.randn(32)
     tiny_x, tiny_w, tiny_b = (Tensor(t, dtype=dtypes.half) for t in (x,w,b))
     torch_x, torch_w, torch_b = (torch.tensor(t, dtype=torch.half) for t in (x,w,b))
@@ -17,11 +17,19 @@ class TestNumericalAccuracy(unittest.TestCase):
     np.testing.assert_allclose(tinygrad_out.numpy(), torch_out.numpy(), rtol=5e-3, atol=5e-3)
 
   # TODO: blocker for true onnx fp16
-  @unittest.skipIf(not is_dtype_supported(dtypes.half, Device.DEFAULT) or Device.DEFAULT == "CLANG", "non-cpu backends fail")
+  @unittest.skipIf(not is_dtype_supported(dtypes.half) or Device.DEFAULT == "CLANG", "non-clang backends fail")
   @unittest.expectedFailure
   def test_conv2d_fp16_noopt(self):
     with Context(NOOPT=1):
-      self.test_conv2d_fp16()
+      self.test_conv2d_fp16_default()
+
+  @unittest.skipIf(not is_dtype_supported(dtypes.half))
+  def test_conv2d_fp16_default_vs_noopt(self):
+    x,w,b = Tensor.randn(1, 12, 128, 128, dtype=dtypes.half), Tensor.randn(32, 12, 3, 3, dtype=dtypes.half), Tensor.randn(32, dtype=dtypes.half)
+    default = Tensor.conv2d(x,w,b).numpy()
+    with Context(NOOPT=1):
+      noopt = Tensor.conv2d(x,w,b).numpy()
+    np.testing.assert_allclose(default, noopt, rtol=2e-3, atol=2e-3)
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_numerical_accuracy.py
+++ b/test/test_numerical_accuracy.py
@@ -6,30 +6,36 @@ from tinygrad.device import Device, is_dtype_supported
 
 class TestNumericalAccuracy(unittest.TestCase):
   # TODO: blocker for true onnx fp16
-  @unittest.skipIf(not is_dtype_supported(dtypes.half) or Device.DEFAULT == "CLANG", "non-clang backends fail")
+  @unittest.skipUnless(is_dtype_supported(dtypes.half) and Device.DEFAULT != "CLANG", "non-clang backends fail")
   @unittest.expectedFailure
   def test_conv2d_fp16_default(self):
-    x,w,b = np.random.randn(1, 12, 128, 128), np.random.randn(32, 12, 3, 3), np.random.randn(32)
+    x,w,b = np.random.randn(1,12,128,128), np.random.randn(32,12,3,3), np.random.randn(32)
     tiny_x, tiny_w, tiny_b = (Tensor(t, dtype=dtypes.half) for t in (x,w,b))
     torch_x, torch_w, torch_b = (torch.tensor(t, dtype=torch.half) for t in (x,w,b))
     tinygrad_out = Tensor.conv2d(tiny_x, tiny_w, tiny_b)
     torch_out = torch.nn.functional.conv2d(torch_x, torch_w, torch_b)
     np.testing.assert_allclose(tinygrad_out.numpy(), torch_out.numpy(), rtol=5e-3, atol=5e-3)
 
-  # TODO: blocker for true onnx fp16
-  @unittest.skipIf(not is_dtype_supported(dtypes.half) or Device.DEFAULT == "CLANG", "non-clang backends fail")
+  @unittest.skipUnless(is_dtype_supported(dtypes.half) and Device.DEFAULT != "CLANG", "non-clang backends fail")
   @unittest.expectedFailure
   def test_conv2d_fp16_noopt(self):
     with Context(NOOPT=1):
       self.test_conv2d_fp16_default()
 
-  @unittest.skipIf(not is_dtype_supported(dtypes.half))
+  @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
   def test_conv2d_fp16_default_vs_noopt(self):
-    x,w,b = Tensor.randn(1, 12, 128, 128, dtype=dtypes.half), Tensor.randn(32, 12, 3, 3, dtype=dtypes.half), Tensor.randn(32, dtype=dtypes.half)
+    x,w,b = Tensor.randn(1,12,128,128, dtype=dtypes.half), Tensor.randn(32,12,3,3, dtype=dtypes.half), Tensor.randn(32, dtype=dtypes.half)
     default = Tensor.conv2d(x,w,b).numpy()
     with Context(NOOPT=1):
       noopt = Tensor.conv2d(x,w,b).numpy()
     np.testing.assert_allclose(default, noopt, rtol=2e-3, atol=2e-3)
+
+  @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
+  def test_conv2d_fp16_vs_fp32(self):
+    x,w,b = Tensor.randn(1,12,128,128), Tensor.randn(32,12,3,3), Tensor.randn(32)
+    fp32_out = Tensor.conv2d(x.float(), w.float(), b.float())
+    fp16_out = Tensor.conv2d(x.half(), w.half(), b.half())
+    np.testing.assert_allclose(fp32_out.numpy(), fp16_out.numpy(), rtol=2e-2, atol=2e-2)
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_numerical_accuracy.py
+++ b/test/test_numerical_accuracy.py
@@ -38,4 +38,5 @@ class TestNumericalAccuracy(unittest.TestCase):
     np.testing.assert_allclose(fp32_out.numpy(), fp16_out.numpy(), rtol=2e-2, atol=2e-2)
 
 if __name__ == "__main__":
+  np.random.seed(0)
   unittest.main()

--- a/test/test_numerical_accuracy.py
+++ b/test/test_numerical_accuracy.py
@@ -1,0 +1,27 @@
+import unittest
+import numpy as np
+import torch
+from tinygrad import Tensor, Context, dtypes
+from tinygrad.device import Device, is_dtype_supported
+
+class TestNumericalAccuracy(unittest.TestCase):
+  # TODO: blocker for true onnx fp16
+  @unittest.skipIf(not is_dtype_supported(dtypes.half, Device.DEFAULT) or Device.DEFAULT == "CLANG", "non-cpu backends fail")
+  @unittest.expectedFailure
+  def test_conv2d_fp16(self):
+    x,w,b = np.random.randn(1, 12, 128, 128), np.random.randn(32, 12, 3, 3), np.random.randn(32)
+    tx,tw,tb = (Tensor(t, dtype=dtypes.half) for t in (x,w,b))
+    tx_,tw_,tb_ = (torch.tensor(t, dtype=torch.half) for t in (x,w,b))
+    tinygrad_out = Tensor.conv2d(tx,tw,tb)
+    torch_out = torch.nn.functional.conv2d(tx_,tw_,tb_)
+    np.testing.assert_allclose(tinygrad_out.numpy(), torch_out.numpy(), rtol=5e-3, atol=5e-3)
+
+  # TODO: blocker for true onnx fp16
+  @unittest.skipIf(not is_dtype_supported(dtypes.half, Device.DEFAULT) or Device.DEFAULT == "CLANG", "non-cpu backends fail")
+  @unittest.expectedFailure
+  def test_conv2d_fp16_noopt(self):
+    with Context(NOOPT=1):
+      self.test_conv2d_fp16()
+
+if __name__ == "__main__":
+  unittest.main()

--- a/test/test_numerical_accuracy.py
+++ b/test/test_numerical_accuracy.py
@@ -10,10 +10,10 @@ class TestNumericalAccuracy(unittest.TestCase):
   @unittest.expectedFailure
   def test_conv2d_fp16(self):
     x,w,b = np.random.randn(1, 12, 128, 128), np.random.randn(32, 12, 3, 3), np.random.randn(32)
-    tx,tw,tb = (Tensor(t, dtype=dtypes.half) for t in (x,w,b))
-    tx_,tw_,tb_ = (torch.tensor(t, dtype=torch.half) for t in (x,w,b))
-    tinygrad_out = Tensor.conv2d(tx,tw,tb)
-    torch_out = torch.nn.functional.conv2d(tx_,tw_,tb_)
+    tiny_x, tiny_w, tiny_b = (Tensor(t, dtype=dtypes.half) for t in (x,w,b))
+    torch_x, torch_w, torch_b = (torch.tensor(t, dtype=torch.half) for t in (x,w,b))
+    tinygrad_out = Tensor.conv2d(tiny_x, tiny_w, tiny_b)
+    torch_out = torch.nn.functional.conv2d(torch_x, torch_w, torch_b)
     np.testing.assert_allclose(tinygrad_out.numpy(), torch_out.numpy(), rtol=5e-3, atol=5e-3)
 
   # TODO: blocker for true onnx fp16

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1956,6 +1956,8 @@ class TestOps(unittest.TestCase):
       lambda x,w: torch.nn.functional.conv2d(x,w,padding=padding).relu(),
       lambda x,w: Tensor.conv2d(x,w,padding=padding).relu())
 
+  # TODO: fix
+  @unittest.skipIf(CI and Device.DEFAULT == "LLVM", "CI segfaults")
   @unittest.expectedFailure
   def test_conv2d_fp16(self):
     helper_test_op([(1,12,128,256), (32,12,3,3), (32,)],

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1957,7 +1957,7 @@ class TestOps(unittest.TestCase):
       lambda x,w: Tensor.conv2d(x,w,padding=padding).relu())
 
   # TODO: fix
-  @unittest.skipIf(CI and Device.DEFAULT == "LLVM", "CI segfaults")
+  @unittest.skipIf(CI and Device.DEFAULT in {"LLVM", "PTX", "NV"}, "crashes in CI")
   @unittest.expectedFailure
   def test_conv2d_fp16(self):
     helper_test_op([(1,12,128,256), (32,12,3,3), (32,)],

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1956,14 +1956,6 @@ class TestOps(unittest.TestCase):
       lambda x,w: torch.nn.functional.conv2d(x,w,padding=padding).relu(),
       lambda x,w: Tensor.conv2d(x,w,padding=padding).relu())
 
-  # TODO: fix
-  @unittest.skipIf(CI and Device.DEFAULT in {"LLVM", "PTX", "NV"}, "crashes in CI")
-  @unittest.expectedFailure
-  def test_conv2d_fp16(self):
-    helper_test_op([(1,12,128,256), (32,12,3,3), (32,)],
-      lambda x,w,b: torch.nn.functional.conv2d(x.half(),w.half(),b.half()),
-      lambda x,w,b: Tensor.conv2d(x.half(),w.half(),b.half()), atol=5e-3, rtol=5e-3)
-
   def test_padding_add(self):
     helper_test_op([(64,64), (60,60)],
       lambda x,w: x+torch.nn.functional.pad(w, (2,2,2,2)),

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1956,6 +1956,12 @@ class TestOps(unittest.TestCase):
       lambda x,w: torch.nn.functional.conv2d(x,w,padding=padding).relu(),
       lambda x,w: Tensor.conv2d(x,w,padding=padding).relu())
 
+  @unittest.expectedFailure
+  def test_conv2d_fp16(self):
+    helper_test_op([(1,12,128,256), (32,12,3,3), (32,)],
+      lambda x,w,b: torch.nn.functional.conv2d(x.half(),w.half(),b.half()),
+      lambda x,w,b: Tensor.conv2d(x.half(),w.half(),b.half()), atol=5e-3, rtol=5e-3)
+
   def test_padding_add(self):
     helper_test_op([(64,64), (60,60)],
       lambda x,w: x+torch.nn.functional.pad(w, (2,2,2,2)),


### PR DESCRIPTION
This is a blocker for true fp16 usage in onnx.
This inaccuracy is also exacerbated when the output is used as input for other ops

for instance this conv->elu->conv->... at the start of openpilot (output of elu is used as input for the next conv)
```
# 0: op "Conv" input shapes [(1, 12, 128, 256), (32, 12, 3, 3), (32,)] opt {'dilations': (1, 1), 'group': 1, 'kernel_shape': (3, 3), 'pads': (1, 1, 1, 1), 'strides': (2, 2)}
# 1: op "Elu" input shapes [(1, 32, 64, 128)] opt {'alpha': 1.0}
# 2: op "Conv" input shapes [(1, 32, 64, 128), (32, 1, 3, 3), (32,)] opt {'dilations': (1, 1), 'group': 32, 'kernel_shape': (3, 3), 'pads': (1, 1, 1, 1), 'strides': (1, 1)}
# 3: op "Elu" input shapes [(1, 32, 64, 128)] opt {'alpha': 1.0}
# 4: op "Conv" input shapes [(1, 32, 64, 128), (16, 32, 1, 1), (16,)] opt {'dilations': (1, 1), 'group': 1, 'kernel_shape': (1, 1), 'pads': (0, 0, 0, 0), 'strides': (1, 1)}
# 5: op "Conv" input shapes [(1, 16, 64, 128), (16, 1, 3, 3), (16,)] opt {'dilations': (1, 1), 'group': 16, 'kernel_shape': (3, 3), 'pads': (1, 1, 1, 1), 'strides': (1, 1)}
# 6: op "Elu" input shapes [(1, 16, 64, 128)] opt {'alpha': 1.0}
# 7: op "Conv" input shapes [(1, 16, 64, 128), (16, 16, 1, 1), (16,)] opt {'dilations': (1, 1), 'group': 1, 'kernel_shape': (1, 1), 'pads': (0, 0, 0, 0), 'strides': (1, 1)}
...
```

caught this using a little verifier I wrote where I compare outputs to torch onnx for each op
for openpilot in particular, after the 7th conv op, `rtol=2e-3, atol=2e-3` (rtol atol for `external_model_benchmark.py`) is already violated.

not too sure whats the right thing to do here.