### PR TITLE
Failing test for not realizing intermediate expand in multi-GPU

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -782,6 +782,15 @@ class TestMultiTensor(unittest.TestCase):
     run_schedule(sched)
     self.assertListEqual(b.tolist(), [0, 0, 0])
 
+  @unittest.expectedFailure
+  def test_dont_realize_intermediate_expand(self):
+    a = Tensor.empty(16, 1).shard_(devices_2, axis=0)
+    b = Tensor.empty(16, 16).to_(devices_2)
+    c = Tensor.empty(16, 16).shard_(devices_2, axis=1)
+    d = a+b
+    (d*c).realize()
+    assert not d.lazydata.is_realized
+
 @unittest.skipIf(CI and Device.DEFAULT in ("GPU", "CUDA", "METAL"), "no GPU CI")
 class TestHandleData(unittest.TestCase):
   def test_copied_to_device(self):


### PR DESCRIPTION
In multi, when the result of an operation is needed on another device, we copy it on the destination device after the operation. this is fine for most cases, and is handled well in scheduling. 

However, in case of a binary op that expands its inputs, 
There's no rule in scheduler that moves copy before binary op. 

and really it doesn't make sense as a rule in scheduler. I think it should be a rule in get_multi_map. because there we expect this type of copy between devices, and moving copies to the beginning (after buffer) makes sense (it's basically all_gather).

I visualize what I mean,
Executing this code
```python
a = Tensor.empty(16, 1).shard_(devices_2, axis=0)
b = Tensor.empty(16, 16).to_(devices_2)
c = Tensor.empty(16, 16).shard_(devices_2, axis=1)
d = a+b
(d*c).realize()
```
This is the result of current get_multi_map:
![image](https://github.com/user-attachments/assets/748bd73c-fb20-43d6-b62e-9cce797940d1)

And after scheduling, copies are still after adds and adds get realized (hence failing test)

===================================================================

What I think should happen (after get_multi_map):
![image](https://github.com/user-attachments/assets/13e7c868-9693-4b0a-8f75-e53b5443f9bc)

Then after scheduling, graph will look like this and we don't realize expand:
![image](https://github.com/user-attachments/assets/ce074622-7e39-40d6-a9cc-2b94c701d23f)