### PR TITLE
remove duplicated ast print

### DIFF
--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -13,7 +13,6 @@ from tinygrad.engine.schedule import ScheduleItem
 
 logkerns, logkerns_level = open(getenv("LOGKERNS", ""), "a") if getenv("LOGKERNS", "") else None, getenv("LOGKERNS_LEVEL", 1)
 def get_kernel(renderer:Renderer, ast:UOp) -> Kernel:
-  if DEBUG >= 5: print(ast)
   k = Kernel(ast, opts=renderer).required_optimizations()
   if not NOOPT:
     if not k.apply_tensor_cores(getenv("TC", 1)): k.hand_coded_optimizations()
@@ -23,7 +22,6 @@ def get_kernel(renderer:Renderer, ast:UOp) -> Kernel:
       rawbufs = bufs_from_lin(kb, allocate=False)
       k = beam_search(kb, rawbufs, BEAM.value, bool(getenv("BEAM_ESTIMATE", 1)))
   if logkerns is not None: logkerns.writelines([f"{(k.ast, k.applied_opts)}\n"])
-  if DEBUG >= 5: print((k.ast, k.applied_opts)) # print here to show final applied_opts for all kernels instead of just in beam_search
   return k
 
 # **************** Runners ****************


### PR DESCRIPTION
`ast` is already printed in `kernel` -> `linearize`, it was being logged twice
https://github.com/tinygrad/tinygrad/blob/a1ee4d587fcd74a01e73236511d1ede3048238cf/tinygrad/codegen/kernel.py#L670

https://github.com/tinygrad/tinygrad/blob/a1ee4d587fcd74a01e73236511d1ede3048238cf/tinygrad/codegen/kernel.py#L675

`applied_opts` are printed on `DEBUG >= 3`

https://github.com/tinygrad/tinygrad/blob/a1ee4d587fcd74a01e73236511d1ede3048238cf/tinygrad/codegen/kernel.py#L674