### PR TITLE
Remove `SimpleMathTrait`

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -23,12 +23,13 @@ class MathTrait:
   def const_like(self:T, b:ConstLike) -> T: raise NotImplementedError
 
   # great functions you get!
-  def ufix(self, x): return self.const_like(x) if not isinstance(x, MathTrait) else x
-  def _binop(self, op, x, reverse): return self.ufix(x).alu(op, self) if reverse else self.alu(op, self.ufix(x))
   def logical_not(self): return self.ne(True)
   def neg(self):
     if (dtype:=getattr(self, 'dtype')) is None: raise TypeError(f"MathTraits __neg__ requires a dtype, {self=}")
     return self.logical_not() if dtype.scalar() == dtypes.bool else self*(-1)
+
+  def ufix(self, x): return self.const_like(x) if not isinstance(x, MathTrait) else x
+  def _binop(self, op, x, reverse): return self.ufix(x).alu(op, self) if reverse else self.alu(op, self.ufix(x))
   def add(self, x, reverse=False): return self._binop(Ops.ADD, x, reverse)
   def mul(self, x, reverse=False): return self._binop(Ops.MUL, x, reverse)
   def bitwise_and(self, x, reverse=False): return self._binop(Ops.AND, x, reverse)
@@ -40,9 +41,17 @@ class MathTrait:
   def div(self, x, reverse=False): return (self.ufix(x)*self.alu(Ops.RECIP)) if reverse else (self*self.ufix(x).alu(Ops.RECIP))
   def lshift(self, x, reverse=False): return self._binop(Ops.SHL, x, reverse)
   def rshift(self, x, reverse=False): return self._binop(Ops.SHR, x, reverse)
+  def cmplt(self, x, reverse=False): return self._binop(Ops.CMPLT, x, reverse)
+  def max(self, x, reverse=False): return self._binop(Ops.MAX, x, reverse)
+
+  def reciprocal(self): return self.alu(Ops.RECIP)
+  def sqrt(self): return self.alu(Ops.SQRT)
+  def sin(self): return self.alu(Ops.SIN)
+  def log2(self): return self.alu(Ops.LOG2)
+  def exp2(self): return self.alu(Ops.EXP2)
+  def threefry(self, seed): return self.alu(Ops.THREEFRY, seed)
 
   def __neg__(self): return self.neg()
-
   def __add__(self, x): return self.add(x)
   def __sub__(self, x): return self.sub(x)
   def __mul__(self, x): return self.mul(x)
@@ -54,6 +63,7 @@ class MathTrait:
   def __xor__(self, x): return self.xor(x)
   def __lshift__(self, x): return self.lshift(x)
   def __rshift__(self, x): return self.rshift(x)
+  def __lt__(self, x): return self.cmplt(x)
 
   def __radd__(self, x): return self.add(x, True)
   def __rsub__(self, x): return self.sub(x, True)
@@ -66,9 +76,8 @@ class MathTrait:
   def __rmod__(self, x): return self.mod(x, True)
   def __rlshift__(self, x): return self.lshift(x, True)
   def __rrshift__(self, x): return self.rshift(x, True)
+  def __gt__(self, x): return self.cmplt(x, True)
 
-  def __lt__(self, x): return self.alu(Ops.CMPLT, self.ufix(x))
-  def __gt__(self, x): return self.ufix(x).alu(Ops.CMPLT, self)
   def __ge__(self, x): return (self < x).logical_not()
   def __le__(self, x): return (self > x).logical_not()
 
@@ -77,15 +86,9 @@ class MathTrait:
   def __ne__(self, x): return self.ne(x)
   # NOTE: __eq__ isn't overridden, and means the same thing as is by default
 
-  def maximum(self, x): return self.alu(Ops.MAX, self.ufix(x))
+  def maximum(self, x): return self.max(x)
   def minimum(self, x): return -(-self).maximum(-x)
   def where(self, x, y): return self.alu(Ops.WHERE, x, x.ufix(y))
-  def threefry(self, seed): return self.alu(Ops.THREEFRY, seed)
-  def reciprocal(self): return self.alu(Ops.RECIP)
-  def sqrt(self): return self.alu(Ops.SQRT)
-  def sin(self): return self.alu(Ops.SIN)
-  def log2(self): return self.alu(Ops.LOG2)
-  def exp2(self): return self.alu(Ops.EXP2)
 
 # the order of these Ops controls the order of the toposort
 class Ops(FastEnum):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -42,7 +42,6 @@ class MathTrait:
   def lshift(self, x, reverse=False): return self._binop(Ops.SHL, x, reverse)
   def rshift(self, x, reverse=False): return self._binop(Ops.SHR, x, reverse)
   def cmplt(self, x, reverse=False): return self._binop(Ops.CMPLT, x, reverse)
-  def max(self, x, reverse=False): return self._binop(Ops.MAX, x, reverse)
 
   def reciprocal(self): return self.alu(Ops.RECIP)
   def sqrt(self): return self.alu(Ops.SQRT)
