### PR TITLE
iteration 3 on big_graph = UOp.sink(*outs)

### DIFF
--- a/tinygrad/engine/lazy.py
+++ b/tinygrad/engine/lazy.py
@@ -123,7 +123,8 @@ class LazyBuffer(MathTrait):
 
   def _copy(self, device:str) -> LazyBuffer:
     assert self.st.contiguous and self.size == self.base.size, f"can only copy contig {self} {self.base}"
-    return create_lazybuffer(device, ShapeTracker.from_shape(self.shape), self.dtype, Ops.COPY, self.buffer.nbytes, (self,), enable_cache=False)
+    return create_lazybuffer(device, ShapeTracker.from_shape(self.shape), self.dtype, Ops.COPY, (self.buffer.nbytes, device), (self,),
+                             enable_cache=False)
 
   def copy_to_device(self, device:str, force:bool=False, clone:bool=False) -> LazyBuffer:
     # no COPY

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -356,11 +356,11 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
   @property
   def base(self) -> UOp: return self.src[0] if self.op is Ops.VIEW and len(self.src) == 1 and self.src[0].op is not Ops.BUFFER else self
   def view(self, new_st:ShapeTracker) -> UOp:
-    assert self.st is not None and self.base.st is not None, f"must have shape {self}"
+    if self.st is None: return UOp(Ops.VIEW, self.dtype.base, (self,), new_st)
     ret = UOp(Ops.VIEW, self.dtype, (self.base,), new_st)
     # instant folding rules
     if self.st.size == 0 or (new_st.views[-1].mask is not None and any((x[1]-x[0]) == 0 for x in new_st.views[-1].mask)): return ret.const_like(0)
-    if new_st.contiguous and self.base.st.shape == new_st.shape: return self.base
+    if new_st.contiguous and self.base.shape == new_st.shape: return self.base
     return ret
   def reshape(self, arg:Tuple[sint, ...]): return self.view(unwrap(self.st).reshape(arg))
   def pad(self, arg:Tuple[Tuple[sint, sint], ...]): return self.view(unwrap(self.st).pad(arg))

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -378,6 +378,9 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
   def device(self) -> str: return unwrap(self._device)
   @functools.cached_property
   def _device(self) -> Optional[str]:
+    # COPY is the only op that can change device
+    if self.op is Ops.COPY: return self.arg[1]
+    # everything else inherits device from the source BUFFER
     return self.arg[1][0] if self.op is Ops.BUFFER else dsrcs[0]._device if len(dsrcs:=[x for x in self.src if x._device is not None]) != 0 else None
   @property
   def buf_uop(self) -> UOp:


### PR DESCRIPTION
exploring what it'd take to make the big graph small and flexible for `merge_views+symbolic_flat`
Like a lot of the stuff that exists is filler, by the time full_ast_rewrite returns the AST is pretty good, how can we move those transformations to as early as possible?