### PR TITLE
add TYPED=1 functionality

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -8,6 +8,7 @@ from tinygrad.dtype import ConstType, ImageDType, PtrDType, dtypes, DType, trunc
 from tinygrad.helpers import ContextVar, prod, getenv, all_same, Context, partition, temp, unwrap, T, argfix
 if TYPE_CHECKING:
   from tinygrad.shape.shapetracker import ShapeTracker
+  ConstLike=Union[ConstType, 'Variable', Tuple[ConstType, ...]]
 
 # wrapper around IntEnum that preserves Enum.__str__ and makes auto() unique across all FastEnum subclasses
 class FastEnum(IntEnum):
@@ -1174,8 +1175,6 @@ renderer = PatternMatcher([
 
 sint = Union[int, UOp]
 Variable = UOp
-
-ConstLike = Union[ConstType, Variable, Tuple[ConstType, ...]]
 
 # *** uop swizzling ***
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -13,6 +13,8 @@ from tinygrad.engine.lazy import LazyBuffer
 from tinygrad.engine.realize import run_schedule
 from tinygrad.engine.memory import memory_planner
 from tinygrad.engine.schedule import ScheduleItem, create_schedule_with_vars
+if TYPE_CHECKING:
+  import numpy as np
 
 # **** start with two base classes, Tensor and Function ****
 


### PR DESCRIPTION
Fix: #7889
```
TYPED=1 python3 -m pytest ../test/
============================= test session starts ==============================
platform darwin -- Python 3.13.0, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/kayparmar/tinygrad
plugins: hypothesis-6.122.1, typeguard-4.4.1
collected 2519 items / 1 error / 2 skipped

==================================== ERRORS ====================================
_________________ ERROR collecting test/models/test_whisper.py _________________
ImportError while importing test module '/Users/kayparmar/tinygrad/test/models/test_whisper.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
models/test_whisper.py:3: in <module>
    from examples.whisper import init_whisper, load_file_waveform, transcribe_file, transcribe_waveform
../examples/whisper.py:11: in <module>
    import librosa
E   ModuleNotFoundError: No module named 'librosa'
=========================== short test summary info ============================
ERROR models/test_whisper.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
========================= 2 skipped, 1 error in 1.61s ==========================

```