### PR TITLE
ops_gpu.py: match getenv("INTEL") or "intel" in device_name

### DIFF
--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -107,7 +107,7 @@ class CLDevice(Compiled):
     self.device_exts = (cl.clGetDeviceInfo(self.device_id, cl.CL_DEVICE_EXTENSIONS, 4096, ctypes.byref(buf := ctypes.create_string_buffer(4096)), ctypes.byref(total := ctypes.c_size_t())), ctypes.string_at(buf, size=total.value).decode())[1]  # noqa: E501
 
     compile_key = hashlib.md5(self.device_name.encode() + self.driver_version.encode()).hexdigest()
-    renderer = IntelRenderer() if "cl_intel_subgroup_matrix_multiply_accumulate" in self.device_exts and getenv("INTEL") else OpenCLRenderer()
+    renderer = IntelRenderer() if ("cl_intel_subgroup_matrix_multiply_accumulate" in self.device_exts and (getenv("INTEL") or "intel" in self.device_name.lower())) else OpenCLRenderer()
     super().__init__(device, CLAllocator(self), renderer, CLCompiler(self, f"compile_cl_{compile_key}"), functools.partial(CLProgram, self))
   def synchronize(self):
     check(cl.clFinish(self.queue))


### PR DESCRIPTION
Without this change an Intel Arc 770 will happily burn GPU cycles without output model tokens in Exo when only `GPU=1` is passed