### PR TITLE
add TORCHVIZ=1 to beautiful_mnist_torch

### DIFF
--- a/examples/other_mnist/beautiful_mnist_torch.py
+++ b/examples/other_mnist/beautiful_mnist_torch.py
@@ -1,5 +1,5 @@
 from tinygrad import dtypes, getenv, Device
-from tinygrad.helpers import trange, colored, DEBUG
+from tinygrad.helpers import trange, colored, DEBUG, temp
 from tinygrad.nn.datasets import mnist
 import torch
 from torch import nn, optim
@@ -38,6 +38,7 @@ if __name__ == "__main__":
   X_test = torch.tensor(X_test.float().numpy(), device=device)
   Y_test = torch.tensor(Y_test.cast(dtypes.int64).numpy(), device=device)
 
+  if getenv("TORCHVIZ"): torch.cuda.memory._record_memory_history()
   model = Model().to(device)
   optimizer = optim.Adam(model.parameters(), 1e-3)
 
@@ -63,3 +64,6 @@ if __name__ == "__main__":
   if target := getenv("TARGET_EVAL_ACC_PCT", 0.0):
     if test_acc >= target and test_acc != 100.0: print(colored(f"{test_acc=} >= {target}", "green"))
     else: raise ValueError(colored(f"{test_acc=} < {target}", "red"))
+  if getenv("TORCHVIZ"):
+    torch.cuda.memory._dump_snapshot(fp:=temp("torchviz.pkl", append_user=True))
+    print(f"saved torch memory snapshot to {fp}, view in https://pytorch.org/memory_viz")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9a948f1d-6fcf-4c4c-9868-891b7305f676)
 The purple is from relu forward
```
??:0:at::_ops::relu::call(at::Tensor const&)
python_torch_functions_2.cpp:0:torch::autograd::THPVariable_relu(_object*, _object*, _object*)
/home/qazal/.local/lib/python3.10/site-packages/torch/nn/functional.py:1704:relu
/home/qazal/code/tinygrad/./examples/other_mnist/beautiful_mnist_torch.py:20:forward
??:0:PyMethod_New
/home/qazal/.local/lib/python3.10/site-packages/torch/nn/modules/module.py:1750:_call_impl
??:0:PyMethod_New
/home/qazal/.local/lib/python3.10/site-packages/torch/nn/modules/module.py:1739:_wrapped_call_impl
??:0:PyInit__datetime
/home/qazal/code/tinygrad/./examples/other_mnist/beautiful_mnist_torch.py:60:<module>
```