### PR TITLE
Fix examples/conversation.py 

### DIFF
--- a/examples/conversation.py
+++ b/examples/conversation.py
@@ -117,7 +117,7 @@ def tts(
   stn_tst = text_mapper.get_text(text_to_synthesize, hps.data.add_blank, hps.data.text_cleaners)
   init_shape = stn_tst.shape
   assert init_shape[0] < pad_length, "text is too long"
-  x_tst, x_tst_lengths = stn_tst.pad(((0, pad_length - init_shape[0]),), 1).unsqueeze(0), Tensor([init_shape[0]], dtype=dtypes.int64)
+  x_tst, x_tst_lengths = stn_tst.pad(((0, pad_length - init_shape[0]),), value=1).unsqueeze(0), Tensor([init_shape[0]], dtype=dtypes.int64)
   sid = Tensor([speaker_id], dtype=dtypes.int64) if model_has_multiple_speakers else None
 
   # Perform inference.

--- a/examples/vits.py
+++ b/examples/vits.py
@@ -4,7 +4,7 @@ from phonemizer.backend import EspeakBackend
 from phonemizer.punctuation import Punctuation
 from functools import reduce
 from pathlib import Path
-from typing import List, Sequence
+from typing import List
 from tinygrad import nn, dtypes
 from tinygrad.helpers import fetch
 from tinygrad.nn.state import torch_load

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -345,7 +345,6 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     if count == 1: return self
     return UOp(Ops.VECTORIZE, self.dtype.vec(count), (self,)*count)
   def cast(self, dtype:DType, bitcast=False, allow_buffer_view=True):
-    if self.dtype == dtype: return self # TODO: move this to the scheduler
     if bitcast: return self.bitcast(dtype, allow_buffer_view)
     if self._device is not None and self._device.startswith("DISK"): raise RuntimeError("CAST isn't supported on DISK")
     if getenv("CAST_BEFORE_VIEW", 1) and dtype.itemsize <= self.dtype.itemsize and self is not self.base:


### PR DESCRIPTION
Fixes 2 issues when trying to run conversation example for the first time:
1. `NotImplementedError: mode=1 is not supported` from a signature change to Tensor.pad
2. `AttributeError: 'Tensor' object has no attribute '_slice'` which looks to be removed in preference of Tensor.pad and shrink