### PR TITLE
remove the fake buffer 3

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2001,8 +2001,8 @@ class TestBigGraph(unittest.TestCase):
     self.assertEqual(len(ctx.realizes), 1)
 
 tensor_const_pm = PatternMatcher([
-  (UPat(Ops.VIEW, src=(UPat(Ops.BUFFER), UPat(Ops.CONST, src=()))), lambda: True),
-  (UPat(Ops.VIEW, src=(UPat(Ops.BUFFER), UPat(Ops.BIND, src=(UPat(Ops.DEFINE_VAR), UPat(Ops.CONST))))), lambda: True),
+  (UPat(Ops.VIEW, src=(UPat(Ops.DEVICE), UPat(Ops.CONST, src=()))), lambda: True),
+  (UPat(Ops.VIEW, src=(UPat(Ops.DEVICE), UPat(Ops.BIND, src=(UPat(Ops.DEFINE_VAR), UPat(Ops.CONST))))), lambda: True),
 ])
 class TestConst(unittest.TestCase):
   # ** part 1: basic functionality of a tensor directly created from CONST


### PR DESCRIPTION
The scheduler still relies on the VIEW(BUFFER, CONST) pattern to match CONST UOps. Or it hardcodes Ops.CONST directly.

This diff should refactor the scheduler such that all the asserts in TestConst pass while on the VIEW(BUFFER, CONST) pattern is gone.

Once merged, it completes work item 1 of "CONST in big graph" https://github.com/tinygrad/tinygrad/issues/8275.