### PR TITLE
TIP 12: spec for allowed UOps in a ScheduleItem

### DIFF
--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -147,7 +147,7 @@ si_lowerer = PatternMatcher([
       else BufferCopy(ctx[0].nbytes, ctx[0].device, ctx[1].device)), list(ctx))),
 ])
 def lower_schedule_item(si:ScheduleItem) -> ExecItem:
-  type_verify([si.ast], si_spec)
+  type_verify(list(si.ast.toposort), si_spec)
   return ExecItem(*cast(tuple[Runner,list], si_lowerer.rewrite(si.ast, si.bufs)), si.metadata)
 
 def lower_schedule(schedule:list[ScheduleItem]) -> Generator[ExecItem, None, None]:

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -151,8 +151,13 @@ to_si = PatternMatcher([
   (UPat(Ops.BUFFER, name="x"), _append_buf),
   # simplify and unbind the final VIEWs
   (UPat(Ops.VIEW, name="x"), _append_st_vars),
-  # don't need SINK on COPY or BUFFER_VIEW
-  (UPat(Ops.SINK, src=(UPat.store(UPat(), UPat(), UPat((Ops.COPY, Ops.BUFFER_VIEW), name="x")),)), lambda x: x),
+  # TODO: remove this after KERNEL refactor
+  # COPY in schedule is COPY(DEVICE, DEFINE_GLOBAL)
+  (UPat(Ops.SINK, src=(UPat.store(UPat(), UPat(), UPat(Ops.COPY, name="copy", src=(UPat.var("device"), UPat.load(UPat.var("glbl"), UPat())))),)),
+   lambda copy,device,glbl: copy.replace(src=(device, glbl))),
+  # subbuffer in schedule is BUFFER_VIEW(DEFINE_GLOBAL)
+  (UPat(Ops.SINK, src=(UPat.store(UPat(), UPat(), UPat(Ops.BUFFER_VIEW, name="view", src=(UPat.load(UPat.var("glbl"), UPat()),))),)),
+   lambda view,glbl: view.replace(src=(glbl,))),
   # don't need contiguous or assign anymore
   (UPat(Ops.CONTIGUOUS, src=(UPat.var("x"),)), lambda x: x),
   (UPat(Ops.ASSIGN, src=(UPat(), UPat.var("x"),)), lambda x: x),

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -152,7 +152,7 @@ to_si = PatternMatcher([
   # simplify and unbind the final VIEWs
   (UPat(Ops.VIEW, name="x"), _append_st_vars),
   # don't need SINK on COPY or BUFFER_VIEW
-  (UPat(Ops.SINK, src=(UPat.store(UPat.var("b"), UPat(), UPat((Ops.COPY, Ops.BUFFER_VIEW), name="x")),)), lambda b,x: x.replace(src=(b, *x.src))),
+  (UPat(Ops.SINK, src=(UPat.store(UPat(), UPat(), UPat((Ops.COPY, Ops.BUFFER_VIEW), name="x")),)), lambda x: x),
   # don't need contiguous or assign anymore
   (UPat(Ops.CONTIGUOUS, src=(UPat.var("x"),)), lambda x: x),
   (UPat(Ops.ASSIGN, src=(UPat(), UPat.var("x"),)), lambda x: x),

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -152,7 +152,7 @@ to_si = PatternMatcher([
   # simplify and unbind the final VIEWs
   (UPat(Ops.VIEW, name="x"), _append_st_vars),
   # don't need SINK on COPY or BUFFER_VIEW
-  (UPat(Ops.SINK, src=(UPat.store(UPat(), UPat(), UPat((Ops.COPY, Ops.BUFFER_VIEW), name="x")),)), lambda x: x.replace(src=())),
+  (UPat(Ops.SINK, src=(UPat.store(UPat(), UPat(), UPat((Ops.COPY, Ops.BUFFER_VIEW), name="x")),)), lambda x: x),
   # don't need contiguous or assign anymore
   (UPat(Ops.CONTIGUOUS, src=(UPat.var("x"),)), lambda x: x),
   (UPat(Ops.ASSIGN, src=(UPat(), UPat.var("x"),)), lambda x: x),

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -152,7 +152,7 @@ to_si = PatternMatcher([
   # simplify and unbind the final VIEWs
   (UPat(Ops.VIEW, name="x"), _append_st_vars),
   # don't need SINK on COPY or BUFFER_VIEW
-  (UPat(Ops.SINK, src=(UPat.store(UPat(), UPat(), UPat((Ops.COPY, Ops.BUFFER_VIEW), name="x")),)), lambda x: x),
+  (UPat(Ops.SINK, src=(UPat.store(UPat(), UPat(), UPat((Ops.COPY, Ops.BUFFER_VIEW), name="x")),)), lambda x: x.replace(src=())),
   # don't need contiguous or assign anymore
   (UPat(Ops.CONTIGUOUS, src=(UPat.var("x"),)), lambda x: x),
   (UPat(Ops.ASSIGN, src=(UPat(), UPat.var("x"),)), lambda x: x),

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -6,6 +6,7 @@ from tinygrad.helpers import all_int, all_same, dedup, prod
 # *** this is the spec of a Tensor in UOp ***
 
 tensor_uop_spec = PatternMatcher([
+  (UPat(Ops.DEVICE, dtypes.void, (), name="device"), lambda device: isinstance(device.arg, str)),
   (UPat(Ops.BUFFER, src=(UPat(Ops.DEVICE),), name="buf"),
    lambda buf: isinstance(buf.arg, tuple) and len(buf.arg) == 2 and all_int(buf.arg) and isinstance(buf.dtype, (DType, ImageDType))),
 
@@ -44,10 +45,9 @@ tensor_uop_spec = PatternMatcher([
 # *** this is the spec of allowed UOps in a ScheduleItem ***
 
 si_spec = PatternMatcher([
-  # TODO: this should probably be COPY(DEVICE, DEFINE_GLOBAL), not LOAD
-  (UPat(Ops.COPY, src=(UPat(Ops.DEVICE), UPat(Ops.LOAD))), lambda: True),
   (UPat(Ops.SINK, src=UPat(Ops.STORE), allow_any_len=True), lambda: True),
-  (UPat(Ops.BUFFER_VIEW, src=(UPat(Ops.LOAD),)), lambda: True),
+  (UPat(Ops.COPY, src=()), lambda: True),
+  (UPat(Ops.BUFFER_VIEW, src=()), lambda: True),
 ])
 
 # ***** uop type spec *****
@@ -55,7 +55,6 @@ si_spec = PatternMatcher([
 # this is the matcher for the final rendered UOps
 # matcher functions returns True or False (or None to not match)
 spec = PatternMatcher([
-  (UPat(Ops.DEVICE, dtypes.void, (), name="device"), lambda device: isinstance(device.arg, str)),
   (UPat(Ops.DEFINE_GLOBAL, name="x"), lambda x: isinstance(x.dtype, (PtrDType, ImageDType)) and not x.dtype.local),
   (UPat(Ops.DEFINE_LOCAL, name="x"), lambda x: isinstance(x.dtype, PtrDType) and x.dtype.local),
   (UPat(Ops.DEFINE_ACC, src=(UPat.var("c"),), name="x", allow_any_len=True),

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -6,6 +6,7 @@ from tinygrad.helpers import all_int, all_same, dedup, prod
 # *** this is the spec of a Tensor in UOp ***
 
 tensor_uop_spec = PatternMatcher([
+  (UPat(Ops.DEVICE, dtypes.void, (), name="device"), lambda device: isinstance(device.arg, str)),
   (UPat(Ops.BUFFER, src=(UPat(Ops.DEVICE),), name="buf"),
    lambda buf: isinstance(buf.arg, tuple) and len(buf.arg) == 2 and all_int(buf.arg) and isinstance(buf.dtype, (DType, ImageDType))),
 
@@ -45,9 +46,10 @@ tensor_uop_spec = PatternMatcher([
 
 si_spec = PatternMatcher([
   (UPat(Ops.SINK, src=UPat(Ops.STORE), allow_any_len=True), lambda: True),
-  # TODO: these should use DEFINE_GLOBAL, not LOAD
-  (UPat(Ops.COPY, src=(UPat(Ops.DEVICE), UPat(Ops.LOAD))), lambda: True),
-  (UPat(Ops.BUFFER_VIEW, src=(UPat(Ops.LOAD),)), lambda: True),
+  (UPat(Ops.BUFFER_VIEW, src=(UPat(Ops.DEFINE_GLOBAL),)), lambda: True),
+  # NOTE: we also allow for device to exist, only for COPY
+  (UPat(Ops.DEVICE, dtypes.void, ()), lambda: True),
+  (UPat(Ops.COPY, src=(UPat(Ops.DEVICE), UPat(Ops.DEFINE_GLOBAL))), lambda: True),
 ])
 
 # ***** uop type spec *****
@@ -55,7 +57,6 @@ si_spec = PatternMatcher([
 # this is the matcher for the final rendered UOps
 # matcher functions returns True or False (or None to not match)
 spec = PatternMatcher([
-  (UPat(Ops.DEVICE, dtypes.void, (), name="device"), lambda device: isinstance(device.arg, str)),
   (UPat(Ops.DEFINE_GLOBAL, name="x"), lambda x: isinstance(x.dtype, (PtrDType, ImageDType)) and not x.dtype.local),
   (UPat(Ops.DEFINE_LOCAL, name="x"), lambda x: isinstance(x.dtype, PtrDType) and x.dtype.local),
   (UPat(Ops.DEFINE_ACC, src=(UPat.var("c"),), name="x", allow_any_len=True),

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -6,7 +6,6 @@ from tinygrad.helpers import all_int, all_same, dedup, prod
 # *** this is the spec of a Tensor in UOp ***
 
 tensor_uop_spec = PatternMatcher([
-  (UPat(Ops.DEVICE, dtypes.void, (), name="device"), lambda device: isinstance(device.arg, str)),
   (UPat(Ops.BUFFER, src=(UPat(Ops.DEVICE),), name="buf"),
    lambda buf: isinstance(buf.arg, tuple) and len(buf.arg) == 2 and all_int(buf.arg) and isinstance(buf.dtype, (DType, ImageDType))),
 
@@ -46,8 +45,9 @@ tensor_uop_spec = PatternMatcher([
 
 si_spec = PatternMatcher([
   (UPat(Ops.SINK, src=UPat(Ops.STORE), allow_any_len=True), lambda: True),
-  (UPat(Ops.COPY, src=()), lambda: True),
-  (UPat(Ops.BUFFER_VIEW, src=()), lambda: True),
+  # TODO: these should use DEFINE_GLOBAL, not LOAD
+  (UPat(Ops.COPY, src=(UPat(Ops.DEVICE), UPat(Ops.LOAD))), lambda: True),
+  (UPat(Ops.BUFFER_VIEW, src=(UPat(Ops.LOAD),)), lambda: True),
 ])
 
 # ***** uop type spec *****
@@ -55,6 +55,7 @@ si_spec = PatternMatcher([
 # this is the matcher for the final rendered UOps
 # matcher functions returns True or False (or None to not match)
 spec = PatternMatcher([
+  (UPat(Ops.DEVICE, dtypes.void, (), name="device"), lambda device: isinstance(device.arg, str)),
   (UPat(Ops.DEFINE_GLOBAL, name="x"), lambda x: isinstance(x.dtype, (PtrDType, ImageDType)) and not x.dtype.local),
   (UPat(Ops.DEFINE_LOCAL, name="x"), lambda x: isinstance(x.dtype, PtrDType) and x.dtype.local),
   (UPat(Ops.DEFINE_ACC, src=(UPat.var("c"),), name="x", allow_any_len=True),

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -42,6 +42,14 @@ tensor_uop_spec = PatternMatcher([
    lambda assign,target,new_val: target.is_realized and (assign.dtype == target.dtype == new_val.dtype)),
 ])
 
+# *** this is the spec of allowed UOps in a ScheduleItem ***
+
+si_spec = PatternMatcher([
+  (UPat(Ops.COPY, src=(UPat(Ops.DEVICE), UPat(Ops.LOAD))), lambda: True),
+  (UPat(Ops.SINK, src=UPat(Ops.STORE), allow_any_len=True), lambda: True),
+  (UPat(Ops.BUFFER_VIEW, src=(UPat(Ops.LOAD),)), lambda: True),
+])
+
 # ***** uop type spec *****
 
 # this is the matcher for the final rendered UOps

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -44,10 +44,13 @@ tensor_uop_spec = PatternMatcher([
 
 # *** this is the spec of allowed UOps in a ScheduleItem ***
 
-si_spec = PatternMatcher([
+si_spec = tensor_uop_spec+PatternMatcher([
+  # TODO: this should probably be COPY(DEVICE, DEFINE_GLOBAL), not LOAD
   (UPat(Ops.COPY, src=(UPat(Ops.DEVICE), UPat(Ops.LOAD))), lambda: True),
   (UPat(Ops.SINK, src=UPat(Ops.STORE), allow_any_len=True), lambda: True),
   (UPat(Ops.BUFFER_VIEW, src=(UPat(Ops.LOAD),)), lambda: True),
+  # NOTE: buffer/bind isn't allowed in a ScheduleItem
+  (UPat((Ops.BUFFER, Ops.BIND)), lambda: False),
 ])
 
 # ***** uop type spec *****


### PR DESCRIPTION
Because this AST is captured by the JIT, we need a spec that defines UOps allowed to go inside the JIT.

This TIP proposes allowing for 3 UOp types:

1. COPY(DEVICE, placeholder)
2. STORE(placeholder, st, val)
3. BUFFER_VIEW(placeholder)

The key similarity is the placeholder UOp. BUFFER is not allowed to exist.

COPY and STORE maintain their full meaning, such that the JIT can create replacement bufs from just the AST.
sadly, BUFFER_VIEW does not maintain enough information to recreate a subbuffer, it needs a new spec. Maybe SHRINK(placeholder)?