### PR TITLE
add avg pool 3d failure test

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2117,6 +2117,7 @@ class TestOps(unittest.TestCase):
       lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=(111,28)),
       lambda x: Tensor.avg_pool2d(x, kernel_size=(111,28)), rtol=1e-5)
 
+  # TODO: linearizer block error
   @unittest.expectedFailure
   def test_avg_pool3d_failure(self):
     helper_test_op([(1,1,16,16,16)],

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2117,6 +2117,15 @@ class TestOps(unittest.TestCase):
       lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=(111,28)),
       lambda x: Tensor.avg_pool2d(x, kernel_size=(111,28)), rtol=1e-5)
 
+  @unittest.expectedFailure
+  def test_avg_pool3d_failure(self):
+    kernel_size = (24, 30, 29)
+    stride = (9, 8, 8)
+    padding = (10, 2, 2)
+    helper_test_op([(1, 1, 32, 48, 60)],
+      lambda x: torch.nn.functional.avg_pool3d(x, kernel_size=kernel_size, stride=stride, padding=padding, count_include_pad=False),
+      lambda x: Tensor.avg_pool2d(x, kernel_size=kernel_size, stride=stride, padding=padding, count_include_pad=False), rtol=1e-5, forward_only=True)
+
   def test_interpolate_linear(self):
     for in_sz, out_sz in [((52,),(29,)), ((29,),(52,))]:
       helper_test_op([(2,3)+in_sz],

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2119,12 +2119,9 @@ class TestOps(unittest.TestCase):
 
   @unittest.expectedFailure
   def test_avg_pool3d_failure(self):
-    kernel_size = (24, 30, 29)
-    stride = (9, 8, 8)
-    padding = (10, 2, 2)
-    helper_test_op([(1, 1, 32, 48, 60)],
-      lambda x: torch.nn.functional.avg_pool3d(x, kernel_size=kernel_size, stride=stride, padding=padding, count_include_pad=False),
-      lambda x: Tensor.avg_pool2d(x, kernel_size=kernel_size, stride=stride, padding=padding, count_include_pad=False), rtol=1e-5, forward_only=True)
+    helper_test_op([(1,1,16,16,16)],
+      lambda x: torch.nn.functional.avg_pool3d(x, kernel_size=(8,8,8), stride=5, padding=1, count_include_pad=False),
+      lambda x: Tensor.avg_pool2d(x, kernel_size=(8,8,8), stride=5, padding=1, count_include_pad=False), rtol=1e-5, forward_only=True)
 
   def test_interpolate_linear(self):
     for in_sz, out_sz in [((52,),(29,)), ((29,),(52,))]:


### PR DESCRIPTION
was spamming some avg pool 3D tests and found a failure edge case

This goes down the `sum` code path for avg pool and is only encountered with 3D.

apparently this hits this assert in linearizer:
 `assert all(len(x.src) == 0 and x.op not in {Ops.BLOCK, Ops.BLOCKSTART, Ops.BLOCKEND, Ops.BLOCKFORK} for x in _uops)`

with `print([x.op for x  in _uops])` -> `[<Ops.BLOCKFORK: 9>, <Ops.BLOCKEND: 10>, <Ops.DEFINE_GLOBAL: 14>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>, <Ops.CONST: 62>]`

with `NOOPT=1` it passes