### PR TITLE
cherry-pick reverted "Use full soname for libgcc_s in CPUProgram (#8642)"

### DIFF
--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -224,7 +224,7 @@ MAP_JIT = 0x0800
 
 # CPUProgram is a jit/shellcode program that can be just mmapped and jumped to
 class CPUProgram:
-  helper_handle = ctypes.CDLL(ctypes.util.find_library('System' if OSX else 'kernel32' if sys.platform == "win32" else 'gcc_s'))
+  helper_handle = ctypes.CDLL(ctypes.util.find_library('System' if OSX else 'kernel32') if OSX or sys.platform == "win32" else 'libgcc_s.so.1')
   def __init__(self, name:str, lib:bytes):
     if sys.platform == "win32":
       PAGE_EXECUTE_READWRITE = 0x40


### PR DESCRIPTION
I encountered the same issue as #8642 and discovered that #8761 had reverted it, which seems unintentional.