### PR TITLE
move more onnx ops into tensor_methods mapping

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -98,9 +98,11 @@ def get_run_onnx(onnx_model: ModelProto):
 
   # mapping from onnx ops to tensor.py ops
   tensor_methods = {
-    op:op.lower() for op in ("Neg", "Reciprocal", "Pow", "Sqrt", "Sign", "Abs", "Exp", "Log", "Mish", "Sin", "Cos", "Tan", "Asin", "Acos", "Atan",
+    **{op:op.lower() for op in ("Neg", "Reciprocal", "Pow", "Sqrt", "Sign", "Abs", "Exp", "Log", "Mish", "Sin", "Cos", "Tan", "Asin", "Acos", "Atan",
     "Relu", "Sigmoid", "MatMul", "Floor", "Ceil", "IsInf", "IsNaN", "Softplus", "HardSwish", "Where", "Mul", "Sinh", "Cosh", "Tanh",
-    "Softsign", "Asinh", "Acosh", "Atanh",  "Elu", "Celu", "Selu", "Xor", "Round", "Erf")
+    "Softsign", "Asinh", "Acosh", "Atanh",  "Elu", "Celu", "Selu", "Xor", "Round", "Erf")},
+    "Less": "__lt__", "Greater": "__gt__", "LessOrEqual": "__le__", "GreaterOrEqual": "__ge__", "Equal": "__eq__", "LogSoftmax": "log_softmax",
+    "Not": "logical_not", "NegativeLogLikelihoodLoss": "nll_loss",
   }
 
   def run_onnx(inputs={}, debug=0):

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -12,11 +12,6 @@ def Identity(x: Tensor): return x
 # TODO: fix buffer_parse
 def Add(x: Tensor, other: Tensor, broadcast=None, axis=None): return x + other if x.dtype == dtypes.float or isinstance(x.dtype, ImageDType) else (x + other).cast(x.dtype)
 def Sub(x: Union[Tensor, Any], other: Tensor): return x - other # some test has input as int
-def Less(x:Tensor,y:Tensor): return x < y
-def LessOrEqual(x:Tensor,y:Tensor): return x <= y
-def Greater(x:Tensor,y:Tensor): return x > y
-def GreaterOrEqual(x:Tensor,y:Tensor): return x >= y
-def Equal(x:Tensor,y:Tensor): return x == y
 def Max(*data_0): return functools.reduce(Tensor.maximum, data_0)
 def Min(*data_0): return functools.reduce(Tensor.minimum, data_0)
 def Sum(*data_0): return functools.reduce(Tensor.add, data_0)
@@ -48,7 +43,6 @@ def ThresholdedRelu(X: Tensor, alpha=1.0): return (X > alpha).where(X, 0)
 def Softmax_1(x: Tensor, axis=1): return x.softmax(axis)
 def Softmax_13(x: Tensor, axis=-1): return x.softmax(axis)
 Softmax = {1: Softmax_1, 13: Softmax_13}   # Softmax default axis changed
-def LogSoftmax(x: Tensor, axis=-1): return x.log_softmax(axis)
 def Clip(x: Tensor, min=None, max=None): return x.clip(float('-inf') if min is None else min, float('inf') if max is None else max).cast(x.dtype)
 
 def _axes(axes, noop_with_empty_axes):
@@ -81,7 +75,6 @@ def Expand(x: Tensor, shape:Tensor): return x.expand(_broadcast_shape(x.shape, t
 def Shrink(x: Tensor, bias=0.0, lambd=0.5): return (x < -lambd)*(x+bias) + (x > lambd)*(x-bias)
 def And(x:Tensor, y:Tensor): return (x==y).where(x, False)
 def Or(x:Tensor, y:Tensor): return (x==y).where(x, True)
-def Not(x:Tensor): return x.logical_not()
 
 def Trilu(x: Tensor, k: Union[Tensor, int]=0, upper=1):
   k = to_python_const(k) if isinstance(k, Tensor) else 0 # onnx passes k as a tensor int64 with one element, default is 0
@@ -292,9 +285,6 @@ def LRN(x: Tensor, size, alpha=1e-4, beta=0.75, bias=1.0):
   return x / (pooled_x.reshape(x.shape) * alpha + bias).pow(beta)
 
 def MeanVarianceNormalization(x: Tensor, axis=(0, 2, 3)): return (x - x.mean(axis, keepdim=True)) / (x.std(axis, keepdim=True, correction=0) + 1e-9)
-
-def NegativeLogLikelihoodLoss(x: Tensor, target: Tensor, weight=None, ignore_index=None, reduction="mean"):
-  return x.nll_loss(target, weight, ignore_index, reduction)
 
 def SoftmaxCrossEntropyLoss(scores: Tensor, labels: Tensor, weights=None, ignore_index=None, reduction="mean"):
   log_probs = scores.log_softmax(1)


### PR DESCRIPTION
The idea I had initially was to extend the `tensor_methods` mapping as much as I could to replace ops in onnx_ops.
This only maps the "same function, different name" case.
There are other cases like "same function, different argument name" cases, and many more...

If this idea is ok, I'll go hard on the ops deletion using this.