### PR TITLE
hotfix: remove duplicate TestTensorMutates [pr]

### DIFF
--- a/test/unit/test_rewrite_map.py
+++ b/test/unit/test_rewrite_map.py
@@ -3,38 +3,6 @@ from tinygrad import dtypes, Tensor
 from tinygrad.ops import UOp, symbolic, graph_rewrite_map, _substitute
 from test.unit.test_tensor_uop_representation import is_pattern, realized_pattern, is_pattern_uop
 
-class TestTensorMutates(unittest.TestCase):
-  def test_mutate_add(self):
-    a = Tensor([1,2,3])
-    b = Tensor([4,5,6])
-    ret = a+b
-    pa = a.lazydata
-    pb = b.lazydata
-    pr = ret.lazydata
-    ret.schedule()
-    self.assertIsNot(pa, a.lazydata)
-    self.assertIsNot(pb, b.lazydata)
-    self.assertIsNot(pr, ret.lazydata)
-    for t in [a,b,ret]: is_pattern(t, realized_pattern)
-
-  def test_reshape_is_same_parent(self):
-    a = Tensor([1,2,3])
-    b = Tensor([4,5,6])
-    c = a+b
-    d = (a+b).reshape(3,1)
-    d.realize()
-    is_pattern_uop(d.lazydata.base, realized_pattern)
-    is_pattern_uop(c.lazydata.base, realized_pattern)
-
-  def test_reshape_is_same_child(self):
-    a = Tensor([1,2,3])
-    b = Tensor([4,5,6])
-    c = a+b
-    d = (a+b).reshape(3,1)
-    c.realize()
-    is_pattern_uop(c.lazydata.base, realized_pattern)
-    is_pattern_uop(d.lazydata.base, realized_pattern)
-
 class TestRewriteMap(unittest.TestCase):
   def test_substitute(self):
     a = UOp.variable('a', 0, 10)


### PR DESCRIPTION
This test already exists in `test/unit/test_tensor_uop_representation.py`
https://github.com/tinygrad/tinygrad/blob/c5782e85d2e8ad3d42ddabbfe60099f38af377cf/test/unit/test_tensor_uop_representation.py#L10-L40