### PR TITLE
Force truncate all UOp constants

### DIFF
--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -233,9 +233,6 @@ class TestExecALU(TestUOps):
     self.assertEqual(exec_alu(Ops.ADD, dtypes.int8, (1, 1)), 2)
     self.assertEqual(exec_alu(Ops.ADD, dtypes.int8, (-128, 0)), -128)
 
-    # test no truncate
-    self.assertEqual(exec_alu(Ops.ADD, dtypes.uint8, (250, 250), truncate_output=False), 500)
-
 class TestConstantFolding(unittest.TestCase):
   def test_cast_const(self):
     t = Tensor(1, dtype=dtypes.float).cast(dtypes.int)


### PR DESCRIPTION
I do not understand why all constant folding computations were done using python int but it does not produce the same result as running compiled code due to lack of wraparound.
If you want to keep using python int, you will need to painstakingly analyze all transformation rules to accurately apply delayed truncate when it is needed. See tests for examples.