### PR TITLE
assert kernel buffer limit at compile time [pr]

### DIFF
--- a/test/external/external_model_benchmark.py
+++ b/test/external/external_model_benchmark.py
@@ -9,6 +9,7 @@ from onnx2torch import convert
 from extra.onnx import get_run_onnx
 from tinygrad.helpers import OSX, DEBUG, fetch
 from tinygrad import Tensor, Device
+from tinygrad.device import CompileError
 
 MODELS = {
   "resnet50": "https://github.com/onnx/models/raw/main/validated/vision/classification/resnet/model/resnet50-caffe2-v1-9.onnx",
@@ -72,10 +73,10 @@ def benchmark_model(m, devices, validate_outs=False):
       for _ in range(3): {k:v.numpy() for k,v in tinygrad_jitted_model(**inputs).items()}
       benchmark(m, f"tinygrad_{device.lower()}_jit", lambda: {k:v.numpy() for k,v in tinygrad_jitted_model(**inputs).items()}) # noqa: F821
       del inputs, tinygrad_model, tinygrad_jitted_model
-    except RuntimeError as e:
+    except CompileError as e:
       # TODO: we don't run the dm model on METAL for now
       if Device.DEFAULT == "METAL":
-        assert "buffer count limit" in str(e)
+        assert "no 'buffer' resource location available" in str(e)
         return
       else: raise e
 

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -12,7 +12,6 @@ from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.shape.view import View
 # from tinygrad.ops import Variable
 from tinygrad.tensor import Tensor, _to_np_dtype
-from tinygrad.engine.schedule import BUF_LIMIT
 from tinygrad.engine.realize import run_schedule, lower_schedule, CompiledRunner
 from tinygrad.helpers import prod, Context, getenv, CI, flatten, dedup, AMX
 from tinygrad.dtype import DType, dtypes
@@ -1701,7 +1700,7 @@ class TestHandCodedOpts(unittest.TestCase):
     # float4/other hcopt shouldn't upcast last axis, since we already have 7 upcast, and the last axis is not very contiguous
     assert k.upcasted == 1 and k.full_shape[-1] == 7
 
-  @unittest.skipIf((buf_max:=BUF_LIMIT.get(Device.DEFAULT)) is not None and buf_max <= 37, "this test uses too many bufs")
+  @unittest.skipIf(Device.DEFAULT == "METAL", "METAL can only run kernels with up to 32 buffers")
   def test_masked_upcast_wino(self):
     monster = Tensor.stack(*[Tensor.stack(*[Tensor.rand(16) for _ in range(6)]) for _ in range(6)])
 

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1364,16 +1364,20 @@ class TestSchedule(unittest.TestCase):
   def test_conv2d_fused_half(self): _test_conv2d(5, dtype=dtypes.half)
 
   @unittest.skip("splitting kernels exceeding device buffer count is not yet supported")
-  def _test_buf_cnt(self, cnt:int):
+  def _test_buf_cnt(self, cnt:int, allowed:int):
+    #if (m:=BUF_LIMIT.get(Device.DEFAULT)) is None or m != 32: self.skipTest(f"test needs a buf_max of 32 {Device.DEFAULT}")
     alu = functools.reduce(lambda x,y: x+y, [Tensor.ones((1, 1)).contiguous().realize() for _ in range(cnt-1)])
     s = alu.schedule()
+    assert len(s) == allowed
     run_schedule(s)
     expected = functools.reduce(lambda x,y: x+y, [np.ones((1, 1)) for _ in range(cnt-1)])
     np.testing.assert_equal(alu.numpy(), expected)
 
-  def test_buf_cnt_at_limit(self): self._test_buf_cnt(31)
-  def test_buf_cnt_over_limit(self): self._test_buf_cnt(32)
-  def test_buf_cnt_over_limit_alt(self): self._test_buf_cnt(63)
+  def test_buf_cnt_at_limit(self): self._test_buf_cnt(31, allowed=1)
+  @unittest.expectedFailure
+  def test_buf_cnt_over_limit(self): self._test_buf_cnt(32, allowed=2)
+  @unittest.expectedFailure
+  def test_buf_cnt_over_limit_alt(self): self._test_buf_cnt(63, allowed=3)
 
   def test_schedule_mem_used(self):
     base = GlobalCounters.mem_used


### PR DESCRIPTION
The scheduler does not yet do this splitting at schedule time. This diff just moves these asserts to the CompileError that the device compiler already does.
Once it's implemented we can remove the expectedFailures, but the scheduler itself does not need to assert this.