### PR TITLE
limit_dims is group_dims [pr]

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1199,6 +1199,8 @@ class TestLinearizer(unittest.TestCase):
     _assert_grouped_dims("gidx", (2,3,4), (16,16,16), False, [2,3,4])
 
     # test splitting globals
+    # test grouping behavior when len(dims) == len(max_sizes)
+    _assert_grouped_dims("gidx", (512,4,2), (8192,2,2), False, [2048,2])
     # _assert_grouped_dims("gidx", (64,3,4), (16,16,16), False, [16,12,4])
     # _assert_grouped_dims("gidx", (64,3,4), (16,4,16), False, [16,4,12])
     # _assert_grouped_dims("gidx", (64,3,4), (16,16,16), True, [12,16,4])


### PR DESCRIPTION
As discussed with @chenyuxyz I'm separating out `group_dims` refactor from the [split_dims PR](https://github.com/tinygrad/tinygrad/pull/9085)

The grouping failure check is moved out of `_group_dims` and the `None` return is introduced, so that if `_group_dims` fails to limit dims, `_split_dims` can try. There is only `RuntimeError` when `len(limited) > len(max_sizes)`, because in such a case `_split_dims` won't help.