### PR TITLE
truncate process replay logs [pr]

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -19,7 +19,7 @@ os.environ["RUN_PROCESS_REPLAY"] = "0"
 os.environ["CAPTURE_PROCESS_REPLAY"] = "0"
 early_stop = multiprocessing.Event()
 logging.basicConfig(level=logging.INFO, format="%(message)s")
-MAX_LINES = 100
+MAX_LINES = 1_000
 def trunc_log(x):
   if len(lines:=repr(x).splitlines()) > MAX_LINES: lines = lines[:MAX_LINES]+[f"WARN: truncated string with {len(lines)} lines"]
   logging.info("\n".join(lines))

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -19,8 +19,9 @@ os.environ["RUN_PROCESS_REPLAY"] = "0"
 os.environ["CAPTURE_PROCESS_REPLAY"] = "0"
 early_stop = multiprocessing.Event()
 logging.basicConfig(level=logging.INFO, format="%(message)s")
+MAX_LINES = 100
 def trunc_log(x):
-  if len(lines:=repr(x).splitlines()) > 100: lines = lines[:100]+[f"WARN: truncated string with {len(lines)} lines"]
+  if len(lines:=repr(x).splitlines()) > MAX_LINES: lines = lines[:MAX_LINES]+[f"WARN: truncated string with {len(lines)} lines"]
   logging.info("\n".join(lines))
 
 # user config

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -20,8 +20,7 @@ os.environ["CAPTURE_PROCESS_REPLAY"] = "0"
 early_stop = multiprocessing.Event()
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 def trunc_log(x):
-  lines = (rep:=repr(x)).splitlines()
-  if len(lines) > 100: lines = lines[:100]+[f"WARN: truncated string with {len(lines)} lines"]
+  if len(lines:=repr(x).splitlines()) > 100: lines = lines[:100]+[f"WARN: truncated string with {len(lines)} lines"]
   logging.info("\n".join(lines))
 
 # user config
@@ -71,7 +70,8 @@ def diff(offset:int, name:str, fxn:Callable) -> None:
     except Exception as e:
       changed += 1
       warnings.warn(f"FAILED TO RECREATE KERNEL {e}", ProcessReplayWarning)
-      for x in args[:-1]: trunc_log(x)
+      if ctx_vars: logging.info(ctx_vars)
+      for x in args[:-2]: trunc_log(x)
       continue
     # diff kernels
     try: assert str(args[-1]) == str(good)


### PR DESCRIPTION
  The print of big_sink over this line limit almost become unreadable and doesn't really add value.
Maybe the process replay capture needs to be exported as an artifact?
New diff print for a `big_sink` with over 15K lines:
![image](https://github.com/user-attachments/assets/8eda4fe7-e826-4115-a752-dca3d74a5a5a)
