### PR TITLE
hotfix: string repr of arg in viz and print [pr]

### DIFF
--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -2,6 +2,7 @@ from typing import Optional, Tuple, Any, List
 import unittest, math
 import numpy as np
 from tinygrad.shape.shapetracker import ShapeTracker
+from tinygrad.shape.view import View # noqa F401
 from tinygrad.tensor import Tensor, _to_np_dtype
 from tinygrad.helpers import CI, DEBUG, getenv, Context, Timing
 from tinygrad.dtype import dtypes, DType
@@ -430,6 +431,14 @@ class TestUOpStr(unittest.TestCase):
   def test_vectorized_str(self):
     vec = UOp(Ops.VECTORIZE, dtypes.int.vec(4), tuple(UOp.const(dtypes.int, x) for x in range(4)))
     assert str(eval(str(vec))) == str(vec)
+
+  def test_device_arg(self):
+    device = UOp(Ops.DEVICE, arg="GPU")
+    assert str(eval(str(device))) == str(device)
+
+  def test_reduceop_arg(self):
+    sum_uop = Tensor.empty(32, 32).sum().lazydata
+    assert str(eval(str(sum_uop))) == str(sum_uop)
 
 @unittest.skip("uop no longer has order like this")
 class TestIndexingOrdering(unittest.TestCase):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -254,7 +254,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
   def key(self) -> bytes:
     return hashlib.sha256(str((self.op, self.dtype, self.arg)).encode() + b"".join([s.key for s in self.src])).digest()
   def __repr__(self): return pretty_print(self, lambda x: f"{type(self).__name__}({x.op}, {x.dtype}, arg={x.argstr()}, src=(%s))")
-  def argstr(self): return f'({", ".join(map(str, self.arg))})' if self.op is Ops.REDUCE_AXIS else self.arg
+  def argstr(self): return f'({", ".join(map(str, self.arg))})' if self.op is Ops.REDUCE_AXIS else repr(self.arg)
 
   @property
   def toposort(self) -> dict[UOp, None]:

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -67,7 +67,9 @@ def uop_to_json(x:UOp) -> dict[int, tuple[str, str, list[int], str, str]]:
     if u.op in {Ops.CONST, Ops.DEVICE}:
       excluded.add(u)
       continue
-    argst = ("\n".join([f"{v.shape} / {v.strides}"+(f" / {v.offset}" if v.offset else "") for v in u.arg.views])) if u.op is Ops.VIEW else str(u.arg)
+    argst = str(u.arg)
+    if u.op is Ops.VIEW:
+      argst = ("\n".join([f"{v.shape} / {v.strides}"+(f" / {v.offset}" if v.offset is not None else "") for v in unwrap(u.st).views]))
     label = f"{str(u.op).split('.')[1]}{(' '+word_wrap(argst.replace(':', ''))) if u.arg is not None else ''}\n{str(u.dtype)}"
     for idx,x in enumerate(u.src):
       if x in excluded:


### PR DESCRIPTION
repro:
```
VIZ=1 python3 test/test_setitem.py TestSetitem.test_jit_setitem_variable_offset
```
kernel `http://localhost:8000/kernels?kernel=9&idx=0`
printing DEVICE arg was wrong too.

also, can we fix the Ops repr? that hack for REDUCE_AXIS is fragile.