### PR TITLE
Share a _resolve_pool_pads function for pool ops in Tensor

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1852,8 +1852,10 @@ class TestOps(unittest.TestCase):
       helper_test_op([(2,4,9,9), (4,4,3,3)],
         lambda x,w: torch.nn.functional.conv_transpose2d(x,w,padding=padding).relu(),
         lambda x,w: Tensor.conv_transpose2d(x,w,padding=padding).relu(), grad_rtol=1e-5)
-    with self.assertRaises(ValueError): Tensor.conv_transpose2d(Tensor.randn((2,16,2,2)), Tensor.randn((32,16,3,3)), padding=(1,1,1))
-    with self.assertRaises(ValueError): Tensor.conv_transpose2d(Tensor.randn((2,16,2,2)), Tensor.randn((32,16,3,3)), padding=(0,1,0,1))
+    self.helper_test_exception([(2,16,2,2), (32,16,3,3)], lambda x,w: torch.nn.functional.conv_transpose2d(x,w,padding=(1,1,1)),
+                   lambda x,w: Tensor.conv_transpose2d(x,w,padding=(1,1,1)), expected=(RuntimeError, ValueError))
+    self.helper_test_exception([(2,16,2,2), (32,16,3,3)], lambda x,w: torch.nn.functional.conv_transpose2d(x,w,padding=(0,1,0,1)),
+                   lambda x,w: Tensor.conv_transpose2d(x,w,padding=(0,1,0,1)), expected=(RuntimeError, ValueError))
 
   def test_dilated_conv_transpose2d(self):
     for dilation in [(1,2), (2,1), 2, 1]:
@@ -1939,7 +1941,8 @@ class TestOps(unittest.TestCase):
     # regression test for https://github.com/tinygrad/tinygrad/pull/7549/
     self.helper_test_exception([(2,16,2,2), (32,16,3,3)], lambda x,w:torch.nn.functional.conv2d(x,w), lambda x,w: Tensor.conv2d(x,w),
                                expected=(RuntimeError, AssertionError))
-    with self.assertRaises(ValueError): Tensor.conv2d(Tensor.randn((2,16,2,2)), Tensor.randn((32,16,3,3)), padding=(1,1,1))
+    self.helper_test_exception([(2,16,2,2), (32,16,3,3)], lambda x,w:torch.nn.functional.conv2d(x,w,padding=(1,1,1)),
+                               lambda x,w: Tensor.conv2d(x,w,padding=(1,1,1)), expected=(RuntimeError, ValueError))
 
   def test_large_input_conv2d(self):
     bs = 4
@@ -2102,8 +2105,10 @@ class TestOps(unittest.TestCase):
         helper_test_op([(32,2,110,28)],
           lambda x: torch.nn.functional.max_pool2d(x, kernel_size=ksz, padding=1),
           lambda x: Tensor.max_pool2d(x, kernel_size=ksz, padding=1))
-    with self.assertRaises(ValueError): Tensor.max_pool2d(Tensor.randn((32,2,110,28)), kernel_size=(2,2), padding=(1,1,1))
-    with self.assertRaises(ValueError): Tensor.max_pool2d(Tensor.randn((32,2,110,28)), kernel_size=(2,2), padding=(0,1,0,1))
+    self.helper_test_exception([(32,2,110,28)], lambda x: torch.nn.functional.max_pool2d(x, kernel_size=(2,2), padding=(1,1,1)),
+                   lambda x: Tensor.max_pool2d(x, kernel_size=(2,2), padding=(1,1,1)), expected=(RuntimeError, ValueError))
+    self.helper_test_exception([(32,2,110,28)], lambda x: torch.nn.functional.max_pool2d(x, kernel_size=(2,2), padding=(0,1,0,1)),
+                   lambda x: Tensor.max_pool2d(x, kernel_size=(2,2), padding=(0,1,0,1)), expected=(RuntimeError, ValueError))
 
   def test_max_pool2d_padding_int(self):
     ksz = (2,2)
@@ -2178,8 +2183,10 @@ class TestOps(unittest.TestCase):
         helper_test_op([shape],
           lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=ksz, padding=1),
           lambda x: Tensor.avg_pool2d(x, kernel_size=ksz, padding=1), rtol=1e-5)
