### PR TITLE
Flash attention

### DIFF
--- a/flash_atten.py
+++ b/flash_atten.py
@@ -1,0 +1,80 @@
+import time
+import numpy
+from tinygrad import Tensor
+
+
+
+q, k, v = Tensor.rand(1,1,20000,768), Tensor.rand(1,1,20000,768), Tensor.rand(1,1,20000,768)
+
+
+
+start = time.time()
+
+res,_ = q.flash_attention(k,v,5000,5000, is_casual=True)
+print(res.abs().sum().numpy())
+
+end = time.time()
+print(f"flash attention first run time : {end - start}")
+print()
+
+
+start = time.time()
+
+print(q.scaled_dot_product_attention(k,v).abs().sum().numpy())
+
+end = time.time()
+print(f"normal attention first run time : {end - start}")
+print()
+
+
+
+q, k, v = Tensor.rand(1,1,20000,768), Tensor.rand(1,1,20000,768), Tensor.rand(1,1,20000,768)
+
+start = time.time()
+
+res,_ = q.flash_attention(k,v,5000,5000, is_casual=True)
+print(res.abs().sum().numpy())
+
+end = time.time()
+print(f"flash attention second run time : {end - start}")
+print()
+
+
+start = time.time()
+
+print(q.scaled_dot_product_attention(k,v).abs().sum().numpy())
+
+end = time.time()
+print(f"normal attention second run time : {end - start}")
+print()
+
+
+
+
+q, k, v = Tensor.rand(1,1,20000,768), Tensor.rand(1,1,20000,768), Tensor.rand(1,1,20000,768)
+res,_ = q.flash_attention(k,v,5000,5000, is_casual=True)
+print(f"error of the flash attention {100 * (q.scaled_dot_product_attention(k,v) - res).abs().sum().numpy() / res.abs().sum().numpy():.5f}% (casual)")
+
+res,_ = q.flash_attention(k,v,5000,5000, is_casual=False)
+mask = Tensor.full((q.shape[0], q.shape[1], q.shape[2], q.shape[2]), float("-inf")).triu(1)
+print(f"error of the flash attention {100 * (q.scaled_dot_product_attention(k,v, attn_mask=mask) - res).abs().sum().numpy() / res.abs().sum().numpy():.5f}% (with mask)")
+print()
+
+q, k, v = Tensor.rand(1,1,50000,768), Tensor.rand(1,1,50000,768), Tensor.rand(1,1,50000,768)
+
+
+try:
+    print("Trying normal attention on a big sequence")
+    q.scaled_dot_product_attention(k,v).numpy()
+except Exception as e:
+    print(f"failure: {e}")
+else:
+    print("success")
+
+try:
+    print("Trying flash attention on a big sequence")
+    q.flash_attention(k,v,5000,5000, is_casual=True)[0].numpy()
+except Exception as e:
+    print(f"failure: {e}")
+else:
+    print("success")


### PR DESCRIPTION
This is the 'FlashAttention-2 forward pass' algorithm from the [https://arxiv.org/abs/2307.08691](https://arxiv.org/abs/2307.08691) paper. I have changed the `./example/gpt2.py` demo to use `Tensor.flash_attention` and it seems to work, also I have made a sort `flash_atten.py` script to compare `scaled_dot_product_attention` and `flash_attention`.

I know that this patch is a sketch/prototype, but I want to ask a few questions:

 - Am I on the right path to adding the implementation of the algo?

 - Is there a way to add the backward pass, without stitching the computation graph with python?
( For example [torch](https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function) has a way to control the backward pass. As far as I understand this is against the idea of tinygrad. )

 - Do you expect this to be implemented on the backend ( `LLVM`, `CLANG`, `CUDA`, ... ) and added as an operation in OPs?
( I guess attention is quite important function, but I doubt. )

```
(p_venv) [tinygrad]$ python flash_atten.py
7681395.5
flash attention first run time : 1.4955716133117676

7681396.5
normal attention first run time : 0.8573811054229736

7680352.5
flash attention second run time : 0.5276808738708496

7680366.5
normal attention second run time : 0.8197903633117676

error of the flash attention 0.00675% (casual)
error of the flash attention 0.00306% (with mask)

Trying normal attention on a big sequence
failure: rm_alloc returned 81: Out of memory
Trying flash attention on a big sequence
success
```

Pls, give feedback.