### PR TITLE
add failing assert for gradient realization [pr]

### DIFF
--- a/test/test_image_dtype.py
+++ b/test/test_image_dtype.py
@@ -113,6 +113,7 @@ class TestImageDType(unittest.TestCase):
     assert it.lazydata.base.realized._buf != b1
 
   # issue caused by: don't realize image to image casts. this is part of a larger problem
+  @unittest.expectedFailure
   def test_lil_model(self):
     with Context(IMAGE=2):
       x = Tensor.zeros(1, 1)
@@ -121,7 +122,10 @@ class TestImageDType(unittest.TestCase):
       loss = x.image_dot(w1).image_dot(w2).float().max()
       loss.backward()
       sched = unwrap(w1.grad).schedule()
-      self.assertEqual(len(sched), 9)
+      # NOTE: the w1 grad must realize to a seperate kernel
+      assert w1.grad.lazydata.is_realized, f"never realized {w1.grad}"
+      self.assertEqual(w1.grad.lazydata.base.buffer.dtype, dtypes.float32)
+      self.assertEqual(len(sched), 10)
       for s,ei in zip(sched, lower_schedule(sched[:])):
         ei.run()
         if s.outputs[0].dtype == dtypes.float:


### PR DESCRIPTION
tensor_map_simple #8580 changed the kernel count here because it is correctly realizing the final CAST to float to a new BUFFER.
![image](https://github.com/user-attachments/assets/26496b66-1b22-4ff7-a3ad-113ea0ced97d)
Right now this is incorrectly folding that gradient with the imagef CAST parent.

