### PR TITLE
Fast DSP for MobileNetV2 (try 2)

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -728,7 +728,9 @@ def get_onnx_ops():
   def QuantizeLinear(x:Tensor, y_scale:Tensor, y_zero_point:Tensor|int=0, axis:int=1, block_size:int=0, output_dtype:int=0, saturate=1):
     out_dtype = y_zero_point.dtype if isinstance(y_zero_point, Tensor) else dtype_parse(output_dtype) if output_dtype else dtypes.uint8
     y_scale, y_zero_point = _prepare_quantize(x, y_scale, y_zero_point, axis, block_size)
-    return _clamp_cast(((x / y_scale).round() + y_zero_point), out_dtype).contiguous()
+    # this appears to work in practice, at least for uchar out_dtype. it folds with the quantize stuff
+    return _clamp_cast((x / y_scale + 0.5 + y_zero_point).int(), out_dtype).contiguous()
+    #return _clamp_cast(((x / y_scale).round() + y_zero_point), out_dtype).contiguous()
 
   def DynamicQuantizeLinear(x: Tensor):
     # only support uint8

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -730,7 +730,7 @@ def get_onnx_ops():
     y_scale, y_zero_point = _prepare_quantize(x, y_scale, y_zero_point, axis, block_size)
     if out_dtype == dtypes.uchar:
       # this appears to work in practice, at least for uchar out_dtype. it folds with the quantize stuff
-      return _clamp_cast((x / y_scale + 0.5 + y_zero_point).int(), out_dtype).contiguous()
+      return _clamp_cast((x / y_scale + 0.4999999 + y_zero_point).int(), out_dtype).contiguous()
     else:
       return _clamp_cast(((x / y_scale).round() + y_zero_point), out_dtype).contiguous()
 

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -728,9 +728,11 @@ def get_onnx_ops():
   def QuantizeLinear(x:Tensor, y_scale:Tensor, y_zero_point:Tensor|int=0, axis:int=1, block_size:int=0, output_dtype:int=0, saturate=1):
     out_dtype = y_zero_point.dtype if isinstance(y_zero_point, Tensor) else dtype_parse(output_dtype) if output_dtype else dtypes.uint8
     y_scale, y_zero_point = _prepare_quantize(x, y_scale, y_zero_point, axis, block_size)
-    # this appears to work in practice, at least for uchar out_dtype. it folds with the quantize stuff
-    return _clamp_cast((x / y_scale + 0.5 + y_zero_point).int(), out_dtype).contiguous()
-    #return _clamp_cast(((x / y_scale).round() + y_zero_point), out_dtype).contiguous()
+    if out_dtype == dtypes.uchar:
+      # this appears to work in practice, at least for uchar out_dtype. it folds with the quantize stuff
+      return _clamp_cast((x / y_scale + 0.5 + y_zero_point).int(), out_dtype).contiguous()
+    else:
+      return _clamp_cast(((x / y_scale).round() + y_zero_point), out_dtype).contiguous()
 
   def DynamicQuantizeLinear(x: Tensor):
     # only support uint8

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -197,8 +197,8 @@ class ClangRenderer(CStyleLanguage):
   if sys.platform == 'win32':
     kernel_prefix = "__attribute__((ms_abi)) "
   def render_vector_prefix(self, dt:DType) -> str:
-    # round (down) to power of two
-    alignment = 2**int(math.log2(dt.itemsize))
+    # round (down) to power of two (this is actually the default clang behavior)
+    alignment = 2**int(math.log2(dt.itemsize)) if getenv("ALIGNED", 1) else 1
     return f"typedef {self.render_dtype(dt.scalar())} {self.render_dtype(dt)} __attribute__((aligned({alignment}),vector_size({dt.itemsize})));"
 
   def render_kernel(self, function_name, kernel, bufs, uops, prefix=None) -> str:

--- a/tinygrad/runtime/ops_dsp.py
+++ b/tinygrad/runtime/ops_dsp.py
@@ -27,6 +27,11 @@ dsp_pm_late = PatternMatcher([
    lambda d: d.replace(src=(UOp(Ops.CUSTOMI, d.dtype, arg="__builtin_HEXAGON_V6_vd0_128B()"),)+d.src[1:])),
 ])
 
+# NOTE: this just increases readability of the generated code
+dsp_string = PatternMatcher([
+  (UPat(Ops.CONST, (dtypes.int8, dtypes.uint8), name="x"), lambda ctx,x: str(x.arg)),
+])
+
 class DSPRenderer(ClangRenderer):
   device = "DSP"
   supports_float4 = True
@@ -34,6 +39,7 @@ class DSPRenderer(ClangRenderer):
   kernel_prefix = "__attribute__((noinline)) "
   pre_matcher = dsp_pm
   extra_matcher = dsp_pm_late+ClangRenderer.extra_matcher
+  string_rewrite = dsp_string+ClangRenderer.string_rewrite
   type_map = { **ClangRenderer.type_map, dtypes.uint64: "unsigned long long", dtypes.int64: "long long" }
   code_for_op = {**ClangRenderer.code_for_op, Ops.SIN: lambda x,dtype: f"__builtin_sin({x})",
                  Ops.LOG2: lambda x,dtype: f"__builtin_log2l({x})" if dtype == dtypes.float64 else f"__builtin_log2f({x})",


### PR DESCRIPTION
`export PATH=/opt/homebrew/Cellar/llvm/19.1.7_1/bin:$PATH`

`DEBUG=2 CNT=4 DEVECTORIZE=0 CPU=1 DONT_REALIZE_EXPAND=1 QUANT=1 python3 examples/test_onnx_imagenet.py https://github.com/xamcat/mobcat-samples/raw/refs/heads/master/onnx_runtime/InferencingSample/InferencingSample/mobilenetv2-7.onnx`

`DEBUG=2 CNT=4 DEVECTORIZE=0 CPU=1 DONT_REALIZE_EXPAND=1 python3 examples/test_onnx_imagenet.py /tmp/model.quant.onnx`

`ALIGNED=0 QUANTIZE=1 DEBUG=2 DEVECTORIZE=0 python3 extra/replay_pkl.py /tmp/im.pkl`