### PR TITLE
type check jit add method in realize

### DIFF
--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional, cast, Generator, Tuple
+from typing import List, Dict, Optional, cast, Generator, Tuple, TYPE_CHECKING
 import time, pprint
 from dataclasses import dataclass, replace
 from tinygrad.helpers import colored, getenv, DEBUG, GlobalCounters, ansilen, BEAM, NOOPT, all_int, CAPTURING, Metadata, TRACEMETA
@@ -7,6 +7,7 @@ from tinygrad.device import Device, Buffer
 from tinygrad.renderer import Renderer, ProgramSpec
 from tinygrad.codegen.kernel import Kernel
 from tinygrad.engine.schedule import ScheduleItem
+if TYPE_CHECKING: from tinygrad.engine.jit import TinyJit
 
 # **************** Program Creation ****************
 
@@ -170,7 +171,7 @@ def lower_schedule(schedule:List[ScheduleItem]) -> Generator[ExecItem, None, Non
 
 # **************** main run function ****************
 
-capturing: List = []  # put classes with an add method in here
+capturing: List["TinyJit"] = []  # put classes with an add method in here
 
 def run_schedule(schedule:List[ScheduleItem], var_vals:Optional[Dict[Variable, int]]=None, do_update_stats=True):
   for ei in lower_schedule(schedule):


### PR DESCRIPTION
I think it was the circular import that prevented this from being added in the first place? 

Combining `TYPE_CHECKING` conditonal import and quotation mark for forward reference seems to solve the problem