### PR TITLE
torch: support in-place operations on views

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,8 +175,8 @@ jobs:
       run: PYTHONPATH=. DEBUG=2 python3 extra/torch_backend/torch_tests.py TestTinyBackendPRIVATEUSE1.test_unary_log_tiny_float32
     - name: Test Ops with TINY_BACKEND (expect failure)
       run: PYTHONPATH=. LLVM=1 LLVMOPT=0 TINY_BACKEND=1 python3 -m pytest -n auto test/test_ops.py --durations=20 || true
-    - name: Test in-place operations on views (expect failure)
-      run: PYTHONPATH=. TORCH_DEBUG=1 python3 extra/torch_backend/test_inplace.py || true
+    - name: Test in-place operations on views
+      run: PYTHONPATH=. TORCH_DEBUG=1 python3 extra/torch_backend/test_inplace.py
 
   torchbackendmore:
     name: Torch Backend Tests More

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,6 +175,8 @@ jobs:
       run: PYTHONPATH=. DEBUG=2 python3 extra/torch_backend/torch_tests.py TestTinyBackendPRIVATEUSE1.test_unary_log_tiny_float32
     - name: Test Ops with TINY_BACKEND (expect failure)
       run: PYTHONPATH=. LLVM=1 LLVMOPT=0 TINY_BACKEND=1 python3 -m pytest -n auto test/test_ops.py --durations=20 || true
+    - name: Test in-place operations on views (expect failure)
+      run: PYTHONPATH=. TORCH_DEBUG=1 python3 extra/torch_backend/test_inplace.py || true
 
   torchbackendmore:
     name: Torch Backend Tests More

