### PR TITLE
fix "fatal bad object" log in process replay [pr]

### DIFF
--- a/.github/actions/process-replay/action.yml
+++ b/.github/actions/process-replay/action.yml
@@ -7,7 +7,9 @@ runs:
       shell: bash
       run: |
         export PR_TITLE=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
-        export COMMIT_MESSAGE=$(git show -s --format=%B ${{ github.event.pull_request.head.sha }})
+        export CURRENT_SHA=${{ github.event.pull_request && github.event.pull_request.head.sha || github.sha }}
+        git fetch origin $CURRENT_SHA
+        export COMMIT_MESSAGE=$(git show -s --format=%B "$CURRENT_SHA")
         export CURRENT_HEAD=$(git rev-parse HEAD)
         cp test/external/process_replay/process_replay.py ./process_replay.py && git fetch origin master && git -c advice.detachedHead=false checkout origin/master && PYTHONPATH=. python3 process_replay.py
         git checkout $CURRENT_HEAD  # restore to branch


### PR DESCRIPTION
On pull_request creation, this need to check the pull_request.head.sha since HEAD points to the automatic merge commit.
Tested on pull_request, push and workflow_dispatch events.