### PR TITLE
skip test_allreduce on systems with insufficient GPUs

### DIFF
--- a/test/unit/test_allreduce.py
+++ b/test/unit/test_allreduce.py
@@ -1,10 +1,12 @@
-import unittest
+import unittest, os
 from tinygrad import Tensor, Device
 from tinygrad.helpers import Context
 from tinygrad.ops import Ops
 
 class TestRingAllReduce(unittest.TestCase):
   def test_schedule_ring(self):
+    if len([d for d in os.environ.get('CUDA_VISIBLE_DEVICES','').split(",") if d.strip()]) < 6:
+      self.skipTest("Test requires at least 6 GPUs")
     with Context(RING=2):
       N = 6
       ds = tuple(f"{Device.DEFAULT}:{i}" for i in range(N))


### PR DESCRIPTION
Updated `test_allreduce.py`:
Conditionally skip ring allreduce test on <6 GPUs to prevent ordinal errors during pre-commit tests.

<details>
  <summary>Error i was getting on running pre-commit:</summary>

  ![Screenshot from 2025-02-14 11-41-33](https://github.com/user-attachments/assets/e6d44af9-1f38-4f5e-8c1d-ec0538383d81)
  
  ![Screenshot from 2025-02-14 11-41-51](https://github.com/user-attachments/assets/df2b9728-a180-434b-b623-b11038dfc637)
</details>