### PR TITLE
fix pre-commit ruff error [pr]

### DIFF
--- a/test/mockgpu/driver.py
+++ b/test/mockgpu/driver.py
@@ -77,7 +77,8 @@ class VirtFile:
   def build_fstat(st_dev=0x20, st_ino=0x100000, st_mode=0o100777, st_nlink=1, st_uid=0, st_gid=0, st_rdev=0, st_size=0,
                   st_blksize=4096, st_blocks=0, st_atime=0, st_mtime=0, st_ctime=0):
     fmt_string = 'QQQIIIQQiQqqq'
-    assert (ssz:=struct.calcsize(fmt_string)) == 96, f"{ssz} != 96"
+    ssz = struct.calcsize(fmt_string)
+    assert ssz == 96, f"{ssz} != 96"
     return struct.pack(fmt_string, st_dev, st_ino, st_nlink, st_mode, st_uid, st_gid,
                        st_rdev, st_size, st_blksize, st_blocks, st_atime, st_mtime, st_ctime)
 


### PR DESCRIPTION
pre-commit started failing after #8396:
```
ruff.....................................................................Failed
- hook id: ruff
- exit code: 1

test/mockgpu/driver.py:80:13: RUF018 Avoid assignment expressions in `assert` statements
   |
78 |                   st_blksize=4096, st_blocks=0, st_atime=0, st_mtime=0, st_ctime=0):
79 |     fmt_string = 'QQQIIIQQiQqqq'
80 |     assert (ssz:=struct.calcsize(fmt_string)) == 96, f"{ssz} != 96"
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF018
81 |     return struct.pack(fmt_string, st_dev, st_ino, st_nlink, st_mode, st_uid, st_gid,
82 |                        st_rdev, st_size, st_blksize, st_blocks, st_atime, st_mtime, st_ctime)
   |
```