### PR TITLE
simpler as_strided

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -49,7 +49,7 @@ def as_strided(tensor:torch.Tensor, size, stride, storage_offset=None):
   # make big ret with stride 1
   ret = ret.reshape(numel, *wow)
   # stupid 0 stride
-  ret = ret.shrink(tuple((0,1) if st == 0 else None for st in stride)).expand([1337 if st == 0 else None for st in stride])
+  ret = ret.shrink(tuple((0,1) if st == 0 else None for st in stride)).expand([size[i] if st == 0 else None for i,st in enumerate(stride)])
   slices = tuple(slice(0,None,(st if st != 0 else 1)) for st in stride)
   shrinks = tuple(slice(0,sz) for sz in size)
   # do strides and shrink to size

--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -48,7 +48,9 @@ def as_strided(tensor:torch.Tensor, size, stride, storage_offset=None):
   ret = ret.expand(*wow, numel).flatten()
   # make big ret with stride 1
   ret = ret.reshape(numel, *wow)
-  slices = tuple(slice(0,None,st) for st in stride)
+  # stupid 0 stride
+  ret = ret.shrink(tuple((0,1) if st == 0 else None for st in stride)).expand([1337 if st == 0 else None for st in stride])
+  slices = tuple(slice(0,None,(st if st != 0 else 1)) for st in stride)
   shrinks = tuple(slice(0,sz) for sz in size)
   # do strides and shrink to size
   ret = ret[slices][shrinks]

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2476,6 +2476,40 @@ class TestOps(unittest.TestCase):
     n = (x < 0).where(x, 1).numpy()
     assert np.all(n == 1.)
 
+  # DEEPSEEK R1 HELP ME WRITE TESTS
+  def test_as_strided(self):
+    # Basic test with simple striding
+    helper_test_op([(4,)], lambda x: torch.as_strided(x, size=(2,2), stride=(2,1)), lambda x: x.as_strided((2,2), (2,1)))
+
+    # Test with overlapping elements
+    helper_test_op([(9,)], lambda x: torch.as_strided(x, size=(3,3), stride=(3,1)), lambda x: x.as_strided((3,3), (3,1)))
+
+    # Edge case: zero-size dimension
+    helper_test_op([(4,)], lambda x: torch.as_strided(x, size=(0,2), stride=(1,1)), lambda x: x.as_strided((0,2), (1,1)), forward_only=True)
+
+    # Test with non-contiguous storage
+    helper_test_op([(2,3)], lambda x: torch.as_strided(x, size=(2,2), stride=(3,1)), lambda x: x.as_strided((2,2), (3,1)))
+
+    # Test with storage offset
+    helper_test_op([(5,)], lambda x: torch.as_strided(x, size=(3,), stride=(1,), storage_offset=1),
+                  lambda x: x.as_strided((3,), (1,), storage_offset=1))
+
+    # Test with non-descending strides
+    helper_test_op([(2,3,4,5)], lambda x: torch.as_strided(x, size=(2,3,2,5), stride=(8,1,32,2)),
+                  lambda x: x.as_strided((2,3,2,5), (8,1,32,2)))
+
+    # Edge case: negative stride
+    # TORCH NO SUPPORT
+    # helper_test_op([(4,)], lambda x: torch.as_strided(x, size=(4,), stride=(-1,)), lambda x: x.as_strided((4,), (-1,)))
+
+    # Test with larger dimensions
+    helper_test_op([(24,)], lambda x: torch.as_strided(x, size=(2,3,4), stride=(12,4,1)),
+                  lambda x: x.as_strided((2,3,4), (12,4,1)))
+
+    # Edge case: single element with multiple dimensions
+    helper_test_op([(1,)], lambda x: torch.as_strided(x, size=(1,1,1), stride=(1,1,1)),
+                  lambda x: x.as_strided((1,1,1), (1,1,1)))
+
   def _get_index_randoms(self):
     # indices cannot have gradient
     a = torch.randint(low=-1, high=1, size=(2,1,1,1,1,1), dtype=torch.int64, requires_grad=False)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1092,6 +1092,19 @@ class Tensor(SimpleMathTrait):
 
   # ***** movement high level ops *****
 
+  def as_strided(self, size, stride, storage_offset=None):
+    ret = self.flatten()
+    if storage_offset: ret = ret[storage_offset:]
+    numel = ret.numel()
+    wow = (numel+1,)*(len(size)-1)
+    ret = ret.expand(*wow, numel).flatten()
+    # make big ret with stride 1
+    ret = ret.reshape(numel, *wow)
+    slices = tuple(slice(0,None,st) for st in stride)
+    shrinks = tuple(slice(0,sz) for sz in size)
+    # do strides and shrink to size
+    return ret[slices][shrinks]
+
   def _getitem(self, indices, v: Optional[Tensor] = None) -> Tensor:
     # wrap single index into a list
     if (isinstance(indices, list) and all_int(indices)) or not isinstance(indices, (tuple, list)): indices = [indices]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1100,6 +1100,11 @@ class Tensor(SimpleMathTrait):
     ret = ret.expand(*wow, numel).flatten()
     # make big ret with stride 1
     ret = ret.reshape(numel, *wow)
+
+    # stupid 0 stride
+    ret = ret.shrink(tuple((0,1) if st == 0 else None for st in stride)).expand([1337 if st == 0 else None for st in stride])
+    slices = tuple(slice(0,None,(st if st != 0 else 1)) for st in stride)
+
     slices = tuple(slice(0,None,st) for st in stride)
     shrinks = tuple(slice(0,sz) for sz in size)
     # do strides and shrink to size

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1102,7 +1102,7 @@ class Tensor(SimpleMathTrait):
     ret = ret.reshape(numel, *wow)
 
     # stupid 0 stride
-    ret = ret.shrink(tuple((0,1) if st == 0 else None for st in stride)).expand([1337 if st == 0 else None for st in stride])
+    ret = ret.shrink(tuple((0,1) if st == 0 else None for st in stride)).expand([size[i] if st == 0 else None for i,st in enumerate(stride)])
     slices = tuple(slice(0,None,(st if st != 0 else 1)) for st in stride)
 
     slices = tuple(slice(0,None,st) for st in stride)


### PR DESCRIPTION
Taking a break from agonizing over ORT C++ quantization.

I remember also doing the to_movement_ops way back when!!
That was fun.
I once knew how it worked, but I no longer remember.
all I remember is the shifty expand reshape to get fake 1 stride on multiple dimensions.

I think my quick hacks work. Need sleep. Will clean up when wake up and double check if this is actually correct.
I think it's simpler than to_movement_ops.