### PR TITLE
hotfix: skip test_mean_half_precision_underflow on amd ci

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -820,6 +820,7 @@ class TestAutoCastType(unittest.TestCase):
     np.testing.assert_allclose(t.grad.numpy(), [1, 0])
 
   @unittest.skipIf(Device.DEFAULT == "PYTHON", "very slow")
+  @unittest.skipIf(CI and Device.DEFAULT == "AMD", "very slow")
   @unittest.skipIf(Device.DEFAULT == "WEBGPU", "Binding size is larger than the maximum storage buffer binding size")
   @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
   def test_mean_half_precision_underflow(self):


### PR DESCRIPTION
The global size is very large (781250 gidx) and the emulated version takes more than 1 minute to execute the kernel.