### PR TITLE
make DEFINE_LOCAL variable names argument start from temp0 instead of temp1

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -620,7 +620,7 @@ class Kernel:
             if self.use_tensor_cores == 3:  # for TC=3, emulate the warp addressing with locals
               local_shape = tuple(1 if i >= self.first_reduce and i < self.first_upcast else s for i, s in enumerate(self.full_shape))
               st = store_st = ShapeTracker.from_shape(local_shape)
-              local_buffer = UOp(Ops.DEFINE_LOCAL, tc.dtype_in.ptr(size=st.real_size(), local=True), (), f"temp{i + 1}")
+              local_buffer = UOp(Ops.DEFINE_LOCAL, tc.dtype_in.ptr(size=st.real_size(), local=True), (), f"temp{i}")
               if swizzle: store_st = get_tc_swizzle_st(store_st.shape, *swizzle)
               local_store = UOp.store(local_buffer, store_st.to_uop(), srcs[i])
               srcs[i] = UOp(Ops.LOAD, tc.dtype_in, (local_buffer, st.to_uop(), local_store))
@@ -648,7 +648,7 @@ class Kernel:
             (1,) * (self.shape_len - self.upcasted - self.group_for_reduces - self.first_reduce) + tuple([x[0] for x in self.upcasted_axis(0)])
           st_uop = ShapeTracker.from_shape(local_shape).to_uop()
           local_size = st_uop.arg.real_size()
-          local_buffer = UOp(Ops.DEFINE_LOCAL, op.dtype.ptr(local_size, local=True), (), f"temp{self.reduceops.index(op)+1}")
+          local_buffer = UOp(Ops.DEFINE_LOCAL, op.dtype.ptr(local_size, local=True), (), f"temp{self.reduceops.index(op)}")
           local_load = UOp(Ops.LOAD, op.dtype, (local_buffer, st_uop, UOp.store(local_buffer, st_uop, ret)))
           grouped_reduce = UOp(Ops.REDUCE_AXIS, op.dtype, (local_load,), arg=(op.arg[0], grouped_axes))
           if op is self.reduceops[-1]: return grouped_reduce


### PR DESCRIPTION
1. The only thing breaking process replay is PTX that uses the argument directly, like this PR diff:
```diff
<tinygrad.renderer.ptx.PTXRenderer object at 0x7d979c6c87c0>
[Opt(op=OptOps.GROUPTOP, axis=0, arg=16)]
r_256_16_256
@@ -28,8 +28,8 @@

        ld.param.u64    %dat_u64_0, [data0+0];
        ld.param.u64    %dat_u64_1, [data1+0];
        ld.param.u64    %dat_u64_2, [data2+0];
-       .shared         .align 4 .b8 temp1[64];
-       mov.u64         %local_u64_0, temp1[0];
+       .shared         .align 4 .b8 temp0[64];
+       mov.u64         %local_u64_0, temp0[0];
        mov.u32         %gidx0, %ctaid.x;
        mov.u32         %lidx0, %tid.x;
        mov.b32         %const_s32_0, 0;
```
2. Beautiful result of merging this pr:
![image](https://github.com/user-attachments/assets/2ed7621b-fbbc-4ad3-a7f5-5f8601fc4ad6)


3. Why was it temp1 in the first place? looking at #6030, it originates from:
```python
# lowerer.py

def _to_uop(self, x:UOp) -> UOp:
  if x.op in BUFFER_UOPS:
     # ...
    if x.arg.idx < 0:
      buf = UOp(UOps.DEFINE_LOCAL, PtrDType(x.dtype.base if isinstance(x.dtype, ImageDType) else x.dtype),
                arg=(f"temp{-x.arg.idx}", x.arg.st.real_size()))
```
And since then there's no real reason to keep it as temp1.