--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -177,8 +177,10 @@ def convolution_backward_overrideable(grad_out, input, weight, stride, padding, 
   return tuple([wrap(grads.pop(0)) if m else None for m in output_mask])
 
 def upsample(self, size, align_corners=False, mode=None): return wrap(Tensor.interpolate(unwrap(self), size, mode=mode, align_corners=align_corners))
-for i in ["upsample_linear1d", "upsample_bilinear2d", "upsample_trilinear3d"]:
-  torch.library.impl(f"aten::{i}", "privateuseone")(functools.partial(upsample, mode="linear"))
+for i,pre in enumerate(["", "bi", "tri"]):
+  torch.library.impl(f"aten::upsample_{pre}linear{i+1}d", "privateuseone")(functools.partial(upsample, mode="linear"))
+  torch.library.impl(f"aten::upsample_nearest{i+1}d", "privateuseone")(functools.partial(upsample, mode="nearest"))
+  torch.library.impl(f"aten::_upsample_nearest_exact{i+1}d", "privateuseone")(functools.partial(upsample, mode="nearest-exact"))
 
 @torch.library.impl("aten::_copy_from", "privateuseone")
 # TODO: handle if dest is view?

--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -71,9 +71,11 @@ def topk(self, k, dim=-1, largest=True, sorted=True):
   return torch.return_types.topk((t1.tiny(), t2.tiny()))
 
 @torch.library.impl("aten::_index_put_impl_", "privateuseone")
+@inplace_fn("self")
 def _index_put_impl_(self, indices, values, accumulate=False, unsafe=False):
   # TODO: move to tinygrad
-  return aten._index_put_impl_(self.cpu(), [x.cpu() for x in indices], values.cpu(), accumulate, unsafe).tiny()
+  ret = aten._index_put_impl_(self.cpu(), [x.cpu() if isinstance(x, torch.Tensor) else None for x in indices], values.cpu(), accumulate, unsafe).tiny()
+  return wrap(unwrap(self).assign(unwrap(ret)))
 
 @torch.library.impl("aten::index.Tensor", "privateuseone")
 def index_tensor(x, y):

--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -32,12 +32,13 @@ torch.utils.generate_methods_for_privateuse1_backend()
 def is_view(self: torch.Tensor) -> bool: return getattr(self, "_base", None) is not None
 def realize_with_views(self: torch.Tensor, views: list[torch.Tensor]):
   assert self.device.type == "tiny"
-  b = unwrap(self)
-  b.replace(b.clone().realize())
+  self = unwrap(self)
+  self.replace(self.clone().realize())
   for v in views:
     v = unwrap(v)
-    ret = b
-    for mo in to_movement_ops(v.lazydata.st): ret = apply_mop(ret, mo)
+    ret = self
+    st = ShapeTracker(self.lazydata.st.views + v.lazydata.st.views) # TODO: is this right?
+    for mo in to_movement_ops(st): ret = apply_mop(ret, mo)
     v.replace(ret).realize()
 def maybe_realize_storage(self: torch.Tensor) -> bool:
   if realize:=is_view(self): realize_with_views(self._base, [self]) # TODO: other views could exist

--- a/extra/torch_backend/test_inplace.py
+++ b/extra/torch_backend/test_inplace.py
@@ -7,42 +7,51 @@ import numpy as np
 
 class TestTorchBackendInplace(unittest.TestCase):
   def test_zero(self):
-    a = torch.ones(4, device=device)
+    a = torch.ones(4)
     a.zero_()
     np.testing.assert_equal(a.cpu().numpy(), [0,0,0,0])
 
   def test_view_zero(self):
-    a = torch.ones(4, device=device)
+    a = torch.ones(4)
     a.view((2, 2)).zero_()
     np.testing.assert_equal(a.cpu().numpy(), [0,0,0,0])
 
   def test_slice_zero(self):
-    a = torch.ones(4, device=device)
+    a = torch.ones(4)
     a[2:].zero_()
     np.testing.assert_equal(a.cpu().numpy(), [1,1,0,0])
 
   def test_slice_permute_zero(self):
-    a = torch.ones((3,2), device=device)
+    a = torch.ones((3,2))
     a.permute(1,0)[1:].zero_()
     np.testing.assert_equal(a.cpu().numpy(), [[1,0],[1,0],[1,0]])
 
   def test_slice_fill(self):
-    a = torch.empty(4, device=device)
+    a = torch.zeros(4)
     a[2:].fill_(2)
     np.testing.assert_equal(a.cpu().numpy(), [0,0,2,2])
 
   def test_slice_mul(self):
-    a = torch.ones(4, device=device)
+    a = torch.ones(4)
     a[2:] *= 2
     np.testing.assert_equal(a.cpu().numpy(), [1,1,2,2])
 
   def test_stacked_mul(self):
-    a = torch.ones((3,3), device=device)
+    a = torch.ones((3,3))
     b = a[1:,1:].permute(1,0)
     c = b[1:,:]
     b *= 2
     c *= 3
     np.testing.assert_equal(a.cpu().numpy(), [[1,1,1],[1,2,6],[1,2,6]])
+
+  def test_flatten_reshape_add(self):
+    a = torch.zeros((2,2,12,32))
+    b = a.flatten()
+    c = b.reshape((48,32))
+    a += 1
+    b += 1
+    c += 1
+    np.testing.assert_equal(c.cpu().numpy(), torch.full((48,32),3).cpu().numpy())
 
 if __name__ == "__main__":
   unittest.main()

--- a/extra/torch_backend/test_inplace.py
+++ b/extra/torch_backend/test_inplace.py
@@ -31,5 +31,18 @@ class TestTorchBackendInplace(unittest.TestCase):
     a[2:].fill_(2)
     np.testing.assert_equal(a.cpu().numpy(), [0,0,2,2])
 
+  def test_slice_mul(self):
+    a = torch.ones(4, device=device)
+    a[2:] *= 2
+    np.testing.assert_equal(a.cpu().numpy(), [1,1,2,2])
+
+  def test_stacked_mul(self):
+    a = torch.ones((3,3), device=device)
+    b = a[1:,1:].permute(1,0)
+    c = b[1:,:]
+    b *= 2
+    c *= 3
+    np.testing.assert_equal(a.cpu().numpy(), [[1,1,1],[1,2,6],[1,2,6]])
+
 if __name__ == "__main__":
   unittest.main()

--- a/extra/torch_backend/test_inplace.py
+++ b/extra/torch_backend/test_inplace.py
@@ -1,8 +1,7 @@
 import unittest
 import torch
-import extra.torch_backend.backend
-device = "tiny"
-torch.set_default_device(device)
+import tinygrad.frontend.torch
+torch.set_default_device("tiny")
 import numpy as np
 
 class TestTorchBackendInplace(unittest.TestCase):
@@ -53,6 +52,14 @@ class TestTorchBackendInplace(unittest.TestCase):
     b += 1
     c += 1
     np.testing.assert_equal(c.cpu().numpy(), torch.full((48,32),3).cpu().numpy())
+
+  def test_noncontig(self):
+    a = torch.empty_strided((4,4),(1,4), dtype=torch.int64)
+    # self.assertFalse(a.is_contiguous()) # TODO: we are contiguous when it's not required
+    a.zero_()
+    b = a.view((4,4))
+    b[1:3,:] += 1
+    np.testing.assert_equal(a.cpu().numpy(), [[0]*4,[1]*4,[1]*4,[0]*4])
 
 if __name__ == "__main__":
   unittest.main()

--- a/extra/torch_backend/test_inplace.py
+++ b/extra/torch_backend/test_inplace.py
@@ -33,8 +33,9 @@ class TestTorchBackendInplace(unittest.TestCase):
 
   def test_slice_mul(self):
     a = torch.ones(4)
+    a[:2] *= 3
     a[2:] *= 2
-    np.testing.assert_equal(a.cpu().numpy(), [1,1,2,2])
+    np.testing.assert_equal(a.cpu().numpy(), [3,3,2,2])
 
   def test_stacked_mul(self):
     a = torch.ones((3,3))

--- a/extra/torch_backend/test_inplace.py
+++ b/extra/torch_backend/test_inplace.py
@@ -1,0 +1,35 @@
+import unittest
+import torch
+import extra.torch_backend.backend
+device = "tiny"
+torch.set_default_device(device)
+import numpy as np
+
+class TestTorchBackendInplace(unittest.TestCase):
+  def test_zero(self):
+    a = torch.ones(4, device=device)
+    a.zero_()
+    np.testing.assert_equal(a.cpu().numpy(), [0,0,0,0])
+
+  def test_view_zero(self):
+    a = torch.ones(4, device=device)
+    a.view((2, 2)).zero_()
+    np.testing.assert_equal(a.cpu().numpy(), [0,0,0,0])
+
+  def test_slice_zero(self):
+    a = torch.ones(4, device=device)
+    a[2:].zero_()
+    np.testing.assert_equal(a.cpu().numpy(), [1,1,0,0])
+
+  def test_slice_permute_zero(self):
+    a = torch.ones((3,2), device=device)
+    a.permute(1,0)[1:].zero_()
+    np.testing.assert_equal(a.cpu().numpy(), [[1,0],[1,0],[1,0]])
+
+  def test_slice_fill(self):
+    a = torch.empty(4, device=device)
+    a[2:].fill_(2)
+    np.testing.assert_equal(a.cpu().numpy(), [0,0,2,2])
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Torch in-place operations on views aren't common but they do happen.
This spawned off from #9317 since DistributedDataParallel internally uses views for its gradients and in-place updates.

TODOs:

- [x] Wrap all out functions with this support
- [x] More tests around multiple views
- [x] Sanity check against DDP
