### PR TITLE
make onnx runner a class

### DIFF
--- a/examples/benchmark_onnx.py
+++ b/examples/benchmark_onnx.py
@@ -6,8 +6,6 @@ from extra.onnx import OnnxSession
 def load_onnx_model(fn):
   onnx_file = fetch(fn)
   onnx_model = onnx.load(onnx_file)
-  Tensor.no_grad = True
-  Tensor.training = False
   onnx_sess = OnnxSession(onnx_model)
 
   # find preinitted tensors and ignore them

--- a/examples/benchmark_onnx.py
+++ b/examples/benchmark_onnx.py
@@ -1,14 +1,14 @@
 import sys, onnx, time
 from tinygrad import Tensor, TinyJit, Device, GlobalCounters, fetch
 from tinygrad.tensor import _from_np_dtype
-from extra.onnx import get_run_onnx
+from extra.onnx import OnnxSession
 
 def load_onnx_model(fn):
   onnx_file = fetch(fn)
   onnx_model = onnx.load(onnx_file)
   Tensor.no_grad = True
   Tensor.training = False
-  run_onnx = get_run_onnx(onnx_model)
+  onnx_sess = OnnxSession(onnx_model)
 
   # find preinitted tensors and ignore them
   initted_tensors = {inp.name:None for inp in onnx_model.graph.initializer}
@@ -17,7 +17,7 @@ def load_onnx_model(fn):
   # get real inputs
   input_shapes = {inp.name:tuple(x.dim_value if x.dim_value != 0 else 1 for x in inp.type.tensor_type.shape.dim) for inp in expected_inputs}
   input_types = {inp.name:onnx.helper.tensor_dtype_to_np_dtype(inp.type.tensor_type.elem_type) for inp in expected_inputs}
-  run_onnx_jit = TinyJit(lambda **kwargs: next(iter(run_onnx({k:v.to(Device.DEFAULT) for k,v in kwargs.items()}).values())), prune=True)
+  run_onnx_jit = TinyJit(lambda **kwargs: next(iter(onnx_sess.run({k:v.to(Device.DEFAULT) for k,v in kwargs.items()}).values())), prune=True)
   return run_onnx_jit, input_shapes, input_types
 
 if __name__ == "__main__":

--- a/examples/compile_tensorflow.py
+++ b/examples/compile_tensorflow.py
@@ -8,7 +8,7 @@ import numpy as np
 import subprocess
 import tensorflow as tf
 import tf2onnx
-from extra.onnx import get_run_onnx
+from extra.onnx import OnnxSession
 from tinygrad.tensor import Tensor
 from extra.export_model import export_model_clang, compile_net, jit_model
 
@@ -25,10 +25,10 @@ class TinyOnnx:
   def __init__(self, keras_model):
     input_signature = [tf.TensorSpec([1,32], tf.float32, name='x')]
     onnx_model, _ = tf2onnx.convert.from_keras(keras_model, input_signature, opset=13)
-    self.run_onnx = get_run_onnx(onnx_model)
+    self.onnx_sess = OnnxSession(onnx_model)
 
   def forward(self, x):
-    return self.run_onnx({"x": x}, debug=False)['predictions']
+    return self.onnx_sess.run({"x": x}, debug=False)['predictions']
 
 def compile_onnx_model(onnx_model):
   tinyonnx = TinyOnnx(onnx_model)

--- a/examples/openpilot/compile3.py
+++ b/examples/openpilot/compile3.py
@@ -19,9 +19,6 @@ OUTPUT = sys.argv[2] if len(sys.argv) > 2 else "/tmp/openpilot.pkl"
 
 def compile(onnx_file):
   onnx_model = onnx.load(onnx_file)
-  Tensor.no_grad = True
-  Tensor.training = False
-
   onnx_sess = OnnxSession(onnx_model)
   print("loaded model")
 

--- a/examples/yolov8-onnx.py
+++ b/examples/yolov8-onnx.py
@@ -3,7 +3,7 @@ import os
 from ultralytics import YOLO
 import onnx
 from pathlib import Path
-from extra.onnx import get_run_onnx
+from extra.onnx import OnnxSession
 from tinygrad.tensor import Tensor
 
 os.chdir("/tmp")
@@ -14,5 +14,5 @@ onnx_model = onnx.load(open("yolov8n-seg.onnx", "rb"))
 # TODO: move get example inputs to onnx
 input_shapes = {inp.name:tuple(x.dim_value for x in inp.type.tensor_type.shape.dim) for inp in onnx_model.graph.input}
 print(input_shapes)
