### PR TITLE
llvm cleanups [pr]

### DIFF
--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -11,12 +11,15 @@ def expect(x, err, ret=None):
   if x: raise RuntimeError(llvm.string_cast(err.contents) if not isinstance(err, str) else err)
   return ret
 
-HOST_ARCH = {'arm64': 'AArch64', 'aarch64': 'AArch64', 'x86_64': 'X86', 'AMD64': 'X86'}[platform.machine()]
-HOST_TRIPLE = {'AArch64': 'aarch64', 'X86': 'x86_64'}[HOST_ARCH]
-REQUIRED_COMPONENTS = ['Target', 'TargetInfo', 'TargetMC', 'AsmPrinter']
-
 class LLVMCompiler(Compiler):
-  def __init__(self, target_machine, opt):
+  def __init__(self, host_arch:str, opt:bool):
+    for component in ['Target', 'TargetInfo', 'TargetMC', 'AsmPrinter']: getattr(llvm, f'LLVMInitialize{host_arch}{component}')()
+    triple = ({'AArch64': 'aarch64', 'X86': 'x86_64'}[host_arch]+'-none-unknown-elf').encode()
+
+    target = expect(llvm.LLVMGetTargetFromTriple(triple, ctypes.pointer(tgt:=llvm.LLVMTargetRef()), err:=cerr()), err, tgt)
+    target_machine = llvm.LLVMCreateTargetMachine(target, triple, b'', b'+reserve-x18' if host_arch == 'arm64' else b'',
+                                                  llvm.LLVMCodeGenLevelDefault, llvm.LLVMRelocPIC, llvm.LLVMCodeModelDefault)
+
     self.pbo = llvm.LLVMCreatePassBuilderOptions()
     if opt:
       self.passes = b'default<O2>'
@@ -48,14 +51,5 @@ class LLVMCompiler(Compiler):
 
 class LLVMDevice(Compiled):
   def __init__(self, device:str):
-    for component in REQUIRED_COMPONENTS:
-      getattr(llvm, f'LLVMInitialize{HOST_ARCH}{component}')()
-
-    triple = f'{HOST_TRIPLE}-none-unknown-elf'.encode()
-    target = expect(llvm.LLVMGetTargetFromTriple(triple, ctypes.pointer(tgt:=llvm.LLVMTargetRef()), err:=cerr()), err, tgt)
-    features = b'+reserve-x18' if platform.machine() == 'arm64' else b''
-    target_machine = llvm.LLVMCreateTargetMachine(target, triple, b'', features, llvm.LLVMCodeGenLevelDefault, llvm.LLVMRelocPIC,
-                                                  llvm.LLVMCodeModelDefault)
-
-    super().__init__(device, MallocAllocator, LLVMRenderer('win64cc' if sys.platform == 'win32' else None),
-                     LLVMCompiler(target_machine, getenv("LLVMOPT")), CPUProgram)
+    compiler = LLVMCompiler({'arm64': 'AArch64', 'aarch64': 'AArch64', 'x86_64': 'X86', 'AMD64': 'X86'}[platform.machine()], bool(getenv("LLVMOPT")))
+    super().__init__(device, MallocAllocator, LLVMRenderer('win64cc' if sys.platform == 'win32' else None), compiler, CPUProgram)


### PR DESCRIPTION
@uuuvn See this for how to improve code quality.

I found an issue with the LLVM stuff, run `LLVM=1 pytest -n=auto test/` on Mac. Tons of segfaults!

```
collecting: 19/20 workers......F.....................................s....Fatal Python error: Segmentation fault                                                
                                                                                                                                                                
Thread 0x0000000170d07000 (most recent call first):                                                                                                             
  File "/opt/homebrew/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read                                                                   
  File "/opt/homebrew/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
  File "/opt/homebrew/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
  File "/opt/homebrew/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
  File "/opt/homebrew/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn         
  ```