### PR TITLE
asserts to prepare for Tensor BIND proposal [pr]

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -141,7 +141,7 @@ class Tensor(SimpleMathTrait):
     if isinstance(data, (UOp, MultiLazyBuffer)):
       assert dtype is None or dtype==data.dtype, "dtype doesn't match, and casting isn't supported"
       # NOTE: this is here because LazyBuffer = UOp
-      if isinstance(data, UOp) and data.op is Ops.BIND: data = _metaop(Ops.CONST, tuple(), dtype or data.dtype, device, data)
+      if isinstance(data, UOp) and data.op is Ops.BIND: data = _metaop(Ops.BIND, tuple(), dtype or data.dtype, device, data)
     elif data is None: data = _metaop(Ops.EMPTY, (0,), dtype or dtypes.default_float, device)
     elif isinstance(data, get_args(ConstType)): data = _metaop(Ops.CONST, tuple(), dtype or dtypes.from_py(data), device, data)
     elif isinstance(data, bytes): data = _frompy(data, dtypes.uint8 if dtype is None else dtype)


### PR DESCRIPTION
This diff splits BIND into its own concept in tensor and ops.

This enables independent progress on `CONST(VIEW(DEVICE))` and focuses that diff on natural UPat.cvar folding in the scheduler.

BIND can go from `VIEW(DEVICE, BIND)` to a new spec in a different diff, focusing on ASTs like:
![image](https://github.com/user-attachments/assets/3a4852cb-8b55-46c4-b7fe-677f8a7de5a6)
and answering questions like how do we attach a DEVICE to this BIND?
```
vv = UOp.variable("a", 0, 10).bind(1)
a = Tensor(vv)
```