### PR TITLE
Improved div folding

### DIFF
--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -433,8 +433,7 @@ class TestSymbolic(unittest.TestCase):
   def test_div_mod_recombine_folded_mod(self):
     a = Variable("a", 0, 2)
     b = Variable("b", 0, 100)
-    with self.assertRaises(AssertionError):
-      self.helper_test_variable((31 * a + 1) % 30 + ((31 * a + 1) // 30) * 30, 1, 63, "((a*31)+1)")
+    self.helper_test_variable((31 * a + 1) % 30 + ((31 * a + 1) // 30) * 30, 1, 63, "((a*31)+1)")
     with self.assertRaises(AssertionError):
       self.helper_test_variable((31 * b + 1) % 18 + ((31 * b + 1) // 18) * 18, 1, 3101, "((b*31)+1)")
 

--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -205,6 +205,13 @@ class TestSymbolic(unittest.TestCase):
     self.helper_test_variable((7+9*Variable("x",0,2)+9*Variable("y",0,2)+Variable("z",0,2))%10, 3, 9, "(((z+(x*-1))+(y*-1))+7)")
     self.helper_test_variable((10+12*Variable("x",0,2)+Variable("y", 0, 4)%3)%13, 8, 12, "(((x*-1)+(y%3))+10)")
 
+  def test_div_congruence(self):
+    self.helper_test_variable((3+3*Variable("a",0,3))//4, 0, 3, "a")
+    self.helper_test_variable((18+17*Variable("a",0,2)+17)//18, 1, 3, "(a+1)")
+
+  def test_div_congruence_multiple_vars(self):
+    self.helper_test_variable((9+(9+10)*Variable("x",0,3)+(8+10)*Variable("y",0,2))//10, 0, 10, "((x*2)+(y*2))")
+
   def test_mod_binary_expression(self):
     self.helper_test_variable((3+Variable("a",0,1))%4, 0, 3, "((a*-3)+3)")
     self.helper_test_variable((3+Variable("a",4,5))%4, 0, 3, "((a*-3)+15)")
@@ -450,11 +457,9 @@ class TestSymbolic(unittest.TestCase):
     unrolled_div = (gidx)//4+(gidx+2)//4+(gidx+3)//4+(gidx+1)//4
     self.helper_test_variable(unrolled_div, 0, 2, "gidx")
 
-    # TODO: fix this, it has only one term and is no longer an add chain
-    with self.assertRaises(AssertionError):
-      gidx = Variable("gidx", 0, 1)
-      unrolled_div = (gidx)//4+(gidx+2)//4+(gidx+3)//4+(gidx+1)//4
-      self.helper_test_variable(unrolled_div, 0, 1, "gidx")
+    gidx = Variable("gidx", 0, 1)
+    unrolled_div = (gidx)//4+(gidx+2)//4+(gidx+3)//4+(gidx+1)//4
+    self.helper_test_variable(unrolled_div, 0, 1, "gidx")
 
   def test_arange_unrolled2(self):
     gidx = Variable("gidx", 0, 2559)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -898,7 +898,7 @@ def div_and_mod_folding(x: UOp, c: int, which: Literal[Ops.MOD, Ops.IDIV], split
   # simple cancel div/mod case
   if (q:=x.vmin//c) == (x.vmax//c):
     if which is Ops.MOD: return x - q*c
-    else: return x.const_like(q)
+    return x.const_like(q)
 
   svars, factors, quotients, remainders, gcd, div, const, offset, something_changed = [], [], [], [], c, 1, 0, 0, False
   for u in split_uop(x, Ops.ADD):
@@ -921,7 +921,7 @@ def div_and_mod_folding(x: UOp, c: int, which: Literal[Ops.MOD, Ops.IDIV], split
     r = (offset+remainders[0])%c - offset%c
     offset -= r * v.vmin
     if which is Ops.MOD: return r*v + offset
-    else: return (factors[0]-r)//c * v + (const-offset)//c
+    return (factors[0]-r)//c * v + (const-offset)//c
 
   # a//c = (a-a%c)/c, if we can fold a%c, we can fold a//c
   # within a mod we can freely subtract multiples of c, we use this to see if a is congruent to an expression whose vmin/vmax are between 0 and c
@@ -933,12 +933,12 @@ def div_and_mod_folding(x: UOp, c: int, which: Literal[Ops.MOD, Ops.IDIV], split
   else: # vmin/vmax of the remainder is between 0 and c, we can remove the mod/div
     remainders = [min(r, r-c, key=abs) for r in remainders]
     if which is Ops.MOD: return functools.reduce(operator.add, [r*v for r,v in zip(remainders,svars)], offset)
-    else: return functools.reduce(operator.add, [(f-r)//c * v for f,r,v in zip(factors, remainders,svars)], (const-offset)//c)
+    return functools.reduce(operator.add, [(f-r)//c * v for f,r,v in zip(factors, remainders,svars)], (const-offset)//c)
 
   if gcd != 1: something_changed = True
   if not something_changed:
     if which is Ops.IDIV and (1 < div < c) and (newx:=div_and_mod_folding(x, div, Ops.IDIV)) is not None: return newx//(c//div)
-    else: return None
+    return None
   quo, rem = const//c, (const%c)//gcd
   for q,r,f,v in zip(quotients, remainders, factors, svars):
     if which is Ops.IDIV and (not split_rem) and r!=0:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -932,14 +932,14 @@ def div_and_mod_folding(x: UOp, c: int, which: Literal[Ops.MOD, Ops.IDIV], split
     offset -= r * v.vmin  # determine what the new offset would be
   else: # vmin/vmax of the remainder is between 0 and c, we can remove the mod/div
     remainders = [min(r, r-c, key=abs) for r in remainders]
-    if which is Ops.MOD: return functools.reduce(operator.add, [r*v for r,v in zip(remainders,svars)], offset)
-    return functools.reduce(operator.add, [(f-r)//c * v for f,r,v in zip(factors, remainders,svars)], (const-offset)//c)
+    if which is Ops.MOD: return functools.reduce(operator.add, [r*v for r,v in zip(remainders,svars)], x.const_like(offset))
+    return functools.reduce(operator.add, [(f-r)//c * v for f,r,v in zip(factors, remainders,svars)], x.const_like((const-offset)//c))
 
   if gcd != 1: something_changed = True
   if not something_changed:
     if which is Ops.IDIV and (1 < div < c) and (newx:=div_and_mod_folding(x, div, Ops.IDIV)) is not None: return newx//(c//div)
     return None
-  quo, rem = const//c, (const%c)//gcd
+  quo, rem = x.const_like(const//c), x.const_like((const%c)//gcd)
   for q,r,f,v in zip(quotients, remainders, factors, svars):
     if which is Ops.IDIV and (not split_rem) and r!=0:
       rem += f//gcd * v


### PR DESCRIPTION
Combined div and mod folding, this now also performs the same optimizations as #7887 for div folding.
This fixes  #6935 and also some cases of #7958
With `split_rem=True` this would fix #7958 fully as it makes the treatment of the remainder more consitent between mod and idiv. I added it as a flag to make it easier to play around with and see the difference. 

Im just fuzzing this a little a little longer before Ill mark as ready
