### PR TITLE
Add vectorized support to transcendental

### DIFF
--- a/test/test_transcendental.py
+++ b/test/test_transcendental.py
@@ -128,5 +128,37 @@ class TestTranscendentalSchedule(unittest.TestCase):
       c = c.exp2()
       check_schedule(c, 1)
 
+class TestTranscendentalVectorized(unittest.TestCase):
+  def run_vectorized_test(self, op, np_op, min_val, max_val):
+    with Context(TRANSCENDENTAL=2), np.errstate(all='ignore'):
+      for vec_size in (1, 2, 4, 8):
+        num_elements = (100 // vec_size) * vec_size
+        x_vals = np.linspace(min_val, max_val, num=num_elements).astype(np.float32).reshape(-1, vec_size)
+        t = Tensor(x_vals, dtype=dtypes.float32.vec(vec_size))
+        tg_result = op(t).numpy().reshape(-1)
+        np_result = np_op(x_vals.reshape(-1))
+        np.testing.assert_allclose(tg_result, np_result, atol=2e-5, rtol=1e-5)
+
+  def test_vectorized_sin(self):
+    self.run_vectorized_test(Tensor.sin, np.sin, -100, 100)
+
+  def test_vectorized_log2(self):
+    self.run_vectorized_test(Tensor.log2, np.log2, 0.1, 100)
+
+  def test_vectorized_exp2(self):
+    self.run_vectorized_test(Tensor.exp2, np.exp2, -10, 10)
+
+  def test_vectorized_pow(self):
+    with Context(TRANSCENDENTAL=2), np.errstate(all='ignore'):
+      for vec_size in (1, 2, 4, 8):
+        num_elements = (100 // vec_size) * vec_size
+        bases = np.linspace(1.0, 10.0, num=num_elements).astype(np.float32).reshape(-1, vec_size)
+        exponents = np.linspace(0.0, 3.0, num=num_elements).astype(np.float32).reshape(-1, vec_size)
+        t_base = Tensor(bases, dtype=dtypes.float32.vec(vec_size))
+        t_exponent = Tensor(exponents, dtype=dtypes.float32.vec(vec_size))
+        result = t_base.pow(t_exponent).numpy().reshape(-1)
+        expected = np.power(bases, exponents).reshape(-1)
+        np.testing.assert_allclose(result, expected, atol=1e-5, rtol=1e-5)
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_transcendental.py
+++ b/test/test_transcendental.py
@@ -156,9 +156,9 @@ class TestTranscendentalVectorized(unittest.TestCase):
         exponents = np.linspace(0.0, 3.0, num=num_elements).astype(np.float32).reshape(-1, vec_size)
         t_base = Tensor(bases, dtype=dtypes.float32.vec(vec_size))
         t_exponent = Tensor(exponents, dtype=dtypes.float32.vec(vec_size))
-        result = t_base.pow(t_exponent).numpy().reshape(-1)
-        expected = np.power(bases, exponents).reshape(-1)
-        np.testing.assert_allclose(result, expected, atol=1e-5, rtol=1e-5)
+        tg_result = t_base.pow(t_exponent).numpy().reshape(-1)
+        np_result = np.power(bases, exponents).reshape(-1)
+        np.testing.assert_allclose(tg_result, np_result, atol=1e-5, rtol=1e-5)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/codegen/transcendental.py
+++ b/tinygrad/codegen/transcendental.py
@@ -1,9 +1,9 @@
 import math
 from tinygrad.dtype import dtypes, DType
 from tinygrad.helpers import polyN
-from tinygrad.ops import UOp
+from tinygrad.ops import UOp,Ops
 
-TRANSCENDENTAL_SUPPORTED_DTYPES = (dtypes.float16, dtypes.float32, dtypes.float64)
+TRANSCENDENTAL_SUPPORTED_DTYPES = tuple(dtype.vec(i) for dtype in (dtypes.float16, dtypes.float32, dtypes.float64) for i in (1, 2, 4, 8))
 
 def _lazy_map_numbers(x:UOp, inf:UOp, _inf:UOp, nan:UOp, ratio:UOp):
   """replace inf -> inf, -inf -> _inf, nan -> nan, otherwise -> ratio"""
@@ -172,6 +172,7 @@ def xsin(d:UOp, fast:bool=False, switch_over:float=30.0) -> UOp:
   - fast=True assumes x <= switch_over.
   - switch_over is the threshold for switching to payne_hanek_reduction.
   """
+  if d.dtype.count > 1: return UOp(Ops.VECTORIZE, d.dtype, tuple(xsin(d.gep(i), fast, switch_over) for i in range(d.dtype.count)))
   assert d.dtype in TRANSCENDENTAL_SUPPORTED_DTYPES
   # mask +-inf/nan as zero
   x = _lazy_map_numbers(d, d.const_like(0.0), d.const_like(0.0), d.const_like(0.0), d)
@@ -194,6 +195,7 @@ def xexp2(d:UOp) -> UOp:
   Implements a 1.0 ULP approximation for Ops.EXP2
   - Paper: https://arxiv.org/pdf/2001.09258
   """
+  if d.dtype.count > 1: return UOp(Ops.VECTORIZE, d.dtype, tuple(xexp2(d.gep(i)) for i in range(d.dtype.count)))
   assert d.dtype in TRANSCENDENTAL_SUPPORTED_DTYPES
   # mask +=inf/nan as zero.
   x = _lazy_map_numbers(d, d.const_like(0.0), d.const_like(0.0), d.const_like(0.0), d)
@@ -220,6 +222,7 @@ def xlog2(d:UOp) -> UOp:
   Implements a 1.0 ULP approximation for Ops.LOG2
   Paper: https://arxiv.org/pdf/2001.09258 5.5
   """
+  if d.dtype.count > 1: return UOp(Ops.VECTORIZE, d.dtype, tuple(xlog2(d.gep(i)) for i in range(d.dtype.count)))
   assert d.dtype in TRANSCENDENTAL_SUPPORTED_DTYPES
   # TODO: float16 denormal need float32 to achieve precision
   if d.dtype == dtypes.float16: return xlog2(d.cast(dtypes.float32)).cast(dtypes.float16)
@@ -256,6 +259,7 @@ def xlog2(d:UOp) -> UOp:
   return d.reciprocal().ne(-math.inf).where(r, r.const_like(-math.inf))
 
 def xpow(base:UOp, exponent:UOp) -> UOp:
+  if base.dtype.count > 1: return UOp(Ops.VECTORIZE, base.dtype, tuple(xpow(base.gep(i), exponent.gep(i)) for i in range(base.dtype.count)))
   # start with b ** e = exp2(e * log2(b))
   ret = (base < 0).where(-base, base).log2().mul(exponent).exp2()
   # negative base adjustment: nan for non-integer exponent and -1 for odd exponent


### PR DESCRIPTION
`bounty`: add vectorized support to transcendental(with test)

- [X] added vectorized support (1, 2, 4, 8) for transcendental functions (sin, log2, exp2, pow).
- [X] updated tests to validate correctness, against NumPy.