### PR TITLE
(bounty) Make mnist training run with torch backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,8 +171,8 @@ jobs:
       run: PYTHONPATH=. DEBUG=2 python3 extra/torch_backend/torch_tests.py TestTinyBackendPRIVATEUSE1.test_unary_log_tiny_float32
     - name: Test Ops with TINY_BACKEND (expect failure)
       run: PYTHONPATH=. LLVM=1 LLVMOPT=0 TINY_BACKEND=1 python3 -m pytest -n auto test/test_ops.py || true
-    - name: Test beautiful_mnist in torch with TINY_BACKEND (expect failure)
-      run: PYTHONPATH=. TINY_BACKEND=1 python3 examples/other_mnist/beautiful_mnist_torch.py || true
+    - name: Test beautiful_mnist in torch with TINY_BACKEND
+      run: PYTHONPATH=. ALLOW_DTYPE_MISMATCH=1 TINY_BACKEND=1 python3 examples/other_mnist/beautiful_mnist_torch.py
     - name: Test some torch tests (expect failure)
       run: PYTHONPATH=. python3 -m pytest extra/torch_backend/torch_tests.py -v --tb=no || true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
   torchbackend:
     name: Torch Backend Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4

--- a/extra/torch_backend/test.py
+++ b/extra/torch_backend/test.py
@@ -77,6 +77,11 @@ class TestTorchBackend(unittest.TestCase):
     c = a == b
     print(c.cpu().numpy())
 
+  def test_maxpool2d_backward(self):
+    x = torch.arange(3*3, device=device).reshape(1, 1, 3, 3).requires_grad_(True)
+    torch.nn.functional.max_pool2d(x, kernel_size=2, stride=1).sum().backward()
+    np.testing.assert_equal(x.grad.squeeze().cpu().numpy(), [[0, 0, 0], [0, 1, 1], [0, 1, 1]])
+
   @unittest.skip("meh")
   def test_str(self):
     a = torch.ones(4, device=device)


### PR DESCRIPTION
It runs but with some performance and accuracy issues.

![image](https://github.com/user-attachments/assets/66c949eb-d2ad-41a7-9c93-311a1f802c92)

Few notes:

- Had to workaround thrown errors regarding events and streams in the DeviceGuardImplInterface and made them no-ops. Unsure if this is right.
- Patched pytorch Optimizer class to realize weight and optimizer state tensors on step. Otherwise computation graph blew up.
- Edited test file to delay float conversion as the kernel is gather samples is already really slow and 2x worse with float. Matches behavior of other beautiful_mnist example,