### PR TITLE
Ordered tc kernel opts

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -594,7 +594,7 @@ class Kernel:
         if (tc := self.tensor_core) and (self.use_tensor_cores == 1 or self.use_tensor_cores == 3):
           wd, tcd = self.global_dims, self.first_upcast
           def get_upcast_axes(buf):
-            upcast_axes = int(math.log2(tc.thread_dims[buf]))
+            upcast_axes = int(math.log2(tc.elements_per_thread[buf]))
             return tuple((tcd + len(tc.get_reduce_axes()) + len(tc.get_upcast_axes()) - (i+1), 2) for i in range(upcast_axes))
           def get_tc_swizzle_st(shape, wd_swizzle, tcd_swizzle):
             offset = (tcd - (wd + len(wd_swizzle)))
@@ -619,10 +619,10 @@ class Kernel:
           if self.use_tensor_cores == 1: # real WMMA, use CONTRACT/UNROLL to get the vectorization right
             tc_upcast_axes = (get_upcast_axes(0), get_upcast_axes(1), get_upcast_axes(2))
             wmma_arg = (str(tc), tc.dims, tc.dtype_in, tc.dtype_out, self.opts.device, tc.threads, tc_upcast_axes, tc_reduce_axes)
-            wmma = UOp(Ops.WMMA, dtype=tc.dtype_out.vec(tc.thread_dims[2]), src=(
-              UOp(Ops.CONTRACT, dtype=srcs[0].dtype.vec(tc.thread_dims[0]), src=(srcs[0],), arg=tc_upcast_axes[0]),
-              UOp(Ops.CONTRACT, dtype=srcs[1].dtype.vec(tc.thread_dims[1]), src=(srcs[1],), arg=tc_upcast_axes[1]),
-              UOp.const(tc.dtype_out.vec(tc.thread_dims[2]), 0.0)), arg=wmma_arg)
+            wmma = UOp(Ops.WMMA, dtype=tc.dtype_out.vec(tc.elements_per_thread[2]), src=(
+              UOp(Ops.CONTRACT, dtype=srcs[0].dtype.vec(tc.elements_per_thread[0]), src=(srcs[0],), arg=tc_upcast_axes[0]),
+              UOp(Ops.CONTRACT, dtype=srcs[1].dtype.vec(tc.elements_per_thread[1]), src=(srcs[1],), arg=tc_upcast_axes[1]),
+              UOp.const(tc.dtype_out.vec(tc.elements_per_thread[2]), 0.0)), arg=wmma_arg)
             tc_uop = UOp(Ops.UNROLL, tc.dtype_out, (wmma,), arg=tc_upcast_axes[2])
 
           else: # for TC=3 MUL/SUM instead of WMMA

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -593,7 +593,7 @@ class Kernel:
 
         if (tc := self.tensor_core) and (self.use_tensor_cores == 1 or self.use_tensor_cores == 3):
           wd, tcd = self.global_dims, self.first_upcast
-          def get_upcast_axes(buf):
+          def get_upcast_axes(buf): # upcast along non-zero dimensions of (tc_reduce + tc_upcast)
             upcast_axes = int(math.log2(tc.elements_per_thread[buf]))
             return tuple((tcd + len(tc.get_reduce_axes()) + len(tc.get_upcast_axes()) - (i+1), 2) for i in range(upcast_axes))
           def get_tc_swizzle_st(shape, local_perm, upcast_perm):

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
-import itertools, functools
+import itertools, functools, math
 from dataclasses import dataclass
 from collections import defaultdict
 from typing import Optional, cast, Final, Callable, Sequence
 from enum import Enum, auto
 
-from tinygrad.ops import GroupOp, KernelInfo, UOp, Ops, can_pad, print_uops, type_verify, resolve, Variable, sint, \
-  graph_rewrite, track_rewrites, view_left
+from tinygrad.ops import GroupOp, KernelInfo, UOp, Ops, can_pad, print_uops, type_verify, resolve, Variable, sint, track_rewrites
 from tinygrad.device import Device
 from tinygrad.renderer import Renderer, TensorCore, ProgramSpec
 from tinygrad.dtype import ImageDType
@@ -14,6 +13,7 @@ from tinygrad.helpers import all_same, colored, ansilen, dedup, getenv, prod, ro
 from tinygrad.helpers import DEBUG, TC_OPT, USE_TC, AMX
 from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.shape.view import strides_for_shape
+from tinygrad.engine.schedule import apply_swizzle
 from tinygrad.codegen.linearize import linearize_uop
 from tinygrad.codegen.uopgraph import full_graph_rewrite
 from tinygrad.codegen.lowerer import rewrite_shapetracker_with_index, get_contraction
@@ -298,19 +298,15 @@ class Kernel:
         # can only fuse reduces with the same tc options
         assert all_same(tensor_core_opts)
         if tensor_core_opts[0] is None: continue
-        # tensor core -- unroll the reduce dim, upcast input and local the correct thread pattern
         self.tensor_core_opts = tc_opts = tensor_core_opts[0]
 
         # attempt to pad the tensor axes that require it
         try:
           for axis, dim in tc_opts.axis_pads: self.apply_opt(Opt(OptOps.PADTO, axis, dim), append_opt=False) # PADTO might fail
         except KernelOptError: continue
-        for tc_dim, amt in tc.reduce_axes: self.apply_opt(Opt(OptOps.UNROLL,tc_opts.axes[2]-self.first_reduce,amt), append_opt=False)
-        for opt in tc.opts_seq:
-          if opt == "UP":
-            for tc_dim, amt in tc.early_upcast_axes: self.apply_opt(Opt(OptOps.UPCAST,tc_opts.axes[tc_dim],amt), append_opt=False)
-          elif opt == "LC":
-            for tc_dim, amt in tc.threads: self.apply_opt(Opt(OptOps.LOCAL,tc_opts.axes[tc_dim],amt), append_opt=False)
+        # tensor core -- unroll the reduce dim (K), upcast and local the inner and outer dims (N, M)
+        for dim, amt in tc.get_reduce_axes(): self.apply_opt(Opt(OptOps.UNROLL, tc_opts.axes[2]-self.first_reduce, amt), append_opt=False)
+        for opt in tc.opts: self.apply_opt(Opt({"u":OptOps.UPCAST, "l":OptOps.LOCAL}[opt[0]], tc_opts.axes[int(opt[1])], 2), append_opt=False)
         self.tensor_core = tc
         self.use_tensor_cores = use_tensor_cores  # TC=2 will do the shape ops without the WMMA
         return True
@@ -405,7 +401,7 @@ class Kernel:
       self.upcast()
     elif opt.op is OptOps.UPCAST:                     # yellow
       check(axis < self.first_reduce, "upcast is for non-reduce")
-      check(not (self.tensor_core and self.global_dims <= axis < self.global_dims+len(self.tensor_core.threads)), "can't upcast TC locals")
+      check(not (self.tensor_core and self.global_dims <= axis < self.global_dims+len(self.tensor_core.get_local_axes())), "can't upcast TC locals")
       check(amt <= 16, "don't upcast more than 16")
       self.shift_to(axis, amt, insert_before=None)
       self.upcast()
@@ -596,48 +592,42 @@ class Kernel:
         grouped_axes = reduced_axes(self.first_reduce, self.first_reduce + self.group_for_reduces)
 
         if (tc := self.tensor_core) and (self.use_tensor_cores == 1 or self.use_tensor_cores == 3):
