### PR TITLE
bring GroupOp.Meta back

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -181,6 +181,8 @@ class GroupOp:
   # do not preserve f(0) = 0
   UnsafePad = {Ops.RECIP, Ops.LOG2, Ops.EXP2, Ops.IDIV, Ops.POW}
 
+  Meta = {Ops.COPY, Ops.BUFFER_VIEW}
+
   All = set(Ops)
 
 # some BUFFER ops can be processed with only a view


### PR DESCRIPTION
Still useful for scheduling ops that don't use CompiledRunner.