### PR TITLE
do not create buffers we never realize in scheduler

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -45,7 +45,7 @@ def fix_image(u:UOp):
 sym = symbolic_simple+PatternMatcher([
   # UOp with size 0 is zero
   (UPat(GroupOp.All-{Ops.SINK}, name="root"), lambda root: root.const_like(0) if root.base.st is not None and root.size == 0 \
-    and not (root.base.op is Ops.CONST and root.base.arg == 0) else None),
+   and not (root.base.op is Ops.CONST and root.base.arg == 0) else None),
   # DETACH and CONTIGUOUS_BACKWARD are NOOPs here
   (UPat((Ops.DETACH, Ops.CONTIGUOUS_BACKWARD), name="x"), lambda x: x.src[0]),
   # reduce of size 0 is the identity element
@@ -73,7 +73,7 @@ sym = symbolic_simple+PatternMatcher([
   (UPat(GroupOp.ALU, name="alu"), replace_contiguous),
   # substitute BITCAST/CONTIGUOUS with BUFFER_VIEW on DISK
   (UPat((Ops.BITCAST, Ops.CONTIGUOUS), name="root"),
-  lambda root: root.replace(op=Ops.BUFFER_VIEW) if isinstance(root.device, str) and root.device.startswith("DISK") else None),
+   lambda root: root.replace(op=Ops.BUFFER_VIEW) if isinstance(root.device, str) and root.device.startswith("DISK") else None),
 ])
 
 remove_movement_ops = merge_views+PatternMatcher([

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -103,6 +103,13 @@ do_realize = PatternMatcher([
 def group_realizes(sink:UOp) -> dict[UOp, UOp]:
   # start by adding uops that always realize
   sink = graph_rewrite(sink, do_realize, realizes:={x.base:None for x in sink.src if x.base.op not in {Ops.CONST, Ops.BIND, Ops.BUFFER}})
+  children: dict[UOp, list[UOp]] = {}
+  for u in sink.toposort:
+    for s in u.src: children.setdefault(s, []).append(u)
+  #raise Exception(children)
+  # find all reduces, and pair them to a elementwise op. if they can't be cleanly paired, force realize the reduce (or a contig child)
+
+  reduce_for_op: dict[UOp, UOp] = {}
   return realizes
 
 # break the SINK into kernels

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -311,7 +311,7 @@ def load_buf(ctx:list[UOp], x:UOp):
 
 add_buffer_ops = PatternMatcher([
   # LOAD
-  (UPat(Ops.ASSIGN, src=(UPat.var("x"), UPat(Ops.KERNEL))), load_buf),
+  (UPat(Ops.ASSIGN, src=[UPat.var("x"), UPat(Ops.KERNEL)], allow_any_len=True), load_buf),
   (UPat(Ops.BUFFER, name="x"), load_buf),
   # STORE (except for COPY/BUFFER_VIEW)
   (UPat(Ops.SINK, src=(UPat((Ops.COPY, Ops.BUFFER_VIEW), name="x"),)), lambda x:x),

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -188,7 +188,7 @@ def identity_element(op:Ops, dt:DType) -> ConstType: return dtypes.as_const({Ops
 
 def can_pad(u:UOp, edges:dict[UOp, UOp], visisted:dict[UOp, None]) -> bool:
   if u.op in GroupOp.UnsafePad: return False
-  if (len(u.src) == 2 and u.src[0] in edges) or u in visisted: return True
+  if u in edges or u in visisted: return True
   visisted[u] = None
   return all(can_pad(x.base, edges, visisted) for x in u.src)
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -186,7 +186,7 @@ view_supported_devices = {"LLVM", "CLANG", "CUDA", "NV", "AMD", "METAL", "QCOM",
 # https://en.wikipedia.org/wiki/Identity_element
 def identity_element(op:Ops, dt:DType) -> ConstType: return dtypes.as_const({Ops.ADD:0, Ops.MUL:1, Ops.MAX:dtypes.min(dt)}[op], dt)
 
-def can_pad(u:UOp, edges:dict[UOp, UOp], visisted:dict[UOp, None]) -> bool:
+def can_pad(u:UOp, edges:dict[UOp, None], visisted:dict[UOp, None]) -> bool:
   if u.op in GroupOp.UnsafePad: return False
   if u in edges or u in visisted: return True
   visisted[u] = None

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -404,7 +404,7 @@
     const codeBlock = highlightedCodeBlock(code, lang, false);
     metadata.appendChild(codeBlock);
     // ** rewrite list
-    if (kernel.match_count > 1) {
+    if (kernel.match_count >= 1) {
       const rewriteList = Object.assign(document.createElement("div"), { className: "rewrite-list" })
       metadata.appendChild(rewriteList);
       for (let i=0; i<=kernel.match_count; i++) {


### PR DESCRIPTION
This refactor completely removes the need for an extra "bufferization" stage.
The Tensor UOps from tensor_map are directly used in the grouping logic. Only once a KERNEL UOp is created, we initialize BUFFER UOps.

We can do this by mapping the simplified Tensor UOps to `KERNEL` UOps (see `kernel_map`). So even though the original tensor UOps are rewritten, we have a link from the BUFFER to the Tensor UOp.

benchmarks:

```
~/code/tinygrad (map_tensors) > PYTHONPATH=. python3 test/external/external_benchmark_schedule.py
***** model tensor in     27.98 ms
***** model schedule in  120.38 ms

~/code/tinygrad (master) > PYTHONPATH=. python3 test/external/external_benchmark_schedule.py
***** model tensor in     28.32 ms
***** model schedule in  123.40 ms
```

There are some more deletions this enables, like removing the hacks that deal with "2 src views" in ops, as they no longer exist. I'm keeping this diff as minimal as possible and following up with more deletions.