### PR TITLE
remove contiguous from QuantizeLinear + expand before upcast

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -733,7 +733,7 @@ def get_onnx_ops():
       ret = _clamp_cast(((x / y_scale).round() + y_zero_point), out_dtype)
     # you need both NHWC=1 DONT_GROUP_REDUCES=1 for this to work
     if getenv("NHWC") and len(ret.shape) == 4: return ret.permute(0,2,3,1).contiguous().permute(0,3,1,2)
-    return ret.contiguous()
+    return ret
 
   def DynamicQuantizeLinear(x: Tensor):
     # only support uint8

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1002,5 +1002,6 @@ view_left = merge_views+PatternMatcher([
    lambda e,view: e.contiguous().view(view.st) if any(v.mask is not None for v in view.st.views) else None),
   # view before elementwise ops
   (UPat(Ops.VIEW, src=(UPat({*GroupOp.ALU, Ops.CAST, Ops.BITCAST}, name="e"),), name="view"),
-   lambda e,view: e.replace(src=tuple(s.view(s.st+view.st) if s.op is Ops.VIEW else s.view(view.st) for s in e.src))),
+   lambda ctx,e,view: e.replace(src=tuple(s.view(s.st+view.st) if s.op is Ops.VIEW else s.view(view.st) for s in e.src))
+    if ctx is None or e is not ctx else e.contiguous().view(view.st)),
 ])


### PR DESCRIPTION
```
DEBUG=2 CNT=4 DEVECTORIZE=0 CPU=1 DONT_REALIZE_EXPAND=0 python examples/test_onnx_imagenet.py /tmp/model.quant.onnx
```

213 -> 173 kernels
no contiguous in onnx.py but the scheduler auto detects to store the uchar.