### PR TITLE
simpler subbuffer construction + copyin is always base

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -145,7 +145,7 @@ do_realize = PatternMatcher([
   # realize before expand or unsafe pad ops
   (UPat(Ops.VIEW, name="view", src=(UPatScheduled(name="src"),)), realize_before_view),
   # realize before COPY or BUFFER_VIEW
-  (UPat(Ops.COPY, src=(UPat(), UPat.any(UPatScheduled(), UPatScheduled().view()),)), realize),
+  (UPat(Ops.COPY, src=(UPat(), UPatScheduled())), realize),
   (UPat(Ops.BUFFER_VIEW, src=(UPat.any(UPatScheduled(), UPatScheduled().view()),)), realize),
   # substitute BITCAST/CONTIGUOUS with BUFFER_VIEW on DISK
   (UPatScheduled((Ops.BITCAST, Ops.CONTIGUOUS), name="root", src=(UPat.var("x"),)), create_subbuffer),


### PR DESCRIPTION
This diff moves the BUFFER_VIEW op rewrite to the tensor_map stage:
![image](https://github.com/user-attachments/assets/6dc6425d-3d88-4dfb-9857-b1e377c208e8)

also, COPY.src[1] is always the base, so that UPat.any is not needed.