### PR TITLE
regression test viz failure when there's no tracked context

### DIFF
--- a/test/test_viz.py
+++ b/test/test_viz.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Optional
 import unittest, decimal, json
 from tinygrad.dtype import dtypes
-from tinygrad.helpers import Context
 from tinygrad.ops import TRACK_MATCH_STATS, TrackedPatternMatcher as PatternMatcher, UOp, Ops, UPat, graph_rewrite, track_rewrites, symbolic
 from tinygrad.ops import tracked_ctxs as contexts, tracked_keys as keys
 from tinygrad.device import ProfileDeviceEvent, ProfileRangeEvent, ProfileGraphEvent, ProfileGraphEntry
@@ -114,16 +113,32 @@ class TestViz(unittest.TestCase):
     self.assertEqual(len(ret), 1)
     self.assertIs(ret[0], a.sqrt().sin()) # only rewrite
 
+  # NOTE: calling graph_rewrite when the function isn't decorated with track_rewrites should not VIZ
   @unittest.expectedFailure
   def test_rewrite_without_context(self):
-    add = UOp.const(dtypes.int, 2) + UOp.const(dtypes.int, 1)
     def untracked_graph_rewrite(sink): return graph_rewrite(sink, symbolic)
     @track_rewrites(named=True)
     def tracked_graph_rewrite(sink): return graph_rewrite(sink, symbolic)
+    # test
+    add = UOp.const(dtypes.int, 2) + UOp.const(dtypes.int, 1)
     untracked_graph_rewrite(add)
     self.assertEqual(len(contexts), 0)
     tracked_graph_rewrite(add)
     self.assertEqual(len(contexts), 1)
+
+  def test_inner_rewrite_location(self):
+    # inner rewrite gets tracked in another context
+    def inner_rewrite(sink): return graph_rewrite(sink, symbolic)
+    @track_rewrites(named=True)
+    def tracked_graph_rewrite(sink): return inner_rewrite(sink)
+    # test
+    add = UOp.const(dtypes.int, 2) + UOp.const(dtypes.int, 1)
+    tracked_graph_rewrite(add)
+    self.assertEqual(len(contexts), 1)
+    # location of context is inner_rewrite
+    fp, lineno = contexts[0][0].loc
+    self.assertEqual(lineno, inner_rewrite.__code__.co_firstlineno)
+    self.assertEqual(fp, inner_rewrite.__code__.co_filename)
 
 class TextVizProfiler(unittest.TestCase):
   def test_perfetto_node(self):

--- a/test/test_viz.py
+++ b/test/test_viz.py
@@ -1,7 +1,8 @@
 from typing import Dict, List, Optional
 import unittest, decimal, json
 from tinygrad.dtype import dtypes
-from tinygrad.ops import TRACK_MATCH_STATS, TrackedPatternMatcher as PatternMatcher, UOp, Ops, UPat, graph_rewrite, track_rewrites
+from tinygrad.helpers import Context
+from tinygrad.ops import TRACK_MATCH_STATS, TrackedPatternMatcher as PatternMatcher, UOp, Ops, UPat, graph_rewrite, track_rewrites, symbolic
 from tinygrad.ops import tracked_ctxs as contexts, tracked_keys as keys
 from tinygrad.device import ProfileDeviceEvent, ProfileRangeEvent, ProfileGraphEvent, ProfileGraphEntry
 from tinygrad.viz.serve import get_details, get_metadata, uop_to_json, to_perfetto
@@ -112,6 +113,17 @@ class TestViz(unittest.TestCase):
     ret = helper_test_viz(uop, pm, ctx={a.sin():a.sqrt(), n1.sin():n1.sqrt()}, bottom_up=False)
     self.assertEqual(len(ret), 1)
     self.assertIs(ret[0], a.sqrt().sin()) # only rewrite
+
+  @unittest.expectedFailure
+  def test_rewrite_without_context(self):
+    add = UOp.const(dtypes.int, 2) + UOp.const(dtypes.int, 1)
+    def untracked_graph_rewrite(sink): return graph_rewrite(sink, symbolic)
+    @track_rewrites(named=True)
+    def tracked_graph_rewrite(sink): return graph_rewrite(sink, symbolic)
+    untracked_graph_rewrite(add)
+    self.assertEqual(len(contexts), 0)
+    tracked_graph_rewrite(add)
+    self.assertEqual(len(contexts), 1)
 
 class TextVizProfiler(unittest.TestCase):
   def test_perfetto_node(self):


### PR DESCRIPTION
This diff specifies a previously untested behavior of @track_rewrites.

If graph_rewrite is called outside of any @track_rewrites context, VIZ doesn't track the matches in VIZ. (This broke after i merged 8285)
But if there's an inner graph_rewrite call inside a decroated function, all of its rewrites must be tracked.