### PR TITLE
fix using clone with shrink [pr]

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -667,6 +667,12 @@ class TestZeroShapeTensor(unittest.TestCase):
     b.realize()
     self.assertIsNot(a.lazydata.base.buffer, b.lazydata.base.buffer)
 
+  def test_clone_with_shrink_realized(self):
+    a = Tensor.rand(16, 16).realize()
+    b = a.shrink(((2, 10), None)).clone()
+    b.realize()
+    self.assertIsNot(a.lazydata.base.buffer, b.lazydata.base.buffer)
+
   def test_clone_with_grad(self):
     a = Tensor.rand(16, 16, requires_grad=True)
     a.mul(5.0).add(5.0).mean().backward()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -652,19 +652,20 @@ class TestZeroShapeTensor(unittest.TestCase):
 
   def test_clone(self):
     a = Tensor.rand(16, 16).realize()
-    self.assertIsNot(a.lazydata, a.clone().lazydata)
-    np.testing.assert_allclose(a.numpy(), a.clone().numpy())
+    b = a.clone()
+    np.testing.assert_allclose(a.numpy(), b.numpy())
+    self.assertIsNot(a.lazydata.base.buffer, b.lazydata.base.buffer)
 
     a = Tensor.rand(16, 16).mul(5.0).add(5.0)
-    self.assertIsNot(a.lazydata, a.clone().lazydata)
-    np.testing.assert_allclose(a.numpy(), a.clone().numpy())
+    b = a.clone()
+    np.testing.assert_allclose(a.numpy(), b.numpy())
+    self.assertIsNot(a.lazydata.base.buffer, b.lazydata.base.buffer)
 
   def test_clone_with_shrink(self):
-    a = Tensor.empty(16, 16)
-    self.assertIsNot(a.lazydata, a.clone().lazydata)
-
-    b = a.shrink(((2, 10), None))
-    self.assertIsNot(b.lazydata, b.clone().lazydata)
+    a = Tensor.rand(16, 16)
+    b = a.shrink(((2, 10), None)).clone()
+    b.realize()
+    self.assertIsNot(a.lazydata.base.buffer, b.lazydata.base.buffer)
 
   def test_clone_with_grad(self):
     a = Tensor.rand(16, 16, requires_grad=True)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -428,7 +428,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     return UOp(Ops.VIEW, dtype, (UOp.new_buffer(device, (st:=ShapeTracker.from_shape(shape)).size, dtype),), st)
   def copy_to_device(self, device:str, clone:bool=False) -> UOp:
     # if it's a shrink, do the shrink before the copy with CONTIGUOUS
-    if prod(self.shape) < prod(self.base.shape): return self.contiguous().copy_to_device(device)
+    if prod(self.shape) < prod(self.base.shape): return self.contiguous().copy_to_device(device, clone)
     # COPY is COPY(DEVICE, copyin.base) -> VIEW(copyin.st)
     ret = UOp(Ops.COPY, self.base.dtype, (UOp(Ops.DEVICE, arg=device), self.base), clone)
     op_arg = []

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -428,7 +428,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     return UOp(Ops.VIEW, dtype, (UOp.new_buffer(device, (st:=ShapeTracker.from_shape(shape)).size, dtype),), st)
   def copy_to_device(self, device:str, clone:bool=False) -> UOp:
     # if it's a shrink, do the shrink before the copy with CONTIGUOUS
-    if prod(self.shape) < prod(self.base.shape): return self.contiguous().copy_to_device(device, clone)
+    if prod(self.shape) < prod(self.base.shape): return self.contiguous().copy_to_device(device)
     # COPY is COPY(DEVICE, copyin.base) -> VIEW(copyin.st)
     ret = UOp(Ops.COPY, self.base.dtype, (UOp(Ops.DEVICE, arg=device), self.base), clone)
     op_arg = []


### PR DESCRIPTION
err, tests shouldn't depend on any Tensor/ops methods doing folding before scheduling.
UOp functions always return a new UOp, the equivalence/folding is done after graph_rewrite.