### PR TITLE
faster viz data fetching with streaming [pr]

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -288,7 +288,7 @@
   };
 
   // **** main loop
-  var ret = {};
+  var ret = null;
   var cache = {};
   var kernels = null;
   var currentUOp = 0;
@@ -343,37 +343,44 @@
       }
       kernelList.appendChild(kernelUl);
     });
+    // ***** RHS metadata
+    const kernel = kernels[currentKernel][1][currentUOp];
+    const metadata = document.querySelector(".container.metadata");
+    metadata.innerHTML = "";
+    metadata.appendChild(vsCodeOpener(kernel.loc.join(":").split("/")));
+    metadata.appendChild(highlightedCodeBlock(kernel.code_line, "python", true));
+    if (kernel.kernel_code != null) metadata.appendChild(highlightedCodeBlock(kernel.kernel_code, "cpp", false));
+    return;
+    // ** code blocks
+    let code = ret.uop;
+    let lang = "python"
+    return;
     // ***** UOp graph
     // if (currentKernel == -1) return;
     const cacheKey = `${currentKernel}-${currentUOp}`;
     if (cacheKey in cache) {
-      ret = cache[cacheKey];
+      ret = cache[cacheKey][currentRewrite];
     }
     else {
       const eventSource = new EventSource(`/kernels?kernel=${currentKernel}&idx=${currentUOp}`);
+      data = [];
       eventSource.onmessage = (e) => {
         if (e.data === "END") return eventSource.close();
-        console.log(JSON.parse(e.data));
+        data.push(JSON.parse(e.data));
+        if (ret == null) {
+          ret = data[currentRewrite];
+        }
       };
+      cache[cacheKey] = data;
+      ret = data[currentRewrite];
     }
-    return;
-    renderGraph(ret.graphs[currentRewrite], ret.changed_nodes[currentRewrite]);
-    // ***** RHS metadata
-    const metadata = document.querySelector(".container.metadata");
-    metadata.innerHTML = "";
-    metadata.appendChild(vsCodeOpener(ret.loc.join(":").split("/")));
-    const pre = highlightedCodeBlock(ret.code_line, "python", true)
-    metadata.appendChild(pre);
-
-    // ** code blocks
-    let code = ret.uops[currentRewrite];
-    let lang = "python"
-    if (ret.kernel_code != null) {
-      code = ret.kernel_code;
-      lang = "cpp";
-    }
-    const codeBlock = highlightedCodeBlock(code, lang, false);
-    metadata.appendChild(codeBlock);
+    if (ret == null) return;
+    const k = kernels[currentKernel][1][currentUOp];
+    ret.loc = k.loc
+    ret.code_line = k.code_line
+    ret.match_count = k.match_count
+    console.log(ret)
+    renderGraph(ret.graph, ret.changed_nodes || []);
     // ** rewrite list
     if (ret.match_count > 1) {
       const rewriteList = Object.assign(document.createElement("div"), { className: "rewrite-list" })

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -343,50 +343,7 @@
       }
       kernelList.appendChild(kernelUl);
     });