-run_onnx = get_run_onnx(onnx_model)
-run_onnx({"images": Tensor.zeros(1,3,480,640)}, debug=True)
+onnx_sess = OnnxSession(onnx_model)
+onnx_sess.run({"images": Tensor.zeros(1,3,480,640)}, debug=True)

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -4,7 +4,6 @@ from tinygrad.tensor import Tensor
 from tinygrad.helpers import getenv, DEBUG, all_same
 from tinygrad.dtype import DType, ConstType, dtypes
 from tinygrad.device import is_dtype_supported
-def get_run_onnx():
 
 # ***** protobuf parsing ******
 from onnx import AttributeProto, ModelProto, TensorProto, TypeProto, helper

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -1,13 +1,89 @@
 from typing import Callable, Any, Sequence
-import importlib, functools
-import numpy as np
-from tinygrad import Tensor, dtypes
+import importlib, functools, dataclasses, enum
+from tinygrad.tensor import Tensor
 from tinygrad.helpers import getenv, DEBUG, all_same
-from tinygrad.dtype import DType, ConstType
+from tinygrad.dtype import DType, ConstType, dtypes
 from tinygrad.device import is_dtype_supported
-from onnx import AttributeProto, ModelProto, TensorProto, ValueInfoProto, helper
-from google.protobuf.json_format import MessageToDict
+def get_run_onnx():
 
+# ***** protobuf parsing ******
+from onnx import AttributeProto, ModelProto, TensorProto, TypeProto, helper
+import numpy as np
+
+def dtype_parse(onnx_dtype: int) -> DType:
+  supported: dict[int, DType] = {
+    TensorProto.FLOAT:dtypes.float32, TensorProto.UINT8:dtypes.uint8, TensorProto.INT8:dtypes.int8,
+    TensorProto.UINT16:dtypes.uint16, TensorProto.INT16:dtypes.int16, TensorProto.INT32:dtypes.int32, TensorProto.INT64:dtypes.int64,
+    TensorProto.BOOL:dtypes.bool, TensorProto.FLOAT16:dtypes.float32, TensorProto.DOUBLE:dtypes.double, TensorProto.UINT32:dtypes.uint32,
+    TensorProto.UINT64:dtypes.uint64, TensorProto.BFLOAT16:dtypes.bfloat16,
+  }
+  unsupported = {
+    TensorProto.UNDEFINED, TensorProto.STRING, TensorProto.COMPLEX64, TensorProto.COMPLEX128, TensorProto.FLOAT8E4M3FN, TensorProto.FLOAT8E4M3FNUZ,
+    TensorProto.FLOAT8E5M2, TensorProto.FLOAT8E5M2FNUZ, TensorProto.UINT4, TensorProto.INT4
+  }
+  if onnx_dtype in unsupported: raise NotImplementedError(f"onnx dtype {TensorProto.DataType.Name(onnx_dtype)} is not supported")
+  return supported[onnx_dtype] if is_dtype_supported(supported[onnx_dtype]) else dtypes.float
+
+def attribute_parse(onnx_attribute: AttributeProto):
+  supported: dict[AttributeProto.AttributeType, Callable[[AttributeProto], Any]] = {
+    AttributeProto.FLOAT: lambda a: float(a.f), AttributeProto.INT: lambda a: int(a.i),
+    AttributeProto.STRING: lambda a: a.s.decode("utf-8"), AttributeProto.TENSOR: lambda a: buffer_parse(a.t),
+    AttributeProto.FLOATS: lambda a: tuple(float(x) for x in a.floats), AttributeProto.INTS: lambda a: tuple(int(x) for x in a.ints),
+    AttributeProto.STRINGS: lambda a: tuple(x.decode("utf-8") for x in a.strings)
+  }
+  unsupported = {
+    AttributeProto.UNDEFINED, AttributeProto.GRAPH, AttributeProto.SPARSE_TENSOR, AttributeProto.TYPE_PROTO, AttributeProto.TENSORS,
+    AttributeProto.GRAPHS, AttributeProto.SPARSE_TENSORS, AttributeProto.TYPE_PROTOS
+  }
+  if onnx_attribute.type in unsupported:
+    raise NotImplementedError(f"attribute with type {AttributeProto.AttributeType.Name(onnx_attribute.type)} is not supported")
+  return supported[onnx_attribute.type](onnx_attribute)
+
+def buffer_parse(onnx_tensor: TensorProto) -> Tensor:
+  if onnx_tensor.string_data: raise NotImplementedError("Parsing for buffer with string data is not implemented.")
+  dtype, shape = dtype_parse(onnx_tensor.data_type), tuple(onnx_tensor.dims)
+  if data := list(onnx_tensor.float_data) or list(onnx_tensor.int32_data) or list(onnx_tensor.int64_data) or list(onnx_tensor.double_data) or \
+             list(onnx_tensor.uint64_data):
+    if len(data) == 1: return Tensor(data[0], dtype=dtype).reshape(shape)
+    return Tensor(data, dtype=dtype).reshape(shape).realize()
+  if onnx_tensor.HasField("raw_data"):
+    np_buffer = np.frombuffer(onnx_tensor.raw_data, dtype=helper.tensor_dtype_to_np_dtype(onnx_tensor.data_type)).copy().reshape(shape)
+    if np_buffer.size == 1: return Tensor(np_buffer.item(), dtype=dtype).reshape(shape)
+    return Tensor(np_buffer, dtype=dtype)
+  return Tensor(None)
+
+def type_parse(onnx_type: TypeProto):
+  if is_optional := onnx_type.HasField("optional_type"): onnx_type = onnx_type.optional_type.elem_type
+  if onnx_type.HasField("sequence_type"): value_type, tensor_type = ValueType.SEQUENCE, onnx_type.sequence_type.elem_type.tensor_type
+  elif onnx_type.HasField("tensor_type"): value_type, tensor_type = ValueType.TENSOR, onnx_type.tensor_type
+  else: raise NotImplementedError(f"Unsupported {onnx_type=}")
+  shape, dtype = tuple(d.dim_param or d.dim_value for d in tensor_type.shape.dim), dtype_parse(tensor_type.elem_type)
+  return OnnxValue(value_type, is_optional, shape, dtype)
+
+# ***** onnx spec *****
+class ValueType(enum.Enum):
+  # supported
+  TENSOR = enum.auto(); SEQUENCE = enum.auto()
+  # unsupported
+  MAP = enum.auto(); OPTIONAL = enum.auto(); SPARSE_TENSOR = enum.auto(); OPAQUE = enum.auto()
+
+@dataclasses.dataclass
+class OnnxValue:
+  type: ValueType
+  is_optional: bool
+  shape: tuple[str|int]
+  dtype: DType
+
+@dataclasses.dataclass
+class OnnxNode:
+  num: int
+  op: str
+  inputs: tuple[str]
+  outputs: tuple[str]
+  opts: dict[str, Any]
+  def __repr__(self): return f"{self.num}: op '{self.op}' inputs={self.inputs} opts={self.opts} outputs={self.outputs}"
+
+# ***** python const *****
 cache_misses = 0
 @functools.lru_cache(None)
 def _cached_to_python_const(t:Tensor):
