### PR TITLE
disallow VIEW(BUFFER) in tensor uops [pr]

### DIFF
--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -32,11 +32,6 @@ tensor_uop_spec = PatternMatcher([
   # NOTE: the arg here specifies clone=True, which prevents folding same device copy
   (UPat(Ops.COPY, name="copy", src=(UPat(Ops.DEVICE), UPat.var("x"))), lambda copy,x: isinstance(copy.arg, bool) and copy.dtype == x.dtype),
 
-  # VIEW(BUFFER) applies a ShapeTracker on top of the underlying device buffer
-  # NOTE: VIEW size exactly matches the underlying BUFFER, tensor doesn't apply movement ops to the VIEW
-  (UPat(Ops.VIEW, name="view", src=(UPat(Ops.BUFFER, name="buf"),)),
-   lambda view,buf: view.dtype == buf.dtype and view.size == buf.size and view.st.contiguous),
-
   # ASSIGN changes the value of a realized buffer
   (UPat(Ops.ASSIGN, name="assign", src=(UPat.var("target"), UPat.var("new_val"))),
    lambda assign,target,new_val: target.is_realized and (assign.dtype == target.dtype == new_val.dtype)),


### PR DESCRIPTION
VIEW is no longer a valid tensor UOp. This is possible after #8994 and #8984 reconstruct movement ops on top of the buffer + Tensor.empty constructs with RESHAPE: #8987.