-    // ***** RHS metadata
-    const kernel = kernels[currentKernel][1][currentUOp];
-    const metadata = document.querySelector(".container.metadata");
-    metadata.innerHTML = "";
-    metadata.appendChild(vsCodeOpener(kernel.loc.join(":").split("/")));
-    metadata.appendChild(highlightedCodeBlock(kernel.code_line, "python", true));
-    // ***** collapse/expand
-    let isCollapsed = false;
-    const collapseBtn = document.querySelector(".collapse-btn");
-    collapseBtn.addEventListener("click", () => {
-      isCollapsed = !isCollapsed;
-      mainContainer.classList.toggle("collapsed", isCollapsed);
-      kernelListParent.style.display = isCollapsed ? "none" : "block";
-      metadata.style.display = isCollapsed ? "none" : "block";
-      collapseBtn.style.transform = isCollapsed ? "rotate(180deg)" : "rotate(0deg)";
-    });
-    // ***** resizer
-    function createResizer(element, width, type) {
-      const { minWidth, maxWidth } = width;
-      const handle = Object.assign(document.createElement("div"), { id: `${type}-resize-handle`, className: "resize-handle" });
-      element.appendChild(handle);
-      const resize = (e) => {
-        const change = e.clientX - element.dataset.startX;
-        const adjustedChange = type === "kernel" ? change : -change;
-        const newWidth = ((Number(element.dataset.startWidth) + adjustedChange) / Number(element.dataset.containerWidth)) * 100;
-        if (newWidth >= minWidth && newWidth <= maxWidth) {
-          element.style.width = `${newWidth}%`;
-        }
-      };
-      handle.addEventListener("mousedown", (e) => {
-        e.preventDefault();
-        element.dataset.startX = e.clientX;
-        element.dataset.containerWidth = mainContainer.getBoundingClientRect().width;
-        element.dataset.startWidth = element.getBoundingClientRect().width;
-        document.documentElement.addEventListener("mousemove", resize, false);
-        document.documentElement.addEventListener("mouseup", () => {
-          document.documentElement.removeEventListener("mousemove", resize, false);
-          element.style.userSelect = "initial";
-        }, { once: true });
-      });
-    }
-    createResizer(kernelListParent, { minWidth: 15, maxWidth: 50 }, "kernel"); // left resizer
-    createResizer(metadata, { minWidth: 20, maxWidth: 50 }, "metadata"); // right resizer
-    // ***** Stream uop graphs
+    // ***** UOp graph
     const cacheKey = `${currentKernel}-${currentUOp}`;
     if (cacheKey in cache) {
       ret = cache[cacheKey];
@@ -405,6 +362,12 @@
         }
       };
     }
+    // ***** RHS metadata
+    const metadata = document.querySelector(".container.metadata");
+    metadata.innerHTML = "";
+    const kernel = kernels[currentKernel][1][currentUOp];
+    metadata.appendChild(vsCodeOpener(kernel.loc.join(":").split("/")));
+    metadata.appendChild(highlightedCodeBlock(kernel.code_line, "python", true));
     if (ret.length === 0) return;
     if (kernel.kernel_code == null) metadata.appendChild(highlightedCodeBlock(ret[currentRewrite].uop, "python"));
     renderGraph(ret[currentRewrite].graph, []);
@@ -443,6 +406,46 @@
     } else {
       metadata.appendChild(Object.assign(document.createElement("p"), { textContent: `No rewrites in ${toPath(kernel.loc)}.` }));
     }
+    // ***** collapse/expand
+    let isCollapsed = false;
+    const collapseBtn = document.querySelector(".collapse-btn");
+    collapseBtn.addEventListener("click", () => {
+      isCollapsed = !isCollapsed;
+      mainContainer.classList.toggle("collapsed", isCollapsed);
+      kernelListParent.style.display = isCollapsed ? "none" : "block";
+      metadata.style.display = isCollapsed ? "none" : "block";
+      collapseBtn.style.transform = isCollapsed ? "rotate(180deg)" : "rotate(0deg)";
+    });
+    // ***** resizer
+    function createResizer(element, width, type) {
+      const { minWidth, maxWidth } = width;
+      const handle = Object.assign(document.createElement("div"), { id: `${type}-resize-handle`, className: "resize-handle" });
+      element.appendChild(handle);
+
+      const resize = (e) => {
+        const change = e.clientX - element.dataset.startX;
+        const adjustedChange = type === "kernel" ? change : -change;
+        const newWidth = ((Number(element.dataset.startWidth) + adjustedChange) / Number(element.dataset.containerWidth)) * 100;
+        if (newWidth >= minWidth && newWidth <= maxWidth) {
+          element.style.width = `${newWidth}%`;
+        }
+      };
+
+      handle.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        element.dataset.startX = e.clientX;
+        element.dataset.containerWidth = mainContainer.getBoundingClientRect().width;
+        element.dataset.startWidth = element.getBoundingClientRect().width;
+
+        document.documentElement.addEventListener("mousemove", resize, false);
+        document.documentElement.addEventListener("mouseup", () => {
+          document.documentElement.removeEventListener("mousemove", resize, false);
+          element.style.userSelect = "initial";
+        }, { once: true });
+      });
+    }
+    createResizer(kernelListParent, { minWidth: 15, maxWidth: 50 }, "kernel"); // left resizer
+    createResizer(metadata, { minWidth: 20, maxWidth: 50 }, "metadata"); // right resizer
   }
 
   // **** keyboard shortcuts

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -288,7 +288,7 @@
   };
 
   // **** main loop
