### PR TITLE
Faster KiTS19 dataset tests

### DIFF
--- a/test/external/external_test_datasets.py
+++ b/test/external/external_test_datasets.py
@@ -19,7 +19,7 @@ class ExternalTestDatasets(unittest.TestCase):
   def _create_samples(self, val, num_samples=2):
     self._set_seed()
 
-    img, lbl = np.random.rand(190, 392, 392).astype(np.float32), np.random.randint(0, 100, size=(190, 392, 392)).astype(np.uint8)
+    img, lbl = np.random.rand(8, 8, 8).astype(np.float32), np.random.randint(0, 100, size=(8, 8, 8)).astype(np.uint8)
     img, lbl = nib.Nifti1Image(img, np.eye(4)), nib.Nifti1Image(lbl, np.eye(4))
     dataset = "val" if val else "train"
     preproc_pth = Path(tempfile.gettempdir() + f"/{dataset}")


### PR DESCRIPTION
# Overview
In this PR, I'm making the KiTS19 dataset sample themselves to be of smaller sizes. The correctness of the test shouldn't be affected and I've re-ran the test cases to make sure even if the cache is deleted, it still passes.

I looked into this more because I'm trying to investigate as to why my tests for the RetinaNet MLPerf PR [gets cancelled](https://github.com/tinygrad/tinygrad/actions/runs/12752792214/job/35542988912?pr=8385). As I investigated the duration of these tests, I realized that the KiTS19 dataset (used by UNet3D), was taking approximately ~15s to run for both training and validation sets.

On `master`, here's the duration:
<img width="718" alt="Screenshot 2025-01-13 at 13 40 03" src="https://github.com/user-attachments/assets/7e86d299-ae40-44a5-89eb-0bb6c1d4221e" />

On this PR, here's the duration:
<img width="801" alt="Screenshot 2025-01-13 at 13 45 11" src="https://github.com/user-attachments/assets/2f8475e2-52ba-45e4-a633-66bdc8f2e13c" />
