### PR TITLE
unbind ShapeTrackers without maintaining a cache [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -331,9 +331,10 @@ view_right = merge_views+PatternMatcher([
 ])
 
 def _append_st_vars(ctx:ScheduleItemContext, x:UOp) -> UOp|None:
-  try: st, var_vals = unwrap(x.st).simplify().unbind()
-  except AssertionError: return None # TODO: can it check if an st is already unbound?
-  ctx.var_vals.update(var_vals)
+  st = unwrap(x.st).simplify()
+  if st.vars():
+    st, var_vals = st.unbind()
+    ctx.var_vals.update(var_vals)
   return st.to_uop() if st != x.st else None
 
 def _append_buf(ctx:ScheduleItemContext, x:UOp) -> UOp:

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -332,7 +332,7 @@ view_right = merge_views+PatternMatcher([
 
 def _append_st_vars(ctx:ScheduleItemContext, x:UOp) -> UOp|None:
   st = unwrap(x.st).simplify()
-  if st.vars():
+  if any(x.op is Ops.BIND for x in st.vars()):
     st, var_vals = st.unbind()
     ctx.var_vals.update(var_vals)
   return st.to_uop() if st != x.st else None


### PR DESCRIPTION
This try block is required because there isn't a way to check if a ShapeTracker is already unbound.
Currently calling unbind on an already unbound View will throw error,

The scheduler works around this by maintaining a set of already unbound ShapeTrackers, is there a way to do this without maintaining external state?