### PR TITLE
Fix test_ops.py on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -666,7 +666,7 @@ jobs:
       - name: Run pytest (clang)
         shell: bash
         run: |
-          DEBUG=5 CLANG=1 python -m pytest -n=auto test/test_tiny.py --durations=20
+          DEBUG=5 CLANG=1 python -m pytest -n=auto test/test_tiny.py test/test_ops.py --durations=20
 
   #testunicorn:
   #  name: ARM64 unicorn Test

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -11,6 +11,7 @@ def prod(x:Iterable[T]) -> Union[T,int]: return functools.reduce(operator.mul, x
 
 # NOTE: helpers is not allowed to import from anything else in tinygrad
 OSX = platform.system() == "Darwin"
+WIN = platform.system() == "Windows"
 CI = os.getenv("CI", "") != ""
 
 # fix colors on Windows, https://stackoverflow.com/questions/12492810/python-how-can-i-make-the-ansi-escape-codes-to-work-also-in-windows


### PR DESCRIPTION
Some tests in test_ops.py would fail on Windows with "access violation reading 0xFFFFFFFFFFFFFFFF". See https://github.com/victorqhong/tinygrad/actions/runs/13020694560/job/36320461001?pr=1

The fix is to allocate more memory to prevent reads past the end of the buffers.