### PR TITLE
Remove unused R_AARCH64_CALL26 relocation

### DIFF
--- a/tinygrad/runtime/support/elf.py
+++ b/tinygrad/runtime/support/elf.py
@@ -46,7 +46,6 @@ def relocate(instr: int, ploc: int, tgt: int, r_type: int):
       rel_pg = (tgt & ~0xFFF) - (ploc & ~0xFFF)
       return instr | (getbits(rel_pg, 12, 13) << 29) | (getbits(rel_pg, 14, 32) << 5)
     case libc.R_AARCH64_ADD_ABS_LO12_NC: return instr | (getbits(tgt, 0, 11) << 10)
-    case libc.R_AARCH64_CALL26: return instr | getbits(tgt, 2, 27)
     case libc.R_AARCH64_LDST16_ABS_LO12_NC: return instr | (getbits(tgt, 1, 11) << 10)
     case libc.R_AARCH64_LDST32_ABS_LO12_NC: return instr | (getbits(tgt, 2, 11) << 10)
     case libc.R_AARCH64_LDST64_ABS_LO12_NC: return instr | (getbits(tgt, 3, 11) << 10)


### PR DESCRIPTION
First iteration of the AMX fix was using symbol lookup + trampoline approach which required this, however later i replaced it by marking amx function `static` and assumed that relocation was still used when callee wasn't inlined, however this turned out not to be the case because the callee can't be moved around by linker at link-time and can't be overloaded by other symbols (`static` means priority + local visibility)

Example of this behaviour if my explanation isn't good:
```c
int something;

static __attribute__((noinline)) int callee() {
  return something;
}

int caller() {
  return callee() * 2;
}
```
See how bl is already with offset but adrp+ldr don't have offsets yet because linker can move `int something` but can't `static int callee()`
```
test.o:	file format elf64-littleaarch64

Disassembly of section .text:

0000000000000000 <caller>:
       0: a9bf7bfd     	stp	x29, x30, [sp, #-0x10]!
       4: 910003fd     	mov	x29, sp
       8: 94000004     	bl	0x18 <callee>
       c: 531f7800     	lsl	w0, w0, #1
      10: a8c17bfd     	ldp	x29, x30, [sp], #0x10
      14: d65f03c0     	ret

0000000000000018 <callee>:
      18: 90000008     	adrp	x8, 0x0 <caller>
      1c: f9400108     	ldr	x8, [x8]
      20: b9400100     	ldr	w0, [x8]
      24: d65f03c0     	ret
```
Here relocations for `int something` exist but no relocations for `static int callee()`
```
test.o:	file format elf64-littleaarch64

RELOCATION RECORDS FOR [.text]:
OFFSET           TYPE                     VALUE
0000000000000018 R_AARCH64_ADR_GOT_PAGE   something
000000000000001c R_AARCH64_LD64_GOT_LO12_NC something
```