### PR TITLE
better test for reduce swizzle + don't use double dtype [pr]

### DIFF
--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -104,7 +104,7 @@ class TestPickle(unittest.TestCase):
     assert ref_value == vt2.tolist()
 
   def test_pickle_numpy(self):
-    t = Tensor(np.array([1,2,3,4.]))
+    t = Tensor(np.array([1,2,3,4.]), dtype=dtypes.float32)
     st = pickle.dumps(t)
     t2:Tensor = pickle.loads(st)
     np.testing.assert_equal(t.numpy(), t2.numpy())


### PR DESCRIPTION
fixups from #8580.

hardcoded asts are bad because they'll get out of date. We can use the tensor API to test swizzle now (see run_tensor_ast).


This is currently in two kernels because of how the scheduler fuses things, but swizzling rewrite is capable of rewriting to a single kernel.
![image](https://github.com/user-attachments/assets/b0c9ce80-7874-4aa1-98a8-98751e1106f0)