### PR TITLE
Fix issues with Quickstart example (mnist data loading, dataset dimensions and Tensor creation from sample of indices)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -187,7 +187,7 @@ with Tensor.train():
     out = net(batch)
 
     # compute loss
-    loss = sparse_categorical_crossentropy(out, labels)
+    loss = Tensor.sparse_categorical_crossentropy(out, labels)
 
     # zero gradients
     opt.zero_grad()

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -228,8 +228,8 @@ with Timing("Time: "):
     out = net(batch)
 
     # calculate accuracy
-    pred = out.argmax(axis=-1).numpy()
-    avg_acc += (pred == labels).mean()
+    pred = out.argmax(axis=-1)
+    avg_acc += (pred == labels).numpy().mean()
   print(f"Test Accuracy: {avg_acc / 1000}")
 ```
 
@@ -275,8 +275,8 @@ with Timing("Time: "):
     out = jit(batch)
 
     # calculate accuracy
-    pred = out.argmax(axis=-1).numpy()
-    avg_acc += (pred == labels).mean()
+    pred = out.argmax(axis=-1)
+    avg_acc += (pred == labels).numpy().mean()
   print(f"Test Accuracy: {avg_acc / 1000}")
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -155,11 +155,15 @@ There is a simpler way to do this just by using `get_parameters(net)` from `tiny
 The parameters are just listed out explicitly here for clarity.
 
 Now that we have our network, loss function, and optimizer defined all we are missing is the data to train on!
-There are a couple of dataset loaders in tinygrad located in [/extra/datasets](https://github.com/tinygrad/tinygrad/blob/master/extra/datasets).
 We will be using the MNIST dataset loader.
 
 ```python
-from extra.datasets import fetch_mnist
+from tinygrad.nn.datasets import mnist
+X_train, Y_train, X_test, Y_test = mnist()
+X_train, X_test = X_train.squeeze(), X_test.squeeze() # remove unecessary dimensions for the example
+# We also need to flatten the (28,28) vector to a (784,) vector as input for the model:
+X_train = X_train.flatten(1)
+X_test = X_test.flatten(1)
 ```
 
 Now we have everything we need to start training our neural network.
@@ -169,15 +173,15 @@ We use `with Tensor.train()` to set the internal flag `Tensor.training` to `True
 Upon exit, the flag is restored to its previous value by the context manager.
 
 ```python
-X_train, Y_train, X_test, Y_test = fetch_mnist()
-
 with Tensor.train():
   for step in range(1000):
     # random sample a batch
-    samp = np.random.randint(0, X_train.shape[0], size=(64))
-    batch = Tensor(X_train[samp], requires_grad=False)
+    samp = Tensor.randint(64, high=X_train.shape[0])
+    batch = X_train[samp]
+    batch.requires_grad = False
+
     # get the corresponding labels
-    labels = Tensor(Y_train[samp])
+    labels = Y_train[samp]
 
     # forward pass
     out = net(batch)
@@ -212,8 +216,11 @@ with Timing("Time: "):
   avg_acc = 0
   for step in range(1000):
     # random sample a batch
-    samp = np.random.randint(0, X_test.shape[0], size=(64))
-    batch = Tensor(X_test[samp], requires_grad=False)
+    samp = Tensor.randint(64, high=X_test.shape[0])
+
+    batch = X_test[samp]
+    batch.requires_grad = False
+
     # get the corresponding labels
     labels = Y_test[samp]
 
@@ -256,8 +263,11 @@ with Timing("Time: "):
   avg_acc = 0
   for step in range(1000):
     # random sample a batch
-    samp = np.random.randint(0, X_test.shape[0], size=(64))
-    batch = Tensor(X_test[samp], requires_grad=False)
+    samp = Tensor.randint(64, high=X_test.shape[0])
+
+    batch = X_test[samp]
+    batch.requires_grad = False
+
     # get the corresponding labels
     labels = Y_test[samp]
 


### PR DESCRIPTION
I played with your lib this afternoon. I liked it but I had issues setting up the quickstart tutorial only to notice a few changes were needed for it to work (the way you load the mnist dataset and create a tensor from a sample of indices probably changed since the last time tutorial was updated).

The proposed PR loads the mnist dataset from `tinygrad.nn.datasets` (in the initial example your load from `extra` ? I don't see it anywhere else in the doc) and squeeze then flatten the vectors so it can be fed appropriately to the model in the example (starting with a Linear layer of in_features = 784)