### PR TITLE
match const with shape in UPat.cvar [pr]

### DIFF
--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -3,7 +3,7 @@ import numpy as np
 from tinygrad import Tensor, TinyJit, Variable, dtypes
 from tinygrad.engine.schedule import create_schedule
 from tinygrad.helpers import GlobalCounters
-from tinygrad.ops import PatternMatcher, UPat, UOp
+from tinygrad.ops import PatternMatcher, UPat, UOp, Ops
 
 class TestPickle(unittest.TestCase):
   def test_pickle_code_object(self):
@@ -13,7 +13,7 @@ class TestPickle(unittest.TestCase):
     self.assertEqual(fxn(2), 4)
 
   def test_pickle_pattern_matcher(self):
-    pm = PatternMatcher([(UPat.cvar('x'), lambda x: x*2)])
+    pm = PatternMatcher([(UPat(Ops.CONST, name='x'), lambda x: x*2)])
     sink = UOp.const(dtypes.int, 2)
     tt = pm.rewrite(sink)
     pm_str = pickle.dumps(pm)

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -10,7 +10,7 @@ from tinygrad.codegen.linearize import linearize_uop
 from tinygrad.shape.shapetracker import ShapeTracker, View
 
 simple_pm = PatternMatcher([
-  (UPat.cvar('x', dtypes.int), lambda x: UOp.const(dtypes.float, 1.0) + UOp.const(dtypes.float, 2.0)),
+  (UPat(Ops.CONST, name='x', dtype=dtypes.int), lambda x: UOp.const(dtypes.float, 1.0) + UOp.const(dtypes.float, 2.0)),
   (UPat.cvar('x') + UPat.cvar('y'), lambda x,y: UOp.const(dtypes.float, x.arg+y.arg)),
   (UPat.cvar('x') * UPat.cvar('y') * UPat.cvar('z'), lambda x,y,z: UOp.const(dtypes.float, x.arg*y.arg*z.arg)),
   ((UPat.var('x') + UPat.cvar('c1')) + UPat.cvar('c2'), lambda x,c1,c2: x + (c1.arg+c2.arg)),

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -327,7 +327,7 @@ def _as_const(u:UOp, val:ConstType) -> UOp:
 
 def simplify_reduceop(reduce:UOp, x:UOp) -> Optional[UOp]:
   # remove reduce on unmasked const
-  if all_int(x.shape) and x.is_unrealized_unmasked_const():
+  if all_int(x.shape) and all(v.mask is None for v in unwrap(x.st).views):
     prshape = prod(unwrap(x.st).shape[i] for i in reduce.arg[1])
     ret = x.const_arg
     match reduce.arg[0]:
@@ -375,9 +375,9 @@ ops_folding = PatternMatcher([
   (UPat(Ops.REDUCE_AXIS, name="reduce", src=(UPat.var("x"),)),
    lambda reduce,x:UOp.const(reduce.dtype, identity_element(reduce.arg[0], reduce.dtype)) if x.size == 0 and reduce.size != 0 else None),
   # reduce of const is collapsed (TODO: make this a generic rule for stride0)
-  (UPat(Ops.REDUCE_AXIS, name="reduce", src=(UPat.var("x"),)), simplify_reduceop),
+  (UPat(Ops.REDUCE_AXIS, name="reduce", src=(UPat.cvar("x"),)), simplify_reduceop),
   # CONST doesn't need COPY
-  (UPat(Ops.COPY, src=(UPat.var("x"),)), lambda x:x if x.is_unrealized_const() else None),
+  (UPat(Ops.COPY, src=(UPat.cvar("x"),)), lambda x:x),
   # no double COPY
   (UPat(Ops.COPY, src=(UPat(Ops.VIEW, src=(UPat(), UPat(Ops.COPY, name="base")),))), lambda base: base),
   # no COPY to same device, except clone (arg is True)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -720,7 +720,9 @@ class UPat(MathTrait):
   @staticmethod
   @functools.lru_cache(None)
   def cvar(name:Optional[str]=None, dtype:Optional[DType]=None, vec=True):
-    return UPat((Ops.CONST, Ops.VCONST) if vec else Ops.CONST, dtype=dtype, name=name)
+    return UPat.any(UPat((Ops.CONST, Ops.VCONST) if vec else Ops.CONST, dtype=dtype, name=name),
+                    UPat(Ops.VIEW, src=(UPat(), UPat(Ops.CONST, dtype=dtype))).view(name=name),
+                    UPat(Ops.VIEW, name=name, src=(UPat(), UPat(Ops.CONST, dtype=dtype))))
   @staticmethod
   def const(dtype:Optional[Union[DType, Tuple[DType, ...]]], b:ConstType): return UPat(Ops.CONST, dtype=dtype, arg=b)
 

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -394,7 +394,7 @@ class AMDRenderer(CStyleLanguage):
     (UPat(Ops.CAST, name="x", src=UPat.var("y", dtypes.bfloat16)),lambda x,y: y.cast(dtypes.float).cast(x.dtype) if x.dtype!=dtypes.float else None),
     (UPat(Ops.CAST, dtypes.bfloat16, UPat.var("x")),lambda x: x.cast(dtypes.float).cast(dtypes.bfloat16) if x.dtype!=dtypes.float else None),
     # bfloat16 casting
-    (UPat.cvar('x', dtypes.bfloat16), lambda x: cast_float_to_bf16(UOp.const(dtypes.float, x.arg))),
+    (UPat(Ops.CONST, name='x', dtype=dtypes.bfloat16), lambda x: cast_float_to_bf16(UOp.const(dtypes.float, x.arg))),
     (UPat(Ops.CAST, dtypes.float, UPat.var("x", dtypes.bfloat16)), lambda x: (x.bitcast(dtypes.ushort).cast(dtypes.uint)<<16).bitcast(dtypes.float)),
     (UPat(Ops.CAST, dtype=dtypes.bfloat16, src=UPat.var("x", dtype=dtypes.float)), cast_float_to_bf16)]) + extra_pm
 

--- a/tinygrad/renderer/ptx.py
+++ b/tinygrad/renderer/ptx.py
@@ -74,8 +74,8 @@ def modifier(a: DType, b: DType): return '.rzi' if dtypes.is_int(a) and dtypes.i
   (a.itemsize < b.itemsize or dtypes.is_int(b) or b == dtypes.bool) else ''
 
 string_rewrite = PatternMatcher([
-  (UPat.cvar("x", dtypes.bool), lambda ctx, x: f"setp.ne.s16 {ctx.r[x]}, {render_val(x.arg, x.dtype)}, 0;"),
-  (UPat.cvar("x"), lambda ctx, x: f"mov.b{ctx.types[x.dtype][1:]} {ctx.r[x]}, {render_val(x.arg, x.dtype)};"),
+  (UPat(Ops.CONST, name="x", dtype=dtypes.bool), lambda ctx, x: f"setp.ne.s16 {ctx.r[x]}, {render_val(x.arg, x.dtype)}, 0;"),
+  (UPat(Ops.CONST, name="x"), lambda ctx, x: f"mov.b{ctx.types[x.dtype][1:]} {ctx.r[x]}, {render_val(x.arg, x.dtype)};"),
   (UPat(Ops.STORE, name="x", src=(UPat.var('bidx'), UPat.var("var")), allow_any_len=True), lambda ctx, x, bidx, var: f"st.{mem_type(bidx)}" + \
     f"{f'.v{cnt}' if ((cnt:=var.dtype.count)>1) else ''}.{ctx.mem_types[var.dtype.scalar()]} " + \
     f"[{ctx.r[bidx]}+0], {('{' + ', '.join(ctx.r[var]) + '}') if var.dtype.count > 1 else ctx.r[var]};"),


### PR DESCRIPTION
another option besides early flattening the CONST and keeping the shape in whatever matcher still needs the src shape (eg. REDUCE_AXIS). https://github.com/tinygrad/tinygrad/pull/8187
 
This keeps the CONST spec in the scheduler exactly as-is, while allowing cvar to match it.

There are still challenges like how do we reject if the VIEW is masked or symbolic shape with just this cvar, #8212.