### PR TITLE
Fix running VIZ=1 after package installation + test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         # Test using VIZ=1 after package installation
         VIZ=1 python -c "from tinygrad.tensor import Tensor; Tensor([1,2,3,4,5]).realize()" & VIZ_PID=$!
         echo "started VIZ server at: $(ps -p "$VIZ_PID" -o pid=)"
-        i=0; while ((i++ < 10)); do curl -sSf localhost:8000 > /dev/null && break || { echo "Verify attempt $i failed"; sleep 1; }; done; ((i > 10)) && echo "Could not verify VIZ server" && exit 1
+        i=0; while ((i++ < 10)); do curl -sSf localhost:8000 > /dev/null && break || { echo "VIZ verification attempt $i/10"; sleep 1; }; done; ((i > 10)) && echo "Could not verify VIZ server" && exit 1
         kill $VIZ_PID
         pip install mypy
         mypy -c "from tinygrad.tensor import Tensor; print(Tensor([1,2,3,4,5]))"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,8 @@ jobs:
         python -c "from tinygrad.tensor import Tensor; print(Tensor([1,2,3,4,5]))"
         # Test using VIZ=1 as an external package
         VIZ=1 python -c "from tinygrad.tensor import Tensor; Tensor([1,2,3,4,5]).realize()" & VIZ_PID=$!
-        echo "VIZ process: $(ps -p "$VIZ_PID" -o pid=)"
-        test -n "$(ps -p "$VIZ_PID" -o pid=)"
-        curl localhost:8000
+        echo "started VIZ server at: $(ps -p "$VIZ_PID" -o pid=)"
+        i=0; while ((i++ < 10)); do curl localhost:8000 && break || { echo "verify attempt $i failed"; sleep 1; }; done; ((i > 10)) && echo "couldn't verify VIZ server" && exit 1
         kill $VIZ_PID
         pip install mypy
         mypy -c "from tinygrad.tensor import Tensor; print(Tensor([1,2,3,4,5]))"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,10 @@ jobs:
         source venv/bin/activate
         pip install $GITHUB_WORKSPACE
         python -c "from tinygrad.tensor import Tensor; print(Tensor([1,2,3,4,5]))"
-        # Test using VIZ=1 as an external package
+        # Test using VIZ=1 after package installation
         VIZ=1 python -c "from tinygrad.tensor import Tensor; Tensor([1,2,3,4,5]).realize()" & VIZ_PID=$!
         echo "started VIZ server at: $(ps -p "$VIZ_PID" -o pid=)"
-        i=0; while ((i++ < 10)); do curl localhost:8000 && break || { echo "verify attempt $i failed"; sleep 1; }; done; ((i > 10)) && echo "couldn't verify VIZ server" && exit 1
+        i=0; while ((i++ < 10)); do curl -sSf localhost:8000 > /dev/null && break || { echo "Verify attempt $i failed"; sleep 1; }; done; ((i > 10)) && echo "Could not verify VIZ server" && exit 1
         kill $VIZ_PID
         pip install mypy
         mypy -c "from tinygrad.tensor import Tensor; print(Tensor([1,2,3,4,5]))"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,12 @@ jobs:
         source venv/bin/activate
         pip install $GITHUB_WORKSPACE
         python -c "from tinygrad.tensor import Tensor; print(Tensor([1,2,3,4,5]))"
+        # Test using VIZ=1 as an external package
+        VIZ=1 python -c "from tinygrad.tensor import Tensor; Tensor([1,2,3,4,5]).realize()" & VIZ_PID=$!
+        echo "VIZ process: $(ps -p "$VIZ_PID" -o pid=)"
+        test -n "$(ps -p "$VIZ_PID" -o pid=)"
+        curl localhost:8000
+        kill $VIZ_PID
         pip install mypy
         mypy -c "from tinygrad.tensor import Tensor; print(Tensor([1,2,3,4,5]))"
     - name: Run beautiful_mnist with tinygrad only

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='tinygrad',
       license='MIT',
       long_description=long_description,
       long_description_content_type='text/markdown',
-      packages = ['tinygrad', 'tinygrad.runtime.autogen', 'tinygrad.codegen', 'tinygrad.nn', 'tinygrad.renderer', 'tinygrad.engine',
+      packages = ['tinygrad', 'tinygrad.runtime.autogen', 'tinygrad.codegen', 'tinygrad.nn', 'tinygrad.renderer', 'tinygrad.engine', 'tinygrad.viz',
                   'tinygrad.runtime', 'tinygrad.runtime.support', 'tinygrad.runtime.support.am', 'tinygrad.runtime.graph', 'tinygrad.shape'],
       package_data = {'tinygrad': ['py.typed']},
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='tinygrad',
       long_description_content_type='text/markdown',
       packages = ['tinygrad', 'tinygrad.runtime.autogen', 'tinygrad.codegen', 'tinygrad.nn', 'tinygrad.renderer', 'tinygrad.engine', 'tinygrad.viz',
                   'tinygrad.runtime', 'tinygrad.runtime.support', 'tinygrad.runtime.support.am', 'tinygrad.runtime.graph', 'tinygrad.shape'],
-      package_data = {'tinygrad': ['py.typed']},
+      package_data = {'tinygrad': ['py.typed'], 'tinygrad.viz': ['index.html', 'perfetto.html', 'assets/**/*']},
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License"


### PR DESCRIPTION
VIZ did not run at all after pip install because the package was not included in the tinygrad installation. This was also reported in #9158.
Now tinygrad includes the VIZ server and client assets in the package installation:
```
~> ls -l /opt/homebrew/lib/python3.11/site-packages/tinygrad/viz/
total 80
drwxr-xr-x  6 qazal  admin    192 Feb 20 14:59 assets
-rw-r--r--  1 qazal  admin  18544 Feb 20 14:59 index.html
-rw-r--r--  1 qazal  admin   4458 Feb 20 14:59 perfetto.html
-rw-r--r--  1 qazal  admin  11395 Feb 20 14:59 serve.py
```