### PR TITLE
hotfix: load >2 GiB from disk on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -664,6 +664,9 @@ jobs:
         run: python3 -m pytest -n=auto test/ --ignore=test/models --ignore=test/unit --durations=20
       - name: Run process replay tests
         uses: ./.github/actions/process-replay
+      - name: Run macOS-specific unit test
+        if: matrix.backend == 'cpu'
+        run: python3 -m pytest test/unit/test_disk_tensor.py::TestDiskTensor::test_copy_to_cpu_not_truncated
 
 # ****** Windows Tests ******
 

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -343,6 +343,11 @@ class TestDiskTensor(unittest.TestCase):
       on_dev = t.to(Device.DEFAULT).realize()
       np.testing.assert_equal(on_dev.numpy(), t.numpy())
 
+  @unittest.skipUnless(OSX, "seems to only be an issue on macOS with file size >2 GiB")
+  def test_copy_to_cpu_not_truncated(self):
+    with open((fn:=temp("dt_copy_to_cpu_not_truncated")), "wb") as f: f.write(b'\x01' * (size := int(2 * 1024**3)) + (test := b"test"))
+    x = Tensor.empty(size + len(test), dtype=dtypes.uint8, device=f"disk:{fn}").to("CPU").realize()
+    assert x[size:].data().tobytes() == test
 
 class TestPathTensor(unittest.TestCase):
   def setUp(self):

--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -84,7 +84,8 @@ class DiskAllocator(Allocator):
       # OSX doesn't seem great at mmap, this is faster
       with io.FileIO(self.dev.fd, "a+b", closefd=False) as fo:
         fo.seek(src.offset)
-        fo.readinto(dest)
+        bytes_read = 0
+        while (n := fo.readinto(dest[bytes_read:])) is not None and n > 0: bytes_read += n
     else:
       dest[:] = src._buf()
 

--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -84,9 +84,7 @@ class DiskAllocator(Allocator):
       # OSX doesn't seem great at mmap, this is faster
       with io.FileIO(self.dev.fd, "a+b", closefd=False) as fo:
         fo.seek(src.offset)
-        bytes_read = 0
-        while (n := fo.readinto(dest[bytes_read:])) is not None and n > 0:
-          bytes_read += n
+        fo.readinto(dest)
     else:
       dest[:] = src._buf()
 

--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -84,7 +84,9 @@ class DiskAllocator(Allocator):
       # OSX doesn't seem great at mmap, this is faster
       with io.FileIO(self.dev.fd, "a+b", closefd=False) as fo:
         fo.seek(src.offset)
-        fo.readinto(dest)
+        bytes_read = 0
+        while (n := fo.readinto(dest[bytes_read:])) > 0:
+          bytes_read += n
     else:
       dest[:] = src._buf()
 

--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -85,7 +85,7 @@ class DiskAllocator(Allocator):
       with io.FileIO(self.dev.fd, "a+b", closefd=False) as fo:
         fo.seek(src.offset)
         bytes_read = 0
-        while (n := fo.readinto(dest[bytes_read:])) > 0:
+        while (n := fo.readinto(dest[bytes_read:])) is not None and n > 0:
           bytes_read += n
     else:
       dest[:] = src._buf()


### PR DESCRIPTION
This PR fixes a bug where on macOS, with disk buffers > 2 GiB, not all data was copied, when copying from disk device to CPU device.

Reproducer: (second assertion fails on macOS before this diff):

```
import os
from tinygrad import Tensor, dtypes, Device
from tinygrad.helpers import fetch
model_path = str(fetch("https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-f16.gguf", "Llama-3.2-1B-Instruct-f16.gguf", subdir="llama3-1b-instruct"))
Device.DEFAULT="CPU"
start = 2425053024

x = Tensor.empty(os.stat(model_path).st_size, dtype=dtypes.uint8, device=f"disk:{model_path}")
assert not all(i==0 for i in x[start:].tolist())

y = Tensor.empty(os.stat(model_path).st_size, dtype=dtypes.uint8, device=f"disk:{model_path}").to(Device.DEFAULT)
assert not all(i==0 for i in y[start:].tolist())
```

I think this bug is what was causing the issue geohot reported in [tinychat in browser, Part 3: browser app #9276](https://github.com/tinygrad/tinygrad/pull/9276), which I was able to reproduce (with WASM, on an intel macbook), and which is resolved for me with this diff.