### PR TITLE
only mutate the image Buffer [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -58,11 +58,11 @@ def to_uop(buf:LazyBuffer, ctx:ScheduleContext, buffers:Dict[UOp, Buffer], cache
   # make things that can't be images not images
   dtype = buf.dtype
   if isinstance(dtype, ImageDType) and (prod(buf.shape) != prod(dtype.shape) or not any(buf.shape[x]%4 == 0 for x in buf.st.unit_stride_axes())):
-    assert buf.realized is None, "can't fixup allocated buffer"
+    assert buf.realized is None or buf.realized.dtype == dtype.base, f"allocated buffer must be fixed up already {buf}"
     if DEBUG >= 2: print(f"forcing image {dtype} with shape {buf.shape} to {dtype.base}")
     dtype = buf.dtype.base
-    # hack the underlying buffer too
-    buf.buffer.dtype = buf.dtype = dtype
+    # hack the underlying Buffer too
+    buf.buffer.dtype = dtype
     buf.buffer.options = None
   if buf.is_realized:
     ubuf = UOp.new_buffer(buf.device, buf.size, dtype)


### PR DESCRIPTION
`buf` is UOp in delete_lazy, UOp is immutable. This shouldn't impact correctness of the schedule.