### PR TITLE
Small bug in _reshape_mask

### DIFF
--- a/test/unit/test_view.py
+++ b/test/unit/test_view.py
@@ -39,6 +39,11 @@ class TestView(unittest.TestCase):
     v = View.create(shape=(2,3,4), mask=((0,2),(0,3),(0,4)))
     self.assertTrue(v.contiguous)
 
+  def test_reshape_all_invalid(self):
+    v = View.create((4,5), mask=((0,0), (0,0))).reshape((20,))
+    self.assertIsNotNone(v)
+    self.assertEqual(v, View.create((20,), mask=((0,0),)))
+
 class TestMergeDims(unittest.TestCase):
   def test_contiguous(self):
     shape = (2, 3, 4)

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -65,7 +65,7 @@ def _reshape_mask(_mask:Optional[tuple[tuple[sint, sint], ...]], old_shape:tuple
     else:
       next_mask = next(r_masks, (0, 1))
       # combine if the mask can unfold continuously
-      if mask != (0, old_dim) and next_mask[1] - next_mask[0] != 1: return None
+      if mask != (0, old_dim) and l != r and next_mask[1] - next_mask[0] != 1: return None
       mask, old_dim = (next_mask[0] * old_dim + l, (next_mask[1] - 1) * old_dim + r), old_dim * next(r_shape, 1)
 
   return tuple(reversed(new_mask))


### PR DESCRIPTION
Masks that are everywhere-invalid can always be unfolded but the current condition misses that