### PR TITLE
move Buffer refcount increment outside of schedule.py

### DIFF
--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -86,12 +86,10 @@ class TestGC(unittest.TestCase):
     a.realize()
     real_buf = a.lazydata.buffer
     # after the Tensor UOp is deleted there shouldn't be any references on the Buffer
-    with self.assertRaises(AssertionError):
-      self.assertEqual(real_buf.lb_refcount, 1)
+    self.assertEqual(real_buf.lb_refcount, 1)
     self.assertEqual(bufs_allocated()-init, 1)
     del a.lazydata
-    with self.assertRaises(AssertionError):
-      self.assertEqual(real_buf.lb_refcount, 0)
+    self.assertEqual(real_buf.lb_refcount, 0)
     self.assertEqual(bufs_allocated()-init, 1) # keep the buffer alive
     del real_buf
     self.assertEqual(bufs_allocated()-init, 0)

--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -94,5 +94,19 @@ class TestGC(unittest.TestCase):
     del real_buf
     self.assertEqual(bufs_allocated()-init, 0)
 
+  def test_assign_refcount(self):
+    init = bufs_allocated()
+    a = Tensor.full((4,), 1.).contiguous()
+    a.realize()
+    self.assertEqual(a.lazydata.buffer.lb_refcount, 1)
+    a.assign(Tensor.full((4,), 2.))
+    a.realize()
+    # TODO: master says it's 2
+    self.assertEqual(a.lazydata.buffer.lb_refcount, 1)
+    buf = a.lazydata.buffer
+    del a
+    self.assertEqual(buf.lb_refcount, 0) # no UOps for this Buffer
+    self.assertEqual(bufs_allocated()-init, 1) # Buffer is alive
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -474,8 +474,6 @@ def create_schedule_with_vars(big_sink:UOp) -> tuple[list[ScheduleItem], dict[Va
     # TODO: move this to create_kernels
     k = fix_kernel_ast(u.src[1], var_vals)
     schedule.append(ScheduleItem(k.arg.ast, tuple(s.buf_uop.buffer for s in k.src), k.arg.metadata))
-    # increment the refcount of the target buf (this is required by the JIT and memory planner) TODO: this does not belong here
-    k.src[0].buffer.ref(1)
     for x in children.get(u, []):
       in_degree[x] -= 1
       if in_degree[x] == 0: queue.append(x)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -535,6 +535,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     from tinygrad.device import Buffer
     assert isinstance(self.device, str), f"buffer not supported on multi {self.device}"
     buffers[self] = ret = Buffer(self.device, self.size, self.dtype if isinstance(self.dtype, ImageDType) else self.dtype.base)
+    ret.ref(1)
     return ret
   @property
   def realized(self) -> Optional[Buffer]: return self.buffer if self.op is Ops.BUFFER and self.buffer.is_allocated() else None


### PR DESCRIPTION
`lb_refcount` needs to count alive BUFFER UOps referencing the device.py Buffer.
But schedule only increments references for the new intermediate buffers it creates, or buffers it assigns to.

The new memory planner fails for Tensor.empty https://github.com/tinygrad/tinygrad/pull/9526#issuecomment-2748480115 since there's no ScheduleItem for it, might be more correct to put this when we create a Buffer.