@@ -86,7 +85,7 @@ class MathTrait:
   def __ne__(self, x): return self.ne(x)
   # NOTE: __eq__ isn't overridden, and means the same thing as is by default
 
-  def maximum(self, x): return self.max(x)
+  def maximum(self, x): return self._binop(Ops.MAX, x, False)
   def minimum(self, x): return -(-self).maximum(-x)
   def where(self, x, y): return self.alu(Ops.WHERE, x, x.ufix(y))
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2479,6 +2479,7 @@ class Tensor(MathTrait):
     ```
     """
     return self.cast(dtypes.bool)._apply_broadcasted_uop(UOp.ne, True)
+
   def neg(self):
     """
     Negates the tensor element-wise.
@@ -2488,16 +2489,19 @@ class Tensor(MathTrait):
     ```
     """
     return self*-1 if self.dtype != dtypes.bool else self.logical_not()
+
   def contiguous(self):
     """
     Returns a contiguous tensor.
     """
     return self._apply_uop(UOp.contiguous)
+
   def contiguous_backward(self):
     """
     Inserts a contiguous operation in the backward pass.
     """
     return self._apply_uop(UOp.contiguous_backward)
+
   def log(self):
     """
     Computes the natural logarithm element-wise.
@@ -2509,6 +2513,7 @@ class Tensor(MathTrait):
     ```
     """
     return self.log2()*math.log(2)
+
   def log2(self):
     """
     Computes the base-2 logarithm element-wise.
@@ -2520,6 +2525,7 @@ class Tensor(MathTrait):
     ```
     """
     return self.cast(least_upper_float(self.dtype))._apply_uop(UOp.log2)
+
   def exp(self):
     """
     Computes the exponential function element-wise.
@@ -2531,6 +2537,7 @@ class Tensor(MathTrait):
     ```
     """
     return self.mul(1/math.log(2)).exp2()
+
   def exp2(self):
     """
     Computes the base-2 exponential function element-wise.
@@ -2542,6 +2549,7 @@ class Tensor(MathTrait):
     ```
     """
     return self.cast(least_upper_float(self.dtype))._apply_uop(UOp.exp2)
+
   def relu(self):
     """
     Applies the Rectified Linear Unit (ReLU) function element-wise.
@@ -2670,6 +2678,7 @@ class Tensor(MathTrait):
     ```
     """
     return self.cast(dtypes.int32).cast(self.dtype)
+
   def ceil(self: Tensor) -> Tensor:
     """
     Rounds the tensor element-wise towards positive infinity.
@@ -2679,6 +2688,7 @@ class Tensor(MathTrait):
     ```
     """
     return (self > (b := self.trunc())).where(b+1, b)
+
   def floor(self: Tensor) -> Tensor:
     """
     Rounds the tensor element-wise towards negative infinity.
@@ -2688,6 +2698,7 @@ class Tensor(MathTrait):
     ```
     """
     return (self < (b := self.trunc())).where(b-1, b)
+
   def round(self: Tensor) -> Tensor:
     """
     Rounds the tensor element-wise with rounding half to even.
@@ -2707,6 +2718,7 @@ class Tensor(MathTrait):
     ```
     """
     return (self == float("inf")) * detect_positive + (self == float("-inf")) * detect_negative
+
   def isnan(self:Tensor):
     """
     Checks the tensor element-wise to return True where the element is NaN, otherwise returns False
@@ -2740,6 +2752,7 @@ class Tensor(MathTrait):
     ```
     """
     return self*self
+
   def clamp(self, min_=None, max_=None):
     """
     Clips (clamps) the values in the tensor between `min_` and `max_` element-wise.
@@ -2752,11 +2765,13 @@ class Tensor(MathTrait):
     if min_ is None and max_ is None: raise RuntimeError("at least one of 'min_' or 'max_' must not be None")
     ret = self.maximum(min_) if min_ is not None else self
     return ret.minimum(max_) if max_ is not None else ret
+
   def clip(self, min_=None, max_=None):
     """
     Alias for `Tensor.clamp`.
     """
     return self.clamp(min_, max_)
+
   def sign(self):
     """
     Returns the sign of the tensor element-wise.
@@ -2766,6 +2781,7 @@ class Tensor(MathTrait):
     ```
     """
     return self.ne(0).where((self<0).where(self.full_like(-1), self.full_like(1)), self.full_like(0)) + self*0
+
   def abs(self):
     """
     Computes the absolute value of the tensor element-wise.
@@ -2775,6 +2791,7 @@ class Tensor(MathTrait):
     ```
     """
     return self * self.sign()
+
   def reciprocal(self):
     """
     Compute `1/x` element-wise.

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3266,8 +3266,7 @@ class Tensor(MathTrait):
     ```
     """
     assert dtypes.is_unsigned(self.dtype) and isinstance(x, int) and x >= 0, f"not supported {self.dtype=} {x=}"
-    # return self.mul(2 ** x)
-    return self._apply_broadcasted_uop(UOp.lshift, x, reverse)
+    return self.mul(2 ** x) # return self._apply_broadcasted_uop(UOp.lshift, x, reverse)
 
   def rshift(self, x:int, reverse=False):
     """
