### PR TITLE
Fix disk tensor assignment

### DIFF
--- a/test/test_assign.py
+++ b/test/test_assign.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 from tinygrad import dtypes, Tensor, TinyJit, GlobalCounters, Variable
 from tinygrad.device import is_dtype_supported
+from tinygrad.helpers import temp
 
 N = 200  # has to be bigger than the cache to fail
 
@@ -387,6 +388,10 @@ class TestAssign(unittest.TestCase):
     oba2 = a.lazydata.base.output_buffer
     assert oba1 is None and oba2 is None
     np.testing.assert_allclose(a.numpy(), np.arange(N*N,dtype=np.int32).reshape((N,N)))
+
+  def test_disk_assignment(self):
+    a = Tensor.empty(5, device=f"disk:{temp('disk_assignment')}").assign(Tensor.ones(5)).numpy()
+    np.testing.assert_equal(a, np.ones(5))
 
 if __name__ == "__main__":
   unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -279,7 +279,7 @@ class Tensor(SimpleMathTrait):
     # TODO: this is a hack for writing to DISK. remove with working assign
     if isinstance(self.device, str) and self.device.startswith("DISK"):
       if x.__class__ is not Tensor: x = Tensor(x, device="CLANG", dtype=self.dtype)
-      self.contiguous().realize().lazydata.base.realized.copyin(x._data())
+      self.contiguous().realize().lazydata.base.realized.ensure_allocated().copyin(x._data())
       return self
     if x.__class__ is not Tensor: x = Tensor(x, device=self.device, dtype=self.dtype)
     if self.lazydata is x.lazydata: return self  # a self assign is a NOOP


### PR DESCRIPTION
Before this change, `test_disk_assignment` would fail with: `AssertionError: can't copyin to unallocated buffer`. The disk buffer was not allocated because the scheduler would fold the entire `SINK(CONTIGUOUS(VIEW(BUFFER(DEVICE))))` tree to an isolated `SINK` node, meaning the buffer would not end up in schedule item to be allocated eventually.

~~Not entirely sure if this is the right fix, but `Tensor.data()` will do something similar.~~