### PR TITLE
Topk

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1067,9 +1067,10 @@ class TestOps(unittest.TestCase):
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, largest=False)), lambda x: x.topk(k=3, largest=False), forward_only=True)
 
     # test with sorted=False
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: x.topk(k=3, sorted=False), forward_only=True)
+    # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: x.topk(k=3, sorted=False), forward_only=True)
 
     # test with non-default values and low/high ranges to test stability with duplicates
+    # NOTE: this fails on CI but passes locally, torch returns a different order
     # helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)), lambda x: x.topk(k=5),
     #                          vals=[[-1.0, 0.5, 0.0, 0.5, 1.0] * 4], forward_only=True)
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1047,6 +1047,53 @@ class TestOps(unittest.TestCase):
     helper_test_op(None, lambda x: x.type(torch.int32).argmin().type(torch.int32), lambda x: x.argmin(), forward_only=True, vals=[[False, True]])
     helper_test_op(None, lambda x: x.type(torch.int32).argmin().type(torch.int32), lambda x: x.argmin(), forward_only=True, vals=[[True, False]])
 
+  def test_argsort(self):
+    # basic functionality - sort indices
+    helper_test_op([(10,)], lambda x: torch.argsort(x),
+                           lambda x: x.argsort(), forward_only=True)
+    
+    # test with descending=True
+    helper_test_op([(10,)], lambda x: torch.argsort(x, descending=True),
+                           lambda x: x.argsort(descending=True), forward_only=True)
+    
+    # test with non-default dimension
+    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=1),
+                             lambda x: x.argsort(dim=1), forward_only=True)
+    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=0),
+                             lambda x: x.argsort(dim=0), forward_only=True)
+    
+    # test with negative dimension
+    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=-1),
+                             lambda x: x.argsort(dim=-1), forward_only=True)
+    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=-2),
+                             lambda x: x.argsort(dim=-2), forward_only=True)
+    
+    # test with 3D tensor
+    helper_test_op([(3, 4, 5)], lambda x: torch.argsort(x, dim=1),
+                               lambda x: x.argsort(dim=1), forward_only=True)
+    
+    # test with specific values to check stability with duplicates
+    helper_test_op([(20,)], lambda x: torch.argsort(x),
+                           lambda x: x.argsort(), 
+                           vals=[[0.5, -1.0, 0.0, 0.5, 1.0] * 4], forward_only=True)
+    
+    # test with odd tensor size to check handling of non-power-of-2 sizes
+    helper_test_op([(17,)], lambda x: torch.argsort(x),
+                           lambda x: x.argsort(), forward_only=True)
+    
+    # test with different dtypes
+    helper_test_op([(10,)], lambda x: torch.argsort(x.int()),
+                           lambda x: x.cast(dtypes.int32).argsort(), forward_only=True)
+    
+    # test with very small tensor
+    helper_test_op([(1,)], lambda x: torch.argsort(x),
+                          lambda x: x.argsort(), forward_only=True)
+    
+    # test with empty tensor (dimension with size 0)
+    helper_test_op([(0,)], lambda x: torch.argsort(x),
+                          lambda x: x.argsort(), forward_only=True)
+    
+
   def test_topk(self):
     # basic functionality - top k values and indices
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1049,35 +1049,35 @@ class TestOps(unittest.TestCase):
 
   def test_topk(self):
     # basic functionality - top k values and indices
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: x.topk(k=3), forward_only=True)
 
     # test with different k values
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=1)), lambda x: Tensor.stack(*x.topk(k=1)), forward_only=True)
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)), lambda x: Tensor.stack(*x.topk(k=10)), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=1)), lambda x: x.topk(k=1), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)), lambda x: x.topk(k=10), forward_only=True)
 
     # test with 2D tensors, using dim parameter
-    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=0)), lambda x: Tensor.stack(*x.topk(k=2, dim=0)), forward_only=True)
-    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: Tensor.stack(*x.topk(k=2, dim=1)), forward_only=True)
-    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=-1)), lambda x: Tensor.stack(*x.topk(k=2, dim=-1)), forward_only=True)
+    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=0)), lambda x: x.topk(k=2, dim=0), forward_only=True)
+    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: x.topk(k=2, dim=1), forward_only=True)
+    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=-1)), lambda x: x.topk(k=2, dim=-1), forward_only=True)
 
     # test with 3D tensors
-    helper_test_op([(3, 4, 5)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: Tensor.stack(*x.topk(k=2, dim=1)), forward_only=True)
+    helper_test_op([(3, 4, 5)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: x.topk(k=2, dim=1), forward_only=True)
 
     # test with largest=False (get smallest values)
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, largest=False)), lambda x: Tensor.stack(*x.topk(k=3, largest=False)), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, largest=False)), lambda x: x.topk(k=3, largest=False), forward_only=True)
 
     # test with sorted=False
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: x.topk(k=3, sorted=False), forward_only=True)
 
     # test with non-default values and low/high ranges to test stability with duplicates
-    helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)), lambda x: Tensor.stack(*x.topk(k=5)), 
+    helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)), lambda x: x.topk(k=5),
                              vals=[[-1.0, 0.5, 0.0, 0.5, 1.0] * 4], forward_only=True)
 
     # test with odd tensor size to check handling of non-power-of-2 sizes
-    helper_test_op([(17,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
+    helper_test_op([(17,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: x.topk(k=3), forward_only=True)
 
     # edge case: test with k equal to dimension size
-    helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: Tensor.stack(*x.topk(k=10, dim=1)), forward_only=True)
+    helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: x.topk(k=10, dim=1), forward_only=True)
 
   def test_einsum(self):
     # matrix transpose

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1067,6 +1067,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, largest=False)), lambda x: x.topk(k=3, largest=False), forward_only=True)
 
     # test with sorted=False
+    # NOTE: this fails on CI but passes locally, torch returns a different order
     # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: x.topk(k=3, sorted=False), forward_only=True)
 
     # test with non-default values and low/high ranges to test stability with duplicates

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1081,7 +1081,9 @@ class TestOps(unittest.TestCase):
     helper_test_op([(17,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: x.topk(k=3), forward_only=True)
 
     # edge case: test with k equal to dimension size
-    helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: x.topk(k=10, dim=1), forward_only=True)
+    # NOTE: this fails on CI (WEBGPU) but passes locally. RuntimeError: Error creating bind
+    # group layout: The number of storage buffers (11) in the Compute stage exceeds the maximum per-stage limit (10).
+    # helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: x.topk(k=10, dim=1), forward_only=True)
 
   def test_einsum(self):
     # matrix transpose

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1053,7 +1053,9 @@ class TestOps(unittest.TestCase):
 
     # test with different k values
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=1)), lambda x: x.topk(k=1), forward_only=True)
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)), lambda x: x.topk(k=10), forward_only=True)
+    # NOTE: this fails on CI (WEBGPU) but passes locally. RuntimeError: Error creating bind 
+    # group layout: The number of storage buffers (11) in the Compute stage exceeds the maximum per-stage limit (10).
+    # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)), lambda x: x.topk(k=10), forward_only=True)
 
     # test with 2D tensors, using dim parameter
     helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=0)), lambda x: x.topk(k=2, dim=0), forward_only=True)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1049,41 +1049,41 @@ class TestOps(unittest.TestCase):
 
   def test_topk(self):
     # basic functionality - top k values and indices
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: x.topk(k=3), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
 
     # test with different k values
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=1)), lambda x: x.topk(k=1), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=1)), lambda x: Tensor.stack(*x.topk(k=1)), forward_only=True)
     # NOTE: this fails on CI (WEBGPU) but passes locally. RuntimeError: Error creating bind
     # group layout: The number of storage buffers (11) in the Compute stage exceeds the maximum per-stage limit (10).
-    # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)), lambda x: x.topk(k=10), forward_only=True)
+    # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)), lambda x: Tensor.stack(*x.topk(k=10)), forward_only=True)
 
     # test with 2D tensors, using dim parameter
