### PR TITLE
fix prg size calculation when there are adjacent mapped ranges(no_comgr prereq)

### DIFF
--- a/test/mockgpu/amd/amdgpu.py
+++ b/test/mockgpu/amd/amdgpu.py
@@ -155,7 +155,7 @@ class PM4Executor(AMDQueue):
 
     prg_sz = 0
     for st,sz in self.gpu.mapped_ranges:
-      if st <= prg_addr <= st+sz: prg_sz = sz - (prg_addr - st)
+      if st <= prg_addr < st+sz: prg_sz = sz - (prg_addr - st)
 
     assert prg_sz > 0, "Invalid prg ptr (not found in mapped ranges)"
     err = remu.run_asm(prg_addr, prg_sz, *gl, *lc, args_addr)


### PR DESCRIPTION
prepare for https://github.com/tinygrad/tinygrad/pull/8846

the follow mapped ranges cause `assert prg_sz > 0` fails
```txt
st             st+sz           prg_addr
0x7370607f7000 0x7370607f8000 0x7370607f7000
0x7370607f6000 0x7370607f7000 0x7370607f7000
```