### PR TITLE
fix TORCH_DEBUG=1 sigsegv

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -388,11 +388,11 @@ for k,v in tiny_backend.items(): torch.library.impl(k.replace("aten.", "aten::")
 if TORCH_DEBUG:
   from torch.utils._python_dispatch import TorchDispatchMode
   class DispatchLog(TorchDispatchMode):
-    def __torch_dispatch__(self, func, types, args, kwargs=None):
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
       #print(f"Dispatch Log: {func}(*{args}, **{kwargs})")
       print(f"Dispatch Log: {func}")
       return func(*args, **(kwargs or {}))
-  DispatchLog().__enter__()
+  (_dispatch_log:=DispatchLog()).__enter__() # NOTE: must be kept alive
 
 # NOTE: patch torch optimizer step to avoid continously growing the computation graph
 def realize_optimizer_step(optimizer: torch.optim.Optimizer, *args, **kwargs):

--- a/extra/torch_backend/test.py
+++ b/extra/torch_backend/test.py
@@ -75,7 +75,7 @@ class TestTorchBackend(unittest.TestCase):
     a = torch.ones(4, device=device)
     b = torch.ones(4, device=device)
     c = a == b
-    print(c.cpu().numpy())
+    print(c.cpu())
 
   def test_maxpool2d_backward(self):
     x = torch.arange(3*3, device=device).reshape(1, 1, 3, 3).requires_grad_(True)
@@ -86,10 +86,10 @@ class TestTorchBackend(unittest.TestCase):
     x = torch.zeros(4, device=device, dtype=torch.int64)
     y = torch.ones(4, device=device, dtype=torch.float32).to(dtype=torch.int64)
     res1 = x ^ y # an operation that only works on int types
-    print(res1.cpu().numpy())
+    print(res1.cpu())
     y = y.cpu().float().to(device=device, dtype=torch.int64)
     res2 = x ^ y
-    print(res2.cpu().numpy())
+    print(res2.cpu())
 
   @unittest.skip("meh")
   def test_str(self):


### PR DESCRIPTION
Should keep context classes alive for manual __enter__.
Issue appeared when calling str() on a cpu tensor after backend is imported. Torch tensor str() interacts with list of TorchDispatchMode objects and hence segfault on bad ref.