@@ -25,66 +101,10 @@ def to_python_const(t) -> list[ConstType]|ConstType|bytes:
     cache_misses = info.misses
   return ret
 
-# TODO: use real float16
-# src: onnx/mapping.py
-DTYPE_MAP: dict[int, DType] = {
-  TensorProto.FLOAT:dtypes.float32, TensorProto.UINT8:dtypes.uint8, TensorProto.INT8:dtypes.int8,
-  TensorProto.UINT16:dtypes.uint16, TensorProto.INT16:dtypes.int16, TensorProto.INT32:dtypes.int32, TensorProto.INT64:dtypes.int64,
-  TensorProto.BOOL:dtypes.bool, TensorProto.FLOAT16:dtypes.float32, TensorProto.DOUBLE:dtypes.double, TensorProto.UINT32:dtypes.uint32,
-  TensorProto.UINT64:dtypes.uint64, TensorProto.BFLOAT16:dtypes.bfloat16,
-}
-def dtype_parse(onnx_dtype: int) -> DType:
-  if onnx_dtype not in DTYPE_MAP: raise NotImplementedError(f"onnx dtype {TensorProto.DataType.Name(onnx_dtype)} is not supported")
-  return DTYPE_MAP[onnx_dtype] if is_dtype_supported(DTYPE_MAP[onnx_dtype]) else dtypes.float
-
-# src: onnx/onnx_ml_pb2.pyi
-ATTRIBUTE_MAP: dict[AttributeProto.AttributeType, Callable[[AttributeProto], Any]] = {
-  AttributeProto.FLOAT: lambda a: float(a.f), AttributeProto.INT: lambda a: int(a.i),
-  AttributeProto.STRING: lambda a: a.s.decode("utf-8"), AttributeProto.TENSOR: lambda a: buffer_parse(a.t),
-  AttributeProto.FLOATS: lambda a: tuple(float(x) for x in a.floats), AttributeProto.INTS: lambda a: tuple(int(x) for x in a.ints),
-  AttributeProto.STRINGS: lambda a: tuple(x.decode("utf-8") for x in a.strings)
-}
-def attribute_parse(onnx_attribute: AttributeProto):
-  if onnx_attribute.type not in ATTRIBUTE_MAP:
-    raise NotImplementedError(f"attribute with type {AttributeProto.AttributeType.Name(onnx_attribute.type)} is not supported")
-  return ATTRIBUTE_MAP[onnx_attribute.type](onnx_attribute)
-
-def buffer_parse(onnx_tensor: TensorProto) -> Tensor:
-  if onnx_tensor.string_data: raise NotImplementedError("Parsing for buffer with string data is not implemented.")
-  dtype, shape = dtype_parse(onnx_tensor.data_type), tuple(onnx_tensor.dims)
-  if data := list(onnx_tensor.float_data) or list(onnx_tensor.int32_data) or list(onnx_tensor.int64_data) or list(onnx_tensor.double_data) or \
-             list(onnx_tensor.uint64_data):
-    if len(data) == 1: return Tensor(data[0], dtype=dtype).reshape(shape)
-    return Tensor(data, dtype=dtype).reshape(shape).realize()
-  if onnx_tensor.HasField("raw_data"):
-    np_buffer = np.frombuffer(onnx_tensor.raw_data, dtype=helper.tensor_dtype_to_np_dtype(onnx_tensor.data_type)).copy().reshape(shape)
-    if np_buffer.size == 1: return Tensor(np_buffer.item(), dtype=dtype).reshape(shape)
-    return Tensor(np_buffer, dtype=dtype)
-  return Tensor(None)
-
-onnx_ops = importlib.import_module('extra.onnx_ops')
-ONNXLIMIT = getenv("ONNXLIMIT", -1)
-def get_run_onnx(onnx_model: ModelProto):
-  # model initialization data
-  model_tensors = {inp.name:buffer_parse(inp) for inp in onnx_model.graph.initializer}
-  model_expected_inputs = {inp.name:inp for inp in onnx_model.graph.input if inp.name not in model_tensors}
-  model_attributes = {num:{x.name:attribute_parse(x) for x in n.attribute} for num,n in enumerate(onnx_model.graph.node)}
-
-  # model descriptions
-  # TODO: need a better way of controlling training vs non-training
-  is_onnx_preview_training = any(n.HasField("domain") and n.domain == "ai.onnx.preview.training" for n in onnx_model.graph.node)
-  onnx_model_version = onnx_model.opset_import[0].version
-
-  # used to check validity of user_input according to their dimension variables
-  variable_dims = {}
-
-  # mapping from onnx ops to tensor.py ops
-  tensor_methods = {
-    op:op.lower() for op in ("Neg", "Reciprocal", "Pow", "Sqrt", "Sign", "Abs", "Exp", "Log", "Mish", "Sin", "Cos", "Tan", "Asin", "Acos", "Atan",
-    "Relu", "Sigmoid", "MatMul", "Floor", "Ceil", "IsInf", "IsNaN", "Softplus", "HardSwish", "Where", "Mul", "Sinh", "Cosh", "Tanh",
-    "Softsign", "Asinh", "Acosh", "Atanh",  "Elu", "Celu", "Selu", "Xor", "Round", "Erf", "Mod")
-  }
-
+# ***** runner ******
+debug = int(getenv("DEBUGONNX", "0"))
+limit = int(getenv("ONNXLIMIT", "-1"))
+class OnnxSession:
   # these values are expected to be python consts
   required_input_python_consts: dict[str, tuple[int, ...]] = {
     "Tile": (1,), "Range": (0,1,2), "Expand": (1,), "Reshape": (1,), "Squeeze": (1,), "Unsqueeze": (1,), "Trilu": (1,), "ConstantOfShape": (0,),
@@ -93,85 +113,81 @@ def get_run_onnx(onnx_model: ModelProto):
     **{"Reduce"+r: (1,) for r in ("Max", "Min", "Sum", "Mean", "SumSquare", "Prod", "L1", "L2", "LogSum", "LogSumExp")},
     **{optim: (1,) for optim in ("Adam", "Adagrad", "Momentum")}
   }
