### PR TITLE
refactor safe_load

### DIFF
--- a/examples/webgpu/stable_diffusion/compile.py
+++ b/examples/webgpu/stable_diffusion/compile.py
@@ -29,7 +29,7 @@ def convert_f32_to_f16(input_file, output_file):
     rest_float32_values.tofile(f)
 
 def split_safetensor(fn):
-  _, json_len, metadata = safe_load_metadata(fn)
+  _, data_start, metadata = safe_load_metadata(fn)
   text_model_offset = 3772703308
   chunk_size = 536870912
 
@@ -51,12 +51,12 @@ def split_safetensor(fn):
     part_offset = offset - last_offset
 
     if (part_offset >= chunk_size):
-      part_end_offsets.append(8+json_len+offset)
+      part_end_offsets.append(data_start+offset)
       last_offset = offset
 
   text_model_start = int(text_model_offset/2)
   net_bytes = bytes(open(fn, 'rb').read())
-  part_end_offsets.append(text_model_start+8+json_len)
+  part_end_offsets.append(text_model_start+data_start)
   cur_pos = 0
 
   for i, end_pos in enumerate(part_end_offsets):
@@ -65,7 +65,7 @@ def split_safetensor(fn):
       cur_pos = end_pos
 
   with open(os.path.join(os.path.dirname(__file__), f'./net_textmodel.safetensors'), "wb+") as f:
-    f.write(net_bytes[text_model_start+8+json_len:])
+    f.write(net_bytes[text_model_start+data_start:])
 
   return part_end_offsets
 


### PR DESCRIPTION
- `json_len` becomes `data_start = json_len+8`, since `json_len` is only used as `json_len+8` (which is the start of data). This required changing `examples/webgpu/stable_diffusion/compile.py`.
- switched away from `bitcast` to explicitly load it as uint64_le ([https://github.com/huggingface/safetensors/blob/main/safetensors/src/tensor.rs#L292](https://github.com/huggingface/safetensors/blob/main/safetensors/src/tensor.rs#L292)). This also allows the removal of the assert, which was there for typing.
- improved typing for `safe_load_metadata`
- `safe_load` becomes a dict comprehension.

It does change the API of `safe_load_metadata`.

This is tested by `test/unit/test_disk_tensor.py:TestSafetensors`.