### PR TITLE
OLMoE test_real_world jitted

### DIFF
--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -104,7 +104,7 @@ class TestRealWorld(unittest.TestCase):
     derandomize_model(model)
     @TinyJit
     def test(t): return model(t, 0).realize()
-    helper_test("test_olmoe", lambda: (Tensor([[1,]]),), test, 10.67, 858, all_jitted=True)
+    helper_test("test_olmoe", lambda: (Tensor([[1,]]),), test, 0.0, 858, all_jitted=True)
 
   @unittest.skipIf(CI and Device.DEFAULT == "CPU", "slow")
   def test_train_mnist(self):

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -96,7 +96,7 @@ class TestRealWorld(unittest.TestCase):
       with Context(JIT=0): return model(t, v).realize()
     helper_test("test_gpt2", lambda: (Tensor([[1,]]),Variable("pos", 1, 100).bind(1)), test, 0.23 if CI else 0.9, 137 if CI else 396, all_jitted=True)
 
-  @unittest.skipUnless(is_dtype_supported(dtypes.bfloat16), "need dtypes.bfloat16")
+  @unittest.skipIf(Device.DEFAULT in {"LLVM", "CPU"}, "bf16")
   def test_olmoe(self):
     args_tiny = {"dim": 2048, "hidden_dim": 1024, "n_heads": 16, "n_layers": 16, "norm_eps": 1e-5, "qk_norm": 1e-5, "max_context": 1024,
                  "vocab_size": 50304, "feed_forward": functools.partial(OLMoEFF, 64, 8)}
@@ -104,7 +104,7 @@ class TestRealWorld(unittest.TestCase):
     derandomize_model(model)
     @TinyJit
     def test(t): return model(t, 0).realize()
-    helper_test("test_olmoe", lambda: (Tensor([[1,]]),), test, 100.0, 1000, all_jitted=True)
+    helper_test("test_olmoe", lambda: (Tensor([[1,]]),), test, 10.67, 858, all_jitted=True)
 
   @unittest.skipIf(CI and Device.DEFAULT == "CPU", "slow")
   def test_train_mnist(self):

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -96,6 +96,7 @@ class TestRealWorld(unittest.TestCase):
       with Context(JIT=0): return model(t, v).realize()
     helper_test("test_gpt2", lambda: (Tensor([[1,]]),Variable("pos", 1, 100).bind(1)), test, 0.23 if CI else 0.9, 137 if CI else 396, all_jitted=True)
 
+  @unittest.skipUnless(is_dtype_supported(dtypes.bfloat16), "need dtypes.bfloat16")
   def test_olmoe(self):
     args_tiny = {"dim": 2048, "hidden_dim": 1024, "n_heads": 16, "n_layers": 16, "norm_eps": 1e-5, "qk_norm": 1e-5, "max_context": 1024,
                  "vocab_size": 50304, "feed_forward": functools.partial(OLMoEFF, 64, 8)}

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -96,7 +96,7 @@ class TestRealWorld(unittest.TestCase):
       with Context(JIT=0): return model(t, v).realize()
     helper_test("test_gpt2", lambda: (Tensor([[1,]]),Variable("pos", 1, 100).bind(1)), test, 0.23 if CI else 0.9, 137 if CI else 396, all_jitted=True)
 
-  @unittest.skipIf(Device.DEFAULT in {"LLVM", "CPU"}, "bf16")
+  @unittest.skipUnless(is_dtype_supported(dtypes.bfloat16), "olmoe is bf16")
   def test_olmoe(self):
     args_tiny = {"dim": 2048, "hidden_dim": 1024, "n_heads": 16, "n_layers": 16, "norm_eps": 1e-5, "qk_norm": 1e-5, "max_context": 1024,
                  "vocab_size": 50304, "feed_forward": functools.partial(OLMoEFF, 64, 8)}

--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -104,7 +104,7 @@ class TestRealWorld(unittest.TestCase):
     derandomize_model(model)
     @TinyJit
     def test(t): return model(t, 0).realize()
-    helper_test("test_olmoe", lambda: (Tensor([[1,]]),), test, 0.0, 858, all_jitted=True)
+    helper_test("test_olmoe", lambda: (Tensor([[12092,]]),), test, 10.67, 858, all_jitted=True)
 
   @unittest.skipIf(CI and Device.DEFAULT == "CPU", "slow")
   def test_train_mnist(self):


### PR DESCRIPTION
Do we still want this?
Currently nothing runs cuz `is_dtype_supported(dtypes.bfloat16)` doesn't include GPU despite it running fine on the GPU? I might be dumb here. 
I also just human-token-inferenced and copied the implementation over for the test. If it's wrong, I'll try to understand it better and look it over more.