+  # TODO: move extra.onnx_ops here so we don't have to deal with annoying circular import
+  # TODO: clean up opset stuff after moving extra.onnx_ops here
+  onnx_ops_module = importlib.import_module('extra.onnx_ops')
+  onnx_ops = {
+    **{op: getattr(Tensor, op.lower()) for op in ("Neg", "Reciprocal", "Pow", "Sqrt", "Sign", "Abs", "Exp", "Log", "Mish", "Sin", "Cos", "Tan",
+    "Asin", "Acos", "Atan", "Relu", "Sigmoid", "MatMul", "Floor", "Ceil", "IsInf", "IsNaN", "Softplus", "HardSwish", "Where", "Mul", "Sinh", "Cosh",
+    "Tanh", "Softsign", "Asinh", "Acosh", "Atanh",  "Elu", "Celu", "Selu", "Xor", "Round", "Erf", "Mod")},
+  }
 
-  # src: https://onnx.ai/onnx/repo-docs/IR.html#input-output-data-types
-  # parses and validates inputs based on their shape and dtype specified by model
-  def prepare_input(user_input:Any, model_input:ValueInfoProto):
-    type_proto = model_input.type
-    if type_proto.HasField("optional_type"):
-      if user_input is None: return None
-      type_proto = type_proto.optional_type.elem_type
-    if type_proto.HasField("sequence_type"):
-      if not isinstance(user_input, Sequence): raise RuntimeError(f"{model_input.name} received {user_input}, expected sequence type")
-      dtype = dtype_parse(type_proto.sequence_type.elem_type.tensor_type.elem_type)
-      sequence = [Tensor(i, dtype=dtype, requires_grad=is_onnx_preview_training) if not isinstance(i, Tensor) else i for i in user_input]
-      if not all_same(tuple(t.shape for t in sequence)): raise RuntimeError(f"shapes for {model_input.name} must be homogeneous")
+  def __init__(self, model: ModelProto):
+    # parse model protobuf
+    self.is_training = any(n.HasField("domain") and n.domain == "ai.onnx.preview.training" for n in model.graph.node)
+    Tensor.no_grad = False if self.is_training else True
+    Tensor.training = True if self.is_training else False
+    self.values = {x.name:buffer_parse(x) for x in model.graph.initializer}
+    self.input_spec = {x.name:type_parse(x.type) for x in model.graph.input if x.name not in self.values}
+    self.output_spec = {x.name:type_parse(x.type) for x in model.graph.output}
+    self.nodes = tuple(OnnxNode(num, n.op_type, tuple(n.input), tuple(n.output), {x.name:attribute_parse(x) for x in n.attribute})
+                       for num,n in enumerate(model.graph.node))
+    self.opset_version = model.opset_import[0].version
+    self.variable_dims = {}
+
+  def _parse_input(self, name: str, value: Any, spec: OnnxValue):
+    if spec.is_optional and value is None: return None
+    if spec.type is ValueType.SEQUENCE:
+      if not isinstance(value, Sequence): raise RuntimeError(f"{name} received {value}, expected a sequence type")
+      sequence = [Tensor(v, dtype=spec.dtype, requires_grad=self.is_training) if not isinstance(v, Tensor) else v for v in value]
+      if not all_same(tuple(t.shape for t in sequence)): raise RuntimeError(f"Shapes for {name} sequence must be homogeneous")
+      # TODO: check for var dim
       # TODO: need true float16 for dtype checking