-          def fix_st(st: ShapeTracker, wd_pattern, tcd_pattern):
-            st = ShapeTracker.from_shape(st.shape) # st needs to be contiguous
-            wd, warp_dims = self.global_dims,  tuple(sz for _, sz in tc.threads)
-            tcd, tcd_dims = self.first_upcast, tuple(sz for _, sz in tc.reduce_axes + tc.early_upcast_axes)
-
-            assert st.shape[wd:wd+len(warp_dims)] == warp_dims, f"warp dims wrong: {st.shape[wd:wd+len(warp_dims)]=} != {warp_dims=}"
-            assert st.shape[tcd:tcd+len(tcd_dims)] == tcd_dims, f"tcd dims wrong: {st.shape[tcd:tcd+len(tcd_dims)]=} != {tcd_dims=}"
-            assert tc.expanded_shape is not None
-
-            new_shape = st.shape[:tcd] + tc.expanded_shape + st.shape[tcd+len(tcd_dims):]  # expand the tcd
-            permaxis = list(range(wd)) + [y + (wd if x == 0 else tcd) for x,y in wd_pattern]  + list(range(wd+len(warp_dims),tcd)) + \
-                                         [y + (wd if x == 0 else tcd) for x,y in tcd_pattern] + list(range(tcd+len(tc.expanded_shape),len(new_shape)))
-            return st.reshape(new_shape).permute(tuple(permaxis)).reshape(st.shape).simplify()
+          wd, tcd = self.global_dims, self.first_upcast
+          tcd_reduce_len, tcd_upcast_len = len(tc.get_reduce_axes()), len(tc.get_upcast_axes())
+          def get_upcast_axes(buf): return tuple((tcd+tcd_reduce_len+tcd_upcast_len - (i+1), 2) for i in range(int(math.log2(tc.upcast_size[buf]))))
+          def get_tc_swizzle_st(shape, wd_pattern, tcd_pattern):
+            offset = (tcd - (wd + len(wd_pattern)))
+            permaxis = list(range(wd)) \
+              + [wd + x + (offset if x >= len(wd_pattern) else 0) for x in wd_pattern]  + list(range(wd + len(wd_pattern), tcd)) \
+              + [wd + x + (offset if x >= len(wd_pattern) else 0) for x in tcd_pattern] + list(range(tcd + len(tcd_pattern), len(shape)))
+            return ShapeTracker.from_shape(shape).permute(tuple(permaxis))
 
           srcs = list((ret.src[0] if ret.src[0].op is not Ops.CAST else ret.src[0].src[0]).src)
-          for i, tc_pattern in enumerate([tc.st1_pattern, tc.st2_pattern]):
-            if tc_pattern: srcs[i] = srcs[i].view(fix_st(srcs[i].st_arg if srcs[i].op is Ops.LOAD else srcs[i].src[0].st_arg, *tc_pattern))
+          for i, (src, swizzle) in enumerate(zip(srcs, tc.swizzle)):
+            if swizzle: srcs[i] = apply_swizzle(src.view(get_tc_swizzle_st((src if src.op is Ops.LOAD else src.src[0]).st_arg.shape, *swizzle)))
 
             if self.use_tensor_cores == 3:  # for TC=3, emulate the warp addressing with locals
               local_shape = tuple(1 if i >= self.first_reduce and i < self.first_upcast else s for i, s in enumerate(self.full_shape))
               st = store_st = ShapeTracker.from_shape(local_shape)
               local_buffer = UOp(Ops.DEFINE_LOCAL, tc.dtype_in.ptr(size=st.real_size(), local=True), (), (f"temp{i + 1}", st.real_size()))
-              if tc_pattern: store_st = fix_st(store_st, *tc_pattern)
+              if swizzle: store_st = get_tc_swizzle_st(store_st.shape, *swizzle)
               local_store = UOp.store(local_buffer, store_st.to_uop(), srcs[i])
               srcs[i] = UOp(Ops.LOAD, tc.dtype_in, (local_buffer, st.to_uop(), local_store))
 
-          tc_reduce_axes = tuple(self.first_upcast + ax for ax, _ in tc.reduce_axes)
+          tc_reduce_axes = tuple(tcd + ax for ax, _ in tc.get_reduce_axes())
           if self.use_tensor_cores == 1: # real WMMA, use CONTRACT/UNROLL to get the vectorization right
-            upcast_axes = tuple(tuple((self.first_upcast + ax, sz) for ax, sz in up) for up in tc.upcast_axes)
-            wmma_arg = (str(tc), tc.dims, tc.dtype_in, tc.dtype_out, self.opts.device, prod(sz for _, sz in tc.threads), upcast_axes, tc_reduce_axes)
-            wmma_sz = [prod(x[1] for x in l) for l in upcast_axes]
-            wmma = UOp(Ops.WMMA, dtype=tc.dtype_out.vec(wmma_sz[2]), src=(
-              UOp(Ops.CONTRACT, dtype=srcs[0].dtype.vec(wmma_sz[0]), src=(srcs[0],), arg=upcast_axes[0]),
-              UOp(Ops.CONTRACT, dtype=srcs[1].dtype.vec(wmma_sz[1]), src=(srcs[1],), arg=upcast_axes[1]),
-              UOp.const(tc.dtype_out.vec(wmma_sz[2]), 0.0)), arg=wmma_arg)
-            tc_uop = UOp(Ops.UNROLL, tc.dtype_out, (wmma,), arg=upcast_axes[2])
+            tc_upcast_axes= (get_upcast_axes(0), get_upcast_axes(1), get_upcast_axes(2))
+            wmma_arg = (str(tc), tc.dims, tc.dtype_in, tc.dtype_out, self.opts.device, (2**len(tc.get_local_axes())), tc_upcast_axes, tc_reduce_axes)
+            wmma = UOp(Ops.WMMA, dtype=tc.dtype_out.vec(tc.upcast_size[2]), src=(
+              UOp(Ops.CONTRACT, dtype=srcs[0].dtype.vec(tc.upcast_size[0]), src=(srcs[0],), arg=tc_upcast_axes[0]),
+              UOp(Ops.CONTRACT, dtype=srcs[1].dtype.vec(tc.upcast_size[1]), src=(srcs[1],), arg=tc_upcast_axes[1]),
+              UOp.const(tc.dtype_out.vec(tc.upcast_size[2]), 0.0)), arg=wmma_arg)
+            tc_uop = UOp(Ops.UNROLL, tc.dtype_out, (wmma,), arg=tc_upcast_axes[2])
 
           else: # for TC=3 MUL/SUM instead of WMMA
             tc_uop = UOp(Ops.REDUCE_AXIS, tc.dtype_out, ((srcs[0] * srcs[1]).cast(tc.dtype_out),), (Ops.ADD, tc_reduce_axes))
 
-          new_reduce_axes = tuple(i for i in axes if i not in tc_reduce_axes)
-          return ret.replace(src=(tc_uop,), arg=(Ops.ADD, new_reduce_axes)) if new_reduce_axes else tc_uop
+          return ret.replace(src=(tc_uop,), arg=(Ops.ADD, new_axes)) if (new_axes := tuple(i for i in axes if i not in tc_reduce_axes)) else tc_uop
 
         ret = ret.replace(arg = (op.arg[0], axes))
         if self.group_for_reduces and grouped_axes:
@@ -656,7 +646,7 @@ class Kernel:
 
       return ret
 
