### PR TITLE
fix torch backend memory leak

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -404,9 +404,33 @@ if TORCH_DEBUG:
   (_dispatch_log:=DispatchLog()).__enter__() # NOTE: must be kept alive
 
 # NOTE: patch torch optimizer step to avoid continously growing the computation graph
+import weakref
+_torch_modules_with_buffers: weakref.WeakSet[torch.nn.Module] = weakref.WeakSet()
+def register_torch_buffer(mod, _name, _buffer): _torch_modules_with_buffers.add(mod)
+def get_real_tinygrad_buffers():
+  res = set()
+  for mod in _torch_modules_with_buffers:
+    for _,b in mod.named_buffers(recurse=False):
+      if b is not None and str(b.device) == "tiny":
+        res.add(unwrap(b))
+  return res
+torch.nn.modules.module.register_module_buffer_registration_hook(register_torch_buffer)
+
+def realize_optimizer_step(optimizer: torch.optim.Optimizer, *args, **kwargs):
+  tinygrad_tensors = []
+  for param_group in optimizer.param_groups:
+    for param in param_group["params"]:
+      if param is None: continue
+      tinygrad_tensors.append(param.data)
+  for state_dict in optimizer.state.values():
+    for _, value in state_dict.items():
+      if torch.is_tensor(value): tinygrad_tensors.append(value)
+  real_tinygrad_tensors = [unwrap(x) for x in tinygrad_tensors if str(x.device) == "tiny"]
+  real_tinygrad_tensors += get_real_tinygrad_buffers()
+  if len(real_tinygrad_tensors): Tensor.realize(*real_tinygrad_tensors)
+
 _optimizer_init = torch.optim.Optimizer.__init__
 def _optimizer_patched_init(self, *args, **kwargs):
   _optimizer_init(self, *args, **kwargs)
-  from tinygrad.tensor import all_tensors
-  self.register_step_post_hook(lambda *_: Tensor.realize(*[t for r in all_tensors if (t:=r()) is not None]))
+  self.register_step_post_hook(realize_optimizer_step)
 torch.optim.Optimizer.__init__ = _optimizer_patched_init


### PR DESCRIPTION
Realize all tensors on optimizer step.

Things like running stats from batch norm aren't captured in optimizer state or parameters. One would need to hook the model (isn't an easy way to get at it from the optimizer) and/or the specific layers. This is more foolproof, maybe sub-optimal.