-    with self.assertRaises(ValueError): Tensor.avg_pool2d(Tensor.randn((32,2,111,28)), kernel_size=(2,2), padding=(1,1,1))
-    with self.assertRaises(ValueError): Tensor.max_pool2d(Tensor.randn((32,2,110,28)), kernel_size=(2,2), padding=(0,1,0,1))
+    self.helper_test_exception([shape], lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=(2,2), padding=(1,1,1)),
+                               lambda x: Tensor.avg_pool2d(x, kernel_size=(2,2), padding=(1,1,1)), expected=(RuntimeError, ValueError))
+    self.helper_test_exception([shape], lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=(2,2), padding=(0,1,0,1)),
+                               lambda x: Tensor.avg_pool2d(x, kernel_size=(2,2), padding=(0,1,0,1)), expected=(RuntimeError, ValueError))
 
   def test_avg_pool2d_padding_not_counted(self):
     shape = (32,2,111,28)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1852,6 +1852,8 @@ class TestOps(unittest.TestCase):
       helper_test_op([(2,4,9,9), (4,4,3,3)],
         lambda x,w: torch.nn.functional.conv_transpose2d(x,w,padding=padding).relu(),
         lambda x,w: Tensor.conv_transpose2d(x,w,padding=padding).relu(), grad_rtol=1e-5)
+    with self.assertRaises(ValueError): Tensor.conv_transpose2d(Tensor.randn((2,16,2,2)), Tensor.randn((32,16,3,3)), padding=(1,1,1))
+    with self.assertRaises(ValueError): Tensor.conv_transpose2d(Tensor.randn((2,16,2,2)), Tensor.randn((32,16,3,3)), padding=(0,1,0,1))
 
   def test_dilated_conv_transpose2d(self):
     for dilation in [(1,2), (2,1), 2, 1]:
@@ -1937,6 +1939,7 @@ class TestOps(unittest.TestCase):
     # regression test for https://github.com/tinygrad/tinygrad/pull/7549/
     self.helper_test_exception([(2,16,2,2), (32,16,3,3)], lambda x,w:torch.nn.functional.conv2d(x,w), lambda x,w: Tensor.conv2d(x,w),
                                expected=(RuntimeError, AssertionError))
+    with self.assertRaises(ValueError): Tensor.conv2d(Tensor.randn((2,16,2,2)), Tensor.randn((32,16,3,3)), padding=(1,1,1))
 
   def test_large_input_conv2d(self):
     bs = 4
@@ -2099,6 +2102,8 @@ class TestOps(unittest.TestCase):
         helper_test_op([(32,2,110,28)],
           lambda x: torch.nn.functional.max_pool2d(x, kernel_size=ksz, padding=1),
           lambda x: Tensor.max_pool2d(x, kernel_size=ksz, padding=1))
+    with self.assertRaises(ValueError): Tensor.max_pool2d(Tensor.randn((32,2,110,28)), kernel_size=(2,2), padding=(1,1,1))
+    with self.assertRaises(ValueError): Tensor.max_pool2d(Tensor.randn((32,2,110,28)), kernel_size=(2,2), padding=(0,1,0,1))
 
   def test_max_pool2d_padding_int(self):
     ksz = (2,2)
@@ -2173,6 +2178,8 @@ class TestOps(unittest.TestCase):
         helper_test_op([shape],
           lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=ksz, padding=1),
           lambda x: Tensor.avg_pool2d(x, kernel_size=ksz, padding=1), rtol=1e-5)
+    with self.assertRaises(ValueError): Tensor.avg_pool2d(Tensor.randn((32,2,111,28)), kernel_size=(2,2), padding=(1,1,1))
+    with self.assertRaises(ValueError): Tensor.max_pool2d(Tensor.randn((32,2,110,28)), kernel_size=(2,2), padding=(0,1,0,1))
 
   def test_avg_pool2d_padding_not_counted(self):
     shape = (32,2,111,28)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2070,7 +2070,7 @@ class Tensor(SimpleMathTrait):
   def _resolve_pool_pads(self, padding:Union[int, Sequence[int]], dims:int, allow_asymmetric:bool=True) -> Sequence[int]:
     if not isinstance(padding, int) and not (len(padding) == 2*dims or len(padding) == dims):
       raise ValueError(f"Padding must be an int or a sequence of length {dims} or {2*dims}, but got {padding=} for {self.shape=} with {dims=}.")