-  var ret = null;
+  var ret = [];
   var cache = {};
   var kernels = null;
   var currentUOp = 0;
@@ -350,72 +350,6 @@
     metadata.appendChild(vsCodeOpener(kernel.loc.join(":").split("/")));
     metadata.appendChild(highlightedCodeBlock(kernel.code_line, "python", true));
     if (kernel.kernel_code != null) metadata.appendChild(highlightedCodeBlock(kernel.kernel_code, "cpp", false));
-    return;
-    // ** code blocks
-    let code = ret.uop;
-    let lang = "python"
-    return;
-    // ***** UOp graph
-    // if (currentKernel == -1) return;
-    const cacheKey = `${currentKernel}-${currentUOp}`;
-    if (cacheKey in cache) {
-      ret = cache[cacheKey][currentRewrite];
-    }
-    else {
-      const eventSource = new EventSource(`/kernels?kernel=${currentKernel}&idx=${currentUOp}`);
-      data = [];
-      eventSource.onmessage = (e) => {
-        if (e.data === "END") return eventSource.close();
-        data.push(JSON.parse(e.data));
-        if (ret == null) {
-          ret = data[currentRewrite];
-        }
-      };
-      cache[cacheKey] = data;
-      ret = data[currentRewrite];
-    }
-    if (ret == null) return;
-    const k = kernels[currentKernel][1][currentUOp];
-    ret.loc = k.loc
-    ret.code_line = k.code_line
-    ret.match_count = k.match_count
-    console.log(ret)
-    renderGraph(ret.graph, ret.changed_nodes || []);
-    // ** rewrite list
-    if (ret.match_count > 1) {
-      const rewriteList = Object.assign(document.createElement("div"), { className: "rewrite-list" })
-      metadata.appendChild(rewriteList);
-      for (let i=0; i<=ret.match_count; i++) {
-        const gUl = Object.assign(document.createElement("ul"), { innerText: i, id: `rewrite-${i}` });
-        rewriteList.appendChild(gUl);
-        if (i > ret.graphs.length-1) gUl.classList.add("disabled");
-        if (i === currentRewrite) {
-          gUl.classList.add("active");
-          if (i !== 0) {
-            const diff = ret.diffs[i];
-            const [loc, pattern] = ret.upats[i];
-            const parts = loc.join(":").split("/");
-            const div = Object.assign(document.createElement("div"), { className: "rewrite-container" });
-            const link = vsCodeOpener(parts);
-            div.appendChild(link);
-            const pre = highlightedCodeBlock(pattern, "python", true);
-            div.appendChild(pre);
-            metadata.appendChild(div);
-            const diffHtml = diff.map((line) => {
-              const color = line.startsWith("+") ? "#3aa56d" : line.startsWith("-") ? "#d14b4b" : "#f0f0f5";
-              return `<span style="color: ${color};">${line}</span>`;
-            }).join("<br>");
-            metadata.appendChild(Object.assign(document.createElement("pre"), { innerHTML: `<code>${diffHtml}</code>`, className: "wrap" }));
-          }
-        }
-        gUl.addEventListener("click", () => {
-          currentRewrite = i;
-          main();
-        });
-      }
-    } else {
-      metadata.appendChild(Object.assign(document.createElement("p"), { textContent: `No rewrites in ${toPath(ret.loc)}.` }));
-    }
     // ***** collapse/expand
     let isCollapsed = false;
     const collapseBtn = document.querySelector(".collapse-btn");
@@ -431,7 +365,6 @@
       const { minWidth, maxWidth } = width;
       const handle = Object.assign(document.createElement("div"), { id: `${type}-resize-handle`, className: "resize-handle" });
       element.appendChild(handle);
