### PR TITLE
Solve get_grouped_dims does not split issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -450,7 +450,7 @@ jobs:
     - name: Run selected webgpu tests
       run: |
           WEBGPU=1 python3 -m pytest -n=auto test/ --ignore=test/models --ignore=test/unit \
-          --ignore=test/test_copy_speed.py --ignore=test/test_rearrange_einops.py --ignore=test/test_speed_v_torch.py \
+          --ignore=test/test_copy_speed.py --ignore=test/test_rearrange_einops.py \
           --ignore=test/test_fuzz_shape_ops.py --ignore=test/test_linearizer_failures.py --durations=20
     - name: Run process replay tests
       uses: ./.github/actions/process-replay

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -802,7 +802,7 @@ class TestAutoCastType(unittest.TestCase):
     np.testing.assert_allclose(t.grad.numpy(), [1, 0])
 
   @unittest.skipIf(Device.DEFAULT == "PYTHON", "very slow")
-  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "error due to too large dimensions")
+  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "Binding size is larger than the maximum storage buffer binding size")
   @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
   def test_mean_half_precision_underflow(self):
     N = 10000

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1206,6 +1206,9 @@ class TestLinearizer(unittest.TestCase):
     _assert_grouped_dims("gidx", (128,3,4), (16,4,256), False, [16,3,32])
     _assert_grouped_dims("gidx", (4,4,512), (16,4,256), False, [8,4,256])
 
+    # prefer group_dim strategy when possible
+    _assert_grouped_dims("gidx", (512,4,2), (8192,2,2), False, [2048,2])
+
     # test splitting globals:    len(dims) < len(max)
     #                            len(dim)        ->          len(limited)
     #                              1             ->             2

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1199,16 +1199,23 @@ class TestLinearizer(unittest.TestCase):
     _assert_grouped_dims("gidx", (2,3), (16,16,16), True, [3,2])
     _assert_grouped_dims("gidx", (2,3,4), (16,16,16), False, [2,3,4])
 
-    # test splitting globals: len(dims) == len(max)
+    # test splitting globals:    len(dims) == len(max)
     _assert_grouped_dims("gidx", (64,3,4), (16,16,16), False, [16,12,4])
     _assert_grouped_dims("gidx", (64,3,4), (16,4,16), False, [16,3,16])
     _assert_grouped_dims("gidx", (64,3,4), (16,16,16), True, [16,3,16])
     _assert_grouped_dims("gidx", (128,3,4), (16,4,256), False, [16,3,32])
     _assert_grouped_dims("gidx", (4,4,512), (16,4,256), False, [8,4,256])
 
-    # test splitting globals len(dims) < len(max)
+    # test splitting globals:    len(dims) < len(max)
+    #                            len(dim)        ->          len(limited)
+    #                              1             ->             2
     _assert_grouped_dims("gidx", (128,), (16,16,256), False, [16,8], False)
+    #                              1             ->             3
+    _assert_grouped_dims("gidx", (65536,), (16,16,256), False, [16,16,256], False)
+    #                              2             ->             3
     _assert_grouped_dims("gidx", (128,128), (16,16,256), False, [16,16,64], False)
+    # test when the only divisor is the square root of dim
+    _assert_grouped_dims("gidx", (121,), (12,12,12), False, [11,11], False)
 
     # collapse on onto the left most axis
     _assert_grouped_dims("gidx", (2,3,4,5), (16,16,16), False, [6,4,5])

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1175,13 +1175,14 @@ class TestLinearizer(unittest.TestCase):
         assert end_range < k.uops.index(u)
 
   def test_grouped_dims(self):
-    def _assert_grouped_dims(prefix, dims, max_sizes, reverse_dims, expected_sizes):
+    def _assert_grouped_dims(prefix, dims, max_sizes, reverse_dims, expected_sizes, assert_same_length = True):
       idxs = get_grouped_dims(prefix, dims, max_sizes, reverse_dims)
       loop_idxs = dedup(flatten([[y for y in x.toposort if y.op is Ops.SPECIAL] for x in idxs]))
       loop_idxs = sorted(loop_idxs, key=lambda uop: uop.arg[0])
       sizes = [x.arg[1] for x in loop_idxs]
       assert len(idxs) == len(dims), f"expected idxs to have same length as dims {len(dims)}, got {len(idxs)}"
-      assert len(loop_idxs) == min(len(sizes), len(dims)), f"expected idxs to have length {min(len(sizes), len(dims))}, got {len(loop_idxs)}"
+      if assert_same_length:
+        assert len(loop_idxs) == min(len(sizes), len(dims)), f"expected idxs to have length {min(len(sizes), len(dims))}, got {len(loop_idxs)}"
       assert sizes == expected_sizes, f"expected sizes={expected_sizes}, got {sizes=}"
       # TODO: add these back after uop symbolic
       # for i in range(len(dims)):
@@ -1198,11 +1199,16 @@ class TestLinearizer(unittest.TestCase):
     _assert_grouped_dims("gidx", (2,3), (16,16,16), True, [3,2])
     _assert_grouped_dims("gidx", (2,3,4), (16,16,16), False, [2,3,4])
 
