### PR TITLE
failing test for UOp buffer ref count

### DIFF
--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 from tinygrad.device import Buffer
 from tinygrad.engine.realize import run_schedule
-from tinygrad.ops import UOp
+from tinygrad.ops import UOp, Ops
 from tinygrad.tensor import Tensor
 
 def tensors_allocated():
@@ -78,6 +78,23 @@ class TestGC(unittest.TestCase):
     if bufs_allocated()-init != 0:
       print(inspect.getclosurevars(UOp.toposort.fget))
       raise AssertionError(f"never gced {[x for x in gc.get_objects() if isinstance(x, Buffer)]}")
+
+  def test_buffer_refcount(self):
+    init = bufs_allocated()
+    a = Tensor.empty(10)
+    self.assertEqual(bufs_allocated()-init, 0)
+    a.realize()
+    real_buf = a.lazydata.buffer
+    # after the Tensor UOp is deleted there shouldn't be any references on the Buffer
+    with self.assertRaises(AssertionError):
+      self.assertEqual(real_buf.lb_refcount, 1)
+    self.assertEqual(bufs_allocated()-init, 1)
+    del a.lazydata
+    with self.assertRaises(AssertionError):
+      self.assertEqual(real_buf.lb_refcount, 0)
+    self.assertEqual(bufs_allocated()-init, 1) # keep the buffer alive
+    del real_buf
+    self.assertEqual(bufs_allocated()-init, 0)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 from tinygrad.device import Buffer
 from tinygrad.engine.realize import run_schedule
-from tinygrad.ops import UOp, Ops
+from tinygrad.ops import UOp
 from tinygrad.tensor import Tensor
 
 def tensors_allocated():


### PR DESCRIPTION
This also fails in nimlgen's new memory planner https://github.com/tinygrad/tinygrad/pull/9526#issuecomment-2748480115.
The GC behaves correctly on the real Buffer and the UOp.


The JIT and memory planner still use a custom lb_refcount attribute.
It expects to count alive BUFFER UOps referring to a device.py Buffer, `TestGC.test_buffer_refcount` describes this spec, but higher-level tests are very dependent on the implementation of memory_planner and JIT.