### PR TITLE
test: recompute expanded CAST

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -79,6 +79,12 @@ class TestSchedule(unittest.TestCase):
     c = a+b
     with self.assertRaises(RuntimeError): check_schedule(c, 1)
 
+  def test_expand_buffer_before_cast(self):
+    a = Tensor.randn(4, 2, 1).realize().permute((1, 0, 2))
+    b = a.cast(dtypes.half).expand((2, 4, 4))+2
+    run_schedule(check_schedule(b, 1))
+    np.testing.assert_allclose(b.numpy(), np.broadcast_to(a.numpy().astype(np.float16), (2, 4, 4))+2)
+
   def test_empty_is_not_realized(self):
     a = Tensor.empty(10)
     child = a+2
@@ -1426,7 +1432,7 @@ class TestSchedule(unittest.TestCase):
     a = Tensor.ones(4, 4).contiguous().realize()
     b = a.cast(dtypes.half).expand(2, 4, 4)
     c = b.cast(dtypes.int).expand(2, 2, 4, 4)
-    run_schedule(check_schedule(c, 2))
+    run_schedule(check_schedule(c, 1))
     np.testing.assert_equal(c.numpy(), np.ones(((2, 2, 4, 4)), dtype=np.int32))
 
   def test_base_change_pad_expand(self):

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -79,7 +79,7 @@ class TestSchedule(unittest.TestCase):
     c = a+b
     with self.assertRaises(RuntimeError): check_schedule(c, 1)
 
-  @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
+  @unittest.skipUnless(is_dtype_supported(dtypes.half) and getenv("CAST_AFTER_EXPAND"), "need half and CAST_AFTER_EXPAND=1")
   def test_expand_buffer_before_cast(self):
     a = Tensor.randn(4, 2, 1).realize().permute((1, 0, 2))
     b = a.cast(dtypes.half).expand((2, 4, 4))+2
@@ -1433,7 +1433,7 @@ class TestSchedule(unittest.TestCase):
     a = Tensor.ones(4, 4).contiguous().realize()
     b = a.cast(dtypes.half).expand(2, 4, 4)
     c = b.cast(dtypes.int).expand(2, 2, 4, 4)
-    run_schedule(check_schedule(c, 1))
+    run_schedule(check_schedule(c, 2))
     np.testing.assert_equal(c.numpy(), np.ones(((2, 2, 4, 4)), dtype=np.int32))
 
   def test_base_change_pad_expand(self):

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -79,6 +79,7 @@ class TestSchedule(unittest.TestCase):
     c = a+b
     with self.assertRaises(RuntimeError): check_schedule(c, 1)
 
