### PR TITLE
Synchronize webgpu [pr]

### DIFF
--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -241,3 +241,10 @@ class WebGpuDevice(Compiled):
 
     super().__init__(device, WebGpuAllocator(device_result[1]), WGSLRenderer(), Compiler(),
       functools.partial(WebGPUProgram, (device_result[1], webgpu.WGPUFeatureName_TimestampQuery in supported)))
+
+  def synchronize(self):
+    result: List[Any] = []
+    def cb(status, u1, u2): result[:] = [status]
+    cb_info = create_cb_info(webgpu.WGPUQueueWorkDoneCallbackInfo2, webgpu.WGPUQueueWorkDoneCallback2, cb)
+    wgpu_wait(webgpu.wgpuQueueOnSubmittedWorkDone2(webgpu.wgpuDeviceGetQueue(self.runtime.args[0][0]), cb_info))
+    if result[0] != webgpu.WGPUQueueWorkDoneStatus_Success: raise RuntimeError(webgpu.WGPUQueueWorkDoneStatus__enumvalues[result[0]])


### PR DESCRIPTION
`test_speed_v_torch` showed suspicious results (showed better results then METAL=1)

<img width="1393" alt="Screenshot 2025-02-14 at 21 05 14" src="https://github.com/user-attachments/assets/adc4ebc9-bb39-4796-abed-434a89fc5a9f" />

After synchronize:

<img width="1315" alt="Screenshot 2025-02-14 at 22 16 37" src="https://github.com/user-attachments/assets/7c8cbe94-0ef3-46fd-b585-680ab928033c" />
