### PR TITLE
proposal: preserve src size of REDUCE_AXIS while const folding

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -371,7 +371,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
   def range(dtype:DType, start:sint, end:sint, idx:int): return UOp(Ops.RANGE, dtype=dtype, src=(sint_to_uop(start), sint_to_uop(end)), arg=idx)
   def _reduce_op(self, op:Ops, axis:Tuple[int, ...]):
     axis = tuple(sorted([x for x in axis if resolve(self.shape[x] != 1)]))
-    return self if len(axis) == 0 else UOp(Ops.REDUCE_AXIS, self.dtype, (self,), (op, axis))
+    return self if len(axis) == 0 else UOp(Ops.REDUCE_AXIS, self.dtype, (self,), (op, axis, self.shape))
   def r(self, op:Ops, axis:Tuple[int, ...]) -> UOp:
     new_shape = unwrap(self.st).reduce(axis)
 


### PR DESCRIPTION
This is a prereq for early CONST folding with symbolic correctness.
The CONST src folds first and the maskless VIEW goes away:
![image](https://github.com/user-attachments/assets/9806d3ed-a2fd-45ec-ae4e-eb0ea79b04b7)
![image](https://github.com/user-attachments/assets/6cdbd62e-2a06-4a0a-97a4-cc3f18a3cdae)

when we match REDUCE_AXIS, it needs a way to know if the source was a size 0 VIEW.