-    # test splitting globals
-    # _assert_grouped_dims("gidx", (64,3,4), (16,16,16), False, [16,12,4])
-    # _assert_grouped_dims("gidx", (64,3,4), (16,4,16), False, [16,4,12])
-    # _assert_grouped_dims("gidx", (64,3,4), (16,16,16), True, [12,16,4])
-    # _assert_grouped_dims("gidx", (128,3,4), (16,4,256), False, [16,4,24])
+    # test splitting globals: len(dims) == len(max)
+    _assert_grouped_dims("gidx", (64,3,4), (16,16,16), False, [16,12,4])
+    _assert_grouped_dims("gidx", (64,3,4), (16,4,16), False, [16,3,16])
+    _assert_grouped_dims("gidx", (64,3,4), (16,16,16), True, [16,3,16])
+    _assert_grouped_dims("gidx", (128,3,4), (16,4,256), False, [16,3,32])
+    _assert_grouped_dims("gidx", (4,4,512), (16,4,256), False, [8,4,256])
+
+    # test splitting globals len(dims) < len(max)
+    _assert_grouped_dims("gidx", (128,), (16,16,256), False, [16,8], False)
+    _assert_grouped_dims("gidx", (128,128), (16,16,256), False, [16,16,64], False)
 
     # collapse on onto the left most axis
     _assert_grouped_dims("gidx", (2,3,4,5), (16,16,16), False, [6,4,5])
@@ -1215,11 +1221,11 @@ class TestLinearizer(unittest.TestCase):
 
     # _assert_grouped_dims("gidx", (Variable("start_pos",1,2),3,4,5), (16,16,16), False, [Variable("start_pos",1,2)*3,4,5])
 
-    # # dim too large and not factorable
-    # with self.assertRaises(AssertionError):
-    #   get_grouped_dims("gidx", (23,), (16,16,16), False,)
-    # with self.assertRaises(AssertionError):
-    #   get_grouped_dims("gidx", (128,3,4), (16,4,23), False,)
+    # dim too large and not factorable
+    with self.assertRaises(RuntimeError):
+      get_grouped_dims("gidx", (23,), (16,16,16), False,)
+    with self.assertRaises(RuntimeError):
+      get_grouped_dims("gidx", (128,3,4), (16,2,2), False,)
 
     # too large for sizes
     with self.assertRaises(RuntimeError):

--- a/test/test_specific_conv.py
+++ b/test/test_specific_conv.py
@@ -21,7 +21,6 @@ class TestSpecific(unittest.TestCase):
     (x @ w).reshape(1, 128, 4).contiguous().realize()
 
   @unittest.skipUnless(is_dtype_supported(dtypes.float16), "need float16 support")
-  @unittest.skipIf(Device.DEFAULT == "WEBGPU", "Too large dimensions")
   def test_big_vec_mul(self):
     # from LLaMA
     #   0 buffer<4096, dtypes.float>                      [View((1024, 1, 1, 4), (4, 0, 0, 1), 0, None)]

--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -29,7 +29,6 @@ def _group_dims(dims:tuple[sint, ...], max_sizes:tuple[int, ...]):
   return dims
 
 def _split_dims(dims, max_sizes):
-  if len(dims) == 0 or all(d <= m for d,m in zip(dims, max_sizes)): return dims
   _dims = list(dims) + [1]*(3-len(dims))
   for i in range(len(_dims)):
     while _dims[i] > max_sizes[i]:
@@ -40,8 +39,8 @@ def _split_dims(dims, max_sizes):
 
 def get_grouped_dims(prefix, dims:tuple[sint, ...], max_sizes:tuple[int, ...]|None, reverse=False) -> list[UOp]:
   if reverse: dims = dims[::-1]
-  if max_sizes is not None and len(dims) > len(max_sizes): limited = _group_dims(dims, max_sizes)
-  else: limited = _split_dims(dims, max_sizes) if max_sizes is not None else dims
+  limited = _group_dims(dims, max_sizes) if max_sizes is not None else dims
+  if limited == dims and any(d > m for d,m in zip(dims, max_sizes)): limited = _split_dims(dims, max_sizes)
   ret = raw_idxs = [UOp(Ops.SPECIAL, dtypes.int, (), (f"{prefix}{i}", s)) for i,s in enumerate(limited)]
   if len(limited) < len(dims):
     ret = []

--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -17,7 +17,7 @@ def get_contraction(old_shape:tuple[sint, ...], new_shape:tuple[sint, ...]) -> l
 
 # ***** indexing *****
 
-def _limit_dims(dims:tuple[sint, ...], max_sizes:tuple[int, ...]):
+def _group_dims(dims:tuple[sint, ...], max_sizes:tuple[int, ...]):
   # TODO: symbolic shape
   if not all_int(dims): return dims
   while len(dims) > len(max_sizes):
@@ -28,8 +28,8 @@ def _limit_dims(dims:tuple[sint, ...], max_sizes:tuple[int, ...]):
     else: raise RuntimeError(f"cannot limit dim {dims=}, {max_sizes=}")
   return dims
 