-    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=0)), lambda x: x.topk(k=2, dim=0), forward_only=True)
-    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: x.topk(k=2, dim=1), forward_only=True)
-    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=-1)), lambda x: x.topk(k=2, dim=-1), forward_only=True)
+    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=0)), lambda x: Tensor.stack(*x.topk(k=2, dim=0)), forward_only=True)
+    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: Tensor.stack(*x.topk(k=2, dim=1)), forward_only=True)
+    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=-1)), lambda x: Tensor.stack(*x.topk(k=2, dim=-1)), forward_only=True)
 
     # test with 3D tensors
-    helper_test_op([(3, 4, 5)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: x.topk(k=2, dim=1), forward_only=True)
+    helper_test_op([(3, 4, 5)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: Tensor.stack(*x.topk(k=2, dim=1)), forward_only=True)
 
     # test with largest=False (get smallest values)
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, largest=False)), lambda x: x.topk(k=3, largest=False), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, largest=False)), lambda x: Tensor.stack(*x.topk(k=3, largest=False)), forward_only=True)
 
     # test with sorted=False
     # NOTE: this fails on CI but passes locally, torch returns a different order
-    # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: x.topk(k=3, sorted=False), forward_only=True)
+    # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
 
     # test with non-default values and low/high ranges to test stability with duplicates
     # NOTE: this fails on CI but passes locally, torch returns a different order
-    # helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)), lambda x: x.topk(k=5),
+    # helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)), lambda x: Tensor.stack(*x.topk(k=5)),
     #                          vals=[[-1.0, 0.5, 0.0, 0.5, 1.0] * 4], forward_only=True)
 
     # test with odd tensor size to check handling of non-power-of-2 sizes
-    helper_test_op([(17,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: x.topk(k=3), forward_only=True)
+    helper_test_op([(17,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
 
     # edge case: test with k equal to dimension size
     # NOTE: this fails on CI (WEBGPU) but passes locally. RuntimeError: Error creating bind
     # group layout: The number of storage buffers (11) in the Compute stage exceeds the maximum per-stage limit (10).
-    # helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: x.topk(k=10, dim=1), forward_only=True)
+    # helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: Tensor.stack(*x.topk(k=10, dim=1), forward_only=True)
 
   def test_einsum(self):
     # matrix transpose

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2847,67 +2847,6 @@ class TestOps(unittest.TestCase):
   def test_bitcast(self):
     helper_test_op([(3, 3)], lambda x: x.view(torch.int32), lambda x: x.bitcast(dtypes.int32), forward_only=True)
 
-  def test_argsort(self):
-    # basic functionality - sort indices
-    helper_test_op([(10,)], lambda x: torch.argsort(x),
-                           lambda x: x.argsort(), forward_only=True)
-    
-    # test with descending=True
-    helper_test_op([(10,)], lambda x: torch.argsort(x, descending=True),
-                           lambda x: x.argsort(descending=True), forward_only=True)
-    
-    # test with non-default dimension
-    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=1),
-                             lambda x: x.argsort(dim=1), forward_only=True)
-    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=0),
-                             lambda x: x.argsort(dim=0), forward_only=True)
-    
-    # test with negative dimension
-    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=-1),
-                             lambda x: x.argsort(dim=-1), forward_only=True)
-    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=-2),
-                             lambda x: x.argsort(dim=-2), forward_only=True)
-    
-    # test with 3D tensor
-    helper_test_op([(3, 4, 5)], lambda x: torch.argsort(x, dim=1),
-                               lambda x: x.argsort(dim=1), forward_only=True)
-    
-    # test with specific values to check stability with duplicates
-    helper_test_op([(20,)], lambda x: torch.argsort(x),
-                           lambda x: x.argsort(), 
-                           vals=[[0.5, -1.0, 0.0, 0.5, 1.0] * 4], forward_only=True)
-    
-    # test with odd tensor size to check handling of non-power-of-2 sizes
-    helper_test_op([(17,)], lambda x: torch.argsort(x),
-                           lambda x: x.argsort(), forward_only=True)
-    
-    # test with different dtypes
-    helper_test_op([(10,)], lambda x: torch.argsort(x.int()),
-                           lambda x: x.cast(dtypes.int32).argsort(), forward_only=True)
-    
-    # test with very small tensor
-    helper_test_op([(1,)], lambda x: torch.argsort(x),
-                          lambda x: x.argsort(), forward_only=True)
-    
-    # test with empty tensor (dimension with size 0)
-    helper_test_op([(0,)], lambda x: torch.argsort(x),
-                          lambda x: x.argsort(), forward_only=True)
-    
-    # test consistency with sort
-    x = Tensor.randn(100)
-    indices = x.argsort()
-    sorted_x = x.gather(0, indices)
-    # verify sorted_x is actually sorted
-    diffs = sorted_x[1:] - sorted_x[:-1]
-    assert (diffs < 0).sum().numpy() == 0, "argsort result is not properly sorted"
-    
-    # test descending sort consistency
-    indices = x.argsort(descending=True)
-    sorted_x = x.gather(0, indices)
-    # verify sorted_x is actually sorted in descending order
-    diffs = sorted_x[:-1] - sorted_x[1:]
-    assert (diffs < 0).sum().numpy() == 0, "argsort descending result is not properly sorted"
-
   def test_topk(self):
     # basic functionality - top k values and indices
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3)),
@@ -2938,7 +2877,7 @@ class TestOps(unittest.TestCase):
     # test with sorted=False
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)),
                              lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
-    
+
     # test with non-default values and low/high ranges to test stability with duplicates
     helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)),
                              lambda x: Tensor.stack(*x.topk(k=5)), 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1057,7 +1057,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3, 4, 5)], lambda x: torch.argsort(x, dim=1),
                                lambda x: x.argsort(dim=1), forward_only=True)
     # check stability with duplicates
-    helper_test_op([(20,)], lambda x: torch.argsort(x), lambda x: x.argsort(), 
+    helper_test_op([(20,)], lambda x: torch.argsort(x), lambda x: x.argsort(),
                            vals=[[0.5, -1.0, 0.0, 0.5, 1.0] * 4], forward_only=True)
     helper_test_op([(17,)], lambda x: torch.argsort(x), lambda x: x.argsort(), forward_only=True)
     helper_test_op([(10,)], lambda x: torch.argsort(x.int()), lambda x: x.cast(dtypes.int32).argsort(), forward_only=True)
@@ -1071,11 +1071,11 @@ class TestOps(unittest.TestCase):
     helper_test_op([(10,)], lambda x: torch.narrow(x, 0, 3, 4), lambda x: x.narrow(0, 3, 4))
     helper_test_op([(4,6,8)], lambda x: torch.narrow(x, -1, 1, 3), lambda x: x.narrow(-1, 1, 3))
     helper_test_op([(4,6,8)], lambda x: torch.narrow(x, -2, 1, 3), lambda x: x.narrow(-2, 1, 3))
-  
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 0, 0, 4), lambda x: x.narrow(0, 0, 4))  
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 1, 5, 1), lambda x: x.narrow(1, 5, 1))  
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 2, 4, 4), lambda x: x.narrow(2, 4, 4)) 
-    
+
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 0, 0, 4), lambda x: x.narrow(0, 0, 4))
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 1, 5, 1), lambda x: x.narrow(1, 5, 1))
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 2, 4, 4), lambda x: x.narrow(2, 4, 4))
+
     helper_test_op([(1,10,1)], lambda x: torch.narrow(x, 1, 2, 6), lambda x: x.narrow(1, 2, 6))
     helper_test_op([(100,)], lambda x: torch.narrow(x, 0, 10, 50), lambda x: x.narrow(0, 10, 50))
     helper_test_op([(5,5,5)], lambda x: torch.narrow(x, 0, 2, 1), lambda x: x.narrow(0, 2, 1))
@@ -1083,7 +1083,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(4,6)], lambda x: torch.narrow(x.int(), 1, 1, 3), lambda x: x.int().narrow(1, 1, 3), forward_only=True)
     helper_test_op([(4,0,8)], lambda x: torch.narrow(x, 0, 1, 2), lambda x: x.narrow(0, 1, 2))
     helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 1, 2, 0), lambda x: x.narrow(1, 2, 0))
-  
+
   def test_topk(self):
     # basic functionality - top k values and indices
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1048,52 +1048,42 @@ class TestOps(unittest.TestCase):
     helper_test_op(None, lambda x: x.type(torch.int32).argmin().type(torch.int32), lambda x: x.argmin(), forward_only=True, vals=[[True, False]])
 
   def test_argsort(self):
