### PR TITLE
failing dtype assert in mul gradient, fails in old lazy too

### DIFF
--- a/tinygrad/function.py
+++ b/tinygrad/function.py
@@ -119,6 +119,7 @@ class Mul(Function):
     return x * y
 
   def backward(self, grad_output:LazyBuffer) -> Tuple[Optional[LazyBuffer], Optional[LazyBuffer]]:
+    assert self.y.base.buffer.dtype == grad_output.base.buffer.dtype, f"{self.y.base.buffer.dtype} != {grad_output.base.buffer.dtype}"
     return (self.y * grad_output) if self.needs_input_grad[0] else None, \
            (self.x * grad_output) if self.needs_input_grad[1] else None
 


### PR DESCRIPTION
Basing on `26e049ab404b192789a6489b2d9cec5beea2bc5d`
I think this is the "make things that can't be images not images" issue. The lazydata and the underlying Buffer dtype got out of sync in the old lazy so this never asserted before.