### PR TITLE
CUDA backend on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -598,7 +598,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        backend: [llvm, clang]
+        backend: [llvm, clang, cuda]
 
     name: Windows (${{ matrix.backend }})
     runs-on: windows-latest
@@ -612,7 +612,7 @@ jobs:
           key: windows-minimal
           deps: testing_minimal
       - name: Set env
-        run: printf "${{ matrix.backend == 'llvm' && 'LLVM=1' || matrix.backend == 'clang' && 'CLANG=1'}}"
+        run: printf "${{ matrix.backend == 'llvm' && 'LLVM=1' || matrix.backend == 'clang' && 'CLANG=1' || matrix.backend == 'cuda' && 'CUDA=1'}}"
       - name: Run pytest (${{ matrix.backend }})
         shell: bash
         run: python -m pytest -n=auto test/test_tiny.py test/test_ops.py --durations=20

--- a/tinygrad/runtime/autogen/cuda.py
+++ b/tinygrad/runtime/autogen/cuda.py
@@ -6,8 +6,7 @@
 # POINTER_SIZE is: 8
 # LONGDOUBLE_SIZE is: 16
 #
-import ctypes, ctypes.util
-
+import ctypes, ctypes.util, sys
 
 class AsDictMixin:
     @classmethod
@@ -145,7 +144,7 @@ def char_pointer_cast(string, encoding='utf-8'):
 
 
 _libraries = {}
-_libraries['libcuda.so'] = ctypes.CDLL(ctypes.util.find_library('cuda'))
+_libraries['libcuda.so'] = ctypes.CDLL(ctypes.util.find_library("nvcuda" if sys.platform == "win32" else "cuda"))
 
 
 cuuint32_t = ctypes.c_uint32

--- a/tinygrad/runtime/autogen/cuda.py
+++ b/tinygrad/runtime/autogen/cuda.py
@@ -144,7 +144,7 @@ def char_pointer_cast(string, encoding='utf-8'):
 
 
 _libraries = {}
-_libraries['libcuda.so'] = ctypes.CDLL(ctypes.util.find_library("nvcuda" if sys.platform == "win32" else "cuda"))
+_libraries['libcuda.so'] = ctypes.CDLL(ctypes.util.find_library("nvcuda")) if sys.platform == "win32" else ctypes.CDLL(ctypes.util.find_library("cuda"))
 
 
 cuuint32_t = ctypes.c_uint32

--- a/tinygrad/runtime/autogen/nvrtc.py
+++ b/tinygrad/runtime/autogen/nvrtc.py
@@ -6,11 +6,12 @@
 # POINTER_SIZE is: 8
 # LONGDOUBLE_SIZE is: 16
 #
-import ctypes, ctypes.util
+import ctypes, ctypes.util, os, sys
 
+LIBVER = '_'+ os.path.basename(os.environ.get('CUDA_PATH', ''))[1:].split('.')[0] +'0_0' if sys.platform == 'win32' else ''
 
 _libraries = {}
-_libraries['libnvrtc.so'] = ctypes.CDLL(ctypes.util.find_library('nvrtc'))
+_libraries['libnvrtc.so'] = ctypes.CDLL(ctypes.util.find_library('nvrtc64'+ LIBVER if sys.platform == 'win32' else 'nvrtc'))
 def string_cast(char_pointer, encoding='utf-8', errors='strict'):
     value = ctypes.cast(char_pointer, ctypes.c_char_p).value
     if value is not None and encoding is not None:
@@ -138,7 +139,7 @@ class Union(ctypes.Union, AsDictMixin):
 
 
 
-_libraries['libnvJitLink.so'] = ctypes.CDLL(ctypes.util.find_library('nvJitLink'))
+_libraries['libnvJitLink.so'] = ctypes.CDLL(ctypes.util.find_library('nvJitLink'+ LIBVER))
 c_int128 = ctypes.c_ubyte*16
 c_uint128 = c_int128
 void = None

--- a/tinygrad/runtime/autogen/nvrtc.py
+++ b/tinygrad/runtime/autogen/nvrtc.py
@@ -8,10 +8,10 @@
 #
 import ctypes, ctypes.util, os, sys
 
-LIBVER = '_'+ os.path.basename(os.environ.get('CUDA_PATH', ''))[1:].split('.')[0] +'0_0' if sys.platform == 'win32' else ''
+WIN_VERSION = '_'+ os.path.basename(os.environ.get('CUDA_PATH', ''))[1:].split('.')[0] +'0_0' if sys.platform == 'win32' else ''
 
 _libraries = {}
-_libraries['libnvrtc.so'] = ctypes.CDLL(ctypes.util.find_library('nvrtc64'+ LIBVER if sys.platform == 'win32' else 'nvrtc'))
+_libraries['libnvrtc.so'] = ctypes.CDLL(ctypes.util.find_library('nvrtc64'+ WIN_VERSION)) if sys.platform == 'win32' else ctypes.CDLL(ctypes.util.find_library('nvrtc'))
 def string_cast(char_pointer, encoding='utf-8', errors='strict'):
     value = ctypes.cast(char_pointer, ctypes.c_char_p).value
     if value is not None and encoding is not None:
@@ -139,7 +139,7 @@ class Union(ctypes.Union, AsDictMixin):
 
 
 
-_libraries['libnvJitLink.so'] = ctypes.CDLL(ctypes.util.find_library('nvJitLink'+ LIBVER))
+_libraries['libnvJitLink.so'] = ctypes.CDLL(ctypes.util.find_library('nvJitLink'+ WIN_VERSION)) if sys.platform == 'win32' else ctypes.CDLL(ctypes.util.find_library('nvJitLink'))
 c_int128 = ctypes.c_ubyte*16
 c_uint128 = c_int128
 void = None


### PR DESCRIPTION
CUDA now works and is selected before GPU on Windows. Tests pass. Windows-compatible parts of `pre-commit` pass.

Requirements:

- CUDA 12+ in the form of `cuda_12.8.0_windows_network.exe` or similar has been installed.
- The environment contains the `CUDA_PATH` variable from the CUDA install. Mine is `CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8`. This is used to extract the major version for the DLL name on Windows.
- nVidia claims the versioning in the DLL naming is `bin\nvrtc64_Major Release Version_0.dll`.  Grok claims this is for 12+. That there is a different one for 11.3+, and a different one earlier than that. Users with older versions of CUDA (pre 12) therefore must update CUDA to have it detected.