### PR TITLE
Remove webgpu specific checks from stable diffusion example

### DIFF
--- a/examples/stable_diffusion.py
+++ b/examples/stable_diffusion.py
@@ -189,7 +189,7 @@ class StableDiffusion:
     # make image correct size and scale
     x = (x + 1.0) / 2.0
     x = x.reshape(3,512,512).permute(1,2,0).clip(0,1)*255
-    return x.cast(dtypes.uint8) if Device.DEFAULT != "WEBGPU" else x
+    return x.cast(dtypes.uint8)
 
   def __call__(self, unconditional_context, context, latent, timestep, alphas, alphas_prev, guidance):
     e_t = self.get_model_output(unconditional_context, context, latent, timestep, guidance)
@@ -280,7 +280,7 @@ if __name__ == "__main__":
   print(x.shape)
 
   # save image
-  im = Image.fromarray(x.numpy().astype(np.uint8, copy=False))
+  im = Image.fromarray(x.numpy())
   print(f"saving {args.out}")
   im.save(args.out)
   # Open image.


### PR DESCRIPTION
We already support `uint8`, so no need the prevent that cast. The .`astype(np.uint8)` thing was also introduced because of this, [here](https://github.com/tinygrad/tinygrad/pull/2032/files#diff-9cb47193472565612f6239ffc4a259fc61bd7eb906d263db9198a1a7944929ab), and is not needed.