### PR TITLE
cache viz worker at launch

### DIFF
--- a/tinygrad/viz/lib/graph.js
+++ b/tinygrad/viz/lib/graph.js
@@ -9,7 +9,12 @@ function intersectRect(r1, r2) {
 }
 
 const allWorkers = [];
-window.renderGraph = function(graph, additions, name) {
+let workerUrl = null;
+window.renderGraph = async function(graph, additions, name) {
+  if (workerUrl == null) {
+    const resp = await Promise.all(["/assets/dagrejs.github.io/project/dagre/latest/dagre.min.js","/lib/worker.js"].map(u => fetch(u)));
+    workerUrl = URL.createObjectURL(new Blob([(await Promise.all(resp.map((r) => r.text()))).join("\n")], { type: "application/javascript" }));
+  }
   while (allWorkers.length) {
     const { worker, timeout } = allWorkers.pop();
     worker.terminate();
@@ -22,7 +27,7 @@ window.renderGraph = function(graph, additions, name) {
   d3.select("#bars").html("");
 
   // ** start calculating the new layout (non-blocking)
-  worker = new Worker("/lib/worker.js");
+  worker = new Worker(workerUrl);
   const progressMessage = document.querySelector(".progress-message");
   const timeout = setTimeout(() => {
     progressMessage.style.display = "block";

--- a/tinygrad/viz/lib/worker.js
+++ b/tinygrad/viz/lib/worker.js
@@ -1,5 +1,3 @@
-importScripts("../assets/dagrejs.github.io/project/dagre/latest/dagre.min.js");
-
 const NODE_PADDING = 10;
 const LINE_HEIGHT = 14;
 const canvas = new OffscreenCanvas(0, 0);


### PR DESCRIPTION
It shouldn't have to go to the server for every graph. Before and after server logs:
![image](https://github.com/user-attachments/assets/e2798023-9d9f-400b-aff8-baca0c218f82)

![image](https://github.com/user-attachments/assets/ef804a9e-adf3-4618-a617-d002c4127fc7)

