### PR TITLE
minimal failing test for UOp.toposort gc [pr]

### DIFF
--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
-import gc
+import gc, inspect
 import unittest
 import numpy as np
 from tinygrad.device import Buffer
 from tinygrad.engine.realize import run_schedule
+from tinygrad.ops import UOp
 from tinygrad.tensor import Tensor
 
 def tensors_allocated():
@@ -64,6 +65,18 @@ class TestGC(unittest.TestCase):
     self.assertEqual(bufs_allocated()-init, 1)
     del y
     self.assertEqual(bufs_allocated()-init, 0)
+
+  @unittest.expectedFailure
+  def test_toposort_blocks_gc(self):
+    init = bufs_allocated()
+    x = Tensor.ones(4,4).contiguous().realize()+1
+    self.assertEqual(bufs_allocated()-init, 1)
+    # try commenting this part out, it's green!
+    x.lazydata.toposort
+    del x
+    if bufs_allocated()-init != 0:
+      print(inspect.getclosurevars(UOp.toposort.fget))
+      raise AssertionError(f"never gced {[x for x in gc.get_objects() if isinstance(x, Buffer)]}")
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
> That [UOp.toposort] cache should only be in scope for the function.
https://github.com/tinygrad/tinygrad/pull/8247#issuecomment-2543353016

However, the closure in toposort keeps a reference to the BUFFER uop [around](https://docs.python.org/3/c-api/cell.html) forever.