### PR TITLE
support lowering CONST(VIEW) in lowerer

### DIFF
--- a/test/unit/test_verify_ast.py
+++ b/test/unit/test_verify_ast.py
@@ -92,8 +92,7 @@ class TestVerifyAST(unittest.TestCase):
     buf = UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(), (), 0)
     a = UOp.const(dtypes.int, 0).replace(src=(UOp(Ops.VIEW, dtypes.void, (UOp(Ops.DEVICE, arg="CLANG"),), ShapeTracker.from_shape(())),))
     st = UOp.store(buf, ShapeTracker.from_shape(()).to_uop(), a.cast(dtypes.float))
-    # lowerer asserts because it does not remove ShapeTracker on CONST(VIEW(DEVICE))
-    with self.assertRaises(AssertionError): helper_test_verify_ast(st)
+    helper_test_verify_ast(st)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -5,7 +5,7 @@ from typing import cast
 from tinygrad.dtype import dtypes, PtrDType
 from tinygrad.ops import KernelInfo, UOp, Ops, graph_rewrite, PatternMatcher, UPat, sint, identity_element, sint_to_uop
 from tinygrad.renderer import Renderer
-from tinygrad.helpers import all_int, prod, partition, flatten
+from tinygrad.helpers import all_int, prod, partition, flatten, unwrap
 
 # returns the axes to create new_shape if new_shape can be created by combining axis from old_shape
 def get_contraction(old_shape:tuple[sint, ...], new_shape:tuple[sint, ...]) -> list[list[int]]|None:
@@ -122,8 +122,13 @@ def lower_load_store(ctx: IndexContext, x: UOp):
       if oidx is not ridx: valid = valid * oidx.eq(0)
   return UOp(Ops.STORE, dtypes.void, (buf.index(idx, valid), x.src[2]))
 
+def lower_const(x:UOp):
+  assert all(v.mask is None for v in unwrap(x.st).views), f"VIEW in CONST/DEFINE_VAR source must be unmasked, got {x.st}"
+  return x.replace(src=())
+
 pm_lowerer = PatternMatcher([
   (UPat(Ops.REDUCE_AXIS, name="x"), lower_reduce_axis),
+  (UPat((Ops.CONST, Ops.DEFINE_VAR), src=(UPat(Ops.VIEW),), name="x"), lower_const),
   (UPat(Ops.VALID, src=(UPat(Ops.VIEW),), name="x"), lambda ctx,x: x.st_arg.to_indexed_uops(ctx.idxs)[1]),
   # rewrite LOAD/STORE VIEW to LOAD/STORE with indexed
   (UPat((Ops.LOAD, Ops.STORE), src=(UPat(), UPat(Ops.VIEW)), allow_any_len=True, name="x"), lower_load_store),


### PR DESCRIPTION
Prereq change for #8759.

Lowerer asserts this in master because the ShapeTracker does not get removed.
<img width="1353" alt="Screenshot 2025-01-28 at 11 20 33 AM" src="https://github.com/user-attachments/assets/2623520f-c00c-43ad-a797-7013952a2371" />

```
python3 test/unit/test_verify_ast.py TestVerifyAST.test_const_view_always_valid
```

Generates the correct kernel in this branch:
<img width="1217" alt="Screenshot 2025-01-28 at 11 23 41 AM" src="https://github.com/user-attachments/assets/dad7f7bb-9ccd-4412-9cf5-d827df630dd9" />

