### PR TITLE
remove `smem_prefix_for_cast` for AMD

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -442,6 +442,7 @@ class AMDRenderer(CStyleLanguage):
     Ops.EXP2: lambda x,dtype: f"__ocml_exp2_f{ {dtypes.half:16, dtypes.double:64}.get(dtype, 32)}({x})",
     Ops.SQRT: lambda x,dtype: f"__ocml_sqrt_f{ {dtypes.half:16, dtypes.double:64}.get(dtype, 32)}({x})" }
   smem_prefix = "__attribute__((shared))"
+  smem_prefix_for_cast: bool = False
   barrier = '__builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup");' + '__builtin_amdgcn_s_barrier();' + \
             '__builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup");'
   float4 = "make_float4"


### PR DESCRIPTION
Fixes [CI in #9596](https://github.com/tinygrad/tinygrad/actions/runs/14171158999/job/39695067545?pr=9596#step:8:214)

TC=3 was broken for AMD with the same problem