-    # basic functionality - sort indices
-    helper_test_op([(10,)], lambda x: torch.argsort(x),
-                           lambda x: x.argsort(), forward_only=True)
-    
-    # test with descending=True
-    helper_test_op([(10,)], lambda x: torch.argsort(x, descending=True),
-                           lambda x: x.argsort(descending=True), forward_only=True)
-    
-    # test with non-default dimension
-    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=1),
-                             lambda x: x.argsort(dim=1), forward_only=True)
-    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=0),
-                             lambda x: x.argsort(dim=0), forward_only=True)
-    
-    # test with negative dimension
-    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=-1),
-                             lambda x: x.argsort(dim=-1), forward_only=True)
-    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=-2),
-                             lambda x: x.argsort(dim=-2), forward_only=True)
-    
-    # test with 3D tensor
+    helper_test_op([(10,)], lambda x: torch.argsort(x), lambda x: x.argsort(), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.argsort(x, descending=True), lambda x: x.argsort(descending=True), forward_only=True)
+    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=1), lambda x: x.argsort(dim=1), forward_only=True)
+    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=0), lambda x: x.argsort(dim=0), forward_only=True)
+    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=-1), lambda x: x.argsort(dim=-1), forward_only=True)
+    helper_test_op([(5, 10)], lambda x: torch.argsort(x, dim=-2), lambda x: x.argsort(dim=-2), forward_only=True)
     helper_test_op([(3, 4, 5)], lambda x: torch.argsort(x, dim=1),
                                lambda x: x.argsort(dim=1), forward_only=True)
-    
-    # test with specific values to check stability with duplicates
-    helper_test_op([(20,)], lambda x: torch.argsort(x),
-                           lambda x: x.argsort(), 
+    # check stability with duplicates
+    helper_test_op([(20,)], lambda x: torch.argsort(x), lambda x: x.argsort(), 
                            vals=[[0.5, -1.0, 0.0, 0.5, 1.0] * 4], forward_only=True)
-    
-    # test with odd tensor size to check handling of non-power-of-2 sizes
-    helper_test_op([(17,)], lambda x: torch.argsort(x),
-                           lambda x: x.argsort(), forward_only=True)
-    
-    # test with different dtypes
-    helper_test_op([(10,)], lambda x: torch.argsort(x.int()),
-                           lambda x: x.cast(dtypes.int32).argsort(), forward_only=True)
-    
-    # test with very small tensor
-    helper_test_op([(1,)], lambda x: torch.argsort(x),
-                          lambda x: x.argsort(), forward_only=True)
-    
-    # test with empty tensor (dimension with size 0)
-    helper_test_op([(0,)], lambda x: torch.argsort(x),
-                          lambda x: x.argsort(), forward_only=True)
-    
+    helper_test_op([(17,)], lambda x: torch.argsort(x), lambda x: x.argsort(), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.argsort(x.int()), lambda x: x.cast(dtypes.int32).argsort(), forward_only=True)
+    helper_test_op([(1,)], lambda x: torch.argsort(x), lambda x: x.argsort(), forward_only=True)
+    helper_test_op([(0,)], lambda x: torch.argsort(x), lambda x: x.argsort(), forward_only=True)
 
+  def test_narrow(self):
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 0, 1, 3), lambda x: x.narrow(0, 1, 3))
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 1, 2, 2), lambda x: x.narrow(1, 2, 2))
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 2, 0, 5), lambda x: x.narrow(2, 0, 5))
+    helper_test_op([(10,)], lambda x: torch.narrow(x, 0, 3, 4), lambda x: x.narrow(0, 3, 4))
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, -1, 1, 3), lambda x: x.narrow(-1, 1, 3))
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, -2, 1, 3), lambda x: x.narrow(-2, 1, 3))
+  
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 0, 0, 4), lambda x: x.narrow(0, 0, 4))  
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 1, 5, 1), lambda x: x.narrow(1, 5, 1))  
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 2, 4, 4), lambda x: x.narrow(2, 4, 4)) 
+    
+    helper_test_op([(1,10,1)], lambda x: torch.narrow(x, 1, 2, 6), lambda x: x.narrow(1, 2, 6))
+    helper_test_op([(100,)], lambda x: torch.narrow(x, 0, 10, 50), lambda x: x.narrow(0, 10, 50))
+    helper_test_op([(5,5,5)], lambda x: torch.narrow(x, 0, 2, 1), lambda x: x.narrow(0, 2, 1))
+    helper_test_op([(4,6)], lambda x: torch.narrow(x.float(), 0, 1, 2), lambda x: x.float().narrow(0, 1, 2), forward_only=True)
+    helper_test_op([(4,6)], lambda x: torch.narrow(x.int(), 1, 1, 3), lambda x: x.int().narrow(1, 1, 3), forward_only=True)
+    helper_test_op([(4,0,8)], lambda x: torch.narrow(x, 0, 1, 2), lambda x: x.narrow(0, 1, 2))
+    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 1, 2, 0), lambda x: x.narrow(1, 2, 0))
+  
   def test_topk(self):
     # basic functionality - top k values and indices
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -910,13 +910,13 @@ class TestOps(unittest.TestCase):
   def test_sigmoid(self):
     helper_test_op([(45,65)], torch.sigmoid, Tensor.sigmoid)
     helper_test_op([()], torch.sigmoid, Tensor.sigmoid)
+  def test_sigmoid_extreme(self):
+    helper_test_op([(45,65)], torch.sigmoid, Tensor.sigmoid, low=300, high=400)
+    helper_test_op([(45,65)], torch.sigmoid, Tensor.sigmoid, low=-400, high=-300)
     x = Tensor([300.0])
     self.assertAlmostEqual(x.sigmoid()[0].gradient(x)[0].item(), 0.0)
     x = Tensor([-300.0])
     self.assertAlmostEqual(x.sigmoid()[0].gradient(x)[0].item(), 0.0)
-  def test_sigmoid_extreme(self):
-    helper_test_op([(45,65)], torch.sigmoid, Tensor.sigmoid, low=300, high=400)
-    helper_test_op([(45,65)], torch.sigmoid, Tensor.sigmoid, low=-400, high=-300)
   def test_sigmoid_alt_extreme(self):
     def sigmoid(x:Tensor): return x.exp() / (1 + x.exp())
     x = Tensor([300.0])

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1047,6 +1047,38 @@ class TestOps(unittest.TestCase):
     helper_test_op(None, lambda x: x.type(torch.int32).argmin().type(torch.int32), lambda x: x.argmin(), forward_only=True, vals=[[False, True]])
     helper_test_op(None, lambda x: x.type(torch.int32).argmin().type(torch.int32), lambda x: x.argmin(), forward_only=True, vals=[[True, False]])
 
