### PR TITLE
fix for define_acc rendering bug for ptx + regression test

### DIFF
--- a/test/test_renderer_failures.py
+++ b/test/test_renderer_failures.py
@@ -8,6 +8,7 @@ from tinygrad.dtype import dtypes
 from tinygrad.engine.realize import CompiledRunner
 from tinygrad.helpers import dedup, flatten, prod
 from tinygrad.renderer.cstyle import CStyleLanguage
+from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.ops import UOp, Ops
 from tinygrad.renderer import ProgramSpec
 from tinygrad.tensor import Tensor, _to_np_dtype
@@ -41,7 +42,7 @@ class TestCStyleFailures(unittest.TestCase):
     ret = _test_uop_result([Tensor([1])], uops)[0]
     self.assertEqual(ret[0], 1)
 
-@unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local and Device.DEFAULT == "PTX", "need local")
+@unittest.skipIf(not isinstance(Device[Device.DEFAULT].renderer, PTXRenderer), "tests for ptx renderer")
 class TestPTXFailures(unittest.TestCase):
   def test_gated_store_with_alu(self):
     a = UOp(Ops.DEFINE_GLOBAL, dtypes.int.ptr(), (), 0)
@@ -62,6 +63,13 @@ class TestPTXFailures(unittest.TestCase):
     uops = linearize_uop(full_graph_rewrite(sink, Device[Device.DEFAULT].renderer))
     ret = _test_uop_result([], uops, local_size=[4, 1, 1])[0]
     np.testing.assert_equal(ret, [0, 1, 1, 1])
+
+  def test_gated_define_acc_with_half_dtype(self):
+    a = Tensor.randn(32, 32, dtype=dtypes.half).realize()
+    b = Tensor.randn(34, 32, dtype=dtypes.half).realize()
+    result = a.pad((1,1)).matmul(b, acc_dtype=dtypes.half).numpy()
+    reference = a.pad((1,1)).matmul(b, acc_dtype=dtypes.float).numpy()
+    np.testing.assert_allclose(result, reference)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/renderer/ptx.py
+++ b/tinygrad/renderer/ptx.py
@@ -176,8 +176,7 @@ class PTXRenderer(Renderer):
       if u.op in {Ops.CAST, Ops.BITCAST} and (u.src[0].dtype == u.dtype or isinstance(u.src[0].dtype, PtrDType)):
         r[u] = r[u.src[0]]
         continue
-      if u.op is Ops.DEFINE_ACC and u.dtype in [dtypes.half, dtypes.bool]: r[u.src[0]] = ssa("const", u.src[0])
-      elif u.op is Ops.SPECIAL: r[u] = "%" + u.arg[0]
+      if u.op is Ops.SPECIAL: r[u] = "%" + u.arg[0]
       elif u.op is Ops.DEFINE_VAR: bufs.append((u.arg[0], u.dtype))
       elif u.op is Ops.LOAD:
         assert u.src[0].dtype == dtypes.int64, "load isn't int64"


### PR DESCRIPTION
I don't know why there that special case for `half` and `boolean`

pr has minor diff, before, in that cases, it was allocating two registers and only using one.

fixes issue on #8680 

---

**Before fix**

