### PR TITLE
hotfix: do not fetch cifar with NULL=1

### DIFF
--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -276,7 +276,7 @@ def train_cifar():
 
   set_seed(getenv('SEED', hyp['seed']))
 
-  X_train, Y_train, X_test, Y_test = nn.datasets.cifar()
+  X_train, Y_train, X_test, Y_test = nn.datasets.cifar(device=Device.DEFAULT)
   # one-hot encode labels
   Y_train, Y_test = Y_train.one_hot(10), Y_test.one_hot(10)
   # preprocess data

--- a/tinygrad/nn/datasets.py
+++ b/tinygrad/nn/datasets.py
@@ -8,6 +8,9 @@ def mnist(device=None, fashion=False):
          _mnist("t10k-images-idx3-ubyte.gz")[0x10:].reshape(-1,1,28,28).to(device), _mnist("t10k-labels-idx1-ubyte.gz")[8:].to(device)
 
 def cifar(device=None):
+  if device == "NULL":
+    from tinygrad import dtypes
+    return Tensor.empty(50000, 3, 32, 32, dtype=dtypes.int), Tensor.empty(50000, dtype=dtypes.int), Tensor.empty(10000, 3, 32, 32, dtype=dtypes.int), Tensor.empty(10000, dtype=dtypes.int)
   tt = tar_extract(Tensor.from_url('https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz', gunzip=True))
   train = Tensor.cat(*[tt[f"cifar-10-batches-bin/data_batch_{i}.bin"].reshape(-1, 3073).to(device) for i in range(1,6)])
   test = tt["cifar-10-batches-bin/test_batch.bin"].reshape(-1, 3073).to(device)


### PR DESCRIPTION
needs a generic lazy HTTPTensor really,
is the shape and dtype specified from the kernel graph?