### PR TITLE
minor arg spec check on wmma [pr]

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -946,8 +946,8 @@ spec = PatternMatcher([
   (UPat(Ops.ASSIGN, src=(UPat((Ops.DEFINE_ACC, Ops.DEFINE_GLOBAL)), UPat())), lambda: True),
   (UPat(Ops.ENDRANGE, dtype=dtypes.void, src=(UPat(Ops.RANGE),)), lambda: True),
 
-  # all WMMA has 3 args, <x, w, acc>
-  (UPat(Ops.WMMA, src=(UPat(), UPat(), UPat())), lambda: True),
+  # WMMA has a <a, b, acc>
+  (UPat(Ops.WMMA, src=(UPat(), UPat(), UPat()), name="x"), lambda x: isinstance(x.arg, tuple) and len(x.arg) == 8),
   (UPat(Ops.CONTRACT, name="x"), lambda x: x.dtype.count == prod(y[1] for y in x.arg)),
   (UPat(Ops.UNROLL, name="x"), lambda x: x.src[0].dtype.count == prod(y[1] for y in x.arg)),
 


### PR DESCRIPTION
Thinking in adding `elements_per_threads` as arg to wmma to simplify `ops_python`, George said he was okay in retrieving simple attributes from tc class like `dimensions`, `threads` and `elements_per_threads`

Is there any value in spec checking every wmma arg, or is it enough with checking the length?
```python
# current spec
wmma_arg = (name, dims, dtype_in, dtype_out, device, threads, upcast_axes, reduce_axes)
```