### PR TITLE
fix var vmax when arg in special

### DIFF
--- a/test/unit/test_uop_vmin_vmax.py
+++ b/test/unit/test_uop_vmin_vmax.py
@@ -32,6 +32,11 @@ class TestVminVmaxProperties(unittest.TestCase):
     self.assertEqual(uop.vmin, -6)
     self.assertEqual(uop.vmax, 8)
 
+  def test_vmin_vmax_variable_inside_special(self):
+    uop = UOp(Ops.SPECIAL, dtypes.int, arg=('gidx0', UOp(Ops.DEFINE_VAR, dtypes.int, arg=('i', 1, 10))))
+    self.assertEqual(uop.vmin, 0)
+    self.assertEqual(uop.vmax, 10)
+
   def test_vmin_vmax_multiplication_0_inf(self):
     # vmin and vmax for multiplication with a variable
     x = UOp.const(dtypes.float, 0.0)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -453,7 +453,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     if self.op is Ops.BIND: return self.src[0]._min_max # ignore the bound value
     if self.op in {Ops.EXPAND, Ops.VECTORIZE}: return min(x.vmin for x in self.src), max(x.vmax for x in self.src)
     # TODO: UOps.SPECIAL is UOps.DEFINE_VAR
-    if self.op is Ops.SPECIAL: return 0, self.arg[1]-1 if isinstance(self.arg[1], int) else dtypes.max(self.dtype)
+    if self.op is Ops.SPECIAL: return 0, self.arg[1]-1 if isinstance(self.arg[1], int) else self.arg[1].vmax
     if self.op is Ops.CONST: return self.arg, self.arg
     if self.op is Ops.VCONST: return (min(self.arg), max(self.arg))
     return dtypes.min(self.dtype), dtypes.max(self.dtype)


### PR DESCRIPTION
This caused incorrect int64 indexing conversion when a var is an arg of a special.