### PR TITLE
Make tensor use UOp lshift/rshift; delete SimpleMathTrait

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -704,26 +704,28 @@ class TestOps(unittest.TestCase):
     self.helper_test_exception([(4)], torch.bitwise_not, Tensor.bitwise_not, expected=RuntimeError)
 
   def test_lshift(self):
-    data = [[0,1,2],[1<<8,1<<16,1<<31-1]]
+    data = [[0,1,2],[1<<8,1<<16,1<<31-1],[-5, -1<<16, -1<<31]]
     tor = torch.tensor(data, dtype=torch.int)
-    ten = Tensor(data, dtype=dtypes.uint32)
-    # cast to int32 because torch does not support uint32
-    helper_test_op([], lambda: tor << 0, lambda: (ten << 0).cast(dtypes.int32), forward_only=True)
-    helper_test_op([], lambda: tor << 2, lambda: (ten << 2).cast(dtypes.int32), forward_only=True)
-    helper_test_op([], lambda: tor << 31, lambda: (ten << 31).cast(dtypes.int32), forward_only=True)
-    helper_test_op([], lambda: tor.__lshift__(2), lambda: ten.__lshift__(2).cast(dtypes.int32), forward_only=True)
-    helper_test_op([], lambda: tor.bitwise_left_shift(2), lambda: ten.lshift(2).cast(dtypes.int32), forward_only=True)
+    ten = Tensor(data, dtype=dtypes.int32)
+    helper_test_op([], lambda: tor << 0, lambda: ten << 0, forward_only=True)
+    helper_test_op([], lambda: tor << 100, lambda: ten << 100, forward_only=True)
+    helper_test_op([], lambda: tor << -1, lambda: ten << -1, forward_only=True)
+    helper_test_op([], lambda: tor << 2, lambda: ten << 2, forward_only=True)
+    helper_test_op([], lambda: tor << 31, lambda: ten << 31, forward_only=True)
+    helper_test_op([], lambda: tor.__lshift__(2), lambda: ten.__lshift__(2), forward_only=True)
+    helper_test_op([], lambda: tor.bitwise_left_shift(2), lambda: ten.lshift(2), forward_only=True)
 
   def test_rshift(self):
-    data = [[0,1,2],[1<<8,1<<16,1<<31-1]]
+    data = [[0,1,2],[1<<8,1<<16,1<<31-1],[-5, -1<<16, -1<<31]]
     tor = torch.tensor(data, dtype=torch.int)
-    ten = Tensor(data, dtype=dtypes.uint32)
-    # cast to int32 because torch does not support uint32
-    helper_test_op([], lambda: tor >> 0, lambda: (ten >> 0).cast(dtypes.int32), forward_only=True)
-    helper_test_op([], lambda: tor >> 2, lambda: (ten >> 2).cast(dtypes.int32), forward_only=True)
-    helper_test_op([], lambda: tor >> 31, lambda: (ten >> 31).cast(dtypes.int32), forward_only=True)
-    helper_test_op([], lambda: tor.__rshift__(2), lambda: ten.__rshift__(2).cast(dtypes.int32), forward_only=True)
-    helper_test_op([], lambda: tor.bitwise_right_shift(2), lambda: ten.rshift(2).cast(dtypes.int32), forward_only=True)
+    ten = Tensor(data, dtype=dtypes.int32)
+    helper_test_op([], lambda: tor >> 0, lambda: ten >> 0, forward_only=True)
+    helper_test_op([], lambda: tor >> 100, lambda: ten >> 100, forward_only=True)
+    helper_test_op([], lambda: tor >> -1, lambda: ten >> -1, forward_only=True)
+    helper_test_op([], lambda: tor >> 2, lambda: ten >> 2, forward_only=True)
+    helper_test_op([], lambda: tor >> 31, lambda: ten >> 31, forward_only=True)
+    helper_test_op([], lambda: tor.__rshift__(2), lambda: ten.__rshift__(2), forward_only=True)
+    helper_test_op([], lambda: tor.bitwise_right_shift(2), lambda: ten.rshift(2), forward_only=True)
 
   def test_idiv_shift_rewrite_negative(self):
     a = Tensor(-5).idiv(2).item()

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -17,7 +17,7 @@ class FastEnum(IntEnum):
   @staticmethod
   def _generate_next_value_(_, __, ___, last_values): return 1 + max([0, *last_values, *[max(c) for c in FastEnum.__subclasses__()]])
 
-class SimpleMathTrait:
+class MathTrait:
   # required to implement
   def alu(self:T, arg:Ops, *src) -> T: raise NotImplementedError
   def const_like(self:T, b:ConstLike) -> T: raise NotImplementedError
