### PR TITLE
Fix TestLinearizerFailures.test_failure_53 (bounty)

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -292,7 +292,7 @@ def mv_address(mv): return ctypes.addressof(ctypes.c_char.from_buffer(mv))
 def to_char_p_p(options: list[bytes], to_type=ctypes.c_char):
   return (ctypes.POINTER(to_type) * len(options))(*[ctypes.cast(ctypes.create_string_buffer(o), ctypes.POINTER(to_type)) for o in options])
 @functools.lru_cache(maxsize=None)
-def init_c_struct_t(fields: tuple[tuple[str, ctypes._SimpleCData], ...]):
+def init_c_struct_t(fields: tuple[tuple[str, type[ctypes._SimpleCData] | type[ctypes._Pointer] | type[ctypes.Structure] | type[ctypes.Array]], ...]):
   class CStruct(ctypes.Structure):
     _pack_, _fields_ = 1, fields
   return CStruct


### PR DESCRIPTION
`test_failure_53` is passing:
```
PYTHONPATH=./ python3 test/test_linearizer_failures.py TestLinearizerFailures.test_failure_53
.
----------------------------------------------------------------------
Ran 1 test in 0.058s
```

and `python3 -m pytest test/` looks unchanged with the latest code

after making the change to linearize.py, the stack overflow error was resolved, but I started seeing:
```
tinygrad/helpers.py:297: error: Incompatible types in assignment (expression has type "tuple[tuple[str, SimpleCData[Any]], ...]", base class "Structure" defined the type as "Sequence[tuple[str, type[SimpleCData[Any]] | type[_Pointer[Any]] | type[CFuncPtr] | type[_ctypes.Union] | type[Structure] | type[Array[Any]]] | tuple[str, type[_SimpleCData[Any]] | type[_Pointer[Any]] | type[CFuncPtr] | type[_ctypes.Union] | type[Structure] | type[Array[Any]], int]]")  [assignment]
Found 1 error in 1 file (checked 96 source files)
```
I'm still getting up to speed with the codebase and it's not clear to me why the change to linearize.py introduces this, but the additional change to helpers.py resolves it