### PR TITLE
Preserve metadata across shards

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -396,14 +396,18 @@ class TestMultiTensor(unittest.TestCase):
     if m.conv1.weight.grad.lazydata.metadata is not None: sharded_metadata = m.conv1.weight.grad.lazydata.metadata.name
     # sometimes there is zeros in these grads... why?
     np.testing.assert_allclose(grad, shard_grad, atol=1e-5, rtol=1e-5)
-    if single_metadata is not None: self.assertIsNotNone(sharded_metadata, "Metadata lost after sharding"), self.assertEqual(single_metadata, sharded_metadata, "Metadata name changed after sharding")
+    if single_metadata is not None:
+      self.assertIsNotNone(sharded_metadata, "Metadata lost after sharding")
+      self.assertEqual(single_metadata, sharded_metadata, "Metadata name changed after sharding")
 
   def test_metadata_with_sharded_tensors(self):
     if TRACEMETA < 1: self.skipTest("Test requires TRACEMETA >= 1")
     c = (Tensor.ones(10, 10) + Tensor.ones(10, 10)).relu()
     orig_meta = c.lazydata.metadata.name
     c_sharded = c.shard(devices_2, axis=0)
-    if getenv("DEBUG", 0) >= 2: print(f"Original metadata: {orig_meta}, Sharded metadata: {c_sharded.lazydata.metadata.name if c_sharded.lazydata.metadata else 'None'}")
+    if getenv("DEBUG", 0) >= 2:
+      sharded_meta = c_sharded.lazydata.metadata.name if c_sharded.lazydata.metadata else 'None'
+      print(f"Original metadata: {orig_meta}, Sharded metadata: {sharded_meta}")
     self.assertIsNotNone(c_sharded.lazydata.metadata, "Metadata lost after sharding")
     self.assertEqual(orig_meta, c_sharded.lazydata.metadata.name)
     for i, shard in enumerate(c_sharded.lazydata.src):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -453,13 +453,10 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
         if original_metadata is not None: all_metadata[shard] = original_metadata
         lbs.append(shard)
     sharded_lbs = [lb.copy_to_device(d) for lb,d in zip(lbs, devices)]
-    if original_metadata is not None:
-      for lb in sharded_lbs: all_metadata[lb] = original_metadata
     contiguous_lbs = [lb.contiguous() for lb in sharded_lbs]
-    if original_metadata is not None:
-      for lb in contiguous_lbs: all_metadata[lb] = original_metadata
     ret = UOp.multi(*contiguous_lbs, axis=axis)
-    if original_metadata is not None: all_metadata[ret] = original_metadata
+    if original_metadata is not None:
+      for lb in sharded_lbs + contiguous_lbs + [ret]: all_metadata[lb] = original_metadata
     return ret
 
   # *** from LazyBuffer ***

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -450,7 +450,10 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
       for sz,off in zip(sizes, itertools.accumulate(sizes, initial=0)):
         lbs.append(self.shrink(tuple((0,s) if i != axis else (off,off+sz) for i,s in enumerate(self.shape))))
     sharded_lbs = [lb.copy_to_device(d) for lb,d in zip(lbs, devices)]
-    return UOp.multi(*[lb.contiguous() for lb in sharded_lbs], axis=axis)
+    original_metadata = all_metadata.get(self, None)
+    multi_op = UOp.multi(*[lb.contiguous() for lb in sharded_lbs], axis=axis)
+    if original_metadata is not None: all_metadata[multi_op] = original_metadata
+    return multi_op
 
   # *** from LazyBuffer ***
 


### PR DESCRIPTION
when we shard, keep original metadata instead of overwriting 
added test to check for same (for both individual shard and on final op)