@@ -71,14 +71,14 @@ class SimpleMathTrait:
   def __ne__(self, x): return self.ne(x)
   # NOTE: __eq__ isn't overridden, and means the same thing as is by default
 
-class MathTrait(SimpleMathTrait):
-  # TODO: move to Tensor when new backward is done
   def lshift(self, x, reverse=False): return self._binop(Ops.SHL, x, reverse)
   def rshift(self, x, reverse=False): return self._binop(Ops.SHR, x, reverse)
   def __lshift__(self, x): return self.lshift(x)
   def __rshift__(self, x): return self.rshift(x)
   def __rlshift__(self, x): return self.lshift(x, True)
   def __rrshift__(self, x): return self.rshift(x, True)
+  def __pow__(self, x): return self.pow(x)
+  def __rpow__(self, x): return self.pow(x, True)
 
   def maximum(self, x): return self.alu(Ops.MAX, self.ufix(x))
   def minimum(self, x): return -(-self).maximum(-x)
@@ -89,7 +89,7 @@ class MathTrait(SimpleMathTrait):
   def sin(self): return self.alu(Ops.SIN)
   def log2(self): return self.alu(Ops.LOG2)
   def exp2(self): return self.alu(Ops.EXP2)
-  def pow(self, x): return self.alu(Ops.POW, self.ufix(x))
+  def pow(self, x, reverse=False): return self._binop(Ops.POW, x, reverse)
 
 # the order of these Ops controls the order of the toposort
 class Ops(FastEnum):

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -30,7 +30,7 @@ def lcast(input_type:DType, output_type:DType):
   raise NotImplementedError(f"cast from {input_type} -> {output_type} not implemented")
 
 # llvm ops, lop[<dtype>][<op>]
-unsigned_lop = { Ops.ADD: "add", Ops.MUL: "mul", Ops.IDIV: "udiv", Ops.MOD: "urem",
+unsigned_lop = { Ops.ADD: "add", Ops.MUL: "mul", Ops.IDIV: "udiv", Ops.MOD: "urem", Ops.SHL: "shl", Ops.SHR: "ashr",
                  Ops.CMPLT: "icmp ult", Ops.CMPNE: "icmp ne", Ops.OR: "or", Ops.AND: "and", Ops.XOR: "xor", }
 signed_lop = {**unsigned_lop, Ops.CMPLT: "icmp slt", Ops.IDIV: "sdiv", Ops.MOD: "srem"}
 flags = " nsz arcp contract afn"

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -30,9 +30,9 @@ def lcast(input_type:DType, output_type:DType):
   raise NotImplementedError(f"cast from {input_type} -> {output_type} not implemented")
 
 # llvm ops, lop[<dtype>][<op>]
-unsigned_lop = { Ops.ADD: "add", Ops.MUL: "mul", Ops.IDIV: "udiv", Ops.MOD: "urem", Ops.SHL: "shl", Ops.SHR: "ashr",
+unsigned_lop = { Ops.ADD: "add", Ops.MUL: "mul", Ops.IDIV: "udiv", Ops.MOD: "urem", Ops.SHL: "shl", Ops.SHR: "lshr",
                  Ops.CMPLT: "icmp ult", Ops.CMPNE: "icmp ne", Ops.OR: "or", Ops.AND: "and", Ops.XOR: "xor", }
-signed_lop = {**unsigned_lop, Ops.CMPLT: "icmp slt", Ops.IDIV: "sdiv", Ops.MOD: "srem"}
+signed_lop = {**unsigned_lop, Ops.CMPLT: "icmp slt", Ops.IDIV: "sdiv", Ops.MOD: "srem", Ops.SHR: "ashr"}
 flags = " nsz arcp contract afn"
 float_lop = {Ops.ADD: "fadd"+flags, Ops.MUL: "fmul"+flags, Ops.CMPLT: f"fcmp{flags} ult", Ops.CMPNE: f"fcmp{flags} une", Ops.FDIV: "fdiv"+flags}
 lop = {**{x:unsigned_lop for x in (dtypes.bool,)+dtypes.uints}, **{x:signed_lop for x in dtypes.sints}, **{x:float_lop for x in dtypes.floats}}


### PR DESCRIPTION
Previously, Tensor `lshift`/`rshift` just called `.mul(2**x)` or `.idiv(2**x)`. Now it uses `Ops.SHL` and `Ops.SHR`. This lets you do `Tensor << Tensor` for example, which wasn't possible before. Signed ints are also supported.

Once Tensor bit shifts are implemented properly, you can delete SimpleMathTrait.