### PR TITLE
refactor WebGPU export

### DIFF
--- a/examples/compile_efficientnet.py
+++ b/examples/compile_efficientnet.py
@@ -3,6 +3,7 @@ from extra.models.efficientnet import EfficientNet
 from tinygrad.tensor import Tensor
 from tinygrad.nn.state import get_state_dict, safe_save, safe_load, load_state_dict
 from extra.export_model import export_model
+from tinygrad.export import export_webgpu # refactor in progress to move only webgpu export into tinygrad/tinygrad
 from tinygrad.helpers import getenv, fetch
 import ast
 
@@ -19,9 +20,10 @@ if __name__ == "__main__":
     # loading the state dict from a safetensor file changes the generated kernels
     safe_save(get_state_dict(model), (dirname / "net.safetensors").as_posix())
     load_state_dict(model, safe_load(str(dirname / "net.safetensors")))
-    prg, inp_sizes, out_sizes, state = export_model(model, mode, Tensor.randn(1,3,224,224))
-    with open(dirname / f"net.js", "w") as text_file:
-      text_file.write(prg)
+    #prg, inp_sizes, out_sizes, state = export_model(model, mode, Tensor.randn(1,3,224,224))
+    #with open(dirname / f"net.js", "w") as text_file:
+      #text_file.write(prg)
+    export_webgpu(model.forward, (Tensor.randn(1,3,224,224),), dirname / "net.js")
 
   elif mode == "clang":
     cprog = [prg]

--- a/examples/webgpu/efficientnet/index.html
+++ b/examples/webgpu/efficientnet/index.html
@@ -37,6 +37,8 @@ canvas {  display: none; }
 <div id="time"></div>
 </div>
 <script>
+	const urlParams = new URLSearchParams(window.location.search);
+	const useShaderF16 = urlParams.get('useShaderF16') !== 'false';
 	const ctx = document.getElementById("canvas").getContext("2d", { willReadFrequently: true });
 	const resultText = document.getElementById('result');
 	let labels, net;
@@ -50,7 +52,7 @@ canvas {  display: none; }
 		if (!navigator.gpu) error("WebGPU not supported.");
 		const adapter = await navigator.gpu.requestAdapter();
 		return await adapter.requestDevice({
-			requiredFeatures: ["shader-f16"],
+			requiredFeatures: useShaderF16 ? ["shader-f16"] : [],
 			powerPreference: "high-performance"
 		});
 	};

--- a/examples/webgpu/efficientnet/index.html
+++ b/examples/webgpu/efficientnet/index.html
@@ -104,7 +104,7 @@ canvas {  display: none; }
 			resultText.innerHTML = "loading..."
 			labels = await getLabels();
 			const device = await getDevice();
