### PR TITLE
a few more UPat.var -> UPat.cvar in the scheduler [pr]

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -323,11 +323,8 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     return ret.arg
   @property
   def const_arg(self) -> ConstType:
-    match self.base.op:
-      case Ops.CONST: ret = self.base.arg
-      case Ops.VIEW: ret = self.base.src[1].const_arg
-      case op: raise AssertionError(f"const_arg called on {op}")
-    assert isinstance(ret, get_args(ConstType)), f"const_arg trying to return {ret}"
+    assert self.base.op is Ops.CONST, f"const_arg called on {self.base}"
+    if not isinstance(ret:=self.base.arg, get_args(ConstType)): raise AssertionError(f"const_arg trying to return {ret}")
     return ret
   @property
   def axis_arg(self) -> tuple[int, ...]:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -323,9 +323,11 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     return ret.arg
   @property
   def const_arg(self) -> ConstType:
-    assert self.base.op is Ops.CONST, f"const_arg called on {self.base}"
-    assert isinstance(self.base.arg, get_args(ConstType)), f"const_arg trying to return {self.base.arg}"
-    return self.base.arg
+    match self.base.op:
+      case Ops.CONST: ret = self.base.arg
+      case op: raise AssertionError(f"const_arg called on {op}")
+    assert isinstance(ret, get_args(ConstType)), f"const_arg trying to return {ret}"
+    return ret
   @property
   def axis_arg(self) -> tuple[int, ...]:
     assert self.op in {Ops.REDUCE_AXIS, Ops.WMMA}, f"axis_arg called on {self.op}"

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -324,8 +324,8 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
   @property
   def const_arg(self) -> ConstType:
     assert self.base.op is Ops.CONST, f"const_arg called on {self.base}"
-    if not isinstance(ret:=self.base.arg, get_args(ConstType)): raise AssertionError(f"const_arg trying to return {ret}")
-    return ret
+    assert isinstance(self.base.arg, get_args(ConstType)), f"const_arg trying to return {self.base.arg}"
+    return self.base.arg
   @property
   def axis_arg(self) -> tuple[int, ...]:
     assert self.op in {Ops.REDUCE_AXIS, Ops.WMMA}, f"axis_arg called on {self.op}"


### PR DESCRIPTION
`simplify_reduceop` stays even after `symbolic+ops_folding` since it's folding shape changing ops.
`const_arg` is simple, self is either GroupOp.Movement(CONST) or CONST(). No more VIEW with len(src) == 2 having a different meaning.