### PR TITLE
`simple_matmul.py` uses np to generate random

### DIFF
--- a/extra/gemm/simple_matmul.py
+++ b/extra/gemm/simple_matmul.py
@@ -19,9 +19,10 @@ INT_HIGH = getenv("INT_HIGH", 10)
 
 if __name__ == "__main__":
   def init_matrix(rows, cols):
+    rng = np.random.default_rng()
     if dtype_in in dtypes.ints:
-      return Tensor(np.random.default_rng().integers(INT_LOW, INT_HIGH, (rows, cols)).astype(_to_np_dtype(dtype_in)))
-    return Tensor(np.random.rand(rows, cols).astype(_to_np_dtype(dtype_in)))
+      return Tensor(rng.integers(INT_LOW, INT_HIGH, (rows, cols), _to_np_dtype(dtype_in))).realize()
+    return Tensor(rng.random((rows, cols), "float32").astype(_to_np_dtype(dtype_in))).realize()
 
   a, b = init_matrix(M, K), init_matrix(K, N)
   for i in range(CNT):

--- a/extra/gemm/simple_matmul.py
+++ b/extra/gemm/simple_matmul.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
   def init_matrix(rows, cols):
     rng = np.random.default_rng()
     if dtype_in in dtypes.ints:
-      return Tensor(rng.integers(INT_LOW, INT_HIGH, (rows, cols), _to_np_dtype(dtype_in))).realize()
+      return Tensor(rng.integers(INT_LOW, INT_HIGH, (rows, cols), dtype=_to_np_dtype(dtype_in))).realize()
     return Tensor(rng.random((rows, cols), dtype=np.float32).astype(_to_np_dtype(dtype_in))).realize()
 
   a, b = init_matrix(M, K), init_matrix(K, N)

--- a/extra/gemm/simple_matmul.py
+++ b/extra/gemm/simple_matmul.py
@@ -1,6 +1,6 @@
 import numpy as np
 from tinygrad.helpers import getenv
-from tinygrad.tensor import _to_np_dtype
+from tinygrad.dtype import _to_np_dtype
 from tinygrad import dtypes, Tensor
 
 dtype_in = dtypes.half if getenv("HALF") else dtypes.bfloat16 if getenv("BFLOAT16") else dtypes.float

--- a/extra/gemm/simple_matmul.py
+++ b/extra/gemm/simple_matmul.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     rng = np.random.default_rng()
     if dtype_in in dtypes.ints:
       return Tensor(rng.integers(INT_LOW, INT_HIGH, (rows, cols), _to_np_dtype(dtype_in))).realize()
-    return Tensor(rng.random((rows, cols), "float32").astype(_to_np_dtype(dtype_in))).realize()
+    return Tensor(rng.random((rows, cols), dtype=np.float32).astype(_to_np_dtype(dtype_in))).realize()
 
   a, b = init_matrix(M, K), init_matrix(K, N)
   for i in range(CNT):

--- a/extra/gemm/simple_matmul.py
+++ b/extra/gemm/simple_matmul.py
@@ -20,7 +20,7 @@ INT_HIGH = getenv("INT_HIGH", 10)
 if __name__ == "__main__":
   def init_matrix(rows, cols):
     if dtype_in in dtypes.ints:
-      return Tensor(np.random.randint(INT_LOW, INT_HIGH, (rows, cols)).astype(_to_np_dtype(dtype_in)))
+      return Tensor(np.random.default_rng().integers(INT_LOW, INT_HIGH, (rows, cols)).astype(_to_np_dtype(dtype_in)))
     return Tensor(np.random.rand(rows, cols).astype(_to_np_dtype(dtype_in)))
 
   a, b = init_matrix(M, K), init_matrix(K, N)

--- a/extra/gemm/simple_matmul.py
+++ b/extra/gemm/simple_matmul.py
@@ -1,5 +1,6 @@
 import numpy as np
 from tinygrad.helpers import getenv
+from tinygrad.tensor import _to_np_dtype
 from tinygrad import dtypes, Tensor
 
 dtype_in = dtypes.half if getenv("HALF") else dtypes.bfloat16 if getenv("BFLOAT16") else dtypes.float
@@ -13,12 +14,14 @@ K = getenv("K", N)
 CNT = getenv("CNT", 10)
 ATOL = getenv("ATOL", 1e-4)
 RTOL = getenv("RTOL", 3e-2)
+INT_LOW = getenv("INT_LOW", 0)
+INT_HIGH = getenv("INT_HIGH", 10)
 
 if __name__ == "__main__":
   def init_matrix(rows, cols):
     if dtype_in in dtypes.ints:
-      return Tensor.randint((rows, cols), dtype=dtype_in).realize()
-    return Tensor.rand(rows, cols, dtype=dtype_in).realize()
+      return Tensor(np.random.randint(INT_LOW, INT_HIGH, (rows, cols)).astype(_to_np_dtype(dtype_in)))
+    return Tensor(np.random.rand(rows, cols).astype(_to_np_dtype(dtype_in)))
 
   a, b = init_matrix(M, K), init_matrix(K, N)
   for i in range(CNT):


### PR DESCRIPTION
As requested by George on discord

Using generator for ints but not for floats due to the following benchmarks
```
np.random.randint   : 2.6765651249997973
rng.integers        : 1.0878237079996325
np.random.rand      : 1.4534849159999794
rng.random          : 1.8805371250000462
```