-    return graph_rewrite(fixup_ast(self.ast), view_left)
+    return fixup_ast(self.ast)
 
   # **** this is the lowerer ****
 

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -596,11 +596,11 @@ class Kernel:
           def get_upcast_axes(buf):
             upcast_axes = int(math.log2(tc.elements_per_thread[buf]))
             return tuple((tcd + len(tc.get_reduce_axes()) + len(tc.get_upcast_axes()) - (i+1), 2) for i in range(upcast_axes))
-          def get_tc_swizzle_st(shape, wd_swizzle, tcd_swizzle):
-            offset = (tcd - (wd + len(wd_swizzle)))
+          def get_tc_swizzle_st(shape, local_perm, upcast_perm):
+            offset = (tcd - (wd + len(local_perm)))
             permaxis = list(range(wd)) \
-              + [wd + x + (offset if x >= len(wd_swizzle) else 0) for x in wd_swizzle]  + list(range(wd + len(wd_swizzle), tcd)) \
-              + [wd + x + (offset if x >= len(wd_swizzle) else 0) for x in tcd_swizzle] + list(range(tcd + len(tcd_swizzle), len(shape)))
+              + [wd + x + (offset if x >= len(local_perm) else 0) for x in local_perm]  + list(range(wd + len(local_perm), tcd)) \
+              + [wd + x + (offset if x >= len(local_perm) else 0) for x in upcast_perm] + list(range(tcd + len(upcast_perm), len(shape)))
             return ShapeTracker.from_shape(shape).permute(tuple(permaxis))
 
           srcs = list((ret.src[0] if ret.src[0].op is not Ops.CAST else ret.src[0].src[0]).src)

--- a/tinygrad/engine/search.py
+++ b/tinygrad/engine/search.py
@@ -108,7 +108,7 @@ def get_kernel_actions(lin:Kernel, include_0=True) -> dict[int, Kernel]:
     lin2 = lin.copy()
     try:
       lin2.apply_opt(a)
-      up, lcl, tc_up = 1, 1, prod(tc.dims)//(2**len(tc.get_local_axes())) if (tc:=lin2.tensor_core) else 1
+      up, lcl, tc_up = 1, 1, prod(tc.dims)//tc.threads if (tc:=lin2.tensor_core) else 1
       for s,c in zip(lin2.full_shape, lin2.colors()):
         if c in {"magenta", "yellow"}: up *= s
         elif c in {"cyan", "green", "white"}: lcl *= s

--- a/tinygrad/engine/search.py
+++ b/tinygrad/engine/search.py
@@ -108,7 +108,7 @@ def get_kernel_actions(lin:Kernel, include_0=True) -> dict[int, Kernel]:
     lin2 = lin.copy()
     try:
       lin2.apply_opt(a)
-      up, lcl, tc_up = 1, 1, prod(tc.dims)//prod([x[1] for x in tc.threads]) if (tc:=lin2.tensor_core) else 1
+      up, lcl, tc_up = 1, 1, prod(tc.dims)//(2**len(tc.get_local_axes())) if (tc:=lin2.tensor_core) else 1
       for s,c in zip(lin2.full_shape, lin2.colors()):
         if c in {"magenta", "yellow"}: up *= s
         elif c in {"cyan", "green", "white"}: lcl *= s

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -10,7 +10,7 @@ from tinygrad.dtype import DType
 class TensorCore: # D = A * B + C, A is (M x K), B is (K x N), C and D are (M x N)
   dims: tuple[int,int,int] # N, M, K
   threads: int # number of threads that construct the warp
-  upcast_size: tuple[int, int, int] # per-thread dimensions for how many A/B/C elements the wmma op loads/stores
+  thread_dims: tuple[int, int, int] # per-thread dimensions for how many A/B/C elements the wmma op loads/stores
   dtype_in: DType # dtype for A and B
   dtype_out: DType # dtype for C and D
   opts: tuple[str, ...] # ordered tuple of "ux" or "lx" specifing kernel opts to perform. "ux" upcasts dim x and "lx" localizes dim x
@@ -22,8 +22,8 @@ class TensorCore: # D = A * B + C, A is (M x K), B is (K x N), C and D are (M x 
   def __post_init__(self):
     local_axes, upcast_axes, reduce_axes = len(self.get_local_axes()), len(self.get_upcast_axes()), len(self.get_reduce_axes())
     assert 2**local_axes == self.threads, f"{self.threads} threads construct the warp but {local_axes} local axes of size 2 found in {self.opts}"
-    assert 2**upcast_axes == self.upcast_size[2], (
-      f"{self.upcast_size[2]} elements from C are processed per thread but {upcast_axes} upcast axes of size 2 found in {self.opts}")
+    assert 2**upcast_axes == self.thread_dims[2], (
+      f"{self.thread_dims[2]} elements from C are processed per thread but {upcast_axes} upcast axes of size 2 found in {self.opts}")
     assert all(len(perm[0]) == local_axes and len(perm[1]) == reduce_axes + upcast_axes for perm in self.swizzle if perm), (
       f"swizzle perm should be of len (({local_axes})({reduce_axes + upcast_axes})")
 

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -10,7 +10,7 @@ from tinygrad.dtype import DType
 class TensorCore: # D = A * B + C, A is (M x K), B is (K x N), C and D are (M x N)
   dims: tuple[int,int,int] # N, M, K
   threads: int # number of threads that construct the warp
-  thread_dims: tuple[int, int, int] # per-thread dimensions for how many A/B/C elements the wmma op loads/stores
+  elements_per_thread: tuple[int, int, int] # per-thread dimensions for how many A/B/C elements the wmma op loads/stores
   dtype_in: DType # dtype for A and B
   dtype_out: DType # dtype for C and D
   opts: tuple[str, ...] # ordered tuple of "ux" or "lx" specifing kernel opts to perform. "ux" upcasts dim x and "lx" localizes dim x
@@ -22,8 +22,8 @@ class TensorCore: # D = A * B + C, A is (M x K), B is (K x N), C and D are (M x 
   def __post_init__(self):
     local_axes, upcast_axes, reduce_axes = len(self.get_local_axes()), len(self.get_upcast_axes()), len(self.get_reduce_axes())
     assert 2**local_axes == self.threads, f"{self.threads} threads construct the warp but {local_axes} local axes of size 2 found in {self.opts}"
-    assert 2**upcast_axes == self.thread_dims[2], (
-      f"{self.thread_dims[2]} elements from C are processed per thread but {upcast_axes} upcast axes of size 2 found in {self.opts}")
+    assert 2**upcast_axes == self.elements_per_thread[2], (
+      f"{self.elements_per_thread[2]} elements from C are processed per thread but {upcast_axes} upcast axes of size 2 found in {self.opts}")
     assert all(len(perm[0]) == local_axes and len(perm[1]) == reduce_axes + upcast_axes for perm in self.swizzle if perm), (
       f"swizzle perm should be of len (({local_axes})({reduce_axes + upcast_axes})")
 

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -10,7 +10,7 @@ from tinygrad.dtype import DType
 class TensorCore: # D = A * B + C, A is (M x K), B is (K x N), C and D are (M x N)
   dims: tuple[int,int,int] # N, M, K
   threads: int # number of threads that construct the warp
-  elements_per_thread: tuple[int, int, int] # per-thread dimensions for how many A/B/C elements the wmma op loads/stores
+  elements_per_thread: tuple[int, int, int] # elements per-thread to load/store from A/B/C
   dtype_in: DType # dtype for A and B
   dtype_out: DType # dtype for C and D
   opts: tuple[str, ...] # ordered tuple of "ux" or "lx" specifing kernel opts to perform. "ux" upcasts dim x and "lx" localizes dim x

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -175,7 +175,7 @@ class ClangRenderer(CStyleLanguage):
     CStyleLanguage.extra_matcher
 
   if AMX:
