### PR TITLE
ensure randn seed is realized + remove contiguous from threefry [pr]

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -318,7 +318,6 @@ class TestJit(unittest.TestCase):
     assert len(res3) == 10, "All values should be different, rand works in jit."
     assert res3 != res2, "Jit rand is diff with diff seeds"
 
-  @unittest.expectedFailure # requires contiguous folding
   def test_jit_random_after_unrealized_random(self):
     @TinyJit
     def f(): return Tensor.rand()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -522,9 +522,11 @@ class Tensor(SimpleMathTrait):
       Tensor._device_seeds[device] = Tensor(
         [int.from_bytes(hashlib.sha256(len(Tensor._device_seeds).to_bytes(4, "big")).digest(), "big"), Tensor._seed],
         device=device, dtype=dtypes.uint32, requires_grad=False)
-      Tensor._device_rng_counters[device] = Tensor([0], device=device, dtype=dtypes.uint32, requires_grad=False)
+      # NOTE: this realize exists to ensure the increment is an ASSIGN and not a replace
+      # otherwise when we enter the JIT, the seed stays the same
+      Tensor._device_rng_counters[device] = Tensor([0], device=device, dtype=dtypes.uint32, requires_grad=False).realize()
     # increment rng counter for devices
-    else: Tensor._device_rng_counters[device].assign(Tensor._device_rng_counters[device] + num).contiguous()
+    else: Tensor._device_rng_counters[device].assign(Tensor._device_rng_counters[device] + num)
 
     # threefry random bits
     counts0 = (Tensor.arange(ceildiv(num, 2), device=device, dtype=dtypes.uint32, requires_grad=False)+Tensor._device_rng_counters[device])


### PR DESCRIPTION
This diff brings back the behavior https://github.com/tinygrad/tinygrad/pull/6869 introduced to threefry.

Threefry uses `seed.assign(seed+1)` to ensure every Tensor.rand generates a new random.

The root cause of https://github.com/tinygrad/tinygrad/issues/9108 is that if `Tensor.rand` is called once outside the JIT, the seed Tensor UOp becomes a lazy `ADD`. When this ADD enters the JIT, `seed +=1` of each JIT Item exec never gets written to memory, thus all JIT items read the same seed.

I believe the fix #6869 was not correct though - we do not want to break the graph on seed increment, rather, we want to ensure `seed.assign(seed+1)` isn't just a UOp replace, but a write to memory.