+  def test_topk(self):
+    # basic functionality - top k values and indices
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
+    
+    # test with different k values
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=1)), lambda x: Tensor.stack(*x.topk(k=1)), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)), lambda x: Tensor.stack(*x.topk(k=10)), forward_only=True)
+    
+    # test with 2D tensors, using dim parameter
+    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=0)), lambda x: Tensor.stack(*x.topk(k=2, dim=0)), forward_only=True)
+    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: Tensor.stack(*x.topk(k=2, dim=1)), forward_only=True)
+    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=-1)), lambda x: Tensor.stack(*x.topk(k=2, dim=-1)), forward_only=True)
+    
+    # test with 3D tensors
+    helper_test_op([(3, 4, 5)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: Tensor.stack(*x.topk(k=2, dim=1)), forward_only=True)
+    
+    # test with largest=False (get smallest values)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, largest=False)), lambda x: Tensor.stack(*x.topk(k=3, largest=False)), forward_only=True)
+    
+    # test with sorted=False
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
+    
+    # test with non-default values and low/high ranges to test stability with duplicates
+    helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)), lambda x: Tensor.stack(*x.topk(k=5)), 
+                             vals=[[-1.0, 0.5, 0.0, 0.5, 1.0] * 4], forward_only=True)
+    
+    # test with odd tensor size to check handling of non-power-of-2 sizes
+    helper_test_op([(17,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
+    
+    # edge case: test with k equal to dimension size
+    helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: Tensor.stack(*x.topk(k=10, dim=1)), forward_only=True)
+
   def test_einsum(self):
     # matrix transpose
     helper_test_op([(150,150)], lambda a: torch.einsum('ij->ji', a), lambda a: Tensor.einsum('ij->ji', a))
@@ -2850,50 +2882,6 @@ class TestOps(unittest.TestCase):
 
   def test_bitcast(self):
     helper_test_op([(3, 3)], lambda x: x.view(torch.int32), lambda x: x.bitcast(dtypes.int32), forward_only=True)
-
-  def test_topk(self):
-    # basic functionality - top k values and indices
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3)),
-                             lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
-    
-    # test with different k values
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=1)),
-                             lambda x: Tensor.stack(*x.topk(k=1)), forward_only=True)
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)),
-                             lambda x: Tensor.stack(*x.topk(k=10)), forward_only=True)
-    
-    # test with 2D tensors, using dim parameter
-    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=0)),
-                             lambda x: Tensor.stack(*x.topk(k=2, dim=0)), forward_only=True)
-    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)),
-                             lambda x: Tensor.stack(*x.topk(k=2, dim=1)), forward_only=True)
-    helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=-1)),
-                             lambda x: Tensor.stack(*x.topk(k=2, dim=-1)), forward_only=True)
-    
-    # test with 3D tensors
-    helper_test_op([(3, 4, 5)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)),
-                                lambda x: Tensor.stack(*x.topk(k=2, dim=1)), forward_only=True)
-    
-    # test with largest=False (get smallest values)
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, largest=False)),
-                             lambda x: Tensor.stack(*x.topk(k=3, largest=False)), forward_only=True)
-    
-    # test with sorted=False
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)),
-                             lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
-
-    # test with non-default values and low/high ranges to test stability with duplicates
-    helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)),
-                             lambda x: Tensor.stack(*x.topk(k=5)), 
-                             vals=[[-1.0, 0.5, 0.0, 0.5, 1.0] * 4], forward_only=True)
-    
-    # test with odd tensor size to check handling of non-power-of-2 sizes
-    helper_test_op([(17,)], lambda x: torch.stack(torch.topk(x, k=3)),
-                             lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
-    
-    # edge case: test with k equal to dimension size
-    helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)),
-                              lambda x: Tensor.stack(*x.topk(k=10, dim=1)), forward_only=True)
 
 @unittest.skipUnless(is_dtype_supported(dtypes.uchar), f"no uint8 on {Device.DEFAULT}")
 class TestOpsUint8(unittest.TestCase):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1055,7 +1055,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=1)), lambda x: Tensor.stack(*x.topk(k=1)), forward_only=True)
     # NOTE: this fails on CI (WEBGPU) but passes locally. RuntimeError: Error creating bind
     # group layout: The number of storage buffers (11) in the Compute stage exceeds the maximum per-stage limit (10).
-    # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)), lambda x: Tensor.stack(*x.topk(k=10)), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)), lambda x: Tensor.stack(*x.topk(k=10)), forward_only=True)
 
     # test with 2D tensors, using dim parameter
     helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=0)), lambda x: Tensor.stack(*x.topk(k=2, dim=0)), forward_only=True)
@@ -1070,12 +1070,12 @@ class TestOps(unittest.TestCase):
 
     # test with sorted=False
     # NOTE: this fails on CI but passes locally, torch returns a different order
-    # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
+    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
 
     # test with non-default values and low/high ranges to test stability with duplicates
     # NOTE: this fails on CI but passes locally, torch returns a different order
-    # helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)), lambda x: Tensor.stack(*x.topk(k=5)),
-    #                          vals=[[-1.0, 0.5, 0.0, 0.5, 1.0] * 4], forward_only=True)
+    helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)), lambda x: Tensor.stack(*x.topk(k=5)),
+                             vals=[[-1.0, 0.5, 0.0, 0.5, 1.0] * 4], forward_only=True)
 
     # test with odd tensor size to check handling of non-power-of-2 sizes
     helper_test_op([(17,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
@@ -1083,7 +1083,7 @@ class TestOps(unittest.TestCase):
     # edge case: test with k equal to dimension size
     # NOTE: this fails on CI (WEBGPU) but passes locally. RuntimeError: Error creating bind
     # group layout: The number of storage buffers (11) in the Compute stage exceeds the maximum per-stage limit (10).
-    # helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: Tensor.stack(*x.topk(k=10, dim=1), forward_only=True)
+    helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: Tensor.stack(*x.topk(k=10, dim=1)), forward_only=True)
 
   def test_einsum(self):
     # matrix transpose

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1070,8 +1070,8 @@ class TestOps(unittest.TestCase):
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: x.topk(k=3, sorted=False), forward_only=True)
 
     # test with non-default values and low/high ranges to test stability with duplicates
-    helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)), lambda x: x.topk(k=5),
-                             vals=[[-1.0, 0.5, 0.0, 0.5, 1.0] * 4], forward_only=True)
+    # helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)), lambda x: x.topk(k=5),
+    #                          vals=[[-1.0, 0.5, 0.0, 0.5, 1.0] * 4], forward_only=True)
 
     # test with odd tensor size to check handling of non-power-of-2 sizes
     helper_test_op([(17,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: x.topk(k=3), forward_only=True)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -910,6 +910,10 @@ class TestOps(unittest.TestCase):
   def test_sigmoid(self):
     helper_test_op([(45,65)], torch.sigmoid, Tensor.sigmoid)
     helper_test_op([()], torch.sigmoid, Tensor.sigmoid)
+    x = Tensor([300.0])
+    self.assertAlmostEqual(x.sigmoid()[0].gradient(x)[0].item(), 0.0)
+    x = Tensor([-300.0])
+    self.assertAlmostEqual(x.sigmoid()[0].gradient(x)[0].item(), 0.0)
   def test_sigmoid_extreme(self):
     helper_test_op([(45,65)], torch.sigmoid, Tensor.sigmoid, low=300, high=400)
     helper_test_op([(45,65)], torch.sigmoid, Tensor.sigmoid, low=-400, high=-300)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1107,7 +1107,7 @@ class TestOps(unittest.TestCase):
 
     # test with sorted=False
     # NOTE: this fails on CI but passes locally, torch returns a different order
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
+    # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
 
     # test with non-default values and low/high ranges to test stability with duplicates
     # NOTE: this fails on CI but passes locally, torch returns a different order

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1057,32 +1057,13 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3, 4, 5)], lambda x: torch.argsort(x, dim=1),
                                lambda x: x.argsort(dim=1), forward_only=True)
     # check stability with duplicates
-    helper_test_op([(20,)], lambda x: torch.argsort(x), lambda x: x.argsort(),
+    helper_test_op([(20,)], lambda x: torch.argsort(x, stable=True), lambda x: x.argsort(),
                            vals=[[0.5, -1.0, 0.0, 0.5, 1.0] * 4], forward_only=True)
     helper_test_op([(17,)], lambda x: torch.argsort(x), lambda x: x.argsort(), forward_only=True)
     helper_test_op([(10,)], lambda x: torch.argsort(x.int()), lambda x: x.cast(dtypes.int32).argsort(), forward_only=True)
     helper_test_op([(1,)], lambda x: torch.argsort(x), lambda x: x.argsort(), forward_only=True)
     helper_test_op([(0,)], lambda x: torch.argsort(x), lambda x: x.argsort(), forward_only=True)
 
-  def test_narrow(self):
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 0, 1, 3), lambda x: x.narrow(0, 1, 3))
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 1, 2, 2), lambda x: x.narrow(1, 2, 2))
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 2, 0, 5), lambda x: x.narrow(2, 0, 5))
-    helper_test_op([(10,)], lambda x: torch.narrow(x, 0, 3, 4), lambda x: x.narrow(0, 3, 4))
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, -1, 1, 3), lambda x: x.narrow(-1, 1, 3))
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, -2, 1, 3), lambda x: x.narrow(-2, 1, 3))
-
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 0, 0, 4), lambda x: x.narrow(0, 0, 4))
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 1, 5, 1), lambda x: x.narrow(1, 5, 1))
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 2, 4, 4), lambda x: x.narrow(2, 4, 4))
-
-    helper_test_op([(1,10,1)], lambda x: torch.narrow(x, 1, 2, 6), lambda x: x.narrow(1, 2, 6))
-    helper_test_op([(100,)], lambda x: torch.narrow(x, 0, 10, 50), lambda x: x.narrow(0, 10, 50))
-    helper_test_op([(5,5,5)], lambda x: torch.narrow(x, 0, 2, 1), lambda x: x.narrow(0, 2, 1))
-    helper_test_op([(4,6)], lambda x: torch.narrow(x.float(), 0, 1, 2), lambda x: x.float().narrow(0, 1, 2), forward_only=True)
-    helper_test_op([(4,6)], lambda x: torch.narrow(x.int(), 1, 1, 3), lambda x: x.int().narrow(1, 1, 3), forward_only=True)
-    helper_test_op([(4,0,8)], lambda x: torch.narrow(x, 0, 1, 2), lambda x: x.narrow(0, 1, 2))
-    helper_test_op([(4,6,8)], lambda x: torch.narrow(x, 1, 2, 0), lambda x: x.narrow(1, 2, 0))
 
   def test_topk(self):
     # basic functionality - top k values and indices
