### PR TITLE
Fix uop.st for CLANG+AMX

### DIFF
--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -592,6 +592,13 @@ class TestShapeSpec(unittest.TestCase):
     r = Tensor.empty(4, 4).sum(axis=1)
     self.assertEqual(r.lazydata.st, ShapeTracker.from_shape((4,)))
 
+  def test_st_wmma_none(self):
+    A = UOp(Ops.DEFINE_VAR, dtypes.float.vec(16), arg=('a', UOp.const(dtypes.float, 0), UOp.const(dtypes.float, 1)))
+    B = UOp(Ops.DEFINE_VAR, dtypes.float.vec(16), arg=('b', UOp.const(dtypes.float, 0), UOp.const(dtypes.float, 2)))
+    C = UOp(Ops.DEFINE_VAR, dtypes.float.vec(16), arg=('c', UOp.const(dtypes.float, 0), UOp.const(dtypes.float, 3)))
+    wmma = UOp(Ops.WMMA, dtypes.float.vec(16), (A, B, C))
+    assert wmma.st is None
+
 class TestUOpChildren(unittest.TestCase):
   def test_children_exist(self):
     a = UOp.variable("weird_name_234", 0, 10)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -288,7 +288,10 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     assert all_same([x.shape for x in src_sts]), f"UOp sources must have the same shape {self} {[x.shape for x in src_sts]}"
     match self.op:
       # only reduce ops are allowed to change shape
-      case Ops.REDUCE_AXIS | Ops.WMMA: shape = src_sts[0].reduce(self.axis_arg)
+      case Ops.REDUCE_AXIS: shape = src_sts[0].reduce(self.axis_arg)
+      case Ops.WMMA:
+        if len(src_sts) == 0: return None
+        shape = src_sts[0].reduce(self.axis_arg)
       # everything else derives shape from sources
       case _:
         if len(src_sts) == 0: return None


### PR DESCRIPTION
```python
# CLANG=1 AMX=1 python fun.py will fail with:
# File "/Users/user/src/tinygrad/tinygrad/ops.py", line 291, in st
#   case Ops.REDUCE_AXIS | Ops.WMMA: shape = src_sts[0].reduce(self.axis_arg)
#                                            ~~~~~~~^^^
# IndexError: list index out of range
from tinygrad import *

x = Tensor.rand(1, 32, 64, 128)
w = Tensor.rand(16,32,1,1)
o = x.conv2d(w).elu()
o.realize()
```
This bug was introduced in https://github.com/tinygrad/tinygrad/pull/8428
In process of rewriting `Ops.EXP2` transcendental calls `bitcast` which calls `can_view` which accesses `.st` which fails because it assumes that all `Ops.REDUCE_AXIS | Ops.WMMA` have at least one src with shapetracker