-def _fit_to_max(dims, max_sizes):
-  if len(dims) == 0 or len(dims) > len(max_sizes) or all(d <= m for d,m in zip(dims, max_sizes)): return dims
+def _split_dims(dims, max_sizes):
+  if len(dims) == 0 or all(d <= m for d,m in zip(dims, max_sizes)): return dims
   _dims = list(dims) + [1]*(3-len(dims))
   for i in range(len(_dims)):
     while _dims[i] > max_sizes[i]:
@@ -40,8 +40,8 @@ def _fit_to_max(dims, max_sizes):
 
 def get_grouped_dims(prefix, dims:tuple[sint, ...], max_sizes:tuple[int, ...]|None, reverse=False) -> list[UOp]:
   if reverse: dims = dims[::-1]
-  if max_sizes is not None and len(dims) > len(max_sizes): limited = _limit_dims(dims, max_sizes)
-  else: limited = _fit_to_max(dims, max_sizes) if max_sizes is not None else dims
+  if max_sizes is not None and len(dims) > len(max_sizes): limited = _group_dims(dims, max_sizes)
+  else: limited = _split_dims(dims, max_sizes) if max_sizes is not None else dims
   ret = raw_idxs = [UOp(Ops.SPECIAL, dtypes.int, (), (f"{prefix}{i}", s)) for i,s in enumerate(limited)]
   if len(limited) < len(dims):
     ret = []

--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -33,11 +33,7 @@ def _fit_to_max(dims, max_sizes):
   _dims = list(dims) + [1]*(3-len(dims))
   for i in range(len(_dims)):
     while _dims[i] > max_sizes[i]:
-      div = 1
-      for d in range(2, int(math.sqrt(_dims[i])) + 1):
-        if (_dims[i] % d) == 0:
-          div = d
-          break
+      div = next((d for d in range(2, math.ceil(math.sqrt(_dims[i]))) if (_dims[i] % d) == 0), 1)
       if div == 1: raise RuntimeError(f"cannot limit dim {dims=}, {max_sizes=}")
       _dims[i], _dims[(i+1)%len(_dims)] = _dims[i]//div, _dims[(i+1)%len(_dims)]*div
   return tuple(_dims[:2] if _dims[2] == 1 else _dims[0] if _dims[1:3] == [1,1] else _dims)

--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -40,7 +40,7 @@ def _split_dims(dims, max_sizes):
 def get_grouped_dims(prefix, dims:tuple[sint, ...], max_sizes:tuple[int, ...]|None, reverse=False) -> list[UOp]:
   if reverse: dims = dims[::-1]
   limited = _group_dims(dims, max_sizes) if max_sizes is not None else dims
-  if limited == dims and any(d > m for d,m in zip(dims, max_sizes)): limited = _split_dims(dims, max_sizes)
+  if max_sizes is not None and (limited == dims) and any(d > m for d,m in zip(dims, max_sizes)): limited = _split_dims(dims, max_sizes)
   ret = raw_idxs = [UOp(Ops.SPECIAL, dtypes.int, (), (f"{prefix}{i}", s)) for i,s in enumerate(limited)]
   if len(limited) < len(dims):
     ret = []

--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -40,7 +40,7 @@ def _fit_to_max(dims, max_sizes):
 
 def get_grouped_dims(prefix, dims:tuple[sint, ...], max_sizes:tuple[int, ...]|None, reverse=False) -> list[UOp]:
   if reverse: dims = dims[::-1]
-  if len(dims) > len(max_sizes): limited = _limit_dims(dims, max_sizes) if max_sizes is not None else dims
+  if max_sizes is not None and len(dims) > len(max_sizes): limited = _limit_dims(dims, max_sizes)
   else: limited = _fit_to_max(dims, max_sizes) if max_sizes is not None else dims
   ret = raw_idxs = [UOp(Ops.SPECIAL, dtypes.int, (), (f"{prefix}{i}", s)) for i,s in enumerate(limited)]
   if len(limited) < len(dims):


### PR DESCRIPTION
This closes https://github.com/tinygrad/tinygrad/issues/8043

Our `_limit_dims` in `lowerer` only handles contraction, i.e. cases such as:
`dim=(2,3,4,5)`  `max=(16,16,16)`, so when` len(dim) > len(max)`

But with WebGPU we hit cases not handled by `_limit_dims`, when some element in `dim` is larger than the corresponding element in `max`, resulting in this error:

<img width="685" alt="Screenshot 2025-02-14 at 14 36 17" src="https://github.com/user-attachments/assets/501fa3a8-ac00-4d0c-8784-d3f639498ec9" />

This can come in various forms, such as:
- `dim=(64,3,4)`, `max=(16,16,16)`
- `dim=(128,)`, `max=(16,16,256)`

The algo tries to find a divisor for the current `dim` if it's larger than `max`, and divides it until it's `<= max`. While dividing, it multiplies the next dim by the same amount so the product of the shape doesn't change.

- I removed all skips which were skipped because of this issue.
- I also removed ignore of `test_speed_v_torch` previously failing.
- It also solves `fp16` stable diffusion previously failing with the same error message shown above.