### PR TITLE
Make TYPED=1 work

### DIFF
--- a/tinygrad/__init__.py
+++ b/tinygrad/__init__.py
@@ -1,7 +1,10 @@
 import os
 if int(os.getenv("TYPED", "0")):
   from typeguard import install_import_hook
+  import numpy as np
   install_import_hook(__name__)
+  import tinygrad.tensor
+  tinygrad.tensor.__dict__["np"] = np
 from tinygrad.tensor import Tensor                                    # noqa: F401
 from tinygrad.engine.jit import TinyJit                               # noqa: F401
 from tinygrad.ops import UOp

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -153,8 +153,8 @@ class Tensor(SimpleMathTrait):
       if dtype == dtypes.bfloat16: data = Tensor(_frompy(data, dtypes.float32), device=device).cast(dtypes.bfloat16).lazydata
       else: data = _frompy(data, dtype)
     elif str(type(data)) == "<class 'numpy.ndarray'>":
-      import numpy as np
-      assert isinstance(data, np.ndarray), f"expected np.ndarray, got {data}"
+      import numpy as _np
+      assert isinstance(data, _np.ndarray), f"expected np.ndarray, got {data}"
       if data.shape == (): data = _metaop(Ops.CONST, tuple(), dtype or _from_np_dtype(data.dtype), device, data.item())
       else: data = _fromnp(data.astype(npdtype) if dtype is not None and (npdtype:=_to_np_dtype(dtype)) is not None else data)  # type: ignore [name-defined]
     elif isinstance(data, pathlib.Path):
@@ -350,11 +350,11 @@ class Tensor(SimpleMathTrait):
     print(repr(t.numpy()))
     ```
     """
-    import numpy as np
+    import numpy as _np
     if self.dtype.base == dtypes.bfloat16: return self.float().numpy()
     assert _to_np_dtype(self.dtype.base) is not None, f"no np dtype for {self.dtype.base}"
     assert all_int(self.shape), f"no data if shape is symbolic, {self.shape=}"
-    return np.frombuffer(self._data(), dtype=_to_np_dtype(self.dtype.base)).reshape(self.shape)
+    return _np.frombuffer(self._data(), dtype=_to_np_dtype(self.dtype.base)).reshape(self.shape)
 
   def clone(self) -> Tensor:
     """


### PR DESCRIPTION
typeguard is catching errors now
```
engelbart@Utkarshs-MacBook-Pro tinygrad % PYTHONPATH=. TYPED=1 python examples/beautiful_mnist.py
  0%|                                                       | 0/70 [00:00<?, ?it/s]Traceback (most recent call last):
  File "/Users/engelbart/Desktop/stuff/tinygrad/examples/beautiful_mnist.py", line 43, in <module>
    loss = train_step()
           ^^^^^^^^^^^^
  File "/Users/engelbart/Desktop/stuff/tinygrad/tinygrad/engine/jit.py", line 250, in __call__
    ret = self.fxn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/engelbart/.pyenv/versions/3.11.9/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/engelbart/Desktop/stuff/tinygrad/examples/beautiful_mnist.py", line 32, in train_step
    loss = model(X_train[samples]).sparse_categorical_crossentropy(Y_train[samples]).backward()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/engelbart/Desktop/stuff/tinygrad/tinygrad/tensor.py", line 928, in backward
    for t,g in zip(tensors_need_grad, self.gradient(*tensors_need_grad, gradient=gradient, materialize_grads=True)):
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/engelbart/Desktop/stuff/tinygrad/tinygrad/tensor.py", line 903, in gradient
    grads = compute_gradient(self.lazydata, gradient.lazydata, set(target_uops))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/engelbart/Desktop/stuff/tinygrad/tinygrad/gradient.py", line 65, in compute_gradient
    lgrads: tuple[UOp|None, ...]|None = cast(tuple[UOp, ...]|None, pm_gradient.rewrite(t0, ctx=grads[t0]))
                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/engelbart/Desktop/stuff/tinygrad/tinygrad/ops.py", line 817, in rewrite
    if (ret:=(fxn(ctx=ctx, **match) if has_ctx else fxn(**match))) is not None: return ret
                                                                                ^^^^^^^^^^
  File "/Users/engelbart/Desktop/stuff/tinygrad/venv/lib/python3.11/site-packages/typeguard/_functions.py", line 166, in check_return_type
    check_type_internal(retval, annotation, memo)
  File "/Users/engelbart/Desktop/stuff/tinygrad/venv/lib/python3.11/site-packages/typeguard/_checkers.py", line 951, in check_type_internal
    checker(value, origin_type, args, memo)
  File "/Users/engelbart/Desktop/stuff/tinygrad/venv/lib/python3.11/site-packages/typeguard/_checkers.py", line 454, in check_uniontype
    raise TypeCheckError(f"did not match any element in the union:\n{formatted_errors}")
typeguard.TypeCheckError: the return value (tuple) did not match any element in the union:
  tinygrad.ops.UOp: is not an instance of tinygrad.ops.UOp
  NoneType: is not an instance of NoneType
```
