### PR TITLE
Add `topk` and `sort` Tensor operations

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -45,14 +45,9 @@ def index_tensor(x, y):
 def randperm_generator(n, generator=None, out=None): out.copy_(torch.randperm(n, generator=generator, device="cpu").tiny())
 
 # *** end bad functions on CPU ***
-
 @torch.library.impl("aten::sort", "privateuseone")
 def sort(x, dim=-1, descending=False, *, stable=False):
-
-    # Fix potential integer-to-boolean issue
     descending = bool(int(descending))
-
-
     tt = unwrap(x)
     values, indices = tt.sort(dim, descending)
     return wrap(values), wrap(indices)

--- a/extra/torch_backend/test.py
+++ b/extra/torch_backend/test.py
@@ -123,9 +123,6 @@ class TestTorchBackend(unittest.TestCase):
 
     np.testing.assert_allclose(values.cpu().numpy(), expected_values, rtol=1e-5)
 
-def debug_sort(*args, **kwargs):
-    print(f"Intercepted torch.sort() - args: {args}, kwargs: {kwargs}")
-    return torch.sort(*args, **kwargs)
 
 if __name__ == "__main__":
   unittest.main()

--- a/extra/torch_backend/test.py
+++ b/extra/torch_backend/test.py
@@ -98,14 +98,14 @@ class TestTorchBackend(unittest.TestCase):
     torch.manual_seed(0)
 
     # Generate random tensor
-    x = torch.randn(3, 3, device=device)
+    x = torch.randn(4, 4, device=device)
     k = 2
 
     # Compute top-k in PyTorch with our backend
     values, indices = torch.topk(x, k, dim=-1, largest=True, sorted=True)
 
     # Expected results computed using NumPy
-    expected_values = np.sort(x.cpu().numpy(), axis=-1)[:, -k:][:, ::-1]  # Take last k and reverse
+    expected_values = np.sort(x.cpu().numpy(), axis=-1)[:, -k:][:, ::-1]
 
     np.testing.assert_allclose(values.cpu().numpy(), expected_values, rtol=1e-5)
 
@@ -113,7 +113,7 @@ class TestTorchBackend(unittest.TestCase):
     torch.manual_seed(1)
 
     # Generate random tensor
-    x = torch.randn(3, 10, device=device)
+    x = torch.randn(4, 4, device=device)
 
     # Compute sort in PyTorch with our backend
     values, indices = torch.sort(x, dim=-1, descending=False)

--- a/extra/torch_backend/test.py
+++ b/extra/torch_backend/test.py
@@ -94,5 +94,38 @@ class TestTorchBackend(unittest.TestCase):
     result = a // b
     np.testing.assert_equal(result.cpu().numpy(), [3., 3., 2.])
 
+  def test_topk(self):
+    torch.manual_seed(0)
+
+    # Generate random tensor
+    x = torch.randn(3, 3, device=device)
+    k = 2
+
+    # Compute top-k in PyTorch with our backend
+    values, indices = torch.topk(x, k, dim=-1, largest=True, sorted=True)
+
+    # Expected results computed using NumPy
+    expected_values = np.sort(x.cpu().numpy(), axis=-1)[:, -k:][:, ::-1]  # Take last k and reverse
+
+    np.testing.assert_allclose(values.cpu().numpy(), expected_values, rtol=1e-5)
+
+  def test_sort(self):
+    torch.manual_seed(1)
+
+    # Generate random tensor
+    x = torch.randn(3, 10, device=device)
+
+    # Compute sort in PyTorch with our backend
+    values, indices = torch.sort(x, dim=-1, descending=False)
+
+    # Expected results computed using NumPy
+    expected_values = np.sort(x.cpu().numpy(), axis=-1) # Take last k and reverse
+
+    np.testing.assert_allclose(values.cpu().numpy(), expected_values, rtol=1e-5)
+
+def debug_sort(*args, **kwargs):
+    print(f"Intercepted torch.sort() - args: {args}, kwargs: {kwargs}")
+    return torch.sort(*args, **kwargs)
+
 if __name__ == "__main__":
   unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3428,6 +3428,7 @@ class Tensor(SimpleMathTrait):
   def argsort(self, dim=-1, descending=False):
     """
     Computes the indices that would sort the tensor along a specified dim.
+    TODO: make this use a better sorting algorithm
 
     Args:
         self (Tensor): The input tensor.


### PR DESCRIPTION
Adds `Tensor.topk()`, `Tensor.argsort()` and `Tensor.sort()`.
Plumbs `extra/torch_backend/` to use these instead of the CPU fallback
Add tests in `extra/torch_backend/test.py`
Does not plumb in Argsort to Torch (yet) since Torch seems to not like it.