### PR TITLE
Fix puppeteer install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -440,7 +440,7 @@ jobs:
     # WebGPU e2e tests
     - name: Build WEBGPU Efficientnet
       run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python3 -m examples.compile_efficientnet
-    - name: Install Puppeteer
+    - name: Install Puppeteer if needed
       run: npm list puppeteer || npm install puppeteer
     - name: Run WEBGPU Efficientnet
       run: node test/web/test_webgpu.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,13 +441,7 @@ jobs:
     - name: Build WEBGPU Efficientnet
       run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python3 -m examples.compile_efficientnet
     - name: Install Puppeteer
-      run: |
-        if [ ! -d "node_modules/puppeteer" ]; then
-          echo "Installing Puppeteer..."
-          npm install puppeteer
-        else
-          echo "Puppeteer is already installed."
-        fi
+      run: npm list puppeteer || npm install puppeteer
     - name: Run WEBGPU Efficientnet
       run: node test/web/test_webgpu.js
     - name: Run process replay tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,7 +441,13 @@ jobs:
     - name: Build WEBGPU Efficientnet
       run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python3 -m examples.compile_efficientnet
     - name: Install Puppeteer
-      run: npm install puppeteer
+      run: |
+        if [ ! -d "node_modules/puppeteer" ]; then
+          echo "Installing Puppeteer..."
+          npm install puppeteer
+        else
+          echo "Puppeteer is already installed."
+        fi
     - name: Run WEBGPU Efficientnet
       run: node test/web/test_webgpu.js
     - name: Run process replay tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -440,8 +440,10 @@ jobs:
     # WebGPU e2e tests
     - name: Build WEBGPU Efficientnet
       run: WEBGPU=1 WGPU_BACKEND_TYPE=Metal python3 -m examples.compile_efficientnet
-    - name: Install Puppeteer if needed
-      run: npm list puppeteer || npm install puppeteer
+    - name: Clean npm cache
+      run: npm cache clean --force
+    - name: Install Puppeteer
+      run: npm install puppeteer
     - name: Run WEBGPU Efficientnet
       run: node test/web/test_webgpu.js
     - name: Run process replay tests


### PR DESCRIPTION
To avoid peer dependency issues when installing puppeteer, start with a clean npm cache.