### PR TITLE
generalize where alu fold

### DIFF
--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -516,9 +516,12 @@ class TestSymbolic(unittest.TestCase):
     b = Variable("b", 0, 3)
     aa = cond.where(a, a.ufix(0))
     bb = cond.where(b, b.ufix(1))
+    bb_flipped = cond.where(b.ufix(1), b)
     self.helper_test_variable(aa, 0, 3, "(a if (x<2) else 0)")
     self.helper_test_variable(bb, 0, 3, "(b if (x<2) else 1)")
+    self.helper_test_variable(bb_flipped, 0, 3, "(1 if (x<2) else b)")
     self.helper_test_variable(aa+bb, 0, 6, "((a+b) if (x<2) else 1)")
+    self.helper_test_variable(aa+bb_flipped, 0, 4, "((a+1) if (x<2) else b)")
     self.helper_test_variable(aa.maximum(bb), 0, 3, "(max(a, b) if (x<2) else 1)")
 
     # not combining because it increased total ALU

--- a/tinygrad/codegen/symbolic.py
+++ b/tinygrad/codegen/symbolic.py
@@ -187,9 +187,9 @@ symbolic = symbolic_simple+PatternMatcher([
   # a conditional with the same results either way is a noop, also fold const conditionals
   (UPat.var().where(UPat.var("val"), UPat.var("val")), lambda val: val),
   (UPat.cvar("gate", vec=False).where(UPat.var("c0"), UPat.var("c1")), lambda gate, c0, c1: c0 if gate.arg else c1),
-  # alu of two where with same conds can combine, only do if true branch or false branch is const
+  # alu of two where with same conds can combine, only do if at least 2 branches are consts
   (UPat(GroupOp.Binary, name="alu", src=(UPat.var("c").where(UPat.var("t"), UPat.var("f")), UPat.var("c").where(UPat.var("tt"), UPat.var("ff")))), \
-   lambda alu,c,t,tt,f,ff: c.where(t.alu(alu.op, tt), f.alu(alu.op, ff)) if t.op == tt.op == Ops.CONST or f.op == ff.op == Ops.CONST else None),
+   lambda alu,c,t,tt,f,ff: c.where(t.alu(alu.op, tt), f.alu(alu.op, ff)) if len([x for x in [t,tt,f,ff] if x.op is Ops.CONST]) >= 2 else None),
   # ALU min==max -> CONST (slow!)
   (UPat(GroupOp.ALU, name="x"), lambda x: x.const_like(x.vmin) if x.vmin == x.vmax else None),
   # max folding


### PR DESCRIPTION
previously we fold alu of where with same condition and branches like ((x, const), (y, const)) or ((const, x), (const, y)).

we can also fold ((x, const), (const, y)) or ((const, x), (y, const)) because alu with const does not increase total alu