### PR TITLE
add mod to Tensor

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -559,11 +559,11 @@ class TestOps(unittest.TestCase):
     helper_test_op([()], lambda x: 2/x)
 
   def test_mod(self):
+    helper_test_op(None, lambda x,y: x%y, Tensor.mod, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8], [2, -3, 8, -2, 3, 5]])
+    helper_test_op(None, lambda x,y: x%y, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8], [2, -3, 8, -2, 3, 5]])
     helper_test_op(None, lambda x: x%2, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8]])
     helper_test_op(None, lambda x: x%3, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8]])
     helper_test_op(None, lambda x: 100%x, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8]])
-    # helper_test_op(None, lambda x,y: x%y, Tensor.mod, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8], [2, -3, 8, -2, 3, 5]])
-    # helper_test_op(None, lambda x,y: x%y, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8], [2, -3, 8, -2, 3, 5]])
 
   def test_mul_naninf(self):
     helper_test_op([(45,65)], lambda x: x*math.inf)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -559,11 +559,11 @@ class TestOps(unittest.TestCase):
     helper_test_op([()], lambda x: 2/x)
 
   def test_mod(self):
-    helper_test_op(None, lambda x,y: x%y, Tensor.mod, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8], [2, -3, 8, -2, 3, 5]])
-    helper_test_op(None, lambda x,y: x%y, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8], [2, -3, 8, -2, 3, 5]])
     helper_test_op(None, lambda x: x%2, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8]])
     helper_test_op(None, lambda x: x%3, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8]])
     helper_test_op(None, lambda x: 100%x, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8]])
+    # helper_test_op(None, lambda x,y: x%y, Tensor.mod, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8], [2, -3, 8, -2, 3, 5]])
+    # helper_test_op(None, lambda x,y: x%y, forward_only=True, vals=[[-4, 7, 5, 4, -7, 8], [2, -3, 8, -2, 3, 5]])
 
   def test_mul_naninf(self):
     helper_test_op([(45,65)], lambda x: x*math.inf)

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -521,7 +521,6 @@ def unbind_variable(ctx:ScheduleContext, bind:UOp, st:UOp):
   return UOp.const(bind.dtype, bind).valid(unwrap(st.st))
 
 def load_realized(ctx:ScheduleContext, b:UOp, st:UOp):
-  assert st.size == b.size and unwrap(st.st).contiguous, f"ShapeTracker of realized {b} BUFFER must match the BUFFER size {st}"
   # NOTE: if we're assigning to the BUFFER too, PRELOAD tells toposort to place this load before the ASSIGN
   return UOp(Ops.PRELOAD if b in ctx.assigns else Ops.LOAD, b.dtype.base, (b, unwrap(st.st).to_uop()))
 