@@ -3279,8 +3278,7 @@ class Tensor(MathTrait):
     ```
     """
     assert dtypes.is_unsigned(self.dtype) and isinstance(x, int) and x >= 0, f"not supported {self.dtype=} {x=}"
-    # return self.idiv(2 ** x)
-    return self._apply_broadcasted_uop(UOp.rshift, x, reverse)
+    return self.idiv(2 ** x) # return self._apply_broadcasted_uop(UOp.rshift, x, reverse)
 
   def pow(self, x:Union[Tensor, ConstType], reverse=False) -> Tensor:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3379,9 +3379,6 @@ class Tensor(MathTrait):
 
   def __invert__(self) -> Tensor: return self.bitwise_not()
 
-  def __lshift__(self, x) -> Tensor: return self.lshift(x)
-  def __rshift__(self, x) -> Tensor: return self.rshift(x)
-
   def __pow__(self, x) -> Tensor: return self.pow(x)
   def __matmul__(self, x) -> Tensor: return self.matmul(x)
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3419,8 +3419,6 @@ class Tensor(MathTrait):
   def __gt__(self, x) -> Tensor: return self._apply_broadcasted_uop(UOp.__lt__, x, True)
   def ne(self, x) -> Tensor: return self._apply_broadcasted_uop(UOp.ne, x, False)
 
-  def __eq__(self, x) -> Tensor: return self.eq(x)                      # type: ignore[override]
-
   # ***** functional nn ops *****
 
   def linear(self, weight:Tensor, bias:Optional[Tensor]=None):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3256,7 +3256,7 @@ class Tensor(MathTrait):
     if self.dtype != dtypes.bool and not dtypes.is_int(self.dtype): raise RuntimeError(f"{self.dtype} is not supported")
     return self.logical_not() if self.dtype == dtypes.bool else self ^ -1
 
-  def lshift(self, x:int):
+  def lshift(self, x:int, reverse=False):
     """
     Computes left arithmetic shift of `self` by `x` bits. `self` must have unsigned dtype.
     Equivalent to `self << x`.
@@ -3266,9 +3266,10 @@ class Tensor(MathTrait):
     ```
     """
     assert dtypes.is_unsigned(self.dtype) and isinstance(x, int) and x >= 0, f"not supported {self.dtype=} {x=}"
-    return self.mul(2 ** x)
+    # return self.mul(2 ** x)
+    return self._apply_broadcasted_uop(UOp.lshift, x, reverse)
 
-  def rshift(self, x:int):
+  def rshift(self, x:int, reverse=False):
     """
     Computes right arithmetic shift of `self` by `x` bits. `self` must have unsigned dtype.
     Equivalent to `self >> x`.
@@ -3278,7 +3279,8 @@ class Tensor(MathTrait):
     ```
     """
     assert dtypes.is_unsigned(self.dtype) and isinstance(x, int) and x >= 0, f"not supported {self.dtype=} {x=}"
-    return self.idiv(2 ** x)
+    # return self.idiv(2 ** x)
+    return self._apply_broadcasted_uop(UOp.rshift, x, reverse)
 
   def pow(self, x:Union[Tensor, ConstType], reverse=False) -> Tensor:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -8,7 +8,7 @@ from tinygrad.helpers import argfix, make_tuple, flatten, prod, all_int, round_u
 from tinygrad.helpers import IMAGE, WINO, _METADATA, Metadata, TRACEMETA, ceildiv, fetch, polyN, unwrap
 from tinygrad.multi import get_multi_map
 from tinygrad.gradient import compute_gradient
-from tinygrad.ops import smax, smin, resolve, UOp, Ops, sint, Variable, SimpleMathTrait, identity_element
+from tinygrad.ops import smax, smin, resolve, UOp, Ops, sint, Variable, MathTrait, identity_element
 from tinygrad.device import Device, BufferSpec
 from tinygrad.engine.realize import run_schedule
 from tinygrad.engine.memory import memory_planner
@@ -115,7 +115,7 @@ def _flat_to_grouped(padding:Sequence[sint]) -> tuple[tuple[sint, sint], ...]: r
 
 ReductionStr = Literal["mean", "sum", "none"]
 
-class Tensor(SimpleMathTrait):
+class Tensor(MathTrait):
   """
   A `Tensor` is a multi-dimensional matrix containing elements of a single data type.
 


### PR DESCRIPTION
Removed `__eq__`, `__lshift__`, `__rshift__` from `Tensor` because they are now implemented in `MathTrait`. Are there more functions I can remove?

I want to get rid the in-place functions (e.g. `__iadd__`). But it seems like they must be in `Tensor.py` because we need `assign()` to take care of reassigning the `lazydata`, something we can only do in `Tensor`, not `UOp`.

It seems all other functions in `Tensor` that are wrappers for `UOp`s must remain because they take care of broadcasting dimensions and casting `dtype`s.
