### PR TITLE
always fit fresh viz graph into view [pr]

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -340,7 +340,7 @@
       };
     }
     if (ret.length === 0) return;
-    renderGraph(ret[currentRewrite].graph, ret[currentRewrite].changed_nodes || [], kernel.name);
+    renderGraph(ret[currentRewrite].graph, ret[currentRewrite].changed_nodes || [], kernel.name, recenter=currentRewrite === 0);
     // ***** RHS metadata
     const metadata = document.querySelector(".container.metadata");
     metadata.innerHTML = "";

--- a/tinygrad/viz/lib/graph.js
+++ b/tinygrad/viz/lib/graph.js
@@ -9,7 +9,7 @@ function intersectRect(r1, r2) {
 }
 
 let [workerUrl, worker, timeout] = [null, null, null];
-window.renderGraph = async function(graph, additions, name) {
+window.renderGraph = async function(graph, additions, name, recenter=false) {
   if (name === "View Memory Graph") {
     return renderMemoryGraph(graph);
   }
@@ -59,6 +59,7 @@ window.renderGraph = async function(graph, additions, name) {
       points.push(intersectRect(g.node(e.w), points[points.length-1]));
       return line(points);
     }).attr("marker-end", "url(#arrowhead)");
+    if (recenter) document.getElementById("zoom-to-fit-btn").click();
   };
 }
 


### PR DESCRIPTION
The first step in a rewrite is a new sink passed into graph_rewrite, each of these sinks are different sizes so it makes sense to recenter at the first step.

I've found the kernel graphs go outside the view port a lot when navigating from Tensor graph to smaller AST graphs.