### PR TITLE
remove inputs+outputs attributes from ScheduleItem [pr]

### DIFF
--- a/test/test_conv_shapetracker.py
+++ b/test/test_conv_shapetracker.py
@@ -26,8 +26,8 @@ class TestConvShapetracker(unittest.TestCase):
     print(si)
     ldb = [x for x in si.ast.toposort if x.op is Ops.LOAD][0]
     st: ShapeTracker = ldb.st_arg.simplify()
-    print(si.inputs[0].size)
-    self.assertEqual(si.inputs[0].size, st.real_size())
+    print(si.bufs[1].size)
+    self.assertEqual(si.bufs[1].size, st.real_size())
     for v in st.views: print(v)
 
     # same st
@@ -45,7 +45,7 @@ class TestConvShapetracker(unittest.TestCase):
     for v in test_st.views: print(v)
     for i in range(prod(st.shape)):
       i1, i2 = shapetracker_getitem(st, i), shapetracker_getitem(test_st, i)
-      print(i, i1, i2, si.inputs[0].size, i1==i2)
+      print(i, i1, i2, si.bufs[1].size, i1==i2)
       #self.assertEqual(i1, i2)
 
     with self.assertRaises(AssertionError):

--- a/test/test_image_dtype.py
+++ b/test/test_image_dtype.py
@@ -129,8 +129,8 @@ class TestImageDType(unittest.TestCase):
       self.assertEqual(len(sched), 10)
       for s,ei in zip(sched, lower_schedule(sched[:])):
         ei.run()
-        if s.outputs[0].dtype == dtypes.float:
-          lst = s.outputs[0].as_buffer().cast("f").tolist()
+        if s.bufs[0].dtype == dtypes.float:
+          lst = s.bufs[0].as_buffer().cast("f").tolist()
           print(lst)
           assert not np.any(np.isnan(lst))
 

--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -536,8 +536,8 @@ class TestMultiTensor(unittest.TestCase):
     for p in get_parameters(bn): p.shard_(devices_4).realize()
 
     out = bn(t)
-    scheds = [sched for sched in out.schedule() if sched.outputs[0].device in devices_4 and sched.ast.op is not Ops.COPY]
-    assert set(out.device for sched in scheds for out in sched.outputs) == set(devices_4), "should have ast on each shard device"
+    scheds = [sched for sched in out.schedule() if sched.bufs[0].device in devices_4 and sched.ast.op is not Ops.COPY]
+    assert set(sched.bufs[0].device for sched in scheds) == set(devices_4), "should have ast on each shard device"
     asts = [sched.ast for sched in scheds]
     assert len(asts)
     # test case to show that ast can be different on devices

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -19,9 +19,8 @@ class TestTimeLinearizer(unittest.TestCase):
   def test_reasonable_time(self):
     a = Tensor([1,2,3,4]).realize()
     si = (a+1).schedule()[0]
-    out = Buffer(Device.DEFAULT, si.outputs[0].size, si.outputs[0].dtype).allocate()
-    memops = {x.src[0].arg:x.src[-1].arg.real_size() for x in si.ast.toposort if x.op is Ops.LOAD}
-    rawbufs = [out] + [Buffer(Device.DEFAULT, memops[i], x.dtype).allocate() for i,x in enumerate(si.inputs, start=len(si.outputs))]
+    # create fresh empty buffers
+    rawbufs = [Buffer(b.device, b.size, b.dtype).allocate() for b in si.bufs]
     tm = time_linearizer(Kernel(si.ast), rawbufs, allow_test_size=False, cnt=10, disable_cache=True)
     assert tm > 0 and tm != float('inf')
 

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -1,4 +1,4 @@
-import sys, functools, atexit, pickle
+import sys, atexit, pickle
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from tinygrad.ops import UOp, Variable, Ops, GroupOp, PatternMatcher, UPat, graph_rewrite, graph_rewrite_map, track_rewrites, buffers

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -233,16 +233,6 @@ class ScheduleItem:
   ast: UOp
   bufs: tuple[Buffer, ...]
   metadata: tuple[Metadata, ...]
-  @property
-  def outputs(self) -> tuple[Buffer, ...]:
-    """Read/write or write only buffers in the schedule."""
-    return tuple(b for i,b in enumerate(self.bufs) if i in self.output_idxs)
-  @property
-  def inputs(self) -> tuple[Buffer, ...]:
-    """Read only buffers in the schedule."""
-    return tuple(b for i,b in enumerate(self.bufs) if i not in self.output_idxs)
-  @functools.cached_property
-  def output_idxs(self) -> tuple[int, ...]: return tuple(x.src[0].arg for x in self.ast.src) if self.ast.op is Ops.SINK else (0,)
 
 # **** Kernel creation
 


### PR DESCRIPTION
These are expressed in the Kernel graph now. Schedule linearization no longer relies on ScheduleItem for the toposort, as the toposort of `sched_sink` is always correct.

The memory_planner currently accesses Buffer objects directly, could it just use the BUFFER UOp?

In master the progression of Tensor.schedule rewrites is:

1. const folding + movement_ops->view
2. break into KERNEL
3. linearize the sched_sink
3. convert Kernel UOp to ScheduleItem (this creates Buffer)
4. memory_planner
5. lower_schedule_item