### PR TITLE
move llvm_bf16_cast to the renderer [pr]

### DIFF
--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -75,7 +75,8 @@ llvm_rewrite = PatternMatcher([
 
 def llvm_bf16_cast(buf:UOp, idx:UOp, root:UOp):
   new_buf = buf.replace(dtype=dtypes.ushort.ptr(size=cast(PtrDType,buf.dtype).size))
-  return UOp(Ops.LOAD, dtypes.ushort, (UOp(Ops.INDEX, new_buf.dtype, (new_buf, idx)),)).cast(dtypes.uint).mul(1<<16).bitcast(dtypes.float32).cast(root.dtype)
+  ld = UOp(Ops.LOAD, dtypes.ushort, (UOp(Ops.INDEX, new_buf.dtype, (new_buf, idx)),))
+  return ld.cast(dtypes.uint).mul(1<<16).bitcast(dtypes.float32).cast(root.dtype)
 
 class LLVMRenderer(Renderer):
   device = "LLVM"

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -73,6 +73,10 @@ llvm_rewrite = PatternMatcher([
   (UPat(Ops.ENDIF, name="x"), lambda ctx,x: f"  br label %ifskip_{ctx[x.src[0]][1:]}\nifskip_{ctx[x.src[0]][1:]}:"),
 ])
 
+def llvm_bf16_cast(buf:UOp, idx:UOp):
+  new_buf = buf.replace(dtype=dtypes.ushort.ptr(size=cast(PtrDType,buf.dtype).size))
+  return UOp(Ops.LOAD, dtypes.ushort, (UOp(Ops.INDEX, new_buf.dtype, (new_buf, idx)),)).cast(dtypes.uint).mul(1<<16).bitcast(dtypes.float32)
+
 class LLVMRenderer(Renderer):
   device = "LLVM"
   supports_float4 = False
@@ -87,6 +91,8 @@ class LLVMRenderer(Renderer):
     (UPat(Ops.CAST, dtype=dtypes.bool, name="x"), lambda x: x.src[0] != x.src[0].const_like(0)),
     # rewrite MAX to CMPLT + WHERE
     (UPat(Ops.MAX, name="m"), lambda m: (m.src[0] < m.src[1]).where(m.src[1], m.src[0])),
+    # rewrite bf16 LOAD hack
+    (UPat(Ops.CAST, dtype=dtypes.float, src=(UPat.load(UPat.index(UPat.var("buf"), UPat.var("idx")), dtype=dtypes.bfloat16),)), llvm_bf16_cast),
   ])
 
   def render(self, name: str, uops: list[UOp]) -> str:

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -74,9 +74,8 @@ llvm_rewrite = PatternMatcher([
 ])
 
 def llvm_bf16_cast(buf:UOp, idx:UOp, root:UOp):
-  new_buf = buf.replace(dtype=dtypes.ushort.ptr(size=cast(PtrDType,buf.dtype).size))
-  ld = UOp(Ops.LOAD, dtypes.ushort, (UOp(Ops.INDEX, new_buf.dtype, (new_buf, idx)),))
-  return ld.cast(dtypes.uint).mul(1<<16).bitcast(dtypes.float32).cast(root.dtype)
+  u16_buf = buf.replace(dtype=dtypes.ushort.ptr(size=cast(PtrDType,buf.dtype).size))
+  return UOp.load(UOp.index(u16_buf, idx), dtype=dtypes.ushort).cast(dtypes.uint).mul(1<<16).bitcast(dtypes.float32).cast(root.dtype)
 
 class LLVMRenderer(Renderer):
   device = "LLVM"

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3710,7 +3710,6 @@ class Tensor(SimpleMathTrait):
     # hack for devices that don't support bfloat16
     assert self.dtype == dtypes.bfloat16
     return self.to("LLVM").cast(dtype)
-    #return self.to("LLVM").bitcast(dtypes.uint16).cast(dtypes.uint32).mul(1<<16).bitcast(dtypes.float32).cast(dtype)
 
   def cast(self, dtype:DTypeLike) -> Tensor:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3709,7 +3709,8 @@ class Tensor(SimpleMathTrait):
   def llvm_bf16_cast(self, dtype:DTypeLike):
     # hack for devices that don't support bfloat16
     assert self.dtype == dtypes.bfloat16
-    return self.to("LLVM").bitcast(dtypes.uint16).cast(dtypes.uint32).mul(1<<16).bitcast(dtypes.float32).cast(dtype)
+    return self.to("LLVM").cast(dtype)
+    #return self.to("LLVM").bitcast(dtypes.uint16).cast(dtypes.uint32).mul(1<<16).bitcast(dtypes.float32).cast(dtype)
 
   def cast(self, dtype:DTypeLike) -> Tensor:
     """


### PR DESCRIPTION
`def llvm_bf16_cast` can be deleted from tensor.py after this. Is there any reason not to put this in all renderers?
This is currently blocking https://github.com/tinygrad/tinygrad/pull/8473.