### PR TITLE
delete is_unrealized_const, it's just CONST [pr]

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2006,15 +2006,12 @@ class TestConst(unittest.TestCase):
 
   def test_uop_methods(self):
     a = Tensor(1)
-    self.assertTrue(a.lazydata.is_unrealized_const())
     self.assertTrue(a.lazydata.is_unrealized_unmasked_const())
 
     a = Tensor.ones((4, 4))
-    self.assertTrue(a.lazydata.is_unrealized_const())
     self.assertTrue(a.lazydata.is_unrealized_unmasked_const())
 
     a = Tensor.ones((4, 4)).pad((1, 1),)
-    self.assertTrue(a.lazydata.is_unrealized_const())
     self.assertFalse(a.lazydata.is_unrealized_unmasked_const())
 
   def test_const_schedule(self):

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -375,7 +375,7 @@ def group_realizes(ctx:ScheduleContext) -> list[list[UOp]]:
       group = {tr: None}
       ctx.realizes[tr] = tr
     reduce_for_op.update((tr, r) for tr in group)
-    if FUSE_ARANGE and r_uop.arg[0] is Ops.ADD and r_uop.src[0].base.is_unrealized_const(): reduce_of_const.append(r)
+    if FUSE_ARANGE and r_uop.arg[0] is Ops.ADD and r_uop.src[0].base.op is Ops.CONST: reduce_of_const.append(r)
   # fuse double reduces with no other child
   for reduceop in double_reduces:
     top_reduce = uval(ctx.allbufs[reduceop]).src[0].base.buf_uop
@@ -458,7 +458,7 @@ ops_folding = PatternMatcher([
   # reduce of const is collapsed (TODO: make this a generic rule for stride0)
   (UPat(Ops.REDUCE_AXIS, name="reduce", src=(UPat.var("x"),)), simplify_reduceop),
   # CONST doesn't need COPY
-  (UPat(Ops.COPY, src=(UPat.var("x"),)), lambda x:x if x.is_unrealized_const() else None),
+  (UPat(Ops.COPY, src=(UPat.cvar("x"),)), lambda x: x),
   # no double COPY
   (UPat(Ops.COPY, src=(UPat(Ops.VIEW, src=(UPat(), UPat(Ops.COPY, name="base")),))), lambda base: base),
   # no COPY to same device, except clone (arg is True)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -423,7 +423,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     return splitted._reduce_op(op, axis)._reduce_op(op, (len(new_shape),)).reshape(new_shape)  # reduce original axes, then split
   def assign(self, x:UOp): return UOp(Ops.ASSIGN, self.dtype, (self,x))
   def contiguous(self, allow_buffer_view=True):
-    if not unwrap(self.st).contiguous or self.size != self.base.size or self.is_unrealized_const():
+    if not unwrap(self.st).contiguous or self.size != self.base.size or self.base.op is Ops.CONST:
       if allow_buffer_view and self.can_view(): return self.metaop(Ops.BUFFER_VIEW, self.shape, self.dtype, self.device, None, (self,))
       return self.alu(Ops.CONTIGUOUS)
     forced_realize.add(self.base)
@@ -453,18 +453,16 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     # no COPY
     if self.device == device and not clone: return self
     # TODO: hack const metaop early here, fix this in multi
-    if self.is_unrealized_const(): return UOp.metaop(Ops.CONST, (), self.dtype, device, self.const_arg).view(unwrap(self.st))
+    if self.base.op is Ops.CONST: return UOp.metaop(Ops.CONST, (), self.dtype, device, self.const_arg).view(unwrap(self.st))
     # if it's a shrink, do the shrink before the copy with CONTIGUOUS
     if prod(self.shape) < prod(self.base.shape): return self.contiguous().copy_to_device(device)
     # copy the base and apply the shapetracker on the new device
     if not unwrap((src:=self.base).st).contiguous: raise RuntimeError(f"can only copy contiguous {self}")
     return UOp.metaop(Ops.COPY, src.shape, src.dtype, device, (device, clone), (src,)).view(unwrap(self.st))
   def clone(self) -> UOp: return self.copy_to_device(self.device, clone=True)
-  # TOOD: checking op is shorter, delete this.
-  def is_unrealized_const(self): return self.base.op is Ops.CONST
-  def is_unrealized_unmasked_const(self): return self.is_unrealized_const() and all(v.mask is None for v in unwrap(self.st).views)
+  def is_unrealized_unmasked_const(self): return self.base.op is Ops.CONST and all(v.mask is None for v in unwrap(self.st).views)
   def can_view(self):
-    return (self.st is not None and self._device is not None and self.st.consecutive and not self.is_unrealized_const() and
+    return (self.st is not None and self._device is not None and self.st.consecutive and self.base.op is not Ops.CONST and
             not isinstance(self.dtype, ImageDType) and self.device.split(":")[0] in view_supported_devices)
   @property
   def lbs(self): return [self]


### PR DESCRIPTION
sadly we can't part ways with `is_unrealized_unmasked_const` yet, tensor.py and multi use it and *GroupOp.Movement can exist on top of a CONST, we only remove_movement_ops in the scheduler.