### PR TITLE
WIP: linearzer rewrite

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2351,7 +2351,7 @@ class TestOps(unittest.TestCase):
       lambda x: Tensor.avg_pool2d(x, kernel_size=(111,28)), rtol=1e-5)
 
   # TODO: linearizer block error
-  @unittest.expectedFailure
+  # @unittest.expectedFailure
   def test_avg_pool3d_failure(self):
     with Context(NOOPT=0):
       helper_test_op([(1,1,16,16,16)],

--- a/tinygrad/codegen/linearize.py
+++ b/tinygrad/codegen/linearize.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import collections, heapq
+import collections, heapq, functools
 from dataclasses import dataclass
 from tinygrad.ops import UOp, Ops, PatternMatcher, UPat, graph_rewrite, GroupOp
 from tinygrad.spec import type_verify
@@ -8,227 +8,237 @@ from tinygrad.helpers import dedup, flatten, partition
 
 DONT_PLACE_IN_BLOCK = {Ops.NAME, Ops.DEFINE_GLOBAL, Ops.DEFINE_LOCAL, Ops.DEFINE_VAR, Ops.SPECIAL, Ops.CONST, *GroupOp.Block}
 
-def disp(y:UOp) -> str:
-  if y.op is Ops.BLOCKSTART: return "w"+disp(y.src[0])
-  if y.op is Ops.IF: return f'IF{id(y)}'
-  if y.op is Ops.RANGE: return str(y.arg)
-  return "<NONE>"
+# root_uop -> sink
+def linearize_uop(root_uop:UOp, skip_check:bool=not __debug__) -> list[UOp]:
+  scope_blocks = {}
 
-@dataclass(frozen=True)
-class BasicBlock:
-  ctx: tuple[UOp, ...]
-  lst: tuple[UOp, ...]
-  end: UOp|None = None
-  def __lt__(self, o:BasicBlock): return tuple(x.tuplize for x in self.ctx+self.lst) < tuple(x.tuplize for x in o.ctx+o.lst)
-  def __repr__(self):
-    return f"{(str(disp(self.end))+' ') if self.end is not None else ''}"+\
-           f"{[disp(y) for y in self.ctx]} {len(self.lst)}" + "\n" + '\n'.join([str(x.op) for x in self.lst])
+  class LinearizeScope:
+    def __init__(self):
+      self.define_acc = []
+      self.start = []
+      self.end = []
+      self.context = []
+      self.body = []
+      self.subgraph_nodes = set()
+    
+    def fuse(self, other):
+      scope = LinearizeScope()
+      scope.define_acc = dedup(self.define_acc + other.define_acc)
+      scope.start = dedup(self.start + other.start)
+      scope.end = dedup(self.end + other.end)
+      scope.body = dedup(self.body + other.body)
+      scope.subgraph_nodes = set.union(self.subgraph_nodes, other.subgraph_nodes)
 
-def append_to_block(ctx:tuple[dict[UOp, tuple[UOp, ...]], dict[UOp, list[UOp]]], x:UOp):
-  block_ctxs, children = ctx
-  in_this_block = set(x.arg.lst)
+      for elem in scope.subgraph_nodes:
+        for src in elem.src:
+          if src not in scope.subgraph_nodes:
+            scope.context.append(src)
 
-  # collections to build
-  new_srcs: list[UOp] = []
-  to_append: list[UOp] = []
-  old_blocks: dict[tuple[UOp, ...], UOp] = {}
-  new_blocks: dict[tuple[UOp, ...], list[UOp]] = {}
+      body_set = set(scope.body)
+      for i in scope.start + scope.end:
+        assert i not in body_set, "Broken skopes"
 
-  for u in x.src:
-    if u.op is Ops.BLOCK:
-      # merge sibling blocks. NOTE: blocks must only have one output source
-      assert u.arg.ctx not in old_blocks, "sibling should never have been created"
-      old_blocks[u.arg.ctx] = u
-    elif u.op not in DONT_PLACE_IN_BLOCK and set(children[u]).issubset(in_this_block):
-      # if it can go in blocks and all its children are in the block, we add it to the block
-      if (block_ctx:=block_ctxs[u]) == x.arg.ctx:
-        # if it's the same context, we place the UOp in this block and append the parents to its srcs
-        new_srcs.extend(u.src)
-        to_append.append(u)
+      return scope
+
+    @functools.cached_property
+    def linear(self):
+      linear = []
+
+      for elem in self.define_acc:
+        linear.append(elem)
+
+      for elem in self.end:
+        linear.append(elem)
+      
+      curr_context = set(self.context + self.define_acc + self.end)
+      simple_set = set([elem for elem in self.body if elem.op not in {Ops.ASSIGN, Ops.STORE}])
+      scope_set = set([elem for elem in self.body if elem.op in {Ops.ASSIGN, Ops.STORE}])
+      fusion_set = set()
+      poped = True
+      while True:
+        poped = False
+        pop_list = []
+        for elem in simple_set:
+          ready = True
+          for cont in elem.src:
+            if cont not in curr_context:
+              ready = False
+              break
+          
+          if ready:
+            pop_list.append(elem)
+            curr_context.add(elem)
+            if self.start[0].op is Ops.SINK:
+              for s in elem.src:
+                assert elem.op is Ops.DEFINE_ACC or s in linear
+            linear.append(elem)
+            poped = True
+
+        for elem in pop_list:
+          simple_set.remove(elem)
+        
+        if poped:
+          continue
+
+        for elem in scope_set:
+          elem_scope = scope_blocks[elem]
+          ready = True
+          for cont in elem_scope.context:
+            if cont not in curr_context:
+              ready = False
+              break
+
+          if ready:
+            fusion_set.add(elem)
+        
+        for elem in fusion_set:
+          scope_set.discard(elem)
+        
+        if not fusion_set:
+          assert not simple_set and not scope_set, "Linearization Failed"
+          break
+
+        fusion_elem = fusion_set.pop()
+        fusion_elem = scope_blocks[fusion_elem]
+        for cont_elem in fusion_elem.subgraph_nodes:
+          curr_context.add(cont_elem)
+        pop_list = []
+        for elem in fusion_set:
+          scope_elem = scope_blocks[elem]
+          fusable = True
+          for i in scope_elem.end:
+            if i not in fusion_elem.end:
+              fusable = False
+
+          for i in fusion_elem.end:
+            if i not in scope_elem.end:
+              fusable = False
+          
+          if not fusable:
+            continue
+
+          fusion_elem = fusion_elem.fuse(scope_elem)
+          for cont_elem in scope_elem.subgraph_nodes:
+            curr_context.add(cont_elem)
+
+          pop_list.append(elem)
+        
+        for elem in pop_list:
+          fusion_set.remove(elem)
+        
+        linear = linear + fusion_elem.linear
+
+        for e in fusion_elem.subgraph_nodes:
+          assert e in fusion_elem.linear
+
+      for elem in self.start:
+        linear.append(elem)
+      
+      if self.start[0].op is Ops.ASSIGN:
+        for elem in self.end[::-1]:
+          linear.append(UOp(Ops.ENDRANGE, src=(elem,)))
+      
+      if self.start[0].op is Ops.STORE:
+        for elem in self.end[::-1]:
+          linear.append(UOp(Ops.ENDIF, src=(elem,)))
+
+      if self.start[0].op is Ops.SINK:
+        for i, o in enumerate(linear):
+          for s in o.src:
+            assert o.op is Ops.DEFINE_ACC or s in linear[:i]
+
+      assert root_uop.arg is not None
+      linear = [UOp(Ops.NAME, arg=root_uop.arg.name)] + [elem for elem in root_uop.toposort if elem.op is Ops.DEFINE_GLOBAL] + [elem for elem in linear if elem.op is not Ops.DEFINE_GLOBAL]
+      return linear
+
+  def _make_scope(scope_start:UOp):
+    scope = LinearizeScope()
+    scope.start.append(scope_start)
+    stack = [(scope_start, None, False)]
+    scope.subgraph_nodes.add(scope_start)
+    visited = set()
+    while stack:
+      curr_uop, pare_uop, bubbling = stack.pop()
+      if curr_uop in visited:
+        if curr_uop in scope.subgraph_nodes and pare_uop is not None:
+          scope.subgraph_nodes.add(pare_uop)
+        continue
+      elif bubbling:
+        visited.add(curr_uop)
+
+      if bubbling:
+        if curr_uop.op == Ops.RANGE and scope_start.op == Ops.ASSIGN or \
+           curr_uop.op == Ops.IF and scope_start.op == Ops.STORE or\
+           curr_uop.src == () and scope_start.op == Ops.SINK:
+          scope.end.append(curr_uop)
+          scope.subgraph_nodes.add(curr_uop)
+
+        if curr_uop in scope.subgraph_nodes and pare_uop is not None:
+          scope.subgraph_nodes.add(pare_uop)
+          if curr_uop.key != scope_start.key and curr_uop.op not in {Ops.RANGE, Ops.IF} and \
+            not (curr_uop.src == () and scope_start.op == Ops.SINK):
+            if curr_uop.op is Ops.DEFINE_ACC:
+              scope.define_acc.append(curr_uop)
+            else:
+              scope.body.append(curr_uop)
       else:
-        # if it's a different context, we create a new block with this UOp
-        new_blocks.setdefault(block_ctx, []).append(u)
-    else:
-      # otherwise, we keep it in the srcs
-      new_srcs.append(u)
-  if len(to_append) == 0 and len(new_blocks) == 0: return None
+        stack.append((curr_uop, pare_uop, True))
+        if curr_uop.op not in {Ops.ASSIGN, Ops.STORE, Ops.RANGE, Ops.IF} or pare_uop is None:
+          for uop_src in curr_uop.src:
+            stack.append((uop_src, curr_uop, False))
+        elif curr_uop.op in {Ops.ASSIGN, Ops.STORE}:
+          for uop_src in scope_blocks[curr_uop].context:
+            stack.append((uop_src, curr_uop, False))
+    
+    for elem in scope.body:
+      assert elem.op not in {Ops.RANGE, Ops.IF}, "Colliding scopes"
+      if elem.op in {Ops.ASSIGN, Ops.STORE}:
+        scope.subgraph_nodes = set.union(scope.subgraph_nodes, scope_blocks[elem].subgraph_nodes)
 
-  for rng,lst in new_blocks.items():
-    srcs = flatten(y.src for y in lst)
-    if (old_block:=old_blocks.pop(rng, None)) is not None:
-      # NOTE: order shouldn't matter here
-      srcs.extend(old_block.src)
-      lst.extend(old_block.arg.lst)
-    new_block = UOp(Ops.BLOCK, dtypes.void, tuple(dedup(srcs)), BasicBlock(rng, tuple(lst)))
-    lrng = list(rng)
-    for r in rng[::-1]:
-      if r not in x.arg.ctx and r.op is not Ops.BLOCKSTART:
-        lrng.remove(r)
-        new_block = UOp(Ops.BLOCKEND, src=(new_block,),
-                        arg=BasicBlock(tuple(lrng), (UOp(Ops.ENDIF if r.op is Ops.IF else Ops.ENDRANGE, src=(r,)),), r))
-    new_srcs.append(new_block)
-  return UOp(Ops.BLOCK, dtypes.void, tuple(dedup(list(old_blocks.values())+new_srcs)), BasicBlock(x.arg.ctx, tuple(to_append)+x.arg.lst))
+    for elem in scope.subgraph_nodes:
+      for src in elem.src:
+        if src not in scope.subgraph_nodes:
+          scope.context.append(src)
+    
+    scope.context = dedup(scope.context)
 
-make_basic_blocks = PatternMatcher([
-  (UPat(Ops.SINK, name="x"),
-    lambda x: UOp(Ops.BLOCK, src=x.src+((UOp(Ops.NAME, arg=x.arg.name),) if x.arg is not None else ()), arg=BasicBlock((), (x,)))),
-  (UPat(Ops.BLOCK, name="x"), append_to_block),
-])
+    return scope
 
-def block_merge(ctx, x:UOp):
-  # ctx is children here
-  if x.op is Ops.BLOCKEND:
-    # if it's a BLOCKEND, see if we are done with placement. if all the children of the range are in here
-    in_this_block = set(x.arg.lst)
-    if len([y for y in ctx[x.arg.end] if y not in in_this_block]) == 0:
-      # find the parent block that has the BLOCKSTART in the ctx
-      parent_blocks = [y for y in x.src if y.op is Ops.BLOCK and UOp(Ops.BLOCKSTART, src=(x.arg.end,)) in y.arg.ctx]
-      assert len(parent_blocks) <= 1, "should never have two parent blocks"
-      if len(parent_blocks) == 1:
-        parent_block = parent_blocks[0]
-        # range needs DEFINE_ACC to be before the range (never in DEFINE_ACC for if)
-        early_ops, late_ops = partition(x.arg.lst, lambda y: y.op is Ops.DEFINE_ACC and x.arg.end in y.src)
-        return UOp(Ops.BLOCK, dtypes.void, tuple(y for y in x.src if y is not parent_block)+parent_block.src,
-                  BasicBlock(tuple(y for y in x.arg.ctx if y is not x.arg.end), tuple(early_ops)+parent_block.arg.lst+tuple(late_ops)))
+  scopes_list = [elem for elem in root_uop.toposort if elem.op in {Ops.ASSIGN, Ops.STORE}]
+  for scope_start in scopes_list:
+    scope = _make_scope(scope_start)
+    scope_blocks[scope_start] = scope
+    print(" ----- ")
+    for i in scope.start:
+      print(f"scope start {i.op}")
+    print(" -   - ")
+    for i in scope.body:
+      print(f"scope elem {i.op}")
+    print(" -   - ")
+    for i in scope.end:
+      print(f"scope end {i.op}")
+    print(" -   - ")
+    for i in scope.context:
+      print(f"scope context {i.op}")
+    print(" ----- ")
 
-  new_srcs: list[UOp] = []
-  to_append: list[UOp] = []
-  new_ctx = x.arg.ctx
-  placed = set()
-  for u in x.src:
-    if u.op is Ops.BLOCK and (tuple(u.arg.ctx) == tuple(x.arg.ctx) or (x.arg.end is not None and x.arg.end in u.arg.ctx)):
-      # NOTE: this can't appear in srcs twice or it would be a BLOCKFORK
-      new_ctx += tuple(y for y in u.arg.ctx if y not in x.arg.ctx)
-      new_srcs.extend(u.src)
-      to_append.extend(u.arg.lst)
-    elif u.op is Ops.BLOCKFORK and x.src.count(u) == u.arg: # block fork appears # of times in srcs
-      if u not in placed:
-        new_srcs.extend(u.src)
-        placed.add(u)
-    else:
-      # keep it in srcs
-      new_srcs.append(u)
-  if len(to_append) == 0 and len(placed) == 0: return None
-  return UOp(x.op, dtypes.void, tuple(new_srcs), BasicBlock(tuple(sorted(new_ctx, key=lambda x: x.tuplize)), tuple(to_append)+x.arg.lst, x.arg.end))
+  scope = _make_scope(root_uop)
+  print(" --- global --- ")
+  for i in scope.start:
+    print(f"scope start {i.op}")
+  print(" -   - ")
+  for i in scope.body:
+    print(f"scope elem {i.op}")
+  print(" -   - ")
+  for i in scope.end:
+    print(f"scope end {i.op}")
+  print(" -   - ")
+  for i in scope.context:
+    print(f"scope context {i.op}")
+  print(" --- global --- ")
 
-pm_block_merge = PatternMatcher([(UPat((Ops.BLOCKEND, Ops.BLOCK), name="x"), block_merge),])
-
-def block_finalize(block:UOp):
-  if len(block.src) == 0: return None
-  _uops = sorted(dedup(block.src), key=lambda x: x.tuplize)
-  assert all(len(x.src) == 0 and x.op not in {Ops.BLOCK, Ops.BLOCKSTART, Ops.BLOCKEND, Ops.BLOCKFORK} for x in _uops)
-  _uops += block.arg.lst
-  # strip the SINK
-  assert _uops[-1].op is Ops.SINK, "doesn't end with SINK"
-  return UOp(Ops.BLOCK, arg=BasicBlock((), tuple(_uops[:-1])))
-
-pm_block_finalize = PatternMatcher([(UPat(Ops.BLOCK, name="block"), block_finalize)])
-
-# NOTE: any toposort should be valid here, unlike last time this isn't required, it's just for speed
-def block_reorder(in_block:UOp):
-  in_this_block = set(in_block.arg.lst)
-  local_children: collections.defaultdict[UOp, list[UOp]] = collections.defaultdict(list)
-  in_degree: collections.defaultdict[UOp, int] = collections.defaultdict(int)
-  priorities:dict[UOp, int] = {}
-
-  # get local children and assign priorities
-  for u in reversed(in_block.arg.lst):
-    for s in u.src:
-      if s in in_this_block:
-        local_children[s].append(u)
-        in_degree[u] += 1
-    # put loads in the beginning of the block and prevent priority inversion
-    priorities[u] = min([-1000 if u.op is Ops.LOAD else 0] + [priorities[x] for x in local_children[u]])
-
-  # placement queue
-  queue:list[tuple[int, tuple, UOp]] = []
-  def push(u:UOp): heapq.heappush(queue, (priorities[u], u.tuplize, u))
-
-  # place the first ones that don't have deps
-  for u in in_block.arg.lst:
-    if u not in in_degree: push(u)
-
-  newlst = []
-  while queue:
-    _,_,x = heapq.heappop(queue)
-    newlst.append(x)
-    for u in local_children[x]:
-      in_degree[u] -= 1
-      if in_degree[u] == 0: push(u)
-
-  assert len(newlst) == len(in_block.arg.lst), f"len mismatch {len(newlst)} != {len(in_block.arg.lst)}"
-  return in_block.replace(arg=BasicBlock(in_block.arg.ctx, tuple(newlst)))
-
-def linearize_uop(sink:UOp, skip_check:bool=not __debug__) -> list[UOp]:
-  assert sink.op is Ops.SINK, f"sink isn't sink, it's {sink.op}"
-
-  # get children and all block contexts
-  temp_block_ctxs: dict[UOp, list[UOp]] = {}
-  children: dict[UOp, list[UOp]] = {}
-  for u in sink.toposort:
-    this_block_ctx: list[UOp] = []
-    for s in u.src:
-      # save children
-      children.setdefault(s, []).append(u)
-      # compute block ctx
-      if s.op in {Ops.RANGE, Ops.IF}: this_block_ctx.append(s)
-      # don't flow (fully) through assign and store
-      elif s.op is Ops.STORE:
-        # ugh, deal with non-reduce locals. probably wrong
-        if isinstance(s.src[0].dtype, PtrDType) and s.src[0].dtype.local:
-          idx_context, store_context = temp_block_ctxs[s.src[0]], temp_block_ctxs[s]
-          this_block_ctx += [x for x in store_context if x not in idx_context and x.op is Ops.RANGE]
-      elif s.op is Ops.ASSIGN:
-        # flow though assign, but remove the ranges used in the assign
-        assert s.src[0].op is Ops.DEFINE_ACC
-        this_block_ctx += [x for x in temp_block_ctxs[s.src[1]] if x not in s.src[0].src[1:]]
-      else:
-        # flow though everything else
-        this_block_ctx += temp_block_ctxs[s]
-    temp_block_ctxs[u] = sorted(dedup(this_block_ctx), key=lambda x: x.tuplize)
-
-  # make final block_ctxs, add BLOCKSTART to block_ctxs for IF and RANGE
-  block_ctxs: dict[UOp, tuple[UOp, ...]] = {}
-  for u in sink.toposort:
-    block_ctxs[u] = ((UOp(Ops.BLOCKSTART, src=(u,)),) + tuple(temp_block_ctxs[u])) if u.op in {Ops.IF, Ops.RANGE} else tuple(temp_block_ctxs[u])
-
-  # TODO: there's probably a clever way to remove this while loop
-  while 1:
-    sink = graph_rewrite(sink, make_basic_blocks, ctx=(block_ctxs, children))
-
-    # add BLOCKFORK (slow!)
-    block_parent_count = collections.Counter(flatten([x.src for x in sink.toposort if x.op is Ops.BLOCK]))
-    non_block_parents = set(flatten([x.src for x in sink.toposort if x.op is not Ops.BLOCK]))
-    forks = {u:UOp(Ops.BLOCKFORK, src=(UOp(Ops.BLOCK, src=u.src, arg=BasicBlock(block_ctxs[u], (u,))),), arg=child_count)
-      for u,child_count in block_parent_count.items() if u.op not in DONT_PLACE_IN_BLOCK and child_count > 1 and u not in non_block_parents}
-
-    if not len(forks): break
-    sink = sink.substitute(forks)
-
-  # combine matching BLOCKENDS
-  blockends_to_arg: dict[UOp, list[UOp]] = {}
-  for be in sink.toposort:
-    if be.op is Ops.BLOCKEND: blockends_to_arg.setdefault(be.arg.end, []).append(be)
-  new_forks = {}
-  for k,v in blockends_to_arg.items():
-    # NOTE: if any BLOCKEND is the parent of any other with the same arg, this algo fails
-    if len(v) > 1:
-      out = UOp(Ops.BLOCKFORK, src=(UOp(Ops.BLOCKEND, src=tuple(flatten(x.src for x in v)),
-                                        arg=BasicBlock(tuple(dedup(flatten([y.arg.ctx for y in v]))), v[0].arg.lst, k)),), arg=len(v))
-      for u in v: new_forks[u] = out
-  sink = sink.substitute(new_forks)
-
-  # reorder ops in block for speed
-  sink = sink.substitute({u:newu for u in sink.toposort if u.op is Ops.BLOCK and (newu:=block_reorder(u)) is not u})
-
-  # final rewrite to merge all blocks into one
-  sink = graph_rewrite(sink, pm_block_merge, ctx=children)
-
-  # there should just be one block left, with a few parents with 0 srcs (now done in a rewriter)
-  sink = graph_rewrite(sink, pm_block_finalize)
-
-  # sanity checks (NOTE: these can cause things to be skipped in BEAM)
-  if not skip_check: type_verify(sink.arg.lst)
-
-  # return the list. TODO: refactor to return the UOp
-  return list(sink.arg.lst)
+  print(" --- final --- ")
+  for i in scope.linear:
+    print(f"scope linear --> {i.op}")
+  print(" --- final --- ")
+  return scope.linear[:-1]

--- a/tinygrad/codegen/linearize.py
+++ b/tinygrad/codegen/linearize.py
@@ -1,28 +1,26 @@
 from __future__ import annotations
-import collections, heapq, functools
-from dataclasses import dataclass
+import functools
 from tinygrad.ops import UOp, Ops, PatternMatcher, UPat, graph_rewrite, GroupOp
-from tinygrad.spec import type_verify
-from tinygrad.dtype import dtypes, PtrDType
-from tinygrad.helpers import dedup, flatten, partition
+from tinygrad.helpers import dedup
 
 DONT_PLACE_IN_BLOCK = {Ops.NAME, Ops.DEFINE_GLOBAL, Ops.DEFINE_LOCAL, Ops.DEFINE_VAR, Ops.SPECIAL, Ops.CONST, *GroupOp.Block}
 
+
 # root_uop -> sink
-def linearize_uop(root_uop:UOp, skip_check:bool=not __debug__) -> list[UOp]:
-  scope_blocks = {}
+def linearize_uop(root_uop: UOp, skip_check: bool = not __debug__) -> list[UOp]:
+  scope_blocks: dict[UOp, LinearizeScope] = {}
 
   class LinearizeScope:
     def __init__(self):
-      self.define_acc = []
-      self.start = []
-      self.end = []
-      self.context = []
-      self.body = []
-      self.subgraph_nodes = set()
-    
-    def fuse(self, other):
-      scope = LinearizeScope()
+      self.define_acc: list[UOp] = []
+      self.start: list[UOp] = []
+      self.end: list[UOp] = []
+      self.context: list[UOp] = []
+      self.body: list[UOp] = []
+      self.subgraph_nodes: set[UOp] = set()
+
+    def fuse(self, other: LinearizeScope) -> LinearizeScope:
+      scope: LinearizeScope = LinearizeScope()
       scope.define_acc = dedup(self.define_acc + other.define_acc)
       scope.start = dedup(self.start + other.start)
       scope.end = dedup(self.end + other.end)
@@ -34,37 +32,39 @@ def linearize_uop(root_uop:UOp, skip_check:bool=not __debug__) -> list[UOp]:
           if src not in scope.subgraph_nodes:
             scope.context.append(src)
 
-      body_set = set(scope.body)
-      for i in scope.start + scope.end:
-        assert i not in body_set, "Broken skopes"
+      if not skip_check:
+        body_set: set[UOp] = set(scope.body)
+        for i in scope.start + scope.end:
+          assert i not in body_set, "Broken skopes"
 
       return scope
 
     @functools.cached_property
     def linear(self):
-      linear = []
+      linear: list[UOp] = []
 
       for elem in self.define_acc:
         linear.append(elem)
 
       for elem in self.end:
         linear.append(elem)
-      
-      curr_context = set(self.context + self.define_acc + self.end)
-      simple_set = set([elem for elem in self.body if elem.op not in {Ops.ASSIGN, Ops.STORE}])
-      scope_set = set([elem for elem in self.body if elem.op in {Ops.ASSIGN, Ops.STORE}])
-      fusion_set = set()
-      poped = True
+
+      curr_context: set[UOp] = set(self.context + self.define_acc + self.end)
+      simple_set: set[UOp] = set([elem for elem in self.body if elem.op not in {Ops.ASSIGN, Ops.STORE}])
+      scope_set: set[UOp] = set([elem for elem in self.body if elem.op in {Ops.ASSIGN, Ops.STORE}])
+      fusion_set: set[UOp] = set()
+      poped: bool = True
+
       while True:
         poped = False
-        pop_list = []
+        pop_list: list[UOp] = []
         for elem in simple_set:
-          ready = True
+          ready: bool = True
           for cont in elem.src:
             if cont not in curr_context:
               ready = False
               break
-          
+
           if ready:
             pop_list.append(elem)
             curr_context.add(elem)
@@ -76,13 +76,13 @@ def linearize_uop(root_uop:UOp, skip_check:bool=not __debug__) -> list[UOp]:
 
         for elem in pop_list:
           simple_set.remove(elem)
-        
+
         if poped:
           continue
 
         for elem in scope_set:
-          elem_scope = scope_blocks[elem]
-          ready = True
+          elem_scope: LinearizeScope = scope_blocks[elem]
+          ready: bool = True
           for cont in elem_scope.context:
             if cont not in curr_context:
               ready = False
@@ -90,22 +90,22 @@ def linearize_uop(root_uop:UOp, skip_check:bool=not __debug__) -> list[UOp]:
 
           if ready:
             fusion_set.add(elem)
-        
+
         for elem in fusion_set:
           scope_set.discard(elem)
-        
+
         if not fusion_set:
           assert not simple_set and not scope_set, "Linearization Failed"
           break
 
-        fusion_elem = fusion_set.pop()
-        fusion_elem = scope_blocks[fusion_elem]
+        fusion_elem: UOp = fusion_set.pop()
+        fusion_elem: LinearizeScope = scope_blocks[fusion_elem]
         for cont_elem in fusion_elem.subgraph_nodes:
           curr_context.add(cont_elem)
-        pop_list = []
+        pop_list: list[UOp] = []
         for elem in fusion_set:
-          scope_elem = scope_blocks[elem]
-          fusable = True
+          scope_elem: LinearizeScope = scope_blocks[elem]
+          fusable: bool = True
           for i in scope_elem.end:
             if i not in fusion_elem.end:
               fusable = False
@@ -113,7 +113,7 @@ def linearize_uop(root_uop:UOp, skip_check:bool=not __debug__) -> list[UOp]:
           for i in fusion_elem.end:
             if i not in scope_elem.end:
               fusable = False
-          
+
           if not fusable:
             continue
 
@@ -122,10 +122,10 @@ def linearize_uop(root_uop:UOp, skip_check:bool=not __debug__) -> list[UOp]:
             curr_context.add(cont_elem)
 
           pop_list.append(elem)
-        
+
         for elem in pop_list:
           fusion_set.remove(elem)
-        
+
         linear = linear + fusion_elem.linear
 
         for e in fusion_elem.subgraph_nodes:
@@ -143,38 +143,37 @@ def linearize_uop(root_uop:UOp, skip_check:bool=not __debug__) -> list[UOp]:
           for s in o.src:
             assert o.op is Ops.DEFINE_ACC or s in linear[:i]
 
-      linear = sorted([elem for elem in root_uop.toposort if elem.op is Ops.DEFINE_GLOBAL], key=lambda x: x.arg) + [elem for elem in linear if elem.op is not Ops.DEFINE_GLOBAL]
+      linear = sorted([elem for elem in root_uop.toposort if elem.op is Ops.DEFINE_GLOBAL], key=lambda x: x.arg) + [
+        elem for elem in linear if elem.op is not Ops.DEFINE_GLOBAL
+      ]
       if self.start[0].op is Ops.SINK:
         assert root_uop.arg is not None
         linear = [UOp(Ops.NAME, arg=root_uop.arg.name)] + linear
 
       return linear
 
-  def _make_scope(scope_start:UOp):
-    scope = LinearizeScope()
+  def _make_scope(scope_start: UOp):
+    scope: LinearizeScope = LinearizeScope()
     scope.start.append(scope_start)
-    stack = [(scope_start, None, False)]
+    stack: list[tuple[UOp, UOp | None, bool]] = [(scope_start, None, False)]
     scope.subgraph_nodes.add(scope_start)
-    visited = set()
+    visited: set[UOp] = set()
     while stack:
       curr_uop, pare_uop, bubbling = stack.pop()
       if curr_uop in visited:
         if curr_uop in scope.subgraph_nodes and pare_uop is not None:
           scope.subgraph_nodes.add(pare_uop)
         continue
-      elif bubbling:
-        visited.add(curr_uop)
 
       if bubbling:
-        if curr_uop.op in {Ops.RANGE, Ops.IF} and scope_start.op in {Ops.ASSIGN, Ops.STORE} or \
-           curr_uop.src == () and scope_start.op == Ops.SINK:
+        visited.add(curr_uop)
+        if curr_uop.op in {Ops.RANGE, Ops.IF} and scope_start.op in {Ops.ASSIGN, Ops.STORE} or curr_uop.src == () and scope_start.op == Ops.SINK:
           scope.end.append(curr_uop)
           scope.subgraph_nodes.add(curr_uop)
 
         if curr_uop in scope.subgraph_nodes and pare_uop is not None:
           scope.subgraph_nodes.add(pare_uop)
-          if curr_uop.key != scope_start.key and curr_uop.op not in {Ops.RANGE, Ops.IF} and \
-            not (curr_uop.src == () and scope_start.op == Ops.SINK):
+          if curr_uop.key != scope_start.key and curr_uop.op not in {Ops.RANGE, Ops.IF} and not (curr_uop.src == () and scope_start.op == Ops.SINK):
             if curr_uop.op is Ops.DEFINE_ACC:
               scope.define_acc.append(curr_uop)
             else:
@@ -187,7 +186,7 @@ def linearize_uop(root_uop:UOp, skip_check:bool=not __debug__) -> list[UOp]:
         elif curr_uop.op in {Ops.ASSIGN, Ops.STORE}:
           for uop_src in scope_blocks[curr_uop].context:
             stack.append((uop_src, curr_uop, False))
-    
+
     for elem in scope.body:
       assert elem.op not in {Ops.RANGE, Ops.IF}, "Colliding scopes"
       if elem.op in {Ops.ASSIGN, Ops.STORE}:
@@ -197,46 +196,15 @@ def linearize_uop(root_uop:UOp, skip_check:bool=not __debug__) -> list[UOp]:
       for src in elem.src:
         if src not in scope.subgraph_nodes:
           scope.context.append(src)
-    
+
     scope.context = dedup(scope.context)
 
     return scope
 
-  scopes_list = [elem for elem in root_uop.toposort if elem.op in {Ops.ASSIGN, Ops.STORE}]
+  scopes_list: list[UOp] = [elem for elem in root_uop.toposort if elem.op in {Ops.ASSIGN, Ops.STORE}]
   for scope_start in scopes_list:
-    scope = _make_scope(scope_start)
+    scope: LinearizeScope = _make_scope(scope_start)
     scope_blocks[scope_start] = scope
-    print(" ----- ")
-    for i in scope.start:
-      print(f"scope start {i.op}")
-    print(" -   - ")
-    for i in scope.body:
-      print(f"scope elem {i.op}")
-    print(" -   - ")
-    for i in scope.end:
-      print(f"scope end {i.op}")
-    print(" -   - ")
-    for i in scope.context:
-      print(f"scope context {i.op}")
-    print(" ----- ")
 
-  scope = _make_scope(root_uop)
-  print(" --- global --- ")
-  for i in scope.start:
-    print(f"scope start {i.op}")
-  print(" -   - ")
-  for i in scope.body:
-    print(f"scope elem {i.op}")
-  print(" -   - ")
-  for i in scope.end:
-    print(f"scope end {i.op}")
-  print(" -   - ")
-  for i in scope.context:
-    print(f"scope context {i.op}")
-  print(" --- global --- ")
-
-  print(" --- final --- ")
-  for i in scope.linear:
-    print(f"scope linear --> {i.op}")
-  print(" --- final --- ")
+  scope: LinearizeScope = _make_scope(root_uop)
   return scope.linear[:-1]


### PR DESCRIPTION
WIP: Global rewrite of SINK.

This attempts to split the compute graph on multiple scopes before the linearization process starts. I am not sure if this is possible with local changes to the graph, because this scopes can be overlapping for this implementation.

For example the case for TestOps.test_avg_pool3d_failure:

ASSIGN1  -- depends -- > RANGE1, RANGE2
ASSIGN2  -- depends -- > RANGE1
ASSIGN3  -- depends -- > RANGE2

We can try to make with by shoving everything in a nested loop:
```
Loop RANGE1 {
  Loop RANGE2 {
    ASSIGN1
    ASSIGN2
    ASSIGN3
  }
}
```

or we can have multiple loops with duplicate operations for RANGE, LOAD ... :
```
Loop RANGE1 {
  Loop RANGE2 {
    ASSIGN1
  }
}
Loop RANGE1 {
  ASSIGN2
}
Loop RANGE2 {
  ASSIGN3
}
```

The current implementation tries to do the first variant and fails because can't shove a ASSIGN2 and ASSIGN3 because one must be in the nested loop.

This scratch implementation tries to do the second approach.

Opinion?