### PR TITLE
specialcase for bfloat16->float16 cast

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3727,8 +3727,7 @@ class Tensor(SimpleMathTrait):
       # NOTE: values within the int32 range and outside the unsigned dtype range will cause values to wrap around
       return self._apply_uop(UOp.cast, dtype=dtypes.int32)._apply_uop(UOp.cast, dtype=dt)
     if self.dtype == dtypes.bfloat16 and dt == dtypes.float16:
-        return (self._apply_uop(UOp.cast, dtype=dtypes.float32)
-                    ._apply_uop(UOp.cast, dtype=dtypes.float16))
+        return (self._apply_uop(UOp.cast, dtype=dtypes.float32)._apply_uop(UOp.cast, dtype=dtypes.float16))
     return self if self.dtype == dt else self._apply_uop(UOp.cast, dtype=dt)
 
   def bitcast(self, dtype:DTypeLike) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3726,6 +3726,9 @@ class Tensor(SimpleMathTrait):
     if (dt:=to_dtype(dtype)) in {dtypes.uint8, dtypes.uint16} and dtypes.is_float(self.dtype):
       # NOTE: values within the int32 range and outside the unsigned dtype range will cause values to wrap around
       return self._apply_uop(UOp.cast, dtype=dtypes.int32)._apply_uop(UOp.cast, dtype=dt)
+    if self.dtype == dtypes.bfloat16 and dt == dtypes.float16:
+        return (self._apply_uop(UOp.cast, dtype=dtypes.float32)
+                    ._apply_uop(UOp.cast, dtype=dtypes.float16))
     return self if self.dtype == dt else self._apply_uop(UOp.cast, dtype=dt)
 
   def bitcast(self, dtype:DTypeLike) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3727,7 +3727,7 @@ class Tensor(SimpleMathTrait):
       # NOTE: values within the int32 range and outside the unsigned dtype range will cause values to wrap around
       return self._apply_uop(UOp.cast, dtype=dtypes.int32)._apply_uop(UOp.cast, dtype=dt)
     if self.dtype == dtypes.bfloat16 and dt == dtypes.float16:
-        return (self._apply_uop(UOp.cast, dtype=dtypes.float32)._apply_uop(UOp.cast, dtype=dtypes.float16))
+      return (self._apply_uop(UOp.cast, dtype=dtypes.float32)._apply_uop(UOp.cast, dtype=dtypes.float16))
     return self if self.dtype == dt else self._apply_uop(UOp.cast, dtype=dt)
 
   def bitcast(self, dtype:DTypeLike) -> Tensor:


### PR DESCRIPTION
an alternative for https://github.com/tinygrad/tinygrad/pull/8935

