### PR TITLE
test fixup prereqs for delete_buffer_view [pr]

### DIFF
--- a/docs/abstractions3.py
+++ b/docs/abstractions3.py
@@ -48,7 +48,7 @@ for si in schedule: print(str(si)[:80])
 # 4. Lower a schedule.
 
 from tinygrad.engine.realize import lower_schedule_item, ExecItem
-lowered: List[ExecItem] = [ExecItem(lower_schedule_item(si).prg, list(si.bufs)) for si in tqdm(schedule)]
+lowered: List[ExecItem] = [lower_schedule_item(si) for si in tqdm(schedule)]
 
 # *****
 # 5. Run the schedule


### PR DESCRIPTION
1. Kernel count tests should count CompiledRunners. `si_lowerer` can rewrite ASTs to any ExecItem that makes sense (eg. `STORE(LOAD)` -> `ViewOp`)

2. abstractions3 should use the ExecItem passed from lower_schedule_item. Buffers used in ExecItem can be different from the ScheduleItem, this is an existing behavior: `TestLinearizer.test_load_removed`.