### PR TITLE
fix view_left for unsafe pad ops [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -113,7 +113,7 @@ sym = symbolic_simple+PatternMatcher([
 
 # **** UOp realization
 
-DONT_PUSH_VIEWS = {Ops.BUFFER, *GroupOp.Buffer, Ops.ASSIGN, Ops.SINK}
+DONT_PUSH_VIEWS = {Ops.BUFFER, *GroupOp.Buffer, Ops.ASSIGN, Ops.SINK, Ops.CONTIGUOUS}
 
 @dataclass(frozen=True)
 class GrouperContext:


### PR DESCRIPTION
This was creating nan in the new_grouper branch because it pushed the padded view through the recip:
![image](https://github.com/user-attachments/assets/cedfcca3-681a-4b73-aafb-c21daef672c4)

Currently the existing grouper handles this by recursing the graph locally (at the MUL), the new grouper will push the VIEW left, past the mul, and when we reach the unsafe op, insert a contiguous.