+  @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
   def test_expand_buffer_before_cast(self):
     a = Tensor.randn(4, 2, 1).realize().permute((1, 0, 2))
     b = a.cast(dtypes.half).expand((2, 4, 4))+2

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -84,8 +84,9 @@ sym = symbolic_simple+PatternMatcher([
   (UPat(Ops.CAST, name="cast", src=(UPat(Ops.VIEW, name="vm", src=(UPat(Ops.CONTIGUOUS, name="base"))),)),
    lambda cast,base,vm: base.view(vm.st) if isinstance(cast.dtype, ImageDType) and isinstance(base.dtype, ImageDType) else None),
   # put CAST to smaller dtype before EXPAND
-  (UPat(Ops.CAST, name="cast", src=(UPat(Ops.VIEW, name="vm"),)), lambda cast,vm: vm.base.cast(cast.dtype).view(vm.st) \
-    if vm.base.op is not Ops.BUFFER and cast.dtype.itemsize <= vm.dtype.itemsize and resolve(prod(vm.shape) > vm.st.real_size()) else None),
+  (UPat(Ops.CAST, name="cast", src=(UPat(Ops.VIEW, name="vm"),)), lambda cast,vm: vm.base.cast(cast.dtype).view(vm.st)
+     if (not getenv("CAST_AFTER_EXPAND") or vm.base.op is not Ops.BUFFER) and cast.dtype.itemsize <= vm.dtype.itemsize
+     and resolve(prod(vm.shape) > vm.st.real_size()) else None),
   # make things that can't be images not images
   (UPat(GroupOp.All-{Ops.BUFFER, Ops.VIEW, Ops.CONST, Ops.DEVICE}, name="u"), lambda u: u.replace(dtype=dt.base) if isinstance(dt:=u.dtype,ImageDType)
    and (prod(u.shape) != prod(dt.shape) or not any(u.shape[x]%4 == 0 for x in u.st.unit_stride_axes())) else None),
@@ -103,8 +104,8 @@ sym = symbolic_simple+PatternMatcher([
   (UPat(GroupOp.Unary, src=UPat(Ops.VIEW, src=(UPat.var("inp"),), name="v"), name="alu"),
    lambda inp,v,alu: inp.alu(alu.op).view(v.st) if resolve(prod(alu.shape) > v.st.real_size()) else None),
   # put CAST after expanding BUFFER
-  (UPat(Ops.VIEW, src=(UPat(Ops.CAST, src=(UPat.var("x"),)),), name="v"),
-   lambda x,v: x.view(x.st+v.st).cast(v.dtype) if x.base.op is Ops.BUFFER and resolve(prod(v.shape) > prod(x.shape)) else None),
+  (UPat(Ops.VIEW, src=(UPat(Ops.CAST, src=(UPat.var("x"),)),), name="v"), lambda x,v: x.view(x.st+v.st).cast(v.dtype) if getenv("CAST_AFTER_EXPAND")
+    and x.base.op is Ops.BUFFER and resolve(prod(v.shape) > prod(x.shape)) else None),
 ])
 
 remove_movement_ops = merge_views+PatternMatcher([

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -84,8 +84,8 @@ sym = symbolic_simple+PatternMatcher([
   (UPat(Ops.CAST, name="cast", src=(UPat(Ops.VIEW, name="vm", src=(UPat(Ops.CONTIGUOUS, name="base"))),)),
    lambda cast,base,vm: base.view(vm.st) if isinstance(cast.dtype, ImageDType) and isinstance(base.dtype, ImageDType) else None),
   # put CAST to smaller dtype before EXPAND
-  (UPat(Ops.CAST, name="cast", src=(UPat(Ops.VIEW, name="vm", src=(UPat(GroupOp.All-{Ops.BUFFER}),)),)), lambda cast,vm: vm.base.cast(cast.dtype).view(vm.st) \
-    if cast.dtype.itemsize <= vm.dtype.itemsize and resolve(prod(vm.shape) > vm.st.real_size()) else None),
+  (UPat(Ops.CAST, name="cast", src=(UPat(Ops.VIEW, name="vm"),)), lambda cast,vm: vm.base.cast(cast.dtype).view(vm.st) \
+    if vm.base.op is not Ops.BUFFER and cast.dtype.itemsize <= vm.dtype.itemsize and resolve(prod(vm.shape) > vm.st.real_size()) else None),
   # make things that can't be images not images
   (UPat(GroupOp.All-{Ops.BUFFER, Ops.VIEW, Ops.CONST, Ops.DEVICE}, name="u"), lambda u: u.replace(dtype=dt.base) if isinstance(dt:=u.dtype,ImageDType)
    and (prod(u.shape) != prod(dt.shape) or not any(u.shape[x]%4 == 0 for x in u.st.unit_stride_axes())) else None),
@@ -102,6 +102,7 @@ sym = symbolic_simple+PatternMatcher([
   # put UnaryOps before EXPANDs
   (UPat(GroupOp.Unary, src=UPat(Ops.VIEW, src=(UPat.var("inp"),), name="v"), name="alu"),
    lambda inp,v,alu: inp.alu(alu.op).view(v.st) if resolve(prod(alu.shape) > v.st.real_size()) else None),
+  # put CAST after expanding BUFFER
   (UPat(Ops.VIEW, src=(UPat(Ops.CAST, src=(UPat.var("x"),)),), name="v"),
    lambda x,v: x.view(x.st+v.st).cast(v.dtype) if x.base.op is Ops.BUFFER and resolve(prod(v.shape) > prod(x.shape)) else None),
 ])


### PR DESCRIPTION
bert has many elementwise kernels that just store a half:
```
VIZ=1 GPU=1 BERT_SIZE="tiny" DEFAULT_FLOAT=HALF BENCHMARK=5 MODEL="bert" python examples/mlperf/model_train.py
```
from the 84th scheduler call:
![image](https://github.com/user-attachments/assets/4518b0fc-8daa-4693-8fd8-534bdef99326)

`CAST_AFTER_EXPAND=1` decreases number of ScheduleItems from 100 -> 59 for eval and  550 to 505 for the training step.

However, this is slower in benchmarks because it's using less flops:
![image](https://github.com/user-attachments/assets/4b67d98c-afcd-4be8-b201-74fcb19d5608)
