### PR TITLE
Memory efficient .cat implementation via binary tree partioning.

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1257,7 +1257,7 @@ class Tensor(SimpleMathTrait):
     x = self.shrink(tuple((0, i) if d != dim else None for d,i in enumerate(index.shape))).unsqueeze(-1).transpose(-1, dim)
     return (x * index.unsqueeze(-1)._one_hot_along_dim(self.shape[dim])).sum(-1, acc_dtype=self.dtype)
 
-  def cat(self, *args, dim:int=0, eager:bool=True) -> Tensor:
+  def cat(self, *args, dim:int=0, eager:bool=False) -> Tensor:
     """
     Concatenates self with other `Tensor` in `args` along an axis specified by `dim`.
     All tensors must have the same shape except in the concatenating dimension.
@@ -1271,6 +1271,7 @@ class Tensor(SimpleMathTrait):
     Returns:
       Tensor: Concatenated tensor
     """
+    if self.ndim == 0: raise IndexError("Dimension out of range for scalar tensor")
     dim = self._resolve_dim(dim)
     for arg in args: assert arg.ndim==self.ndim and all(ti==ai for i,(ti,ai) in enumerate(zip(self.shape, arg.shape)) if i!=dim)
     tensors = [self, *args]


### PR DESCRIPTION
The way that cat is implemented currently is a bit memory inefficient. For example, this:

```
from tinygrad import Tensor
l = [Tensor.randn(1, 256, 256, 7) for i in range(256)] # (d h w c) is common for MRI data
Tensor.cat(*l).realize() # (256,256,256,7)
```
would fail with:

```
program_source:3:5823: error: no 'buffer' resource location available for 'data[0..256]'
```

This is because the current implementation does a pad for adjacent tensors to accommodate each other, then adds them together, then does a foldl along the list of tensors. This approach materializes far more large tensors than is needed (the latter tensors in the list are mostly 0s)

A better approach would be to do recursively concatenate pairs of tensors, which results in fewer large tensors. For the example above, the dimensions for the materialized intermediate tensors would be:

128 [2,256,256,7]s -> 64 [4,256,256,7]s -> 32 [8,256,256,7]s -> ... 2 [128,256,256,7]s -> [256,256,256,7]s

My implementation of this approach passes test_ops.py, but fails some tests in the full suite:
```
FAILED test/test_gc.py::TestGC::test_gc - ReferenceError: weakly-referenced object no longer exists
FAILED test/test_gc.py::TestGC::test_gc_complex - ReferenceError: weakly-referenced object no longer exists
FAILED test/test_gc.py::TestGC::test_schedule_gc - ReferenceError: weakly-referenced object no longer exists
FAILED test/test_gc.py::TestGC::test_schedule_gc_with_inputs - ReferenceError: weakly-referenced object no longer exists
FAILED test/test_gc.py::TestGC::test_toposort_blocks_gc - ReferenceError: weakly-referenced object no longer exists
FAILED test/test_multitensor.py::TestShrinkMultiTensorShardedAxis::test_add_different_tensors - AssertionError: can only pad to whole axis
FAILED test/test_multitensor.py::TestBatchNorm::test_batchnorm - AssertionError: can only pad to whole axis
```

And also contains some flaws:
- Tensors would roughly have uniform distribution of dimensions along the concatenation dim for the memory efficiency claims to hold.
- It materializes log(n)ish intermediate tensors, which might have side effects when using gradients.
- I added an "eager" flag to the .cat method, which realizes the intermediate tensors during the concatenation steps. While this is more memory efficient, it causes the function to fail 8 tests in test_ops.py.

I'll move forward with detailed benchmarks and fix the failed tests if this seems valuable.

Feedback very welcome!