### PR TITLE
torch backend: explicit view tracking for inplace ops

### DIFF
--- a/extra/torch_backend/test_inplace.py
+++ b/extra/torch_backend/test_inplace.py
@@ -61,5 +61,11 @@ class TestTorchBackendInplace(unittest.TestCase):
     b[1:3,:] += 1
     np.testing.assert_equal(a.cpu().numpy(), [[0]*4,[1]*4,[1]*4,[0]*4])
 
+  def test_detach(self):
+    a = torch.zeros(4)
+    d = a.detach()
+    d += torch.arange(4)
+    np.testing.assert_array_equal(a.cpu(), torch.arange(4).cpu())
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Track views as metadata on the C++ TensorImpl so as to not lose it on detach().
Failing test/test_ops.py from 24 => 13.
Part of #9317