### PR TITLE
Explicit tensor check on MaskRCNN

### DIFF
--- a/extra/models/mask_rcnn.py
+++ b/extra/models/mask_rcnn.py
@@ -1166,7 +1166,7 @@ class Mask:
 
   def __call__(self, features, proposals, targets=None):
     x = self.feature_extractor(features, proposals)
-    if x:
+    if x is not None:
       mask_logits = self.predictor(x)
       if not Tensor.training:
         result = self.post_processor(mask_logits, proposals)


### PR DESCRIPTION
**Overview**
This PR fixes a small issue I found when I was testing the MaskRCNN MLPerf eval script as I was working on the RetinaNet training script. On `master`, MaskRCNN is not explicitly checking if `x` is not `None` which results to the following error:
```bash
Traceback (most recent call last):
  File "/home/flata/tinygrad/examples/mlperf/model_eval.py", line 252, in <module>
    globals()[nm]()
  File "/home/flata/tinygrad/examples/mlperf/model_eval.py", line 229, in eval_mrcnn
    batch_result = compute_prediction_batched(batch_imgs, mdl)
  File "/home/flata/tinygrad/examples/mask_rcnn.py", line 197, in compute_prediction_batched
    predictions = model(image)
  File "/home/flata/tinygrad/extra/models/mask_rcnn.py", line 1264, in __call__
    x, result, _ = self.roi_heads(features, proposals)
  File "/home/flata/tinygrad/extra/models/mask_rcnn.py", line 1184, in __call__
    x, detections, _ = self.mask(features, detections, targets)
  File "/home/flata/tinygrad/extra/models/mask_rcnn.py", line 1169, in __call__
    if x:
  File "/home/flata/tinygrad/tinygrad/tensor.py", line 3841, in _wrapper
    if _METADATA.get() is not None: return fn(*args, **kwargs)
  File "/home/flata/tinygrad/tinygrad/tensor.py", line 196, in __bool__
    def __bool__(self): raise TypeError("__bool__ on Tensor is not defined")
TypeError: __bool__ on Tensor is not defined
```

With this fix applied, the eval script continues as expected.