### PR TITLE
always viz the first graph + non blocking matches fetch [pr]

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3787,7 +3787,7 @@ class Tensor(SimpleMathTrait):
     if (dt:=to_dtype(dtype)) in {dtypes.uint8, dtypes.uint16} and dtypes.is_float(self.dtype):
       # NOTE: values within the int32 range and outside the unsigned dtype range will cause values to wrap around
       return self._apply_uop(UOp.cast, dtype=dtypes.int32)._apply_uop(UOp.cast, dtype=dt)
-    return self if self.dtype == dt else self._apply_uop(UOp.cast, dtype=dt)
+    return self._apply_uop(UOp.cast, dtype=dt)
 
   def bitcast(self, dtype:DTypeLike) -> Tensor:
     """

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3787,7 +3787,7 @@ class Tensor(SimpleMathTrait):
     if (dt:=to_dtype(dtype)) in {dtypes.uint8, dtypes.uint16} and dtypes.is_float(self.dtype):
       # NOTE: values within the int32 range and outside the unsigned dtype range will cause values to wrap around
       return self._apply_uop(UOp.cast, dtype=dtypes.int32)._apply_uop(UOp.cast, dtype=dt)
-    return self._apply_uop(UOp.cast, dtype=dt)
+    return self if self.dtype == dt else self._apply_uop(UOp.cast, dtype=dt)
 
   def bitcast(self, dtype:DTypeLike) -> Tensor:
     """

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -46,6 +46,10 @@
   ul.active {
     color: #f0f0f5;
   }
+  ul.disabled {
+    opacity: 0.6;
+    pointer-events: none;
+  }
   svg {
     width: 100%;
     height: 100%;
@@ -287,6 +291,10 @@
     const pageCount = Math.ceil((kernels[currentKernel][1][currentUOp].match_count+1)/limit);
     for (let i=0; i < pageCount; i++) {
       const chunk = await (await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}&offset=${i*limit+1}&limit=${limit}`)).json();
+      for (let j=0; j<chunk.graphs.length; j++) {
+        const gUl = document.getElementById(`rewrite-${ret.graphs.length+j}`);
+        if (gUl != null) gUl.classList.remove("disabled");
+      }
       // TODO: this shouldn't exist after the viz api refactor
       for (const [k,v] of Object.entries(chunk)) {
         if (Array.isArray(v) && k !== "loc") ret[k].push(...v);
@@ -386,8 +394,9 @@
       const rewriteList = Object.assign(document.createElement("div"), { className: "rewrite-list" })
       metadata.appendChild(rewriteList);
       for (let i=0; i<=ret.match_count; i++) {
-        const gUl = Object.assign(document.createElement("ul"), { innerText: i, key: `rewrite-${i}` });
+        const gUl = Object.assign(document.createElement("ul"), { innerText: i, id: `rewrite-${i}` });
         rewriteList.appendChild(gUl);
+        if (i > ret.graphs.length-1) gUl.classList.add("disabled");
         if (i === currentRewrite) {
           gUl.classList.add("active");
           if (i !== 0) {

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -370,7 +370,6 @@
       cache[cacheKey] = ret;
       // fetch the rest of matches (this is non blocking)
       fetchMatches();
-      cache[cacheKey] = ret;
     }
     renderGraph(ret.graphs[currentRewrite], ret.changed_nodes[currentRewrite]);
     // ***** RHS metadata

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -285,20 +285,13 @@
   async function fetchMatches() {
     const limit = 100;
     const pageCount = Math.ceil((kernels[currentKernel][1][currentUOp].match_count+1)/limit);
-    var newRet = {};
     for (let i=0; i < pageCount; i++) {
-      const chunk = await (await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}&offset=${i*limit}&limit=${limit}`)).json();
-      if (i === 0) newRet = chunk;
-      else {
-        // TODO: this shouldn't exist after the viz api refactor
-        for (const [k,v] of Object.entries(chunk)) {
-          if (Array.isArray(v) && k !== "loc") newRet[k].push(...v);
-        }
+      const chunk = await (await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}&offset=${i*limit+1}&limit=${limit}`)).json();
+      // TODO: this shouldn't exist after the viz api refactor
+      for (const [k,v] of Object.entries(chunk)) {
+        if (Array.isArray(v) && k !== "loc") ret[k].push(...v);
       }
     }
-    cache[`${currentKernel}-${currentUOp}`] = newRet;
-    ret = newRet;
-    main();
   }
 
   // **** main loop
@@ -389,10 +382,10 @@
     const codeBlock = highlightedCodeBlock(code, lang, false);
     metadata.appendChild(codeBlock);
     // ** rewrite list
-    if (ret.graphs.length > 1) {
+    if (ret.match_count > 1) {
       const rewriteList = Object.assign(document.createElement("div"), { className: "rewrite-list" })
       metadata.appendChild(rewriteList);
-      ret.graphs.forEach((rw, i) => {
+      for (let i=0; i<=ret.match_count; i++) {
         const gUl = Object.assign(document.createElement("ul"), { innerText: i, key: `rewrite-${i}` });
         rewriteList.appendChild(gUl);
         if (i === currentRewrite) {
@@ -418,8 +411,8 @@
           currentRewrite = i;
           main();
         });
-      })
-    } else if (ret.match_count === 0) {
+      }
+    } else {
       metadata.appendChild(Object.assign(document.createElement("p"), { textContent: `No rewrites in ${toPath(ret.loc)}.` }));
     }
     // ***** collapse/expand

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -193,13 +193,6 @@
     border-radius: 8px;
     padding: 8px;
   }
-  .progress {
-    font-size: 20px;
-    z-index: 2;
-    align-self: center;
-    justify-content: center;
-    width: 100%;
-  }
   </style>
 </head>
 <body>
@@ -211,7 +204,6 @@
       <a class="btn nav-btn" href="/profiler">Profiler</a>
     </div>
     <div class="container kernel-list-parent"><div class="container kernel-list"></div></div>
-    <p class="progress"></p>
     <div class="graph">
       <svg id="graph-svg">
         <g id="render"></g>
@@ -290,6 +282,24 @@
     hljs.highlightElement(codeEl);
     return pre;
   };
+  async function fetchMatches() {
+    const limit = 100;
+    const pageCount = Math.ceil((kernels[currentKernel][1][currentUOp].match_count+1)/limit);
+    var newRet = {};
+    for (let i=0; i < pageCount; i++) {
+      const chunk = await (await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}&offset=${i*limit}&limit=${limit}`)).json();
+      if (i === 0) newRet = chunk;
+      else {
+        // TODO: this shouldn't exist after the viz api refactor
+        for (const [k,v] of Object.entries(chunk)) {
+          if (Array.isArray(v) && k !== "loc") newRet[k].push(...v);
+        }
+      }
+    }
+    cache[`${currentKernel}-${currentUOp}`] = newRet;
+    ret = newRet;
+    main();
+  }
 
   // **** main loop
   var ret = {};
