### PR TITLE
pickle ContextVars in process replay [pr]

### DIFF
--- a/test/external/process_replay/helpers.py
+++ b/test/external/process_replay/helpers.py
@@ -14,4 +14,4 @@ def get_process_replay_ctx() -> Tuple[ProcessReplayContext, Dict]:
   loc = "\n".join(traceback.format_list(stack))
   try: head_sha = subprocess.check_output(["git", "rev-parse", "HEAD"]).strip().decode()
   except Exception: head_sha = ""
-  return ProcessReplayContext(loc, head_sha, getenv("GITHUB_RUN_ID") or None), {k:v.value for k,v in ContextVar._cache.items()}
+  return ProcessReplayContext(loc, head_sha, getenv("GITHUB_RUN_ID") or None), ContextVar._cache

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -60,7 +60,7 @@ def diff(offset:int, name:str, fxn:Callable) -> Union[Tuple[int, int], bool]:
       continue
     # try recreate
     try:
-      with Context(**{k:v for k,v in args[-2].items() if k in ContextVar._cache and k != "DEBUG"}): good = fxn(*args[:-2])
+      with Context(**{k:v.value for k,v in args[-2].items() if k in ContextVar._cache and k != "DEBUG"}): good = fxn(*args[:-2])
       if good is None: continue
     except Exception as e:
       changed += 1

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -1,7 +1,7 @@
 import unittest, pickle, types
 import numpy as np
 from tinygrad import Tensor, TinyJit, Variable, dtypes
-from tinygrad.helpers import GlobalCounters
+from tinygrad.helpers import GlobalCounters, ContextVar
 from tinygrad.ops import PatternMatcher, UPat, UOp
 
 class TestPickle(unittest.TestCase):
@@ -94,6 +94,15 @@ class TestPickle(unittest.TestCase):
     print("post jit")
     out = add_fxn(x, y)
     np.testing.assert_equal(out.numpy(), 102)
+
+  def test_pickle_context_var(self):
+    v = ContextVar("a", 0)
+    v.value = 1
+    vs = pickle.dumps(v)
+    v.value = 2
+    v2 = pickle.loads(vs)
+    self.assertEqual(v2.value, 1)
+    self.assertEqual(v.value, 2)
 
   def test_pickle_schedule(self):
     a = Tensor([1,2])

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -1,7 +1,7 @@
 import unittest, pickle, types
 import numpy as np
 from tinygrad import Tensor, TinyJit, Variable, dtypes
-from tinygrad.helpers import GlobalCounters, ContextVar
+from tinygrad.helpers import GlobalCounters, ContextVar, Context
 from tinygrad.ops import PatternMatcher, UPat, UOp
 
 class TestPickle(unittest.TestCase):
@@ -96,13 +96,11 @@ class TestPickle(unittest.TestCase):
     np.testing.assert_equal(out.numpy(), 102)
 
   def test_pickle_context_var(self):
-    v = ContextVar("a", 0)
-    v.value = 1
-    vs = pickle.dumps(v)
-    v.value = 2
+    v = ContextVar("test_var", 0)
+    with Context(test_var=1):
+      vs = pickle.dumps(v)
     v2 = pickle.loads(vs)
     self.assertEqual(v2.value, 1)
-    self.assertEqual(v.value, 2)
 
   def test_pickle_schedule(self):
     a = Tensor([1,2])

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -281,8 +281,7 @@ def schedule_uop(pre:UOp, ctx:ScheduleContext) -> ScheduleItem:
   for buf_uop in si_ctx.sinked:
     for luop in si_ctx.tensor_uops[buf_uop]: luop.become(buf_uop.view(unwrap(luop.st)))
   # capture process replay
-  if getenv("RUN_PROCESS_REPLAY"):
-    PROCESS_REPLAY_CAPTURE[str(pre.key)] = pickle.dumps((pre, si_ctx.assigns, {k:v.value for k,v in ContextVar._cache.items()}, sink))
+  if getenv("RUN_PROCESS_REPLAY"): PROCESS_REPLAY_CAPTURE[str(pre.key)] = pickle.dumps((pre, si_ctx.assigns, ContextVar._cache, sink))
   return ScheduleItem(sink, tuple(u.buffer for u in si_ctx.bufs if u.size != 0), tuple(si_ctx.metadata),
                       tuple(ubuf for ubuf,ops in si_ctx.assign_adj.items() if any(x.op is Ops.PRELOAD for x in ops)))
 


### PR DESCRIPTION
I remember when I tried to do this before it raised errors, now the context can actually be pickled.