### PR TITLE
Fix AttributeError occurring after ValueError in _apply_uop

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -485,6 +485,12 @@ class TestTinygrad(unittest.TestCase):
     subprocess.run([f'NPY=1 {Device.DEFAULT}=1 python3 -c "from tinygrad import Device; assert Device.DEFAULT == \\"{Device.DEFAULT}\\""'],
                     shell=True, check=True)
 
+  def test_no_attributeerror_after_apply_uop_exception(self):
+    try:
+      Tensor.arange(4).reshape(3,2)
+    except ValueError:
+      Tensor.zeros(2, 2).realize()
+
 @unittest.skip("this test is just flaky, sync issue")
 class TestMoveTensor(unittest.TestCase):
   d0, d1 = f"{Device.DEFAULT}:0", f"{Device.DEFAULT}:1"

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -31,7 +31,7 @@ def _apply_map_to_tensors(applied_map:dict[UOp, UOp]) -> None:
 
   # link the found UOps back to Tensors. exit early if there's no Tensors to realize
   # NOTE: this uses all_tensors, but it's fast
-  fixed_tensors: list[Tensor] = [t for tref in all_tensors if (t:=tref()) is not None and getattr(t, 'lazydata', None) in all_uops]
+  fixed_tensors: list[Tensor] = [t for tref in all_tensors if (t:=tref()) is not None and t.lazydata in all_uops]
 
   if len(fixed_tensors):
     # potentially rewrite all the discovered Tensors

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -31,7 +31,7 @@ def _apply_map_to_tensors(applied_map:dict[UOp, UOp]) -> None:
 
   # link the found UOps back to Tensors. exit early if there's no Tensors to realize
   # NOTE: this uses all_tensors, but it's fast
-  fixed_tensors: list[Tensor] = [t for tref in all_tensors if (t:=tref()) is not None and t.lazydata in all_uops]
+  fixed_tensors: list[Tensor] = [t for tref in all_tensors if (t:=tref()) is not None and getattr(t, 'lazydata', None) in all_uops]
 
   if len(fixed_tensors):
     # potentially rewrite all the discovered Tensors


### PR DESCRIPTION
Hello,

I'm new to tinygrad so I've been screwing around with it in the Python repl, and I found a bug. If I supply invalid arguments to `reshape()`, then a `ValueError` is thrown as expected. However, after that happens, I'm no longer able to `realize()` or `numpy()` any new tensors within that execution context, as an `AttributeError` is thrown:

```
>>> from tinygrad import Tensor
>>> print(Tensor.arange(16).reshape(1, 1, 4, 4).numpy())
[[[[ 0  1  2  3]
   [ 4  5  6  7]
   [ 8  9 10 11]
   [12 13 14 15]]]]
>>> print(Tensor.arange(16).reshape(1, 4, 4, 4).numpy())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 3946, in _wrapper
    ret = fn(*args, **kwargs)
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 959, in reshape
    return self._apply_uop(UOp.reshape, arg=new_shape) if new_shape != self.shape else self
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 3921, in _wrapper
    if _METADATA.get() is not None: return fn(*args, **kwargs)
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 228, in _apply_uop
    ret.lazydata = fxn(*[t.lazydata for t in (self,)+x], **kwargs)
  File "/home/joalmo/coding/tinygrad/tinygrad/ops.py", line 523, in reshape
    def reshape(self, arg:tuple[sint, ...]): return self._mop(Ops.RESHAPE, arg)
  File "/home/joalmo/coding/tinygrad/tinygrad/ops.py", line 520, in _mop
    if self.st == ret.st: return self  # ignore NOOPs, also check ret.st
  File "/usr/lib/python3.10/functools.py", line 981, in __get__
    val = self.func(instance)
  File "/home/joalmo/coding/tinygrad/tinygrad/ops.py", line 294, in st
    if self.op in GroupOp.Movement: return unwrap(self.src[0].st).mop(self.op, self.arg)
  File "/home/joalmo/coding/tinygrad/tinygrad/shape/shapetracker.py", line 139, in mop
    def mop(self, op, arg): return mops[op](self, arg)
  File "/home/joalmo/coding/tinygrad/tinygrad/shape/shapetracker.py", line 136, in reshape
    if getenv("MERGE_VIEW", 1) and (new_view := self.views[-1].reshape(new_shape)) is not None: return ShapeTracker(self.views[0:-1] + (new_view,))
  File "/home/joalmo/coding/tinygrad/tinygrad/shape/view.py", line 281, in reshape
    if resolve(prod(self.shape) != prod(new_shape), False): raise ValueError(f"size mismatched, can't reshape {self.shape=} -> {new_shape=}")
ValueError: size mismatched, can't reshape self.shape=(16,) -> new_shape=(1, 4, 4, 4)
>>> print(Tensor.arange(16).reshape(1, 1, 4, 4).numpy())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 3921, in _wrapper
    if _METADATA.get() is not None: return fn(*args, **kwargs)
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 362, in numpy
    return np.frombuffer(self._data(), dtype=_to_np_dtype(self.dtype.base)).reshape(self.shape)
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 3921, in _wrapper
    if _METADATA.get() is not None: return fn(*args, **kwargs)
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 304, in _data
    cpu = self.cast(self.dtype.base).contiguous().to("CLANG").realize()
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 3921, in _wrapper
    if _METADATA.get() is not None: return fn(*args, **kwargs)
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 266, in realize
    run_schedule(*self.schedule_with_vars(*lst), do_update_stats=do_update_stats)
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 3921, in _wrapper
    if _METADATA.get() is not None: return fn(*args, **kwargs)
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 255, in schedule_with_vars
    _apply_map_to_tensors(becomes_map)
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 34, in _apply_map_to_tensors
    fixed_tensors: list[Tensor] = [t for tref in all_tensors if (t:=tref()) is not None and t.lazydata in all_uops]
  File "/home/joalmo/coding/tinygrad/tinygrad/tensor.py", line 34, in <listcomp>
    fixed_tensors: list[Tensor] = [t for tref in all_tensors if (t:=tref()) is not None and t.lazydata in all_uops]
AttributeError: 'Tensor' object has no attribute 'lazydata'
```

I did some digging and found that when an exception is thrown in `_apply_uop`, the `lazydata` field does not end up getting populated on the tensor, but a weakref to the tensor is still retained in the `all_tensors` set. So when we end up looping over `all_tensors` and we try to access `t.lazydata` on this tensor, we get the `AttributeError`. This bug appears to have been introduced in a relatively recent commit: https://github.com/tinygrad/tinygrad/commit/e82ba1454

This PR fixes the bug by skipping over tensors with no `lazydata` without throwing an `AttributeError`. I also added a regression test which would fail by throwing `AttributeError` if this fix was not in place.

Thank you for your time!