-      # if not all(t.dtype is dtype for t in sequence):
-      #   raise RuntimeError(f"{model_input.name} has dtype mismatch for sequence type. Expected {dtype}, received {tensor.dtype}.")
       return sequence
-    if type_proto.HasField("tensor_type"):
-      dtype = dtype_parse(type_proto.tensor_type.elem_type)
-      tensor = Tensor(user_input, dtype=dtype, requires_grad=is_onnx_preview_training) if not isinstance(user_input, Tensor) else user_input
+    if spec.type is ValueType.TENSOR:
+      tensor = Tensor(value, dtype=spec.dtype, requires_grad=self.is_training) if not isinstance(value, Tensor) else value
       # TODO: need true float16 for dtype checking
-      # if dtype is not tensor.dtype: raise RuntimeError(f"{model_input.name} has mismatch for dtype. Expected {dtype}, received {tensor.dtype}.")
-      for dim, onnx_dim in enumerate(type_proto.tensor_type.shape.dim):
-        dim_param, dim_value = onnx_dim.dim_param, onnx_dim.dim_value
-        user_dim_input = tensor.shape[dim]
-        if dim_param: dim_value = variable_dims[dim_param] if dim_param in variable_dims else variable_dims.setdefault(dim_param, user_dim_input)
-        if user_dim_input != dim_value:
-          raise RuntimeError(f"{model_input.name} has mismatch for dim={dim_param or dim}. Expected {dim_value}, received {user_dim_input}.")
+      for dim, (onnx_dim, user_dim_input) in enumerate(zip(spec.shape, tensor.shape, strict=True)):
+        if isinstance(onnx_dim, str):
+          onnx_dim = self.variable_dims[onnx_dim] if onnx_dim in self.variable_dims else self.variable_dims.setdefault(onnx_dim, user_dim_input)
+        if user_dim_input != onnx_dim:
+          raise RuntimeError(f"{name} has mismatch on {dim=}. Expected {onnx_dim}, received {user_dim_input}.")
       return tensor
