### PR TITLE
Realized only exists on base

### DIFF
--- a/docs/abstractions2.py
+++ b/docs/abstractions2.py
@@ -104,7 +104,7 @@ print(sched[-1].ast)
 run_schedule(sched)
 
 # check the data out
-assert out.realized is not None and out.realized.as_buffer().cast('I')[0] == 5
+assert out.base.realized is not None and out.base.realized.as_buffer().cast('I')[0] == 5
 
 
 print("******** fourth, the Tensor ***********")

--- a/docs/abstractions2.py
+++ b/docs/abstractions2.py
@@ -104,7 +104,7 @@ print(sched[-1].ast)
 run_schedule(sched)
 
 # check the data out
-assert out.base.realized is not None and out.base.realized.as_buffer().cast('I')[0] == 5
+assert out.is_realized and out.buffer.as_buffer().cast('I')[0] == 5
 
 
 print("******** fourth, the Tensor ***********")

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2226,7 +2226,7 @@ class TestConst(unittest.TestCase):
     self.assertEqual(len(sched), 1)
     run_schedule(sched)
     # add gets assigned to a new buffer
-    self.assertIsNot(add.lazydata.realized, b.lazydata.realized)
+    self.assertIsNot(add.lazydata.base.realized, b.lazydata.base.realized)
     self.assertListEqual(add.tolist(), [4, 2, 2, 2, 2, 4])
 
   # ** part 3: Tensor variable bindings

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -545,9 +545,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     buffers[self] = ret = Buffer(self.device, self.size, self.dtype if isinstance(self.dtype, ImageDType) else self.dtype.base)
     return ret
   @property
-  def realized(self) -> Optional[Buffer]:
-    if self.op is Ops.VIEW and len(self.src) == 1 and self.src[0].op is Ops.BUFFER: return self.src[0].realized
-    return self.buffer if self.op is Ops.BUFFER else None
+  def realized(self) -> Optional[Buffer]: return self.buffer if self.op is Ops.BUFFER else None
   @property
   def is_realized(self) -> bool:
     return all(x.base.realized is not None for x in self.base.real_lbs) if self.base.op is Ops.MULTI else self.base.realized is not None


### PR DESCRIPTION
only abstractions2 needs updating, the rest of tinygrad follows this structure already. This works now because given any VIEW(BUFFER) UOp, `.base` is _always_ the buffer.