before:
```
hans@DESKTOP-EE15SLU:~/projects/exo$ ./.venv/bin/python ./.venv/bin/exo --inference-engine tinygrad --run-model llama-3.1-8b --prompt test
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
Selected inference engine: tinygrad

  _____  _____  
 / _ \ \/ / _ \ 
|  __/>  < (_) |
 \___/_/\_\___/ 
    
Detected system: Linux
Inference engine name after selection: tinygrad
Using inference engine: TinygradDynamicShardInferenceEngine with shard downloader: SingletonShardDownloader
[64744, 64797, 63103, 52881, 55003, 54919, 55613, 58126, 53424, 64334, 52511, 49296, 52789, 52602, 64031, 54720, 54729, 58625, 54453]
Chat interface started:
 - http://172.28.112.207:52415
 - http://172.17.0.1:52415
 - http://127.0.0.1:52415
 - http://172.29.0.1:52415
 - http://172.30.0.1:52415
ChatGPT API endpoint served at:
 - http://172.28.112.207:52415/v1/chat/completions
 - http://172.17.0.1:52415/v1/chat/completions
 - http://127.0.0.1:52415/v1/chat/completions
 - http://172.29.0.1:52415/v1/chat/completions
 - http://172.30.0.1:52415/v1/chat/completions
has_read=True, has_write=True
Processing prompt: <|begin_of_text|><|start_header_id|>user<|end_header_id|>

test<|eot_id|><|start_header_id|>assistant<|end_header_id|>


  0%|                                                                                                                                                                | 0/292 [00:00<?, ?it/s]
loaded weights in 113.71 ms, 0.03 GB loaded at 0.30 GB/s
Error processing prompt: Nvrtc Error 6, NVRTC_ERROR_COMPILATION
<null>(18): error: more than one user-defined conversion from "nv_bfloat16" to "half" applies:
            function "__half::__half(float)"
/usr/include/cuda_fp16.hpp(214): here
            function "__half::__half(short)"
/usr/include/cuda_fp16.hpp(227): here
            function "__half::__half(unsigned short)"
/usr/include/cuda_fp16.hpp(228): here
            function "__half::__half(int)"
/usr/include/cuda_fp16.hpp(229): here
            function "__half::__half(unsigned int)"
/usr/include/cuda_fp16.hpp(230): here
            function "__half::__half(long long)"
/usr/include/cuda_fp16.hpp(231): here
            function "__half::__half(unsigned long long)"
/usr/include/cuda_fp16.hpp(232): here

<null>(18): error: more than one user-defined conversion from "nv_bfloat16" to "half" applies:
            function "__half::__half(float)"
/usr/include/cuda_fp16.hpp(214): here
            function "__half::__half(short)"
/usr/include/cuda_fp16.hpp(227): here
            function "__half::__half(unsigned short)"
/usr/include/cuda_fp16.hpp(228): here
            function "__half::__half(int)"
/usr/include/cuda_fp16.hpp(229): here
            function "__half::__half(unsigned int)"
/usr/include/cuda_fp16.hpp(230): here
            function "__half::__half(long long)"
/usr/include/cuda_fp16.hpp(231): here
            function "__half::__half(unsigned long long)"
/usr/include/cuda_fp16.hpp(232): here

<null>(18): error: more than one user-defined conversion from "nv_bfloat16" to "half" applies:
            function "__half::__half(float)"
/usr/include/cuda_fp16.hpp(214): here
            function "__half::__half(short)"
/usr/include/cuda_fp16.hpp(227): here
            function "__half::__half(unsigned short)"
/usr/include/cuda_fp16.hpp(228): here
            function "__half::__half(int)"
/usr/include/cuda_fp16.hpp(229): here
            function "__half::__half(unsigned int)"
/usr/include/cuda_fp16.hpp(230): here
            function "__half::__half(long long)"
/usr/include/cuda_fp16.hpp(231): here
            function "__half::__half(unsigned long long)"
/usr/include/cuda_fp16.hpp(232): here

<null>(18): error: more than one user-defined conversion from "nv_bfloat16" to "half" applies:
            function "__half::__half(float)"
/usr/include/cuda_fp16.hpp(214): here
            function "__half::__half(short)"
/usr/include/cuda_fp16.hpp(227): here
            function "__half::__half(unsigned short)"
/usr/include/cuda_fp16.hpp(228): here
            function "__half::__half(int)"
/usr/include/cuda_fp16.hpp(229): here
            function "__half::__half(unsigned int)"
/usr/include/cuda_fp16.hpp(230): here
            function "__half::__half(long long)"
/usr/include/cuda_fp16.hpp(231): here
            function "__half::__half(unsigned long long)"
/usr/include/cuda_fp16.hpp(232): here

4 errors detected in the compilation of "<null>".

Traceback (most recent call last):
  File "/home/hans/projects/exo/exo/main.py", line 237, in run_model_cli
    await node.process_prompt(shard, prompt, request_id=request_id)
  File "/home/hans/projects/exo/exo/orchestration/node.py", line 181, in process_prompt
    resp = await self._process_prompt(base_shard, prompt, request_id, inference_state)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/exo/orchestration/node.py", line 214, in _process_prompt
    result, inference_state = await self.inference_engine.infer_prompt(request_id, shard, prompt, inference_state)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/exo/inference/inference_engine.py", line 44, in infer_prompt
    tokens = await self.encode(shard, prompt)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/exo/inference/tinygrad/inference.py", line 89, in encode
    await self.ensure_shard(shard)
  File "/home/hans/projects/exo/exo/inference/tinygrad/inference.py", line 152, in ensure_shard
    model_shard = await loop.run_in_executor(self.executor, build_transformer, model_path, shard, parameters)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/exo/inference/tinygrad/inference.py", line 59, in build_transformer
    load_state_dict(model, weights, strict=False, consume=False)  # consume=True
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/nn/state.py", line 157, in load_state_dict
    else: v.replace(state_dict[k].to(v.device)).realize()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/tensor.py", line 3945, in _wrapper
    ret = fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/tensor.py", line 262, in realize
    run_schedule(*self.schedule_with_vars(*lst), do_update_stats=do_update_stats)
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 166, in run_schedule
    for ei in lower_schedule(schedule):
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 159, in lower_schedule
    raise e
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 153, in lower_schedule
    try: yield lower_schedule_item(si)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 148, in lower_schedule_item
    def lower_schedule_item(si:ScheduleItem) -> ExecItem: return ExecItem(*cast(tuple[Runner,list], si_lowerer.rewrite(si.ast, si.bufs)), si.metadata)
                                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/ops.py", line 822, in rewrite
    if (ret:=(fxn(ctx=ctx, **match) if has_ctx else fxn(**match))) is not None: return ret
              ^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 142, in <lambda>
    (UPat(Ops.SINK, name="sink"), lambda ctx,sink: (runner:=get_runner(ctx[0].device, sink), [ctx[x] for x in runner.p.globals])),
                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 111, in get_runner
    method_cache[ckey] = method_cache[bkey] = ret = CompiledRunner(replace(prg, device=device))
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 44, in __init__
    self.lib:bytes = precompiled if precompiled is not None else Device[p.device].compiler.compile_cached(p.src)
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/device.py", line 275, in compile_cached
    lib = self.compile(src)
          ^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/runtime/support/compiler_cuda.py", line 53, in compile
    def compile(self, src:str) -> bytes: return self._compile_program(src, nvrtc.nvrtcGetPTX, nvrtc.nvrtcGetPTXSize)
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/runtime/support/compiler_cuda.py", line 49, in _compile_program
    nvrtc_check(nvrtc.nvrtcCompileProgram(prog, len(self.compile_options), to_char_p_p([o.encode() for o in self.compile_options])), prog)
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/runtime/support/compiler_cuda.py", line 16, in nvrtc_check
    raise CompileError(f"Nvrtc Error {status}, {ctypes.string_at(nvrtc.nvrtcGetErrorString(status)).decode()}\n{err_log}")
tinygrad.device.CompileError: Nvrtc Error 6, NVRTC_ERROR_COMPILATION
<null>(18): error: more than one user-defined conversion from "nv_bfloat16" to "half" applies:
            function "__half::__half(float)"
/usr/include/cuda_fp16.hpp(214): here
            function "__half::__half(short)"
/usr/include/cuda_fp16.hpp(227): here
            function "__half::__half(unsigned short)"
/usr/include/cuda_fp16.hpp(228): here
            function "__half::__half(int)"
/usr/include/cuda_fp16.hpp(229): here
            function "__half::__half(unsigned int)"
/usr/include/cuda_fp16.hpp(230): here
            function "__half::__half(long long)"
/usr/include/cuda_fp16.hpp(231): here
            function "__half::__half(unsigned long long)"
/usr/include/cuda_fp16.hpp(232): here

<null>(18): error: more than one user-defined conversion from "nv_bfloat16" to "half" applies:
            function "__half::__half(float)"
/usr/include/cuda_fp16.hpp(214): here
            function "__half::__half(short)"
/usr/include/cuda_fp16.hpp(227): here
            function "__half::__half(unsigned short)"
/usr/include/cuda_fp16.hpp(228): here
            function "__half::__half(int)"
/usr/include/cuda_fp16.hpp(229): here
            function "__half::__half(unsigned int)"
/usr/include/cuda_fp16.hpp(230): here
            function "__half::__half(long long)"
/usr/include/cuda_fp16.hpp(231): here
            function "__half::__half(unsigned long long)"
/usr/include/cuda_fp16.hpp(232): here

<null>(18): error: more than one user-defined conversion from "nv_bfloat16" to "half" applies:
            function "__half::__half(float)"
/usr/include/cuda_fp16.hpp(214): here
            function "__half::__half(short)"
/usr/include/cuda_fp16.hpp(227): here
            function "__half::__half(unsigned short)"
/usr/include/cuda_fp16.hpp(228): here
            function "__half::__half(int)"
/usr/include/cuda_fp16.hpp(229): here
            function "__half::__half(unsigned int)"
/usr/include/cuda_fp16.hpp(230): here
            function "__half::__half(long long)"
/usr/include/cuda_fp16.hpp(231): here
            function "__half::__half(unsigned long long)"
/usr/include/cuda_fp16.hpp(232): here

<null>(18): error: more than one user-defined conversion from "nv_bfloat16" to "half" applies:
            function "__half::__half(float)"
/usr/include/cuda_fp16.hpp(214): here
            function "__half::__half(short)"
/usr/include/cuda_fp16.hpp(227): here
            function "__half::__half(unsigned short)"
/usr/include/cuda_fp16.hpp(228): here
            function "__half::__half(int)"
/usr/include/cuda_fp16.hpp(229): here
            function "__half::__half(unsigned int)"
/usr/include/cuda_fp16.hpp(230): here
            function "__half::__half(long long)"
/usr/include/cuda_fp16.hpp(231): here
            function "__half::__half(unsigned long long)"
/usr/include/cuda_fp16.hpp(232): here

4 errors detected in the compilation of "<null>".

Task was destroyed but it is pending!
task: <Task pending name='Task-6' coro=<Node.periodic_topology_collection() running at /home/hans/projects/exo/exo/orchestration/node.py:530> wait_for=<Future pending 
cb=[Task.task_wakeup()]>>
  0%|                                                                                                                                                                | 0/292 [00:00<?, ?it/s]
loaded weights in  94.65 ms, 0.03 GB loaded at 0.35 GB/s
Task was destroyed but it is pending!
task: <Task pending name='Task-14' coro=<TinygradDynamicShardInferenceEngine.ensure_shard() running at /home/hans/projects/exo/exo/inference/tinygrad/inference.py:152> wait_for=<Future 
pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/lib/python3.12/asyncio/futures.py:387, Task.task_wakeup()]>>
╭────────────────────────────────────────────────────────────────────────────────── Exo Cluster (1 node) ───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                           │
│                                                            _____  _____                                                                                                                   │
│                                                           / _ \ \/ / _ \                                                                                                                  │
│                                                          |  __/>  < (_) |                                                                                                                 │
│                                                           \___/_/\_\___/                                                                                                                  │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                        Web Chat URL (tinychat): http://172.28.112.207:52415                                                                                               │
│                               ChatGPT API endpoint: http://172.28.112.207:52415/v1/chat/completions                                                                                       │
│                          GPU poor                      ▼                                         GPU rich                                                                                 │
│                                   [🟥🟥🟥🟥🟥🟥🟥🟥🟧🟧🟧🟧🟧🟧🟧🟨🟨🟨🟨🟨🟨🟨🟨🟩🟩🟩🟩🟩🟩🟩]                                                                                          │
│                                                  71.20 TFLOPS                                                                                                                             │
│                                                        ▲                                                                                                                                  │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                            Linux Box (NVIDIA GEF/RCE RTX 3090) 24GB                                                                                       │
│                                                            71.2TFLOPS                                                                                                                     │
│                                                            [0.00-1.00]                                                                                                                    │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ 💬️ <|begin_of_text|><|start_header_id|>user<|end_header_id|>                                                                                                                              │
│ test<|eot_id|><|start_header_id|>assistant<|end_header_id|>                                                                                                                               │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯hans@DESKTOP-EE15SLU:~/projects/exo$ 
```
after:
```
hans@DESKTOP-EE15SLU:~/projects/exo$ ./.venv/bin/python ./.venv/bin/exo --inference-engine tinygrad --run-model llama-3.1-8b --prompt test
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
Selected inference engine: tinygrad

  _____  _____  
 / _ \ \/ / _ \ 
|  __/>  < (_) |
 \___/_/\_\___/ 
    
Detected system: Linux
Inference engine name after selection: tinygrad
Using inference engine: TinygradDynamicShardInferenceEngine with shard downloader: SingletonShardDownloader
[64797, 63103, 52881, 55003, 54919, 55613, 58126, 53424, 64334, 52511, 49296, 52789, 52602, 64031, 54720, 54729, 58625, 54453, 58876]
Chat interface started:
 - http://127.0.0.1:52415
 - http://172.30.0.1:52415
 - http://172.29.0.1:52415
 - http://172.28.112.207:52415
 - http://172.17.0.1:52415
ChatGPT API endpoint served at:
 - http://127.0.0.1:52415/v1/chat/completions
 - http://172.30.0.1:52415/v1/chat/completions
 - http://172.29.0.1:52415/v1/chat/completions
 - http://172.28.112.207:52415/v1/chat/completions
 - http://172.17.0.1:52415/v1/chat/completions
has_read=True, has_write=True
Processing prompt: <|begin_of_text|><|start_header_id|>user<|end_header_id|>

test<|eot_id|><|start_header_id|>assistant<|end_header_id|>


  0%|                                                                                                                                                                | 0/292 [00:00<?, ?it/s]
ram used:  0.00 GB, layers.0.attention.wq.weight                      :   0%|▎                                                                               | 1/292 [00:00<00:10, 27.69it/s]
ram used:  0.03 GB, layers.0.attention.wk.weight                      :   1%|▌                                                                               | 2/292 [00:00<00:07, 40.49it/s]
ram used:  0.04 GB, layers.0.attention.wv.weight                      :   1%|▊                                                                               | 3/292 [00:00<00:05, 50.64it/s]
ram used:  0.05 GB, layers.0.attention.wo.weight                      :   1%|█                                                                               | 4/292 [00:00<00:05, 52.46it/s]
ram used:  0.08 GB, layers.0.feed_forward.w1.weight                   :   2%|█▎                                                                              | 5/292 [00:00<00:06, 41.41it/s]
ram used:  0.20 GB, layers.0.feed_forward.w2.weight                   :   2%|█▋                                                                              | 6/292 [00:00<00:08, 35.40it/s]
ram used:  0.32 GB, layers.0.feed_forward.w3.weight                   :   2%|█▉                                                                              | 7/292 [00:00<00:08, 31.98it/s]
ram used:  0.44 GB, layers.0.attention_norm.weight                    :   3%|██▏                                                                             | 8/292 [00:00<00:08, 35.28it/s]
ram used:  0.44 GB, layers.0.ffn_norm.weight                          :   3%|██▍                                                                             | 9/292 [00:00<00:07, 39.17it/s]
ram used:  0.44 GB, layers.1.attention.wq.weight                      :   3%|██▋                                                                            | 10/292 [00:00<00:06, 40.39it/s]
ram used:  0.47 GB, layers.1.attention.wk.weight                      :   4%|██▉                                                                            | 11/292 [00:00<00:06, 43.25it/s]
ram used:  0.48 GB, layers.1.attention.wv.weight                      :   4%|███▏                                                                           | 12/292 [00:00<00:06, 45.61it/s]
ram used:  0.49 GB, layers.1.attention.wo.weight                      :   4%|███▌                                                                           | 13/292 [00:00<00:06, 46.27it/s]
ram used:  0.52 GB, layers.1.feed_forward.w1.weight                   :   5%|███▊                                                                           | 14/292 [00:00<00:06, 42.23it/s]
ram used:  0.64 GB, layers.1.feed_forward.w2.weight                   :   5%|████                                                                           | 15/292 [00:00<00:07, 39.34it/s]
ram used:  0.75 GB, layers.1.feed_forward.w3.weight                   :   5%|████▎                                                                          | 16/292 [00:00<00:07, 37.65it/s]
ram used:  0.87 GB, layers.1.attention_norm.weight                    :   6%|████▌                                                                          | 17/292 [00:00<00:06, 39.70it/s]
ram used:  0.87 GB, layers.1.ffn_norm.weight                          :   6%|████▊                                                                          | 18/292 [00:00<00:06, 41.78it/s]
ram used:  0.87 GB, layers.2.attention.wq.weight                      :   7%|█████▏                                                                         | 19/292 [00:00<00:06, 42.79it/s]
ram used:  0.91 GB, layers.2.attention.wk.weight                      :   7%|█████▍                                                                         | 20/292 [00:00<00:06, 44.28it/s]
ram used:  0.91 GB, layers.2.attention.wv.weight                      :   7%|█████▋                                                                         | 21/292 [00:00<00:05, 45.89it/s]
ram used:  0.92 GB, layers.2.attention.wo.weight                      :   8%|█████▉                                                                         | 22/292 [00:00<00:05, 46.39it/s]
ram used:  0.96 GB, layers.2.feed_forward.w1.weight                   :   8%|██████▏                                                                        | 23/292 [00:00<00:05, 44.83it/s]
ram used:  1.07 GB, layers.2.feed_forward.w2.weight                   :   8%|██████▍                                                                        | 24/292 [00:00<00:06, 43.43it/s]
loaded weights in 578.55 ms, 1.31 GB loaded at 2.26 GB/s
Error processing prompt: CUDA Error 2, out of memory
Traceback (most recent call last):
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/device.py", line 196, in alloc
    try: return super().alloc(size, options)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/device.py", line 176, in alloc
    return self._alloc(size, options if options is not None else BufferSpec())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/runtime/ops_cuda.py", line 71, in _alloc
    if options.host: return init_c_var(ctypes.c_void_p(), lambda x: check(cuda.cuMemHostAlloc(ctypes.byref(x), size, 0x01)))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/helpers.py", line 295, in init_c_var
    def init_c_var(ctypes_var, creat_cb): return (creat_cb(ctypes_var), ctypes_var)[1]
                                                  ^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/runtime/ops_cuda.py", line 71, in <lambda>
    if options.host: return init_c_var(ctypes.c_void_p(), lambda x: check(cuda.cuMemHostAlloc(ctypes.byref(x), size, 0x01)))
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/runtime/ops_cuda.py", line 13, in check
    if status != 0: raise RuntimeError(f"CUDA Error {status}, {ctypes.string_at(init_c_var(ctypes.POINTER(ctypes.c_char)(), lambda x: cuda.cuGetErrorString(status, 
ctypes.byref(x)))).decode()}")  # noqa: E501
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^^^^^
RuntimeError: CUDA Error 2, out of memory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/hans/projects/exo/exo/main.py", line 237, in run_model_cli
    await node.process_prompt(shard, prompt, request_id=request_id)
  File "/home/hans/projects/exo/exo/orchestration/node.py", line 181, in process_prompt
    resp = await self._process_prompt(base_shard, prompt, request_id, inference_state)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/exo/orchestration/node.py", line 214, in _process_prompt
    result, inference_state = await self.inference_engine.infer_prompt(request_id, shard, prompt, inference_state)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/exo/inference/inference_engine.py", line 44, in infer_prompt
    tokens = await self.encode(shard, prompt)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/exo/inference/tinygrad/inference.py", line 89, in encode
    await self.ensure_shard(shard)
  File "/home/hans/projects/exo/exo/inference/tinygrad/inference.py", line 152, in ensure_shard
    model_shard = await loop.run_in_executor(self.executor, build_transformer, model_path, shard, parameters)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/exo/inference/tinygrad/inference.py", line 59, in build_transformer
    load_state_dict(model, weights, strict=False, consume=False)  # consume=True
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/nn/state.py", line 157, in load_state_dict
    else: v.replace(state_dict[k].to(v.device)).realize()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/tensor.py", line 3948, in _wrapper
    ret = fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/tensor.py", line 262, in realize
    run_schedule(*self.schedule_with_vars(*lst), do_update_stats=do_update_stats)
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 168, in run_schedule
    ei.run(var_vals, do_update_stats=do_update_stats)
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 124, in run
    et = self.prg(bufs, var_vals, wait=wait or DEBUG >= 2)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 92, in __call__
    self.copy(dest, src)
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 87, in copy
    dest.copyin(src.as_buffer(allow_zero_copy=True))  # may allocate a CPU buffer depending on allow_zero_copy
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/device.py", line 158, in copyin
    self.allocator._copyin(self._buf, mv)
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/runtime/ops_cuda.py", line 78, in _copyin
    host_mem = self.alloc(len(src), BufferSpec(host=True))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/device.py", line 199, in alloc
    return super().alloc(size, options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/device.py", line 176, in alloc
    return self._alloc(size, options if options is not None else BufferSpec())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/runtime/ops_cuda.py", line 71, in _alloc
    if options.host: return init_c_var(ctypes.c_void_p(), lambda x: check(cuda.cuMemHostAlloc(ctypes.byref(x), size, 0x01)))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/helpers.py", line 295, in init_c_var
    def init_c_var(ctypes_var, creat_cb): return (creat_cb(ctypes_var), ctypes_var)[1]
                                                  ^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/runtime/ops_cuda.py", line 71, in <lambda>
    if options.host: return init_c_var(ctypes.c_void_p(), lambda x: check(cuda.cuMemHostAlloc(ctypes.byref(x), size, 0x01)))
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hans/projects/exo/.venv/lib/python3.12/site-packages/tinygrad/runtime/ops_cuda.py", line 13, in check
    if status != 0: raise RuntimeError(f"CUDA Error {status}, {ctypes.string_at(init_c_var(ctypes.POINTER(ctypes.c_char)(), lambda x: cuda.cuGetErrorString(status, 
ctypes.byref(x)))).decode()}")  # noqa: E501
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^^^^^
RuntimeError: CUDA Error 2, out of memory
Task was destroyed but it is pending!
task: <Task pending name='Task-32' coro=<UDPDiscovery.on_listen_message() running at /home/hans/projects/exo/exo/networking/udp/udp_discovery.py:139>>
/home/hans/projects/exo/exo/main.py:389: RuntimeWarning: coroutine 'UDPDiscovery.on_listen_message' was never awaited
  if loop: loop.close()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Task was destroyed but it is pending!
task: <Task pending name='Task-33' coro=<UDPDiscovery.on_listen_message() running at /home/hans/projects/exo/exo/networking/udp/udp_discovery.py:139>>
Task was destroyed but it is pending!
task: <Task pending name='Task-6' coro=<Node.periodic_topology_collection() running at /home/hans/projects/exo/exo/orchestration/node.py:530> wait_for=<Future pending 
cb=[Task.task_wakeup()]>>
  0%|                                                                                                                                                                | 0/292 [00:00<?, ?it/s]
loaded weights in  29.77 ms, 0.03 GB loaded at 1.13 GB/s
Task was destroyed but it is pending!
task: <Task pending name='Task-12' coro=<TinygradDynamicShardInferenceEngine.ensure_shard() running at /home/hans/projects/exo/exo/inference/tinygrad/inference.py:152> wait_for=<Future 
pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/lib/python3.12/asyncio/futures.py:387, Task.task_wakeup()]>>
╭────────────────────────────────────────────────────────────────────────────────── Exo Cluster (1 node) ───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                           │
│                                                            _____  _____                                                                                                                   │
│                                                           / _ \ \/ / _ \                                                                                                                  │
│                                                          |  __/>  < (_) |                                                                                                                 │
│                                                           \___/_/\_\___/                                                                                                                  │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                          Web Chat URL (tinychat): http://127.0.0.1:52415                                                                                                  │
│                                  ChatGPT API endpoint: http://127.0.0.1:52415/v1/chat/completions                                                                                         │
│                          GPU poor                      ▼                                         GPU rich                                                                                 │
│                                   [🟥🟥🟥🟥🟥🟥🟥🟥🟧🟧🟧🟧🟧🟧🟧🟨🟨🟨🟨🟨🟨🟨🟨🟩🟩🟩🟩🟩🟩🟩]                                                                                          │
│                                                  71.20 TFLOPS                                                                                                                             │
│                                                        ▲                                                                                                                                  │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                            Linux Box (NVIDIA GEF/RCE RTX 3090) 24GB                                                                                       │
│                                                            71.2TFLOPS                                                                                                                     │
│                                                            [0.00-1.00]                                                                                                                    │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ 💬️ <|begin_of_text|><|start_header_id|>user<|end_header_id|>                                                                                                                              │
│ test<|eot_id|><|start_header_id|>assistant<|end_header_id|>                                                                                                                               │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
│                                                                                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯hans@DESKTOP-EE15SLU:~/projects/exo$ 
```

(I think the allocation error is a separate issue specific to me, I'm suspecting a GPU<->Windows 10<->WSL issue, but haven't figured it out yet)