### PR TITLE
Revert "do not block gc in UOp.toposort (#9623)"

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -241,15 +241,6 @@ class UOpMetaClass(type):
 buffers:weakref.WeakKeyDictionary[UOp, Buffer] = weakref.WeakKeyDictionary() # this maps BUFFER uops to their device Buffers
 all_metadata:weakref.WeakKeyDictionary[UOp, Metadata] = weakref.WeakKeyDictionary()
 
-def _toposort(u:UOp, cache:set[UOp]):
-  if u in cache: return {}
-  nodes: dict[UOp, None] = {}
-  # NOTE: this is a lot faster than the comprehension in parents
-  for parent in u.src: nodes.update(_toposort(parent, cache))
-  nodes[u] = None
-  cache.add(u)
-  return nodes
-
 # NOTE: this should be frozen, but frozen is slower
 @dataclass(eq=False, slots=True)
 class UOp(MathTrait, metaclass=UOpMetaClass):
@@ -280,6 +271,14 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
 
   @property
   def toposort(self) -> dict[UOp, None]:
+    def _toposort(u:UOp, cache:set[UOp]):
+      if u in cache: return {}
+      nodes: dict[UOp, None] = {}
+      # NOTE: this is a lot faster than the comprehension in parents
+      for parent in u.src: nodes.update(_toposort(parent, cache))
+      nodes[u] = None
+      cache.add(u)
+      return nodes
     return _toposort(self, cache=set())
 
   # returns map of UOps to their children in the graph rooted by self


### PR DESCRIPTION
This reverts commit f1a35bbb5438955c2dac624aef912ff80bc748eb.

Bert segfaulted in master. Did not happen in update_benchmark https://github.com/tinygrad/tinygrad/compare/593cba8a70c68060806cafd9453aa272e2e8706d...d9d82c9081d63c863c1f347a905202ad34951409.