### PR TITLE
RetinaNet dataloader

### DIFF
--- a/examples/mlperf/dataloader.py
+++ b/examples/mlperf/dataloader.py
@@ -348,6 +348,167 @@ def batch_load_unet3d(preprocessed_dataset_dir:Path, batch_size:int=6, val:bool=
       # happens with BENCHMARK set
       pass
 
+### RetinaNet
+
+def load_retinanet_data(base_dir:Path, val:bool, queue_in:Queue, queue_out:Queue,
+                        imgs:Tensor, boxes:Tensor, labels:Tensor, matches:Tensor|None=None,
+                        anchors:Tensor|None=None, seed:int|None=None):
+  from extra.datasets.openimages import image_load, random_horizontal_flip, resize
+  from examples.mlperf.helpers import box_iou, find_matches, generate_anchors
+  import torch
+
+  while (data:=queue_in.get()) is not None:
+    idx, img, tgt = data
+    img = image_load(base_dir, img["subset"], img["file_name"])
+
+    if val:
+      img = resize(img)[0]
+    else:
+      if seed is not None:
+        np.random.seed(seed)
+        random.seed(seed)
+        torch.manual_seed(seed)
+
+      img, tgt = random_horizontal_flip(img, tgt)
+      img, tgt, _ = resize(img, tgt=tgt)
+      match_quality_matrix = box_iou(tgt["boxes"], (anchor := np.concatenate(generate_anchors((800, 800)))))
+      match_idxs = find_matches(match_quality_matrix, allow_low_quality_matches=True)
+      clipped_match_idxs = np.clip(match_idxs, 0, None)
+      clipped_boxes, clipped_labels = tgt["boxes"][clipped_match_idxs], tgt["labels"][clipped_match_idxs]
+
+      boxes[idx].contiguous().realize().lazydata.base.realized.as_buffer(force_zero_copy=True)[:] = clipped_boxes.tobytes()
+      labels[idx].contiguous().realize().lazydata.base.realized.as_buffer(force_zero_copy=True)[:] = clipped_labels.tobytes()
+      matches[idx].contiguous().realize().lazydata.base.realized.as_buffer(force_zero_copy=True)[:] = match_idxs.tobytes()
+      anchors[idx].contiguous().realize().lazydata.base.realized.as_buffer(force_zero_copy=True)[:] = anchor.tobytes()
+
+    imgs[idx].contiguous().realize().lazydata.base.realized.as_buffer(force_zero_copy=True)[:] = img.tobytes()
+
+    queue_out.put(idx)
+  queue_out.put(None)
+
+def batch_load_retinanet(dataset, val:bool, base_dir:Path, batch_size:int=32, shuffle:bool=True, seed:int|None=None):
+  def _enqueue_batch(bc):
+    from extra.datasets.openimages import prepare_target
+    for idx in range(bc * batch_size, (bc+1) * batch_size):
+      img = dataset.loadImgs(next(dataset_iter))[0]
+      ann = dataset.loadAnns(dataset.getAnnIds(img_id:=img["id"]))
+      tgt = prepare_target(ann, img_id, (img["height"], img["width"]))
+
+      if img_ids is not None:
+        img_ids[idx] = img_id
+
+      if img_sizes is not None:
+        img_sizes[idx] = tgt["image_size"]
+
+      queue_in.put((idx, img, tgt))
+
+  def _setup_shared_mem(shm_name:str, size:tuple[int, ...], dtype:dtypes) -> tuple[shared_memory.SharedMemory, Tensor]:
+    if os.path.exists(f"/dev/shm/{shm_name}"): os.unlink(f"/dev/shm/{shm_name}")
+    shm = shared_memory.SharedMemory(name=shm_name, create=True, size=prod(size))
+    shm_tensor = Tensor.empty(*size, dtype=dtype, device=f"disk:/dev/shm/{shm_name}")
+    return shm, shm_tensor
+
+  image_ids = sorted(dataset.imgs.keys())
+  batch_count = min(32, len(image_ids) // batch_size)
+
+  queue_in, queue_out = Queue(), Queue()
+  procs, data_out_count = [], [0] * batch_count
+
+  shm_imgs, imgs = _setup_shared_mem("retinanet_imgs", (batch_size * batch_count, 800, 800, 3), dtypes.uint8)
+
+  if val:
+    boxes, labels, matches, anchors = None, None, None, None
+    img_ids, img_sizes = [None] * (batch_size * batch_count), [None] * (batch_size * batch_count)
+  else:
+    img_ids, img_sizes = None, None
+    shm_boxes, boxes = _setup_shared_mem("retinanet_boxes", (batch_size * batch_count, 120087, 4), dtypes.float32)
+    shm_labels, labels = _setup_shared_mem("retinanet_labels", (batch_size * batch_count, 120087), dtypes.int64)
+    shm_matches, matches = _setup_shared_mem("retinanet_matches", (batch_size * batch_count, 120087), dtypes.int64)
+    shm_anchors, anchors = _setup_shared_mem("retinanet_anchors", (batch_size * batch_count, 120087, 4), dtypes.float64)
+
+  shutdown = False
+  class Cookie:
+    def __init__(self, bc):
+      self.bc = bc
+    def __del__(self):
+      if not shutdown:
+        try: _enqueue_batch(self.bc)
+        except StopIteration: pass
+
+  def shuffle_indices(indices, seed):
+    rng = random.Random(seed)
+    rng.shuffle(indices)
+
+  if shuffle: shuffle_indices(image_ids, seed=seed)
+  dataset_iter = iter(image_ids)
+
+  try:
+    for _ in range(cpu_count()):
+      proc = Process(
+        target=load_retinanet_data,
+        args=(base_dir, val, queue_in, queue_out, imgs, boxes, labels),
+        kwargs={"matches": matches, "anchors": anchors, "seed": seed}
+      )
+      proc.daemon = True
+      proc.start()
+      procs.append(proc)
+
+    for bc in range(batch_count):
+      _enqueue_batch(bc)
+
+    for _ in range(len(image_ids) // batch_size):
+      while True:
+        bc = queue_out.get() // batch_size
+        data_out_count[bc] += 1
+        if data_out_count[bc] == batch_size: break
+
+      data_out_count[bc] = 0
+
+      if val:
+        yield (imgs[bc * batch_size:(bc + 1) * batch_size],
+               img_ids[bc * batch_size:(bc + 1) * batch_size],
+               img_sizes[bc * batch_size:(bc + 1) * batch_size],
+               Cookie(bc))
+      else:
+        yield (imgs[bc * batch_size:(bc + 1) * batch_size],
+               boxes[bc * batch_size:(bc + 1) * batch_size],
+               labels[bc * batch_size:(bc + 1) * batch_size],
+               matches[bc * batch_size:(bc + 1) * batch_size],
+               anchors[bc * batch_size:(bc + 1) * batch_size],
+               Cookie(bc))
+  finally:
+    shutdown = True
+
+    for _ in procs: queue_in.put(None)
+    queue_in.close()
+
+    for _ in procs:
+      while queue_out.get() is not None: pass
+    queue_out.close()
+
+    # shutdown processes
+    for proc in procs: proc.join()
+
+    shm_imgs.close()
+
+    if not val:
+      shm_boxes.close()
+      shm_labels.close()
+      shm_matches.close()
+      shm_anchors.close()
+
+    try:
+      shm_imgs.unlink()
+
+      if not val:
+        shm_boxes.unlink()
+        shm_labels.unlink()
+        shm_matches.unlink()
+        shm_anchors.unlink()
+    except FileNotFoundError:
+      # happens with BENCHMARK set
+      pass
+
 if __name__ == "__main__":
   def load_unet3d(val):
     assert not val, "validation set is not supported due to different sizes on inputs"
@@ -367,6 +528,14 @@ if __name__ == "__main__":
     with tqdm(total=len(files)) as pbar:
       for x,y,c in batch_load_resnet(val=val):
         pbar.update(x.shape[0])
+
+  def load_retinanet(val):
+    from extra.datasets.openimages import BASEDIR, download_dataset
+    from pycocotools.coco import COCO
+    dataset = COCO(download_dataset(base_dir:=getenv("BASE_DIR", BASEDIR), "validation" if val else "train"))
+    with tqdm(total=len(dataset.imgs.keys())) as pbar:
+      for x in batch_load_retinanet(dataset, val, base_dir):
+        pbar.update(x[0].shape[0])
 
   load_fn_name = f"load_{getenv('MODEL', 'resnet')}"
   if load_fn_name in globals():

--- a/extra/datasets/openimages.py
+++ b/extra/datasets/openimages.py
@@ -4,6 +4,7 @@ import numpy as np
 from PIL import Image
 from pathlib import Path
 import boto3, botocore
+from tinygrad import Tensor, dtypes
 from tinygrad.helpers import fetch, tqdm, getenv
 import pandas as pd
 import concurrent.futures
@@ -139,11 +140,7 @@ def fetch_openimages(output_fn:str, base_dir:Path, subset:str):
 
 def image_load(base_dir, subset, fn):
   img_folder = base_dir / f"{subset}/data"
-  img = Image.open(img_folder / fn).convert('RGB')
-  import torchvision.transforms.functional as F
-  ret = F.resize(img, size=(800, 800))
-  ret = np.array(ret)
-  return ret, img.size[::-1]
+  return Image.open(img_folder / fn).convert('RGB')
 
 def prepare_target(annotations, img_id, img_size):
   boxes = [annot["bbox"] for annot in annotations]
@@ -164,7 +161,7 @@ def iterate(coco, base_dir, bs=8):
     X, targets  = [], []
     for img_id in image_ids[i:i+bs]:
       img_dict = coco.loadImgs(img_id)[0]
-      x, original_size = image_load(base_dir, img_dict['subset'], img_dict["file_name"])
+      x, original_size = resize(image_load(base_dir, img_dict['subset'], img_dict["file_name"]))
       X.append(x)
       annotations = coco.loadAnns(coco.getAnnIds(img_id))
       targets.append(prepare_target(annotations, img_id, original_size))
@@ -179,6 +176,34 @@ def download_dataset(base_dir:Path, subset:str) -> Path:
 
   return ann_file
 
+def random_horizontal_flip(img, tgt, prob=0.5):
+  import torch
+  import torchvision.transforms.functional as F
+  if torch.rand(1) < prob:
+    w = img.size[0]
+    img = F.hflip(img)
+    tgt["boxes"][:, [0, 2]] = w - tgt["boxes"][:, [2, 0]]
+  return img, tgt
+
+def resize(img:Image, tgt:dict[str, np.ndarray|tuple]|None=None, size:tuple[int, int]=(800, 800)) -> tuple[np.ndarray, np.ndarray, tuple]|tuple[np.ndarray, tuple]:
+  import torchvision.transforms.functional as F
+  img_size = img.size[::-1]
+  img = F.resize(img, size=size)
+  img = np.array(img)
+
+  if tgt is not None:
+    ratios = [s / s_orig for s, s_orig in zip(size, img_size)]
+    ratio_h, ratio_w = ratios
+    x_min, y_min, x_max, y_max = [tgt["boxes"][:, i] for i in range(tgt["boxes"].shape[-1])]
+    x_min = x_min * ratio_w
+    x_max = x_max * ratio_w
+    y_min = y_min * ratio_h
+    y_max = y_max * ratio_h
+
+    tgt["boxes"] = np.stack([x_min, y_min, x_max, y_max], axis=1)
+    return img, tgt, img_size
+
+  return img, img_size
 
 if __name__ == "__main__":
   download_dataset(base_dir:=getenv("BASE_DIR", BASEDIR), "train")


### PR DESCRIPTION
# Overview
As part of #8385, this PR adds the implementation for the RetinaNet dataloader that will be responsible for loading both training and validation datasets.

Note that future PRs will use this as part of `model_eval.py` as well as the main training loop.

# Tasks
- [ ] Add dataloader tests
- [ ] Ensure dataloader CI test works