-    tensor_cores = [TensorCore(dims=(sz,sz,1), threads=1, upcast_size=(sz,sz,sz*sz), dtype_in=dt, dtype_out=dt, swizzle=(None,((),(4,5,6,7,0,1,2,3))),
+    tensor_cores = [TensorCore(dims=(sz,sz,1), threads=1, thread_dims=(sz,sz,sz*sz), dtype_in=dt, dtype_out=dt, swizzle=(None,((),(4,5,6,7,0,1,2,3))),
       opts=("u0","u0","u0","u0","u1","u1","u1","u1")) for dt,sz in [(dt, 64 // dt.itemsize) for dt in [dtypes.float]]]
 
   def render_vector_prefix(self, dt:DType) -> str:
@@ -226,7 +226,7 @@ class OpenCLRenderer(CStyleLanguage):
 
 class IntelRenderer(OpenCLRenderer):
   device, suffix, kernel_prefix = "GPU", "INTEL", "__attribute__((intel_reqd_sub_group_size(8)))\n" + "__kernel "
-  tensor_cores = [TensorCore(dims=(8,8,16), threads=8, upcast_size=(16,16,8), dtype_in=dtypes.half, dtype_out=dtypes.float,
+  tensor_cores = [TensorCore(dims=(8,8,16), threads=8, thread_dims=(16,16,8), dtype_in=dtypes.half, dtype_out=dtypes.float,
     opts=("l0","l0","l0","u1","u1","u1"), swizzle=(((4,5,6),(0,1,2,3,7,8,9)), ((0,1,2),(7,8,9,3,4,5,6))))]
 
   string_rewrite = PatternMatcher([
@@ -245,7 +245,7 @@ class IntelRenderer(OpenCLRenderer):
 class MetalRenderer(CStyleLanguage):
   device = "METAL"
   shared_max = 32768
-  tensor_cores = [TensorCore(dims=(8,8,8), threads=32, upcast_size=(2,2,2), dtype_in=di, dtype_out=do, opts=("u0","l0","l1","l1","l0","l1"),
+  tensor_cores = [TensorCore(dims=(8,8,8), threads=32, thread_dims=(2,2,2), dtype_in=di, dtype_out=do, opts=("u0","l0","l1","l1","l0","l1"),
     swizzle=(((6,1,2,7,4),(8,0,3,5)), ((0,5,6,3,7),(1,2,4,8)))) for di,do in [(dtypes.float,dtypes.float),(dtypes.half,dtypes.float),
     (dtypes.half,dtypes.half),(dtypes.bfloat16,dtypes.float),(dtypes.bfloat16,dtypes.bfloat16)]]
   def __init__(self): self.tensor_cores = MetalRenderer.tensor_cores if hasattr(os, 'uname') and os.uname().machine == "arm64" else []
@@ -294,7 +294,7 @@ class CUDARenderer(CStyleLanguage):
   local_max = (1024, 1024, 64)
   shared_max = 49152
   # https://docs.nvidia.com/cuda/parallel-thread-execution/#warp-level-matrix-fragment-mma-16816-float
-  tensor_cores = [TensorCore(dims=(8,16,16), threads=32, upcast_size=(8,4,4), dtype_in=di, dtype_out=do, opts=("u0","l0","l0","l1","l1","l1","u1"),
+  tensor_cores = [TensorCore(dims=(8,16,16), threads=32, thread_dims=(8,4,4), dtype_in=di, dtype_out=do, opts=("u0","l0","l0","l1","l1","l1","u1"),
     swizzle=(((6,7,2,3,4),(0,1,9,5,10,8)), ((6,7,9,0,1),(2,3,4,10,5,8)))) for di,do in ([(dtypes.half,dtypes.float),(dtypes.bfloat16,dtypes.float)])]
   def __init__(self, arch:str): self.tensor_cores, self.arch = CUDARenderer.tensor_cores if int(arch[3:]) >= 80 else [], arch
   def __reduce__(self): return self.__class__, (self.arch,)
@@ -362,7 +362,7 @@ class AMDRenderer(CStyleLanguage):
   device = "AMD"
   shared_max = 65536
   # https://gpuopen.com/learn/wmma_on_rdna3/
-  tensor_cores = [TensorCore(dims=(16,16,16), threads=32, upcast_size=(16,16,8), dtype_in=di, dtype_out=do,
+  tensor_cores = [TensorCore(dims=(16,16,16), threads=32, thread_dims=(16,16,8), dtype_in=di, dtype_out=do,
     opts=("l0","l0","l0","l0","l1","u1","u1","u1"), swizzle=(((4,9,10,11,0),(1,2,3,5,6,7,8)), ((0,1,2,3,4),(9,10,11,5,6,7,8))))
     for di,do in [(dtypes.half,dtypes.float),(dtypes.half,dtypes.half)]]
 

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -175,9 +175,8 @@ class ClangRenderer(CStyleLanguage):
     CStyleLanguage.extra_matcher
 
   if AMX:
-    tensor_cores = [TensorCore(dims=(sz,sz,1), threads=0, upcast_size=(sz,sz,sz*sz), dtype_in=dt, dtype_out=dt,
-      opts=("u0","u0","u0","u0","u1","u1","u1","u1"), swizzle=(None, ((),(4,5,6,7,0,1,2,3))))
-      for dt,sz in [(dt, 64 // dt.itemsize) for dt in [dtypes.float]]]
+    tensor_cores = [TensorCore(dims=(sz,sz,1), threads=1, upcast_size=(sz,sz,sz*sz), dtype_in=dt, dtype_out=dt, swizzle=(None,((),(4,5,6,7,0,1,2,3))),
+      opts=("u0","u0","u0","u0","u1","u1","u1","u1")) for dt,sz in [(dt, 64 // dt.itemsize) for dt in [dtypes.float]]]
 
   def render_vector_prefix(self, dt:DType) -> str:
     return f"typedef {self.render_dtype(dt.scalar())} {self.render_dtype(dt)} __attribute__((aligned({(sz:=dt.itemsize)}),vector_size({sz})));"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -175,8 +175,8 @@ class ClangRenderer(CStyleLanguage):
     CStyleLanguage.extra_matcher
 
   if AMX:
-    tensor_cores = [TensorCore(dims=(sz,sz,1), threads=[], reduce_axes=[], upcast_axes=([(1,sz)],[(0,sz)],[(1,sz),(0,sz)]), dtype_in=dt, dtype_out=dt)
-      for dt, sz in [(dt, 64//dt.itemsize) for dt in [dtypes.float]]]
+    tensor_cores = [TensorCore(dims=(sz,sz,1), upcast_size=(sz,sz,sz*sz), dtype_in=dt, dtype_out=dt, opts=("u0","u0","u0","u0","u1","u1","u1","u1"),
+      swizzle=(None, ((),(4,5,6,7,0,1,2,3)))) for dt,sz in [(dt, 64 // dt.itemsize) for dt in [dtypes.float]]]
 
   def render_vector_prefix(self, dt:DType) -> str:
     return f"typedef {self.render_dtype(dt.scalar())} {self.render_dtype(dt)} __attribute__((aligned({(sz:=dt.itemsize)}),vector_size({sz})));"
@@ -226,12 +226,12 @@ class OpenCLRenderer(CStyleLanguage):
 
 class IntelRenderer(OpenCLRenderer):
   device, suffix, kernel_prefix = "GPU", "INTEL", "__attribute__((intel_reqd_sub_group_size(8)))\n" + "__kernel "
-  tensor_cores = [TensorCore(dims=(8,8,16),threads=[(0,8)],dtype_in=di,dtype_out=do,reduce_axes=[(0,16)],upcast_axes=([(0,16)],[(0,16)],[(1,8)]),
-    st1_pattern=(((1,0),),((1,2),(1,1),(0,0))),expanded_shape=(8,2,8)) for di,do in [(dtypes.half,dtypes.float),(dtypes.bfloat16,dtypes.float)]]
+  tensor_cores = [TensorCore(dims=(8,8,16), upcast_size=(16,16,8), dtype_in=dtypes.half, dtype_out=dtypes.float, opts=("l0","l0","l0","u1","u1","u1"),
+    swizzle=(((4,5,6),(0,1,2,3,7,8,9)), ((0,1,2),(7,8,9,3,4,5,6))))]
 
   string_rewrite = PatternMatcher([
-    (UPat(Ops.CAST, dtype=dtypes.bfloat16, src=(UPat.var('x', dtype=dtypes.float))), lambda ctx,x: f"intel_convert_bfloat16_as_ushort({ctx[x[0]]})"),
-    (UPat(Ops.CAST, dtype=dtypes.float, src=(UPat.var('x', dtype=dtypes.bfloat16))), lambda ctx,x: f"intel_convert_as_bfloat16_float({ctx[x[0]]})"),
+    (UPat(Ops.CAST, dtype=dtypes.bfloat16, src=(UPat.var('x', dtype=dtypes.float))), lambda ctx,x: f"intel_convert_bfloat16_as_ushort({ctx[x]})"),
+    (UPat(Ops.CAST, dtype=dtypes.float, src=(UPat.var('x', dtype=dtypes.bfloat16))), lambda ctx,x: f"intel_convert_as_bfloat16_float({ctx[x]})"),
   ]) + OpenCLRenderer.string_rewrite
 
   def render_kernel(self, function_name, kernel, bufs, uops, prefix=None) -> str:
@@ -245,10 +245,9 @@ class IntelRenderer(OpenCLRenderer):
 class MetalRenderer(CStyleLanguage):
   device = "METAL"
   shared_max = 32768
-  tensor_cores = [TensorCore(dims=(8,8,8),threads=[(0,2),(1,4),(0,2),(1,2)],expanded_shape=(2,2,2,2),upcast_axes=([(1,2)],[(1,2)],[(1,2)]),
-    st1_pattern=(((1,1),(0,1),(1,0),(0,3)),((0,0),(0,2),(1,3),(1,2))),st2_pattern=(((0,0),(1,1),(1,2),(0,2),(1,0)),((0,1),(0,3),(1,3))),
-    dtype_in=di,dtype_out=do,reduce_axes=[(0,8)]) for di,do in [(dtypes.float,dtypes.float),(dtypes.half,dtypes.float),(dtypes.half,dtypes.half),
-                                                                (dtypes.bfloat16,dtypes.float),(dtypes.bfloat16,dtypes.bfloat16)]]
+  tensor_cores = [TensorCore(dims=(8,8,8), upcast_size=(2,2,2), dtype_in=di, dtype_out=do, opts=("u0","l0","l1","l1","l0","l1"),
+    swizzle=(((6,1,2,7,4),(8,0,3,5)), ((0,5,6,3,7),(1,2,4,8)))) for di,do in [(dtypes.float,dtypes.float),(dtypes.half,dtypes.float),
+    (dtypes.half,dtypes.half),(dtypes.bfloat16,dtypes.float),(dtypes.bfloat16,dtypes.bfloat16)]]
   def __init__(self): self.tensor_cores = MetalRenderer.tensor_cores if hasattr(os, 'uname') and os.uname().machine == "arm64" else []
 
   # language options
@@ -295,10 +294,8 @@ class CUDARenderer(CStyleLanguage):
   local_max = (1024, 1024, 64)
   shared_max = 49152
   # https://docs.nvidia.com/cuda/parallel-thread-execution/#warp-level-matrix-fragment-mma-16816-float
-  tensor_cores = [TensorCore(dims=(8,16,16), threads=[(0,2),(0,2),(1,2),(1,2),(1,2)], dtype_in=di, dtype_out=do, expanded_shape=(2,2,2,2,2,2),
-    st1_pattern=(((1,1),(1,0),(0,2),(0,3),(0,4)),((1,3),(1,5),(1,2),(0,0),(0,1),(1,4))),
-    st2_pattern=(((1,1),(1,0),(1,4),(0,0),(0,1)),((0,4),(0,2),(1,5),(0,3),(1,3),(1,2))), reduce_axes=[(0,8),(1,2)],
-    upcast_axes=([(0,8)],[(2,2),(3,2)],[(3,2),(2,2)])) for di, do in ([(dtypes.half,dtypes.float),(dtypes.bfloat16,dtypes.float)])]
+  tensor_cores = [TensorCore(dims=(8,16,16), upcast_size=(8,4,4), dtype_in=di, dtype_out=do, opts=("u0","l0","l0","l1","l1","l1","u1"),
+    swizzle=(((6,7,2,3,4),(0,1,9,5,10,8)), ((6,7,9,0,1),(2,3,4,10,5,8)))) for di,do in ([(dtypes.half,dtypes.float),(dtypes.bfloat16,dtypes.float)])]
   def __init__(self, arch:str): self.tensor_cores, self.arch = CUDARenderer.tensor_cores if int(arch[3:]) >= 80 else [], arch
   def __reduce__(self): return self.__class__, (self.arch,)
 
@@ -365,9 +362,8 @@ class AMDRenderer(CStyleLanguage):
   device = "AMD"
   shared_max = 65536
   # https://gpuopen.com/learn/wmma_on_rdna3/
-  tensor_cores = [TensorCore(dims=(16,16,16), threads=[(0,8),(0,2),(1,2)], dtype_in=di, dtype_out=do, reduce_axes=[(0,16)], opts_seq=("LC","UP"),
-    upcast_axes = ([(0,16)],[(0,16)],[(1,8)]), st1_pattern=(((1,2),(0,2),(1,1),(0,1)),((1,0),(0,0))), expanded_shape=(16,2,4))
-    for (di, do) in [(dtypes.half, dtypes.float), (dtypes.half, dtypes.half)]]
+  tensor_cores = [TensorCore(dims=(16,16,16), upcast_size=(16,16,8), dtype_in=di, dtype_out=do, opts=("l0","l0","l0","l0","l1","u1","u1","u1"),
+    swizzle=(((4,9,10,11,0),(1,2,3,5,6,7,8)), ((0,1,2,3,4),(9,10,11,5,6,7,8)))) for di,do in [(dtypes.half,dtypes.float),(dtypes.half,dtypes.half)]]
 
   # language options
   ockl = [(f"__ockl_get_{name}", "unsigned int", "size_t", "const") for name in ["local_id", "group_id", "local_size"]]

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -175,8 +175,9 @@ class ClangRenderer(CStyleLanguage):
     CStyleLanguage.extra_matcher
 
   if AMX:
-    tensor_cores = [TensorCore(dims=(sz,sz,1), upcast_size=(sz,sz,sz*sz), dtype_in=dt, dtype_out=dt, opts=("u0","u0","u0","u0","u1","u1","u1","u1"),
-      swizzle=(None, ((),(4,5,6,7,0,1,2,3)))) for dt,sz in [(dt, 64 // dt.itemsize) for dt in [dtypes.float]]]
+    tensor_cores = [TensorCore(dims=(sz,sz,1), threads=0, upcast_size=(sz,sz,sz*sz), dtype_in=dt, dtype_out=dt,
+      opts=("u0","u0","u0","u0","u1","u1","u1","u1"), swizzle=(None, ((),(4,5,6,7,0,1,2,3))))
+      for dt,sz in [(dt, 64 // dt.itemsize) for dt in [dtypes.float]]]
 
   def render_vector_prefix(self, dt:DType) -> str:
     return f"typedef {self.render_dtype(dt.scalar())} {self.render_dtype(dt)} __attribute__((aligned({(sz:=dt.itemsize)}),vector_size({sz})));"
@@ -226,8 +227,8 @@ class OpenCLRenderer(CStyleLanguage):
 
 class IntelRenderer(OpenCLRenderer):
   device, suffix, kernel_prefix = "GPU", "INTEL", "__attribute__((intel_reqd_sub_group_size(8)))\n" + "__kernel "
-  tensor_cores = [TensorCore(dims=(8,8,16), upcast_size=(16,16,8), dtype_in=dtypes.half, dtype_out=dtypes.float, opts=("l0","l0","l0","u1","u1","u1"),
-    swizzle=(((4,5,6),(0,1,2,3,7,8,9)), ((0,1,2),(7,8,9,3,4,5,6))))]
+  tensor_cores = [TensorCore(dims=(8,8,16), threads=8, upcast_size=(16,16,8), dtype_in=dtypes.half, dtype_out=dtypes.float,
+    opts=("l0","l0","l0","u1","u1","u1"), swizzle=(((4,5,6),(0,1,2,3,7,8,9)), ((0,1,2),(7,8,9,3,4,5,6))))]
 
   string_rewrite = PatternMatcher([
     (UPat(Ops.CAST, dtype=dtypes.bfloat16, src=(UPat.var('x', dtype=dtypes.float))), lambda ctx,x: f"intel_convert_bfloat16_as_ushort({ctx[x]})"),
@@ -245,7 +246,7 @@ class IntelRenderer(OpenCLRenderer):
 class MetalRenderer(CStyleLanguage):
   device = "METAL"
   shared_max = 32768
-  tensor_cores = [TensorCore(dims=(8,8,8), upcast_size=(2,2,2), dtype_in=di, dtype_out=do, opts=("u0","l0","l1","l1","l0","l1"),
+  tensor_cores = [TensorCore(dims=(8,8,8), threads=32, upcast_size=(2,2,2), dtype_in=di, dtype_out=do, opts=("u0","l0","l1","l1","l0","l1"),
     swizzle=(((6,1,2,7,4),(8,0,3,5)), ((0,5,6,3,7),(1,2,4,8)))) for di,do in [(dtypes.float,dtypes.float),(dtypes.half,dtypes.float),
     (dtypes.half,dtypes.half),(dtypes.bfloat16,dtypes.float),(dtypes.bfloat16,dtypes.bfloat16)]]
   def __init__(self): self.tensor_cores = MetalRenderer.tensor_cores if hasattr(os, 'uname') and os.uname().machine == "arm64" else []
@@ -294,7 +295,7 @@ class CUDARenderer(CStyleLanguage):
   local_max = (1024, 1024, 64)
   shared_max = 49152
   # https://docs.nvidia.com/cuda/parallel-thread-execution/#warp-level-matrix-fragment-mma-16816-float
-  tensor_cores = [TensorCore(dims=(8,16,16), upcast_size=(8,4,4), dtype_in=di, dtype_out=do, opts=("u0","l0","l0","l1","l1","l1","u1"),
+  tensor_cores = [TensorCore(dims=(8,16,16), threads=32, upcast_size=(8,4,4), dtype_in=di, dtype_out=do, opts=("u0","l0","l0","l1","l1","l1","u1"),
     swizzle=(((6,7,2,3,4),(0,1,9,5,10,8)), ((6,7,9,0,1),(2,3,4,10,5,8)))) for di,do in ([(dtypes.half,dtypes.float),(dtypes.bfloat16,dtypes.float)])]
   def __init__(self, arch:str): self.tensor_cores, self.arch = CUDARenderer.tensor_cores if int(arch[3:]) >= 80 else [], arch
   def __reduce__(self): return self.__class__, (self.arch,)
@@ -362,8 +363,9 @@ class AMDRenderer(CStyleLanguage):
   device = "AMD"
   shared_max = 65536
   # https://gpuopen.com/learn/wmma_on_rdna3/
-  tensor_cores = [TensorCore(dims=(16,16,16), upcast_size=(16,16,8), dtype_in=di, dtype_out=do, opts=("l0","l0","l0","l0","l1","u1","u1","u1"),
-    swizzle=(((4,9,10,11,0),(1,2,3,5,6,7,8)), ((0,1,2,3,4),(9,10,11,5,6,7,8)))) for di,do in [(dtypes.half,dtypes.float),(dtypes.half,dtypes.half)]]
+  tensor_cores = [TensorCore(dims=(16,16,16), threads=32, upcast_size=(16,16,8), dtype_in=di, dtype_out=do,
+    opts=("l0","l0","l0","l0","l1","u1","u1","u1"), swizzle=(((4,9,10,11,0),(1,2,3,5,6,7,8)), ((0,1,2,3,4),(9,10,11,5,6,7,8))))
+    for di,do in [(dtypes.half,dtypes.float),(dtypes.half,dtypes.half)]]
 
   # language options
   ockl = [(f"__ockl_get_{name}", "unsigned int", "size_t", "const") for name in ["local_id", "group_id", "local_size"]]


### PR DESCRIPTION
# Tensor core refactor

**New approach** 
Avoids having to swizzle output as the correct swizzle for the output is constructed through kernel opts.

**Overview**
The refactor focuses primarily on the **implementation** side of tensor cores (`TC`) rather than over their abstraction, as George mentioned. While an abstraction refactor could align with the kernel OptOps refactor into pattern-matching (`PM`) rules, this current work keeps tensor cores clean. It addresses:

1. Complex thread access patterns required for specific backends.
2. Simplifying support for new TC shapes.
3. Constructing output swizzles through kernel opts.
4. Use the swizzle from the docs.

> By `thread access pattern` I mean the elements of the tensor core each collaborating thread is in charge of loading (from `A` and `B`) and storing (from `C`).

**Implementation details**
The `TC` class has been simplified, removing redundancies. Each tensor core now requires: `dims`, `upcast_size`, `dtype_in`, `dtype_out`, `opts`, and optionally, `swizzle`. All properties but the swizzle can be extracted directly through the documentation for each tensor core.

``` python
@dataclass(frozen=True)
class TensorCore: # D = A * B + C, A is (M x K), B is (K x N), C and D are (M x N)
dims: tuple[int,int,int] # N, M, K
threads: int # number of threads that construct the warp
elements_per_thread: tuple[int, int, int] # elements per-thread to load/store from A/B/C
dtype_in: DType # dtype for A and B
dtype_out: DType # dtype for C and D
opts: tuple[str, ...] # ordered tuple of "ux" or "lx" specifing kernel opts to perform. "ux" upcasts dim x and "lx" localizes dim x
swizzle: tuple[Optional[tuple[tuple[int, ...], tuple[int, ...]]], Optional[tuple[tuple[int, ...], tuple[int, ...]]]] = (None, None)
```

1. `threads`
Number of threads that construct the warp
2. `elements_per_thread`
Specifies the elements each thread load/store for A/B/C. Although this could theoretically be inferred from the shapetracker of the resulting source for the WMMA uop, padded tensor cores make this logic overly complex. Explicitly defining `elements_per_thread` simplifies this. This property can be derived from documentation.
3. `opts`
Specifies the kernel opts to perform over tensor cores buffers and the order in which to perform them. All kernel OptOps use a fixed value of 2, enabling a more straightforward permutation of shapes for the swizzle.
5. `swizzle`
The `st1_pattern` and `st2_pattern` properties have been replaced with `swizzle`, a tuple of two optional permutations describing the permutation required in order to fix the thread access patterns for the inputs of the tensor core.

**Advantages of the refactor**
The new implementation reduces the complexity of adding support for new tensor core shapes. Previously, the process required defining `thread_patterns`, `reduce_axes`, `upcast_axes`, `expanded_shapes`, and `local/upcast order`, all being specific to Tinygrad implementation. Now, only three elements are necessary apart from input and output dtypes:

1. tensor core dimensions (N, M, K)
2. threads
3. elements_per_thread
4. kernel opts to perform

These values are readily available in backend documentation and will get the tc running. While swizzling still needs to be implemented manually to get the correct result, this approach mostly eliminates concerns about Tinygrad-specific details.

**Making sense of the swizzle**

In order to explain the swizzle, I'm going to make a walkthrough in adding `tf32` tc support for CUDA. As a sidenote; I'm tempted to add the support for the other TC shapes in order to claim the bounties (Turing tc, int8 tc, ...) but it would be a good sign if somebody else could figure them out somehow simply.

Form the docs, we learn that the tensor core shape for `sm_80` with `tf32` as input dtype is:

<img src="https://github.com/user-attachments/assets/25d41165-f060-43d7-94a5-48b7f223e605" width="512">

In the figure, color scaling represent the threads. Threads are continuous from darker to lighter and then they follow the dotted line. That represent the elements that each thread is responsible for loading into the tensor core. Thread0 (T0) is responsible for loading a0-a3, b0-b1 and stores c0-c3. Thread1 (T1) is responsible for the following, lighter orange, elements.

From a first glance into the docs we can get `dims` and `upcast_size` properties of the tensor core:

1. `dims = (N=8, M=16, K=8)`
2. `elements_per_thread = (4(a0,a1,a2,a3), 2(b0,b1), 4(c0,c1,c2,c3))`

<img src="https://github.com/user-attachments/assets/a2d1576e-46cf-439e-9434-531c9e61d3ae" width="512">

And, from a closer look, we can also derive the opts property as well. When deriving the kernel opts for wmma, each operation (“opt”) can either be an upcast (`u`) or a localization (`l`). Each opt is performed with a size of 2, and we traverse the matrix elements in a contiguous order to decide which dimension we need to act on:
1. **Starting at c0 → c1 (first row).**
    - We move along dimension 0 by performing an upcast: `u0`.
    - We continue along that same row with two localizations: `l0`, `l0`.
    - Thus, for the first row, our sequence is `("u0", "l0", "l0")`.

2. **Covering the next rows (still in the top half).**
    - We move to rows 2, 3–4, and 5–8 by localizing along dimension 1 each time. This yields three additional `l1`s:  
        `("u0", "l0", "l0", "l1", "l1", "l1")`.
    - Notice that at this point, we have localized five times total (`l0` three times plus `l1` twice, or vice versa depending how you count). Each localization has a size of 2, so `2**5=32`. This matches the 32 threads in a warp that collaborate for wmma.

3. **Moving to the second half of the matrix.**
    - Once we reach the lower rows (or the “second half” in memory layout terms), we see that it is reached by upcasting along dimension 1, giving `u1`.
    - Therefore, the final sequence becomes:`("u0", "l0", "l0", "l1", "l1", "l1", "u1")`

This final set of opts captures how the warp threads move through the matrix in a pattern of upcasting (to jump over a large dimension range) and localizing (to move sequentially through contiguous sub-blocks) until the entire block of data is covered.

The tensor core can then be added to the backend as follows:
```python
tensor_cores += [TensorCore(dims=(8,16,8), threads=32, elements_per_thread=(4,2,4), dtype_in=dtypes.float, dtype_out=dtypes.float, opts=("u0","l0","l0","l1","l1","l1","u1"))]
```

To figure out the required swizzle, the simplest approach is to perform a matrix multiplication with the same shape as the tensor core being configured. Running the following command: `DEBUG=3 N=8 M=16 K=8 python extra/gemm/simple_matmul.py` yields:

``` bash
TENSOR CORES [(1, 8, 1)] [(0, 16, 8)] WMMA_8_16_8_float_float
r_2_2_2_2_2_2_2_2_2_2
UOp(Ops.SINK, dtypes.void, arg=KernelInfo(local_dims=5, upcasted=5, dont_use_locals=False), src=(
  UOp(Ops.STORE, dtypes.void, arg=None, src=(
    UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(128), arg=0, src=()),
    UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(2, 2, 2, 2, 2, 1, 1, 1, 2, 2), strides=(2, 4, 8, 16, 32, 0, 0, 0, 1, 64), offset=0, mask=None, contiguous=False),)), src=()),
    UOp(Ops.UNROLL, dtypes.float, arg=((9, 2), (8, 2)), src=(
      UOp(Ops.WMMA, dtypes.float.vec(4), arg=('WMMA_8_16_8_float_float', (8, 16, 8), dtypes.float, dtypes.float, 'CUDA', 32, (((9, 2), (8, 2)), ((9, 2),), ((9, 2), (8, 2))), (5, 6, 7)), src=(
        UOp(Ops.CONTRACT, dtypes.float.vec(4), arg=((9, 2), (8, 2)), src=(
          UOp(Ops.LOAD, dtypes.float, arg=None, src=(
            UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(128), arg=1, src=()),
            UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), strides=(0, 0, 8, 16, 32, 1, 2, 4, 0, 64), offset=0, mask=None, contiguous=False),)), src=()),)),)),
        UOp(Ops.CONTRACT, dtypes.float.vec(2), arg=((9, 2),), src=(
          UOp(Ops.LOAD, dtypes.float, arg=None, src=(
            UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(64), arg=2, src=()),
            UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), strides=(2, 4, 0, 0, 0, 8, 16, 32, 1, 0), offset=0, mask=None, contiguous=False),)), src=()),)),)),
        UOp(Ops.CONST, dtypes.float.vec(4), arg=0.0, src=()),)),)),)),))
[Opt(op=OptOps.TC, axis=0, amt=0)]

[...]

AssertionError: 
Not equal to tolerance rtol=0.03, atol=0.0001

Mismatched elements: 116 / 128 (90.6%)
Max absolute difference among violations: 2.3470442
Max relative difference among violations: 1.7517731
 ACTUAL: array([[2.176485, 2.176485, 2.176485, 2.176485, 2.176485, 2.176485,
        2.176485, 2.176485],
       [0.830115, 0.830115, 0.830115, 0.830115, 0.830115, 0.830115,...
 DESIRED: array([[0.959163, 1.724498, 2.56779 , 1.680298, 2.10738 , 2.124444,
        2.029053, 2.191531],
       [0.357985, 0.685142, 1.55628 , 0.793698, 1.318517, 1.090871,...
```

While the matmul runs successfully, the assertion error indicates that swizzling has not yet been performed. 
Note, however, that the output does have the correct swizzle; the strides for the local and upcast axes matches the documentation. Local strides are `(2, 4, 8, 16, 32)` and upcast strides are `(1, 64)`. 

We need to configure the ShapeTracker such that each thread is responsible for loading and storing the elements as specified in the documentation. In order to figure out the required swizzle, we are going to focus on the current ShapeTrackers for the buffers:

```python
A => ShapeTracker(views=(View(shape=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), strides=(0, 0, 8, 16, 32, 1, 2, 4, 0, 64), [...])))
B => ShapeTracker(views=(View(shape=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), strides=(2, 4, 0, 0, 0, 8, 16, 32, 1, 0), [...])))
```

Since the matrix multiplication matches the shape of the tensor core in use, all dimensions are either localized, reduced, or upcasted by TC OptOps. This means there are no global dimensions or extra reduce dimensions.

With a thread count of 32 and each local dimension fixed to 2, the resulting shape for locals is `(2, 2, 2, 2, 2)`, as `32 = 2 ** 5`. The product of `M * N = 8 * 16 = 4 * 32` leaves a remainder of 4 that cannot be localized, so it is upcasted, resulting in an upcasted shape of `(2, 2)`.

The reduce dimension `K = 8` is split into `(2, 2, 2)`. this results in shapetrackers having 10 dimensions of size 2.

The shapetracker configuration is as follows: `(locals)(reduce)(upcast) = (2, 2, 2, 2, 2) (2, 2, 2) (2, 2)`

From the docs we get the desired strides for the threads and upcasts.

<img src="https://github.com/user-attachments/assets/66b6b1f2-190a-4576-8b13-fdad9e9998ac" width="512">

In order to get the swizzle permutations, we just need to start from the real strides of the shapetracker and permute to the desired strides for fixing the buffer.


<img src="https://github.com/user-attachments/assets/4cbd7c5d-4164-416a-8424-5383cf372122" width="512">

Now, if we introduce the permutations we get from the figures as the swizzle and run the same test as before, we get the correct result. We can see the shapetrackers have been fixed, getting the desired strides from the figures above.

```python
tensor_cores += [TensorCore(dims=(8,16,8), threads=32, elements_per_thread=(4,2,4), dtype_in=dtypes.float, dtype_out=dtypes.float, opts=("u0","l0","l0","l1","l1","l1","u1"), swizzle=(((5,6,2,3,4),(0,1,8,9,7)), ((5,6,8,0,1),(2,3,4,9,7))))]
```

``` bash
TENSOR CORES [(1, 8, 1)] [(0, 16, 8)] WMMA_8_16_8_float_float
r_2_2_2_2_2_2_2_2_2_2
UOp(Ops.SINK, dtypes.void, arg=KernelInfo(local_dims=5, upcasted=5, dont_use_locals=False), src=(
  UOp(Ops.STORE, dtypes.void, arg=None, src=(
    UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(128), arg=0, src=()),
    UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(2, 2, 2, 2, 2, 1, 1, 1, 2, 2), strides=(2, 4, 8, 16, 32, 0, 0, 0, 1, 64), offset=0, mask=None, contiguous=False),)), src=()),
    UOp(Ops.UNROLL, dtypes.float, arg=((9, 2), (8, 2)), src=(
      UOp(Ops.WMMA, dtypes.float.vec(4), arg=('WMMA_8_16_8_float_float', (8, 16, 8), dtypes.float, dtypes.float, 'CUDA', 32, (((9, 2), (8, 2)), ((9, 2),), ((9, 2), (8, 2))), (5, 6, 7)), src=(
        UOp(Ops.CONTRACT, dtypes.float.vec(4), arg=((9, 2), (8, 2)), src=(
          UOp(Ops.LOAD, dtypes.float, arg=None, src=(
            UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(128), arg=1, src=()),
            UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), strides=(1, 2, 8, 16, 32, 0, 0, 0, 64, 4), offset=0, mask=None, contiguous=False),)), src=()),)),)),
        UOp(Ops.CONTRACT, dtypes.float.vec(2), arg=((9, 2),), src=(
          UOp(Ops.LOAD, dtypes.float, arg=None, src=(
            UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(64), arg=2, src=()),
            UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), strides=(8, 16, 1, 2, 4, 0, 0, 0, 0, 32), offset=0, mask=None, contiguous=False),)), src=()),)),)),
        UOp(Ops.CONST, dtypes.float.vec(4), arg=0.0, src=()),)),)),)),))
[Opt(op=OptOps.TC, axis=0, amt=0)]
*** CUDA      14 r_2_2_2_2_2_2_2_2_2_2                     arg  3 mem  0.00 GB tm     13.31us/     2.23ms (     0.15 GFLOPS    0.1|0.1     GB/s) ['matmul']
opened device CLANG from pid:818029
*** CLANG     15 copy      512,   CLANG <- CUDA            arg  2 mem  0.00 GB tm     93.66us/     2.32ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CLANG     16 copy      256,   CLANG <- CUDA            arg  2 mem  0.00 GB tm     63.75us/     2.39ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CLANG     17 copy      512,   CLANG <- CUDA            arg  2 mem  0.00 GB tm     38.80us/     2.43ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
```

**tf32 kernel**
``` c
#define INFINITY (__int_as_float(0x7f800000))
#define NAN (__int_as_float(0x7fffffff))
__device__ float4 __WMMA_8_16_8_float_float(float4 a, float2 b, float4 c){
  int *a_pk = (int *)(&a), *b_pk = (int *)(&b);
  asm("mma.sync.aligned.m16n8k8.row.col.f32.tf32.tf32.f32"
      "{%0, %1, %2, %3}, {%4, %5, %6, %7},"
      "{%8, %9}, {%0, %1, %2, %3};"
    : "+f"(c.x), "+f"(c.y), "+f"(c.z), "+f"(c.w)
    : "r"(a_pk[0]), "r"(a_pk[1]), "r"(a_pk[2]), "r"(a_pk[3]), "r"(b_pk[0]), "r"(b_pk[1]));
  return c;
}
extern "C" __global__ void __launch_bounds__(32) r_2_2_2_2_2_2_2_2_2_2(float* data0, float* data1, float* data2) {
  int lidx0 = threadIdx.x; /* 8 */
  int lidx1 = threadIdx.y; /* 2 */
  int lidx2 = threadIdx.z; /* 2 */
  int alu0 = (lidx1<<4);
  int alu1 = (lidx2<<5);
  int alu2 = (lidx0>>2);
  int alu3 = (alu2<<3);
  int alu4 = (lidx0&1);
  int alu5 = ((lidx0>>1)&1);
  int alu6 = ((alu5<<1)+alu4+alu3+alu0+alu1);
  float val0 = *(data1+alu6);
  float val1 = *(data1+(alu6+4));
  float val2 = *(data1+(alu6+64));
  float val3 = *(data1+(alu6+68));
  int alu7 = ((alu4<<3)+(alu5<<4)+alu2+(lidx1<<1)+(lidx2<<2));
  float val4 = *(data2+alu7);
  float val5 = *(data2+(alu7+32));
  float4 wmma0 = __WMMA_8_16_8_float_float(make_float4(val0,val2,val1,val3), make_float2(val4,val5), make_float4(0.0f,0.0f,0.0f,0.0f));
  int alu8 = ((alu4<<1)+(alu5<<2)+alu3+alu0+alu1);
  *((float2*)((data0+alu8))) = make_float2(wmma0.x,wmma0.y);
  *((float2*)((data0+(alu8+64)))) = make_float2(wmma0.z,wmma0.w);
}
```