### PR TITLE
add RECORD_TRACEBACKS=1 option to process replay

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -36,7 +36,7 @@ class ProcessReplayWarning(Warning): pass
 def recreate_sched(big_sink:UOp) -> list[UOp]:
   sched, _, __ = create_schedule_with_vars(big_sink)
   return [x.ast for x in sched]
-def recreate_kernel(ast:UOp, opts:Renderer, applied_opts:list[Opt], name:str) -> str:
+def recreate_kernel(ast:UOp, opts:Renderer, applied_opts:list[Opt], name:str, _) -> str:
   k = Kernel(ast, opts=opts)
   for opt in applied_opts: k.apply_opt(opt)
   # NOTE: replay with the captured renderer, not the one in master

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -698,7 +698,11 @@ class Kernel:
     src = self.opts.render(self.uops)
 
     if CAPTURE_PROCESS_REPLAY:
-      diskcache_put("kernel_process_replay", str(id(self)), (self.ast, self.opts, self.applied_opts, self.uops[0].arg, ContextVar._cache, src))
+      if getenv("RECORD_TRACEBACKS"):
+        import traceback
+        bt = "\n".join(traceback.format_list(traceback.extract_stack()[:-1]))
+      else: bt = None
+      diskcache_put("kernel_process_replay", str(id(self)), (self.ast, self.opts, self.applied_opts, self.uops[0].arg, bt, ContextVar._cache, src))
 
     # group non-local bufs by the op type (LOAD or STORE) and the buffer arg. take the max access of that buffer in bytes
     # TODO: these max and min don't work on symbolic, and results are very wrong.

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -698,11 +698,12 @@ class Kernel:
     src = self.opts.render(self.uops)
 
     if CAPTURE_PROCESS_REPLAY:
+      # NOTE: calling traceback.extract_stack() is very slow, recording backtraces isn't included by default yet
       if getenv("RECORD_TRACEBACKS"):
         import traceback
-        bt = "\n".join(traceback.format_list(traceback.extract_stack()[:-1]))
-      else: bt = None
-      diskcache_put("kernel_process_replay", str(id(self)), (self.ast, self.opts, self.applied_opts, self.uops[0].arg, bt, ContextVar._cache, src))
+        stack = "\n".join(traceback.format_list(traceback.extract_stack()[:-1]))
+      else: stack = None
+      diskcache_put("kernel_process_replay", str(id(self)), (self.ast, self.opts, self.applied_opts, self.uops[0].arg, stack, ContextVar._cache, src))
 
     # group non-local bufs by the op type (LOAD or STORE) and the buffer arg. take the max access of that buffer in bytes
     # TODO: these max and min don't work on symbolic, and results are very wrong.


### PR DESCRIPTION
Capturing with RECORD_TRACEBACKS=1 will also include the location of the kernel if process replay fails to generate the diff:

![image](https://github.com/user-attachments/assets/b1a3e1b0-2c64-4289-84a2-e26fb23a81ab)
`traceback.extract_stack` is very slow though. If we wanna make this the default process_replay path maybe it should manually recurse sys._getframe.