### PR TITLE
add `Tensor.isclose` and `Tensor.allclose`

### DIFF
--- a/docs/tensor/ops.md
+++ b/docs/tensor/ops.md
@@ -6,6 +6,8 @@
 ::: tinygrad.Tensor.min
 ::: tinygrad.Tensor.any
 ::: tinygrad.Tensor.all
+::: tinygrad.Tensor.isclose
+::: tinygrad.Tensor.allclose
 ::: tinygrad.Tensor.mean
 ::: tinygrad.Tensor.var
 ::: tinygrad.Tensor.std

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1242,6 +1242,36 @@ class TestOps(unittest.TestCase):
   def test_all_zero_axis(self):
     helper_test_op([(1,0,3,0,5)], lambda x: x.all(axis=(1,3)), forward_only=True)
 
+  def test_isclose(self):
+    helper_test_op([(3, 4)], lambda x: x.isclose(x), forward_only=True)
+    helper_test_op(None, lambda x: x.isclose(x + 1e-6), vals=[[1.0, 2.0, 3.0]], forward_only=True)
+    helper_test_op(None, lambda x: x.isclose(x + 0.1), vals=[[1.0, 2.0, 3.0]], forward_only=True)
+    helper_test_op(None, lambda x: x.isclose(x + 0.1, rtol=0.2, atol=0.0), vals=[[1.0, 2.0, 3.0]], forward_only=True)
+    helper_test_op(None, lambda x: x.isclose(x + 1e-9), vals=[[0.0, 0.0, 0.0]], forward_only=True)
+    helper_test_op([(2, 3, 4)], lambda x: x.isclose(x + 1e-6), forward_only=True)
+
+  def test_isclose_edge_cases(self):
+    helper_test_op(None, lambda x: x.isclose(x), vals=[[float("inf"), float("-inf"), 1.0]], forward_only=True)
+    helper_test_op(None, lambda x: x.isclose(x), vals=[[float("nan"), 1.0]], forward_only=True)
+    helper_test_op(None, lambda x: x.isclose(x), vals=[[float("nan"), 1.0]], forward_only=True)
+
+  def test_allclose(self):
+    helper_test_op([(3, 4, 5, 6)], lambda x: x.allclose(x), forward_only=True)
+    helper_test_op(None, lambda x: x.allclose(x), vals=[[1.0, 2.0]], forward_only=True)
+    helper_test_op(None, lambda x: x.allclose(x + 1e-6), vals=[[1.0, 2.0]], forward_only=True)
+    helper_test_op(None, lambda x: x.allclose(x + 0.1), vals=[[1.0, 2.0]], forward_only=True)
+    helper_test_op([()], lambda x: x.allclose(x), forward_only=True)
+    helper_test_op(None, lambda x: x.allclose(x + 0.1, rtol=0.2, atol=0.0), vals=[[1.0, 2.0]], forward_only=True)
+
+  def test_allclose_edge_cases(self):
+    helper_test_op(None, lambda x: x.allclose(x), vals=[[float("inf"), float("-inf")]], forward_only=True)
+    helper_test_op(None, lambda x: x.allclose(x), vals=[[float("nan"), 1.0]], forward_only=True)
+    helper_test_op(None, lambda x: x.allclose(x + 1e-9), vals=[[0.0, 0.0]], forward_only=True)
+
+  def test_allclose_mixed_cases(self):
+    helper_test_op(None, lambda x: x.allclose(x + 1e-6), vals=[[1.0, 2.0, 3.0 + 0.1]], forward_only=True)
+    helper_test_op(None, lambda x: x.allclose(x), vals=[[0.0, 1.0, float("inf")]], forward_only=True)
+
   def test_mean(self):
     helper_test_op([(3,4,5,6)], lambda x: x.mean())
     helper_test_op([()], lambda x: x.mean())

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1712,6 +1712,44 @@ class Tensor(SimpleMathTrait):
     """
     return self.logical_not().any(axis, keepdim).logical_not()
 
+  def isclose(self, other:Tensor, rtol:float=1e-05, atol:float=1e-08) -> Tensor:
+    """
+    Returns a new tensor with element-wise comparison of closeness to `other` within a tolerance.
+
+    The `rtol` and `atol` keyword arguments control the relative and absolute tolerance of the comparison.
+
+    Two `NaN` values are not close to each other.
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor([1, 2, 3])
+    print(t.numpy())
+    ```
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor([1, 2, 3])
+    print(t.isclose(Tensor([1, 2, 3.1])).numpy())
+    ```
+    """
+    return ((self - other).abs() <= atol + rtol * other.abs()) * (self.isnan() | other.isnan()).logical_not()
+
+  def allclose(self, other:Tensor, rtol:float=1e-05, atol:float=1e-08) -> Tensor:
+    """
+    Tests if all elements of the tensor are close to the `other` ones within a tolerance.
+
+    The `rtol` and `atol` keyword arguments control the relative and absolute tolerance of the comparison.
+
+    Two `NaN values are not close to each other.
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor([1, 2, 3])
+    print(t.numpy())
+    ```
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor([1, 2, 3])
+    print(t.allclose(Tensor([1, 2, 3.1])).numpy())
+    ```
+    """
+    return self.isclose(other, rtol, atol).all()
+
   def mean(self, axis:Optional[Union[int, Sequence[int]]]=None, keepdim=False):
     """
     Returns the mean value of the tensor along the specified axis or axes.


### PR DESCRIPTION
As [discussed on Discord](https://discord.com/channels/1068976834382925865/1070745817025106080/1333669036533354497), let's try to add `Tensor.isclose` and `Tensor.allclose` operations. For reference:
- [`torch.isclose`](https://pytorch.org/docs/stable/generated/torch.isclose.html)
- [`torch.allclose`](https://pytorch.org/docs/stable/generated/torch.allclose.html)

I tried to implement some tests with `helper_test_op()`, but I am not sure I did that correctly.

Also, the tests for `Tensor.allclose()` are failing, which I think is due to the fact that PyTorch returns a `bool` and not a `torch.Tensor` object:
```
=========================================================================================================================== short test summary info ===========================================================================================================================
FAILED test/test_ops.py::TestOps::test_allclose - AttributeError: 'bool' object has no attribute 'detach'
FAILED test/test_ops.py::TestOps::test_allclose_edge_cases - AttributeError: 'bool' object has no attribute 'detach'
FAILED test/test_ops.py::TestOps::test_allclose_mixed_cases - AttributeError: 'bool' object has no attribute 'detach'
==================================================================================================== 3 failed, 1436 passed, 82 skipped, 24 xfailed, 23 warnings in 47.03s =====================================================================================================
```