### PR TITLE
scheduler cleanups + better cycle assert [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -102,8 +102,7 @@ def realize_before_view(ctx:GrouperContext, view:UOp, src:UOp) -> None:
 
 do_realize = PatternMatcher([
   # always realize SINK parents
-  (UPat(Ops.SINK, name="s"),
-   lambda ctx,s: ctx.realizes.update((x.base, None) for x in s.src if x.base.op not in {Ops.CONST, Ops.BIND, Ops.BUFFER})),
+  (UPat(Ops.SINK, name="s"), lambda ctx,s: ctx.realizes.update((x.base, None) for x in s.src if x.base.op not in {Ops.CONST, Ops.BIND, Ops.BUFFER})),
   # always realize ASSIGN/CONTIGUOUS/COPY/BUFFER_VIEW
   (UPat({Ops.ASSIGN, Ops.CONTIGUOUS, Ops.COPY, Ops.BUFFER_VIEW}, name="tr"), realize),
   # realize before expand or unsafe pad ops

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -328,8 +328,8 @@ fix_kernel_ops = PatternMatcher([
 ])
 
 def load_buf(ctx:list[UOp], x:UOp):
-  if x.base not in ctx: ctx.append(x.base)
-  return UOp(Ops.LOAD, x.dtype, (UOp(Ops.DEFINE_GLOBAL, x.dtype.ptr(x.base.size), (), ctx.index(x.base)), unwrap(x.st).to_uop()))
+  if x not in ctx: ctx.append(x)
+  return UOp(Ops.LOAD, x.dtype, (UOp(Ops.DEFINE_GLOBAL, x.dtype.ptr(x.size), (), ctx.index(x)), unwrap(x.st).to_uop()))
 
 add_buffer_ops = PatternMatcher([
   # LOAD

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -418,7 +418,9 @@ def create_schedule_with_vars(big_sink:UOp) -> tuple[list[ScheduleItem], dict[Va
       if any(x.op is Ops.ASSIGN and x.buf_uop is s for x in u.toposort):
         raise RuntimeError(f"cycle detected in graph, kernel for {u.buf_uop} must either depend on ASSIGN or BUFFER")
       assign_rep[a] = kernel_assign[s] = a.replace(src=a.src+(u,))
-  if assign_rep: sched_sink = sched_sink.substitute(assign_rep)
+  if assign_rep:
+    sched_sink = sched_sink.substitute(assign_rep)
+    type_verify(list(sched_sink.toposort), kernel_spec)
 
   # display the final graph
   if getenv("VIZ"): graph_rewrite(sched_sink, PatternMatcher([]), name="View Kernel Graph")


### PR DESCRIPTION
If the DEBUG=2 for image fixup adds value I'm open to adding it back, I think since we have VIZ it's not needed anymore.
The new cycle assert makes it easier to find the KERNEL in VIZ:
![image](https://github.com/user-attachments/assets/f1973be7-a762-4fa5-9cd8-e8b40f3f01f6)

```
RuntimeError: cycle detected in graph, kernel for UOp(Ops.BUFFER, dtypes.float, arg=4, src=(
  UOp(Ops.DEVICE, dtypes.void, arg='METAL', src=()),
  UOp(Ops.UNIQUE, dtypes.void, arg=2, src=()),)) must either depend on ASSIGN or BUFFER
```