### PR TITLE
add tests for mul/div buffer collapsing in the scheduler [pr]

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1222,27 +1222,6 @@ class TestLinearizer(unittest.TestCase):
     assert idxs[1].arg == ('gidx1', 5), idxs[1].arg
     assert idxs[2].arg == ('gidx2', 4), idxs[2].arg
 
-  def test_div_collapse(self):
-    def helper(t, msg, max_ops=0):
-      sched = [si for si in t.schedule() if si.ast.op is Ops.SINK]
-      assert len(sched) == 1
-
-      lin = Kernel(sched[0].ast)
-      assert sum(u.op in {Ops.RECIP, Ops.FDIV} for u in lin.linearize().uops) == max_ops, msg
-
-    a = Tensor.empty((4,4))
-    b = Tensor.empty((4,4))
-    d = Tensor.empty((4,4))
-
-    c = (a*b)/b
-    helper(c, "found Ops.RECIP in (a*b)/b operation")
-
-    c = a/a
-    helper(c, "found Ops.RECIP in (a/a) operation")
-
-    c = (a/b)/d
-    helper(c, "found multiple Ops.RECIP in (a/b)/d operation", 1)
-
   def test_sum_collapse(self):
     t = Tensor([2]).reshape(1, 1).expand(256, 256).sum()
     sched = [si for si in t.schedule() if si.ast.op is Ops.SINK]

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -223,14 +223,12 @@ class TestSchedule(unittest.TestCase):
   @unittest.expectedFailure
   def test_div_collapse_const(self):
     a = Tensor.empty(32)
-    b = Tensor.empty(32)
     expr = a/a
     check_schedule(expr, 0)
     self.assertIsNone(expr.lazydata.base.realized)
 
   def test_mul_collapse_buffer(self):
     a = Tensor.empty(32)
-    b = Tensor.empty(32)
     expr = a*1
     check_schedule(expr, 0)
     # NOTE: no BUFFER gets allocated if the tensor collapses to a CONST
@@ -238,7 +236,6 @@ class TestSchedule(unittest.TestCase):
 
   def test_mul_collapse_const(self):
     a = Tensor.empty(32)
-    b = Tensor.empty(32)
     expr = a*0
     check_schedule(expr, 0)
     # NOTE: no BUFFER gets allocated if the tensor collapses to a CONST

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -211,35 +211,35 @@ class TestSchedule(unittest.TestCase):
     reduceops = [x for si in schedule for x in si.ast.toposort if x.op is Ops.REDUCE_AXIS]
     assert len(reduceops) == 2
 
-  @unittest.expectedFailure
   def test_div_collapse_buffer(self):
-    a = Tensor.empty(32)
-    b = Tensor.empty(32)
+    a = Tensor.full((4,), 4.0).contiguous().realize()
+    b = Tensor.full((4,), 2.0).contiguous().realize()
+    GlobalCounters.reset()
     expr = (a*b)/b
-    check_schedule(expr, 0)
-    # (a*b)/b shares the BUFFER with a
-    self.assertIs(expr.lazydata.base.realized, a.lazydata.base.realized)
+    expr.realize()
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+    self.assertEqual(GlobalCounters.global_ops, 0)
+    np.testing.assert_allclose(expr.numpy(), np.full((4,), 4.0))
 
-  @unittest.expectedFailure
   def test_div_collapse_const(self):
-    a = Tensor.empty(32)
+    a = Tensor.full((4,), 4.0).contiguous().realize()
+    GlobalCounters.reset()
     expr = a/a
-    check_schedule(expr, 0)
-    self.assertIsNone(expr.lazydata.base.realized)
+    expr.realize()
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+    self.assertEqual(GlobalCounters.global_ops, 0)
+    np.testing.assert_allclose(expr.numpy(), np.full((4,), 1.0))
 
-  def test_mul_collapse_buffer(self):
-    a = Tensor.empty(32)
-    expr = a*1
-    check_schedule(expr, 0)
-    # NOTE: no BUFFER gets allocated if the tensor collapses to a CONST
-    self.assertIs(expr.lazydata.base.realized, a.lazydata.base.realized)
-
-  def test_mul_collapse_const(self):
-    a = Tensor.empty(32)
-    expr = a*0
-    check_schedule(expr, 0)
-    # NOTE: no BUFFER gets allocated if the tensor collapses to a CONST
-    self.assertIsNone(expr.lazydata.base.realized)
+  def test_div_collapse(self):
+    a = Tensor.full((4,), 1.0).contiguous().realize()
+    b = Tensor.full((4,), 2.0).contiguous().realize()
+    c = Tensor.full((4,), 3.0).contiguous().realize()
+    GlobalCounters.reset()
+    expr = (a/b)/c
+    expr.realize()
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+    self.assertLessEqual(GlobalCounters.global_ops, 12)
+    np.testing.assert_allclose(expr.numpy(), (a.numpy()/b.numpy())/c.numpy())
 
   def test_dedup_assign(self):
     a = Tensor.ones(4).contiguous().realize()

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -238,7 +238,7 @@ class TestSchedule(unittest.TestCase):
     expr = (a/b)/c
     expr.realize()
     self.assertEqual(GlobalCounters.kernel_count, 1)
-    self.assertLessEqual(GlobalCounters.global_ops, 12)
+    self.assertLessEqual(GlobalCounters.global_ops, 4*3)
     np.testing.assert_allclose(expr.numpy(), (a.numpy()/b.numpy())/c.numpy())
 
   def test_dedup_assign(self):


### PR DESCRIPTION
The simple_tensor_map diff changes the schedule for `(a*b)/b`,
Because it applies symbolic on the raw tensor uops that div folding can happen in the scheduler, no additional kernels needed.

Right now this happens late in the lowerer.