### PR TITLE
feat(FLUX1): load T5, CLIP, AE from path

### DIFF
--- a/examples/flux1.py
+++ b/examples/flux1.py
@@ -327,9 +327,9 @@ class Flux:
     return self.final_layer(img, vec)  # (N, T, patch_size ** 2 * out_channels)
 
 def get_local_path(url: str, base_path: str, url_parts:int) -> str:
-    base_path = os.path.join(base_path, "")  # This adds trailing slash/backslash depending on OS
-    parts = url.split("/")[url_parts:]
-    return os.path.join(base_path, *parts)
+  base_path = os.path.join(base_path, "")  # This adds trailing slash/backslash depending on OS
+  parts = url.split("/")[url_parts:]
+  return os.path.join(base_path, *parts)
 
 # https://github.com/black-forest-labs/flux/blob/main/src/flux/util.py
 def load_flow_model(name:str, model_path:str):


### PR DESCRIPTION
This PR using all related model weights from just single `model_path`. Previously, the implementation only took the main model weights from the specified path and downloaded the others from the internet. 

Since weights like T5, CLIP, and AE models are typically stored together in the same folder structure, we now extract that structure from the URLs and use it to look for local files. We can define a arg for each of the model but I believe this is way more nicer than defining bunch of explicit args.


Thanks