### PR TITLE
simple failing test for extra ops in VALID [pr]

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -98,6 +98,13 @@ class TestSchedule(unittest.TestCase):
     a.realize()
     assert not a.lazydata.is_realized
 
+  @unittest.expectedFailure
+  def test_simplify_padded_const(self):
+    a = Tensor.empty(1022).cummax(axis=0)
+    sched = a.schedule()
+    ast = sched[0].ast
+    self.assertLessEqual(len([u for u in ast.toposort if u.op is Ops.WHERE]), 6)
+
   def test_basic_binop_fusion(self):
     a = Tensor.empty(10)
     b = Tensor.empty(10)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -101,7 +101,7 @@ class TestSchedule(unittest.TestCase):
   @unittest.expectedFailure
   def test_simplify_padded_const(self):
     a = Tensor.empty(1022).cummax(axis=0)
-    sched = a.schedule()
+    sched = check_schedule(a, 5)
     ast = sched[0].ast
     self.assertLessEqual(len([u for u in ast.toposort if u.op is Ops.WHERE]), 6)
 


### PR DESCRIPTION
Since alu2 already depends on alu1 we don't need the extra `alu2?alu1:0`:

```diff

kernel void E_4_511(device float* data0, device float* data1, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int gidx0 = gid.x; /* 511 */
  int gidx1 = gid.y; /* 4 */
  int alu0 = (gidx0+(gidx1<<8));
  bool alu1 = ((gidx0<255)!=1);
  bool alu2 = (alu1&((alu0<257)!=1));
  float val0 = (alu2?*(data1+(alu0+-257)):0.0f);
- *(data0+(gidx0+(gidx1*511))) = (val0+((alu2?alu1:0)?0.0f:(alu1?((float)(-INFINITY)):0.0f))+(alu1?0.0f:((float)(-INFINITY))));
+ *(data0+(gidx0+(gidx1*511))) = (val0+(alu2?0.0f:(alu1?((float)(-INFINITY)):0.0f))+(alu1?0.0f:((float)(-INFINITY))));
}
```
