### PR TITLE
simpler helpers.Context [pr]

### DIFF
--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -59,10 +59,14 @@ class TestContextVars(unittest.TestCase):
   def test_nested_context(self):
     with Context(VARIABLE=1):
       with Context(VARIABLE=2):
-        with Context(VARIABLE=3):
+        MORE = ContextVar("MORE", 2)
+        with Context(VARIABLE=3, MORE=3):
           self.assertEqual(VARIABLE.value, 3)
+          self.assertEqual(MORE.value, 3)
         self.assertEqual(VARIABLE.value, 2)
+        self.assertEqual(MORE.value, 2)
       self.assertEqual(VARIABLE.value, 1)
+      self.assertEqual(MORE.value, 2)  # TODO: should this raise?
     self.assertEqual(VARIABLE.value, 0)
 
   def test_decorator(self):

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -77,14 +77,12 @@ def getenv(key:str, default=0): return type(default)(os.getenv(key, default))
 def temp(x:str) -> str: return (pathlib.Path(tempfile.gettempdir()) / x).as_posix()
 
 class Context(contextlib.ContextDecorator):
-  stack: ClassVar[list[dict[str, int]]] = [{}]
   def __init__(self, **kwargs): self.kwargs = kwargs
   def __enter__(self):
-    Context.stack[-1] = {k:o.value for k,o in ContextVar._cache.items()} # Store current state.
-    for k,v in self.kwargs.items(): ContextVar._cache[k].value = v # Update to new temporary state.
-    Context.stack.append(self.kwargs) # Store the temporary state so we know what to undo later.
+    self.old_context:dict[str, int] = {k:v.value for k,v in ContextVar._cache.items()}
+    for k,v in self.kwargs.items(): ContextVar._cache[k].value = v
   def __exit__(self, *args):
-    for k in Context.stack.pop(): ContextVar._cache[k].value = Context.stack[-1].get(k, ContextVar._cache[k].value)
+    for k,v in self.old_context.items(): ContextVar._cache[k].value = v
 
 class ContextVar:
   _cache: ClassVar[dict[str, ContextVar]] = {}


### PR DESCRIPTION
instead of having a class var for whole stack, store the old context in each Context.

also updated a test that ContextVar created in Context is not being cleared after the Context block