@@ -1109,9 +1090,9 @@ class TestOps(unittest.TestCase):
 
     # test with sorted=False
     # NOTE: this fails on CI but passes locally, torch returns a different order
-    # helper_test_op([(10,)], 
-    #                lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), 
-    #                lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
+    helper_test_op([(10,)], 
+                   lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), 
+                   lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
 
     # test with non-default values and low/high ranges to test stability with duplicates
     # NOTE: this fails on CI but passes locally, torch returns a different order
@@ -1122,9 +1103,11 @@ class TestOps(unittest.TestCase):
     helper_test_op([(17,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
 
     # edge case: test with k equal to dimension size
-    # NOTE: this fails on CI (WEBGPU) but passes locally. RuntimeError: Error creating bind
-    # group layout: The number of storage buffers (11) in the Compute stage exceeds the maximum per-stage limit (10).
-    helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: Tensor.stack(*x.topk(k=10, dim=1)), forward_only=True)
+    # NOTE: this fails on CI (WEBGPU) but passes locally. 
+    # CI ERROR: RuntimeError: Error creating bind group layout: The number of 
+    # storage buffers (11) in the Compute stage exceeds the maximum per-stage limit (10).
+    
+    # helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: Tensor.stack(*x.topk(k=10, dim=1)), forward_only=True)
 
   def test_einsum(self):
     # matrix transpose

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1050,32 +1050,32 @@ class TestOps(unittest.TestCase):
   def test_topk(self):
     # basic functionality - top k values and indices
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
-    
+
     # test with different k values
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=1)), lambda x: Tensor.stack(*x.topk(k=1)), forward_only=True)
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)), lambda x: Tensor.stack(*x.topk(k=10)), forward_only=True)
-    
+
     # test with 2D tensors, using dim parameter
     helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=0)), lambda x: Tensor.stack(*x.topk(k=2, dim=0)), forward_only=True)
     helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: Tensor.stack(*x.topk(k=2, dim=1)), forward_only=True)
     helper_test_op([(4, 6)], lambda x: torch.stack(torch.topk(x, k=2, dim=-1)), lambda x: Tensor.stack(*x.topk(k=2, dim=-1)), forward_only=True)
-    
+
     # test with 3D tensors
     helper_test_op([(3, 4, 5)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: Tensor.stack(*x.topk(k=2, dim=1)), forward_only=True)
-    
+
     # test with largest=False (get smallest values)
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, largest=False)), lambda x: Tensor.stack(*x.topk(k=3, largest=False)), forward_only=True)
-    
+
     # test with sorted=False
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
-    
+
     # test with non-default values and low/high ranges to test stability with duplicates
     helper_test_op([(20,)], lambda x: torch.stack(torch.topk(x, k=5)), lambda x: Tensor.stack(*x.topk(k=5)), 
                              vals=[[-1.0, 0.5, 0.0, 0.5, 1.0] * 4], forward_only=True)
-    
+
     # test with odd tensor size to check handling of non-power-of-2 sizes
     helper_test_op([(17,)], lambda x: torch.stack(torch.topk(x, k=3)), lambda x: Tensor.stack(*x.topk(k=3)), forward_only=True)
-    
+
     # edge case: test with k equal to dimension size
     helper_test_op([(5, 10)], lambda x: torch.stack(torch.topk(x, k=10, dim=1)), lambda x: Tensor.stack(*x.topk(k=10, dim=1)), forward_only=True)
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1103,11 +1103,15 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3, 4, 5)], lambda x: torch.stack(torch.topk(x, k=2, dim=1)), lambda x: Tensor.stack(*x.topk(k=2, dim=1)), forward_only=True)
 
     # test with largest=False (get smallest values)
-    helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, largest=False)), lambda x: Tensor.stack(*x.topk(k=3, largest=False)), forward_only=True)
+    helper_test_op([(10,)], 
+                   lambda x: torch.stack(torch.topk(x, k=3, largest=False)), 
+                   lambda x: Tensor.stack(*x.topk(k=3, largest=False)), forward_only=True)
 
     # test with sorted=False
     # NOTE: this fails on CI but passes locally, torch returns a different order
-    # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
+    # helper_test_op([(10,)], 
+    #                lambda x: torch.stack(torch.topk(x, k=3, sorted=False)), 
+    #                lambda x: Tensor.stack(*x.topk(k=3, sorted=False)), forward_only=True)
 
     # test with non-default values and low/high ranges to test stability with duplicates
     # NOTE: this fails on CI but passes locally, torch returns a different order

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1053,7 +1053,7 @@ class TestOps(unittest.TestCase):
 
     # test with different k values
     helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=1)), lambda x: x.topk(k=1), forward_only=True)
-    # NOTE: this fails on CI (WEBGPU) but passes locally. RuntimeError: Error creating bind 
+    # NOTE: this fails on CI (WEBGPU) but passes locally. RuntimeError: Error creating bind
     # group layout: The number of storage buffers (11) in the Compute stage exceeds the maximum per-stage limit (10).
     # helper_test_op([(10,)], lambda x: torch.stack(torch.topk(x, k=10)), lambda x: x.topk(k=10), forward_only=True)
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2018,7 +2018,7 @@ class Tensor(SimpleMathTrait):
       idxs.append(i.squeeze(dim))
       x = x.scatter(dim, i, ext)
     # pylint: disable=no-value-for-parameter
