### PR TITLE
Make simplify use symbolic_flat

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -322,7 +322,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
 
   def simplify(self):
     with Context(TRACK_MATCH_STATS=0):
-      return graph_rewrite(self, symbolic)
+      return graph_rewrite(self, symbolic_flat)
   def ssimplify(self) -> Union[UOp, ConstType]: return ret.arg if (ret:=self.simplify()).op is Ops.CONST else ret
   def _eval(self, dtype, expected_type:Type[T]) -> T:
     assert self.dtype in dtype, f"eval with wrong dtype {self}"


### PR DESCRIPTION
Is there a specific reason this is not using symbolic_flat?