-    if not allow_asymmetric and not (isinstance(padding, int) or len(padding) == dims): raise ValueError("Only supports per-dimension padding")
+    if not allow_asymmetric and not (isinstance(padding, int) or len(padding) == dims): raise ValueError("Only per-dimension padding is supported.")
     return [padding]*2*dims if isinstance(padding, int) else (padding if len(padding) == 2*dims else [p for p in padding for _ in range(2)][::-1])
 
   def _apply_ceil_mode(self, pads:Sequence[int], k_:Tuple[sint, ...], s_:Union[Tuple[int, ...], int], d_:Union[Tuple[int, ...], int]) -> List[int]:
@@ -2224,7 +2224,7 @@ class Tensor(SimpleMathTrait):
     """
     x, w = self, weight.unflatten(0, (groups, -1)).transpose(1, 2).flip(*range(3, len(weight.shape)+1))
     HW = weight.shape[2:]
-    if not (isinstance(padding, int) or len(padding) == len(HW)): raise ValueError("Only supports per-dimension padding.")
+    if not (isinstance(padding, int) or len(padding) == len(HW)): raise ValueError("Only per-dimension padding is supported.")
     stride, dilation, padding, output_padding = [make_tuple(x, len(HW)) for x in (stride, dilation, padding, output_padding)]
     if any(s>1 for s in stride):
       # handle strides: (k) -> reshape -> (k,1) -> pad -> (k,s) -> reshape -> (k*s) -> shrink (k-(s-1))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2067,20 +2067,22 @@ class Tensor(SimpleMathTrait):
     x = x.shrink(tuple(noop + flatten(((0,o), (0,k)) for o,k in zip(o_,k_))))
     return x.permute(*range(len(noop)), *[len(noop)+i*2 for i in range(len(i_))], *[len(noop)+i*2+1 for i in range(len(i_))])
 
-  def _padding2d(self, padding:Union[int, Sequence[int]], dims:int) -> Sequence[int]:
+  def _resolve_pool_pads(self, padding:Union[int, Sequence[int]], dims:int, allow_asymmetric:bool=True) -> Sequence[int]:
+    if not isinstance(padding, int) and not (len(padding) == 2*dims or len(padding) == dims):
+      raise ValueError(f"Padding must be an int or a sequence of length {dims} or {2*dims}, but got {padding=} for {self.shape=} with {dims=}.")
+    if not allow_asymmetric and not (isinstance(padding, int) or len(padding) == dims): raise ValueError("Only supports per-dimension padding")
     return [padding]*2*dims if isinstance(padding, int) else (padding if len(padding) == 2*dims else [p for p in padding for _ in range(2)][::-1])
 
-  def _ceil_mode_padding2d(self,k_:tuple[sint, ...], s_:Union[tuple[int, ...], int], d_:Union[tuple[int, ...], int],
-                           p_:Union[tuple[int, ...], int]) -> Sequence[int]:
-    (d_,s_,p_), i_ = (make_tuple(x, len(k_)) for x in (d_,s_,p_)), self.shape[-len(k_):]
+  def _apply_ceil_mode(self, pads:Sequence[int], k_:Tuple[sint, ...], s_:Union[Tuple[int, ...], int], d_:Union[Tuple[int, ...], int]) -> List[int]:
+    pads = list(pads) # make a copy and ensure it's mutable
+    (d_,s_), i_ = (make_tuple(x, len(k_)) for x in (d_,s_)), self.shape[-len(k_):]
     # https://arxiv.org/pdf/1603.07285 section 5.1, relationship 15.
-    o_ = [ceildiv(i+2*p - (d*(k-1)+1), s) + 1 for i,d,k,s,p in zip(i_,d_,k_,s_,p_)]
-    pads = list(self._padding2d(p_, len(k_)))
+    o_ = [ceildiv(i+2*p - (d*(k-1)+1), s) + 1 for i,d,k,s,p in zip(i_,d_,k_,s_,pads)]
     # we have to do additional padding before `_pool` so that `o_` in `_pool` is calculated correctly
     # `s*(o-1) + (d*(k-1)+1) - (i+2*p)` -> last_sliding_window_start + full_kernel_size - padded_input_shape
     # we decrease padding in the case that a sliding window starts in the end padded region, thereby decreasing `o_` in `_pool`
     # `smax(s*(o-1) - (p+i-1), 0)` -> last_sliding_window_start - (left_pad + input_size - zero_offset)
-    for dim,(o,i,s,p,k,d) in enumerate(zip(o_,i_,s_,p_,k_,d_)): pads[-1-dim*2] += s*(o-1) + (d*(k-1)+1) - (i+2*p) - smax(s*(o-1) - (p+i-1), 0)
+    for dim,(o,i,s,k,d,p) in enumerate(zip(o_,i_,s_,k_,d_,pads)): pads[-1-dim*2] += s*(o-1) + (d*(k-1)+1) - (i+2*p) - smax(s*(o-1) - (p+i-1), 0)
     return pads
 
   # NOTE: these work for more than 2D
@@ -2110,8 +2112,9 @@ class Tensor(SimpleMathTrait):
     ```
     """
     axis = tuple(range(-len(k_ := make_tuple(kernel_size, 2)), 0))
