### PR TITLE
test: get kernel.py uop_sts from the st property

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -82,23 +82,6 @@ class Kernel:
     for x in self.reduceops:
       self.sts.append(unwrap(x.st))
       self.sts.append(unwrap(x.src[0].st))
-      # TEMP
-      good = uop_sts_map[x]
-      compare = unwrap(x.st)
-      try:
-        assert good == compare
-      except AssertionError:
-        from test.helpers import print_diff
-        print_diff(good, compare)
-        print(f"SHAPETRACKER DOESN'T MATCH FOR REDUCEOP {x}")
-      good = uop_sts_map[x.src[0]]
-      compare = unwrap(x.src[0].st)
-      try:
-        assert good == compare
-      except AssertionError:
-        from test.helpers import print_diff
-        print_diff(good, compare)
-        print(f"SHAPETRACKER DOESN'T MATCH FOR REDUCEOP SRC {x.src[0]}")
 
     # move all reduce axes to the end
     reduce = list(enumerate(zip(self.full_shape, self.output_shape)))

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -10,7 +10,7 @@ from tinygrad.ops import GroupOp, KernelInfo, UOp, Ops, can_pad, print_uops, typ
 from tinygrad.device import Device
 from tinygrad.renderer import Renderer, TensorCore, ProgramSpec
 from tinygrad.dtype import ImageDType
-from tinygrad.helpers import all_same, colored, ansilen, dedup, getenv, prod, round_up, all_int, to_function_name, diskcache_put
+from tinygrad.helpers import all_same, colored, ansilen, dedup, getenv, prod, round_up, all_int, to_function_name, diskcache_put, unwrap
 from tinygrad.helpers import DEBUG, TC_OPT, USE_TC, AMX
 from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.shape.view import strides_for_shape
@@ -57,7 +57,7 @@ class Kernel:
     if ast.op is Ops.SINK: self.ast = ast
 
     self.opts = opts if opts is not None else Device[Device.DEFAULT].renderer
-    try: uop_sts_map = verify_ast(self.ast)
+    try: verify_ast(self.ast)
     except AssertionError as e:
       print("INVALID AST")
       print(self.ast)
@@ -80,8 +80,8 @@ class Kernel:
     # add the shapetrackers for each reduce
     # we use this to track which axes are reduced in each reduce
     for x in self.reduceops:
-      self.sts.append(uop_sts_map[x])
-      self.sts.append(uop_sts_map[x.src[0]])
+      self.sts.append(unwrap(x.st))
+      self.sts.append(unwrap(x.src[0].st))
 
     # move all reduce axes to the end
     reduce = list(enumerate(zip(self.full_shape, self.output_shape)))

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -57,7 +57,7 @@ class Kernel:
     if ast.op is Ops.SINK: self.ast = ast
 
     self.opts = opts if opts is not None else Device[Device.DEFAULT].renderer
-    try: verify_ast(self.ast)
+    try: uop_sts_map = verify_ast(self.ast)
     except AssertionError as e:
       print("INVALID AST")
       print(self.ast)
@@ -82,6 +82,23 @@ class Kernel:
     for x in self.reduceops:
       self.sts.append(unwrap(x.st))
       self.sts.append(unwrap(x.src[0].st))
+      # TEMP
+      good = uop_sts_map[x]
+      compare = unwrap(x.st)
+      try:
+        assert good == compare
+      except AssertionError:
+        from test.helpers import print_diff
+        print_diff(good, compare)
+        print(f"SHAPETRACKER DOESN'T MATCH FOR REDUCEOP {x}")
+      good = uop_sts_map[x.src[0]]
+      compare = unwrap(x.src[0].st)
+      try:
+        assert good == compare
+      except AssertionError:
+        from test.helpers import print_diff
+        print_diff(good, compare)
+        print(f"SHAPETRACKER DOESN'T MATCH FOR REDUCEOP SRC {x.src[0]}")
 
     # move all reduce axes to the end
     reduce = list(enumerate(zip(self.full_shape, self.output_shape)))

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -81,7 +81,8 @@ class Kernel:
     # we use this to track which axes are reduced in each reduce
     for x in self.reduceops:
       self.sts.append(unwrap(x.st))
-      self.sts.append(unwrap(x.src[0].st))
+      buf_uop_srcs = [y for y in x.toposort if y.op in GroupOp.Buffer]
+      self.sts.append(unwrap(buf_uop_srcs[0].st))
 
     # move all reduce axes to the end
     reduce = list(enumerate(zip(self.full_shape, self.output_shape)))

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -278,6 +278,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
   def has_st(self) -> bool: return self.op not in {Ops.DEFINE_LOCAL, Ops.DEFINE_GLOBAL, Ops.BUFFER, Ops.CONST, Ops.DEFINE_VAR}
   @functools.cached_property
   def st(self) -> Optional[ShapeTracker]:
+    if self.op is Ops.WHERE and self.src[0].op is Ops.VALID: return self.src[0].st
     if self.op is Ops.VIEW: return self.arg
     if self.op in GroupOp.Movement: return unwrap(self.src[0].st).mop(self.op, self.arg)
     # buffer ops can have a non contiguous shapetracker


### PR DESCRIPTION
we need to rewrite `verify_ast` to pattern matchers, I plan to share the shape verification with big graph. Like a universal `shape_spec` on top of #8311.


what's different here and why?