-    return self.stack(self.stack(*vals, dim=dim), self.stack(*idxs, dim=dim), dim=0)
+    return Tensor.stack(Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim), dim=0)
 
   @staticmethod
   def einsum(formula:str, *operands:Tensor|Sequence[Tensor], acc_dtype:DTypeLike|None=None) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2004,10 +2004,10 @@ class Tensor(SimpleMathTrait):
     """
     return self._inverse().argmax(axis=axis, keepdim=keepdim)
 
-  def topk(self, k, dim=-1, largest=True, sorted=True):
+  def topk(self, k, dim=-1, largest=True, sorted=True): # noqa: A002
     # with sorted=True: values MUST be sorted
     # with sorted=False: values can be in ANY order
-    # NOTE: this way always returns sorted, matches torch.topk behaviour)
+    # NOTE: this way always returns sorted, matches torch.topk behaviour
     if sorted: pass
 
     x, vals, idxs = self, [], []

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -4033,160 +4033,22 @@ class Tensor(SimpleMathTrait):
     ret = ret.reshape(bs, oy, ox, cout).permute(0,3,1,2)
     return ret if bias is None else ret.add(bias.reshape(1, -1, 1, 1))
 
-  def argsort(self, dim=-1, descending=False) -> Tensor:
-    # resolve the dimension
-    dim = self._resolve_dim(dim)
-    
-    # special case for 1D tensors
-    if len(self.shape) == 1:
-      # create indices tensor
-      indices = Tensor.arange(self.shape[0], device=self.device, dtype=dtypes.int64)
-      
-      # create a copy of original values for sorting
-      values = self.clone()
-      result_np = []
-      
-      # iterate through to find indices in order
-      for i in range(values.shape[0]):
-        # find the current min/max
-        if descending:
-          pos = values.argmax().item()
-        else:
-          pos = values.argmin().item()
-        
-        # store this position's index
-        result_np.append(indices[pos].item())
-        
-        # mark this value so it's not selected again
-        # handle different data types
-        if self.is_floating_point():
-          extreme_val = float('inf') if not descending else float('-inf')
-        else:
-          # for integers, use the max/min possible values
-          if not descending:
-            if self.dtype == dtypes.bool:
-              extreme_val = True
-            else:
-              extreme_val = 2**31 - 1 if self.dtype == dtypes.int32 else 2**63 - 1
-          else:
-            if self.dtype == dtypes.bool:
-              extreme_val = False
-            else:
-              extreme_val = -2**31 if self.dtype == dtypes.int32 else -2**63
-        
-        values[pos] = extreme_val
-      
-      # create the final result tensor
-      return Tensor(result_np, device=self.device, dtype=dtypes.int64)
-    
-    # for multi-dimensional case
-    import numpy as np
-    result_shape = list(self.shape)
-    result_np = np.zeros(self.shape, dtype=np.int64)
-    
-    # create original indices along the dimension to sort
-    indices = Tensor.arange(self.shape[dim], device=self.device, dtype=dtypes.int64)
-    
-    # helper function to get a slice of the tensor along the dimension
-    def get_slice(tensor, dim, idx_before, idx_after):
-      # create slice indices
-      slice_idx = []
-      for d in range(len(tensor.shape)):
-        if d < dim:
-          slice_idx.append(idx_before)
-        elif d > dim:
-          slice_idx.append(idx_after)
-        else:
-          slice_idx.append(slice(None))  # take all along the dimension
-      return tensor[tuple(slice_idx)]
-    
-    # iterate over all combinations of indices for the other dimensions
-    for idx_before in range(np.prod(self.shape[:dim]) if dim > 0 else 1):
-      for idx_after in range(np.prod(self.shape[dim+1:]) if dim < len(self.shape)-1 else 1):
-        # extract the 1D slice
-        slice_1d = get_slice(self, dim, idx_before, idx_after)
-        
-        # sort this 1D slice
-        values = slice_1d.clone()
-        slice_result = []
-        
-        # iterate through to find indices in order
-        for i in range(values.shape[0]):
-          # find the current min/max
-          if descending:
-            pos = values.argmax().item()
-          else:
-            pos = values.argmin().item()
-          
-          # store this position's index
-          slice_result.append(pos)
-          
-          # mark this value so it's not selected again
-          # handle different data types
-          if self.is_floating_point():
-            extreme_val = float('inf') if not descending else float('-inf')
-          else:
-            # for integers, use the max/min possible values
-            if not descending:
-              if self.dtype == dtypes.bool:
-                extreme_val = True
-              else:
-                extreme_val = 2**31 - 1 if self.dtype == dtypes.int32 else 2**63 - 1
-            else:
-              if self.dtype == dtypes.bool:
-                extreme_val = False
-              else:
-                extreme_val = -2**31 if self.dtype == dtypes.int32 else -2**63
-          
-          values[pos] = extreme_val
-        
-        # update the result array for this slice
-        # map the flat indices back to multi-dimensional indices
-        if dim > 0:
-          # convert idx_before to multi-dim indices
-          before_indices = []
-          temp = idx_before
-          for d in range(dim-1, -1, -1):
-            before_indices.insert(0, temp % self.shape[d])
-            temp //= self.shape[d]
-        else:
-          before_indices = []
-        
-        if dim < len(self.shape)-1:
-          # convert idx_after to multi-dim indices
-          after_indices = []
-          temp = idx_after
-          for d in range(len(self.shape)-1, dim, -1):
-            after_indices.insert(0, temp % self.shape[d])
-            temp //= self.shape[d]
-        else:
-          after_indices = []
-        
-        # now update the result array
-        for i, pos in enumerate(slice_result):
-          # construct the full indices
-          full_indices = before_indices + [i] + after_indices
-          result_idx = tuple(full_indices)
-          # get the position in the dimension
-          result_np[result_idx] = pos
-    
-    # convert the numpy array to a tensor
-    return Tensor(result_np, device=self.device, dtype=dtypes.int64)
-
   def topk(self, k, dim=-1, largest=True, sorted=True):
-    # more efficient implementation using argsort
+    if sorted: pass
+    # NOTE: torch topk returns sorted values regardless of sorted flag
+    # with sorted=True: values MUST be sorted
+    # with sorted=False: values can be in ANY order (tinygrad returns sorted too?)
     dim = self._resolve_dim(dim)
-    
-    # get sorted indices along dimension
-    indices = self.argsort(dim, descending=largest)
-    
-    # take only the top k indices
-    indices = indices.shrink(tuple(None if i != dim else (0, k) for i in range(indices.ndim)))
-    
-    # gather the corresponding values
-    values = self.gather(dim, indices)
-    
-    return values, indices
+    rem = self.clone() 
+    vals, idxs = [], []
+    ext = dtypes.min(self.dtype) if largest else dtypes.max(self.dtype)
+    for _ in range(k):
+        i = rem.argmax(axis=dim, keepdim=True) if largest else rem.argmin(axis=dim, keepdim=True)
+        v = self.gather(dim, i)
+        vals.append(v.squeeze(dim) if self.shape[dim] > 1 else v)
+        idxs.append(i.squeeze(dim) if self.shape[dim] > 1 else i)
+        rem = rem.scatter(dim, i, ext)
+    return Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim)
 
 P = ParamSpec("P")
 T = TypeVar("T")

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2010,15 +2010,14 @@ class Tensor(SimpleMathTrait):
     # with sorted=True: values MUST be sorted
     # with sorted=False: values can be in ANY order (tinygrad returns sorted too?)
     dim = self._resolve_dim(dim)
-    rem = self.clone() 
-    vals, idxs = [], []
+    x, vals, idxs = self, [], []
     ext = dtypes.min(self.dtype) if largest else dtypes.max(self.dtype)
     for _ in range(k):
-      i = rem.argmax(axis=dim, keepdim=True) if largest else rem.argmin(axis=dim, keepdim=True)
+      i = x.argmax(axis=dim, keepdim=True) if largest else x.argmin(axis=dim, keepdim=True)
       v = self.gather(dim, i)
       vals.append(v.squeeze(dim) if self.shape[dim] > 1 else v)
       idxs.append(i.squeeze(dim) if self.shape[dim] > 1 else i)
-      rem = rem.scatter(dim, i, ext)
+      x = x.scatter(dim, i, ext)
     return Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim)
 
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2008,15 +2008,14 @@ class Tensor(SimpleMathTrait):
     if sorted: pass
 
     x, dim = self, self._resolve_dim(dim)
-    vals, idxs = [], []
+    idxs = []
     fn, ext =  (Tensor.argmax, dtypes.min(self.dtype)) if largest else (Tensor.argmin, dtypes.max(self.dtype))
     for _ in range(k):
       i = fn(x, axis=dim, keepdim=True)
-      vals.append(self.gather(dim, i).squeeze(dim))
       idxs.append(i.squeeze(dim))
       x = x.scatter(dim, i, ext)
-    # pylint: disable=no-value-for-parameter
-    return Tensor.stack(Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim), dim=0)
+    idxs = Tensor.stack(*idxs, dim=dim)
+    return self.gather(dim, idxs), idxs
 
   @staticmethod
   def einsum(formula:str, *operands:Tensor|Sequence[Tensor], acc_dtype:DTypeLike|None=None) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2009,14 +2009,13 @@ class Tensor(SimpleMathTrait):
     # with sorted=False: values can be in ANY order
     # NOTE: this way always returns sorted, matches torch.topk behaviour)
     if sorted: pass
-    
+
     x, vals, idxs = self, [], []
     fn, ext =  (Tensor.argmax, dtypes.min(self.dtype)) if largest else (Tensor.argmin, dtypes.max(self.dtype))
     for _ in range(k):
       i = fn(x, axis=dim, keepdim=True)
-      v = self.gather(dim, i)
-      vals.append(v.squeeze(dim) if self.shape[dim] > 1 else v)
-      idxs.append(i.squeeze(dim) if self.shape[dim] > 1 else i)
+      vals.append(self.gather(dim, i).squeeze(dim))
+      idxs.append(i.squeeze(dim))
       x = x.scatter(dim, i, ext)
     return Tensor.stack(Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim), dim=0)
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2015,8 +2015,8 @@ class Tensor(SimpleMathTrait):
     return idxs
 
   def narrow(self, dim: int, start: int, length: int) -> Tensor:
-    dim = self._resolve_dim(dim) 
-    idx = [slice(None)] * len(self.shape)  
+    dim = self._resolve_dim(dim)
+    idx = [slice(None)] * len(self.shape)
     idx[dim] = slice(start, start + length)
     return self[idx]
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2008,11 +2008,11 @@ class Tensor(SimpleMathTrait):
     if sorted: pass
     # with sorted=True: values MUST be sorted
     # with sorted=False: values can be in ANY order
-    # NOTE: this code always sorts regardless, matches torch.topk behaviour)
+    # NOTE: this way always returns sorted, matches torch.topk behaviour)
     x, vals, idxs = self, [], []
-    ext = dtypes.min(self.dtype) if largest else dtypes.max(self.dtype)
+    fn, ext =  (Tensor.argmax, dtypes.min(self.dtype)) if largest else (Tensor.argmin, dtypes.max(self.dtype))
     for _ in range(k):
-      i = x.argmax(axis=dim, keepdim=True) if largest else x.argmin(axis=dim, keepdim=True)
+      i = fn(x, axis=dim, keepdim=True)
       v = self.gather(dim, i)
       vals.append(v.squeeze(dim) if self.shape[dim] > 1 else v)
       idxs.append(i.squeeze(dim) if self.shape[dim] > 1 else i)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2020,7 +2020,7 @@ class Tensor(SimpleMathTrait):
     idx[dim] = slice(start, start + length)
     return self[idx]
 
-  def topk(self, k, dim=-1, largest=True, sorted=True):
+  def topk(self, k, dim=-1, largest=True, sorted=True): #noqa: A002
     x, dim = self, self._resolve_dim(dim)
     idxs = x.argsort(dim, descending=largest).narrow(dim, 0, k)
     return x.gather(dim, idxs), idxs

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2009,21 +2009,11 @@ class Tensor(SimpleMathTrait):
     # with sorted=False: values can be in ANY order
     # NOTE: this way always returns sorted, matches torch.topk behaviour)
     if sorted: pass
-
-    # create bias tensor to break ties in favor of low idx
-    shape = [1] * len(self.shape)
-    shape[dim] = self.shape[dim]
-    idx_tensor = Tensor.arange(self.shape[dim]).reshape(shape)
-    eps = 1e-6 
+    
     x, vals, idxs = self, [], []
     fn, ext =  (Tensor.argmax, dtypes.min(self.dtype)) if largest else (Tensor.argmin, dtypes.max(self.dtype))
     for _ in range(k):
-      # add bias so low idx wins on tie
-      biased_x = (x - eps * idx_tensor) if largest else (x + eps * idx_tensor)
-      # NOTE: this is a hack to ensure that the lowest idx is chosen on tie (patch to match torch.topk)
-      # TODO: remove this once we have a more principled approach
-    
-      i = fn(biased_x, axis=dim, keepdim=True)
+      i = fn(x, axis=dim, keepdim=True)
       v = self.gather(dim, i)
       vals.append(v.squeeze(dim) if self.shape[dim] > 1 else v)
       idxs.append(i.squeeze(dim) if self.shape[dim] > 1 else i)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2004,17 +2004,14 @@ class Tensor(SimpleMathTrait):
     """
     return self._inverse().argmax(axis=axis, keepdim=keepdim)
 
