### PR TITLE
simple failing test for graph_rewrite children [pr]

### DIFF
--- a/test/test_rewrite_tracked_childen.py
+++ b/test/test_rewrite_tracked_childen.py
@@ -1,6 +1,7 @@
 import unittest
 from tinygrad import Tensor
-from tinygrad.ops import PatternMatcher, Ops, UPat, graph_rewrite, RewriteContext, UOp
+from tinygrad.ops import PatternMatcher, Ops, UPat, graph_rewrite, RewriteContext, UOp, merge_views
+from tinygrad.engine.schedule import sym
 
 class TestRewriteTrackedChildren(unittest.TestCase):
   def test_children_in_context(self):
@@ -46,6 +47,15 @@ class TestRewriteTrackedChildren(unittest.TestCase):
     print([x().arg for x in view_w_child.children])
     print([x.arg for x in sink.get_children_map()[view_w_child]])
     self.assertSetEqual(set([x.arg for x in sink.get_children_map()[view_w_child]]), set((3,4)))
+
+  @unittest.expectedFailure
+  def test_child_after_parent_update(self):
+    def print_children(ctx, r):
+      print(ctx.children[r])
+    extra = PatternMatcher([(UPat(Ops.REDUCE_AXIS, name="r"), print_children)])
+    a = Tensor.empty(3, 3)
+    r = (a+0).sum()
+    s = graph_rewrite(r.lazydata, merge_views+sym+extra, track_children=True)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_rewrite_tracked_childen.py
+++ b/test/test_rewrite_tracked_childen.py
@@ -55,7 +55,7 @@ class TestRewriteTrackedChildren(unittest.TestCase):
     extra = PatternMatcher([(UPat(Ops.REDUCE_AXIS, name="r"), print_children)])
     a = Tensor.empty(3, 3)
     r = (a+0).sum()
-    s = graph_rewrite(r.lazydata, merge_views+sym+extra, track_children=True)
+    graph_rewrite(r.lazydata, merge_views+sym+extra, track_children=True)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_rewrite_tracked_childen.py
+++ b/test/test_rewrite_tracked_childen.py
@@ -51,6 +51,7 @@ class TestRewriteTrackedChildren(unittest.TestCase):
   @unittest.expectedFailure
   def test_child_after_parent_update(self):
     def print_children(ctx, r):
+      ctx.update_children()
       print(ctx.children[r])
     extra = PatternMatcher([(UPat(Ops.REDUCE_AXIS, name="r"), print_children)])
     a = Tensor.empty(3, 3)


### PR DESCRIPTION
```
  File "/Users/qazal/code/tinygrad/test/test_rewrite_tracked_childen.py", line 53, in print_children
    print(ctx.children[r])
          ~~~~~~~~~~~~^^^
KeyError: UOp(Ops.REDUCE_AXIS, dtypes.float, arg=(Ops.ADD, (0, 1)), src=(
  UOp(Ops.VIEW, dtypes.float, arg=ShapeTracker(views=(View(shape=(3, 3), strides=(3, 1), offset=0, mask=None, contiguous=True),)), src=(
    UOp(Ops.BUFFER, dtypes.float, arg=9, src=(
      UOp(Ops.DEVICE, dtypes.void, arg='METAL', src=()),
      UOp(Ops.UNIQUE, dtypes.void, arg=0, src=()),)),)),))
```
After (a+0).sum() becomes a.sum()