-    type_field_names = [field.name for field,_ in type_proto.ListFields()]
-    raise NotImplementedError(f"{model_input.name} with {type_field_names=} is not supported")
+    raise NotImplementedError(f"{name} was not parsed properly")
 
-  def run_onnx(inputs={}, debug=0):
-    debug = getenv("DEBUGONNX") or debug
-    if debug >= 3: print("Model initialization data:\n" + "\n".join(f"\t{i.name} - {model_tensors[i.name]}" for i in onnx_model.graph.initializer))
+  def _dispatch_op(self, op, inps, opts):
+    if op in self.onnx_ops: return self.onnx_ops[op](*inps, **opts)
+    if hasattr(self.onnx_ops_module, op):
+      fxn = getattr(self.onnx_ops_module, op)
+      if isinstance(fxn, dict):
+        for k in sorted(fxn.keys()):
+          if k <= self.opset_version:
+            real_fxn = fxn[k]
+      else: real_fxn = fxn
+      return real_fxn(*inps, **opts)
+    raise NotImplementedError(f"{op=} not supported")
 
-    if debug >= 1: print("Model input:")
-    for name, value_info in model_expected_inputs.items():
+  def run(self, inputs={}, debug=debug, limit=limit):
+    for name, input_spec in self.input_spec.items():
       if name not in inputs: raise RuntimeError(f"Please provide input data for {name}")
-      model_tensors[name] = prepare_input(inputs[name], value_info)
-      if debug >= 1: print(f"\t{name} - {model_tensors[name]}")
-      if debug >= 2: print(f"\t\t{MessageToDict(value_info.type)}")
+      self.values[name] = self._parse_input(name, inputs[name], input_spec)
 
-    for num,n in enumerate(onnx_model.graph.node):
-      inp_tensors = [model_tensors.get(x) for x in n.input]
-      required_consts = required_input_python_consts.get(n.op_type, ())
-      inp = [to_python_const(t) if i in required_consts else t for i,t in enumerate(inp_tensors)]
-      opt = model_attributes[num]
+    for node in self.nodes:
+      inps = [self.values.get(name) for name in node.inputs]
+      opts, op = node.opts, node.op
 
-      if debug >= 1: print(f"{num}: op \"{n.op_type}\" input shapes {[x.shape if isinstance(x, Tensor) else x for x in inp_tensors]} opt {opt}")
-      if debug >= 3:
-        print("\tinputs:")
-        print("\n".join(f"\t\t{x} - {t!r}" + (" (to_python_const)" if i in required_consts else "") for i,(x,t) in enumerate(zip(n.input, inp))))
+      # provide additional opts
+      if op == "Split" and 'num_outputs' not in opts: opts['num_outputs'] = len(node.outputs)
+      if op == "Gradient": opts['intermediate_tensors'] = self.values
 
-      # provide additional arguments
-      if n.op_type == "Split" and 'num_outputs' not in opt: opt['num_outputs'] = len(n.output)
-      if n.op_type == "Gradient": opt['intermediate_tensors'] = model_tensors
+      required_consts = self.required_input_python_consts.get(op, ())
+      inps = [to_python_const(t) if i in required_consts else t for i,t in enumerate(inps)]
 
-      # run op
-      if n.op_type in tensor_methods: ret = getattr(Tensor, tensor_methods[n.op_type])(*inp, **opt)
-      elif hasattr(onnx_ops, n.op_type):
-        fxn = getattr(onnx_ops, n.op_type)
-        if isinstance(fxn, dict):
-          for k in sorted(fxn.keys()):
-            if k <= onnx_model_version:
-              real_fxn = fxn[k]
-        else:
-          real_fxn = fxn
-        ret = real_fxn(*inp, **opt)
-      else:
-        print("UNSUPPORTED", n.op_type, n.input, n.output)
-        raise NotImplementedError(f"op_type {n.op_type} not supported")
+      if debug >= 1: print(node)
+      if debug >= 2: print("\tinputs:\n" + "\n".join(f"\t\t{x} - {i!r}" for x,i in zip(node.inputs, inps)))
+      ret = self._dispatch_op(op, inps, opts)
+      ret = ret if isinstance(ret, tuple) else (ret,)
+      self.values.update(dict(zip(node.outputs, ret[:len(node.outputs)], strict=True)))
 
