### PR TITLE
Fix fuse arange rewrite

### DIFF
--- a/test/test_arange.py
+++ b/test/test_arange.py
@@ -190,5 +190,23 @@ class TestIndexing(unittest.TestCase):
       assert slices_sum.shape == (5,)
       np.testing.assert_allclose(slices_sum.numpy(), np.array([5, 7, 9, 11, 13]))
 
+  def test_arange_slices_rewrite(self):
+    # Test that our rewrite rule correctly handles sliced arange tensors
+    with Context(FUSE_ARANGE=1):
+      t = Tensor.arange(12)
+      # Test different slice combinations
+      slices = [
+        t[:6] + t[6:],  # Simple split
+        t[::2] + t[1::2],  # Strided slices
+        t[:4] + t[4:8] + t[8:]  # Multiple slices
+      ]
+      expected = [
+        np.arange(12)[:6] + np.arange(12)[6:],  # Simple split
+        np.arange(12)[::2] + np.arange(12)[1::2],  # Strided slices
+        np.arange(12)[:4] + np.arange(12)[4:8] + np.arange(12)[8:]  # Multiple slices
+      ]
+      for s, e in zip(slices, expected):
+        np.testing.assert_allclose(s.numpy(), e)
+
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_arange.py
+++ b/test/test_arange.py
@@ -182,5 +182,13 @@ class TestIndexing(unittest.TestCase):
   # at least the arange is being fused
   def test_llama_embedding_opt(self): self.test_llama_embedding(0, 1_736_704_000 if CI else 5_898_240_000)
 
+  def test_arange_slices_with_fuse(self):
+    # Test the specific case from issue #9509
+    with Context(FUSE_ARANGE=1):
+      t = Tensor.arange(10)
+      slices_sum = t[:5] + t[5:]
+      assert slices_sum.shape == (5,)
+      np.testing.assert_allclose(slices_sum.numpy(), np.array([5, 7, 9, 11, 13]))
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
## Description
This PR fixes issue #9509  using rewrite rules instead of context managers.

### Changes
- Added rewrite rule `pm_fuse_arange` to detect and handle sliced arange tensors
- Improved test coverage with different slice patterns
- Handles both size mismatches and non-unit strides
- Maintains optimization benefits for non-sliced cases

### Implementation Details
- Added pattern matcher in `schedule.py` to detect sliced arange operations
- Rewrite rule checks for:
  1. Size mismatches between base tensor and view
  2. Non-unit strides in views
- Prevents FUSE_ARANGE optimization when these conditions are detected
- Allows operation to proceed through general path that correctly handles shapes

### Test Cases
Added comprehensive test cases in `test_arange.py` that verify:
- Simple splits (e.g., `t[:6] + t[6:]`)
- Strided slices (e.g., `t[::2] + t[1::2]`)
- Multiple slices (e.g., `t[:4] + t[4:8] + t[8:]`)
Let me know if any changes are required from team 