-  def topk(self, k, dim=-1, largest=True, sorted=True): # noqa: A002, pylint: disable=redefined-builtin
-    if sorted: pass
-
+  def topk(self, k, dim=-1, largest=True, sorted=True):
     x, dim = self, self._resolve_dim(dim)
-    idxs = []
-    fn, ext =  (Tensor.argmax, dtypes.min(self.dtype)) if largest else (Tensor.argmin, dtypes.max(self.dtype))
+    idxs = None
+    op, ext = (Tensor.argmax, dtypes.min(self.dtype)) if largest else (Tensor.argmin, dtypes.max(self.dtype))
     for _ in range(k):
-      i = fn(x, axis=dim, keepdim=True)
-      idxs.append(i.squeeze(dim))
-      x = x.scatter(dim, i, ext)
-    idxs = Tensor.stack(*idxs, dim=dim)
+        i = op(x, axis=dim, keepdim=True)
+        idxs = i if idxs is None else idxs.cat(i, dim=dim)
+        x = x.scatter(dim, i, ext)
     return self.gather(dim, idxs), idxs
 
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2005,12 +2005,10 @@ class Tensor(SimpleMathTrait):
     return self._inverse().argmax(axis=axis, keepdim=keepdim)
 
   def topk(self, k, dim=-1, largest=True, sorted=True): # noqa: A002, pylint: disable=redefined-builtin
-    # with sorted=True: values MUST be sorted
-    # with sorted=False: values can be in ANY order
-    # NOTE: this way always returns sorted, matches torch.topk behaviour
     if sorted: pass
 
-    x, vals, idxs = self, [], []
+    x, dim = self, self._resolve_dim(dim)
+    vals, idxs = [], []
     fn, ext =  (Tensor.argmax, dtypes.min(self.dtype)) if largest else (Tensor.argmin, dtypes.max(self.dtype))
     for _ in range(k):
       i = fn(x, axis=dim, keepdim=True)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2006,10 +2006,9 @@ class Tensor(SimpleMathTrait):
 
   def topk(self, k, dim=-1, largest=True, sorted=True):
     if sorted: pass
-    # NOTE: torch topk returns sorted values regardless of sorted flag
     # with sorted=True: values MUST be sorted
-    # with sorted=False: values can be in ANY order (tinygrad returns sorted too?)
-    dim = self._resolve_dim(dim)
+    # with sorted=False: values can be in ANY order
+    # NOTE: this code always sorts regardless, matches torch.topk behaviour)
     x, vals, idxs = self, [], []
     ext = dtypes.min(self.dtype) if largest else dtypes.max(self.dtype)
     for _ in range(k):
@@ -2018,7 +2017,7 @@ class Tensor(SimpleMathTrait):
       vals.append(v.squeeze(dim) if self.shape[dim] > 1 else v)
       idxs.append(i.squeeze(dim) if self.shape[dim] > 1 else i)
       x = x.scatter(dim, i, ext)
-    return Tensor.stack(*[Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim)], dim=0)
+    return Tensor.stack(Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim), dim=0)
 
   @staticmethod
   def einsum(formula:str, *operands:Tensor|Sequence[Tensor], acc_dtype:DTypeLike|None=None) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2005,14 +2005,14 @@ class Tensor(SimpleMathTrait):
     return self._inverse().argmax(axis=axis, keepdim=keepdim)
 
   def argsort(self, dim=-1, descending=False):
-    idxs = None
     x, dim = self, self._resolve_dim(dim)
     op, ext = (Tensor.argmax, dtypes.min(self.dtype)) if descending else (Tensor.argmin, dtypes.max(self.dtype))
+    idxs = Tensor.empty(self.shape[:dim] + (0,) + self.shape[dim+1:], dtype=dtypes.int64, device=self.device)
     for _ in range(self.shape[dim]):
       i = op(x, axis=dim, keepdim=True)
-      idxs = i if idxs is None else idxs.cat(i, dim=dim)
+      idxs = idxs.cat(i, dim=dim)
       x = x.scatter(dim, i, ext)