@@ -556,14 +555,13 @@ create_ctx = PatternMatcher([(UPat(Ops.VIEW, name="view", src=(UPat(Ops.BUFFER, 
 # **** movement ops
 
 remove_movement_ops = PatternMatcher([
-  (UPat(GroupOp.Movement, name="x"), lambda x: x.base.view(unwrap(x.st))),
+  # NOTE: movement ops are always applied to base
+  (UPat(GroupOp.Movement, name="mov", src=(UPat.any(UPat.var("x").view(), UPat.var("x")))), lambda x,mov: x.view(unwrap(mov.st))),
   # some masked views can collapse to 0, VIEW(x) -> CONST(VIEW)
   (UPat(Ops.VIEW, name="view"),
    lambda view: view.const_like(0) if (vm:=view.st.views[-1].mask) is not None and any((x[1]-x[0]) == 0 for x in vm) else None),
-  # merge one src (unrealized) views
-  # NOTE: we can't merge realized buffer views here, because the buffer is realized before the view
-  (UPat(Ops.VIEW, src=(UPat(Ops.VIEW, src=(UPat.var("x"),), name="v1")), name="v2"),
-   lambda x,v1,v2: v1.replace(arg=v1.arg+v2.arg) if x.op is not Ops.BUFFER else None),
+  # merge one src views.
+  (UPat(Ops.VIEW, src=(UPat(Ops.VIEW, src=(UPat(),), name="v1")), name="v2"), lambda v1,v2: v1.replace(arg=v1.arg+v2.arg)),
   # merge unmasked const views
   (UPat(Ops.VIEW, name="view", src=(UPat(Ops.CONST, name="const", src=(UPat(Ops.VIEW, name="st"),) ),)),
    lambda st,const,view: const.replace(src=(st.replace(arg=st.st+view.st),)) if all(v.mask is None for v in (st.st+view.st).views) else None),

--- a/tinygrad/function.py
+++ b/tinygrad/function.py
@@ -113,9 +113,6 @@ class Mul(Function):
 class IDiv(Function):
   def forward(self, x:UOp, y:UOp) -> UOp: return x // y
 
-class Mod(Function):
-  def forward(self, x:UOp, y:UOp) -> UOp: return x % y
-
 # ************* ternary ops *************
 
 class Where(Function):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -595,7 +595,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
       # SHL/SHR on consts only
       if self.op is Ops.SHL and s1_vmin == s1_vmax and all_int(t:=(s0_vmin, s0_vmax, s1_vmin)): return t[0] << t[2], t[1] << t[2]
       if self.op is Ops.SHR and s1_vmin == s1_vmax and all_int(t:=(s0_vmin, s0_vmax, s1_vmin)): return t[0] >> t[2], t[1] >> t[2]
-      if self.op is Ops.MOD and s1_vmin > 0 and s0_vmin >= 0: return 0, s1_vmax-1
+      if self.op is Ops.MOD and s1_vmin > 0: return 0, s1_vmax-1
       if self.op is Ops.IDIV:
         if s1_vmin == s1_vmax:  # min/max are equal in a CONST
           if s1_vmin > 0: return s0_vmin//s1_vmin, s0_vmax//s1_vmin

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -595,7 +595,8 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
       # SHL/SHR on consts only
       if self.op is Ops.SHL and s1_vmin == s1_vmax and all_int(t:=(s0_vmin, s0_vmax, s1_vmin)): return t[0] << t[2], t[1] << t[2]
       if self.op is Ops.SHR and s1_vmin == s1_vmax and all_int(t:=(s0_vmin, s0_vmax, s1_vmin)): return t[0] >> t[2], t[1] >> t[2]
-      if self.op is Ops.MOD and s1_vmin > 0: return 0, s1_vmax-1
+      # if self.op is Ops.MOD and s1_vmin > 0: return 0, s1_vmax-1
+      if self.op is Ops.MOD and s1_vmin > 0 and (s0_vmin >= 0 or (self.src[1].op is Ops.CONST and self.src[1].arg % 2 == 0)): return 0, s1_vmax-1
       if self.op is Ops.IDIV:
         if s1_vmin == s1_vmax:  # min/max are equal in a CONST
           if s1_vmin > 0: return s0_vmin//s1_vmin, s0_vmax//s1_vmin

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -595,8 +595,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
       # SHL/SHR on consts only
       if self.op is Ops.SHL and s1_vmin == s1_vmax and all_int(t:=(s0_vmin, s0_vmax, s1_vmin)): return t[0] << t[2], t[1] << t[2]
       if self.op is Ops.SHR and s1_vmin == s1_vmax and all_int(t:=(s0_vmin, s0_vmax, s1_vmin)): return t[0] >> t[2], t[1] >> t[2]
-      # if self.op is Ops.MOD and s1_vmin > 0: return 0, s1_vmax-1
-      if self.op is Ops.MOD and s1_vmin > 0 and (s0_vmin >= 0 or (self.src[1].op is Ops.CONST and self.src[1].arg % 2 == 0)): return 0, s1_vmax-1
+      if self.op is Ops.MOD and s1_vmin > 0 and s0_vmin >= 0: return 0, s1_vmax-1
       if self.op is Ops.IDIV:
         if s1_vmin == s1_vmax:  # min/max are equal in a CONST
           if s1_vmin > 0: return s0_vmin//s1_vmin, s0_vmax//s1_vmin

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3140,7 +3140,7 @@ class Tensor(SimpleMathTrait):
     ```
     """
     a, b = self._broadcasted(x, reverse)
-    return (r := F.Mod.apply(a, b)) + b * (((r < 0) & (b > 0)) | ((r > 0) & (b < 0)))
+    return a-b*(a/b).floor().cast(dtypes.int32)
 
   def xor(self, x:Union[Tensor, ConstType], reverse=False) -> Tensor:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3140,8 +3140,7 @@ class Tensor(SimpleMathTrait):
     ```
     """
     a, b = self._broadcasted(x, reverse)
-    r = F.Mod.apply(a, b).contiguous()
-    return r + b * (((r < 0) & (b > 0)) | ((r > 0) & (b < 0)))
+    return (r := F.Mod.apply(a, b)) + b * (((r < 0) & (b > 0)) | ((r > 0) & (b < 0)))
 
   def xor(self, x:Union[Tensor, ConstType], reverse=False) -> Tensor:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3140,7 +3140,7 @@ class Tensor(SimpleMathTrait):
     ```
     """
     a, b = self._broadcasted(x, reverse)
-    return a-b*(a/b).floor().cast(dtypes.int32)
+    return F.Mod.apply(a, b)
 
   def xor(self, x:Union[Tensor, ConstType], reverse=False) -> Tensor:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3140,7 +3140,7 @@ class Tensor(SimpleMathTrait):
     ```
     """
     a, b = self._broadcasted(x, reverse)
-    return (r := F.Mod.apply(a, b)) + b * (((r < 0) & (b > 0)) | ((r > 0) & (b < 0)))
+    return a - b * ((a/b).floor()).cast(a.dtype)
 
   def xor(self, x:Union[Tensor, ConstType], reverse=False) -> Tensor:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3140,7 +3140,8 @@ class Tensor(SimpleMathTrait):
     ```
     """
     a, b = self._broadcasted(x, reverse)
-    return F.Mod.apply(a, b)
+    r = F.Mod.apply(a, b).contiguous()
+    return r + b * (((r < 0) & (b > 0)) | ((r > 0) & (b < 0)))
 
   def xor(self, x:Union[Tensor, ConstType], reverse=False) -> Tensor:
     """


### PR DESCRIPTION
tests passed by splitting the kernel with contiguous 🤔 
I guess some rewrite is rewriting this part `r + b * (((r < 0) & (b > 0)) | ((r > 0) & (b < 0)))` away
gonna stare at this a bit more and maybe practice my VIZ skillz...


  
> possibily can be cleaner with a floor div

something like this without the new `class Mod(Function):`?
```python
def mod(self, x:Union[Tensor, ConstType], reverse=False) -> Tensor:
  a, b = self._broadcasted(x, reverse)
  return a - b * (a/b).floor().cast(self.dtype)
```

or by fixing `def __floordiv__(self, x): return self.idiv(x)  # TODO: idiv is trunc div, not floordiv`?