-
       const resize = (e) => {
         const change = e.clientX - element.dataset.startX;
         const adjustedChange = type === "kernel" ? change : -change;
@@ -440,13 +373,11 @@
           element.style.width = `${newWidth}%`;
         }
       };
-
       handle.addEventListener("mousedown", (e) => {
         e.preventDefault();
         element.dataset.startX = e.clientX;
         element.dataset.containerWidth = mainContainer.getBoundingClientRect().width;
         element.dataset.startWidth = element.getBoundingClientRect().width;
-
         document.documentElement.addEventListener("mousemove", resize, false);
         document.documentElement.addEventListener("mouseup", () => {
           document.documentElement.removeEventListener("mousemove", resize, false);
@@ -456,6 +387,7 @@
     }
     createResizer(kernelListParent, { minWidth: 15, maxWidth: 50 }, "kernel"); // left resizer
     createResizer(metadata, { minWidth: 20, maxWidth: 50 }, "metadata"); // right resizer
+    // ***** UOp graph
   }
 
   // **** keyboard shortcuts

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -292,7 +292,7 @@
   var cache = {};
   var kernels = null;
   var currentUOp = 0;
-  var currentKernel = 0;
+  var currentKernel = -1;
   var currentRewrite = 0;
   var expandKernel = true;
   async function main() {
@@ -300,7 +300,7 @@
     // ***** LHS kernels list
     if (kernels == null) {
       kernels = await (await fetch("/kernels")).json();
-      currentKernel = 0;
+      currentKernel = -1;
     }
     const kernelListParent = document.querySelector(".container.kernel-list-parent");
     const kernelList = document.querySelector(".container.kernel-list");
@@ -344,12 +344,14 @@
       kernelList.appendChild(kernelUl);
     });
     // ***** UOp graph
+    if (currentKernel == -1) return;
     const cacheKey = `${currentKernel}-${currentUOp}`;
     if (cacheKey in cache) {
       ret = cache[cacheKey];
-    } else {
-      const eventSource = new EventSource(`/kernels?kernel=${currentKernel}&idx=${currentUOp}`);
+    }
+    else {
       ret = [];
+      const eventSource = new EventSource(`/kernels?kernel=${currentKernel}&idx=${currentUOp}`);
       eventSource.onmessage = (e) => {
         if (e.data === "END") return eventSource.close();
         const chunk = JSON.parse(e.data);
@@ -367,7 +369,8 @@
     metadata.innerHTML = "";
     const kernel = kernels[currentKernel][1][currentUOp];
     metadata.appendChild(vsCodeOpener(kernel.loc.join(":").split("/")));
-    metadata.appendChild(highlightedCodeBlock(kernel.code_line, "python", true));
+    const pre = highlightedCodeBlock(kernel.code_line, "python", true)
+    metadata.appendChild(pre);
     if (ret.length === 0) return;
     if (kernel.kernel_code == null) metadata.appendChild(highlightedCodeBlock(ret[currentRewrite].uop, "python"));
     renderGraph(ret[currentRewrite].graph, []);
@@ -501,7 +504,7 @@
     }
     if (event.key == "ArrowRight") {
       event.preventDefault()
-      const totalRewrites = ret.graphs.length-1;
+      const totalRewrites = ret.length-1;
       currentRewrite = Math.min(totalRewrites, currentRewrite+1)
       main()
     }

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -286,29 +286,13 @@
     hljs.highlightElement(codeEl);
     return pre;
   };
-  async function fetchMatches() {
-    const limit = 100;
-    const pageCount = Math.ceil((kernels[currentKernel][1][currentUOp].match_count+1)/limit);
-    for (let i=0; i < pageCount; i++) {
-      const res = await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}&offset=${i*limit+1}&limit=${limit}`);
-      const chunk = await res.json(); // TODO: this is slow!
-      for (let j=0; j<chunk.graphs.length; j++) {
-        const gUl = document.getElementById(`rewrite-${ret.graphs.length+j}`);
-        if (gUl != null) gUl.classList.remove("disabled");
-      }
-      // TODO: this shouldn't exist after the viz api refactor
-      for (const [k,v] of Object.entries(chunk)) {
-        if (Array.isArray(v) && k !== "loc") ret[k].push(...v);
-      }
-    }
-  }
 
   // **** main loop
   var ret = {};
   var cache = {};
   var kernels = null;
   var currentUOp = 0;
-  var currentKernel = -1;
+  var currentKernel = 0;
   var currentRewrite = 0;
   var expandKernel = true;
   async function main() {
@@ -316,7 +300,7 @@
     // ***** LHS kernels list
     if (kernels == null) {
       kernels = await (await fetch("/kernels")).json();
-      currentKernel = -1;
+      currentKernel = 0;
     }
     const kernelListParent = document.querySelector(".container.kernel-list-parent");
     const kernelList = document.querySelector(".container.kernel-list");
@@ -360,18 +344,19 @@
       kernelList.appendChild(kernelUl);
     });
     // ***** UOp graph
-    if (currentKernel == -1) return;
+    // if (currentKernel == -1) return;
     const cacheKey = `${currentKernel}-${currentUOp}`;
     if (cacheKey in cache) {
       ret = cache[cacheKey];
     }
     else {
-      // always fetch the first graph
-      ret = await (await fetch(`/kernels?kernel=${currentKernel}&idx=${currentUOp}&offset=0&limit=1`)).json();
-      cache[cacheKey] = ret;
-      // fetch the rest of matches (this is non blocking)
-      fetchMatches();
+      const eventSource = new EventSource(`/kernels?kernel=${currentKernel}&idx=${currentUOp}`);
+      eventSource.onmessage = (e) => {
+        if (e.data === "END") return eventSource.close();
+        console.log(JSON.parse(e.data));
+      };
     }
+    return;
     renderGraph(ret.graphs[currentRewrite], ret.changed_nodes[currentRewrite]);
     // ***** RHS metadata
     const metadata = document.querySelector(".container.metadata");

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -349,18 +349,18 @@
       ret = cache[cacheKey];
     } else {
       const eventSource = new EventSource(`/kernels?kernel=${currentKernel}&idx=${currentUOp}`);
-      const data = [];
+      ret = [];
       eventSource.onmessage = (e) => {
         if (e.data === "END") return eventSource.close();
-        data.push(JSON.parse(e.data));
-        cache[cacheKey] = data;
-        if (data.length === 1) {
-          // if it's the first one render this new rgaph
-          main();
-        } else {
-          // otherwise just update the matches list
-        }
+        const chunk = JSON.parse(e.data);
+        ret.push(chunk);
+        // if it's the first one render this new rgaph
+        if (ret.length === 1) return main();
+        // otherwise just enable the graph selector
+        const gUl = document.getElementById(`rewrite-${ret.length}`);
+        if (gUl != null) gUl.classList.remove("disabled");
       };
+      cache[cacheKey] = ret;
     }
     // ***** RHS metadata
     const metadata = document.querySelector(".container.metadata");

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -364,6 +364,8 @@
       };
       cache[cacheKey] = ret;
     }
+    if (ret.length === 0) return;
+    renderGraph(ret[currentRewrite].graph, ret[currentRewrite].changed_nodes || []);
     // ***** RHS metadata
     const metadata = document.querySelector(".container.metadata");
     metadata.innerHTML = "";
@@ -371,9 +373,16 @@
     metadata.appendChild(vsCodeOpener(kernel.loc.join(":").split("/")));
     const pre = highlightedCodeBlock(kernel.code_line, "python", true)
     metadata.appendChild(pre);
-    if (ret.length === 0) return;
-    if (kernel.kernel_code == null) metadata.appendChild(highlightedCodeBlock(ret[currentRewrite].uop, "python"));
-    renderGraph(ret[currentRewrite].graph, []);
+
+   // ** code blocks
+    let code = ret[currentRewrite].uop;
+    let lang = "python"
+    if (kernel.kernel_code != null) {
+      code = kernel.kernel_code;
+      lang = "cpp";
+    }
+    const codeBlock = highlightedCodeBlock(code, lang, false);
+    metadata.appendChild(codeBlock);
     // ** rewrite list
     if (kernel.match_count > 1) {
       const rewriteList = Object.assign(document.createElement("div"), { className: "rewrite-list" })

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -349,7 +349,6 @@
     metadata.innerHTML = "";
     metadata.appendChild(vsCodeOpener(kernel.loc.join(":").split("/")));
     metadata.appendChild(highlightedCodeBlock(kernel.code_line, "python", true));
-    if (kernel.kernel_code != null) metadata.appendChild(highlightedCodeBlock(kernel.kernel_code, "cpp", false));
     // ***** collapse/expand
     let isCollapsed = false;
     const collapseBtn = document.querySelector(".collapse-btn");
@@ -387,7 +386,63 @@
     }
     createResizer(kernelListParent, { minWidth: 15, maxWidth: 50 }, "kernel"); // left resizer
     createResizer(metadata, { minWidth: 20, maxWidth: 50 }, "metadata"); // right resizer
-    // ***** UOp graph
+    // ***** Stream uop graphs
+    const cacheKey = `${currentKernel}-${currentUOp}`;
+    if (cacheKey in cache) {
+      ret = cache[cacheKey];
+    } else {
+      const eventSource = new EventSource(`/kernels?kernel=${currentKernel}&idx=${currentUOp}`);
+      const data = [];
+      eventSource.onmessage = (e) => {
+        if (e.data === "END") return eventSource.close();
+        data.push(JSON.parse(e.data));
+        cache[cacheKey] = data;
+        if (data.length === 1) {
+          // if it's the first one render this new rgaph
+          main();
+        } else {
+          // otherwise just update the matches list
+        }
+      };
+    }
+    if (ret.length === 0) return;
+    if (kernel.kernel_code == null) metadata.appendChild(highlightedCodeBlock(ret[currentRewrite].uop, "python"));
+    renderGraph(ret[currentRewrite].graph, []);
+    // ** rewrite list
+    if (kernel.match_count > 1) {
+      const rewriteList = Object.assign(document.createElement("div"), { className: "rewrite-list" })
+      metadata.appendChild(rewriteList);
+      for (let i=0; i<=kernel.match_count; i++) {
+        const gUl = Object.assign(document.createElement("ul"), { innerText: i, id: `rewrite-${i}` });
+        rewriteList.appendChild(gUl);
+        if (i > ret.length-1) gUl.classList.add("disabled");
+        if (i === currentRewrite) {
+          gUl.classList.add("active");
+          if (i !== 0) {
+            const diff = ret[i].diff;
+            const [loc, pattern] = ret[i].upat;
+            const parts = loc.join(":").split("/");
+            const div = Object.assign(document.createElement("div"), { className: "rewrite-container" });
+            const link = vsCodeOpener(parts);
+            div.appendChild(link);
+            const pre = highlightedCodeBlock(pattern, "python", true);
+            div.appendChild(pre);
+            metadata.appendChild(div);
+            const diffHtml = diff.map((line) => {
+              const color = line.startsWith("+") ? "#3aa56d" : line.startsWith("-") ? "#d14b4b" : "#f0f0f5";
+              return `<span style="color: ${color};">${line}</span>`;
+            }).join("<br>");
+            metadata.appendChild(Object.assign(document.createElement("pre"), { innerHTML: `<code>${diffHtml}</code>`, className: "wrap" }));
+          }
+        }
+        gUl.addEventListener("click", () => {
+          currentRewrite = i;
+          main();
+        });
+      }
+    } else {
+      metadata.appendChild(Object.assign(document.createElement("p"), { textContent: `No rewrites in ${toPath(kernel.loc)}.` }));
+    }
   }
 
   // **** keyboard shortcuts

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -136,7 +136,8 @@ class Handler(BaseHTTPRequestHandler):
           chunk = "data: "+json.dumps(ret)+"\n\n"
           self.wfile.write(chunk.encode("utf-8"))
           self.wfile.flush()
-        return
+        self.wfile.write("data: END\n\n".encode("utf-8"))
+        return self.wfile.flush()
       ret, content_type = json.dumps(kernels).encode(), "application/json"
     elif url.path == "/get_profile" and perfetto_profile is not None: ret, content_type = perfetto_profile, "application/json"
     else: status_code = 404

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -129,10 +129,11 @@ class Handler(BaseHTTPRequestHandler):
         kidx, ridx = getarg("kernel"), getarg("idx")
         # stream details
         self.send_response(200)
-        self.send_header('Content-Type', "application/json")
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
         self.end_headers()
         for ret in get_details(contexts[0][kidx], contexts[1][kidx][ridx]):
-          chunk = json.dumps(ret)+"\n"
+          chunk = "data: "+json.dumps(ret)+"\n\n"
           self.wfile.write(chunk.encode("utf-8"))
           self.wfile.flush()
         return

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -21,15 +21,15 @@ uops_colors = {Ops.LOAD: "#ffc0c0", Ops.PRELOAD: "#ffc0c0", Ops.STORE: "#87CEEB"
 class GraphRewriteMetadata(TypedDict):
   loc: tuple[str, int]           # [path, lineno] calling graph_rewrite
   match_count: int               # total match count in this context
+  code_line: str
+  kernel_code: str|None
 
-class GraphRewriteDetails(GraphRewriteMetadata):
-  graphs: list[dict]             # JSON serialized UOp at every rewrite step
-  uops: list[str]                # strigified UOp at every rewrite step
-  diffs: list[list[str]]         # string diff of the single UOp that changed
-  changed_nodes: list[list[int]] # the changed UOp id + all its parents ids
-  code_line: str                 # source code calling graph_rewrite
-  kernel_code: str|None          # optionally render the final kernel code
-  upats: list[tuple[tuple[str, int], str]|None]
+class GraphRewriteDetails(TypedDict):
+  graph: dict
+  uop: dict
+  diff: list[str]|None
+  changed_nodes: list[int]|None
+  upat: tuple[tuple[str, int], str]|None
 
 # NOTE: if any extra rendering in VIZ fails, we don't crash
 def pcall(fxn:Callable[..., str], *args, **kwargs) -> str:
@@ -61,30 +61,22 @@ def uop_to_json(x:UOp) -> dict[int, tuple[str, list[int], str]]:
     graph[id(u)] = (label, [id(x) for x in u.src if x not in excluded], uops_colors.get(u.op, "#ffffff"))
   return graph
 
-def get_metadata(keys:list[Any], contexts:list[list[TrackedGraphRewrite]]) -> list[tuple[str, list[GraphRewriteMetadata]]]:
-  return [(to_function_name(k.name) if isinstance(k, Kernel) else str(k),
-           [{"loc": v.loc, "match_count": len(v.matches)} for v in vals]) for k,vals in zip(keys, contexts)]
-
 @functools.lru_cache(None)
 def _prg(k:Kernel): return k.to_program().src
-def get_details(k:Any, ctx:TrackedGraphRewrite, metadata:GraphRewriteMetadata, offset=0, limit=200) -> GraphRewriteDetails:
-  ret:GraphRewriteDetails = {"uops":[pcall(str, sink:=ctx.sink)], "graphs":[uop_to_json(sink)], "code_line":lines(ctx.loc[0])[ctx.loc[1]-1].strip(),
-                             "kernel_code":pcall(_prg, k) if isinstance(k, Kernel) else None, **metadata,
-                             "diffs":[[]], "upats":[None], "changed_nodes":[[]]} # NOTE: the first graph just renders the input UOp
-  if limit == 1: return ret
+def to_metadata(k:Any,v:TrackedRewriteContext) -> GraphRewriteMetadata:
+  return {"loc":v.loc, "match_count":len(v.matches), "code_line":lines(v.loc[0])[v.loc[1]-1].strip(),
+          "kernel_code":pcall(_prg, k) if isinstance(k, Kernel) else None}
+def get_metadata(keys:list[Any], contexts:list[list[TrackedGraphRewrite]]) -> list[tuple[str, list[GraphRewriteMetadata]]]:
+  return [(to_function_name(k.name) if isinstance(k, Kernel) else str(k), [to_metadata(v) for v in vals]) for k,vals in zip(keys, contexts)]
+
+def get_details(k:Any, ctx:TrackedGraphRewrite) -> Generator[GraphRewriteDetails]:
+  sink = ctx.sink
   replaces: dict[UOp, UOp] = {}
-  for i,(u0,u1,upat) in enumerate(tqdm(ctx.matches)):
+  for u0,u1,upat in tqdm(ctx.matches):
     replaces[u0] = u1
-    new_sink = sink.substitute(replaces)
-    ret["graphs"].append(new_sink_js:=uop_to_json(new_sink))
-    ret["changed_nodes"].append([id(x) for x in u1.toposort if id(x) in new_sink_js])
-    ret["diffs"].append(list(difflib.unified_diff(pcall(str, u0).splitlines(), pcall(str, u1).splitlines())))
-    ret["upats"].append((upat.location, upat.printable()))
-    # TODO: this is O(n^2)!
-    ret["uops"].append(str(sink:=new_sink))
-  # if the client requested a chunk we only send that chunk
-  # TODO: is there a way to cache the replaces dict here?
-  return cast(GraphRewriteDetails, {k:v[offset:offset+limit] if isinstance(v,list) else v for k,v in ret.items()})
+    sink = sink.substitute(replaces)
+    yield {"graph": (sink_json:=uop_to_json(sink)), "uop":str(sink), "changed_nodes":[id(x) for x in u1.toposort if id(x) in sink_json],
+           "diff":list(difflib.unified_diff(pcall(str, u0).splitlines(), pcall(str, u1).splitlines())), "upat":(upat.location, upat.printable())}
 
 # Profiler API
 devices:dict[str, tuple[decimal.Decimal, decimal.Decimal, int]] = {}
@@ -135,7 +127,7 @@ class Handler(BaseHTTPRequestHandler):
       if "kernel" in (query:=parse_qs(url.query)):
         def getarg(k:str,default=0): return int(query[k][0]) if k in query else default
         kidx, ridx = getarg("kernel"), getarg("idx")
-        jret:Any = get_details(contexts[0][kidx], contexts[1][kidx][ridx], kernels[kidx][1][ridx], getarg("offset", 0), getarg("limit", 200))
+        all_matches = get_details(contexts[0][kidx], contexts[1][kidx][ridx], getarg("offset", 0))
       else: jret = kernels
       ret, content_type = json.dumps(jret).encode(), "application/json"
     elif url.path == "/get_profile" and perfetto_profile is not None: ret, content_type = perfetto_profile, "application/json"

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -74,6 +74,7 @@ def get_details(k:Any, ctx:TrackedGraphRewrite) -> Generator[GraphRewriteDetails
   replaces: dict[UOp, UOp] = {}
   for u0,u1,upat in tqdm(ctx.matches):
     replaces[u0] = u1
+    sink = sink.substitute(replaces)
     yield {"graph": (sink_json:=uop_to_json(sink)), "uop":str(sink), "changed_nodes":[id(x) for x in u1.toposort if id(x) in sink_json],
            "diff":list(difflib.unified_diff(pcall(str, u0).splitlines(), pcall(str, u1).splitlines())), "upat":(upat.location, upat.printable())}
 


### PR DESCRIPTION
Time to fully load `VIZ=1 python ./examples/beautiful_mnist.py` tensor_map rewrite (1,209 rewrites):

master: [300s](https://github.com/user-attachments/assets/505bd970-dfb3-45b2-9ed0-a80999ffac14)
branch: 48s
![image](https://github.com/user-attachments/assets/d5b89684-c2f8-48c7-b645-7c1cd787e92c)

The client streams rewrites so they become instantly available.
We incrementally load the matches, and the graph stays responsive:

https://github.com/user-attachments/assets/6725e543-26be-4ad8-87f8-6ae1f274e958

The final performance optimization left is D3 render itself.
Currently, renderGraph uses the main thread. This blocks the rest of the UI when you select a new match in the large graph.