### PR TITLE
[bounty] add vectorized support to transcendental

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -427,7 +427,7 @@ jobs:
     - name: Test LLVM=1 DEVECTORIZE=0
       run: LLVM=1 DEVECTORIZE=0 python3 -m pytest -n auto test/test_tiny.py test/test_ops.py -k "not test_avg_pool3d_failure"
     - name: Test LLVM=1 DEVECTORIZE=0 for model
-      run: LLVM=1 DEVECTORIZE=0 python3 test/models/test_efficientnet.py
+      run: LLVM=1 DEVECTORIZE=0 python3 -m pytest -n auto test/models/test_efficientnet.py
     #- name: Test CLANG=1 DEVECTORIZE=0
     #  run: CLANG=1 DEVECTORIZE=0 python3 -m pytest -n auto test/test_tiny.py test/test_ops.py -k "not test_avg_pool3d_failure"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -426,6 +426,8 @@ jobs:
       run: PYTHONPATH="." DEBUG=2 DSP=1 python3 test/test_quantize_onnx.py
     - name: Test LLVM=1 DEVECTORIZE=0
       run: LLVM=1 DEVECTORIZE=0 python3 -m pytest -n auto test/test_tiny.py test/test_ops.py -k "not test_avg_pool3d_failure"
+    - name: Test LLVM=1 DEVECTORIZE=0 for model
+      run: LLVM=1 DEVECTORIZE=0 python3 test/models/test_efficientnet.py
     #- name: Test CLANG=1 DEVECTORIZE=0
     #  run: CLANG=1 DEVECTORIZE=0 python3 -m pytest -n auto test/test_tiny.py test/test_ops.py -k "not test_avg_pool3d_failure"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -407,7 +407,7 @@ jobs:
       with:
         key: dsp-minimal
         deps: testing_minimal
-        pydeps: "onnx==1.16.0 onnxruntime"
+        pydeps: "onnx==1.16.0 onnxruntime pillow"
         llvm: "true"
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/tinygrad/codegen/rewriter.py
+++ b/tinygrad/codegen/rewriter.py
@@ -462,8 +462,7 @@ devectorize = PatternMatcher([
 ])
 
 devectorize_load_store = PatternMatcher([
-  # TODO: add vectorized support to transcendental
-  (UPat((Ops.INDEX, Ops.EXP2, Ops.LOG2, Ops.SIN), name="alu"), no_vectorized_alu),
+  (UPat(Ops.INDEX, name="alu"), no_vectorized_alu),
   (UPat((Ops.LOAD, Ops.STORE), name="ls"), no_vectorized_load_store),
 ])
 

--- a/tinygrad/codegen/transcendental.py
+++ b/tinygrad/codegen/transcendental.py
@@ -1,7 +1,7 @@
 import math
 from tinygrad.dtype import dtypes, DType
 from tinygrad.helpers import polyN
-from tinygrad.ops import UOp
+from tinygrad.ops import UOp, Ops
 
 TRANSCENDENTAL_SUPPORTED_DTYPES = (dtypes.float16, dtypes.float32, dtypes.float64)
 
@@ -172,6 +172,7 @@ def xsin(d:UOp, fast:bool=False, switch_over:float=30.0) -> UOp:
   - fast=True assumes x <= switch_over.
   - switch_over is the threshold for switching to payne_hanek_reduction.
   """
+  if d.dtype.count > 1: return UOp(Ops.VECTORIZE, d.dtype, tuple(xsin(d.gep(i), fast, switch_over) for i in range(d.dtype.count)))
   assert d.dtype in TRANSCENDENTAL_SUPPORTED_DTYPES
   # mask +-inf/nan as zero
   x = _lazy_map_numbers(d, d.const_like(0.0), d.const_like(0.0), d.const_like(0.0), d)
@@ -194,6 +195,7 @@ def xexp2(d:UOp) -> UOp:
   Implements a 1.0 ULP approximation for Ops.EXP2
   - Paper: https://arxiv.org/pdf/2001.09258
   """
+  if d.dtype.count > 1: return UOp(Ops.VECTORIZE, d.dtype, tuple(xexp2(d.gep(i)) for i in range(d.dtype.count)))
   assert d.dtype in TRANSCENDENTAL_SUPPORTED_DTYPES
   # mask +=inf/nan as zero.
   x = _lazy_map_numbers(d, d.const_like(0.0), d.const_like(0.0), d.const_like(0.0), d)
@@ -220,6 +222,7 @@ def xlog2(d:UOp) -> UOp:
   Implements a 1.0 ULP approximation for Ops.LOG2
   Paper: https://arxiv.org/pdf/2001.09258 5.5
   """
+  if d.dtype.count > 1: return UOp(Ops.VECTORIZE, d.dtype, tuple(xlog2(d.gep(i)) for i in range(d.dtype.count)))
   assert d.dtype in TRANSCENDENTAL_SUPPORTED_DTYPES
   # TODO: float16 denormal need float32 to achieve precision
   if d.dtype == dtypes.float16: return xlog2(d.cast(dtypes.float32)).cast(dtypes.float16)


### PR DESCRIPTION
My understanding of this:

**Before:** Previously `rewriter.py` was responsible for handling a special case for vectorization of transcendental operations (`Ops.EXP2`, `Ops.LOG2`, `Ops.SIN`).

**After:**  We remove the special case from `rewriter.py` and instead handle vectorization directly in each transcendental function in `transcendental.py`.

**Why:** I can read `rewriter.py` and understand how it handles both scalar and vector inputs. Easier to understand since it's self-contained.

**Note:** Added `pillow` to `pydeps` in the `testdsp` job. I think it's fine but let me know if you want that different, e.g. using deps instead.

Based on https://github.com/tinygrad/tinygrad/pull/9053