### PR TITLE
Fix TYPED=1 by moving ConstLike to appropriate place

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -642,6 +642,13 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     ret = graph_rewrite(self.simplify() if simplify else self, renderer)
     return ret.arg if ret.op is Ops.NOOP else str(ret)
 
+# *** what was symbolic.py ***
+
+sint = Union[int, UOp]
+Variable = UOp
+
+ConstLike = Union[ConstType, Variable, tuple[ConstType, ...]]
+
 @dataclass(frozen=True)
 class KernelInfo:
   local_dims: int = 0           # number of local dimensions  (this is remapping RANGE to SPECIAL)
@@ -1298,13 +1305,6 @@ renderer = PatternMatcher([
   (UPat(Ops.WHERE, src=UPat(Ops.NOOP), name="x"), lambda x: UOp(Ops.NOOP, arg=f"({x.src[1].arg} if {x.src[0].arg} else {x.src[2].arg})")),
   (UPat(GroupOp.ALU, src=UPat(Ops.NOOP), name="x"), lambda x: UOp(Ops.NOOP, arg=f"({x.src[0].arg}{syms[x.op]}{x.src[1].arg})")),
 ])
-
-# *** what was symbolic.py ***
-
-sint = Union[int, UOp]
-Variable = UOp
-
-ConstLike = Union[ConstType, Variable, tuple[ConstType, ...]]
 
 # *** uop swizzling ***
 


### PR DESCRIPTION
Hi, 

by moving ConstLike to appropriate place (right after UOp), TYPED=1 is able to run 

Best

Leo