```python
minimal repro:
from tinygrad import Tensor
from tinygrad.helpers import Context

with Context(DEBUG=0):
  a = Tensor.randn(33, 33, dtype="half").realize()
  b = Tensor.randn(37, 33, dtype="half").realize()

c = a.pad((2,2)).matmul(b, acc_dtype="half").realize()

print(c.numpy())
------------------------------

        .reg            .u64 %dat_u64_<3>;
        .reg            .s32 %const_s32_<5>;
        .reg            .f16 %const_f16_<5>;
        .reg            .pred %const_pred_<1>;
        .reg            .u32 %const_u32_<4>;
        .reg            .s32 %alu_s32_<9>;
        .reg            .f16 %acc_f16_<4>;
        .reg            .s32 %ridx_s32_<1>;
        .reg            .s64 %cast_s64_<3>;
        .reg            .pred %alu_pred_<4>;
        .reg            .s64 %alu_s64_<6>;
        .reg            .f16 %val_f16_<5>;
        .reg            .f32 %cast_f32_<9>;
        .reg            .f32 %alu_f32_<4>;
        .reg            .f16 %cast_f16_<4>;
        .reg            .pred %pred_pred_<1>;
        .reg            .u32 %lidx1;
        .reg            .u32 %lidx0;
        .reg            .u32 %gidx0;
        ld.param.u64    %dat_u64_0, [data0+0];
        ld.param.u64    %dat_u64_1, [data1+0];
        ld.param.u64    %dat_u64_2, [data2+0];
        mov.u32         %gidx0, %ctaid.x;
        mov.u32         %lidx0, %tid.x;
        mov.u32         %lidx1, %tid.y;
        mov.b32         %const_s32_0, -1;
        mov.b32         %const_s32_1, 0;
        mov.b16         %const_f16_0, 0x0000;
        setp.ne.s16     %const_pred_0, 1, 0;
        mov.b32         %const_s32_2, 1;
        mov.b32         %const_u32_0, 1U;
        mov.b32         %const_u32_1, 2U;
        mov.b32         %const_u32_2, 5U;
        mov.b32         %const_u32_3, 9U;
        mov.b32         %const_s32_3, 33;
        mov.b32         %const_s32_4, 34;
        shl.b32         %alu_s32_0, %gidx0, %const_u32_3;
        shl.b32         %alu_s32_1, %lidx0, %const_u32_2;
        add.s32         %alu_s32_2, %alu_s32_0, %alu_s32_1;
        shl.b32         %alu_s32_3, %lidx1, %const_u32_1;
        mov.b16         %acc_f16_0, 0x0000;
        mov.b16         %acc_f16_1, 0x0000;
        mov.b16         %acc_f16_2, 0x0000;
        mov.b16         %acc_f16_3, 0x0000;
        mov.u32         %ridx_s32_0, %const_s32_1;
        LOOP_ridx_s32_0:
        add.s32         %alu_s32_4, %alu_s32_2, %ridx_s32_0;
        add.s32         %alu_s32_5, %alu_s32_4, %const_s32_0;
        cvt.s64.s32     %cast_s64_0, %alu_s32_5;
        setp.lt.s32     %alu_pred_0, %ridx_s32_0, %const_s32_2;
        setp.lt.s32     %alu_pred_1, %ridx_s32_0, %const_s32_3;
        xor.pred        %alu_pred_2, %alu_pred_0, %const_pred_0;
        shl.b32         %alu_s32_6, %ridx_s32_0, %const_u32_2;
        add.s32         %alu_s32_7, %alu_s32_3, %alu_s32_6;
        cvt.s64.s32     %cast_s64_1, %alu_s32_7;
        shl.b64         %alu_s64_0, %cast_s64_0, %const_u32_0;
        add.s64         %alu_s64_1, %dat_u64_1, %alu_s64_0;
        shl.b64         %alu_s64_2, %cast_s64_1, %const_u32_0;
        add.s64         %alu_s64_3, %dat_u64_2, %alu_s64_2;
        ld.global.v4.b16        {%val_f16_0, %val_f16_1, %val_f16_2, %val_f16_3}, [%alu_s64_3+0];
        and.pred        %alu_pred_3, %alu_pred_1, %alu_pred_2;
        @%alu_pred_3    ld.global.b16 %val_f16_4, [%alu_s64_1+0];
        @!%alu_pred_3   mov.b16 %val_f16_4, %const_f16_4;
        cvt.f32.f16     %cast_f32_0, %acc_f16_0;
        cvt.f32.f16     %cast_f32_1, %acc_f16_1;
        cvt.f32.f16     %cast_f32_2, %acc_f16_2;
        cvt.f32.f16     %cast_f32_3, %acc_f16_3;
        cvt.f32.f16     %cast_f32_4, %val_f16_0;
        cvt.f32.f16     %cast_f32_5, %val_f16_1;
        cvt.f32.f16     %cast_f32_6, %val_f16_2;
        cvt.f32.f16     %cast_f32_7, %val_f16_3;
        cvt.f32.f16     %cast_f32_8, %val_f16_4;
        fma.rn.f32      %alu_f32_0, %cast_f32_4, %cast_f32_8, %cast_f32_0;
        cvt.rn.f16.f32  %cast_f16_0, %alu_f32_0;
        fma.rn.f32      %alu_f32_1, %cast_f32_5, %cast_f32_8, %cast_f32_1;
        cvt.rn.f16.f32  %cast_f16_1, %alu_f32_1;
        fma.rn.f32      %alu_f32_2, %cast_f32_6, %cast_f32_8, %cast_f32_2;
        cvt.rn.f16.f32  %cast_f16_2, %alu_f32_2;
        fma.rn.f32      %alu_f32_3, %cast_f32_7, %cast_f32_8, %cast_f32_3;
        cvt.rn.f16.f32  %cast_f16_3, %alu_f32_3;
        mov.b16         %acc_f16_0, %cast_f16_0;
        mov.b16         %acc_f16_1, %cast_f16_1;
        mov.b16         %acc_f16_2, %cast_f16_2;
        mov.b16         %acc_f16_3, %cast_f16_3;
        add.s32         %ridx_s32_0, %ridx_s32_0, 1;
        setp.lt.s32     %pred_pred_0, %ridx_s32_0, %const_s32_4;
        @%pred_pred_0   bra LOOP_ridx_s32_0;
        add.s32         %alu_s32_8, %alu_s32_2, %alu_s32_3;
        cvt.s64.s32     %cast_s64_2, %alu_s32_8;
        shl.b64         %alu_s64_4, %cast_s64_2, %const_u32_0;
        add.s64         %alu_s64_5, %dat_u64_0, %alu_s64_4;
        st.global.v4.b16        [%alu_s64_5+0], {%acc_f16_0, %acc_f16_1, %acc_f16_2, %acc_f16_3};
        ret;

------------------------------
output:

[[nan nan nan ... nan nan nan]
 [nan nan nan ... nan nan nan]
 [nan nan nan ... nan nan nan]
 ...
 [nan nan nan ... nan nan nan]
 [nan nan nan ... nan nan nan]
 [nan nan nan ... nan nan nan]]
```

