### PR TITLE
Add 'attend' to Embedding class

### DIFF
--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -325,6 +325,12 @@ class Embedding:
     arange, idx, vals = self.arange.expand(big_shp), idx.reshape(idx.shape+(1, 1)).expand(big_shp), self.weight.expand(big_shp)
     return (arange == idx).mul(vals).sum(-2, acc_dtype=vals.dtype)
 
+  def attend(self, x:Tensor) -> Tensor:
+    """
+    Re-project embeddings into the vocab space for models with shared in/out embeds.
+    """
+    return x @ self.weight.T
+
 class LSTMCell:
   """
   A long short-term memory (LSTM) cell.


### PR DESCRIPTION
Small LLMs like LLAMA 3.2-1/3B sometimes use the same embeddings for input and output token embeddings. This produces the need to be able to project the output of the last model using the embedding weights. I added an `attend` method to `Embedding` for this.

This is relatively trivial to do without a helper method so the utility/LOC is questionable, but I don't know how strict that is and will leave it up to the maintainers.

```python
if Config.shared_embeds:
	self.unembed = lambda x: x @ self.embed.weight.T
else:
	self.unembed = nn.Linear(Config.model_dim, Config.vocab_size)
```