### PR TITLE
increase `Linux(DSP)` timeout (10 -> 15min)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -467,7 +467,7 @@ jobs:
   testdsp:
     name: Linux (DSP)
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4


### PR DESCRIPTION
flaky, failed me twice today in ci [(failed task)](https://github.com/tinygrad/tinygrad/actions/runs/13863016046/job/38795785728)