### PR TITLE
minimal failing test for #8975 [pr]

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2516,6 +2516,16 @@ class TestUOpBecome(unittest.TestCase):
     assert UPat(Ops.VIEW, src=(UPat(Ops.BUFFER))).match(b.lazydata, {}) # scheduling replaces the tensor lazydata with a VIEW(BUFFER)
     self.assertIs(a.lazydata.base.buffer, b.lazydata.base.buffer)
 
+   # TODO: this fails because the shrink must be applied on top of the BUFFER
+   # currently it's a VIEW
+  @unittest.expectedFailure
+  def test_become_buf_with_mops(self):
+    a = Tensor.empty(2, 4, 2)
+    noop = a.shrink(((1, 2), (0, 4), (0, 2))).reshape(4, 2)*1+0
+    noop.realize()
+    late_add = noop+2
+    late_add.realize() # UOp verification error
+
   def test_become_const_in_base(self):
     a = Tensor.empty(4)
     b = a*0


### PR DESCRIPTION
This will be fixed by backtracking from a VIEW to the movement ops that resulted in that VIEW, and instead of the BUFFER, apply those movement ops.

First, there is a chain of movement ops:

![image](https://github.com/user-attachments/assets/9eda4817-d9cd-4d3e-837e-9abcb62830e6)

These movement ops make a single VIEW:
![image](https://github.com/user-attachments/assets/76f4e53f-7983-449f-8017-9beebea00414)

Then the ADD and MUL tensors both become VIEW(BUFFER), we should have a way to replace that VIEW with the chain of movement ops that created it.