### PR TITLE
Fix add chain

### DIFF
--- a/test/unit/test_simplify_valid_idx.py
+++ b/test/unit/test_simplify_valid_idx.py
@@ -234,8 +234,8 @@ class TestImageSimplification(unittest.TestCase):
 
     self.check(load,
                "((((idx2*2)+ridx0)<11)&((((idx1*8)+ridx1)<3)!=True))",
-               "(((idx0+((idx1*512)+(ridx1*64)))+832)%1024)",
-               "((((idx2*2)+ridx0)+(((idx1+((ridx1+5)//8))+1)//2))+-4)")
+               "((((idx0+(idx1*512))+(ridx1*64))+832)%1024)",
+               "((((idx2*2)+(((idx1+((ridx1+5)//8))+1)//2))+ridx0)+-4)")
 
   def test_simplify1(self):
     # idx has the form (A % m, A // m + k) and valid has (c0 < A) and (A < c1)

--- a/test/unit/test_simplify_valid_idx.py
+++ b/test/unit/test_simplify_valid_idx.py
@@ -234,8 +234,8 @@ class TestImageSimplification(unittest.TestCase):
 
     self.check(load,
                "((((idx2*2)+ridx0)<11)&((((idx1*8)+ridx1)<3)!=True))",
-               "((((idx0+(idx1*512))+(ridx1*64))+832)%1024)",
-               "((((idx2*2)+(((idx1+((ridx1+5)//8))+1)//2))+ridx0)+-4)")
+               "(((idx0+((idx1*512)+(ridx1*64)))+832)%1024)",
+               "((((idx2*2)+ridx0)+(((idx1+((ridx1+5)//8))+1)//2))+-4)")
 
   def test_simplify1(self):
     # idx has the form (A % m, A // m + k) and valid has (c0 < A) and (A < c1)

--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -454,6 +454,11 @@ class TestSymbolic(unittest.TestCase):
     unrolled_div = (gidx+2561)//4+(gidx+2562)//4+(gidx+2560)//4+(gidx+2559)//4
     self.helper_test_variable(unrolled_div, 2559, 5118, "(gidx+2559)")
 
