### PR TITLE
torch backend: partial fix for strided related test fails

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -188,7 +188,6 @@ def empty_strided(size, stride, dtype, layout=None, device=None, pin_memory=Fals
 def empty_memory_format(size, dtype=None, layout=None, device=None, pin_memory=False, memory_format=None):
   if TORCH_DEBUG: print(f"empty.memory_format {size=} {dtype=} {layout=} {device=} {pin_memory=} {memory_format=}")
   ret = Tensor.empty(*size, dtype=_from_torch_dtype(dtype or torch.get_default_dtype()), device=_from_torch_device(device)).contiguous()
-  #ret = Tensor.full(size, float('NaN'), dtype=_from_torch_dtype(dtype or torch.get_default_dtype()), device=_from_torch_device(device)).contiguous()
   return wrap(ret)
 
 @torch.library.impl("aten::max_pool2d_with_indices", "privateuseone")

--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -56,7 +56,6 @@ view_ops = {
   "aten.t": Tensor.transpose,
   "aten.squeeze.dim": Tensor.squeeze,
   "aten.unsqueeze": Tensor.unsqueeze,
-  "aten.repeat": Tensor.repeat,
   "aten.detach": Tensor.detach,
 }
 
@@ -64,7 +63,7 @@ for k,v in view_ops.items(): torch.library.impl(k.replace("aten.", "aten::"), "p
 
 # in place operations with views
 def realize_with_views(self: Tensor, views: Tensor):
-  if not self.lazydata.st.contiguous: raise ValueError("base of view must be contiguous") # TODO: support?
+  if not self.lazydata.st.contiguous: self.replace(self.contiguous())
   self.replace(self.clone().realize())
   for v in views:
     ret = self
@@ -163,26 +162,33 @@ def cached_to_movement_ops(shape, st) -> list:
 from tinygrad.shape.shapetracker import ShapeTracker, View
 from extra.to_movement_ops import to_movement_ops, apply_mop, MovementOps
 @torch.library.impl("aten::as_strided", "privateuseone")
-@wrap_view_op
-def as_strided(tensor:Tensor, size, stride, storage_offset=None):
-  # TODO: this is heavyweight
-  st = ShapeTracker((View.create(tuple(tensor.shape)), View.create(tuple(size), tuple(stride), 0 if storage_offset is None else storage_offset)))
-  ret = tensor
-  if prod(size) == 1: return ret.flatten()[storage_offset].reshape(size)
-  if TORCH_DEBUG >= 1: print("**** as_strided", tensor.shape, size, stride, st)
-  for mo in cached_to_movement_ops(tuple(tensor.shape), st): ret = apply_mop(ret, mo)
-  return ret
+def as_strided(tensor:torch.Tensor, size, stride, storage_offset=None):
+  storage_offset = storage_offset or tensor.storage_offset()
+  @wrap_view_op
+  def _as_strided(tensor:Tensor, size, stride, storage_offset=None):
+    # multiple as_strided do not compound
+    base = canonical_base(tensor)
+    # TODO: this is heavyweight
+    st = ShapeTracker(base.lazydata.st.views + (View.create(tuple(size), tuple(stride), storage_offset),))
+    ret = base
+    if TORCH_DEBUG >= 1: print("**** as_strided", tensor.shape, size, stride, st)
+    if prod(size) == 1: return ret.flatten()[storage_offset].reshape(size)
+    for mo in cached_to_movement_ops(tuple(base.shape), st): ret = apply_mop(ret, mo)
+    return ret
+  return _as_strided(tensor, size, stride, storage_offset)
 
 @torch.library.impl("aten::empty_strided", "privateuseone")
 def empty_strided(size, stride, dtype, layout=None, device=None, pin_memory=False):
   if TORCH_DEBUG: print(f"empty_strided {size=} {stride=} {dtype=} {layout=} {device=} {pin_memory=}")
-  ret = Tensor.empty(*size, dtype=_from_torch_dtype(dtype), device=_from_torch_device(device))
+  ret = Tensor.empty(*size, dtype=_from_torch_dtype(dtype), device=_from_torch_device(device)).contiguous()
+  # TODO: should return with requested strides
   return wrap(ret)
 
 @torch.library.impl("aten::empty.memory_format", "privateuseone")
 def empty_memory_format(size, dtype=None, layout=None, device=None, pin_memory=False, memory_format=None):
   if TORCH_DEBUG: print(f"empty.memory_format {size=} {dtype=} {layout=} {device=} {pin_memory=} {memory_format=}")
   ret = Tensor.empty(*size, dtype=_from_torch_dtype(dtype or torch.get_default_dtype()), device=_from_torch_device(device)).contiguous()
+  #ret = Tensor.full(size, float('NaN'), dtype=_from_torch_dtype(dtype or torch.get_default_dtype()), device=_from_torch_device(device)).contiguous()
   return wrap(ret)
 
 @torch.library.impl("aten::max_pool2d_with_indices", "privateuseone")
@@ -275,14 +281,18 @@ def _copy_from(src: torch.Tensor, dest, non_blocking=False):
   cast_dtype = _from_torch_dtype(dest.dtype)
   if src.is_tiny and dest.is_tiny:
     to_device = _from_torch_device(dest.device)
-    unwrap(dest).assign(unwrap(src).cast(cast_dtype).to(to_device))
-    if realize: Tensor.realize(unwrap(dest))
+    src,dest = unwrap(src),unwrap(dest)
+    # TODO we need to properly match dest shape and strides, not blindly assign
+    if dest.lazydata.st.contiguous or dest.lazydata.is_realized: src = src.contiguous() # this only solves some cases
+    dest.assign(src.cast(cast_dtype).to(to_device))
+    if realize: Tensor.realize(dest)
   elif src.is_tiny and dest.is_cpu:
     # TODO: is there a better way?
     dest.resize_(src.numel()).resize_(src.shape)
     dest.copy_(torch.from_numpy(unwrap(src).cast(cast_dtype).numpy()))
   elif src.is_cpu and dest.is_tiny:
     to_device = _from_torch_device(dest.device)
+    # TODO we need to properly match dest shape and strides, not blindly assign
     unwrap(dest).assign(Tensor(src.numpy()).cast(cast_dtype).to(to_device))
     if realize: Tensor.realize(unwrap(dest))
   else:
@@ -482,6 +492,7 @@ tiny_backend = {**{k:wrap_out(v) for k,v in tiny_backend_out.items()}, **{
   "aten.scatter.value_reduce": Tensor.scatter,
   "aten.gather": lambda self, dim, index: self.gather(dim, index.cast(dtypes.int)),
   "aten.where.self": Tensor.where, # NOTE: this is needed as well as the out type
+  "aten.repeat": lambda x,*repeats: Tensor.repeat(x,*repeats).contiguous(), # not a view
   "aten._softmax": lambda self,dim,half_to_float: self.softmax(dim),
   "aten._log_softmax": lambda self,dim,half_to_float: self.log_softmax(dim),
   "aten.random_": inplace_fn("self")(lambda self:

--- a/extra/torch_backend/test.py
+++ b/extra/torch_backend/test.py
@@ -54,7 +54,7 @@ class TestTorchBackend(unittest.TestCase):
     a = torch.Tensor([1,2,3,4]).to(device)
     np.testing.assert_equal(a[:3].cpu().numpy(), [1,2,3])
     np.testing.assert_equal(a[1:].cpu().numpy(), [2,3,4])
-  
+
   def test_as_strided(self):
     a = torch.arange(70, device=device).reshape(1,1,10,7)
     a = a.as_strided((1,1,10,5), (0,0,7,1), storage_offset=0)

--- a/extra/torch_backend/test.py
+++ b/extra/torch_backend/test.py
@@ -54,6 +54,12 @@ class TestTorchBackend(unittest.TestCase):
     a = torch.Tensor([1,2,3,4]).to(device)
     np.testing.assert_equal(a[:3].cpu().numpy(), [1,2,3])
     np.testing.assert_equal(a[1:].cpu().numpy(), [2,3,4])
+  
+  def test_as_strided(self):
+    a = torch.arange(70, device=device).reshape(1,1,10,7)
+    a = a.as_strided((1,1,10,5), (0,0,7,1), storage_offset=0)
+    a = a.as_strided((1,1,5,5), (50,50,7,1), storage_offset=21)
+    np.testing.assert_equal(a.cpu().numpy().sum(-1), [[[115,150,185,220,255]]])
 
   def test_plus_inplace(self):
     a = torch.ones(4, device=device)

--- a/extra/torch_backend/wrapped_tensor.cpp
+++ b/extra/torch_backend/wrapped_tensor.cpp
@@ -92,9 +92,12 @@ struct TinyOpaqueTensorImpl : public OpaqueTensorImpl<OpaqueHandle> {
       c10::Device device,
       OpaqueHandle opaque_handle,
       c10::IntArrayRef sizes,
-      c10::IntArrayRef strides)
-      : OpaqueTensorImpl<OpaqueHandle>(key_set, data_type, device, opaque_handle, sizes)
-        { this->sizes_and_strides_.set_strides(strides); }
+      c10::IntArrayRef strides,
+      int64_t storage_offset)
+      : OpaqueTensorImpl<OpaqueHandle>(key_set, data_type, device, opaque_handle, sizes) {
+    this->sizes_and_strides_.set_strides(strides);
+    this->storage_offset_ = storage_offset;
+  }
 };
 }
 
@@ -113,15 +116,11 @@ at::Tensor wrap_tensor(py::object &py_obj, c10::ScalarType dtype, c10::DeviceInd
   // TODO: we have to get the dtype and the shape from the tinygrad Tensor
   std::vector<int64_t> sizes = py_obj.attr("shape").cast<std::vector<int64_t>>();
 
-  // Last dimension stride is 1 for contiguous row-major layout
-  std::vector<int64_t> strides(sizes.size());
-  if (sizes.size() >= 1) {
-    strides[sizes.size() - 1] = 1;
-
-    // Compute strides from right to left
-    for (int64_t i = sizes.size() - 2; i >= 0; --i) {
-      strides[i] = strides[i + 1] * sizes[i + 1];
-    }
+  py::list views = py_obj.attr("lazydata").attr("st").attr("views");
+  std::vector<int64_t> strides = views[views.size() - 1].attr("strides").cast<std::vector<int64_t>>();
+  int64_t storage_offset = 0;
+  for (auto& v: views) {
+    storage_offset += v.attr("offset").cast<int64_t>(); // TODO: is this correct?
   }
 
   return at::detail::make_tensor<at::TinyOpaqueTensorImpl<std::shared_ptr<c10::SafePyObject>>>(
@@ -129,7 +128,7 @@ at::Tensor wrap_tensor(py::object &py_obj, c10::ScalarType dtype, c10::DeviceInd
     c10::scalarTypeToTypeMeta(dtype),
     at::Device(at::kPrivateUse1, device_index),
     std::make_shared<c10::SafePyObject>(py_obj.release().ptr(), getPyInterpreter()),
-    sizes, strides);
+    sizes, strides, storage_offset);
 }
 
 py::object unwrap_tensor(const at::Tensor &tensor) {


### PR DESCRIPTION
Report correct strides and offset to torch. The offset is necessary as part of some of the backwards as_strided calculations that torch does (like in [CopySlices](https://github.com/pytorch/pytorch/blob/c97632154108f27a84ae843844b3f7fd15994c65/torch/csrc/autograd/functions/tensor.cpp#L199)).

Fix to repeat not being a view.
Fix to behavior of as_strided. The operation should perform on the base "storage" and doesn't stack. Added test.
Some TODOs added where we need to be respecting requested strides.

Mostly as a result of investigation into `TINY_BACKEND=1 python test/test_ops.py TestOps.test_pad_circular_mode` failure.
The test now passes, but others are still failing. Looking to see results on #9302

This also fixed test_cat but broke two einsum tests, taking a look at those next.