### PR TITLE
torch fix casting and add ops for sd vae(s)

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -324,6 +324,7 @@ tiny_backend = {**{k:wrap_out(v) for k,v in tiny_backend_out.items()}, **{
   "aten.logical_not": Tensor.logical_not,
   "aten.masked_fill_.Scalar": lambda self,mask,value: self.assign(mask.where(self, value)),
   "aten.multinomial": Tensor.multinomial,
+  "aten.pad": Tensor.pad,
   "aten.reflection_pad2d": functools.partial(Tensor.pad, mode="reflect"),
 }}
 

--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -142,7 +142,8 @@ def convolution_backward_overrideable(grad_out, input, weight, stride, padding, 
 @torch.library.impl("aten::_copy_from", "privateuseone")
 def _copy_from(src, dest, non_blocking=False):
   if str(src.device) == "tiny" and str(dest.device) == "tiny":
-    unwrap(dest).replace(unwrap(src), allow_shape_mismatch=True)
+    dest, src = unwrap(dest), unwrap(src)
+    dest.replace(src.cast(dest.dtype), allow_shape_mismatch=True)
   elif str(src.device) == "tiny" and str(dest.device) == "cpu":
     # TODO: is there a better way?
     dest.resize_(src.numel()).resize_(src.shape)
@@ -191,6 +192,7 @@ decomps = [
   aten._softmax_backward_data, aten.embedding_dense_backward,
   aten.linalg_vector_norm,
   aten.binary_cross_entropy, aten.binary_cross_entropy_backward,
+  aten.upsample_nearest2d.out,
   # activations
   aten.hardswish, aten.hardswish_backward,
   aten.hardtanh, aten.hardtanh_backward,

--- a/extra/torch_backend/test.py
+++ b/extra/torch_backend/test.py
@@ -81,7 +81,16 @@ class TestTorchBackend(unittest.TestCase):
     x = torch.arange(3*3, device=device).reshape(1, 1, 3, 3).requires_grad_(True)
     torch.nn.functional.max_pool2d(x, kernel_size=2, stride=1).sum().backward()
     np.testing.assert_equal(x.grad.squeeze().cpu().numpy(), [[0, 0, 0], [0, 1, 1], [0, 1, 1]])
-
+  
+  def test_copy_cast(self):
+    x = torch.zeros(4, device=device, dtype=torch.int64)
+    y = torch.ones(4, device=device, dtype=torch.float32).to(dtype=torch.int64)
+    res1 = x ^ y # an operation that only works on int types
+    print(res1.cpu().numpy())
+    y = y.cpu().float().to(device=device, dtype=torch.int64)
+    res2 = x ^ y
+    print(res2.cpu().numpy())
+  
   @unittest.skip("meh")
   def test_str(self):
     a = torch.ones(4, device=device)

--- a/extra/torch_backend/test.py
+++ b/extra/torch_backend/test.py
@@ -81,7 +81,7 @@ class TestTorchBackend(unittest.TestCase):
     x = torch.arange(3*3, device=device).reshape(1, 1, 3, 3).requires_grad_(True)
     torch.nn.functional.max_pool2d(x, kernel_size=2, stride=1).sum().backward()
     np.testing.assert_equal(x.grad.squeeze().cpu().numpy(), [[0, 0, 0], [0, 1, 1], [0, 1, 1]])
-  
+
   def test_copy_cast(self):
     x = torch.zeros(4, device=device, dtype=torch.int64)
     y = torch.ones(4, device=device, dtype=torch.float32).to(dtype=torch.int64)
@@ -90,7 +90,7 @@ class TestTorchBackend(unittest.TestCase):
     y = y.cpu().float().to(device=device, dtype=torch.int64)
     res2 = x ^ y
     print(res2.cpu().numpy())
-  
+
   @unittest.skip("meh")
   def test_str(self):
     a = torch.ones(4, device=device)


### PR DESCRIPTION
Fix copy to cast as that is the expected behavior [here](https://github.com/pytorch/pytorch/blob/af720cd5a7edafbf3ee791ce4aaa52a5da2049f6/torch/csrc/lazy/ts_backend/tensor_aten_ops.cpp#L56).

After this commit, the image AE models from https://github.com/madebyollin/taesd should work. Tested in ComfyUI, quite simple to patch in tinygrad. Tried an actual SDXL VAE and it runs but produces incorrect results. 