### PR TITLE
select torch device in examples/beautiful_mnist_torch.py

### DIFF
--- a/examples/other_mnist/beautiful_mnist_torch.py
+++ b/examples/other_mnist/beautiful_mnist_torch.py
@@ -1,5 +1,5 @@
-from tinygrad import dtypes, getenv
-from tinygrad.helpers import trange, colored
+from tinygrad import dtypes, getenv, Device
+from tinygrad.helpers import trange, colored, DEBUG
 from tinygrad.nn.datasets import mnist
 import torch
 from torch import nn, optim
@@ -30,7 +30,8 @@ if __name__ == "__main__":
     import tinygrad.frontend.torch
     device = torch.device("tiny")
   else:
-    device = torch.device("mps")
+    device = torch.device({"METAL":"mps","NV":"cuda"}.get(Device.DEFAULT, "cpu"))
+  if DEBUG >= 1: print(f"using torch backend {device}")
   X_train, Y_train, X_test, Y_test = mnist()
   X_train = torch.tensor(X_train.float().numpy(), device=device)
   Y_train = torch.tensor(Y_train.cast(dtypes.int64).numpy(), device=device)


### PR DESCRIPTION
Now it shouldn't crash when running on a tinybox.
```
~/code/tinygrad (torch_select_device) > time DEBUG=1 python ./examples/other_mnist/beautiful_mnist_torch.py 
opened device NV from pid:1634738
using torch backend cuda
opened device DISK:/raid/downloads/e8e6ed0857e9bb000985bfea8283b0b3.gunzip from pid:1634738
opened device CPU from pid:1634738
opened device DISK:/raid/downloads/684fe191a76d9107981692e6f0d3842f.gunzip from pid:1634738
opened device DISK:/raid/downloads/40a9ec2164c7887e8a5f1225de927907.gunzip from pid:1634738
opened device DISK:/raid/downloads/7b1e157ab43d54d0946f76d1bb6df574.gunzip from pid:1634738
loss:   0.07 test_accuracy: 98.26%: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 70/70 [00:00<00:00, 79.38it/s]

real    0m7.183s
user    0m10.797s
sys     0m3.246s
~/code/tinygrad (torch_select_device) > time DEBUG=1 CPU=1 python ./examples/other_mnist/beautiful_mnist_torch.py 
using torch backend cpu
opened device DISK:/raid/downloads/e8e6ed0857e9bb000985bfea8283b0b3.gunzip from pid:1634853
opened device CPU from pid:1634853
opened device DISK:/raid/downloads/684fe191a76d9107981692e6f0d3842f.gunzip from pid:1634853
opened device DISK:/raid/downloads/40a9ec2164c7887e8a5f1225de927907.gunzip from pid:1634853
opened device DISK:/raid/downloads/7b1e157ab43d54d0946f76d1bb6df574.gunzip from pid:1634853
loss:   0.06 test_accuracy: 98.12%: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 70/70 [00:15<00:00,  4.57it/s]

real    0m19.034s
user    3m49.589s
sys     1m36.208s
```