### PR TITLE
simpler buf_uop [pr]

### DIFF
--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -2,7 +2,7 @@ import unittest, pickle, types
 import numpy as np
 from tinygrad import Tensor, TinyJit, Variable, dtypes
 from tinygrad.helpers import GlobalCounters, ContextVar, Context
-from tinygrad.ops import PatternMatcher, UPat, UOp
+from tinygrad.ops import PatternMatcher, UPat, UOp, Ops
 
 class TestPickle(unittest.TestCase):
   def test_pickle_code_object(self):
@@ -67,7 +67,8 @@ class TestPickle(unittest.TestCase):
   # NOTE: currently Buffer exists on the uop, not tensor
   def test_pickle_buffer_uop(self):
     t = Tensor.arange(4).realize()
-    a = t.lazydata.buf_uop
+    a = t.lazydata
+    assert a.op is Ops.BUFFER
     self.assertIsNotNone(buffer:=a.realized)
     s = pickle.dumps(a)
     # free buffers

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -522,9 +522,8 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     return dsrcs[0]._device if len(dsrcs:=[x for x in self.src if x._device is not None]) != 0 else None
   @property
   def buf_uop(self) -> UOp:
-    if self.base.op is Ops.BUFFER: return self.base
-    assert self.base.op in {*GroupOp.Buffer, Ops.ASSIGN}, f"buf_uop called on {self.op}"
-    return self.src[0].buf_uop
+    assert self.op is Ops.ASSIGN, f"must be ASSIGN {self.op}"
+    return self.src[0].base
   @property
   def buffer(self) -> Buffer:
     if self is not self.base:


### PR DESCRIPTION
After KERNEL UOp we don't allow for STORE(BUFFER)/LOAD(BUFFER), these are always created with DEFINE_GLOBAL.