### PR TITLE
hotfix: viz should show if there's a rewrite [pr]

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -404,7 +404,7 @@
     const codeBlock = highlightedCodeBlock(code, lang, false);
     metadata.appendChild(codeBlock);
     // ** rewrite list
-    if (kernel.match_count > 1) {
+    if (kernel.match_count >= 1) {
       const rewriteList = Object.assign(document.createElement("div"), { className: "rewrite-list" })
       metadata.appendChild(rewriteList);
       for (let i=0; i<=kernel.match_count; i++) {


### PR DESCRIPTION
It used to say "no rewrites", match_count is different from graphs length!

![image](https://github.com/user-attachments/assets/271a4725-6331-4a3c-9093-44ddd9e4b007)
