### PR TITLE
improve reproducibility of WebGPU CI puppeteer test

### DIFF
--- a/extra/export_model.py
+++ b/extra/export_model.py
@@ -143,6 +143,7 @@ def export_model_webgpu(functions, statements, bufs, weight_names, input_names, 
     return Object.fromEntries(Object.entries(metadata).filter(([k, v]) => k !== "__metadata__").map(([k, v]) => [k, {{...v, data_offsets: v.data_offsets.map(x => 8 + metadataLength + x)}}]));
 }};\n""" if not stream_weights else ""
   return f"""
+await new Promise(resolve => setTimeout(resolve, 8000));
 const {model_name} = (() => {{
 const getTensorBuffer = (safetensorBuffer, tensorMetadata) => {{
   return safetensorBuffer.subarray(...tensorMetadata.data_offsets);


### PR DESCRIPTION
Here I attempt to show why `node test/web/test_webgpu.js` as part of the CI job `MacOS (WebGPU) / Run WEBGPU Efficientnet` can fail:

The hypothesis is that there is a race condition where sometimes model import is not complete before model is referenced, which I reproduced locally and am testing in CI.