-			net = await timer(() => model.load(device, '../../net.safetensors'), "(compilation)");
+			net = await timer(() => model.load(device, '../../net.js.safetensors'), "(compilation)");
 			resultText.innerHTML = "ready"
 		} catch (e) {
 			error(e)

--- a/test/web/test_webgpu.js
+++ b/test/web/test_webgpu.js
@@ -1,6 +1,6 @@
 const puppeteer = require("puppeteer");
 const { spawn } = require("child_process");
-const res = spawn("python", ["-m", "http.server", "8000"], { shell: true });
+const child = spawn("python", ["-m", "http.server", "8000"], { shell: true, detached: true });
 
 async function timeout(time) {
   return new Promise((resolve) => setTimeout(resolve, time));
@@ -8,7 +8,11 @@ async function timeout(time) {
 
 function cleanup(err) {
   console.log("cleaning up");
-  res.kill();
+  try {
+    process.kill(-child.pid);
+  } catch (error) {
+    console.error("Error while killing process group:", error);
+  }
   if (err != null) {
     console.error(err);
     process.exit(1);

--- a/test/web/test_webgpu.js
+++ b/test/web/test_webgpu.js
@@ -1,3 +1,5 @@
+const disableShaderF16 = process.argv.includes('--disableShaderF16');
+const query = disableShaderF16 ? "?useShaderF16=false" : "";
 const puppeteer = require("puppeteer");
 const { spawn } = require("child_process");
 const child = spawn("python", ["-m", "http.server", "8000"], { shell: true, detached: true });
@@ -51,7 +53,7 @@ async function runTest() {
       console.log(`error from page ${message}`),
     );
 
-  const res = await page.goto("http://localhost:8000/examples/webgpu/efficientnet/index.html");
+  const res = await page.goto(`http://localhost:8000/examples/webgpu/efficientnet/index.html${query}`);
   if (res.status() !== 200) throw new Error("Failed to load page");
 
   const textSelector = await page.waitForSelector("#result");

--- a/tinygrad/export.py
+++ b/tinygrad/export.py
@@ -1,0 +1,254 @@
+# export a computational graph for use outside of tinygrad, including references to state
+
+# TODO: is there a better place in tinygrad for this?
+# TODO: refactor in progress, simplify everything
+
+from tinygrad import Tensor, dtypes, TinyJit, Device
+from tinygrad.ops import Ops
+from tinygrad.renderer import ProgramSpec
+from tinygrad.nn.state import get_state_dict, safe_save
+from tinygrad.helpers import Context
+from tinygrad.dtype import DType
+from typing import Callable, Sequence, Any, Tuple, Dict, List, Optional
+from collections import OrderedDict
+
+def compile_net(run:TinyJit, special_names:Dict[int,str]) -> Tuple[Dict[str,str],List[Tuple[str,List[str],List[int]]],Dict[str,Tuple[int,DType,int]],Dict[str,Tensor]]:
+  functions, bufs, bufs_to_save, statements, bufnum = {}, {}, {}, [], 0
+  for ji in run.jit_cache:
+    fxn: ProgramSpec = ji.prg.p
+    functions[fxn.function_name] = fxn.src   # NOTE: this assumes all with the same name are the same
+    cargs = []
+    for i,arg in enumerate(ji.bufs):
+      key = id(arg)
+      if key not in bufs:
+        if key in special_names:
+          bufs[key] = (special_names[key], arg.size*arg.dtype.itemsize, arg.dtype, key)
+        else:
+          bufs[key] = (f"buf_{bufnum}", arg.size*arg.dtype.itemsize, arg.dtype, key)
+          bufnum += 1
+          if i > 0: bufs_to_save[bufs[key][0]] = arg   # if first usage of a buffer is not an output, and it's not a special name
+      cargs.append(bufs[key][0])
+    cargs += [var for var in fxn.vars if getattr(var, "op", None) is Ops.DEFINE_VAR] # symbolic vars; is it necessary or sufficient to check for DEFINE_VAR?
+    statements.append((fxn.function_name, cargs, fxn.global_size, fxn.local_size))
+
+  #return functions, statements, {name:(size, dtype, key) for (name,size,dtype,key) in bufs.values()}, bufs_to_save
+  return functions, statements, {name:(size, dtype, key) for (name,size,dtype,key) in bufs.values()}
+
+def jit_model(model, *args) -> Tuple[TinyJit,Dict[int,str]]:
+  assert hasattr(model, "forward") or callable(model), "model needs a forward function"
+  @TinyJit
+  def run(*x):
+    out = model.forward(*x) if hasattr(model, "forward") else model(*x)
+    assert isinstance(out, tuple) or isinstance(out, list) or isinstance(out, Tensor), "model output must be a Tensor, tuple, or a list of Tensors for export"
+    out = [out] if isinstance(out, Tensor) else out
+    return [o.realize() for o in out]
+
+  # twice to run the JIT
+  for _ in range(2): the_output = run(*args)
+  special_names = {}
+
+  # hack to put the inputs back
+  for (j,i),idx in run.input_replace.items():
+    realized_input = args[idx].lazydata.base.realized
+    run.jit_cache[j].bufs[i] = realized_input
+    special_names[id(realized_input)] = f'input{idx}'
+
+  # TODO: fetch this from the jit in self.input_replace and self.ret (hint: use get_parameters on self.ret)
+  for i, output in enumerate(the_output):
+    special_names[id(output.lazydata.base.realized)] = f'output{i}'
+  return run, special_names
+
+def dtype_to_js_type(dtype: DType) -> str:
+  return f"{'Uint' if dtype in dtypes.uints else 'Int' if (dtype in dtypes.sints or dtype == dtypes.bool) else 'Float'}{8*dtype.itemsize}Array"
+
+#def export_webgpu(functions, statements, bufs, weight_names, input_names, output_names, model_name, symbolic_vars={}, stream_weights=False) -> Tuple[str,int,int]:
+def export_webgpu(fxn:Callable[..., Tensor|Sequence[Tensor]], inputs:Sequence[Any], js_outfile:Optional[str]=None, model_name="model", save_weights=True):
+  """
+  Exports a javascript WebGPU implementation of a tinygrad model.
+  """
+
+  #assert Device.DEFAULT in EXPORT_SUPPORTED_DEVICE, "only WEBGPU, CPU, CUDA, GPU, METAL are supported"
+  Device.DEFAULT="WEBGPU"
+  #state_dict = get_state_dict(model)
+  state_dict = get_state_dict(getattr(fxn, "__self__", None))
+  for k,v in state_dict.items():
+    v.to("WEBGPU").realize()
+
+  with Context(JIT=2): run, special_names = jit_model(fxn, *inputs)
+  functions, statements, bufs = compile_net(run, special_names)
+
+
+  weight_names = {id(x.lazydata.base.realized): name for name, x in state_dict.items()}
+  input_names = [name for _,name in special_names.items() if "input" in name]
+  output_names = [name for _,name in special_names.items() if "output" in name]
+
+  # handle symbolic variables; TODO: refactor to fix some of this stuff upstream in tinygrad
+  symbolic_vars = OrderedDict()
+  for i, (_, args, global_size, _) in enumerate(statements):
+    for j, var in enumerate(args):
+      if getattr(var, "op", None) is Ops.DEFINE_VAR and isinstance(getattr(var, "arg", None), tuple) and isinstance(var.arg[0], str):
+        if var not in symbolic_vars:
+          symbolic_vars[var] = var.arg[0]
+          bufs[symbolic_vars[var]] = (var.dtype.itemsize, var.dtype, symbolic_vars[var])
+        statements[i][1][j] = symbolic_vars[var]
+
+    if global_size:
+      for j, dim in enumerate(global_size):
+        if getattr(dim, "op", None) is Ops.ADD and len(dim.src) == 2 and {dim.src[0].op, dim.src[1].op} == {Ops.DEFINE_VAR, Ops.CONST}:
+          name, val = dim.src if dim.src[1].op is Ops.CONST else reversed(dim.src)
+          global_size[j] = f"_{name.arg[0]}[0] + {val.arg}"
+
+
+
+  #prg = export_model_webgpu(functions, statements, bufs, weight_names, input_names, output_names, model_name, symbolic_vars, stream_weights)
+  #return prg, {input:bufs[input][0] for input in input_names}, {output:bufs[output][0] for output in output_names}, state
+
+
+
+
+  kernel_code = '\n\n'.join([f"const {key} = `{code.replace(key, 'main')}`;" for key, code in functions.items()])
+  kernel_names = ', '.join([name for (name, _, _, _) in statements])
+  input_names += list(symbolic_vars.values())
+  input_buffer_types = [dtype_to_js_type(bufs[inp_name][1]) for inp_name in input_names]
+  output_buffer_types = [dtype_to_js_type(bufs[out_name][1]) for out_name in output_names]
+
+  buf_type = lambda x: "uniform" if x in set(symbolic_vars.values()) else "storage"
+  create_bind_group_layouts = ",".join([
+    "device.createBindGroupLayout({{entries: [{{binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: {{ type: 'uniform' }}}}, {}]}})".format(
+        ",".join([f"{{binding: {argIdx+1}, visibility: GPUShaderStage.COMPUTE, buffer: {{ type: '{buf_type(argName)}' }} }}" for argIdx, argName in enumerate(args)])
+    )
+    for _, (_, args, _, _) in enumerate(statements)
+  ])
+  layouts = f"const layouts=[{create_bind_group_layouts}]"
+  kernel_calls = '\n        '.join([f"addComputePass(device, commandEncoder, pipelines[{i}], layouts[{i}], infinityBuf, [{', '.join(args)}], [{', '.join(str(x) for x in global_size)}]);" for i, (_name, args, global_size, _local_size) in enumerate(statements) ])
+
+  buf_type = lambda x: "createUniformBuf" if x in set(uop.arg[0] for uop in symbolic_vars) else "createEmptyBuf"
+  map_to_external_weight = lambda _key: f"state_dict['{weight_names[_key]}']" if not save_weights else f"getTensorBuffer(safetensor, metadata['{weight_names[_key]}'])"
+  _bufs =  '\n    '.join([f"const {name} = " + (f"{buf_type(_key)}(device, {size});" if _key not in weight_names else f"createWeightBuf(device, {size}, {map_to_external_weight(_key)})") + ";"  for name,(size,dtype,_key) in bufs.items()])
+  gpu_write_bufs =  '\n    '.join([f"const gpuWriteBuffer{i} = device.createBuffer({{size:{input_name}.size, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE }});" for i,input_name in enumerate(input_names)])
+  input_writers = '\n    '.join([f"await gpuWriteBuffer{i}.mapAsync(GPUMapMode.WRITE);\n        new {input_buffer_types[i]}(gpuWriteBuffer{i}.getMappedRange()).set(" + f'_{inp_name});' + f"\n        gpuWriteBuffer{i}.unmap();\n        commandEncoder.copyBufferToBuffer(gpuWriteBuffer{i}, 0, {inp_name}, 0, gpuWriteBuffer{i}.size);"  for i,inp_name in enumerate(input_names)])
+  gpu_read_bufs = '\n    '.join([f"const gpuReadBuffer{i} = device.createBuffer({{size:{output_name}.size, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ }});" for i,output_name in enumerate(output_names)])
+  outbuf_copies = '\n        '.join([f"commandEncoder.copyBufferToBuffer({output_name}, 0, gpuReadBuffer{i}, 0, output{i}.size);" for i,output_name in enumerate(output_names)])
+  output_readers = '\n        '.join([f"await gpuReadBuffer{i}.mapAsync(GPUMapMode.READ);\n        const resultBuffer{i} = new {output_buffer_types[i]}(gpuReadBuffer{i}.size/{bufs[output_names[i]][1].itemsize});\n        resultBuffer{i}.set(new {output_buffer_types[i]}(gpuReadBuffer{i}.getMappedRange()));\n        gpuReadBuffer{i}.unmap();" for i in range(len(output_names))])
+  output_return = '[{}]'.format(",".join([f'resultBuffer{i}' for i in range(len(output_names))]))
+  getTensorMetadata = f"""\nconst getTensorMetadata = (safetensorBuffer) => {{
+    const metadataLength = Number(new DataView(safetensorBuffer.buffer).getBigUint64(0, true));
+    const metadata = JSON.parse(new TextDecoder("utf8").decode(safetensorBuffer.subarray(8, 8 + metadataLength)));
+    return Object.fromEntries(Object.entries(metadata).filter(([k, v]) => k !== "__metadata__").map(([k, v]) => [k, {{...v, data_offsets: v.data_offsets.map(x => 8 + metadataLength + x)}}]));
+}};\n""" if save_weights else ""
+  #return f"""
+  prg = f"""
+const {model_name} = (() => {{
+const getTensorBuffer = (safetensorBuffer, tensorMetadata) => {{
+  return safetensorBuffer.subarray(...tensorMetadata.data_offsets);
+}};
+{getTensorMetadata}
+const createEmptyBuf = (device, size) => {{
+    return device.createBuffer({{size, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST }});
+}};
+
+const createUniformBuf = (device, size) => {{
+  return device.createBuffer({{size, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST}})
+}}
+
+const createInfinityUniformBuf = (device) => {{
+  const size = 4;
+  const buf = device.createBuffer({{
+    mappedAtCreation: true,
+    size,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST
+  }});
+  new Float32Array(buf.getMappedRange())[0] = Infinity;
+  buf.unmap();
+  return buf;
+}};
+
+const createWeightBuf = (device, size, data) => {{
+  const buf = device.createBuffer({{ size, usage: GPUBufferUsage.STORAGE{" | GPUBufferUsage.COPY_DST" if not save_weights else ", mappedAtCreation: true"} }});
+  {"data.bytes = buf;" if not save_weights else "new Uint8Array(buf.getMappedRange()).set(data); buf.unmap();"}
+  return buf;
+}};
+
+const addComputePass = (device, commandEncoder, pipeline, layout, infinityUniformBuf, bufs, workgroup) => {{
+  const bindGroup = device.createBindGroup({{
+    layout: layout,
+    entries: [
+      {{ binding: 0, resource: {{ buffer: infinityUniformBuf }} }},
+      ...bufs.map((buffer, index) => ({{ binding: index + 1, resource: {{ buffer }} }}))
+    ]
+  }});
+
+  const passEncoder = commandEncoder.beginComputePass();
+  passEncoder.setPipeline(pipeline);
+  passEncoder.setBindGroup(0, bindGroup);
+  passEncoder.dispatchWorkgroups(...workgroup);
+  passEncoder.end();
+}};
+
+{kernel_code}
+
+const setupNet = async (device, {"state_dict" if not save_weights else "safetensor"}) => {{
+    {"const metadata = getTensorMetadata(safetensor);" if not not save_weights else ""}
+    const infinityBuf = createInfinityUniformBuf(device);
+
+    {layouts}
+
+    {_bufs}
+
+    {gpu_write_bufs}
+
+    {gpu_read_bufs}
+
+    const kernels = [{kernel_names}];
+    const pipelines = await Promise.all(kernels.map(async (name, i) => {{
+      return await device.createComputePipelineAsync({{
+          layout: device.createPipelineLayout({{
+              bindGroupLayouts: [layouts[i]],
+          }}),
+          compute: {{
+              module: device.createShaderModule({{
+                  code: name,
+              }}),
+              entryPoint: "main",
+          }},
+      }});
+  }}))
+
+    return async ({",".join([f"_{input_name}" for input_name in input_names])}) => {{
+        const commandEncoder = device.createCommandEncoder();
+        {input_writers}
+        {kernel_calls}
+        {outbuf_copies}
+        const gpuCommands = commandEncoder.finish();
+        device.queue.submit([gpuCommands]);
+
+        {output_readers}
+        return {output_return};
+    }}
+}}
+const load = async (device, weight_path) => {{ return await fetch(weight_path).then(x => x.arrayBuffer()).then(x => setupNet(device, new Uint8Array(x))); }}
+return {{ load, setupNet }};
+}})();
+export default {model_name};
+"""
+
+  if js_outfile:
+    with open(js_outfile, "w") as f: f.write(prg)
+  if save_weights and state_dict:
+    safe_save(state_dict, f"{js_outfile}.safetensors")
+
+  return prg, state_dict
+
+
+"""
+from examples.llama3 import build_transformer
+model_path = fetch("https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-f16.gguf", "Llama-3.2-1B-Instruct-f16.gguf", subdir="llama3-1b-instruct")
+TEMPERATURE, TOP_K, TOP_P, ALPHA_F, ALPHA_P = 0.95, 0, 0.0, 0.0, 0.0
+max_context=1024
+start_pos = Variable("start_pos", 0, max_context).bind(0)
+model_input = [Tensor([[128000]]), start_pos, TEMPERATURE, TOP_K, TOP_P, ALPHA_F, ALPHA_P]
+model = build_transformer(model_path, model_size="1B", quantize="int8", scale_dtype=dtypes.float32, device="NV", max_context=max_context)
+
+export_model_webgpu(model.forward, model_input, "webgpu_model.js")
+done = 1
+"""


### PR DESCRIPTION
This PR moves WebGPU export into the main tinygrad codebase, with the goal of making it easy to deploy models to the browser from tinygrad, PyTorch (tiny backend), or ONNX (after import to tinygrad).

To see example usage of the new `export_webgpu` in CI, see `examples/compile_efficientnet.py` which is run from the CI job `MacOS (WebGPU)`:

`from tinygrad.export import export_webgpu`
`# ... model setup`
`export_webgpu(model.forward, (Tensor.randn(1,3,224,224),), dirname / "net.js")`
`# this results in net.js and net.js.safetensors being saved to disk`

The above `export_webgpu` API is similar to [exporting ONNX models from torch](https://pytorch.org/docs/stable/onnx.html), but here we export a javascript file and safetensors file, ready to run in the browser with no further dependencies. Because this export doesn't rely on a browser ONNX runtime, it'll likely be faster and have smaller footprint, and not be limited by ONNX runtime op compatibility.

For reference browser ONNX runtimes see [Microsoft's ONNX runtime for web](https://onnxruntime.ai/docs/tutorials/web/), and [wonnx](https://github.com/webonnx/wonnx).

The commits until now are a starting point before more refactoring, simplification, and documentation/examples. The `export_webgpu` interface can evolve.