### PR TITLE
BIND in tensor_uop_spec + cleanups [pr]

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1957,13 +1957,9 @@ class TestView(unittest.TestCase):
     np.testing.assert_equal(b.numpy(), 0)
 
   def test_zero_size_alt(self):
-    st = ShapeTracker.from_shape((135, 0, 9))
-    a = UOp(Ops.VIEW, dtypes.float, (UOp.new_buffer(Device.DEFAULT, 121, dtypes.float), UOp(Ops.EMPTY, dtypes.float)), st)
-    b = a.pad(pad_arg:=((0, 0), (0, 0), (18, 0)))
-    self.assertEqual(b.st, st.pad(pad_arg))
-    # TODO: why does this help?
-    b = graph_rewrite(b, remove_movement_ops)
-    self.assertIs(b.base.src[1], UOp.const(dtypes.float, 0))
+    a = Tensor.empty(135, 0, 9)
+    b = a.pad(((0, 0), (0, 0), (18, 0)))
+    check_schedule(b, 0)
 
   def test_partial_mask(self):
     # partial masked out does not degrade into CONST

--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -410,7 +410,7 @@ class TestUOpMethod(unittest.TestCase):
     with self.assertRaises(AssertionError): UOp.const(dtypes.int, var).const_arg
     const = UOp.const(dtypes.int, 1)
     self.assertEqual(const.const_arg, 1)
-    tensor_const = UOp(Ops.VIEW, dtypes.int, (UOp.new_buffer(Device.DEFAULT, 1, dtypes.int), const), ShapeTracker.from_shape(()))
+    tensor_const = UOp.metaop(Ops.CONST, (), dtypes.int, Device.DEFAULT, 1)
     self.assertEqual(tensor_const.const_arg, 1)
 
 class TestUOpStr(unittest.TestCase):


### PR DESCRIPTION
more work towards splitting BIND from CONST, also updates fragile tests to use stable Tensor / UOp APIs.