### PR TITLE
Do not "oob"-write zero to regCOMPUTE_THREAD_TRACE_ENABLE every exec

### DIFF
--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -100,7 +100,7 @@ class AMDComputeQueue(HWQueue):
     if prg.dev.has_scratch_base_registers:
       self.pkt3(amd_gpu.PACKET3_SET_SH_REG, gfxreg(amd_gpu.regCOMPUTE_DISPATCH_SCRATCH_BASE_LO), *data64_le(prg.dev.scratch.va_addr >> 8))
     if prg.dev.target < 110000: self.pkt3(amd_gpu.PACKET3_SET_SH_REG, gfxreg(amd_gpu.mmCP_COHER_START_DELAY), 0x20)
-    self.pkt3(amd_gpu.PACKET3_SET_SH_REG, gfxreg(amd_gpu.regCOMPUTE_RESTART_X), 0, 0, 0, 0)
+    self.pkt3(amd_gpu.PACKET3_SET_SH_REG, gfxreg(amd_gpu.regCOMPUTE_RESTART_X), 0, 0, 0)
     self.pkt3(amd_gpu.PACKET3_SET_SH_REG, gfxreg(amd_gpu.regCOMPUTE_STATIC_THREAD_MGMT_SE0), 0xFFFFFFFF, 0xFFFFFFFF)
     self.pkt3(amd_gpu.PACKET3_SET_SH_REG, gfxreg(amd_gpu.regCOMPUTE_STATIC_THREAD_MGMT_SE2), 0xFFFFFFFF, 0xFFFFFFFF)
     self.pkt3(amd_gpu.PACKET3_SET_SH_REG, gfxreg(amd_gpu.regCOMPUTE_STATIC_THREAD_MGMT_SE4), 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF)


### PR DESCRIPTION
```python
self.pkt3(amd_gpu.PACKET3_SET_SH_REG, gfxreg(amd_gpu.regCOMPUTE_RESTART_X), 0, 0, 0, 0)
```

Will write zero to regCOMPUTE_RESTART_{X,Y,Z} and regCOMPUTE_THREAD_TRACE_ENABLE because of:

```python
regCOMPUTE_RESTART_X = 0x1bbb
regCOMPUTE_RESTART_Y = 0x1bbc
regCOMPUTE_RESTART_Z = 0x1bbd
regCOMPUTE_THREAD_TRACE_ENABLE = 0x1bbe
```

There is also a similar "oob"-write to regCOMPUTE_PIPELINESTAT_ENABLE and regCOMPUTE_PERFCOUNT_ENABLE in:

```python
self.pkt3(amd_gpu.PACKET3_SET_SH_REG, gfxreg(amd_gpu.regCOMPUTE_START_X), 0, 0, 0, *local_size, 0, 0)
```

But it doesn't seem to be strictly required for SQTT, so i left it alone