### PR TITLE
hotfix: assert schedule and prescheduled are the same set [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -480,5 +480,6 @@ def create_schedule_with_vars(big_sink:UOp) -> tuple[list[ScheduleItem], dict[Va
       if in_degree[x] == 0: queue.append(x)
   # confirm everything was scheduled correctly
   if len(schedule) != (groups:=len(prescheduled)): raise RuntimeError(f"cycle detected in graph, grouped {groups} but only scheduled {len(schedule)}")
+  assert set(schedule) == set(prescheduled), "schedule and prescheduled must match"
   if DEBUG >= 1 and len(schedule) >= 10: print(f"scheduled {len(schedule)} kernels")
   return schedule, var_vals, becomes_map


### PR DESCRIPTION
The only thing different between these two lists is the order.
prescheduled is normal DFS (graph_rewrite order)
schedule is the custom BFS for assigns and the rest.