### PR TITLE
little better VIEW simplifier pattern [pr]

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1267,7 +1267,8 @@ ConstLike = Union[ConstType, Variable, tuple[ConstType, ...]]
 merge_views = PatternMatcher([
   # VIEW(VIEW) merges to a single VIEW
   (UPat(Ops.VIEW, name="vm1", src=(UPat(Ops.VIEW, name="vm2"),)), lambda vm1,vm2: vm2.replace(arg=vm2.st+vm1.st)),
-  (UPat(Ops.VIEW, name="vm", src=(UPat.var("x"),)), lambda vm,x: x if vm.st.contiguous and x.st is not None and x.shape == vm.shape else None),
+  # remove VIEW if it's contiguous and same as the base shape
+  (UPat(Ops.VIEW, name="vm", src=(UPat(GroupOp.All-{Ops.DEVICE}, name="x"),)), lambda vm,x: x if vm.st.contiguous and x.shape == vm.shape else None),
   # merge unmasked const views
   (UPat(Ops.VIEW, name="view", src=(UPat((Ops.CONST, Ops.DEFINE_VAR), name="const", src=(UPat(Ops.VIEW, name="st"),) ),)),
    lambda st,const,view: const.replace(src=(st.replace(arg=st.st+view.st),)) if all(v.mask is None for v in (st.st+view.st).views) else None),


### PR DESCRIPTION
After BUFFER got a ShapeTracker of shape=(N,), the only UOp that can have a VIEW child and no ShapeTracker is a DEVICE, in CONST(VIEW(DEVICE)), maybe even that shouldn't be allowed. Like `.base` should always itself have some ShapeTracker. What is the shape of a device? `()`?