### PR TITLE
remove unused memsize_to_str and minor cleanups [pr]

### DIFF
--- a/examples/llama3.py
+++ b/examples/llama3.py
@@ -47,7 +47,7 @@ def concat_weights(models, device=None):
     disk_tensors: List[Tensor] = [model[name] for model in models]
     if len(disk_tensors) == 1 or len(disk_tensors[0].shape) == 1:
       return disk_tensors[0].to(device=device)
-    axis = 1 if name.endswith(".attention.wo.weight") or name.endswith(".feed_forward.w2.weight") else 0
+    axis = 1 if name.endswith((".attention.wo.weight", ".feed_forward.w2.weight")) else 0
     lazy_tensors = [data.to(device=device) for data in disk_tensors]
     return lazy_tensors[0].cat(*lazy_tensors[1:], dim=axis)
   return {name: convert(name) for name in {name: None for model in models for name in model}}

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -27,7 +27,7 @@ def all_same(items:Union[tuple[T, ...], list[T]]): return all(x == items[0] for 
 def all_int(t: Sequence[Any]) -> TypeGuard[tuple[int, ...]]: return all(isinstance(s, int) for s in t)
 def colored(st, color:Optional[str], background=False): return f"\u001b[{10*background+60*(color.upper() == color)+30+['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'].index(color.lower())}m{st}\u001b[0m" if color is not None else st  # replace the termcolor library with one line  # noqa: E501
 def colorize_float(x: float): return colored(f"{x:7.2f}x", 'green' if x < 0.75 else 'red' if x > 1.15 else 'yellow')
-def memsize_to_str(_bytes: int) -> str: return [f"{(_bytes / d):.2f} {pr}" for d,pr in [(1e9,"GB"),(1e6,"MB"),(1e3,"KB"),(1,"B")] if _bytes > d][0]
+def memsize_to_str(b: int) -> str: return next((f"{(b / d):.2f} {pr}" for d,pr in [(1e9,"GB"),(1e6,"MB"),(1e3,"KB"),(1,"B")] if b >= d), "0.00 B")
 def time_to_str(t:float, w=8) -> str: return next((f"{t * d:{w}.2f}{pr}" for d,pr in [(1, "s "),(1e3, "ms")] if t > 10/d), f"{t * 1e6:{w}.2f}us")
 def ansistrip(s:str): return re.sub('\x1b\\[(K|.*?m)', '', s)
 def ansilen(s:str): return len(ansistrip(s))

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -50,7 +50,7 @@ def data64_le(data:Any) -> tuple[Any, Any]: return (data & 0xFFFFFFFF, data >> 3
 def getbits(value: int, start: int, end: int): return (value >> start) & ((1 << end-start+1) - 1)
 def i2u(bits: int, value: int): return value if value >= 0 else (1<<bits)+value
 def merge_dicts(ds:Iterable[dict[T,U]]) -> dict[T,U]:
-  kvs = set((k,v) for d in ds for k,v in d.items())
+  kvs = set([(k,v) for d in ds for k,v in d.items()])
   assert len(kvs) == len(set(kv[0] for kv in kvs)), f"cannot merge, {kvs} contains different values for the same key"
   return {k:v for d in ds for k,v in d.items()}
 def partition(itr:Iterable[T], fxn:Callable[[T],bool]) -> tuple[list[T], list[T]]:
@@ -75,7 +75,7 @@ def word_wrap(x, wrap=80): return x if len(x) <= wrap or '\n' in x[0:wrap] else 
 def polyN(x:T, p:list[float]) -> T: return functools.reduce(lambda acc,c: acc*x+c, p, 0.0)  # type: ignore
 
 @functools.lru_cache(maxsize=None)
-def to_function_name(s:str): return ''.join(c if c in (string.ascii_letters+string.digits+'_') else f'{ord(c):02X}' for c in ansistrip(s))
+def to_function_name(s:str): return ''.join([c if c in (string.ascii_letters+string.digits+'_') else f'{ord(c):02X}' for c in ansistrip(s)])
 @functools.lru_cache(maxsize=None)
 def getenv(key:str, default=0): return type(default)(os.getenv(key, default))
 def temp(x:str, append_user:bool=False) -> str:

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -124,7 +124,7 @@ class Handler(BaseHTTPRequestHandler):
       with open(os.path.join(os.path.dirname(__file__), "index.html"), "rb") as f: ret = f.read()
     elif (url:=urlparse(self.path)).path == "/profiler":
       with open(os.path.join(os.path.dirname(__file__), "perfetto.html"), "rb") as f: ret = f.read()
-    elif (self.path.startswith("/assets/") or self.path.startswith("/lib/")) and '/..' not in self.path:
+    elif self.path.startswith(("/assets/", "/lib/")) and '/..' not in self.path:
       try:
         with open(os.path.join(os.path.dirname(__file__), self.path.strip('/')), "rb") as f: ret = f.read()
         if url.path.endswith(".js"): content_type = "application/javascript"


### PR DESCRIPTION
Encountered `IndexError: list index out of range` when calling `memsize_to_str()` with inputs <= 1. This PR fixes the issue:

```py
from tinygrad.helpers import memsize_to_str

print(memsize_to_str(0))  # error -> 0.00 B
print(memsize_to_str(1))  # error -> 1.00 B
print(memsize_to_str(1000))  # 1000.00 B -> 1.00 KB
print(memsize_to_str(1234))  # same
```

Since there are no existing tests for `memsize_to_str()`, I haven't added any new ones. Let me know if you'd like tests to be included.