### PR TITLE
isolate simple failing test for subbuffer on CONST [pr]

### DIFF
--- a/test/test_tensor_uop.py
+++ b/test/test_tensor_uop.py
@@ -84,6 +84,14 @@ class TestTensorUOp(unittest.TestCase):
     sched = empty.schedule()
     self.assertEqual(len(sched), 0)
 
+  def test_contiguous_folded_alu(self):
+    a = Tensor.empty(8, 8)
+    # NOTE: the buffer for mul_0 late folds to just a CONST
+    mul_0 = a*0
+    out = mul_0.shrink(((4, 8), (0, 8))).contiguous()
+    out.realize()
+    self.assertEqual(out.tolist(), Tensor.zeros(4, 8).tolist())
+
 reduce_kernel = UPat(Ops.SINK, src=(UPat(Ops.STORE, src=(UPat(), UPat(), UPat(Ops.REDUCE_AXIS)))))
 class TestReduceOp(unittest.TestCase):
   def test_no_split_reduce_kernel(self):

--- a/test/test_tensor_uop.py
+++ b/test/test_tensor_uop.py
@@ -3,7 +3,7 @@ import numpy as np
 import unittest
 from tinygrad import Tensor, Device, dtypes
 from tinygrad.engine.realize import run_schedule
-from tinygrad.ops import Ops, UOp, UPat
+from tinygrad.ops import Ops, UOp, UPat, view_supported_devices
 
 class TestTensorUOp(unittest.TestCase):
   def test_fromcpu_shape_tracker(self):
@@ -84,6 +84,7 @@ class TestTensorUOp(unittest.TestCase):
     sched = empty.schedule()
     self.assertEqual(len(sched), 0)
 
+  @unittest.skipIf(Device.DEFAULT in view_supported_devices, "BUFFER_VIEW cannot exist on a CONST")
   def test_contiguous_folded_alu(self):
     a = Tensor.empty(8, 8)
     # NOTE: the buffer for mul_0 late folds to just a CONST


### PR DESCRIPTION
BUFFER_VIEW cannot be correct if the parent operation late folds to a CONST. There is fundamentally no BUFFER on a CONST, so this throws an error.
discovered this when deleting forced_realize:
![image](https://github.com/user-attachments/assets/b852684b-0f00-44fc-8a63-d300fdd6334f)

mul*0 becomes just a CONST. What does BUFFER_VIEW(CONST) mean at that point? Should we rewrite it to a CONTIGUOUS(CONST)?