### PR TITLE
big graph 3

### DIFF
--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -160,6 +160,7 @@ def lower_schedule_item(si:ScheduleItem) -> ExecItem:
 def lower_schedule(schedule:List[ScheduleItem]) -> Generator[ExecItem, None, None]:
   while len(schedule):
     si = schedule.pop(0)
+    if si.ast.op is Ops.NOOP: continue # NOOP is passthrough
     try: yield lower_schedule_item(si)
     except Exception as e:
       if DEBUG >= 2:

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -1,7 +1,7 @@
 import functools
 from dataclasses import dataclass
 from typing import Tuple, List, Dict
-from tinygrad.ops import GroupOp, UOp, Ops, PatternMatcher, UPat, Variable, graph_rewrite, track_rewrites, merge_views
+from tinygrad.ops import GroupOp, UOp, Ops, PatternMatcher, UPat, Variable, graph_rewrite, track_rewrites, merge_views, view_left
 from tinygrad.helpers import Metadata, unwrap, unwrap_or
 from tinygrad.device import Buffer
 from tinygrad.shape.shapetracker import ShapeTracker
@@ -43,7 +43,7 @@ realize = PatternMatcher([
 def add_buf(ctx:List[UOp], b:UOp):
   ctx.append(b)
   return UOp(Ops.DEFINE_GLOBAL, b.dtype, (), len(ctx)-1)
-to_ast = PatternMatcher([
+to_ast = view_left+PatternMatcher([
   # ** buffer op rules
   # const is just const
   (UPat(Ops.VIEW, name="st", src=(UPat(), UPat.cvar("x"))), lambda st,x: UOp.const_with_shape(x.dtype, x.arg, st.shape)),

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -1,6 +1,7 @@
 import functools
 from dataclasses import dataclass
 from typing import Tuple, List, Dict
+from tinygrad.dtype import dtypes
 from tinygrad.ops import GroupOp, UOp, Ops, PatternMatcher, UPat, Variable, graph_rewrite, track_rewrites, merge_views, view_left
 from tinygrad.helpers import Metadata, unwrap, unwrap_or
 from tinygrad.device import Buffer
@@ -46,7 +47,7 @@ def add_buf(ctx:List[UOp], b:UOp):
 to_ast = view_left+PatternMatcher([
   # ** buffer op rules
   # const is just const
-  (UPat(Ops.VIEW, name="st", src=(UPat(), UPat.cvar("x"))), lambda st,x: UOp.const_with_shape(x.dtype, x.arg, st.shape)),
+  (UPat(Ops.VIEW, name="st", src=(UPat(), UPat.cvar("x"))), lambda st,x: UOp(Ops.VALID, dtypes.bool, (st.st.to_uop(),)).where(x, 0)),
   # buffer view is load
   (UPat(Ops.VIEW, name="st", src=(UPat(Ops.DEFINE_GLOBAL, name="ptr"),)), lambda st,ptr: UOp.load(ptr, st.st.to_uop(), dtype=ptr.dtype.base)),
   # buffer+op view is store

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -40,6 +40,8 @@ realize = PatternMatcher([
   (UPat(Ops.COPY, name="cp", src=(UPat.var("x"),)), lambda ctx,cp,x: None if (bx:=unwrap_or(_bufferize(ctx, x), x)) is x else cp.replace(src=(bx,))),
   (UPat(Ops.VIEW, name="x", src=(UPat(Ops.BUFFER), UPat(GroupOp.Meta))), _bufferize),
   (UPat(Ops.CONTIGUOUS, name="x"), _bufferize),
+  # very simple rule
+  (UPat(Ops.REDUCE_AXIS, name="x"), _bufferize),
 ])
 
 def add_buf(ctx:List[UOp], b:UOp):

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -32,6 +32,7 @@ def _bufferize(ctx:Dict[UOp, UOp], x:UOp):
   if x in ctx or x.op is Ops.VIEW and len(x.src) == 1: return None
   buf_uop = x.buf_uop if x.op is Ops.VIEW else UOp.new_buffer(x.device, x.size, x.dtype)
   ctx[buf_uop] = x
+  buf_uop.buffer.ref(1)
   return buf_uop.view(unwrap(x.st))
 realize = PatternMatcher([
   (UPat(Ops.SINK, name="sink"),

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -1,20 +1,10 @@
-import sys, atexit, functools, pickle
-from collections import defaultdict, deque
-from dataclasses import dataclass, field
-from typing import Set, Tuple, List, Dict, Optional, DefaultDict
-from tinygrad.ops import GroupOp, UOp, Ops, PatternMatcher, UPat, Variable, can_pad, graph_rewrite, resolve, track_rewrites, view_left, merge_views
-from tinygrad.ops import identity_element, buffers, exec_alu
-from tinygrad.helpers import Context, Metadata, all_int, all_same, colored, diskcache_put, merge_dicts, prod, dedup, getenv, unwrap
-from tinygrad.helpers import FUSE_CONV_BW, FUSE_ARANGE, DEBUG, ContextVar
-from tinygrad.dtype import ConstType, ImageDType, dtypes
-from tinygrad.shape.shapetracker import ShapeTracker
-from tinygrad.shape.view import View, strides_for_shape
+import functools
+from dataclasses import dataclass
+from typing import Tuple, List, Dict
+from tinygrad.ops import GroupOp, UOp, Ops, PatternMatcher, UPat, Variable, graph_rewrite, track_rewrites, symbolic, merge_views
+from tinygrad.helpers import Metadata, unwrap, unwrap_or
 from tinygrad.device import Buffer
-
-# creation can recurse a lot
-sys.setrecursionlimit(10000)
-
-BUF_LIMIT = {"METAL":32}
+from tinygrad.shape.shapetracker import ShapeTracker
 
 # **** ScheduleItem return type
 
@@ -35,510 +25,59 @@ class ScheduleItem:
   @functools.cached_property
   def output_idxs(self) -> Tuple[int, ...]: return tuple(x.src[0].arg for x in self.ast.src) if self.ast.op is Ops.SINK else (0,)
 
-# **** Schedule context and big graph
-
-@dataclass(frozen=True)
-class ScheduleContext:
-  tensor_uops: Dict[UOp, List[UOp]] = field(default_factory=dict)    # this maps BUFFER uops of this schedule to the tensor uop
-  var_vals: Dict[Variable, int] = field(default_factory=dict)        # this maps a BIND's DEFINE_VAR to its value
-  assigns: Set[UOp] = field(default_factory=set)                     # this holds all the BUFFER uops we ASSIGN to in this schedule
-  realizes: Dict[UOp, UOp] = field(default_factory=dict)             # this holds all the BUFFER uops we mutate in this schedule
-  allbufs: Dict[UOp, UOp] = field(default_factory=dict)              # this maps BUFFER uops the actual op
-  ops_metadata: Dict[UOp, Metadata] = field(default_factory=dict)    # this maps fused ops to Metadata
-  contiguous: Dict[UOp, UOp] = field(default_factory=dict)           # this maps roots to places they are made contiguous
-  children: DefaultDict[UOp, Dict[UOp, None]] = field(default_factory=lambda: defaultdict(dict))
-
-def to_uop(buf:UOp, ctx:ScheduleContext, cache:Dict[UOp, UOp]) -> UOp:
-  if (r:=cache.get(buf)) is not None: return r
-  # shapeless op is passthrough
-  # realized is passthrough
-  if buf.st is None or buf.base.is_realized: return buf
-  # view is passthrough
-  if buf is not buf.base:
-    cache[buf] = ret = to_uop(buf.base, ctx, cache).view(buf.st)
-    return ret
-  # make things that can't be images not images
-  dtype = buf.dtype
-  if isinstance(dtype, ImageDType) and (prod(buf.shape) != prod(dtype.shape) or not any(buf.shape[x]%4 == 0 for x in buf.st.unit_stride_axes())):
-    if DEBUG >= 2: print(f"forcing image {dtype} with shape {buf.shape} to {dtype.base}")
-    dtype = buf.dtype.base
-  # meta ops and assign already have a target buffer, otherwise we create a new one
-  buf_uop = buf.buf_uop if buf.op in {Ops.ASSIGN, Ops.VIEW} else UOp.new_buffer(buf.device, buf.size, dtype)
-  if buf.op is Ops.VIEW: op = buf.src[1].replace(src=tuple(to_uop(x, ctx, cache) for x in buf.src[1].src))
-  else: op = buf.replace(dtype=dtype.base, src=tuple(to_uop(x, ctx, cache) for x in buf.src))
-  # track the underlying tensor uop for this op
-  ctx.tensor_uops[buf_uop] = [buf]
-  # (early) bufferize
-  cache[buf] = ret = UOp(Ops.VIEW, dtype.base, (buf_uop, op.alu(Ops.CONTIGUOUS) if buf.forced_realize else op), buf.st)
-  return ret
-
-# **** AST graph rewrite
-
-# ** movement ops
-
-def apply_swizzle(u:UOp) -> UOp:
-  with Context(TRACK_MATCH_STATS=0): return graph_rewrite(u, view_left)
-
-def swizzle_r(r:UOp, src:UOp, st:ShapeTracker) -> UOp:
-  input_st = ShapeTracker.from_shape(unwrap(src.st).shape)
-  tmp = input_st.permute(tuple(i for i in range(len(input_st.shape)) if i not in r.axis_arg)+r.axis_arg)
-  prshape = prod(rshape:=tmp.shape[-len(r.axis_arg):])
-  strides = strides_for_shape(rshape)
-  nv = [View.create(v.shape+rshape, tuple(x*prshape for x in v.strides)+strides,
-                    v.offset*prshape, v.mask+tuple((0,s) for s in rshape) if v.mask is not None else None) for v in st.views]
-  # update input_st and axis
-  new_input_st = tmp + ShapeTracker(tuple(nv))
-  new_axis = tuple(range(len(st.shape), len(st.shape) + len(r.axis_arg)))
-  return apply_swizzle(src.view(new_input_st)).r(r.arg[0], new_axis).view(ShapeTracker.from_shape(st.shape))
-
-def push_swizzle_down_through_reduce(r:UOp, v:UOp, src:UOp) -> UOp:
-  if not (swizzle_st:=unwrap(v.st)).contiguous or v.size != src.size: raise AssertionError(f"can't push {v} down through {src}")
-  output_shape = swizzle_st.reduce(r.axis_arg)
-  return src.r(r.arg[0], tuple(i for i,(s,u) in enumerate(zip(src.shape, output_shape)) if s != u)).view(ShapeTracker.from_shape(output_shape))
-
-def push_swizzle_down_through_elementwise(root:UOp) -> Optional[UOp]:
-  if not (swizzles := [x for x in root.src if x.base is not x]): return None
-  assert all_same([(x.shape, prod(x.src[0].shape)) for x in swizzles]), f"swizzles must have the same size {swizzles}"
-  new_input_st = ShapeTracker.from_shape(swizzles[0].src[0].shape)
-  ret = root.replace(src=tuple(x if not x.has_st else x.src[0] if x in swizzles else apply_swizzle(x.view(new_input_st)) for x in root.src))
-  # update the ASSIGN offset to match the new shape
-  if ret.op is Ops.ASSIGN and ret.arg is not None: ret = ret.replace(arg=ret.arg+new_input_st,)
-  return ret if ret.op is Ops.STORE else ret.view(ShapeTracker.from_shape(swizzles[0].shape))
-
-def merge_double_reduce(root:UOp, first_reduce:UOp) -> UOp:
-  assert root.arg[0] == first_reduce.arg[0], "can't merge reduceops with different alu"
-  assert not any(x.op is Ops.REDUCE_AXIS for x in first_reduce.src[0].toposort), "can't merge more than two reduceops at a time"
-  return first_reduce.src[0].r(first_reduce.arg[0], root.axis_arg+first_reduce.axis_arg)
-
-# push VIEW to stores
-view_right = merge_views+PatternMatcher([
-  # ASSIGN with offset swizzles STORE
-  (UPat(Ops.STORE, src=(UPat.var("b"), UPat.var("st"), UPat(Ops.ASSIGN, name="a"))),
-   lambda a,b,st: None if a.arg is None else apply_swizzle(UOp.store(b, st, a.replace(arg=None)).view(a.arg))),
-  # non contiguous VIEW on a reduce creates a new VIEW
-  (UPat(Ops.REDUCE_AXIS, src=(UPat.var("src"),), name="r").view(name="v"), lambda v,r,src: None if v.st.contiguous else swizzle_r(r, src, v.st)),
-  # push a VIEW down to STORE, through a reduce (ONLY reshapes)
-  (UPat(Ops.REDUCE_AXIS, src=(UPat.var("src").view(name="v"),), name="r"), push_swizzle_down_through_reduce),
-  # push VIEW(s) down to STORE, through an elementwise op (ONLY reshapes)
-  (UPat((*GroupOp.ALU, Ops.CAST, Ops.BITCAST, Ops.ASSIGN, Ops.CONTIGUOUS, Ops.STORE), name="root"), push_swizzle_down_through_elementwise),
-  (UPat(Ops.REDUCE_AXIS, src=(UPat(Ops.REDUCE_AXIS, name="first_reduce"),), name="root"), merge_double_reduce),
-])
-
-# ** ScheduleItem context builder
-
-@dataclass(frozen=True)
-class ScheduleItemContext:
-  tensor_uops: Dict[UOp, List[UOp]]
-  ops_metadata: Dict[UOp, Metadata]
-  assigns: Set[UOp]
-  var_vals: Dict[Variable, int]
-  sinked: Dict[UOp, UOp]
-  sts: Set[ShapeTracker] = field(default_factory=set)
-  bufs: List[UOp] = field(default_factory=list)
-  metadata: Set[Metadata] = field(default_factory=set)
-  assign_adj: Dict[UOp, List[UOp]] = field(default_factory=dict)
-
-def _append_st_vars(ctx:ScheduleItemContext, x:UOp) -> Optional[UOp]:
-  if (st:=unwrap(x.st)) in ctx.sts: return None
-  st, var_vals = st.simplify().unbind()
-  ctx.var_vals.update(var_vals)
-  ctx.sts.add(st)
-  return st.to_uop() if st != x.st else None
-
-def _append_buf(ctx:ScheduleItemContext, x:UOp) -> UOp:
-  ctx.bufs.append(x)
-  return UOp(Ops.DEFINE_GLOBAL, x.dtype, (), len(ctx.bufs)-1)
-append_bufs = PatternMatcher([(UPat(Ops.BUFFER, name="x"), _append_buf)])
-
-def _append_preload(ctx:ScheduleItemContext, x:UOp, b:UOp) -> UOp:
-  (adj_loads:=ctx.assign_adj.setdefault(b, [])).append(x)
-  if not all_same([x.op for x in adj_loads]): raise RuntimeError(f"Detected cycle when fusing {adj_loads}. Can only fuse PRELOAD or LOAD of {b}")
-  return x.replace(op=Ops.LOAD)
-check_preload = PatternMatcher([(UPat(Ops.PRELOAD, src=(UPat.var("b"), UPat()), name="x"), _append_preload),])
-
-to_si = PatternMatcher([
-  (UPat(Ops.VIEW, name="x"), _append_st_vars),
-  (UPat(Ops.SINK, src=(UPat.store(UPat.var("b"), UPat(), UPat(GroupOp.Meta, name="x")),)), lambda b,x: x.replace(src=(b, *x.src))),
-  # don't need contiguous or assign anymore
-  (UPat(Ops.CONTIGUOUS, src=(UPat.var("x"),)), lambda x: x),
-  (UPat(Ops.ASSIGN, src=(UPat(), UPat.var("x"),)), lambda x: x),
-])
-
-add_metadata = PatternMatcher([(UPat(tuple(Ops), name="x"), lambda ctx,x: None if (m:=ctx.ops_metadata.get(x)) is None else ctx.metadata.add(m)),])
-add_assign_adjacents = PatternMatcher([(UPat.load(UPat.var("b"), UPat(), name="x"), lambda ctx,b,x: ctx.assign_adj.setdefault(b, []).append(x)
-                               if b in ctx.assigns else None)])
-
-# late folding for multi output kernels
-multioutput = PatternMatcher([(UPat.load(UPat.var("b"), UPat()), lambda ctx,b: ctx.sinked.get(b)),])
-
-def schedule_uop(pre:UOp, ctx:ScheduleContext) -> ScheduleItem:
-  # create the ast context
-  si_ctx = ScheduleItemContext(ctx.tensor_uops, ctx.ops_metadata, ctx.assigns, ctx.var_vals, {x.buf_uop:x.src[2] for x in pre.src})
-  create_ctx = add_metadata if len(si_ctx.assigns) == 0 else add_metadata+add_assign_adjacents
-  sink = graph_rewrite(pre, create_ctx if len(si_ctx.sinked) == 1 else multioutput+create_ctx, si_ctx)
-  # do movement ops
-  sink = graph_rewrite(graph_rewrite(sink, view_left), view_right)
-  # convert to AST
-  sink = graph_rewrite(graph_rewrite(sink, to_si+check_preload if len(si_ctx.assigns) != 0 else to_si, si_ctx), append_bufs, si_ctx)
-  # assert buffer count limit
-  if (limit:=BUF_LIMIT.get(device:=si_ctx.bufs[0].device)) is not None and len(si_ctx.bufs) >= limit:
-    if DEBUG >= 3: print(sink)
-    raise RuntimeError(f"Kernel for {si_ctx.metadata} exceeded the {limit} buffer count limit for {device} with {len(si_ctx.bufs)} buffers.")
-  # we also allow masked views. if it has a single view and it's equal when you shrink a contig, it's fine
-  for ubuf,ops in si_ctx.assign_adj.items():
-    if si_ctx.sinked.get(ubuf) is not None and not all((s:=x.st_arg).contiguous or (len(s.views) == 1 and (m:=s.views[0].mask) is not None \
-        and ShapeTracker.from_shape(s.shape).shrink(m) == s.shrink(m)) for x in ops):
-      raise RuntimeError("self operand of augmented assign must be contiguous.\nhelp: consider using .contiguous():\n"
-                         +colored("   - a += a.T\n", "red")+colored("   + a += a.T.contiguous()", "green"))
-  # can only schedule once
-  for buf_uop in si_ctx.sinked:
-    for luop in si_ctx.tensor_uops[buf_uop]: luop.become(buf_uop.view(unwrap(luop.st)))
-  # capture process replay
-  if getenv("RUN_PROCESS_REPLAY"):
-    PROCESS_REPLAY_CAPTURE[str(pre.key)] = pickle.dumps((pre, si_ctx.assigns, {k:v.value for k,v in ContextVar._cache.items()}, sink))
-  return ScheduleItem(sink, tuple(u.buffer for u in si_ctx.bufs if u.size != 0), tuple(si_ctx.metadata),
-                      tuple(ubuf for ubuf,ops in si_ctx.assign_adj.items() if any(x.op is Ops.PRELOAD for x in ops)))
-
-PROCESS_REPLAY_CAPTURE: Dict[str, bytes] = {}
-if getenv("RUN_PROCESS_REPLAY"):
-  @atexit.register
-  def save_process_replay() -> None:
-    for k,v in PROCESS_REPLAY_CAPTURE.items(): diskcache_put("schedule_process_replay", k, v, prepickled=True)
-
-# **** Schedule grouping
-
-def is_scheduled(u:UOp) -> bool: return u.op is Ops.VIEW and len(u.src) == 2
-def uval(u:UOp) -> UOp:
-  assert is_scheduled(u), f"must be a scheduled op {u}"
-  return r.src[0] if (r:=u.src[1]).op is Ops.CONTIGUOUS and not (r.src[0].base.op is Ops.VIEW and len(r.src[0].base.src) == 2) else r
-
-def recursive_group(tr:UOp, st:ShapeTracker, r:UOp, children:DefaultDict[UOp, Dict[UOp, None]], allbufs:Dict[UOp, UOp], realizes:Dict[UOp, UOp],
-                     reduce_for_op:Dict[UOp, UOp], group:Dict[UOp, None], cache:Dict[Tuple[UOp, ShapeTracker], None]) -> None:
-  """recursively search the uop for groupable children, realize the UOp if a child can't group"""
-  if (tr, st) in cache: return
-  cache.setdefault((tr, st))
-  rsize = unwrap(allbufs[r].st).size
-  if tr in realizes and tr is not r:
-    # can only fuse contiguous
-    # max one reduceop per kernel
-    if not st.contiguous or st.size != rsize or tr in reduce_for_op: group.setdefault(r)
-    return group.setdefault(tr)
-  for tr_next in children[tr]:
-    # max one reduceop per kernel
-    if (tr_next_uop:=uval(allbufs[tr_next]).base).op is Ops.REDUCE_AXIS: return group.setdefault(r)
-    # can only fuse contiguous
-    if len(st_childs:=dedup(unwrap(x.st) for x in tr_next_uop.src if is_scheduled(x.base) and x.base.buf_uop == tr)) > 1: return group.setdefault(r)
-    recursive_group(tr_next, st+st_childs[0], r, children, allbufs, realizes, reduce_for_op, group, cache)
-
-def get_isolated_children(r:UOp, reduce_for_op:Dict[UOp, UOp], children:DefaultDict[UOp, Dict[UOp, None]], allbufs:Dict[UOp, UOp],
-                           realizes:Dict[UOp, UOp], group:Dict[UOp, None]) -> Dict[UOp, None]:
-  rc_parents, cache = deque(group), set()
-  while rc_parents:
-    if (p:=uval(allbufs[rc_parents.pop()])) in cache: continue
-    cache.add(p)
-    # max one reduceop per kernel
-    if p.op is Ops.REDUCE_AXIS: return {}
-    rc_parents.extend(x.base.buf_uop for x in p.src if is_scheduled(x.base) and x.base.buf_uop is not r)
-  # search descendants of the reduceop that can cleanly group
-  descendants: Dict[UOp, None] = {}
-  for tr in group: recursive_group(tr, unwrap(allbufs[tr].st), tr, children, allbufs, realizes, reduce_for_op, descendants, cache={})
-  return merge_dicts([group, {} if any(tr in group for tr in descendants) else descendants])
-
-def group_realizes(ctx:ScheduleContext) -> List[List[UOp]]:
-  """search the big graph for all the reduceops that need to realize, sometimes group/fuse the reduceop"""
-  # find all reduces, and pair them to a elementwise op. if they can't be cleanly paired, force realize the reduce (or a contig child)
-  reduce_for_op: Dict[UOp, UOp] = {}
-  reduce_of_const: List[UOp] = []
-  double_reduces: List[UOp] = []
-  for r, r_uop in ctx.allbufs.items():
-    if (r_uop:=uval(r_uop)).op is not Ops.REDUCE_AXIS: continue
-    if FUSE_CONV_BW and uval((x:=r_uop.src[0]).base).op is r_uop.op and x.base is not x: double_reduces.append(r)
-    if r in ctx.realizes: continue
-    group: Dict[UOp, None] = {}
-    recursive_group(r, unwrap(r_uop.st), r, ctx.children, ctx.allbufs, ctx.realizes, reduce_for_op, group, cache={})
-    # max one reduceop per kernel
-    can_chase = all(tr not in reduce_for_op for tr in group)
-    # TODO: forced_realize exists because the scheduler is incapable of checking for self-contained DAGs
-    forced_realize = r in group
-    if not forced_realize and len(group) > 1:
-      group = get_isolated_children(r, reduce_for_op, ctx.children, ctx.allbufs, ctx.realizes, group)
-    # can only fuse assign if no other assign_target is used in the kernel
-    if not forced_realize and any(x in ctx.assigns for x in group):
-      parents = deque((r, *group))
-      while parents and not forced_realize:
-        if (p_uop:=ctx.allbufs.get(p:=parents.pop())) is None: continue
-        if (p_uop:=uval(p_uop)).op is Ops.ASSIGN and p not in group: forced_realize, can_chase = True, False
-        if p in ctx.realizes: continue
-        parents.extend([x.base.src[0] for x in p_uop.src if x.base.op is Ops.VIEW and len(x.base.src) != 0])
-    if forced_realize or not group:
-      tr = r
-      if can_chase:
-        # can chase this down to contiguous children
-        st = unwrap(r_uop.st)
-        while len(ctx.children[tr]) == 1:
-          tr_next_uop = uval(ctx.allbufs[(tr_next:=next(iter(ctx.children[tr])))])
-          st_childs = dedup([unwrap(x.st) for x in tr_next_uop.src if is_scheduled(x.base) and x.base.buf_uop is tr])
-          if len(st_childs) > 1: break
-          if st.size != st_childs[0].size: break
-          st = st + st_childs[0]
-          if not st.contiguous or tr_next_uop.op is Ops.REDUCE_AXIS: break
-          tr = tr_next
-        # don't cast to higher size before store (tr cannot be realized if forced_realize)
-        if (tr_uop:=uval(ctx.allbufs[tr])).op is Ops.CAST and tr_uop.dtype.base.itemsize > tr_uop.src[0].dtype.base.itemsize:
-          tr = tr_uop.src[0].base.buf_uop
-      group = {tr: None}
-      ctx.realizes[tr] = tr
-    reduce_for_op.update((tr, r) for tr in group)
-    if FUSE_ARANGE and r_uop.arg[0] is Ops.ADD and uval(r_uop.src[0].base).op is Ops.CONST: reduce_of_const.append(r)
-  # fuse double reduces with no other child
-  for reduceop in double_reduces:
-    top_reduce = uval(ctx.allbufs[reduceop]).src[0].base.buf_uop
-    if len(ctx.children[top_reduce]) == 1: del ctx.realizes[top_reduce]
-  # maybe fuse arange with its children
-  for rbuf in reduce_of_const:
-    group = {tr:None for tr,rop in reduce_for_op.items() if rop is rbuf}
-    if any(luop.forced_realize for tr in group for luop in ctx.tensor_uops[tr]): continue
-    kernel_children = {c for tr in group for c in ctx.children[tr] if uval(ctx.allbufs[c]).op not in {Ops.COPY, Ops.BUFFER_VIEW}}
-    if len(kernel_children) == 0: continue
-    for tr in group: del ctx.realizes[tr]
-  # group BUFFER uops into kernels
-  output_groups: DefaultDict[UOp, List[UOp]] = defaultdict(list)
-  for ubuf in ctx.realizes: output_groups[reduce_for_op.get(ubuf, ubuf)].append(ubuf)
-  return list(output_groups.values())
-
-# **** Schedule creation and BFS toposort
-
-# ** ops in the big graph can either be pre-realized or scheduled (fused/realized)
-
-class UPatScheduled(UPat):
-  def __init__(self, *args, **kwargs): super().__init__(Ops.VIEW, name="base", src=(UPat(Ops.BUFFER, name="b"),
-                                                                       UPat(*args, **{"name":"to_store",**kwargs})))
-
-# ** this is schedule level const folding
-
-def _as_const(u:UOp, val:ConstType) -> UOp:
-  assert is_scheduled(u), f"must be scheduled to fold {u}"
-  st = (base:=ShapeTracker.from_shape(())).reshape((1,)*len(u.shape)).expand(u.shape)
-  return UOp(Ops.VIEW, u.dtype, (u.buf_uop, UOp.const(u.dtype, val)), base).view(st)
-
-def simplify_reduceop(reduce:UOp, x:UOp) -> Optional[UOp]:
-  # remove reduce on unmasked const
-  if all_int(x.shape) and x.is_unrealized_unmasked_const():
-    prshape = prod(unwrap(x.st).shape[i] for i in reduce.arg[1])
-    ret = x.const_arg
-    match reduce.arg[0]:
-      case Ops.ADD: ret *= prshape
-      case Ops.MUL: ret **= prshape
-      case Ops.MAX: pass # NOTE: Ops.MAX is passthrough
-      case _: return None
-    return UOp.const(reduce.dtype, ret)
-  return None
-
-def simplify_alu(alu:UOp):
-  if not all(x.is_unrealized_unmasked_const() for x in alu.src): return None
-  # this needs to have a VIEW next (it has to, right?)
-  return UOp.const(alu.dtype, exec_alu(alu.op, alu.dtype, [s.const_arg for s in alu.src]))
-
-def simplify_binop(binop:UOp, x:UOp, y:UOp):
-  if all_int(x.shape) and x.is_unrealized_unmasked_const(): other, const = y, x
-  elif all_int(y.shape) and y.is_unrealized_unmasked_const():
-    if binop.op is Ops.IDIV and y.const_arg == 1: return x
-    other, const = x, y
-  else: return None
-  if binop.op is Ops.ADD and const.const_arg == 0: return other
-  if binop.op is Ops.MUL and const.const_arg == 1: return other
-  if binop.op is Ops.MUL and const.const_arg == 0: return UOp.const(binop.dtype, 0)
-
-def found_contiguous(ctx:ScheduleContext, contig:UOp, base:UOp, b:UOp):
-  if contig.src[0].op is Ops.VIEW and len(contig.src[0].src):
-    old_base = contig.src[0].src[0]
-    if old_base.op is Ops.VIEW and (sti:=unwrap(contig.src[0].st).invert(old_base.shape)) is not None: ctx.contiguous[old_base] = base.view(sti)
-def replace_contiguous(ctx:ScheduleContext, alu:UOp):
-  new_src = list(alu.src)
-  for i,s in enumerate(alu.src):
-    if (replace_src:=ctx.contiguous.get(s, None)) is not None: new_src[i] = replace_src
-  if tuple(new_src) != alu.src: return alu.replace(src=tuple(new_src))
-
-ops_folding = PatternMatcher([
-  # op with size 0 is zero
-  (UPatScheduled(), lambda b,to_store,base: _as_const(base, 0) if base.size == 0 else None),
-  # DETACH is a NOOP here
-  (UPat(Ops.DETACH, name="detach"), lambda detach: detach.src[0]),
-  # elementwise const folding
-  (UPat(GroupOp.ALU, name="alu"), simplify_alu),
-  (UPat({Ops.ADD, Ops.MUL, Ops.IDIV}, name="binop", src=(UPat.var("x"), UPat.var("y"))), simplify_binop),
-  (UPat(Ops.CAST, src=(UPat.var("x"),), name="cast"),
-   lambda x,cast: UOp.const(cast.dtype, x.const_arg) if all_int(x.shape) and x.is_unrealized_unmasked_const() else None),
-  # reduce of size 0 is the identity element
-  (UPat(Ops.REDUCE_AXIS, name="reduce", src=(UPat.var("x"),)),
-   lambda reduce,x:UOp.const(reduce.dtype, identity_element(reduce.arg[0], reduce.dtype)) if x.size == 0 and reduce.size != 0 else None),
-  # reduce of const is collapsed (TODO: make this a generic rule for stride0)
-  (UPat(Ops.REDUCE_AXIS, name="reduce", src=(UPat.var("x"),)), simplify_reduceop),
-  # CONST doesn't need COPY
-  (UPat(Ops.COPY, src=(UPat.var("x"),)), lambda x:x if x.is_unrealized_const() else None),
-  # no double COPY
-  (UPat(Ops.COPY, src=(UPat(Ops.VIEW, src=(UPat(), UPat(Ops.COPY, name="base")),))), lambda base: base),
-  # no COPY to same device, except clone (arg is True)
-  (UPatScheduled(Ops.COPY, src=UPat(Ops.VIEW, name="copyin"), name="copy"),
-   lambda base,b,copyin,copy: copyin if base.device == copy.device and copy.arg is not True else None),
-  # support for using a contiguous permuted view instead of the parent view if one exists
-  (UPatScheduled(Ops.CONTIGUOUS, name="contig"), found_contiguous),
-  (UPat(GroupOp.ALU, name="alu"), replace_contiguous),
-])
-
-# ** buffer merging
-
-def merge(ctx:ScheduleContext, v1:UOp, b1:UOp, v2:UOp, b2:UOp) -> UOp:
-  assert v1.st is not None and v2.st is not None and v1.st == v2.st, f"implicit movementop {v1.st} {v2.st}"
-  # if b2 is realized also realize b1
-  if b2 in ctx.realizes:
-    ctx.realizes[b1] = b1
-    del ctx.realizes[b2]
-  # ops referring to b2 now ref to b1
-  ctx.tensor_uops[b1] += ctx.tensor_uops[b2]
-  del ctx.tensor_uops[b2]
-  # merge
-  return v1
-
-def merge_realized(ctx:ScheduleContext, v1:UOp, b1:UOp, v2:UOp, b2:UOp):
-  # early become
-  for luop in ctx.tensor_uops.get(b1, [])+ctx.tensor_uops.get(b2, []): luop.become(b1.view(unwrap(luop.st)))
-  return v1
-
-merge_bufs = PatternMatcher([
-  # merge base
-  (UPat(Ops.VIEW, name="v2", src=(UPat(Ops.BUFFER, name="b2"), UPat(Ops.VIEW, name="v1", src=(UPat(Ops.BUFFER, name="b1"), UPat())))), merge),
-  (UPat(Ops.VIEW, name="v2", src=(UPat(Ops.BUFFER, name="b2"), UPat(Ops.VIEW, name="v1", src=(UPat(Ops.BUFFER, name="b1"),)))), merge_realized),
-  # collapse view
-  (UPat(Ops.VIEW, src=(UPat(Ops.BUFFER), UPat(Ops.VIEW, src=(UPat(Ops.BUFFER), UPat())).view(name="mv"))), lambda mv:mv),
-  (UPat(Ops.VIEW, src=(UPat(Ops.BUFFER), UPat(Ops.VIEW, src=(UPat(Ops.BUFFER),)).view(name="mv"))), lambda mv:mv),
-])
-
-# ** this decides which ops get realized
-
-def realize(ctx:ScheduleContext, b:UOp, to_store:UOp, **kwargs) -> None:
-  if to_store.op not in {Ops.CONST, Ops.BIND}: ctx.realizes.update([(b, to_store)])
-
-def realize_view(ctx:ScheduleContext, view:UOp, src:UOp, b:UOp, **kwargs) -> None:
-  if src.st is None: return None
-  st = unwrap(view.st)
-  # fold simple pads
-  if len(st.views) == 1 and (m:=st.views[-1].mask) is not None and all_int(src.shape) and resolve(prod(src.shape) >= prod([y-x for x,y in m])):
-    return None if can_pad(src, ctx.realizes, set()) else realize(ctx, b, src)
-  # early realize before expand
-  if resolve(prod(src.shape) < prod(st.shape)): return realize(ctx, b, src)
-  # otherwise safety check pads
-  return None if (all(v.mask is None for v in st.views) or can_pad(src, ctx.realizes, set())) else realize(ctx, b, src)
-
-def fold_img_cast(ctx:ScheduleContext, xb:UOp, view:UOp, b:UOp, to_cast:UOp, **kwargs) -> Optional[UOp]:
-  if not isinstance(xb.dtype, ImageDType) or b not in ctx.realizes or xb not in ctx.realizes or uval(to_cast).op in GroupOp.Meta: return None
-  del ctx.realizes[b]
-  return to_cast.view(unwrap(view.st))
-
-def init_big_graph(sink:UOp) -> Optional[UOp]:
-  new_src = tuple(x.base for x in sink.src if is_scheduled(x.base) and x.base.src[1].op is not Ops.CONST)
-  return None if new_src == sink.src else UOp(Ops.NOOP) if len(new_src) == 0 else UOp.sink(*new_src)
-
-do_realize = PatternMatcher([
-  # always realize sinked ops
-  (UPat(Ops.SINK, name="sink"), init_big_graph),
-  # always realize meta ops
-  (UPatScheduled({Ops.ASSIGN, Ops.CONTIGUOUS, *GroupOp.Meta}), realize),
-  # realize before expand or unsafe pad ops
-  (UPatScheduled(name="src").view(name="view"), realize_view),
-  # don't realize image to image casts
-  (UPatScheduled(Ops.CAST, src=(UPat(Ops.VIEW, src=(UPat.var("xb"), UPat()), name="to_cast"),), dtype=dtypes.float).view(name="view"), fold_img_cast),
-  # realize before COPY or BUFFER_VIEW
-  (UPat((Ops.COPY, Ops.BUFFER_VIEW), src=(UPat.any(UPatScheduled(), UPatScheduled().view()),)), realize),
-  # ASSIGN only needs the buffer
-  (UPat(Ops.ASSIGN, src=(UPat(Ops.VIEW, name="dest"), UPat.var("src")), name="x"), lambda dest,src,x: x.replace(src=(dest.base.buf_uop, src))),
-])
-
-# ** this breaks down realized ops into STOREs and rewrites the ops to LOADs
-
-def generate_valid(ctx:ScheduleContext, b:UOp, to_store:UOp, base:UOp) -> UOp:
-  if to_store.op is Ops.BIND: ctx.var_vals.update([to_store.unbind()])
-  return UOp.const_with_shape(base.dtype, to_store if to_store.op is Ops.BIND else to_store.arg, unwrap(base.st).shape)
-
-def append_realize(ctx:ScheduleContext, b:UOp, to_store:UOp, base:UOp) -> UOp:
-  ctx.realizes[b] = UOp.store(b, ShapeTracker.from_shape(base.shape).to_uop(), append_op(ctx, b, to_store))
-  return UOp(Ops.LOAD, base.dtype, (b, unwrap(base.st).to_uop()))
-
-def append_op(ctx:ScheduleContext, b:UOp, to_store:UOp) -> UOp:
-  # TODO: metadata post merge
-  if (m:=ctx.tensor_uops[b][0].metadata) is not None: ctx.ops_metadata[to_store] = m
-  return to_store
-
-break_sched = PatternMatcher([
-  # consts are always fused and generated
-  (UPatScheduled({Ops.CONST, Ops.BIND}), generate_valid),
-  # view of realized buffer just loads
-  (UPat(Ops.BUFFER, name="b").view(name="v"), lambda ctx,b,v: UOp(Ops.PRELOAD if b in ctx.assigns else Ops.LOAD, b.dtype.base, (b, v.st.to_uop()))),
-  # all other views either fold or realize with a store
-  (UPatScheduled(), lambda ctx,b,to_store,base: append_realize(ctx, b, to_store, base) if b in ctx.realizes else append_op(ctx, b, to_store)),
-])
-
-# **** Schedule context builder
-
-def append_uop(ctx:ScheduleContext, view:UOp, buf_uop:UOp) -> None:
-  ctx.allbufs[buf_uop] = view
-  if (op:=uval(view)).op is Ops.ASSIGN: ctx.assigns.add(buf_uop)
-  for x in op.src:
-    if is_scheduled(x.base): ctx.children.setdefault(x.base.buf_uop, {})[buf_uop] = None
-  # BUFFER_VIEW overrides the underlying buffer
-  if op.op is Ops.BUFFER_VIEW:
-    buffers[buf_uop] = (x:=op.src[0]).base.buffer.view(view.size, view.dtype, unwrap(x.st).views[0].offset*x.dtype.itemsize)
-  buf_uop.buffer.ref(1)
-create_ctx = PatternMatcher([(UPat(Ops.VIEW, name="view", src=(UPat(Ops.BUFFER, name="buf_uop"), UPat())), append_uop)])
-
 remove_movement_ops = PatternMatcher([(UPat(GroupOp.Movement, name="x"), lambda x: x.base.view(unwrap(x.st))),])
+prune = PatternMatcher([
+  # root is VIEW, wraps a CONST and a BUFFER, is this fine?
+  (UPat(Ops.VIEW, name="view", src=(UPat(), UPat.cvar("x"))), lambda view,x: x if all(v.mask is None for v in unwrap(view.st).views) else None),
+])
+
+def _bufferize(ctx:Dict[UOp, UOp], x:UOp):
+  if x in ctx or x.op is Ops.VIEW and len(x.src) == 1: return None
+  buf_uop = x.buf_uop if x.op is Ops.VIEW else UOp.new_buffer(x.device, x.size, x.dtype)
+  ctx[buf_uop] = x
+  return buf_uop.view(unwrap(x.st))
+realize = PatternMatcher([
+  (UPat(Ops.SINK, name="sink"),
+   lambda ctx,sink: UOp(Ops.SINK, src=new_src) if (new_src:=tuple(nx for x in sink.src if (nx:=_bufferize(ctx, x)) is not None))!=sink.src else None),
+  (UPat(Ops.COPY, name="cp", src=(UPat.var("x"),)), lambda ctx,cp,x: None if (bx:=unwrap_or(_bufferize(ctx, x), x)) is x else cp.replace(src=(bx,))),
+  (UPat(Ops.VIEW, name="x", src=(UPat(Ops.BUFFER), UPat(GroupOp.Meta))), _bufferize),
+])
+
+def add_buf(ctx:List[UOp], b:UOp):
+  ctx.append(b)
+  return UOp(Ops.DEFINE_GLOBAL, b.dtype, (), len(ctx)-1)
+to_ast = PatternMatcher([
+  # buffer becomes a ptr
+  (UPat(Ops.BUFFER, name="b"), add_buf),
+  # buffer views become global load
+  (UPat(Ops.VIEW, name="st", src=(UPat(Ops.DEFINE_GLOBAL, name="ptr"),)), lambda st,ptr: UOp.load(ptr, st.st.to_uop(), dtype=ptr.dtype.base)),
+  # buffer+op views become global stores
+  (UPat(Ops.VIEW, name="st", src=(UPat(Ops.DEFINE_GLOBAL, name="ptr"), UPat.var("v"))), lambda st,ptr,v: UOp.store(ptr, st.st.to_uop(), v)),
+  # sink rules
+  (UPat(Ops.SINK, src=(UPat.store(UPat.var("dest"), UPat(), UPat(GroupOp.Meta, name="metaop")),)),
+   lambda metaop,dest: metaop.replace(src=(dest,)+metaop.src)),
+  (UPat(Ops.SINK, src=(UPat(Ops.LOAD),)), lambda: UOp(Ops.NOOP)),
+])
+
+cut_edges = PatternMatcher([
+  (UPat(Ops.VIEW, name="st", src=(UPat(Ops.BUFFER, name="parent"), UPat(Ops.BUFFER).view())), lambda parent,st: parent.view(unwrap(st.st))),
+])
+
+def schedule_uop(out:UOp, dest:UOp) -> ScheduleItem:
+  sink = out.sink() if out.op is Ops.VIEW else UOp(Ops.VIEW, out.dtype, (dest, out), unwrap(out.st)).sink()
+  sink = graph_rewrite(sink, cut_edges, dest, bottom_up=True)
+  bufs: List[UOp] = []
+  sink = graph_rewrite(sink, to_ast, bufs)
+  return ScheduleItem(sink, tuple(b.buffer for b in bufs), (), ())
 
 @track_rewrites(named=True)
 def create_schedule_with_vars(outs:List[UOp]) -> Tuple[List[ScheduleItem], Dict[Variable, int]]:
-  if len(outs:=dedup(x.base for x in outs if x.base.realized is None and x.base.op is not Ops.CONST)) == 0: return [], {}
-  # create the big graph
-  ctx = ScheduleContext()
-  cache: Dict[UOp, UOp] = {}
-  # to_uop is removing (many) of the movement ops
-  for u in (big_graph:=UOp.sink(*(to_uop(x, ctx, cache) for x in outs))).src: ctx.realizes[u.buf_uop] = u
-  big_graph = graph_rewrite(big_graph, remove_movement_ops+ops_folding+do_realize, ctx)
-  big_graph = graph_rewrite(big_graph, merge_bufs, ctx)
-  # create the scheduler context
-  graph_rewrite(big_graph, create_ctx, ctx)
-  # group realizes into kernels
-  store_groups = group_realizes(ctx)
-  graph_rewrite(big_graph, break_sched, ctx)
-  # preschedule realize groups
-  prescheduled: List[ScheduleItem] = []
-  for store_uops in store_groups:
-    if len(stores:=[ctx.realizes[u] for u in store_uops if ctx.realizes[u].op is Ops.STORE]) != 0:
-      prescheduled.append(schedule_uop(UOp.sink(*stores), ctx))
-  # do BFS
-  schedule_targets = {out:si for si in prescheduled for out in si.outputs}
-  graph: DefaultDict[ScheduleItem, List[ScheduleItem]] = defaultdict(list)
-  in_degree: DefaultDict[ScheduleItem, int] = defaultdict(int)
-  for si in prescheduled:
-    # realize outputs before a parent is assigned to
-    parents_assigns = dedup(xsi for x in si.assign_preloads if (xsi:=schedule_targets.get(x.buffer)) and xsi is not si)
-    for assign in parents_assigns:
-      graph[si].append(assign)
-      in_degree[assign] += 1
-    # realize outputs after all parents are realized
-    scheduled_parents = dedup(xsi for x in si.inputs if (xsi:=schedule_targets.get(x)) is not None and xsi not in parents_assigns)
-    for x in scheduled_parents:
-      graph[x].append(si)
-      in_degree[si] += 1
-  queue = deque(si for si in prescheduled if in_degree[si] == 0)
-  schedule: List[ScheduleItem] = []
-  while queue:
-    schedule.append(si:=queue.popleft())
-    for x in graph[si]:
-      in_degree[x] -= 1
-      if in_degree[x] == 0: queue.append(x)
-  # confirm everything was scheduled correctly
-  if len(schedule) != (groups:=len(prescheduled)): raise RuntimeError(f"cycle detected in graph, grouped {groups} but only scheduled {len(schedule)}")
-  if DEBUG >= 1 and len(schedule) >= 10: print(f"scheduled {len(schedule)} kernels")
-  return schedule, ctx.var_vals
+  sink = graph_rewrite(UOp.sink(*outs), remove_movement_ops+merge_views+prune+symbolic)
+  realizes: Dict[UOp, UOp] = {}
+  graph_rewrite(sink, realize, realizes)
+  schedule = [schedule_uop(u, b) for b,u in realizes.items()]
+  for tensor_uop, buf_uop in zip(outs, reversed(list(realizes))): tensor_uop.become(buf_uop.view(ShapeTracker.from_shape(tensor_uop.shape)))
+  return schedule, {}
 
 def create_schedule(outs:List[UOp]) -> List[ScheduleItem]:
   schedule, var_vals = create_schedule_with_vars(outs)

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -1,7 +1,7 @@
 import functools
 from dataclasses import dataclass
 from typing import Tuple, List, Dict
-from tinygrad.ops import GroupOp, UOp, Ops, PatternMatcher, UPat, Variable, graph_rewrite, track_rewrites, symbolic, merge_views
+from tinygrad.ops import GroupOp, UOp, Ops, PatternMatcher, UPat, Variable, graph_rewrite, track_rewrites, merge_views
 from tinygrad.helpers import Metadata, unwrap, unwrap_or
 from tinygrad.device import Buffer
 from tinygrad.shape.shapetracker import ShapeTracker
@@ -26,10 +26,6 @@ class ScheduleItem:
   def output_idxs(self) -> Tuple[int, ...]: return tuple(x.src[0].arg for x in self.ast.src) if self.ast.op is Ops.SINK else (0,)
 
 remove_movement_ops = PatternMatcher([(UPat(GroupOp.Movement, name="x"), lambda x: x.base.view(unwrap(x.st))),])
-prune = PatternMatcher([
-  # root is VIEW, wraps a CONST and a BUFFER, is this fine?
-  (UPat(Ops.VIEW, name="view", src=(UPat(), UPat.cvar("x"))), lambda view,x: x if all(v.mask is None for v in unwrap(view.st).views) else None),
-])
 
 def _bufferize(ctx:Dict[UOp, UOp], x:UOp):
   if x in ctx or x.op is Ops.VIEW and len(x.src) == 1: return None
@@ -41,22 +37,29 @@ realize = PatternMatcher([
    lambda ctx,sink: UOp(Ops.SINK, src=new_src) if (new_src:=tuple(nx for x in sink.src if (nx:=_bufferize(ctx, x)) is not None))!=sink.src else None),
   (UPat(Ops.COPY, name="cp", src=(UPat.var("x"),)), lambda ctx,cp,x: None if (bx:=unwrap_or(_bufferize(ctx, x), x)) is x else cp.replace(src=(bx,))),
   (UPat(Ops.VIEW, name="x", src=(UPat(Ops.BUFFER), UPat(GroupOp.Meta))), _bufferize),
+  (UPat(Ops.CONTIGUOUS, name="x"), _bufferize),
 ])
 
 def add_buf(ctx:List[UOp], b:UOp):
   ctx.append(b)
   return UOp(Ops.DEFINE_GLOBAL, b.dtype, (), len(ctx)-1)
 to_ast = PatternMatcher([
-  # buffer becomes a ptr
-  (UPat(Ops.BUFFER, name="b"), add_buf),
-  # buffer views become global load
+  # ** buffer op rules
+  # const is just const
+  (UPat(Ops.VIEW, name="st", src=(UPat(), UPat.cvar("x"))), lambda st,x: UOp.const_with_shape(x.dtype, x.arg, st.shape)),
+  # buffer view is load
   (UPat(Ops.VIEW, name="st", src=(UPat(Ops.DEFINE_GLOBAL, name="ptr"),)), lambda st,ptr: UOp.load(ptr, st.st.to_uop(), dtype=ptr.dtype.base)),
-  # buffer+op views become global stores
+  # buffer+op view is store
   (UPat(Ops.VIEW, name="st", src=(UPat(Ops.DEFINE_GLOBAL, name="ptr"), UPat.var("v"))), lambda st,ptr,v: UOp.store(ptr, st.st.to_uop(), v)),
-  # sink rules
+  # ** sink rules
   (UPat(Ops.SINK, src=(UPat.store(UPat.var("dest"), UPat(), UPat(GroupOp.Meta, name="metaop")),)),
    lambda metaop,dest: metaop.replace(src=(dest,)+metaop.src)),
   (UPat(Ops.SINK, src=(UPat(Ops.LOAD),)), lambda: UOp(Ops.NOOP)),
+  # ** misc rules
+  # buffer becomes a ptr
+  (UPat(Ops.BUFFER, name="b"), add_buf),
+  # don't need contiguous anymore
+  (UPat(Ops.CONTIGUOUS, src=(UPat.var("x"),)), lambda x:x),
 ])
 
 cut_edges = PatternMatcher([
@@ -72,7 +75,7 @@ def schedule_uop(out:UOp, dest:UOp) -> ScheduleItem:
 
 @track_rewrites(named=True)
 def create_schedule_with_vars(outs:List[UOp]) -> Tuple[List[ScheduleItem], Dict[Variable, int]]:
-  sink = graph_rewrite(UOp.sink(*outs), remove_movement_ops+merge_views+prune+symbolic)
+  sink = graph_rewrite(UOp.sink(*outs), remove_movement_ops+merge_views)
   realizes: Dict[UOp, UOp] = {}
   graph_rewrite(sink, realize, realizes)
   schedule = [schedule_uop(u, b) for b,u in realizes.items()]

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -56,6 +56,7 @@ def partition(itr:Iterable[T], fxn:Callable[[T],bool]) -> Tuple[List[T], List[T]
 def unwrap(x:Optional[T]) -> T:
   assert x is not None
   return x
+def unwrap_or(x:Optional[T], y:T) -> T: return y if x is None else x
 def get_child(obj, key):
   for k in key.split('.'):
     if k.isnumeric(): obj = obj[int(k)]


### PR DESCRIPTION
These decisions from big graph2 are the constraint to making progress on scheduler folding rules:

1. [early bufferization](https://github.com/tinygrad/tinygrad/issues/8253)
2. late merge_views
3. maskless [CONST has a shapetracker](https://github.com/tinygrad/tinygrad/pull/8210)

These were required to make progress on switching the scheduler to the graph_rewrite engine while building on a LazyBuffer foundation.

Now that [lazy is gone](https://github.com/tinygrad/tinygrad/pull/7801), big graph 3's goal is to delete all this complexity and make big graph capable of rewrites like CAST_BEFORE_VIEW, SPLIT_REDUCEOP, etc.