### PR TITLE
Fix allocator memory alignment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -662,11 +662,11 @@ jobs:
       - name: Run pytest (llvm)
         shell: bash
         run: |
-          DEBUG=5 LLVM=1 python -m pytest -n=auto test/test_tiny.py --durations=20
+          DEBUG=5 LLVM=1 python -m pytest -n=auto test/test_tiny.py test/test_ops.py --durations=20
       - name: Run pytest (clang)
         shell: bash
         run: |
-          DEBUG=5 CLANG=1 python -m pytest -n=auto test/test_tiny.py --durations=20
+          DEBUG=5 CLANG=1 python -m pytest -n=auto test/test_tiny.py test/test_ops.py --durations=20
 
   #testunicorn:
   #  name: ARM64 unicorn Test


### PR DESCRIPTION
The allocator does not enforce memory alignment, and this can cause issues when the block is used by certain instructions. 

For example, the following is a kernel generated by `test_maximum` in `test_ops.py`. The third instruction uses [`vmovapd`](https://www.felixcloutier.com/x86/movapd) which will trigger an exception if the address in `rdx` is not aligned to 16 bytes.

```asm
0x000000: push  rbp
0x000001: mov   rbp, rsp
0x000004: vmovapd       xmm0, xmmword ptr [rdx]
0x000008: vmovss        xmm3, dword ptr [rdx + 4]
0x00000d: vmovss        xmm1, dword ptr [rip + 0xa7]
0x000015: vucomiss      xmm1, xmm3
0x000019: vmovaps       xmm2, xmm1
0x00001d: ja    0x33
0x00001f: vucomiss      xmm3, dword ptr [rip + 0x95]
0x000027: vmovaps       xmm2, xmm3
0x00002b: jne   0x33
0x00002d: jp    0x33
0x00002f: vmovaps       xmm2, xmm1
0x000033: vshufpd       xmm4, xmm0, xmm0, 1
0x000038: vucomiss      xmm1, xmm4
0x00003c: vmovaps       xmm3, xmm1
0x000040: ja    0x56
0x000042: vucomiss      xmm4, dword ptr [rip + 0x72]
0x00004a: vmovaps       xmm3, xmm4
0x00004e: jne   0x56
0x000050: jp    0x56
0x000052: vmovaps       xmm3, xmm1
0x000056: vshufps       xmm5, xmm0, xmm0, 0xff
0x00005b: vucomiss      xmm1, xmm5
0x00005f: vmovaps       xmm4, xmm1
0x000063: ja    0x79
0x000065: vucomiss      xmm5, dword ptr [rip + 0x4f]
0x00006d: vmovaps       xmm4, xmm5
0x000071: jne   0x79
0x000073: jp    0x79
0x000075: vmovaps       xmm4, xmm1
0x000079: vmovss        xmm5, dword ptr [rip + 0x3f]
0x000081: vfmadd213ss   xmm5, xmm0, dword ptr [rip + 0x3a]
0x00008a: vcmpneqss     k1, xmm0, xmm1
0x000091: vmovss        xmm5 {k1}, xmm5, xmm0
0x000097: vcmpltss      k1, xmm0, xmm1
0x00009e: vmovss        xmm5 {k1}, xmm5, xmm1
0x0000a4: vinsertps     xmm0, xmm5, xmm2, 0x10
0x0000aa: vinsertps     xmm0, xmm0, xmm3, 0x20
0x0000b0: vinsertps     xmm0, xmm0, xmm4, 0x30
0x0000b6: vmovaps       xmmword ptr [rcx], xmm0
0x0000ba: pop   rbp
0x0000bb: ret
0x0000bc: add   byte ptr [rax], al
0x0000be: add   byte ptr [rax], al
0x0000c2: add   byte ptr [rdi], bh
0x0000c4: add   byte ptr [rax], al
0x0000c6: sar   byte ptr [rdi], 0
```

And if we dump the address of the parameters being passed to it (WinDBG) we see that they are not aligned to 16-bytes but 8-bytes instead. Perhaps something specific to how the allocator behaves on windows?

The compiler is using `vmovapd` because the parameter uses the `float4` typedef which is aligned to `16` bytes in the C kernel.

This allows `test_ops.py` to run under CLANG on Windows, essentially an alternative to #8796.