### PR TITLE
make viz work with uop mutability

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -51,7 +51,7 @@ def get_metadata(contexts:List[Tuple[Any, List[TrackedRewriteContext]]]) -> List
   for k,ctxs in contexts:
     name = to_function_name(k.name) if isinstance(k, Kernel) else k
     for ctx in ctxs:
-      if ctx.sink.op is Ops.CONST: continue
+      if pickle.loads(ctx.sink).op is Ops.CONST: continue
       upats = [(upat.location, upat.printable(), tm) for _,_,upat,tm in ctx.matches if upat is not None]
       if name not in kernels: kernels[name] = []
       kernels[name].append((k, ctx, GraphRewriteMetadata(ctx.loc, lines(ctx.loc[0])[ctx.loc[1]-1].strip(), name, upats)))
@@ -80,11 +80,12 @@ def _prg(k:Optional[Kernel]) -> Optional[str]:
   try: return k.to_program().src if isinstance(k, Kernel) else None
   except Exception: return None
 def get_details(k:Any, ctx:TrackedRewriteContext, metadata:GraphRewriteMetadata) -> GraphRewriteDetails:
-  g = GraphRewriteDetails(**asdict(metadata), graphs=[ctx.sink], diffs=[], changed_nodes=[], kernel_code=pcall(_prg, k))
+  g = GraphRewriteDetails(**asdict(metadata), graphs=[pickle.loads(ctx.sink)], diffs=[], changed_nodes=[], kernel_code=pcall(_prg, k))
   replaces: Dict[UOp, UOp] = {}
-  sink = ctx.sink
-  for i,(u0,u1,upat,_) in enumerate(ctx.matches):
+  sink = g.graphs[0]
+  for i,(u0_b,u1_b,upat,_) in enumerate(ctx.matches):
     if ctx.bottom_up: replaces = {} # if it's bottom_up it's single pass
+    u0, u1 = pickle.loads(u0_b), None if u1_b is None else pickle.loads(u1_b)
     replaces[u0] = u0 if u1 is None else u1
     # if the match didn't result in a rewrite we move forward
     if u1 is None: continue


### PR DESCRIPTION
test_tiny_add without prepickle
![image](https://github.com/user-attachments/assets/812948ea-1077-4157-99c6-ae206c10ac12)

with prepickle
![image](https://github.com/user-attachments/assets/6af71b1d-7242-45c4-8d17-76f62492f515)

resolves "rewritten sink wasn't rewritten" in abstractions_4.