+  def test_arange_add_chain_split(self):
+    gidx = Variable("gidx", 0, 2559)
+    unrolled_div = ((gidx+2561)//4+(gidx+2562)//4)+((gidx+2560)//4+(gidx+2559)//4)
+    self.helper_test_variable(unrolled_div, 2559, 5118, "(gidx+2559)")
+
   def test_arange_unrolled4_small(self):
     gidx = Variable("gidx", 0, 3)
     unrolled_div = (gidx)//4+(gidx+2)//4+(gidx+3)//4+(gidx+1)//4

--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -259,6 +259,16 @@ class TestSymbolic(unittest.TestCase):
     a = Variable("a", 0, 124)
     self.helper_test_variable((a//2+1)//2, 0, 31, "((a+2)//4)")
 
+  def test_flatten_albelian_tree(self):
+    a,b,c,d = Variable("a", 0, 124), Variable("b", 0, 124), Variable("c", 0, 124), Variable("d", 0, 124)
+    e,f,g,h = Variable("e", 0, 124), Variable("f", 0, 124), Variable("g", 0, 124), Variable("h", 0, 124)
+    self.helper_test_variable((a+b)+(c+d), 0, 4*124, "(b+(a+(c+d)))")
+    self.helper_test_variable((a+b)+(c+d)+(e+f)+(g+h), 0, 8*124, "(b+(a+(d+(c+(f+(e+(g+h)))))))")
+    self.helper_test_variable((a+(c+d)+b)+((e+f)+g+h), 0, 8*124, "(b+(a+(d+(c+(h+(g+(e+f)))))))")
+    self.helper_test_variable((a*b)*(c*d), 0, 124**4, "(b*(a*(c*d)))")
+    self.helper_test_variable((a*b)*(c*d)*(e*f)*(g*h), 0, 124**8, "(b*(a*(d*(c*(f*(e*(g*h)))))))")
+    self.helper_test_variable((a*(c*d)*b)*((e*f)*g*h), 0, 124**8, "(b*(a*(d*(c*(h*(g*(e*f)))))))")
+
   def test_distribute_mul(self):
     self.helper_test_variable(Node.sum([Variable("a", 0, 3), Variable("b", 0, 5)])*3, 0, 24, "((a*3)+(b*3))")
     self.helper_test_variable((1+Variable("a", 0, 3))*(-2)+12, 4, 10, "((a*-2)+10)")

--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -126,6 +126,12 @@ class TestSymbolic(unittest.TestCase):
     a = Variable("a", 0, 8)
     self.helper_test_variable(a+a, 0, 16, "(a*2)")
 
+  @unittest.expectedFailure
+  def test_add_self_in_chain(self):
+    a,b,c = Variable("a", 0, 8), Variable("b", 0, 8), Variable("c", 0, 8)
+    self.helper_test_variable((a+b)+(c+a), 0, 4*8, "(b+(c+(a*2)))")
+    self.helper_test_variable(a*10+b+c+a, 0, 13*8, "(b+(c+(a*11)))")
+
   def test_sub_self(self):
     a = Variable("a", 0, 8)
     self.helper_test_variable(a-a, 0, 0, "0")
@@ -468,6 +474,12 @@ class TestSymbolic(unittest.TestCase):
     gidx = Variable("gidx", 0, 2559)
     unrolled_div = ((gidx+2561)//4+(gidx+2562)//4)+((gidx+2560)//4+(gidx+2559)//4)
     self.helper_test_variable(unrolled_div, 2559, 5118, "(gidx+2559)")
+
+  @unittest.expectedFailure
+  def test_arange_add_split_unsorted(self):
+    gidx = Variable("gidx", 0, 2559)
+    unrolled_div = ((gidx+2561)//4+gidx+(gidx+2562)//4)+(gidx+2560)//4+(gidx+2559)//4
+    self.helper_test_variable(unrolled_div, 2559, 7677, "((gidx*2)+2559)")
 
   def test_arange_unrolled4_small(self):
     gidx = Variable("gidx", 0, 3)

--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -735,7 +735,8 @@ class TestSymbolicRealWorld(unittest.TestCase):
     # NOTE: this used to have 13,151,129,600 in the output which is out of int32 range.
     self.assertIn(idx.render(),
       ("((((((((((lidx5+1)//16)*802816)+(((lidx5+1)%16)*49))+(gidx0*3211264))+(gidx1*784))+(gidx2*8))+(lidx4*100352))+lidx3)+2207744)",
-       '((lidx3+((((((((lidx5+1)//16)*802816)+(((lidx5+1)%16)*49))+(gidx0*3211264))+(gidx1*784))+(gidx2*8))+(lidx4*100352)))+2207744)',
+       "((lidx3+((((((((lidx5+1)//16)*802816)+(((lidx5+1)%16)*49))+(gidx0*3211264))+(gidx1*784))+(gidx2*8))+(lidx4*100352)))+2207744)",
+       "(((((((lidx3+(gidx0*3211264))+(gidx1*784))+(gidx2*8))+(lidx4*100352))+(((lidx5+1)//16)*802816))+(((lidx5+1)%16)*49))+2207744)"
       ))
 
 class TestBounds(unittest.TestCase):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1081,7 +1081,8 @@ symbolic_simple = PatternMatcher([
 symbolic = symbolic_simple+PatternMatcher([
   # ** COMMUTATIVE flipping **
   (UPat(GroupOp.Commutative, name='x'), lambda x: x.replace(src=x.src[::-1]) if x.src[1].tuplize < x.src[0].tuplize else None),
-  ((UPat.var("x1") + (UPat.var("x2")) + UPat.var("x3")), lambda x1,x2,x3: x1+x3+x2 if x3.tuplize < x2.tuplize else None),
+  ((UPat.var("x1", dtype=dtypes.ints) + (UPat.var("x2", dtype=dtypes.ints)) + UPat.var("x3", dtype=dtypes.ints)),
+    lambda x1,x2,x3: x1+x3+x2 if x3.tuplize < x2.tuplize else None),
   # group like
   ((UPat.var("x") + UPat.var("y")) + UPat.var("x") * UPat.cvar("c"), lambda x,y,c: (x+x*c)+y),
   # ** boolean algebra **

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -158,7 +158,7 @@ class GroupOp:
   # BinaryOps that can be flipped or reordered
   Commutative = {Ops.ADD, Ops.MUL, Ops.MAX, Ops.CMPNE, Ops.XOR, Ops.AND, Ops.OR}
   Associative = {Ops.ADD, Ops.MUL, Ops.MAX, Ops.XOR, Ops.AND, Ops.OR}
-  Albelian = set.intersection(Commutative, Associative)
+  Abelian = set.intersection(Commutative, Associative)
 
   # do not preserve f(0) = 0
   UnsafePad = {Ops.RECIP, Ops.LOG2, Ops.EXP2, Ops.IDIV}
@@ -1086,7 +1086,7 @@ symbolic = symbolic_simple+PatternMatcher([
   # ** group stuff **
   # flattening of ADD, MULL chains etc, generalization of (x1+x2) + (x3+x4) -> x1+x2+x3+x4
   *((UPat.var("x1").alu(op, UPat.var("x2")).alu(op, UPat(op, name="x3")), lambda x1,x2,x3,op=op: x1.alu(op,x3).alu(op,x2)
-    if x2.op is not op else x2.alu(op,x3).alu(op,x1)) for op in GroupOp.Albelian),
+    if x2.op is not op else x2.alu(op,x3).alu(op,x1) if x1.op is not op else None) for op in GroupOp.Abelian),
   ((UPat.var("x") + UPat.var("y")) + UPat.var("x") * UPat.cvar("c"), lambda x,y,c: (x+x*c)+y),
   # ** boolean algebra **
   (UPat.var("x") | (UPat.var("x") & UPat.var()), lambda x: x), # x|(x&y) -> x

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -158,7 +158,7 @@ class GroupOp:
   # BinaryOps that can be flipped or reordered
   Commutative = {Ops.ADD, Ops.MUL, Ops.MAX, Ops.CMPNE, Ops.XOR, Ops.AND, Ops.OR}
   Associative = {Ops.ADD, Ops.MUL, Ops.MAX, Ops.XOR, Ops.AND, Ops.OR}
-  Abelian = set.intersection(Commutative, Associative)
+  CommAssoc = set.intersection(Commutative, Associative)
 
   # do not preserve f(0) = 0
   UnsafePad = {Ops.RECIP, Ops.LOG2, Ops.EXP2, Ops.IDIV}
@@ -1086,7 +1086,7 @@ symbolic = symbolic_simple+PatternMatcher([
   # ** group stuff **
   # flattening of ADD, MULL chains etc, generalization of (x1+x2) + (x3+x4) -> x1+x2+x3+x4
   *((UPat.var("x1").alu(op, UPat.var("x2")).alu(op, UPat(op, name="x3")), lambda x1,x2,x3,op=op: x1.alu(op,x3).alu(op,x2)
-    if x2.op is not op else x2.alu(op,x3).alu(op,x1) if x1.op is not op else None) for op in GroupOp.Abelian),
+    if x2.op is not op else x2.alu(op,x3).alu(op,x1) if x1.op is not op else None) for op in GroupOp.CommAssoc),
   ((UPat.var("x") + UPat.var("y")) + UPat.var("x") * UPat.cvar("c"), lambda x,y,c: (x+x*c)+y),
   # ** boolean algebra **
   (UPat.var("x") | (UPat.var("x") & UPat.var()), lambda x: x), # x|(x&y) -> x

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1082,7 +1082,7 @@ symbolic = symbolic_simple+PatternMatcher([
   # ** COMMUTATIVE flipping **
   (UPat(GroupOp.Commutative, name='x'), lambda x: x.replace(src=x.src[::-1]) if x.src[1].tuplize < x.src[0].tuplize else None),
   ((UPat.var("x1") + UPat.var("x2")) + UPat(Ops.ADD, name="x3"),
-    lambda x1,x2,x3: (x1+x3)+x2 if x1 is not Ops.ADD and x2.op is not Ops.ADD else None),
+    lambda x1,x2,x3: (x1+x3)+x2 if x1.op is not Ops.ADD and x2.op is not Ops.ADD else None),
   # group like
   ((UPat.var("x") + UPat.var("y")) + UPat.var("x") * UPat.cvar("c"), lambda x,y,c: (x+x*c)+y),
   # ** boolean algebra **

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1081,8 +1081,8 @@ symbolic_simple = PatternMatcher([
 symbolic = symbolic_simple+PatternMatcher([
   # ** COMMUTATIVE flipping **
   (UPat(GroupOp.Commutative, name='x'), lambda x: x.replace(src=x.src[::-1]) if x.src[1].tuplize < x.src[0].tuplize else None),
-  ((UPat.var("x1") + UPat.var("x2")) + UPat(Ops.ADD, name="x3"),
-    lambda x1,x2,x3: (x1+x3)+x2 if x1.op is not Ops.ADD and x2.op is not Ops.ADD else None),
+  ((UPat.var("x1") + UPat.var("x2")) + UPat(Ops.ADD, name="x3"), lambda x1,x2,x3: (x1+x3)+x2 if x2.op is not Ops.ADD else
+    (x2+x3)+x1 if x1.op is not Ops.ADD else None),
   # group like
   ((UPat.var("x") + UPat.var("y")) + UPat.var("x") * UPat.cvar("c"), lambda x,y,c: (x+x*c)+y),
   # ** boolean algebra **

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1081,6 +1081,7 @@ symbolic_simple = PatternMatcher([
 symbolic = symbolic_simple+PatternMatcher([
   # ** COMMUTATIVE flipping **
   (UPat(GroupOp.Commutative, name='x'), lambda x: x.replace(src=x.src[::-1]) if x.src[1].tuplize < x.src[0].tuplize else None),
+  ((UPat.var("x1") + UPat.var("x2")) + (UPat.var("x3") + UPat.var("x4")), lambda x1,x2,x3,x4: x1+x2+x3+x4),
   # group like
   ((UPat.var("x") + UPat.var("y")) + UPat.var("x") * UPat.cvar("c"), lambda x,y,c: (x+x*c)+y),
   # ** boolean algebra **

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1081,7 +1081,7 @@ symbolic_simple = PatternMatcher([
 symbolic = symbolic_simple+PatternMatcher([
   # ** COMMUTATIVE flipping **
   (UPat(GroupOp.Commutative, name='x'), lambda x: x.replace(src=x.src[::-1]) if x.src[1].tuplize < x.src[0].tuplize else None),
-  ((UPat.var("x1") + UPat.var("x2")) + (UPat.var("x3") + UPat.var("x4")), lambda x1,x2,x3,x4: x1+x2+x3+x4),
+  ((UPat.var("x1") + (UPat.var("x2")) + UPat.var("x3")), lambda x1,x2,x3: x1+x3+x2 if x3.tuplize < x2.tuplize else None),
   # group like
   ((UPat.var("x") + UPat.var("y")) + UPat.var("x") * UPat.cvar("c"), lambda x,y,c: (x+x*c)+y),
   # ** boolean algebra **

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1081,8 +1081,8 @@ symbolic_simple = PatternMatcher([
 symbolic = symbolic_simple+PatternMatcher([
   # ** COMMUTATIVE flipping **
   (UPat(GroupOp.Commutative, name='x'), lambda x: x.replace(src=x.src[::-1]) if x.src[1].tuplize < x.src[0].tuplize else None),
-  ((UPat.var("x1", dtype=dtypes.ints) + (UPat.var("x2", dtype=dtypes.ints)) + UPat.var("x3", dtype=dtypes.ints)),
-    lambda x1,x2,x3: x1+x3+x2 if x3.tuplize < x2.tuplize else None),
+  ((UPat.var("x1") + UPat.var("x2")) + UPat(Ops.ADD, name="x3"),
+    lambda x1,x2,x3: (x1+x3)+x2 if x1 is not Ops.ADD and x2.op is not Ops.ADD else None),
   # group like
   ((UPat.var("x") + UPat.var("y")) + UPat.var("x") * UPat.cvar("c"), lambda x,y,c: (x+x*c)+y),
   # ** boolean algebra **

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -155,8 +155,10 @@ class GroupOp:
   Buffer = {Ops.LOAD, Ops.PRELOAD, Ops.STORE, Ops.VALID}
   Block = {Ops.BLOCK, Ops.BLOCKEND, Ops.BLOCKFORK, Ops.BLOCKSTART}
 
-  # BinaryOps that can be flipped
+  # BinaryOps that can be flipped or reordered
   Commutative = {Ops.ADD, Ops.MUL, Ops.MAX, Ops.CMPNE, Ops.XOR, Ops.AND, Ops.OR}
+  Associative = {Ops.ADD, Ops.MUL, Ops.MAX, Ops.XOR, Ops.AND, Ops.OR}
+  Albelian = set.intersection(Commutative, Associative)
 
   # do not preserve f(0) = 0
   UnsafePad = {Ops.RECIP, Ops.LOG2, Ops.EXP2, Ops.IDIV}
@@ -1081,9 +1083,10 @@ symbolic_simple = PatternMatcher([
 symbolic = symbolic_simple+PatternMatcher([
   # ** COMMUTATIVE flipping **
   (UPat(GroupOp.Commutative, name='x'), lambda x: x.replace(src=x.src[::-1]) if x.src[1].tuplize < x.src[0].tuplize else None),
-  ((UPat.var("x1") + UPat.var("x2")) + UPat(Ops.ADD, name="x3"), lambda x1,x2,x3: (x1+x3)+x2 if x2.op is not Ops.ADD else
-    (x2+x3)+x1 if x1.op is not Ops.ADD else None),
-  # group like
+  # ** group stuff **
+  # flattening of ADD, MULL chains etc, generalization of (x1+x2) + (x3+x4) -> x1+x2+x3+x4
+  *((UPat.var("x1").alu(op, UPat.var("x2")).alu(op, UPat(op, name="x3")), lambda x1,x2,x3,op=op: x1.alu(op,x3).alu(op,x2)
+    if x2.op is not op else x2.alu(op,x3).alu(op,x1)) for op in GroupOp.Albelian),
   ((UPat.var("x") + UPat.var("y")) + UPat.var("x") * UPat.cvar("c"), lambda x,y,c: (x+x*c)+y),
   # ** boolean algebra **
   (UPat.var("x") | (UPat.var("x") & UPat.var()), lambda x: x), # x|(x&y) -> x


### PR DESCRIPTION
If the root of the add chain is split, i.e. its sources are both also add, then the `fold_unrolled__divs` pattern won't match at the root of the add chain.
```
  (UPat(Ops.ADD, name="divs", src=[UPat(), UPat(Ops.IDIV)]), fold_unrolled_divs),
```
