### PR TITLE
hotfix DEBUG in speed_v_theoretical.py conv

### DIFF
--- a/test/external/speed_v_theoretical.py
+++ b/test/external/speed_v_theoretical.py
@@ -72,7 +72,7 @@ class TestKernelSpeed(unittest.TestCase):
         x = self._get_tensor(BS, CIN, H, W)
         if i >= 3:
           GlobalCounters.time_sum_s = 0
-          with Context(DEBUG=max(DEBUG, 2)): _c = f(conv, x)
+          with Context(DEBUG=max(DEBUG.value, 2)): _c = f(conv, x)
           tms.append(GlobalCounters.time_sum_s)
         else:
           _c = f(conv, x)


### PR DESCRIPTION
infinite loop with manual DEBUG set `DEBUG=2 python test/external/speed_v_theoretical.py -k conv`

```
  File "/Users/chenyu/code/tinygrad/tinygrad/helpers.py", line 95, in __ge__
    def __ge__(self, x): return self.value >= x
                                ^^^^^^^^^^^^^^^
  [Previous line repeated 4984 more times]
RecursionError: maximum recursion depth exceeded in comparison
```