-    reg_pads, ceil_pads = self._padding2d(padding,len(k_)), self._ceil_mode_padding2d(k_, stride if stride is not None else k_, dilation, padding)
     def pool(x:Tensor, padding_:Sequence[int]) -> Tensor: return x.pad(padding_)._pool(k_, stride if stride is not None else k_, dilation)
+    reg_pads = self._resolve_pool_pads(padding, len(k_), allow_asymmetric=False)
+    ceil_pads = self._apply_ceil_mode(reg_pads, k_, stride if stride is not None else k_, dilation)
     if not count_include_pad:
       pads = ceil_pads if ceil_mode else reg_pads
       return pool(self, pads).sum(axis) / pool(self.ones_like(), pads).sum(axis)
@@ -2139,8 +2142,8 @@ class Tensor(SimpleMathTrait):
     print(t.max_pool2d(padding=1).numpy())
     ```
     """
-    k_ = make_tuple(kernel_size, 2)
-    pads = self._ceil_mode_padding2d(k_, stride if stride is not None else k_, dilation, padding) if ceil_mode else self._padding2d(padding, len(k_))
+    pads = self._resolve_pool_pads(padding, len(k_ := make_tuple(kernel_size, 2)), allow_asymmetric=False)
+    if ceil_mode: pads = self._apply_ceil_mode(pads, k_, stride if stride is not None else k_, dilation)
     return self.pad(pads, value=dtypes.min(self.dtype))._pool(k_, stride if stride is not None else k_, dilation).max(tuple(range(-len(k_), 0)))
 
   def conv2d(self, weight:Tensor, bias:Optional[Tensor]=None, groups=1, stride=1, dilation=1, padding:int|tuple[int, ...]=0,
@@ -2160,9 +2163,8 @@ class Tensor(SimpleMathTrait):
     """
     if IMAGE: return self.image_conv2d(weight, bias, groups, stride, dilation, padding, acc_dtype)
     (bs,cin_), (cout,cin), HW = self.shape[:2], weight.shape[:2], weight.shape[2:]
+    padding_ = self._resolve_pool_pads(padding, len(HW))
     assert groups*cin == cin_ and len(self.shape) == len(weight.shape), f"Input Tensor shape {self.shape} does not match the shape of the weights {weight.shape}. ({groups*cin} vs. {cin_})"  # noqa: E501
-    if isinstance(padding, (tuple,list)): assert len(padding) == 2*len(HW) or len(padding) == len(HW), f"Expected padding of length {2*len(HW)} or {len(HW)}, but got {len(padding)} for tensor of shape {self.shape}"  # noqa: E501
-    padding_ = self._padding2d(padding, len(HW))
 
     # conv2d is a pooling op (with padding)
     x = self.pad(padding_)._pool(HW, stride, dilation)   # (bs, groups*cin, oy, ox, H, W)
@@ -2222,6 +2224,7 @@ class Tensor(SimpleMathTrait):
     """
     x, w = self, weight.unflatten(0, (groups, -1)).transpose(1, 2).flip(*range(3, len(weight.shape)+1))
     HW = weight.shape[2:]
+    if not (isinstance(padding, int) or len(padding) == len(HW)): raise ValueError("Only supports per-dimension padding.")
     stride, dilation, padding, output_padding = [make_tuple(x, len(HW)) for x in (stride, dilation, padding, output_padding)]
     if any(s>1 for s in stride):
       # handle strides: (k) -> reshape -> (k,1) -> pad -> (k,s) -> reshape -> (k*s) -> shrink (k-(s-1))
@@ -3876,7 +3879,7 @@ class Tensor(SimpleMathTrait):
     else: w = w.reshape(cout//4, H, rcin_hi, W, rcin_lo, 4).permute(0,1,2,3,5,4)
 
     # prepare input
-    x = x.permute(0,3,4,5,1,2).pad(self._padding2d(padding, 2))._pool((H, W), stride, dilation) # -> (bs, groups, rcin_hi, rcin_lo, oy, ox, H, W)
+    x = x.permute(0,3,4,5,1,2).pad(self._resolve_pool_pads(padding,2))._pool((H,W), stride, dilation)# -> (bs, groups, rcin_hi, rcin_lo, oy, ox, H, W)
     x = x.permute(0,4,5,1,2,3,6,7).reshape(bs, (oy := x.shape[4]), (ox := x.shape[5]), *cout_expand[0:2], 1, 1, rcin_hi, rcin_lo, H, W)
 
     # prepare weights

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2066,10 +2066,10 @@ class Tensor(SimpleMathTrait):
     return x.permute(*range(len(noop)), *[len(noop)+i*2 for i in range(len(i_))], *[len(noop)+i*2+1 for i in range(len(i_))])
 
   def _resolve_pool_pads(self, padding:Union[int, Sequence[int]], dims:int, allow_asymmetric:bool=True) -> Sequence[int]:
-    if not isinstance(padding, int) and not (len(padding) == 2*dims or len(padding) == dims):
-      raise ValueError(f"Padding must be an int or a sequence of length {dims} or {2*dims}, but got {padding=} for {self.shape=} with {dims=}.")
     if not allow_asymmetric and not (isinstance(padding, int) or len(padding) == dims):
       raise ValueError(f"Padding must be an int or a sequence of length {dims}.")
+    if not isinstance(padding, int) and not (len(padding) == 2*dims or len(padding) == dims):
+      raise ValueError(f"Padding must be an int or a sequence of length {dims} or {2*dims}, but got {padding=} for {self.shape=} with {dims=}.")
     return [padding]*2*dims if isinstance(padding, int) else (padding if len(padding) == 2*dims else [p for p in padding for _ in range(2)][::-1])
 
   def _apply_ceil_mode(self, pads:Sequence[int], k_:Tuple[sint, ...], s_:Union[Tuple[int, ...], int], d_:Union[Tuple[int, ...], int]) -> List[int]:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2068,7 +2068,8 @@ class Tensor(SimpleMathTrait):
   def _resolve_pool_pads(self, padding:Union[int, Sequence[int]], dims:int, allow_asymmetric:bool=True) -> Sequence[int]:
     if not isinstance(padding, int) and not (len(padding) == 2*dims or len(padding) == dims):
       raise ValueError(f"Padding must be an int or a sequence of length {dims} or {2*dims}, but got {padding=} for {self.shape=} with {dims=}.")
-    if not allow_asymmetric and not (isinstance(padding, int) or len(padding) == dims): raise ValueError("Only per-dimension padding is supported.")
+    if not allow_asymmetric and not (isinstance(padding, int) or len(padding) == dims):
+      raise ValueError(f"Padding must be an int or a sequence of length {dims}.")
     return [padding]*2*dims if isinstance(padding, int) else (padding if len(padding) == 2*dims else [p for p in padding for _ in range(2)][::-1])
 
   def _apply_ceil_mode(self, pads:Sequence[int], k_:Tuple[sint, ...], s_:Union[Tuple[int, ...], int], d_:Union[Tuple[int, ...], int]) -> List[int]:
@@ -2222,7 +2223,7 @@ class Tensor(SimpleMathTrait):
     """
     x, w = self, weight.unflatten(0, (groups, -1)).transpose(1, 2).flip(*range(3, len(weight.shape)+1))
     HW = weight.shape[2:]
-    if not (isinstance(padding, int) or len(padding) == len(HW)): raise ValueError("Only per-dimension padding is supported.")
+    if not (isinstance(padding, int) or len(padding) == len(HW)): raise ValueError(f"Padding must be an int or a sequence of length {len(HW)}.")
     stride, dilation, padding, output_padding = [make_tuple(x, len(HW)) for x in (stride, dilation, padding, output_padding)]
     if any(s>1 for s in stride):
       # handle strides: (k) -> reshape -> (k,1) -> pad -> (k,s) -> reshape -> (k*s) -> shrink (k-(s-1))


### PR DESCRIPTION
from #8109 
basically `_padding2d -> _resolve_pool_pads` and use it for all pool functions.
This also acts as an extra layer of protection over pool padding.

There were times where x.avg_pool(..., padding=[0,1,0,1]) was running and accidentally passing tests in onnx when asymmetric pads wasn't even supported. (e.g. [0,1,0,1] was zip-ed as [0,1] in calculations) 

so _resolve_pool_pads must run at the start of a pool op to ensure padding correctness.

`conv_transpose2d` can use this function when we actually support asymmetric padding.