### PR TITLE
is_realized only if buffer is allocated

### DIFF
--- a/test/test_const_folding.py
+++ b/test/test_const_folding.py
@@ -219,7 +219,7 @@ class TestReduceOpsConstFolding(unittest.TestCase):
     # contiguous folded const can still schedule
     a = Tensor.empty(1, 0).sum().contiguous()
     _check_ast_count(2, a+2)
-    self.assertIsNotNone(a.lazydata.base.realized)
+    self.assertIs(a.lazydata.base.op, Ops.BUFFER)
     np.testing.assert_equal((Tensor.empty(1, 0).sum().contiguous()+2).numpy(), 2)
     # otherwise we just fuse it
     _check_ast_count(1, (Tensor.empty(1, 0).sum()+2).contiguous())

--- a/test/test_image_dtype.py
+++ b/test/test_image_dtype.py
@@ -123,16 +123,16 @@ class TestImageDType(unittest.TestCase):
       loss = x.image_dot(w1).image_dot(w2).float().max()
       loss.backward()
       sched = unwrap(w1.grad).schedule()
-      # NOTE: the w1 grad must realize to a seperate kernel
-      assert w1.grad.lazydata.is_realized, f"never realized {w1.grad}"
-      self.assertEqual(w1.grad.lazydata.base.buffer.dtype, dtypes.float32)
-      self.assertEqual(len(sched), 10)
       for s,ei in zip(sched, lower_schedule(sched[:])):
         ei.run()
         if s.bufs[0].dtype == dtypes.float:
           lst = s.bufs[0].as_buffer().cast("f").tolist()
           print(lst)
           assert not np.any(np.isnan(lst))
+      # NOTE: the w1 grad must realize to a seperate kernel
+      assert w1.grad.lazydata.is_realized, f"never realized {w1.grad}"
+      self.assertEqual(w1.grad.lazydata.base.buffer.dtype, dtypes.float32)
+      self.assertEqual(len(sched), 10)
 
 @unittest.skipIf(Device.DEFAULT not in ("QCOM", "GPU"), "only images on GPU")
 class TestImageRealization(unittest.TestCase):

--- a/test/unit/test_tensor_uop_representation.py
+++ b/test/unit/test_tensor_uop_representation.py
@@ -121,7 +121,7 @@ class TestTensorUopRepresentation(unittest.TestCase):
     vi = UOp.variable("i", 1, 3).bind(1)
     a = Tensor.empty(3, vi)
     is_pattern(a, UPat(Ops.RESHAPE, src=(UPat(Ops.BUFFER),)))
-    self.assertEqual(a.lazydata.base.realized.size, 9)
+    self.assertEqual(a.lazydata.base.buffer.size, 9)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -525,7 +525,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     buffers[self] = ret = Buffer(self.device, self.size, self.dtype if isinstance(self.dtype, ImageDType) else self.dtype.base)
     return ret
   @property
-  def realized(self) -> Optional[Buffer]: return self.buffer if self.op is Ops.BUFFER else None
+  def realized(self) -> Optional[Buffer]: return self.buffer if self.op is Ops.BUFFER and self.buffer.is_allocated() else None
   @property
   def is_realized(self) -> bool:
     return all(x.base.realized is not None for x in self.base.real_lbs) if self.base.op is Ops.MULTI else self.base.realized is not None

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -20,7 +20,7 @@ tensor_uop_spec = buffer_spec+PatternMatcher([
    lambda mv,x: (isinstance(mv.arg, tuple) and mv.dtype == x.dtype) or
    # "make things that can't be images not images" can change the buffer dtype
    # this is fine as long as it's a realized buffer and base dtypes match.
-   ((isinstance(mv.dtype, ImageDType) or isinstance(x.dtype, ImageDType)) and x.dtype.base == mv.dtype.base and x.is_realized)),
+   ((isinstance(mv.dtype, ImageDType) or isinstance(x.dtype, ImageDType)) and x.dtype.base == mv.dtype.base and x.base.op is Ops.BUFFER)),
   (UPat(Ops.VIEW, src=(UPat(GroupOp.All-{Ops.BUFFER, Ops.CONST, Ops.DEVICE}),)), lambda: False),
 
   # Tensor variable bindings

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -38,9 +38,9 @@ tensor_uop_spec = buffer_spec+PatternMatcher([
   # NOTE: the arg here specifies clone=True, which prevents folding same device copy
   (UPat(Ops.COPY, name="copy", src=(UPat(Ops.DEVICE), UPat.var("x"))), lambda copy,x: isinstance(copy.arg, bool) and copy.dtype == x.dtype),
 
-  # ASSIGN changes the value of a realized buffer
+  # ASSIGN changes the value of a buffer
   (UPat(Ops.ASSIGN, name="assign", src=(UPat.var("target"), UPat.var("new_val"))),
-   lambda assign,target,new_val: target.is_realized and (assign.dtype == target.dtype == new_val.dtype)),
+   lambda assign,target,new_val: target.base.op is Ops.BUFFER and (assign.dtype == target.dtype == new_val.dtype)),
 ])
 
 # ***** uop type spec *****

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -270,7 +270,7 @@ class Tensor(SimpleMathTrait):
     # TODO: this is a hack for writing to DISK. remove with working assign
     if isinstance(self.device, str) and self.device.startswith("DISK"):
       if x.__class__ is not Tensor: x = Tensor(x, device="CPU", dtype=self.dtype)
-      self.contiguous().realize().lazydata.base.realized.ensure_allocated().copyin(x._data())
+      self.contiguous().realize().lazydata.base.buffer.ensure_allocated().copyin(x._data())
       return self
     if x.__class__ is not Tensor: x = Tensor(x, device=self.device, dtype=self.dtype)
     if self.lazydata is x.lazydata: return self  # a self assign is a NOOP


### PR DESCRIPTION
Previously "is_realized" and a Tensor mapping to a BUFFER (even if it is unallocated) meant the same thing.
This diff separates scheduling/becomes_map from realization further by making is_realized only apply if the Buffer is allocated on device.

This also fixes the [issue reported on discord](https://discord.com/channels/1068976834382925865/1069001075828469790/1343587073164050578) regarding using Tensor.empty as a JIT input_rawbuffer.


test_const_folding and test_schedule only call create_schedule and do not execute any kernels, I changed the tests to check the BUFFER op instead of the `is_realized` property.