### PR TITLE
move uops print to debug >= 6

### DIFF
--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -679,7 +679,7 @@ class Kernel:
     #if __debug__: type_verify(list(modified_ast.toposort), shape_spec)
 
     self.uops:list[UOp] = linearize_uop(full_graph_rewrite(rewrite_shapetracker_with_index(modified_ast, self.opts), self.opts))
-    if DEBUG >= 5: print_uops(self.uops)
+    if DEBUG >= 6: print_uops(self.uops)
     return self
 
   def to_program(self, name_override:Optional[str]=None, ast_transform:Optional[Callable]=None) -> ProgramSpec:


### PR DESCRIPTION
I think it is still convenient to have ast printed independently. `VIZ` is great for many things, but for very simple stuff I think the overhead is not worth launching it, that is why I think `DEBUG=5` printing only the `ast` / `modified_ast` is useful.