### PR TITLE
Workaround for #8457: make RewriteContext rewrite() iterative to avoid Python stack limit

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -892,6 +892,8 @@ class RewriteContext:
     stack: list[tuple[UOp, list[UOp], bool]] = [(n, [], False)] # n, map result, returning from recursive call
     ret: Optional[UOp] = None
     while stack:
+      if len(stack) > 10000:
+        raise RecursionError("rewrite depth exceeded")
       n, results, returning = stack[-1]
       if len(results) < len(n.src):
         if (result := ret if returning else self.replace.get(n.src[len(results)])) is not None:


### PR DESCRIPTION
On my 24.04 LTS system, Ubuntu installs Python 3.12.3-0ubuntu2. This seems to run into an unclear bug (#8457) where the SDXL demo busts the Python stack limit, even though `setrecursionlimit` is set high. It doesn't seem to be the 3.12 bug/change where C calls have their own limit either, because there's no C calls corecursing in the backtrace. I'm confused; but just in case, here's a rewrite of the relevant class that makes the recursion explicit so Python can't complain. With this, the SDXL demo works again on my system.

Is it a good idea to merge this? Eeeeehhhhhhhhhhhhhhhh. It is very ugly code. At least I should probably check if it's fixed on a newer Python; if it's just a matter of waiting... then again, it's unclear how long Ubuntu 24 LTS is gonna be on this version.