### PR TITLE
viz early serialize to json + don't viz rewrites on const [pr]

### DIFF
--- a/test/test_viz.py
+++ b/test/test_viz.py
@@ -15,7 +15,7 @@ def helper_test_viz(sink:UOp, pm:PatternMatcher, **kwargs) -> List[UOp]:
   assert len(contexts[0]) == 1
   k = get_metadata(keys, contexts)[0][0]
   g = get_details(*k)
-  return g.graphs[1:]
+  return g.uops[1:]
 
 class TestViz(unittest.TestCase):
   def setUp(self):


### PR DESCRIPTION
const can have some rewrites (eg. unmasked VIEW(CONST(VIEW)) -> CONST(VIEW+VIEW)) but because it's nodeless, VIZ shouldn't try to highlight anything in the graph.

Currently in master there's this extra square:
![image](https://github.com/user-attachments/assets/20741a60-a3c7-442d-a519-c87186f20c22)

There shouldn't be anything:
![image](https://github.com/user-attachments/assets/afa1415c-f568-4faa-8a66-23c7f715aaf9)
