### PR TITLE
rename to KernelContext and move the linearize_sched comment [pr]

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -19,7 +19,7 @@ os.environ["RUN_PROCESS_REPLAY"] = "0"
 os.environ["CAPTURE_PROCESS_REPLAY"] = "0"
 early_stop = multiprocessing.Event()
 logging.basicConfig(level=logging.INFO, format="%(message)s")
-MAX_LINES = 1_000
+MAX_LINES = 500
 def trunc_log(x):
   if len(lines:=repr(x).splitlines()) > MAX_LINES: lines = lines[:MAX_LINES]+[f"WARN: truncated string with {len(lines)} lines"]
   logging.info("\n".join(lines))


### PR DESCRIPTION
The scheduler creates KERNEL UOps and update the becomes_map in the same loop.
Then, it'll give the sched_sink to the schedule linearizer.