### PR TITLE
Force WebGPU backend type [pr]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -449,7 +449,7 @@ jobs:
         WEBGPU=1 DEBUG=4 FORWARD_ONLY=1 python3 test/test_ops.py TestOps.test_add
     - name: Run selected webgpu tests
       run: |
-          WEBGPU=1 python3 -m pytest -n=auto test/ --ignore=test/models --ignore=test/unit \
+          WEBGPU=1 Backend="WGPUBackendType_Vulkan" python3 -m pytest -n=auto test/ --ignore=test/models --ignore=test/unit \
           --ignore=test/test_copy_speed.py --ignore=test/test_rearrange_einops.py \
           --ignore=test/test_fuzz_shape_ops.py --ignore=test/test_linearizer_failures.py --durations=20
     - name: Run process replay tests
@@ -565,7 +565,7 @@ jobs:
         key: osx-webgpu
         webgpu: 'true'
     - name: Build WEBGPU Efficientnet
-      run: WEBGPU=1 python3 -m examples.compile_efficientnet
+      run: WEBGPU=1 Backend="WGPUBackendType_Metal" python3 -m examples.compile_efficientnet
     - name: Clean npm cache
       run: npm cache clean --force
     - name: Install Puppeteer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -449,7 +449,7 @@ jobs:
         WEBGPU=1 DEBUG=4 FORWARD_ONLY=1 python3 test/test_ops.py TestOps.test_add
     - name: Run selected webgpu tests
       run: |
-          WEBGPU=1 Backend="WGPUBackendType_Vulkan" python3 -m pytest -n=auto test/ --ignore=test/models --ignore=test/unit \
+          WEBGPU=1 WEBGPU_BACKEND="WGPUBackendType_Vulkan" python3 -m pytest -n=auto test/ --ignore=test/models --ignore=test/unit \
           --ignore=test/test_copy_speed.py --ignore=test/test_rearrange_einops.py \
           --ignore=test/test_fuzz_shape_ops.py --ignore=test/test_linearizer_failures.py --durations=20
     - name: Run process replay tests
@@ -565,7 +565,7 @@ jobs:
         key: osx-webgpu
         webgpu: 'true'
     - name: Build WEBGPU Efficientnet
-      run: WEBGPU=1 Backend="WGPUBackendType_Metal" python3 -m examples.compile_efficientnet
+      run: WEBGPU=1 WEBGPU_BACKEND="WGPUBackendType_Metal" python3 -m examples.compile_efficientnet
     - name: Clean npm cache
       run: npm cache clean --force
     - name: Install Puppeteer

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -49,3 +49,4 @@ VISIBLE_DEVICES     | [list[int]]| restricts the NV/AMD devices that are availab
 JIT                 | [0-2]      | 0=disabled, 1=[jit enabled](quickstart.md#jit) (default), 2=jit enabled, but graphs are disabled
 VIZ                 | [1]        | 0=disabled, 1=[viz enabled](https://github.com/tinygrad/tinygrad/tree/master/tinygrad/viz)
 ALLOW_TF32          | [1]        | enable TensorFloat-32 tensor cores on Ampere or newer GPUs.
+WEBGPU_BACKEND      | [[WGPUBackendType_Metal, ...](../tinygrad/runtime/autogen/webgpu.py#L327)]          | Force select a backend for WebGPU (Metal, DirectX, OpenGL, Vulkan...)

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -49,4 +49,4 @@ VISIBLE_DEVICES     | [list[int]]| restricts the NV/AMD devices that are availab
 JIT                 | [0-2]      | 0=disabled, 1=[jit enabled](quickstart.md#jit) (default), 2=jit enabled, but graphs are disabled
 VIZ                 | [1]        | 0=disabled, 1=[viz enabled](https://github.com/tinygrad/tinygrad/tree/master/tinygrad/viz)
 ALLOW_TF32          | [1]        | enable TensorFloat-32 tensor cores on Ampere or newer GPUs.
-WEBGPU_BACKEND      | [[WGPUBackendType_Metal, ...](../tinygrad/runtime/autogen/webgpu.py#L327)]          | Force select a backend for WebGPU (Metal, DirectX, OpenGL, Vulkan...)
+WEBGPU_BACKEND      | [WGPUBackendType_Metal, ...]          | Force select a backend for WebGPU (Metal, DirectX, OpenGL, Vulkan...)

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -198,7 +198,7 @@ class WebGpuDevice(Compiled):
     webgpu.WGPURequestAdapterStatus__enumvalues, 1, 2, instance,
 
     webgpu.WGPURequestAdapterOptions(powerPreference=webgpu.WGPUPowerPreference_HighPerformance,
-      backendType=backend_types.get(os.getenv("Backend", ""), 0)))
+      backendType=backend_types.get(os.getenv("WEBGPU_BACKEND", ""), 0)))
 
     # Get supported features
     supported_features = webgpu.WGPUSupportedFeatures()

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -5,6 +5,9 @@ from tinygrad.helpers import round_up, OSX
 from tinygrad.runtime.autogen import webgpu
 from typing import List, Any
 import ctypes
+import os
+
+backend_types = {v: k for k, v in webgpu.WGPUBackendType__enumvalues.items() }
 
 try:
   instance = webgpu.wgpuCreateInstance(webgpu.WGPUInstanceDescriptor(features = webgpu.WGPUInstanceFeatures(timedWaitAnyEnable = True)))
@@ -193,7 +196,9 @@ class WebGpuDevice(Compiled):
     # Requesting an adapter
     adapter_res = _run(webgpu.wgpuInstanceRequestAdapterF, webgpu.WGPURequestAdapterCallbackInfo, webgpu.WGPURequestAdapterCallback,
     webgpu.WGPURequestAdapterStatus__enumvalues, 1, 2, instance,
-    webgpu.WGPURequestAdapterOptions(powerPreference=webgpu.WGPUPowerPreference_HighPerformance))
+
+    webgpu.WGPURequestAdapterOptions(powerPreference=webgpu.WGPUPowerPreference_HighPerformance,
+      backendType=backend_types.get(os.getenv("Backend"), 0)))
 
     # Get supported features
     supported_features = webgpu.WGPUSupportedFeatures()

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -198,7 +198,7 @@ class WebGpuDevice(Compiled):
     webgpu.WGPURequestAdapterStatus__enumvalues, 1, 2, instance,
 
     webgpu.WGPURequestAdapterOptions(powerPreference=webgpu.WGPUPowerPreference_HighPerformance,
-      backendType=backend_types.get(os.getenv("Backend"), 0)))
+      backendType=backend_types.get(os.getenv("Backend", ""), 0)))
 
     # Get supported features
     supported_features = webgpu.WGPUSupportedFeatures()


### PR DESCRIPTION
`WEBGPU_BACKEND="WGPUBackendType_*"` now allows to force a backend. Some systems might allow multiple backends (OpenGL, Vulkan), and we sometimes want to select something other than the default. If the `env` is omitted, Dawn will select a default one.