### PR TITLE
assert the same things without mutating or accessing internal ops state [pr]

### DIFF
--- a/test/test_const_folding.py
+++ b/test/test_const_folding.py
@@ -10,7 +10,7 @@ def _check_ast_count(desired_count:int, t:Tensor):
   # NOTE: this has side effect because everything can be scheduled only once
   schedule = create_schedule(t.lazydata.lbs)
   asts = [s for s in schedule if s.ast.op is Ops.SINK]
-  assert len(asts) == desired_count
+  assert len(asts) == desired_count, f"{len(asts)} != {desired_count}"
 
 class TestUnaryOpsConstFolding(unittest.TestCase):
   def test_all_consts_ops(self):

--- a/test/test_lazybuffer.py
+++ b/test/test_lazybuffer.py
@@ -73,8 +73,7 @@ class TestLazyBuffer(unittest.TestCase):
   def test_forced_realized_alu(self):
     a = Tensor.randn(2, 2).realize()
     b = Tensor.randn(2, 2).realize()
-    add = a + b
-    add.lazydata.forced_realize = True
+    add = (a+b).contiguous()
     out = add+2
     sched = create_schedule([out.lazydata])
     self.assertEqual(len(sched), 2)
@@ -82,8 +81,7 @@ class TestLazyBuffer(unittest.TestCase):
     np.testing.assert_allclose(out.numpy(), a.numpy()+b.numpy()+2)
 
   def test_forced_realized_metaop(self):
-    empty = Tensor.empty(1)
-    empty.lazydata.forced_realize = True
+    empty = Tensor.empty(1).contiguous()
     sched = create_schedule([empty.lazydata])
     self.assertEqual(len(sched), 1)
     self.assertIs(sched[0].ast.op, Ops.EMPTY)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1548,7 +1548,7 @@ class TestIndexing(unittest.TestCase):
   def test_arange_shrink_copy(self):
     a = Tensor.arange(12).reshape(4, 3).shrink(((1, 2), (1, 3))).to("CLANG")
     sched = self.check_schedule(a, 1)
-    self.assertIs(sched[2].ast.op, Ops.COPY)
+    self.assertIs(sched[-1].ast.op, Ops.COPY)
     np.testing.assert_equal(a.numpy(), [[4, 5]])
 
   @unittest.skipIf(Device.DEFAULT == "CLANG", "tests copy from ext device")

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1399,8 +1399,9 @@ class TestIndexing(unittest.TestCase):
       s = Tensor.schedule(*lst)
       kernels = [si for si in s if si.ast.op is Ops.SINK]
       for si in kernels: verify_ast(si.ast)
-      run_schedule(s)
+      run_schedule(s.copy())
       if FUSE_ARANGE: self.assertEqual(len(kernels), cnt)
+    return s
 
   def test_simple_indexing(self):
     X = Tensor.randn(10, 10).realize()
@@ -1539,26 +1540,23 @@ class TestIndexing(unittest.TestCase):
   @unittest.skipUnless(Device.DEFAULT in view_supported_devices, "need view")
   def test_arange_view_op(self):
     a = Tensor.arange(12).reshape(4, 3).shrink(((1, 2), (1, 3))).contiguous()
-    assert isinstance(a.lazydata, LazyBuffer)
-    self.assertIs(a.lazydata.base.op, Ops.BUFFER_VIEW)
-    self.check_schedule(a, 1)
+    sched = self.check_schedule(a, 1)
+    self.assertIs(sched[1].ast.op, Ops.BUFFER_VIEW)
     np.testing.assert_equal(a.numpy(), [[4, 5]])
 
   @unittest.skipIf(Device.DEFAULT == "CLANG", "tests copy from ext device")
   def test_arange_shrink_copy(self):
     a = Tensor.arange(12).reshape(4, 3).shrink(((1, 2), (1, 3))).to("CLANG")
-    assert isinstance(a.lazydata, LazyBuffer)
-    self.assertIs(a.lazydata.base.op, Ops.COPY)
-    self.check_schedule(a, 1)
+    sched = self.check_schedule(a, 1)
+    self.assertIs(sched[1].ast.op, Ops.COPY)
     np.testing.assert_equal(a.numpy(), [[4, 5]])
 
   @unittest.skipIf(Device.DEFAULT == "CLANG", "tests copy from ext device")
   def test_arange_expand_copy(self):
-    a = Tensor.arange(4).reshape(2, 2, 1).expand(2, 2, 2).to("CLANG")
-    assert isinstance(a.lazydata, LazyBuffer)
-    self.assertIs(a.lazydata.base.op, Ops.COPY)
-    self.assertIs(a.lazydata.base.srcs[0].base.op, Ops.ADD)
-    self.check_schedule(a, 1)
+    a = Tensor.arange(4).reshape(2, 2, 1).expand(2, 2, 2).contiguous().to("CLANG")
+    sched = self.check_schedule(a, 1)
+    self.assertIs(sched[1].ast.op, Ops.COPY)
+    self.assertIs(sched[0].ast.src[0].src[2].op, Ops.ADD)
     np.testing.assert_equal(a.numpy(), [[[0, 0], [1, 1]], [[2, 2], [3, 3]]])
 
   @unittest.skip("TODO: support pads in graph_rewrite")

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1548,7 +1548,7 @@ class TestIndexing(unittest.TestCase):
   def test_arange_shrink_copy(self):
     a = Tensor.arange(12).reshape(4, 3).shrink(((1, 2), (1, 3))).to("CLANG")
     sched = self.check_schedule(a, 1)
-    self.assertIs(sched[1].ast.op, Ops.COPY)
+    self.assertIs(sched[2].ast.op, Ops.COPY)
     np.testing.assert_equal(a.numpy(), [[4, 5]])
 
   @unittest.skipIf(Device.DEFAULT == "CLANG", "tests copy from ext device")


### PR DESCRIPTION
to keep the delete_lazy diff more minimal. The asserts mean the same thing.