### PR TITLE
LDS

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -340,7 +340,7 @@ class Kernel:
 
   def apply_opt(self, opt:Opt, append_opt:bool=True):
     if self.dont_use_locals: check(opt.op not in {OptOps.LOCAL, OptOps.GROUP, OptOps.GROUPTOP}, "not using locals")
-    if (getenv("LDS") and not self.tensor_core and opt.op in (OptOps.UNROLL, OptOps.LOCAL) and opt.arg is not None and not isinstance(opt.arg, tuple) 
+    if (getenv("LDS") and not self.tensor_core and opt.op in (OptOps.UNROLL, OptOps.LOCAL) and opt.arg is not None and not isinstance(opt.arg, tuple)
         and int(opt.arg) > 2 and opt.arg % 2 == 0):
       for i in range(int(math.log2(opt.arg))):
         self.apply_opt((new_opt:=Opt(opt.op, opt.axis, 2)))

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -667,11 +667,11 @@ class Kernel:
 
     if DEBUG >= 3:
       print(self.name)
-      if DEBUG >= 5: print(self.ast)
+      if DEBUG >= 4: print(self.ast)
       for i,(buf,st) in enumerate([(buf,st) for buf,st in zip(self.bufs, self.sts) if buf.op not in {Ops.CONST, Ops.VALID}]):
         print(f"{i:2d}: {str(st.shape):25s} {str(buf.src[0].dtype).replace('dtypes.',''):20s}", st.real_strides())
       print(self.applied_opts)
-      if DEBUG >= 5: print(modified_ast)
+      if DEBUG >= 4: print(modified_ast)
     # verify AST matches the spec after applying opts
     if __debug__: type_verify(list(modified_ast.toposort))
     # TODO: sadly modified_ast doesn't pass the shape spec because of how group_for_reduces constructs UOps, there's probably a way to fix this

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -665,6 +665,7 @@ class Kernel:
     def transform_load(ctx:tuple[Kernel, set[UOp]], global_load:UOp):
       if global_load in ctx[1] or global_load.src[0].op is not Ops.DEFINE_GLOBAL: return None
       src_st, buf = global_load.st_arg, global_load.src[0]
+      if all(s == 0 for i,s in enumerate(src_st.real_strides()) if (i >= ctx[0].global_dims and i < ctx[0].first_reduce)): return None
       wd, fr, tcd = ctx[0].global_dims, ctx[0].first_reduce, ctx[0].first_upcast
       local_shape = tuple(1 if st == 0 or i < wd or (i >= fr and i < tcd) else src_st.shape[i] for i,st in enumerate(src_st.real_strides()))
       load_st = store_st = ShapeTracker.from_shape(local_shape)

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -723,10 +723,9 @@ class Kernel:
 
     if (any(opt.op == OptOps.GROUPTOP for opt in self.applied_opts)): return ast
 
-    if (OptOps.UNROLL not in [opt.op for opt in self.applied_opts] or OptOps.LOCAL not in [opt.op for opt in self.applied_opts]):
-      if OptOps.TC not in [opt.op for opt in self.applied_opts]:
-        return ast
+    if (OptOps.UNROLL not in [opt.op for opt in self.applied_opts] or OptOps.LOCAL not in [opt.op for opt in self.applied_opts]): return ast
     if not all_same([opt.arg for opt in self.applied_opts if opt.op in (OptOps.UNROLL, OptOps.LOCAL)]): return ast
+
     return graph_rewrite(ast, PatternMatcher([(UPat(Ops.LOAD, name="global_load"), transform_load)]), ctx=(self, set()))
 
   # **** this is the lowerer ****

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -672,21 +672,21 @@ class Kernel:
       wd, fr, tcd = ctx[0].global_dims, ctx[0].first_reduce, ctx[0].first_upcast
       local_shape = tuple(1 if st == 0 or i < wd or (i >= fr and i < tcd) else src_st.shape[i] for i,st in enumerate(src_st.real_strides()))
       load_st = store_st = ShapeTracker.from_shape(local_shape)
-      # print("local_shape", local_shape)
+      print("local_shape", local_shape)
       (ctx[0].colored_shape())
       # print(ctx[0].applied_opts)
       perm = list(range(len(ctx[0].full_shape)))
-      # print("perm", perm, ctx[0].first_reduce)
-      # print(ctx[0].upcasted_axis(buf.arg))
-      # print(ctx[0].local_dims)
-      # print("fist reduce", ctx[0].first_reduce)
-      # print("fist upcast", ctx[0].first_upcast)
+      print("perm", perm, ctx[0].first_reduce)
+      print(ctx[0].upcasted_axis(buf.arg))
+      print(ctx[0].local_dims)
+      print("fist reduce", ctx[0].first_reduce)
+      print("fist upcast", ctx[0].first_upcast)
       for i in range(len(perm)):
         if i >= ctx[0].global_dims and i < ctx[0].first_reduce and local_shape[i] == 1:
-          # print("we need to permute this local")
+          print("we need to permute this local")
           for upcast_index, index in enumerate(range(ctx[0].first_upcast, len(perm))):
             if ctx[0].upcasted_axis(buf.arg)[upcast_index][2]:
-              # print(f"permuting {perm[i]} for {perm[index]}")
+              print(f"permuting {perm[i]} for {perm[index]}")
               perm[i], perm[index] = perm[index], perm[i]
       # print(perm)
       local_buffer = UOp(Ops.DEFINE_LOCAL, global_load.dtype.ptr(size=store_st.real_size(), local=True), (), f"temp{buf.arg}")

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -669,12 +669,18 @@ class Kernel:
       wd, fr, tcd = ctx[0].global_dims, ctx[0].first_reduce, ctx[0].first_upcast
       local_shape = tuple(1 if st == 0 or i < wd or (i >= fr and i < tcd) else src_st.shape[i] for i,st in enumerate(src_st.real_strides()))
       load_st = store_st = ShapeTracker.from_shape(local_shape)
+      print("src_st before  swizzle",src_st)
+      print("store before   swizzle",store_st)
       for i in range(len(src_st.shape)):
         if i >= ctx[0].global_dims and i < ctx[0].first_reduce and store_st.shape[i] == 1:
           for upcast_index, index in enumerate(range(ctx[0].first_upcast, len(store_st.shape))):
             if ctx[0].upcasted_axis(buf.arg)[upcast_index][2] and store_st.shape[index] != 1:
               store_st, src_st = store_st.permute_axis_pair((index, i)), src_st.permute_axis_pair((index, i))
               break
+      print("src_st after   swizzle",src_st)
+      print("store_st after swizzle",store_st)
+      print("load_st               ",load_st)
+      print("-----------------------")
       local_buffer = UOp(Ops.DEFINE_LOCAL, global_load.dtype.ptr(size=store_st.real_size(), local=True), (), f"temp{buf.arg}")
       global_load = global_load.replace(src=(buf, src_st.to_uop()))
       ctx[1].add(global_load)

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Optional, cast, Final, Callable, Sequence
 
 from tinygrad.ops import GroupOp, KernelInfo, UOp, Ops, can_pad, resolve, Variable, sint, graph_rewrite, track_rewrites, view_left, print_uops
-from tinygrad.ops import PatternMatcher
+from tinygrad.ops import PatternMatcher, UPat
 from tinygrad.spec import type_verify, shape_spec
 from tinygrad.device import Device
 from tinygrad.renderer import Renderer, TensorCore, ProgramSpec, Opt, OptOps
@@ -662,68 +662,26 @@ class Kernel:
     return graph_rewrite(fixup_ast(self.ast), view_left)
 
   def lds(self, ast) -> UOp:
-    from tinygrad.ops import UPat
     def transform_load(ctx:tuple[Kernel, set[UOp]], global_load:UOp):
       if global_load in ctx[1] or global_load.src[0].op is not Ops.DEFINE_GLOBAL: return None
       src_st, buf = global_load.st_arg, global_load.src[0]
       wd, fr, tcd = ctx[0].global_dims, ctx[0].first_reduce, ctx[0].first_upcast
       local_shape = tuple(1 if st == 0 or i < wd or (i >= fr and i < tcd) else src_st.shape[i] for i,st in enumerate(src_st.real_strides()))
       load_st = store_st = ShapeTracker.from_shape(local_shape)
-      print("local_shape", local_shape)
-      (ctx[0].colored_shape())
-      # print(ctx[0].applied_opts)
-      # perm = list(range(len(ctx[0].full_shape)))
-      # print("perm", perm, ctx[0].first_reduce)
-      # print(ctx[0].upcasted_axis(buf.arg))
-      # print(ctx[0].local_dims)
-      # print("fist reduce", ctx[0].first_reduce)
-      # print("fist upcast", ctx[0].first_upcast)
-      # print(local_shape)
-      # print(load_st)
-      # print("testing permute_Axes")
-      # print(load_st.permute_axes((2,3)))
-      # for i in range(len(perm)):
-      #   print(i, perm)
-      #   if i >= ctx[0].global_dims and i < ctx[0].first_reduce and local_shape[i] == 1:
-      #     print("we need to permute this local")
-      #     for upcast_index, index in enumerate(range(ctx[0].first_upcast, len(perm))):
-      #       print(upcast_index, index)
-      #       if ctx[0].upcasted_axis(buf.arg)[upcast_index][2]:
-      #         print(f"permuting {perm[i]} for {perm[index]}")
-      #         perm[i], perm[index] = perm[index], perm[i]
-      #         break
       for i in range(len(src_st.shape)):
-        print(i, src_st.real_strides())
-        print(i, store_st.real_strides())
         if i >= ctx[0].global_dims and i < ctx[0].first_reduce and store_st.shape[i] == 1:
-          print(f"we need to permute this local [{i}] = {store_st.shape[i]}")
           for upcast_index, index in enumerate(range(ctx[0].first_upcast, len(store_st.shape))):
-            print(f"index : {index}, upcast_index : {upcast_index}, store shape {store_st.shape[index]}")
             if ctx[0].upcasted_axis(buf.arg)[upcast_index][2] and store_st.shape[index] != 1:
-              print("can be permuted as it is reduce")
-              print(f"we might want to permute {i} with {index}")
-              store_st = store_st.permute_axes((index, i))
-              src_st = src_st.permute_axes((index, i))
+              store_st, src_st = store_st.permute_axes((index, i)), src_st.permute_axes((index, i))
               break
-          # for upcast_index, index in enumerate(range(ctx[0].first_upcast, len(store_st.shape))):
-          #   print(upcast_index, index)
-          #     # print(f"permuting {perm[i]} for {perm[index]}")
-          #     print(i, index, upcast_index)
-          #     store_st = store_st.permute_axes((i, index))
-          #     src_st = src_st.permute_axes((index, i))
-          #     # perm[i], perm[index] = perm[index], perm[i]
-          #     break
-      # print(perm)
       local_buffer = UOp(Ops.DEFINE_LOCAL, global_load.dtype.ptr(size=store_st.real_size(), local=True), (), f"temp{buf.arg}")
       global_load = global_load.replace(src=(buf, src_st.to_uop()))
       ctx[1].add(global_load)
       local_store = UOp.store(local_buffer, store_st.to_uop(), global_load)
-      # print("using LDS!!")
       return UOp(Ops.LOAD, global_load.dtype, (local_buffer, load_st.to_uop(), local_store))
 
-    if (any(opt.op == OptOps.GROUPTOP for opt in self.applied_opts)): return ast
-
-    if (OptOps.UNROLL not in [opt.op for opt in self.applied_opts] or OptOps.LOCAL not in [opt.op for opt in self.applied_opts]): return ast
+    if any(opt.op == OptOps.GROUPTOP for opt in self.applied_opts): return ast
+    if OptOps.UNROLL not in [opt.op for opt in self.applied_opts] or OptOps.LOCAL not in [opt.op for opt in self.applied_opts]: return ast
     if not all_same([opt.arg for opt in self.applied_opts if opt.op in (OptOps.UNROLL, OptOps.LOCAL)]): return ast
 
     return graph_rewrite(ast, PatternMatcher([(UPat(Ops.LOAD, name="global_load"), transform_load)]), ctx=(self, set()))

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -725,13 +725,8 @@ class Kernel:
 
     if (OptOps.UNROLL not in [opt.op for opt in self.applied_opts] or OptOps.LOCAL not in [opt.op for opt in self.applied_opts]):
       if OptOps.TC not in [opt.op for opt in self.applied_opts]:
-        # print("There should be local and unroll for lds or Tensor Core")
         return ast
-
-    # print(self.upcasted_axis(1))
-    if not all_same([opt.arg for opt in self.applied_opts if opt.op in (OptOps.UNROLL, OptOps.LOCAL)]):
-      # print("unroll and local opts should be the same size")
-      return ast
+    if not all_same([opt.arg for opt in self.applied_opts if opt.op in (OptOps.UNROLL, OptOps.LOCAL)]): return ast
     return graph_rewrite(ast, PatternMatcher([(UPat(Ops.LOAD, name="global_load"), transform_load)]), ctx=(self, set()))
 
   # **** this is the lowerer ****
@@ -747,11 +742,11 @@ class Kernel:
 
     if DEBUG >= 3:
       print(self.name)
-      if DEBUG >= 4: print(self.ast)
+      if DEBUG >= 5: print(self.ast)
       for i,(buf,st) in enumerate([(buf,st) for buf,st in zip(self.bufs, self.sts) if buf.op not in {Ops.CONST, Ops.VALID}]):
         print(f"{i:2d}: {str(st.shape):25s} {str(buf.src[0].dtype).replace('dtypes.',''):20s}", st.real_strides())
       print(self.applied_opts)
-      if DEBUG >= 4: print(modified_ast)
+      if DEBUG >= 5: print(modified_ast)
     # verify AST matches the spec after applying opts
     if __debug__: type_verify(list(modified_ast.toposort))
     # TODO: sadly modified_ast doesn't pass the shape spec because of how group_for_reduces constructs UOps, there's probably a way to fix this

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -672,7 +672,7 @@ class Kernel:
         if i >= ctx[0].global_dims and i < ctx[0].first_reduce and store_st.shape[i] == 1:
           for upcast_index, index in enumerate(range(ctx[0].first_upcast, len(store_st.shape))):
             if ctx[0].upcasted_axis(buf.arg)[upcast_index][2] and store_st.shape[index] != 1:
-              store_st, src_st = store_st.permute_axes((index, i)), src_st.permute_axes((index, i))
+              store_st, src_st = store_st.permute_axis_pair((index, i)), src_st.permute_axis_pair((index, i))
               break
       local_buffer = UOp(Ops.DEFINE_LOCAL, global_load.dtype.ptr(size=store_st.real_size(), local=True), (), f"temp{buf.arg}")
       global_load = global_load.replace(src=(buf, src_st.to_uop()))

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -357,9 +357,9 @@ class Kernel:
       check(self._apply_tc_opt(use_tensor_cores, cast(int, opt.axis), tc_select, tc_opt), "no tensor core available")
       self.applied_opts.append(opt)
       return
+
     axis = self.real_axis(opt)
     check(axis < len(self.full_shape), "invalid axis")
-
 
     if opt.op is OptOps.SWAP: amt = cast(int, opt.arg)  # arg is an axis in the SWAPs
     elif opt.arg is not None:

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -107,6 +107,9 @@ class CStyleLanguage(Renderer):
     tmp = "const sampler_t smp = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;\n" if any(isinstance(dtype, ImageDType) for _,(dtype,_) in bufs) else ""  # noqa: E501
     buftypes = [(name, self.render_dtype(dtype, mutable)+self.buffer_suffix if isinstance(dtype, (ImageDType, PtrDType)) else
                 self.arg_int_prefix if dtype == dtypes.int else None) for name,(dtype,mutable) in bufs]
+    barrier_count = kernel.count("    threadgroup_barrier(mem_flags::mem_threadgroup);")
+    for i in range(barrier_count):
+      kernel.remove("    threadgroup_barrier(mem_flags::mem_threadgroup);")
     prg = ''.join([f"{self.kernel_prefix}void {self.get_kernel_modifier(uops)}{function_name}(",] +
     [', '.join([f'{t} {name}' for name,t in buftypes] + self.extra_args)] +
     [") {\n" + tmp] + ['\n'.join(kernel), "\n}"])

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -107,9 +107,9 @@ class CStyleLanguage(Renderer):
     tmp = "const sampler_t smp = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;\n" if any(isinstance(dtype, ImageDType) for _,(dtype,_) in bufs) else ""  # noqa: E501
     buftypes = [(name, self.render_dtype(dtype, mutable)+self.buffer_suffix if isinstance(dtype, (ImageDType, PtrDType)) else
                 self.arg_int_prefix if dtype == dtypes.int else None) for name,(dtype,mutable) in bufs]
-    barrier_count = kernel.count("    threadgroup_barrier(mem_flags::mem_threadgroup);")
-    for i in range(barrier_count):
-      kernel.remove("    threadgroup_barrier(mem_flags::mem_threadgroup);")
+    # barrier_count = kernel.count("    threadgroup_barrier(mem_flags::mem_threadgroup);")
+    # for i in range(barrier_count):
+      # kernel.remove("    threadgroup_barrier(mem_flags::mem_threadgroup);")
     prg = ''.join([f"{self.kernel_prefix}void {self.get_kernel_modifier(uops)}{function_name}(",] +
     [', '.join([f'{t} {name}' for name,t in buftypes] + self.extra_args)] +
     [") {\n" + tmp] + ['\n'.join(kernel), "\n}"])

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -107,9 +107,6 @@ class CStyleLanguage(Renderer):
     tmp = "const sampler_t smp = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;\n" if any(isinstance(dtype, ImageDType) for _,(dtype,_) in bufs) else ""  # noqa: E501
     buftypes = [(name, self.render_dtype(dtype, mutable)+self.buffer_suffix if isinstance(dtype, (ImageDType, PtrDType)) else
                 self.arg_int_prefix if dtype == dtypes.int else None) for name,(dtype,mutable) in bufs]
-    # barrier_count = kernel.count("    threadgroup_barrier(mem_flags::mem_threadgroup);")
-    # for i in range(barrier_count):
-      # kernel.remove("    threadgroup_barrier(mem_flags::mem_threadgroup);")
     prg = ''.join([f"{self.kernel_prefix}void {self.get_kernel_modifier(uops)}{function_name}(",] +
     [', '.join([f'{t} {name}' for name,t in buftypes] + self.extra_args)] +
     [") {\n" + tmp] + ['\n'.join(kernel), "\n}"])

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -132,7 +132,7 @@ class ShapeTracker:
   def shrink(self, arg: tuple[tuple[sint, sint], ...]) -> ShapeTracker: return ShapeTracker(self.views[0:-1] + (self.views[-1].shrink(arg), ))
   def expand(self, new_shape: tuple[sint, ...]) -> ShapeTracker: return ShapeTracker(self.views[0:-1] + (self.views[-1].expand(new_shape), ))
   def permute(self, axis: tuple[int, ...]) -> ShapeTracker: return ShapeTracker(self.views[0:-1] + (self.views[-1].permute(axis), ))
-  def permute_axes(self, axis: tuple[int, int]) -> ShapeTracker:
+  def permute_axis_pair(self, axis: tuple[int, int]) -> ShapeTracker:
     perm = list(range(len(self.shape)))
     perm[axis[0]], perm[axis[1]] = perm[axis[1]], perm[axis[0]]
     return self.permute(tuple(perm))

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -132,6 +132,10 @@ class ShapeTracker:
   def shrink(self, arg: tuple[tuple[sint, sint], ...]) -> ShapeTracker: return ShapeTracker(self.views[0:-1] + (self.views[-1].shrink(arg), ))
   def expand(self, new_shape: tuple[sint, ...]) -> ShapeTracker: return ShapeTracker(self.views[0:-1] + (self.views[-1].expand(new_shape), ))
   def permute(self, axis: tuple[int, ...]) -> ShapeTracker: return ShapeTracker(self.views[0:-1] + (self.views[-1].permute(axis), ))
+  def permute_axes(self, axis: tuple[int, int]) -> ShapeTracker:
+    perm = list(range(len(self.shape)))
+    perm[axis[0]], perm[axis[1]] = perm[axis[1]], perm[axis[0]]
+    return self.permute(tuple(perm))
   def flip(self, mul: tuple[int, ...]) -> ShapeTracker: return ShapeTracker(self.views[0:-1] + (self.views[-1].flip(mul), ))
 
   def reshape(self, new_shape: tuple[sint, ...]) -> ShapeTracker:


### PR DESCRIPTION
This is a rough draft.

This works focuses on correctness (adding smem caching).
In order to be able to swizzle into local memory, we need the dimensions of the reduced axes to be the same as the dimensions of the local axes. This is necessary in order to be able to permute them freely. As a simplification, right now I'm only enabling LDS on powers of 2. But in the future, if you have a reduce dim of size 5 and a locals of size 5, you should be able to swizzle them.

Thinks I'm avoiding
- TC
- Padded
- OptOps with amt 0
- GROUPTOP
- Speed
- UROLL/LOCALS with size that are not power of 2

TODO
- support most of the things we are currently avoiding right now
- swizzle local memory layout