### PR TITLE
weights_only=False to prepare for pytorch 2.6 in unit tests

### DIFF
--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -10,7 +10,7 @@ def compare_weights_both(url):
   import torch
   fn = fetch(url)
   tg_weights = get_state_dict(torch_load(fn))
-  torch_weights = get_state_dict(torch.load(fn, map_location=torch.device('cpu'), weights_only=True), tensor_type=torch.Tensor)
+  torch_weights = get_state_dict(torch.load(fn, map_location=torch.device('cpu'), weights_only=False), tensor_type=torch.Tensor)
   assert list(tg_weights.keys()) == list(torch_weights.keys())
   for k in tg_weights:
     if tg_weights[k].dtype == dtypes.bfloat16: tg_weights[k] = torch_weights[k].float() # numpy doesn't support bfloat16


### PR DESCRIPTION
While working on https://github.com/tinygrad/tinygrad/pull/8646 I found this failing test:

> FAILED test/unit/test_disk_tensor.py::TestTorchLoad::test_load_resnet - RuntimeError: Cannot use ``weights_only=True`` with files saved in the legacy .tar format. In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.

This was because in that PR I modified setup.py (I removed the `wgpu-py` dependency). By doing so, the actions cache key for linting packages (see: `linting-packages-${{ hashFiles('**/setup.py') }}-3.10`) in `Linters+fuzz+unit Tests` changed, which resulted in not the cached 2.5.1 pytorch version being used, but the new 2.6 being installed.
`weights_only=False` solves the aformentioned error. I made this change in the webgpu PR, but I discussed with @chenyuxyz that it's worth a separate PR.