### PR TITLE
remove PYTHONPATH=. from mypy CI [pr]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,7 +230,7 @@ jobs:
     - name: Lint tinygrad with pylint
       run: python -m pylint tinygrad/
     - name: Run mypy
-      run: PYTHONPATH="." python -m mypy --strict-equality --lineprecision-report . && cat lineprecision.txt
+      run: python -m mypy --strict-equality --lineprecision-report . && cat lineprecision.txt
     - name: Test README
       run: awk '/```python/{flag=1;next}/```/{flag=0}flag' README.md > README.py &&  PYTHONPATH=. python README.py
     - name: Run unit tests


### PR DESCRIPTION
thanks to nimlgen we can do this now #8575.
Seems fast enough:

master:
![image](https://github.com/user-attachments/assets/f4ceac9f-3e78-4d1f-8e9a-8b94f72ac91c)
branch:
![image](https://github.com/user-attachments/assets/f30f7cae-689a-4128-9c6a-8274a93c4444)
