### PR TITLE
hotfix:  gitignore *.log [pr]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,5 @@ weights
 comgr_*
 *.pkl
 site/
-master_schedule.py
 profile_stats
+*.log


### PR DESCRIPTION
When running
```
examples/mlperf/training_submission_v5.0/tinycorp/benchmarks/bert/implementations/tinybox_green/run_and_time.sh
```
the logfiles are in root and `git add .` tries to add them.
Also removing master_schedule.py as this is no longer a thing with the new process_replay.py