### PR TITLE
More complete shapetracker.simplify() (draft)

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1348,7 +1348,7 @@ view_left = merge_views+PatternMatcher([
 
 # *** convert shapetracker indexed uops to highs ilp programs, run highs_inst.clear() and _highs_mod_cache={} first ***
 
-# hackish, this stops exception in ucache
+# hack, this stops exception in ucache
 class hashable_highs_linexp(highspy.highs.highs_linear_expression):
   def __hash__(self): return id(self)
 highspy.highs.highs_linear_expression = hashable_highs_linexp

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1364,12 +1364,12 @@ highs_pre = symbolic_simple+PatternMatcher([
 ])
 
 def _highs_mod(x, d):
-  q = highs_inst.addVariable(lb=-np.inf, ub=np.inf, type=highspy.HighsVarType.kInteger)
+  q = highs_inst.addVariable(lb=x.vmin//d.arg, ub=x.vmax//d.arg, type=highspy.HighsVarType.kInteger)
   highs_inst.addConstr(0 <= x.arg[0] - q*d.arg <= d.arg-1)
   arg = (x.arg[0]-q*d.arg).simplify(), 0, d.arg-1
   return UOp(Ops.HIGHS_EXPR, arg=arg, dtype=dtypes.int)
 def _highs_idiv(x, d):
-  q = highs_inst.addVariable(lb=-np.inf, ub=np.inf, type=highspy.HighsVarType.kInteger)
+  q = highs_inst.addVariable(lb=x.vmin//d.arg, ub=x.vmax//d.arg, type=highspy.HighsVarType.kInteger)
   highs_inst.addConstr(0 <= x.arg[0] - q*d.arg <= d.arg-1)
   arg = q, x.vmin//d.arg, x.vmax//d.arg
   return UOp(Ops.HIGHS_EXPR, arg=arg, dtype=dtypes.int)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -10,6 +10,10 @@ from tinygrad.helpers import PICKLE_BUFFERS, SPLIT_REDUCEOP, DEBUG
 if TYPE_CHECKING:
   from tinygrad.shape.shapetracker import ShapeTracker
   from tinygrad.device import Buffer
+import numpy as np
+import highspy
+
+highs_inst = highspy.Highs()
 
 # wrapper around IntEnum that preserves Enum.__str__ and makes auto() unique across all FastEnum subclasses
 class FastEnum(IntEnum):
@@ -113,6 +117,9 @@ class Ops(FastEnum):
   DEFINE_VAR = auto(); DEFINE_LOCAL = auto(); DEFINE_ACC = auto() # noqa: E702
   VALID = auto(); SPECIAL = auto(); NOOP = auto() # noqa: E702
 
+  # used in converting uops to highspy symbolic
+  HIGHS_EXPR = auto()
+
   # reduce
   REDUCE_AXIS = auto()
 
@@ -159,7 +166,7 @@ class GroupOp:
   Ternary = {Ops.WHERE, Ops.MULACC}
   ALU = set.union(Unary, Binary, Ternary)
 
-  Irreducible = {Ops.CONST, Ops.DEFINE_VAR, Ops.SPECIAL, Ops.RANGE}
+  Irreducible = {Ops.CONST, Ops.DEFINE_VAR, Ops.SPECIAL, Ops.RANGE, Ops.HIGHS_EXPR}
   Movement = {Ops.RESHAPE, Ops.EXPAND, Ops.PERMUTE, Ops.PAD, Ops.SHRINK, Ops.STRIDE}
 
   Buffer = {Ops.LOAD, Ops.PRELOAD, Ops.STORE, Ops.VALID}
@@ -631,6 +638,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     if self.op is Ops.SPECIAL: return 0, self.arg[1]-1 if isinstance(self.arg[1], int) else self.arg[1].vmax
     if self.op is Ops.CONST: return self.arg, self.arg
     if self.op is Ops.VCONST: return (min(self.arg), max(self.arg))
+    if self.op is Ops.HIGHS_EXPR: return self.arg[1], self.arg[2]
     return dtypes.min(self.dtype), dtypes.max(self.dtype)
 
   @functools.cached_property
@@ -997,6 +1005,10 @@ spec = PatternMatcher([
 
   # PTX LOAD/STORE
   (UPat((Ops.LOAD, Ops.STORE), src=(UPat(dtype=dtypes.int64),), allow_any_len=True), lambda: True),
+
+  # HIGHS_EXPR arg is (highspy object, vmin, vmax)
+  (UPat(Ops.HIGHS_EXPR, name="x"), lambda x: x.src==() and isinstance(x.arg,tuple) and len(x.arg)==3 and x.arg[2] >= x.arg[1] \
+   and isinstance(x.arg[0], highspy.highs.highs_linear_expression | highspy.highs.highs_var)),
 ])
 
 def type_verify(uops:list[UOp], *extra_specs:PatternMatcher):
@@ -1332,4 +1344,54 @@ view_left = merge_views+PatternMatcher([
    lambda e,vm: e.replace(src=tuple(s if s.st is None else s.view(vm.st) if s is s.base else s.base.view(s.st+vm.st) for s in e.src))),
   (UPat(Ops.VIEW, name="vm", src=(UPat(GroupOp.Buffer, name="b"),)),
    lambda b,vm: b.replace(src=tuple((s.st+vm.st).to_uop() if s.op is Ops.VIEW else s for s in b.src))),
+])
+
+# *** convert shapetracker indexed uops to highs ilp programs, run highs_inst.clear() and _highs_mod_cache={} first ***
+
+# hackish, this stops exception in ucache
+class hashable_highs_linexp(highspy.highs.highs_linear_expression):
+  def __hash__(self): return id(self)
+highspy.highs.highs_linear_expression = hashable_highs_linexp
+
+highs_pre = symbolic_simple+PatternMatcher([
+  ((UPat.var("x")!=True)!=True, lambda x: x),
+  # change AND to OR per de morgan
+  ((UPat.var("x") & UPat.var("y")) != True, lambda x,y: (x != True) | (y != True)),
+  # need all inequalities as const < var
+  ((UPat.var("x") < UPat.cvar("a")) != True, lambda x,a: a-1 < x),
+  ((UPat.cvar("a") < UPat.var("x")) != True, lambda a,x: x < a+1),
+  (UPat.var("x") < UPat.cvar("a"), lambda x,a: -a < -x ),
+])
+
+def _highs_mod(x, d):
+  q = highs_inst.addVariable(lb=-np.inf, ub=np.inf, type=highspy.HighsVarType.kInteger)
+  highs_inst.addConstr(0 <= x.arg[0] - q*d.arg <= d.arg-1)
+  arg = (x.arg[0]-q*d.arg).simplify(), 0, d.arg-1
+  return UOp(Ops.HIGHS_EXPR, arg=arg, dtype=dtypes.int)
+def _highs_idiv(x, d):
+  q = highs_inst.addVariable(lb=-np.inf, ub=np.inf, type=highspy.HighsVarType.kInteger)
+  highs_inst.addConstr(0 <= x.arg[0] - q*d.arg <= d.arg-1)
+  arg = q, x.vmin//d.arg, x.vmax//d.arg
+  return UOp(Ops.HIGHS_EXPR, arg=arg, dtype=dtypes.int)
+def _highs_mul(x, y):
+  if x.op == y.op == Ops.HIGHS_EXPR: return None
+  prod = (x.arg[0] if x.op == Ops.HIGHS_EXPR else x.arg)*(y.arg[0] if y.op == Ops.HIGHS_EXPR else y.arg)
+  arg = (prod, min(vals:=(x.vmin*y.vmin, x.vmin*y.vmax, x.vmax*y.vmin, x.vmax*y.vmax)), max(vals))
+  return UOp(Ops.HIGHS_EXPR, arg=arg, dtype=dtypes.int)
+def _highs_add(x, y):
+  sum = (x.arg[0] if x.op == Ops.HIGHS_EXPR else x.arg)+(y.arg[0] if y.op == Ops.HIGHS_EXPR else y.arg)
+  return UOp(Ops.HIGHS_EXPR, arg=(sum, x.vmin+y.vmin, x.vmax+y.vmax), dtype=dtypes.int)
+
+H_EXPR_OR_CONST = {Ops.HIGHS_EXPR, Ops.CONST}
+
+# run these when ready to call highs_inst.addVariable()
+highs_reduce = PatternMatcher([
+  (UPat(H_EXPR_OR_CONST, name="x") + UPat(H_EXPR_OR_CONST, name="y"), _highs_add),
+  (UPat(H_EXPR_OR_CONST, name="x") * UPat(H_EXPR_OR_CONST, name="y"), _highs_mul),
+  (UPat(Ops.HIGHS_EXPR, name="x") % UPat(Ops.CONST, name="d"), _highs_mod),
+  (UPat(Ops.HIGHS_EXPR, name="x") // UPat(Ops.CONST, name="d"), _highs_idiv),
+  # express bools as integers >= 0, false if ==0, true if >0
+  (UPat(H_EXPR_OR_CONST, name="a") | UPat(H_EXPR_OR_CONST, name="b"), lambda a,b: a+b),
+  # numerator needs to be >= 0 for this to work
+  (UPat.cvar("a") < UPat.var("x"), lambda a,x: (x-x.vmin)//(a.arg-x.vmin+1)),
 ])

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -8,6 +8,8 @@ from tinygrad.shape.view import View, strides_for_shape, unravel
 from tinygrad.dtype import dtypes
 from tinygrad.ops import UOp, Ops, graph_rewrite, split_uop, symbolic_flat, Variable, sint, uop_given_valid, simplify_valid, sint_to_uop, Context
 from tinygrad.codegen.rewriter import sym
+import numpy as np
+import highspy
 
 def overflow(u: UOp): return u.vmax > dtypes.max(dtypes.int) or u.vmin < dtypes.min(dtypes.int)
 

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -101,7 +101,7 @@ def _collapse_st_keep_shape(st):
   if gt or lt: return None
 
   final = View.create(tuple(st.shape), tuple(strides), offset, tuple((a,b) for a,b in mask))
-  print(f"found reduction {st} --> {final}")
+#  print(f"found reduction {st} --> {final}")
   return final
 
 def _collapse_st_no_keep_shape(st:ShapeTracker) -> Optional[View]:
@@ -181,7 +181,7 @@ def _collapse_st_no_keep_shape(st:ShapeTracker) -> Optional[View]:
     if (mask := _reshape_mask(tuple((a,b) for a,b in mask), tuple(oldshape), tuple(shape))) is None: return None
 
   final = View.create(tuple(shape), tuple(strides), offset, tuple((a,b) for a,b in mask))
-  print(f"found reduction {st} --> {final}")
+#  print(f"found reduction {st} --> {final}")
   return final
 
 def overflow(u: UOp): return u.vmax > dtypes.max(dtypes.int) or u.vmin < dtypes.min(dtypes.int)

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -45,6 +45,13 @@ def solve_highs(constrs, min_obj) -> Optional[int]:
 
 @functools.lru_cache(maxsize=None)
 def collapse_st(st:ShapeTracker, keep_shape:bool=False) -> Optional[View]:
+  try:
+    return _collapse_st(st, keep_shape)
+  except RuntimeError:
+    print(f"highs timeout with {st}, {keep_shape=}")
+    return None
+
+def _collapse_st(st:ShapeTracker, keep_shape:bool=False) -> Optional[View]:
   # Look for a view whose action is equiv. to st; this is complete
   if len(st.views) == 0: raise ValueError()
   if len(st.views) == 1: return st.views[0]
@@ -52,7 +59,7 @@ def collapse_st(st:ShapeTracker, keep_shape:bool=False) -> Optional[View]:
   if not all_int(flatten(((*v.shape, *v.strides, v.offset, *flatten(v.mask or ((0,),))) for v in st.views))):
 #    import pdb; pdb.set_trace()
     return None
-  highs_inst.clear(); highs_inst.setOptionValue("time_limit", 0.5); highs_inst.setOptionValue("log_to_console", False)
+  highs_inst.clear(); highs_inst.setOptionValue("time_limit", 1); highs_inst.setOptionValue("log_to_console", False)
   # presolve sometimes returns "infeasible" incorrectly
   highs_inst.setOptionValue("presolve", "off")
 

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -64,6 +64,7 @@ def _collapse_st(st:ShapeTracker, keep_shape:bool=False) -> Optional[View]:
   highs_inst.clear(); highs_inst.setOptionValue("time_limit", 1); highs_inst.setOptionValue("log_to_console", False)
   # presolve sometimes returns "infeasible" incorrectly
   highs_inst.setOptionValue("presolve", "off")
+  highs_inst.setOptionValue("mip_feasibility_tolerance", 1e-10)
 
 #  import pdb; pdb.set_trace()
 #  print(st)

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -157,6 +157,7 @@ class View:
     if vm1.mask:
       if (new_vm1 := vm1.shrink(vm1.mask)) == vm1 or (merged := vm2 + new_vm1) is None: return None
       return merged.pad(tuple((b,s-e) for (b,e),s in zip(vm1.mask, vm1.shape)))
+    # TODO get rid of most of View.__add__ to save lines (should still handle common cases though)
 #    from tinygrad.shape.shapetracker import views_to_real_strides
 #    if None in (strides := views_to_real_strides((vm2, vm1))): return None
 #    return View.create(vm1.shape, strides, vm2.offset, vm1.mask)

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -157,6 +157,10 @@ class View:
     if vm1.mask:
       if (new_vm1 := vm1.shrink(vm1.mask)) == vm1 or (merged := vm2 + new_vm1) is None: return None
       return merged.pad(tuple((b,s-e) for (b,e),s in zip(vm1.mask, vm1.shape)))
+#    from tinygrad.shape.shapetracker import views_to_real_strides
+#    if None in (strides := views_to_real_strides((vm2, vm1))): return None
+#    return View.create(vm1.shape, strides, vm2.offset, vm1.mask)
+
     if not all_int(vm1.shape): return None
 
     # Project vm1's offset and strides on to vm2.


### PR DESCRIPTION
Please let me know if you think this is worth pursuing, I don't think it is, just because the practical benefit is very small outside of the toy examples and fuzzers (I found 2 less views in test_winograd.py, that was it.) But if you want complete shapetracker simplification as per the bounty, I don't think there's a simpler approach than this, because a complete simplifier would be able to solve arbitrary ILP problems.

It converts subsequences of views in a shapetracker into ILP problems and tries to find an equivalent single-view. There are two cases, one where we keep the final shape, and one where the final shape is arbitrary (for the subsequences in the st that don't contain the final view). The second case is sometimes slow in the ILP solver, I think because constraints have a less clear geometric interpretation which makes the solving harder? (I also tried using graph_rewrite to convert to_indexed_uops into ILP problems, but this was also slow, probably for the same reason.)

The only cases this doesn't handle are 3 -> 2 view simplifications where both views are new, example:
```python
ShapeTracker(views=(View(shape=(5, 5, 5), strides=(-10, 45, 1), offset=40, mask=None, contiguous=False), View(shape=(29, 5, 1), strides=(1, 25, 0), offset=-2, mask=((2, 27), (0, 5), (0, 1)), contiguous=False), View(shape=(72, 1), strides=(1, 0), offset=50, mask=None, contiguous=False)))
ShapeTracker(views=(View(shape=(5, 5, 5), strides=(45, 1, -10), offset=40, mask=None, contiguous=False), View(shape=(72, 1), strides=(1, 0), offset=40, mask=None, contiguous=False)))
```
You would also get a shapetracker equality check out of this method as well, idk if that's useful.

Obviously needs cleanup.