-      # finalization after running the op
-      if not isinstance(ret, tuple): ret = (ret, )
-      if len(n.output) > len(ret): raise RuntimeError(f"expected output size must be less than {len(ret)}, it's {n.output}")
-      for i in range(len(n.output)): model_tensors[n.output[i]] = ret[i]
-      if debug >= 2: print("\toutputs:\n" + "\n".join(f"\t\t{n.output[i]} - {ret[i]}" for i in range(len(n.output))))
-
-      if num == ONNXLIMIT: return {name:model_tensors[name] for name in n.output}
-    return {x.name:model_tensors[x.name] for x in onnx_model.graph.output}
-  return run_onnx
+      if node.num == limit: return {name:self.values[name] for name in node.outputs}
+    return {name:self.values[name] for name in self.output_spec}

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -106,8 +106,7 @@ class OnnxSession:
   def __init__(self, model: ModelProto):
     # parse model protobuf
     self.is_training = any(n.HasField("domain") and n.domain == "ai.onnx.preview.training" for n in model.graph.node)
-    self.old_training = Tensor.training
-    self.old_no_grad = Tensor.no_grad
+    self.old_training, self.old_no_grad = Tensor.training, Tensor.no_grad
     Tensor.training = True if self.is_training else False
     Tensor.no_grad = False if self.is_training else True
     self.values = {x.name:buffer_parse(x) for x in model.graph.initializer}
@@ -194,5 +193,5 @@ class OnnxSession:
 
       # limit is used for debug purposes only
       if node.num == limit: return {name:self.values[name] for name in node.outputs}
-    if self.is_training: Tensor.training, Tensor.no_grad = self.old_training, self.old_no_grad
+    Tensor.training, Tensor.no_grad = self.old_training, self.old_no_grad
     return {name:self.values[name] for name in self.output_spec}

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -575,12 +575,9 @@ from tinygrad.nn.optim import SGD
 def onnx_training(input_group_size):
   def _decorator(func):
     def __wrapper(R:Tensor, T:int, *inputs:Tensor, **kwargs):
-      old_training = Tensor.training
-      Tensor.training = True
       R = R.detach()
       groups = len(inputs) // input_group_size
       ret = [func(R, T, *inps, **kwargs) for inps in (inputs[i::groups] for i in range(groups))]
-      Tensor.training = old_training
       return tuple(flatten(zip(*ret)))
     return __wrapper
   return _decorator
