### PR TITLE
Pass host CPU features to LLVM target

### DIFF
--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -17,9 +17,9 @@ class LLVMCompiler(Compiler):
 
     triple = {'AArch64': b'aarch64', 'X86': b'x86_64'}[host_arch] + b'-none-unknown-elf'
     target = expect(llvm.LLVMGetTargetFromTriple(triple, ctypes.pointer(tgt:=llvm.LLVMTargetRef()), err:=cerr()), err, tgt)
-    cpu, features = ctypes.string_at(llvm.LLVMGetHostCPUName()), ctypes.string_at(llvm.LLVMGetHostCPUFeatures())
+    cpu, feats = ctypes.string_at(llvm.LLVMGetHostCPUName()), ctypes.string_at(llvm.LLVMGetHostCPUFeatures())
     # +reserve-x18 here does the same thing as -ffixed-x18 in ops_clang.py, see comments there for why it's needed on arm osx
-    self.target_machine = llvm.LLVMCreateTargetMachine(target, triple, cpu, b'+reserve-x18,' + features if OSX and host_arch == 'AArch64' else features,
+    self.target_machine = llvm.LLVMCreateTargetMachine(target, triple, cpu, b'+reserve-x18,' + feats if OSX and host_arch == 'AArch64' else feats,
                                                        llvm.LLVMCodeGenLevelDefault, llvm.LLVMRelocPIC, llvm.LLVMCodeModelDefault)
 
     self.pbo = llvm.LLVMCreatePassBuilderOptions()

--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -17,8 +17,9 @@ class LLVMCompiler(Compiler):
 
     triple = {'AArch64': b'aarch64', 'X86': b'x86_64'}[host_arch] + b'-none-unknown-elf'
     target = expect(llvm.LLVMGetTargetFromTriple(triple, ctypes.pointer(tgt:=llvm.LLVMTargetRef()), err:=cerr()), err, tgt)
+    cpu, features = ctypes.string_at(llvm.LLVMGetHostCPUName()), ctypes.string_at(llvm.LLVMGetHostCPUFeatures())
     # +reserve-x18 here does the same thing as -ffixed-x18 in ops_clang.py, see comments there for why it's needed on arm osx
-    self.target_machine = llvm.LLVMCreateTargetMachine(target, triple, b'', b'+reserve-x18' if OSX and host_arch == 'AArch64' else b'',
+    self.target_machine = llvm.LLVMCreateTargetMachine(target, triple, cpu, b'+reserve-x18,' + features if OSX and host_arch == 'AArch64' else features,
                                                        llvm.LLVMCodeGenLevelDefault, llvm.LLVMRelocPIC, llvm.LLVMCodeModelDefault)
 
     self.pbo = llvm.LLVMCreatePassBuilderOptions()


### PR DESCRIPTION
This gets `test_gemm_fp16` to pass on Windows on certain hardware. It would fail because the generated machine code would call compiler-rt functions to perform truncating. This also probably improves performance and is essentially `-march=native`.

Unless this was intentionally left as is to be re-implemented fully in LLVM IR or something.

Before
```asm
0x000000: push  r15
0x000002: push  r14
0x000004: push  rsi
0x000005: push  rdi
0x000006: push  rbx
0x000007: sub   rsp, 0xe0
0x00000e: movaps        xmmword ptr [rsp + 0xd0], xmm15
0x000017: movaps        xmmword ptr [rsp + 0xc0], xmm14
0x000020: movaps        xmmword ptr [rsp + 0xb0], xmm13
0x000029: movaps        xmmword ptr [rsp + 0xa0], xmm12
0x000032: movaps        xmmword ptr [rsp + 0x90], xmm11
0x00003b: movaps        xmmword ptr [rsp + 0x80], xmm10
0x000044: movaps        xmmword ptr [rsp + 0x70], xmm9
0x00004a: movaps        xmmword ptr [rsp + 0x60], xmm8
0x000050: movaps        xmmword ptr [rsp + 0x50], xmm7
0x000055: movaps        xmmword ptr [rsp + 0x40], xmm6
0x00005a: mov   rbx, rdx
0x00005d: mov   r14, rcx
0x000060: add   rbx, 0xc
0x000064: xor   r15d, r15d
0x000067: nop   word ptr [rax + rax]
0x000070: movss xmm0, dword ptr [rbx - 0xc]
0x000075: movss dword ptr [rsp + 0xc], xmm0
0x00007b: movss xmm0, dword ptr [rbx - 8]
0x000080: movss xmm1, dword ptr [rbx - 4]
0x000085: movss dword ptr [rsp + 0x20], xmm1
0x00008b: movss xmm1, dword ptr [rbx]
0x00008f: movss dword ptr [rsp + 0x10], xmm1
0x000095: call  0x9a
0x00009a: movaps        xmmword ptr [rsp + 0x30], xmm0
0x00009f: movss xmm0, dword ptr [rsp + 0x20]
0x0000a5: call  0xaa
0x0000aa: movaps        xmmword ptr [rsp + 0x20], xmm0
0x0000af: movss xmm0, dword ptr [rsp + 0x10]
0x0000b5: call  0xba
0x0000ba: movaps        xmmword ptr [rsp + 0x10], xmm0
0x0000bf: movd  xmm0, dword ptr [rsp + 0xc]
0x0000c5: call  0xca
0x0000ca: movdqa        xmm1, xmmword ptr [rsp + 0x30]
0x0000d0: pextrw        eax, xmm1, 0
0x0000d5: mov   word ptr [r14 + r15*8 + 2], ax
0x0000db: movdqa        xmm1, xmmword ptr [rsp + 0x20]
0x0000e1: pextrw        eax, xmm1, 0
0x0000e6: mov   word ptr [r14 + r15*8 + 4], ax
0x0000ec: movdqa        xmm1, xmmword ptr [rsp + 0x10]
0x0000f2: pextrw        eax, xmm1, 0
0x0000f7: mov   word ptr [r14 + r15*8 + 6], ax
0x0000fd: pextrw        eax, xmm0, 0
0x000102: mov   word ptr [r14 + r15*8], ax
0x000107: inc   r15
0x00010a: add   rbx, 0x10
0x00010e: cmp   r15d, 0x400
0x000115: jb    0x70
0x00011b: movaps        xmm6, xmmword ptr [rsp + 0x40]
0x000120: movaps        xmm7, xmmword ptr [rsp + 0x50]
0x000125: movaps        xmm8, xmmword ptr [rsp + 0x60]
0x00012b: movaps        xmm9, xmmword ptr [rsp + 0x70]
0x000131: movaps        xmm10, xmmword ptr [rsp + 0x80]
0x00013a: movaps        xmm11, xmmword ptr [rsp + 0x90]
0x000143: movaps        xmm12, xmmword ptr [rsp + 0xa0]
0x00014c: movaps        xmm13, xmmword ptr [rsp + 0xb0]
0x000155: movaps        xmm14, xmmword ptr [rsp + 0xc0]
0x00015e: movaps        xmm15, xmmword ptr [rsp + 0xd0]
0x000167: add   rsp, 0xe0
0x00016e: pop   rbx
0x00016f: pop   rdi
0x000170: pop   rsi
0x000171: pop   r14
0x000173: pop   r15
0x000175: ret
```

Notice the `call` instructions, these do not get relocated currently. Their relocation type is `R_X86_64_PLT32` IIRC.

After
```asm
0x000000: add   rdx, 0x180
0x000007: add   rcx, 0xc
0x00000b: xor   eax, eax
0x00000d: nop   dword ptr [rax]
0x000010: mov   r8, rcx
0x000013: mov   r9, rdx
0x000016: xor   r10d, r10d
0x000019: nop   dword ptr [rax]
0x000020: movzx r11d, word ptr [r9 - 0x100]
0x000028: vmovd xmm0, r11d
0x00002d: vcvtph2ps     xmm0, xmm0
0x000032: movzx r11d, word ptr [r9 - 0x80]
0x000037: vmovd xmm1, r11d
0x00003c: vcvtph2ps     xmm1, xmm1
0x000041: movzx r11d, word ptr [r9]
0x000045: vmovd xmm2, r11d
0x00004a: vcvtph2ps     xmm2, xmm2
0x00004f: movzx r11d, word ptr [r9 - 0x180]
0x000057: vmovd xmm3, r11d
0x00005c: vcvtph2ps     xmm3, xmm3
0x000061: vpunpckldq    xmm0, xmm3, xmm0
0x000065: vpunpcklqdq   xmm0, xmm0, xmm1
0x000069: vinsertps     xmm0, xmm0, xmm2, 0x30
0x00006f: vmovups       xmmword ptr [r8 - 0xc], xmm0
0x000075: inc   r10d
0x000078: add   r9, 0x200
0x00007f: add   r8, 0x10
0x000083: cmp   r10d, 0x10
0x000087: jb    0x20
0x000089: inc   eax
0x00008b: add   rdx, 2
0x00008f: add   rcx, 0x100
0x000096: cmp   eax, 0x40
0x000099: jb    0x10
0x00009f: ret
```