### PR TITLE
allow symbolic shape in tensor const parents [pr]

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2273,6 +2273,12 @@ class TestTensorUOpSpec(unittest.TestCase):
     t = graph_rewrite(a.lazydata.sink(), remove_movement_ops+merge_views)
     create_schedule_with_vars(t)
 
+  def test_symbolic_shape_ok(self):
+    a = Tensor.ones(4)
+    vi = UOp.variable("i", 1, 10).bind(4)
+    t = graph_rewrite(a.reshape(vi).sum().lazydata, remove_movement_ops+merge_views)
+    create_schedule_with_vars(t)
+
 class TestBufferUOp(unittest.TestCase):
   # BUFFER has a ShapeTracker of shape=(n,) and stride=(1,)
   def test_buffer_has_buffer(self):

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -31,9 +31,9 @@ tensor_uop_spec = PatternMatcher([
   (UPat(Ops.BIND, dtypes.int, (UPat(Ops.DEFINE_VAR), UPat.cvar(dtype=dtypes.int)), arg=None), lambda: True),
   (UPat(Ops.DEFINE_VAR, src=(UPat(Ops.VIEW, arg=ShapeTracker.from_shape(()))), arg=None), lambda: True),
 
-  # Tensor const has an unmasked ShapeTracker of stride 0 and a device
+  # Tensor const has a device and an unmasked ShapeTracker of stride 0 or a ShapeTracker with symbolic shape
   (UPat(Ops.CONST, src=(UPat(Ops.VIEW, name="st", src=(UPat(Ops.DEVICE),)),)),
-   lambda st: len(st.st.views) == 1 and all(s == 0 for s in st.st.views[0].strides) and st.st.views[0].mask is None),
+   lambda st: st.st.views[0].mask is None and ((len(st.st.views) == 1 and all(s == 0 for s in st.st.views[0].strides)) or not all_int(st.shape))),
 
   # DETACH and CONTIGUOUS change how we interpret the source UOp
   # CONTIGUOUS ensures the source UOp realizes


### PR DESCRIPTION
A tensor const with symbolic shape has a stride 1. Currently this is blocking #8698 as we can add movement ops after the reshape is done.

The tensor const.reshape(bind) becomes:
```
UOp(Ops.CONST, dtypes.float, arg=1.0, src=(
      UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(4,), strides=(0,), offset=0, mask=None, contiguous=False), View(shape=(UOp(Ops.BIND, dtypes.int, arg=None, src=(
  UOp(Ops.DEFINE_VAR, dtypes.int, arg=('i', 1, 10), src=()),
  UOp(Ops.CONST, dtypes.int, arg=4, src=()),)),), strides=(1,), offset=0, mask=None, contiguous=True))), src=(
        UOp(Ops.DEVICE, dtypes.void, arg='METAL', src=()),)),))
```
Unlike normal CONST is has two views and a stride=(1,).

We can still keep the unmasked check. I think this is the only thing a CONST with int shape and UOp shape have in common.