### PR TITLE
type_verify(big_graph.toposort) [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -3,7 +3,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from typing import FrozenSet, Set, Tuple, List, Dict, Optional, DefaultDict
 from tinygrad.ops import GroupOp, UOp, Ops, PatternMatcher, UPat, Variable, can_pad, graph_rewrite, resolve, track_rewrites, view_left, merge_views
-from tinygrad.ops import identity_element, buffers, exec_alu
+from tinygrad.ops import identity_element, buffers, exec_alu, type_verify
 from tinygrad.helpers import Context, Metadata, all_int, all_same, colored, diskcache_put, merge_dicts, prod, dedup, getenv, unwrap
 from tinygrad.helpers import FUSE_CONV_BW, FUSE_ARANGE, DEBUG, ContextVar
 from tinygrad.dtype import ConstType, ImageDType, dtypes
@@ -507,6 +507,7 @@ def create_schedule_with_vars(outs:List[UOp]) -> Tuple[List[ScheduleItem], Dict[
   for u in (big_graph:=UOp.sink(*(to_uop(x, ctx, cache) for x in outs))).src: ctx.realizes[u.buf_uop] = u
   big_graph = graph_rewrite(big_graph, remove_movement_ops+ops_folding+do_realize, ctx)
   big_graph = graph_rewrite(big_graph, merge_bufs, ctx)
+  type_verify(list(big_graph.toposort))
   # create the scheduler context
   graph_rewrite(big_graph, create_ctx, ctx)
   # group realizes into kernels

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -252,14 +252,18 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
 
   @property
   def toposort(self) -> Dict[UOp, None]:
-    @functools.lru_cache(None)
+    local_cache = {}
     def _toposort(u:UOp):
+      if (cret:=local_cache.get(u)) is not None: return cret
       nodes: Dict[UOp, None] = {}
       # NOTE: this is a lot faster than the comprehension in parents
       for parent in u.src: nodes.update(_toposort(parent))
       nodes[u] = None
+      local_cache[u] = nodes
       return nodes
-    return _toposort(self)
+    ret = _toposort(self)
+    del local_cache
+    return ret
 
   @functools.cached_property
   def tuplize(self:UOp) -> Tuple[int, Any, Optional[DType], Tuple]:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -262,6 +262,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
       local_cache[u] = nodes
       return nodes
     ret = _toposort(self)
+    # NOTE: if you comment this it'll keep the cache?
     del local_cache
     return ret
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -252,18 +252,15 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
 
   @property
   def toposort(self) -> Dict[UOp, None]:
-    local_cache = {}
+    @functools.lru_cache(None)
     def _toposort(u:UOp):
-      if (cret:=local_cache.get(u)) is not None: return cret
       nodes: Dict[UOp, None] = {}
       # NOTE: this is a lot faster than the comprehension in parents
       for parent in u.src: nodes.update(_toposort(parent))
       nodes[u] = None
-      local_cache[u] = nodes
       return nodes
     ret = _toposort(self)
-    # NOTE: if you comment this it'll keep the cache?
-    del local_cache
+    del _toposort
     return ret
 
   @functools.cached_property


### PR DESCRIPTION
1. shape change bitcast can have "implicit" movement ops, this is probably fine?
2. the root cause of GC asserts is toposort's lru_cache:
![image](https://github.com/user-attachments/assets/c5278ab2-b5c8-4b08-9555-58021233a33c)
