### PR TITLE
Move efficientnet webgpu example

### DIFF
--- a/examples/webgpu/efficientnet/index.html
+++ b/examples/webgpu/efficientnet/index.html
@@ -17,7 +17,7 @@ canvas {  display: none; }
 * {  text-align: center;  font-family: monospace; }
 </style>
 <title>tinygrad has WebGPU</title>
-<script src="./net.js"></script>
+<script src="../../net.js"></script>
 <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/tinygrad/tinygrad/master/docs/logo.png">
 </head>
 <body>
@@ -61,7 +61,7 @@ canvas {  display: none; }
 
 	const getLabels = async () => (await fetch("https://raw.githubusercontent.com/anishathalye/imagenet-simple-labels/master/imagenet-simple-labels.json")).json();
 
-	const getSavetensorBuffer = async () => new Uint8Array(await (await fetch("./net.safetensors")).arrayBuffer());
+	const getSavetensorBuffer = async () => new Uint8Array(await (await fetch("../../net.safetensors")).arrayBuffer());
 
 	const reorderChannelsAndRemoveAlpha = (data) => {
 		const out = [];

--- a/test/web/test_webgpu.js
+++ b/test/web/test_webgpu.js
@@ -47,7 +47,7 @@ async function runTest() {
       console.log(`error from page ${message}`),
     );
 
-  const res = await page.goto("http://localhost:8000/examples/index.html");
+  const res = await page.goto("http://localhost:8000/examples/webgpu/efficientnet/index.html");
   if (res.status() !== 200) throw new Error("Failed to load page");
 
   const textSelector = await page.waitForSelector("#result");


### PR DESCRIPTION
efficientnet `index.html` was in root examples, should be in its folder, as the other two webgpu examples