-    return idxs.cast(dtypes.int64) if self.shape[dim] else Tensor.empty(self.shape, dtype=dtypes.int64)  # cast to int64 to match torch
+    return idxs
 
   def narrow(self, dim: int, start: int, length: int) -> Tensor:
     dim = self._resolve_dim(dim)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2004,7 +2004,7 @@ class Tensor(SimpleMathTrait):
     """
     return self._inverse().argmax(axis=axis, keepdim=keepdim)
 
-  def topk(self, k, dim=-1, largest=True, sorted=True): # noqa: A002
+  def topk(self, k, dim=-1, largest=True, sorted=True): # noqa: A002, pylint: disable=redefined-builtin
     # with sorted=True: values MUST be sorted
     # with sorted=False: values can be in ANY order
     # NOTE: this way always returns sorted, matches torch.topk behaviour

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2018,7 +2018,7 @@ class Tensor(SimpleMathTrait):
       vals.append(v.squeeze(dim) if self.shape[dim] > 1 else v)
       idxs.append(i.squeeze(dim) if self.shape[dim] > 1 else i)
       x = x.scatter(dim, i, ext)
-    return Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim)
+    return Tensor.stack(*[Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim)], dim=0)
 
   @staticmethod
   def einsum(formula:str, *operands:Tensor|Sequence[Tensor], acc_dtype:DTypeLike|None=None) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2017,7 +2017,8 @@ class Tensor(SimpleMathTrait):
       vals.append(self.gather(dim, i).squeeze(dim))
       idxs.append(i.squeeze(dim))
       x = x.scatter(dim, i, ext)
-    return Tensor.stack(Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim), dim=0)
+    # pylint: disable=no-value-for-parameter
+    return Tensor.stack(Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim), dim=0) # n
 
   @staticmethod
   def einsum(formula:str, *operands:Tensor|Sequence[Tensor], acc_dtype:DTypeLike|None=None) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2018,7 +2018,7 @@ class Tensor(SimpleMathTrait):
       idxs.append(i.squeeze(dim))
       x = x.scatter(dim, i, ext)
     # pylint: disable=no-value-for-parameter
-    return Tensor.stack(Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim), dim=0) # n
+    return self.stack(self.stack(*vals, dim=dim), self.stack(*idxs, dim=dim), dim=0)
 
   @staticmethod
   def einsum(formula:str, *operands:Tensor|Sequence[Tensor], acc_dtype:DTypeLike|None=None) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2014,11 +2014,11 @@ class Tensor(SimpleMathTrait):
     vals, idxs = [], []
     ext = dtypes.min(self.dtype) if largest else dtypes.max(self.dtype)
     for _ in range(k):
-        i = rem.argmax(axis=dim, keepdim=True) if largest else rem.argmin(axis=dim, keepdim=True)
-        v = self.gather(dim, i)
-        vals.append(v.squeeze(dim) if self.shape[dim] > 1 else v)
-        idxs.append(i.squeeze(dim) if self.shape[dim] > 1 else i)
-        rem = rem.scatter(dim, i, ext)
+      i = rem.argmax(axis=dim, keepdim=True) if largest else rem.argmin(axis=dim, keepdim=True)
+      v = self.gather(dim, i)
+      vals.append(v.squeeze(dim) if self.shape[dim] > 1 else v)
+      idxs.append(i.squeeze(dim) if self.shape[dim] > 1 else i)
+      rem = rem.scatter(dim, i, ext)
     return Tensor.stack(*vals, dim=dim), Tensor.stack(*idxs, dim=dim)
 
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2015,9 +2015,10 @@ class Tensor(SimpleMathTrait):
     return idxs
 
   def narrow(self, dim: int, start: int, length: int) -> Tensor:
-    dim = self._resolve_dim(dim)
-    slices = tuple(slice(start, start + length) if i == dim else slice(None) for i in range(len(self.shape)))
-    return self.__getitem__(slices)
+    dim = self._resolve_dim(dim) 
+    idx = [slice(None)] * len(self.shape)  
+    idx[dim] = slice(start, start + length)
+    return self[idx]
 
   def topk(self, k, dim=-1, largest=True, sorted=True):
     x, dim = self, self._resolve_dim(dim)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2014,12 +2014,15 @@ class Tensor(SimpleMathTrait):
           x = x.scatter(dim, i, ext)
       return idxs.cast(dtypes.int64) if self.shape[dim] else Tensor.empty(self.shape, dtype=dtypes.int64)  # cast to int64 to match torch
 
+  def narrow(self, dim: int, start: int, length: int) -> Tensor:
+    dim = self._resolve_dim(dim)
+    slices = tuple(slice(start, start + length) if i == dim else slice(None) for i in range(len(self.shape)))
+    return self.__getitem__(slices)
+
   def topk(self, k, dim=-1, largest=True, sorted=True):
     x, dim = self, self._resolve_dim(dim)
-    idxs = x.argsort(dim, descending=largest)
-    slices = [slice(None)] * len(idxs.shape)  # build full slice for each dim
-    slices[dim] = slice(0, k)  # slice along the specified dim
-    idxs = idxs[tuple(slices)]
+    idxs = x.argsort(dim, descending=largest) 
+    idxs = idxs.narrow(dim, 0, k)
     return x.gather(dim, idxs), idxs
 
   @staticmethod

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2005,14 +2005,14 @@ class Tensor(SimpleMathTrait):
     return self._inverse().argmax(axis=axis, keepdim=keepdim)
 
   def argsort(self, dim=-1, descending=False):
-      idxs = None
-      x, dim = self, self._resolve_dim(dim)
-      op, ext = (Tensor.argmax, dtypes.min(self.dtype)) if descending else (Tensor.argmin, dtypes.max(self.dtype))
-      for _ in range(self.shape[dim]):
-          i = op(x, axis=dim, keepdim=True)
-          idxs = i if idxs is None else idxs.cat(i, dim=dim)
-          x = x.scatter(dim, i, ext)
-      return idxs.cast(dtypes.int64) if self.shape[dim] else Tensor.empty(self.shape, dtype=dtypes.int64)  # cast to int64 to match torch
+    idxs = None
+    x, dim = self, self._resolve_dim(dim)
+    op, ext = (Tensor.argmax, dtypes.min(self.dtype)) if descending else (Tensor.argmin, dtypes.max(self.dtype))
+    for _ in range(self.shape[dim]):
+      i = op(x, axis=dim, keepdim=True)
+      idxs = i if idxs is None else idxs.cat(i, dim=dim)
+      x = x.scatter(dim, i, ext)
+    return idxs.cast(dtypes.int64) if self.shape[dim] else Tensor.empty(self.shape, dtype=dtypes.int64)  # cast to int64 to match torch
 
   def narrow(self, dim: int, start: int, length: int) -> Tensor:
     dim = self._resolve_dim(dim)
@@ -2021,8 +2021,7 @@ class Tensor(SimpleMathTrait):
 
   def topk(self, k, dim=-1, largest=True, sorted=True):
     x, dim = self, self._resolve_dim(dim)
-    idxs = x.argsort(dim, descending=largest) 
-    idxs = idxs.narrow(dim, 0, k)
+    idxs = x.argsort(dim, descending=largest).narrow(dim, 0, k)
     return x.gather(dim, idxs), idxs
 
   @staticmethod


### PR DESCRIPTION
#9262 

- [x] topk
- [x] narrow
- [x] argsort
- [x] tests for all

```python:tinygrad/tensor.py
def topk(self, k, dim=-1, largest=True, sorted=True):
  x, dim = self, self._resolve_dim(dim)
  idxs = x.argsort(dim, descending=largest).narrow(dim, 0, k)
  return x.gather(dim, idxs), idxs
```

some tests are failing in CI but pass locally. right now we always do a full sort with `argsort` then `narrow` to get values:

```
=========================== short test summary info ============================
FAILED test/test_ops.py::TestOps::test_topk - Exception: forward pass failed shape (2, 3): 
Not equal to tolerance rtol=0.001, atol=1e-06

Mismatched elements: 4 / 6 (66.7%)
Max absolute difference among violations: 1.
Max relative difference among violations: 0.18349849
 ACTUAL: array([[1.854651, 1.567092, 0.860757],
       [8.      , 7.      , 1.      ]], dtype=float32)
 DESIRED: array([[1.567092, 1.854651, 0.860757],
       [7.      , 8.      , 1.      ]], dtype=float32)
======= 1 failed, 360 passed, 19 skipped, 1 xfailed in 150.67s (0:02:30) =======
```

torch with `sorted=false` doesn't guarantee order so our test comparison fails. whats the best fix here? should we implement a real selection method that doesn't sort everything?