### PR TITLE
fractional global_sizes tested in CI

### DIFF
--- a/extra/qcom_gpu_driver/qcom_opencl_interop.py
+++ b/extra/qcom_gpu_driver/qcom_opencl_interop.py
@@ -32,6 +32,11 @@ x = Tensor.from_blob(rawbuf_ptr, (8, 8), dtype=dtypes.int, device='QCOM')
 y = (x + 1).numpy()
 print(y)
 
+# testing float values with QCOM tensors
+x_f = Tensor.from_blob(rawbuf_ptr, (8, 8), dtype=dtypes.float, device='QCOM')
+y_f = (x + 1).numpy()
+print(y_f)
+
 # all calculations are done, save to free the object
 cl.clReleaseMemObject(cl_buf)
 


### PR DESCRIPTION
Added float value test to `tinygrad/tree/master/extra/qcom_gpu_driver/qcom_opencl_interop.py`.

Addresses #7181 

Regards,
Ezekiel.