### PR TITLE
fix viz paginate + cleanups

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -366,7 +366,6 @@
           else {
             // TODO: this shouldn't exist after the viz api refactor
             for (const [k,v] of Object.entries(chunk)) {
-              if (["uops", "graphs"].includes(k)) v.splice(0, 1);
               if (Array.isArray(v) && k !== "loc") ret[k].push(...v);
             }
           }

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -373,7 +373,7 @@
         p.style.display = "none";
         cache[cacheKey] = ret;
       }
-      renderGraph(ret.graphs[currentRewrite], currentRewrite == 0 ? [] : ret.changed_nodes[currentRewrite-1]);
+      renderGraph(ret.graphs[currentRewrite], ret.changed_nodes[currentRewrite]);
     }
     // ***** RHS metadata
     const metadata = document.querySelector(".container.metadata");
@@ -401,8 +401,8 @@
         if (i === currentRewrite) {
           gUl.classList.add("active");
           if (i !== 0) {
-            const diff = ret.diffs[i-1];
-            const [loc, pattern] = ret.upats[i-1];
+            const diff = ret.diffs[i];
+            const [loc, pattern] = ret.upats[i];
             const parts = loc.join(":").split("/");
             const div = Object.assign(document.createElement("div"), { className: "rewrite-container" });
             const link = vsCodeOpener(parts);

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -356,9 +356,13 @@
       }
       else {
         const p = document.querySelector(".progress");
+        p.style.display = "none";
         const limit = 100;
         const pageCount = Math.ceil((kernels[currentKernel][1][currentUOp].match_count+1)/limit);
-        p.style.display = pageCount == 1 ? "none" : "flex";
+        if (pageCount > 1) {
+          p.style.display = "flex";
+          d3.select("#graph-svg g").selectAll("*").remove();
+        }
         for (let i=0; i < pageCount; i++) {
           p.innerText = `fetching data ${i+1}/${pageCount}`;
           const chunk = await (await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}&offset=${i*limit}&limit=${limit}`)).json();

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -26,7 +26,7 @@
     padding: 0;
     width: 100%;
     height: 100%;
-    font-family: "Noto Sans", sans-serif;
+    font-family: sans-serif;
     font-optical-sizing: auto;
     font-weight: 400;
     font-style: normal;

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -83,8 +83,7 @@ def get_details(k:Any, ctx:TrackedGraphRewrite, metadata:GraphRewriteMetadata, o
     ret["uops"].append(str(sink:=new_sink))
   # if the client requested a chunk we only send that chunk
   # TODO: is there a way to cache the replaces dict here?
-  if offset != 0: ret = cast(GraphRewriteDetails, {k:v[offset:offset+limit] if isinstance(v,list) else v for k,v in ret.items()})
-  return ret
+  return cast(GraphRewriteDetails, {k:v[offset:offset+limit] if isinstance(v,list) else v for k,v in ret.items()})
 
 # Profiler API
 devices:dict[str, tuple[decimal.Decimal, decimal.Decimal, int]] = {}

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -29,7 +29,7 @@ class GraphRewriteDetails(GraphRewriteMetadata):
   changed_nodes: list[list[int]] # the changed UOp id + all its parents ids
   code_line: str                 # source code calling graph_rewrite
   kernel_code: str|None          # optionally render the final kernel code
-  upats: list[tuple[tuple[str, int], str]]
+  upats: list[tuple[tuple[str, int], str]|None]
 
 # NOTE: if any extra rendering in VIZ fails, we don't crash
 def pcall(fxn:Callable[..., str], *args, **kwargs) -> str:
@@ -70,7 +70,7 @@ def _prg(k:Kernel): return k.to_program().src
 def get_details(k:Any, ctx:TrackedGraphRewrite, metadata:GraphRewriteMetadata, offset=0, limit=200) -> GraphRewriteDetails:
   ret:GraphRewriteDetails = {"uops":[pcall(str, sink:=ctx.sink)], "graphs":[uop_to_json(sink)], "code_line":lines(ctx.loc[0])[ctx.loc[1]-1].strip(),
                              "kernel_code":pcall(_prg, k) if isinstance(k, Kernel) else None, **metadata,
-                             "diffs":[[]], "upats":[[]], "changed_nodes":[[]]} # NOTE: the first graph just renders the input UOp
+                             "diffs":[[]], "upats":[None], "changed_nodes":[[]]} # NOTE: the first graph just renders the input UOp
   replaces: dict[UOp, UOp] = {}
   for i,(u0,u1,upat) in enumerate(tqdm(ctx.matches)):
     replaces[u0] = u1

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -69,7 +69,8 @@ def get_metadata(keys:list[Any], contexts:list[list[TrackedGraphRewrite]]) -> li
 def _prg(k:Kernel): return k.to_program().src
 def get_details(k:Any, ctx:TrackedGraphRewrite, metadata:GraphRewriteMetadata, offset=0, limit=200) -> GraphRewriteDetails:
   ret:GraphRewriteDetails = {"uops":[pcall(str, sink:=ctx.sink)], "graphs":[uop_to_json(sink)], "code_line":lines(ctx.loc[0])[ctx.loc[1]-1].strip(),
-                             "kernel_code":pcall(_prg, k) if isinstance(k, Kernel) else None, "diffs":[], "upats":[], "changed_nodes":[], **metadata}
+                             "kernel_code":pcall(_prg, k) if isinstance(k, Kernel) else None, **metadata,
+                             "diffs":[[]], "upats":[[]], "changed_nodes":[[]]} # NOTE: the first graph just renders the input UOp
   replaces: dict[UOp, UOp] = {}
   for i,(u0,u1,upat) in enumerate(tqdm(ctx.matches)):
     replaces[u0] = u1


### PR DESCRIPTION
VIZ=1  was rendering the wrong final graph for `python test/models/test_mnist.py TestMNIST.test_adam_threestep
` because it was starting from the offset while building the replaces dict. It should start from the first match.
Is there a good way to cache UOp.substitute globally? That would speed this up.
![image](https://github.com/user-attachments/assets/8b693d00-5e99-464a-a6c3-00f94f7d7dcd)
