### PR TITLE
use libllvm19 in ci (no_comgr prereq)

### DIFF
--- a/.github/actions/setup-tinygrad/action.yml
+++ b/.github/actions/setup-tinygrad/action.yml
@@ -212,8 +212,10 @@ runs:
       shell: bash
       run: |
         echo 'Acquire::http::Pipeline-Depth "5";' | sudo tee -a /etc/apt/apt.conf.d/99parallel
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+        echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-19 main" | sudo tee /etc/apt/sources.list.d/llvm.list
         sudo apt update -y || true
-        sudo apt install -y --no-install-recommends llvm-dev
+        sudo apt install -y --no-install-recommends libllvm19
 
     - name: Install LLVM (macOS)
       if: inputs.llvm == 'true' && runner.os == 'macOS'


### PR DESCRIPTION
prepare for https://github.com/tinygrad/tinygrad/pull/8846

llvm 19 is the stable branch according to https://apt.llvm.org