@@ -624,5 +621,12 @@ def Momentum(R:Tensor, T:int, *inputs:Tensor, alpha:float, beta:float, mode:str,
   return [X, V]
 
 def Gradient(*inputs:Tensor, y:str, intermediate_tensors:dict[str, Tensor], **__):
+  print(intermediate_tensors)
+  print(y)
   intermediate_tensors[y].backward()
+  print(inputs[0].requires_grad)
+  print(tuple([t.grad for t in inputs]))
+  print(Tensor.no_grad)
+  print(Tensor.training)
+
   return tuple([t.grad for t in inputs])

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -621,12 +621,5 @@ def Momentum(R:Tensor, T:int, *inputs:Tensor, alpha:float, beta:float, mode:str,
   return [X, V]
 
 def Gradient(*inputs:Tensor, y:str, intermediate_tensors:dict[str, Tensor], **__):
-  print(intermediate_tensors)
-  print(y)
   intermediate_tensors[y].backward()
-  print(inputs[0].requires_grad)
-  print(tuple([t.grad for t in inputs]))
-  print(Tensor.no_grad)
-  print(Tensor.training)
-
   return tuple([t.grad for t in inputs])

--- a/test/external/external_benchmark_openpilot.py
+++ b/test/external/external_benchmark_openpilot.py
@@ -11,9 +11,6 @@ import numpy as np
 OPENPILOT_MODEL = sys.argv[1] if len(sys.argv) > 1 else "https://github.com/commaai/openpilot/raw/v0.9.4/selfdrive/modeld/models/supercombo.onnx"
 
 if __name__ == "__main__":
-  Tensor.no_grad = True
-  Tensor.training = False
-
   onnx_model = onnx.load(onnx_path := fetch(OPENPILOT_MODEL))
   onnx_sess = OnnxSession(onnx_model)
 

--- a/test/external/external_model_benchmark.py
+++ b/test/external/external_model_benchmark.py
@@ -6,7 +6,7 @@ import onnx
 from onnx.helper import tensor_dtype_to_np_dtype
 import onnxruntime as ort
 from onnx2torch import convert
-from extra.onnx import get_run_onnx
+from extra.onnx import OnnxSession
 from tinygrad.helpers import OSX, DEBUG, fetch
 from tinygrad import Tensor, Device
 from tinygrad.device import CompileError
@@ -65,11 +65,11 @@ def benchmark_model(m, devices, validate_outs=False):
     try:
       Device.DEFAULT = device
       inputs = {k:Tensor(inp) for k,inp in np_inputs.items()}
-      tinygrad_model = get_run_onnx(onnx_model)
-      benchmark(m, f"tinygrad_{device.lower()}_jitless", lambda: {k:v.numpy() for k,v in tinygrad_model(inputs).items()})
+      tinygrad_model = OnnxSession(onnx_model)
+      benchmark(m, f"tinygrad_{device.lower()}_jitless", lambda: {k:v.numpy() for k,v in tinygrad_model.run(inputs).items()})
 
       from tinygrad.engine.jit import TinyJit
-      tinygrad_jitted_model = TinyJit(lambda **kwargs: {k:v.realize() for k,v in tinygrad_model(kwargs).items()})
+      tinygrad_jitted_model = TinyJit(lambda **kwargs: {k:v.realize() for k,v in tinygrad_model.run(kwargs).items()})
       for _ in range(3): {k:v.numpy() for k,v in tinygrad_jitted_model(**inputs).items()}
       benchmark(m, f"tinygrad_{device.lower()}_jit", lambda: {k:v.numpy() for k,v in tinygrad_jitted_model(**inputs).items()}) # noqa: F821
       del inputs, tinygrad_model, tinygrad_jitted_model
@@ -115,8 +115,8 @@ def benchmark_model(m, devices, validate_outs=False):
       rtol, atol = 2e-3, 2e-3  # tolerance for fp16 models
       Device.DEFAULT = device
       inputs = {k:Tensor(inp) for k,inp in np_inputs.items()}
-      tinygrad_model = get_run_onnx(onnx_model)
-      tinygrad_out = tinygrad_model(inputs)
+      tinygrad_model = OnnxSession(onnx_model)
+      tinygrad_out = tinygrad_model.run(inputs)
 
       ort_sess = ort.InferenceSession(str(fn), ort_options, ["CPUExecutionProvider"])
       onnx_out = ort_sess.run(output_names, np_inputs)

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -10,7 +10,7 @@ from tinygrad.device import is_dtype_supported
 # pip3 install tabulate
 pytest_plugins = 'onnx.backend.test.report',
 
-from extra.onnx import get_run_onnx
+from extra.onnx import OnnxSession
 
 class TinygradModel(BackendRep):
   def __init__(self, run_onnx, input_names):
@@ -30,8 +30,8 @@ class TinygradBackend(Backend):
     input_initializer = [x.name for x in model.graph.initializer]
     net_feed_input = [x for x in input_all if x not in input_initializer]
     print("prepare", cls, device, net_feed_input)
-    run_onnx = get_run_onnx(model)
-    return TinygradModel(run_onnx, net_feed_input)
+    onnx_sess = OnnxSession(model)
+    return TinygradModel(onnx_sess.run, net_feed_input)
 
   @classmethod
   def supports_device(cls, device: str) -> bool:

--- a/test/models/test_onnx.py
+++ b/test/models/test_onnx.py
@@ -128,7 +128,7 @@ class TestOnnxModel(unittest.TestCase):
 
     def run(img):
       inputs = {input_name: preprocess(img, new=input_new)}
-      tinygrad_out = list(onnx_sess(inputs, debug=debug).values())[0].numpy()
+      tinygrad_out = list(onnx_sess.run(inputs, debug=debug).values())[0].numpy()
       return tinygrad_out.argmax()
 
     cls = run(chicken_img)


### PR DESCRIPTION
Few things of note
- if we ever want to do our own protobuf parsing, I refactored it so that we just have to replace the parse functions under `# ***** protobuf parsing ******` and the model parsing that uses said functions in `OnnxSession.__init__`
- I also added a thing that toggles training. The training ops in onnx that requires gradient all have "ai.onnx.preview.training" as domain. When I was writing tests, I tried to create the node without the domain and it didn't work, so I think that domain name is a must and the check in `__init__` is fine.
- I also added in code the specs that are unsupported. This way we can do without an external src link since the entire spec is in code. (not sure if good idea)
- debug=1 also looks a little different now. DEBUGONNX=1 only shows ops, DEBUGONNX=2 to see attributes, inputs and outputs.

if I can move onnx_ops into onnx, I can make the debug much nicer. 
like right now I can't inspect the ops in `importlib.import_module('extra.onnx_ops')` since there's a darn circular import.

let's see if this refactor is palatable first 🫠 