---


**After fix**

```
        .reg            .u64 %dat_u64_<3>;
        .reg            .s32 %const_s32_<5>;
        .reg            .f16 %const_f16_<1>;
        .reg            .pred %const_pred_<1>;
        .reg            .u32 %const_u32_<4>;
        .reg            .s32 %alu_s32_<9>;
        .reg            .f16 %acc_f16_<4>;
        .reg            .s32 %ridx_s32_<1>;
        .reg            .s64 %cast_s64_<3>;
        .reg            .pred %alu_pred_<4>;
        .reg            .s64 %alu_s64_<6>;
        .reg            .f16 %val_f16_<5>;
        .reg            .f32 %cast_f32_<9>;
        .reg            .f32 %alu_f32_<4>;
        .reg            .f16 %cast_f16_<4>;
        .reg            .pred %pred_pred_<1>;
        .reg            .u32 %lidx1;
        .reg            .u32 %lidx0;
        .reg            .u32 %gidx0;
        ld.param.u64    %dat_u64_0, [data0+0];
        ld.param.u64    %dat_u64_1, [data1+0];
        ld.param.u64    %dat_u64_2, [data2+0];
        mov.u32         %gidx0, %ctaid.x;
        mov.u32         %lidx0, %tid.x;
        mov.u32         %lidx1, %tid.y;
        mov.b32         %const_s32_0, -1;
        mov.b32         %const_s32_1, 0;
        mov.b16         %const_f16_0, 0x0000;
        setp.ne.s16     %const_pred_0, 1, 0;
        mov.b32         %const_s32_2, 1;
        mov.b32         %const_u32_0, 1U;
        mov.b32         %const_u32_1, 2U;
        mov.b32         %const_u32_2, 5U;
        mov.b32         %const_u32_3, 9U;
        mov.b32         %const_s32_3, 33;
        mov.b32         %const_s32_4, 34;
        shl.b32         %alu_s32_0, %gidx0, %const_u32_3;
        shl.b32         %alu_s32_1, %lidx0, %const_u32_2;
        add.s32         %alu_s32_2, %alu_s32_0, %alu_s32_1;
        shl.b32         %alu_s32_3, %lidx1, %const_u32_1;
        mov.b16         %acc_f16_0, 0x0000;
        mov.b16         %acc_f16_1, 0x0000;
        mov.b16         %acc_f16_2, 0x0000;
        mov.b16         %acc_f16_3, 0x0000;
        mov.u32         %ridx_s32_0, %const_s32_1;
        LOOP_ridx_s32_0:
        add.s32         %alu_s32_4, %alu_s32_2, %ridx_s32_0;
        add.s32         %alu_s32_5, %alu_s32_4, %const_s32_0;
        cvt.s64.s32     %cast_s64_0, %alu_s32_5;
        setp.lt.s32     %alu_pred_0, %ridx_s32_0, %const_s32_2;
        setp.lt.s32     %alu_pred_1, %ridx_s32_0, %const_s32_3;
        xor.pred        %alu_pred_2, %alu_pred_0, %const_pred_0;
        shl.b32         %alu_s32_6, %ridx_s32_0, %const_u32_2;
        add.s32         %alu_s32_7, %alu_s32_3, %alu_s32_6;
        cvt.s64.s32     %cast_s64_1, %alu_s32_7;
        shl.b64         %alu_s64_0, %cast_s64_0, %const_u32_0;
        add.s64         %alu_s64_1, %dat_u64_1, %alu_s64_0;
        shl.b64         %alu_s64_2, %cast_s64_1, %const_u32_0;
        add.s64         %alu_s64_3, %dat_u64_2, %alu_s64_2;
        ld.global.v4.b16        {%val_f16_0, %val_f16_1, %val_f16_2, %val_f16_3}, [%alu_s64_3+0];
        and.pred        %alu_pred_3, %alu_pred_1, %alu_pred_2;
        @%alu_pred_3    ld.global.b16 %val_f16_4, [%alu_s64_1+0];
        @!%alu_pred_3   mov.b16 %val_f16_4, %const_f16_0;
        cvt.f32.f16     %cast_f32_0, %acc_f16_0;
        cvt.f32.f16     %cast_f32_1, %acc_f16_1;
        cvt.f32.f16     %cast_f32_2, %acc_f16_2;
        cvt.f32.f16     %cast_f32_3, %acc_f16_3;
        cvt.f32.f16     %cast_f32_4, %val_f16_0;
        cvt.f32.f16     %cast_f32_5, %val_f16_1;
        cvt.f32.f16     %cast_f32_6, %val_f16_2;
        cvt.f32.f16     %cast_f32_7, %val_f16_3;
        cvt.f32.f16     %cast_f32_8, %val_f16_4;
        fma.rn.f32      %alu_f32_0, %cast_f32_4, %cast_f32_8, %cast_f32_0;
        cvt.rn.f16.f32  %cast_f16_0, %alu_f32_0;
        fma.rn.f32      %alu_f32_1, %cast_f32_5, %cast_f32_8, %cast_f32_1;
        cvt.rn.f16.f32  %cast_f16_1, %alu_f32_1;
        fma.rn.f32      %alu_f32_2, %cast_f32_6, %cast_f32_8, %cast_f32_2;
        cvt.rn.f16.f32  %cast_f16_2, %alu_f32_2;
        fma.rn.f32      %alu_f32_3, %cast_f32_7, %cast_f32_8, %cast_f32_3;
        cvt.rn.f16.f32  %cast_f16_3, %alu_f32_3;
        mov.b16         %acc_f16_0, %cast_f16_0;
        mov.b16         %acc_f16_1, %cast_f16_1;
        mov.b16         %acc_f16_2, %cast_f16_2;
        mov.b16         %acc_f16_3, %cast_f16_3;
        add.s32         %ridx_s32_0, %ridx_s32_0, 1;
        setp.lt.s32     %pred_pred_0, %ridx_s32_0, %const_s32_4;
        @%pred_pred_0   bra LOOP_ridx_s32_0;
        add.s32         %alu_s32_8, %alu_s32_2, %alu_s32_3;
        cvt.s64.s32     %cast_s64_2, %alu_s32_8;
        shl.b64         %alu_s64_4, %cast_s64_2, %const_u32_0;
        add.s64         %alu_s64_5, %dat_u64_0, %alu_s64_4;
        st.global.v4.b16        [%alu_s64_5+0], {%acc_f16_0, %acc_f16_1, %acc_f16_2, %acc_f16_3};
        ret;
```
