### PR TITLE
put bert data shard inside jit

### DIFF
--- a/examples/mlperf/dataloader.py
+++ b/examples/mlperf/dataloader.py
@@ -170,13 +170,13 @@ def batch_load_resnet(batch_size=64, val=False, shuffle=True, seed=None, pad_fir
 
 def process_batch_bert(data: List[dict]) -> dict[str, Tensor]:
   return {
-    "input_ids": Tensor(np.concatenate([s["input_ids"] for s in data], axis=0), dtype=dtypes.float32),
-    "input_mask": Tensor(np.concatenate([s["input_mask"] for s in data], axis=0), dtype=dtypes.default_float),
-    "segment_ids": Tensor(np.concatenate([s["segment_ids"] for s in data], axis=0), dtype=dtypes.float32),
-    "masked_lm_positions": Tensor(np.concatenate([s["masked_lm_positions"] for s in data], axis=0), dtype=dtypes.float32),
-    "masked_lm_ids": Tensor(np.concatenate([s["masked_lm_ids"] for s in data], axis=0), dtype=dtypes.float32),
-    "masked_lm_weights": Tensor(np.concatenate([s["masked_lm_weights"] for s in data], axis=0), dtype=dtypes.float32),
-    "next_sentence_labels": Tensor(np.concatenate([s["next_sentence_labels"] for s in data], axis=0), dtype=dtypes.float32),
+    "input_ids": Tensor(np.concatenate([s["input_ids"] for s in data], axis=0), dtype=dtypes.float32, device="CLANG"),
+    "input_mask": Tensor(np.concatenate([s["input_mask"] for s in data], axis=0), dtype=dtypes.default_float, device="CLANG"),
+    "segment_ids": Tensor(np.concatenate([s["segment_ids"] for s in data], axis=0), dtype=dtypes.float32, device="CLANG"),
+    "masked_lm_positions": Tensor(np.concatenate([s["masked_lm_positions"] for s in data], axis=0), dtype=dtypes.float32, device="CLANG"),
+    "masked_lm_ids": Tensor(np.concatenate([s["masked_lm_ids"] for s in data], axis=0), dtype=dtypes.float32, device="CLANG"),
+    "masked_lm_weights": Tensor(np.concatenate([s["masked_lm_weights"] for s in data], axis=0), dtype=dtypes.float32, device="CLANG"),
+    "next_sentence_labels": Tensor(np.concatenate([s["next_sentence_labels"] for s in data], axis=0), dtype=dtypes.float32, device="CLANG"),
   }
 
 def load_file(file: str):

--- a/examples/mlperf/helpers.py
+++ b/examples/mlperf/helpers.py
@@ -222,18 +222,13 @@ def get_mlperf_bert_model():
     config["hidden_dropout_prob"] = config["attention_probs_dropout_prob"] = 0.0
   return BertForPretraining(**config)
 
-def get_data_bert(GPUS:list[str], it):
-  data: dict[str, Tensor] = next(it)
-  for key in data.keys(): data[key].shard_(GPUS, axis=0)
-  return data
-
 def get_fake_data_bert(BS:int):
   return {
-    "input_ids": Tensor.empty((BS, 512), dtype=dtypes.float32),
-    "input_mask": Tensor.empty((BS, 512), dtype=dtypes.default_float),
-    "segment_ids": Tensor.empty((BS, 512), dtype=dtypes.float32),
-    "masked_lm_positions": Tensor.empty((BS, 76), dtype=dtypes.float32),
-    "masked_lm_ids": Tensor.empty((BS, 76), dtype=dtypes.float32),
-    "masked_lm_weights": Tensor.empty((BS, 76), dtype=dtypes.float32),
-    "next_sentence_labels": Tensor.empty((BS, 1), dtype=dtypes.float32),
+    "input_ids": Tensor.empty((BS, 512), dtype=dtypes.float32, device="CLANG"),
+    "input_mask": Tensor.empty((BS, 512), dtype=dtypes.default_float, device="CLANG"),
+    "segment_ids": Tensor.empty((BS, 512), dtype=dtypes.float32, device="CLANG"),
+    "masked_lm_positions": Tensor.empty((BS, 76), dtype=dtypes.float32, device="CLANG"),
+    "masked_lm_ids": Tensor.empty((BS, 76), dtype=dtypes.float32, device="CLANG"),
+    "masked_lm_weights": Tensor.empty((BS, 76), dtype=dtypes.float32, device="CLANG"),
+    "next_sentence_labels": Tensor.empty((BS, 1), dtype=dtypes.float32, device="CLANG"),
   }


### PR DESCRIPTION
python time 45ms -> 9ms, it was spending time to schedule the shard

also init bert data on CLANG since it's from numpy, so we don't create the tensor on default device then shard into GPUS

https://wandb.ai/chenyuxyz/MLPerf-BERT/runs/owclcozb/overview 8% faster per step