### PR TITLE
Test broken const folding wraparound behavior

### DIFF
--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -136,6 +136,14 @@ class TestModularWraparound(unittest.TestCase):
     t(-UOp.const(dtypes.int32, -2**31), -2**31)
     t(-UOp.const(dtypes.int64, -2**63), -2**63)
 
+  @xfail_broken_const_wraparound
+  def test_payne_hanek_reduction_bug(self):
+    t = self._test
+    a = (UOp.const(dtypes.uint, 43748177600).cast(dtypes.uint) | 36).cast(dtypes.ulong)
+    b = 2536655455 * a + 4294967296 * UOp.const(dtypes.ulong, 25366554550)
+    c = (b + 2261737165) // 4611686018427387904
+    t(c, 0)
+
 class TestGraphRewrite(unittest.TestCase):
   def test_dedup(self):
     v1 = UOp(Ops.DEFINE_VAR, dtypes.float)

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -1,5 +1,5 @@
 from typing import List
-import unittest, time
+import unittest, time, pytest
 from tinygrad import dtypes, Device
 from tinygrad.helpers import DEBUG, AMX
 from tinygrad.ops import Ops, UOp, KernelInfo, UPat, PatternMatcher
@@ -92,6 +92,49 @@ class TestGraphRewriteConst(unittest.TestCase):
     self.assertEqual(ret.op, Ops.CONST)
     self.assertEqual(ret.dtype, dtypes.int.vec(3))
     self.assertEqual(ret.arg, 2)
+
+xfail_broken_const_wraparound = pytest.mark.xfail(reason="const folding does not properly implement modular arithmetic")
+class TestModularWraparound(unittest.TestCase):
+  def _test(self, uop:UOp, expected:int):
+    results = to_uops_list([uop])
+    self.assertEqual(len(results), 1)
+    self.assertEqual(results[0].op, Ops.CONST)
+    self.assertEqual(results[0].dtype, uop.dtype)
+    self.assertEqual(results[0].arg, expected)
+
+  @xfail_broken_const_wraparound
+  def test_cast(self):
+    t = self._test
+    t(UOp.const(dtypes.uint, 0xABCD17D6).cast(dtypes.uint8), 0xD6)
+    t(UOp.const(dtypes.uint, 0xABCD17D6).cast(dtypes.uint8).cast(dtypes.uint), 0xD6)
+
+  @xfail_broken_const_wraparound
+  def test_mul(self):
+    t = self._test
+    t(UOp.const(dtypes.uint, 0xABCD17D6) * 0xAABBCCDD, 1147018174)
+    t(UOp.const(dtypes.int, 0xABCD17D6) * 10, -1241321892)
+
+  @xfail_broken_const_wraparound
+  def test_div(self):
+    t = self._test
+    t(UOp.const(dtypes.uint, 0xABCD17D6) * 0xAABBCCDD // 11, 104274379)
+    t(UOp.const(dtypes.int, 0xABCD17D6) * 10 // 11, -112847444)
+
+  @xfail_broken_const_wraparound
+  def test_neg(self):
+    t = self._test
+    t(-UOp.const(dtypes.uint8, 1), 0xFF)
+    t(-UOp.const(dtypes.uint16, 1), 0xFFFF)
+    t(-UOp.const(dtypes.uint32, 1), 0xFFFFFFFF)
+    t(-UOp.const(dtypes.uint64, 1), 0xFFFFFFFFFFFFFFFF)
+
+  @xfail_broken_const_wraparound
+  def test_neg_min_int(self):
+    t = self._test
+    t(-UOp.const(dtypes.int8, -2**7), -2**7)
+    t(-UOp.const(dtypes.int16, -2**15), -2**15)
+    t(-UOp.const(dtypes.int32, -2**31), -2**31)
+    t(-UOp.const(dtypes.int64, -2**63), -2**63)
 
 class TestGraphRewrite(unittest.TestCase):
   def test_dedup(self):


### PR DESCRIPTION
Right now const folding arithmetic uses arbitrary precision int and does not match backends behavior.
This means that you can get wildly different results depending on what part of UOp graph was evaluated at compile time. One example of this is failure in `test_payne_hanek_reduction` in "Add and test constant folding for bitcast" bounty.
I've tried to make a quick fix in #9073 but it obviously requires more work (and it was out of scope of the initial bounty).

This PR adds tests showing some problematic cases. Setting `truncate_output=True` in `exec_alu` fixes some of them but this is far from being a complete solution. At the very least you need a much better test suite.