@@ -355,27 +365,11 @@
         ret = cache[cacheKey];
       }
       else {
-        const p = document.querySelector(".progress");
-        p.style.display = "none";
-        const limit = 100;
-        const pageCount = Math.ceil((kernels[currentKernel][1][currentUOp].match_count+1)/limit);
-        if (pageCount > 1) {
-          p.style.display = "flex";
-          d3.select("#graph-svg g").selectAll("*").remove();
-        }
-        for (let i=0; i < pageCount; i++) {
-          p.innerText = `fetching data ${i+1}/${pageCount}`;
-          const chunk = await (await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}&offset=${i*limit}&limit=${limit}`)).json();
-          if (i === 0) ret = chunk
-          else {
-            // TODO: this shouldn't exist after the viz api refactor
-            for (const [k,v] of Object.entries(chunk)) {
-              if (Array.isArray(v) && k !== "loc") ret[k].push(...v);
-            }
-          }
-        }
-        p.style.display = "none";
+        // always fetch the first graph
+        ret = await (await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}&offset=0&limit=1`)).json();
         cache[cacheKey] = ret;
+        // incrementally fetch the matches (this is non blocking)
+        fetchMatches();
       }
       renderGraph(ret.graphs[currentRewrite], ret.changed_nodes[currentRewrite]);
     }
@@ -426,7 +420,7 @@
           main();
         });
       })
-    } else {
+    } else if (ret.match_count === 0) {
       metadata.appendChild(Object.assign(document.createElement("p"), { textContent: `No rewrites in ${toPath(ret.loc)}.` }));
     }
     // ***** collapse/expand

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -290,7 +290,8 @@
     const limit = 100;
     const pageCount = Math.ceil((kernels[currentKernel][1][currentUOp].match_count+1)/limit);
     for (let i=0; i < pageCount; i++) {
-      const chunk = await (await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}&offset=${i*limit+1}&limit=${limit}`)).json();
+      const res = await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}&offset=${i*limit+1}&limit=${limit}`);
+      const chunk = await res.json(); // TODO: this is slow!
       for (let j=0; j<chunk.graphs.length; j++) {
         const gUl = document.getElementById(`rewrite-${ret.graphs.length+j}`);
         if (gUl != null) gUl.classList.remove("disabled");

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -71,6 +71,7 @@ def get_details(k:Any, ctx:TrackedGraphRewrite, metadata:GraphRewriteMetadata, o
   ret:GraphRewriteDetails = {"uops":[pcall(str, sink:=ctx.sink)], "graphs":[uop_to_json(sink)], "code_line":lines(ctx.loc[0])[ctx.loc[1]-1].strip(),
                              "kernel_code":pcall(_prg, k) if isinstance(k, Kernel) else None, **metadata,
                              "diffs":[[]], "upats":[None], "changed_nodes":[[]]} # NOTE: the first graph just renders the input UOp
+  if limit == 1: return ret
   replaces: dict[UOp, UOp] = {}
   for i,(u0,u1,upat) in enumerate(tqdm(ctx.matches)):
     replaces[u0] = u1


### PR DESCRIPTION
Time to `big_sink` graph render for `VIZ=1 python ./examples/beautiful_mnist.py`:

This branch: `35s`
Master: `360s`

I think the first (input) sink and the output sink add value individually, we need to always display these first.

Iterating through all the matches is expensive, especially for larger graphs, but we shouldn't block VIZ because of it. This diff loads matches incrementally.

The extra "progress" element won't actually be needed, I wanna just update the right sidebar's rewrite number style based on if the graph is fetched or not. The `ul` already has styling for "active"/"non-active" states.