### PR TITLE
hcq better timeout handling

### DIFF
--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -210,10 +210,9 @@ class HCQSignal(Generic[DeviceType]):
       timeout: Maximum time to wait in milliseconds. Defaults to 10s.
     """
     start_time = int(time.time() * 1000)
-    while (time_spent:=int(time.time() * 1000) - start_time) < timeout:
-      if self.value >= value: return
+    while self.value < value and (time_spent:=int(time.time() * 1000) - start_time) < timeout:
       self._sleep(time_spent)
-    raise RuntimeError(f"Wait timeout: {timeout} ms! (the signal is not set to {value}, but {self.value})")
+    if self.value < value: raise RuntimeError(f"Wait timeout: {timeout} ms! (the signal is not set to {value}, but {self.value})")
 
 @contextlib.contextmanager
 def hcq_profile(dev:HCQCompiled, enabled, desc, queue_type:Optional[Type[HWQueue]]=None, queue:Optional[HWQueue]=None):


### PR DESCRIPTION
Now we check signal value before raising, to solve `RuntimeError: Wait timeout: 30000 ms! (the signal is not set to 724, but 724)`.

Updates #8242

