### PR TITLE
AMD_LLVM speed

### DIFF
--- a/test/external/speed_compare_hip_llvm.py
+++ b/test/external/speed_compare_hip_llvm.py
@@ -1,0 +1,50 @@
+from tinygrad import Device
+from tinygrad.engine.realize import CompiledRunner
+from tinygrad.helpers import getenv, colorize_float
+from extra.optimization.helpers import load_worlds, ast_str_to_lin
+from tinygrad.engine.search import bufs_from_lin
+from tinygrad.runtime.support.compiler_amd import HIPCompiler, AMDLLVMCompiler
+from tinygrad.renderer.cstyle import AMDRenderer
+from tinygrad.renderer.llvmir import AMDLLVMRenderer
+
+if __name__ == "__main__":
+  ast_strs = load_worlds(filter_reduce=False, filter_novariable=True)
+  dev = Device["AMD"]
+  amd_render = AMDRenderer(dev.arch)
+  llvm_render = AMDLLVMRenderer()
+  single = getenv("NUM", -1)
+  if single != -1: ast_strs = ast_strs[single:single+1]
+  avg_tm_hip, avg_tm_llvm = 0, 0
+  for num, ast in enumerate(ast_strs):
+    dev.compiler = HIPCompiler(dev.arch)
+    lin_hip = ast_str_to_lin(ast, opts=amd_render)
+    lin_hip.hand_coded_optimizations()
+    hip_prg = lin_hip.to_program()
+    hip_runner = CompiledRunner(hip_prg)
+
+    bufs = bufs_from_lin(lin_hip)
+
+    # llvm compile
+    dev.compiler = AMDLLVMCompiler(dev.arch)
+    lin = ast_str_to_lin(ast, opts=llvm_render)
+    lin.hand_coded_optimizations()
+    lin.linearize()
+    llvm_prg = lin.to_program()
+    llvm_runner = CompiledRunner(llvm_prg)
+
+    # warmup
+    try:
+      hip_runner(bufs, {}, wait=True)
+    except RuntimeError:
+      print("hip failed ast:", num)
+      continue
+    llvm_runner(bufs, {}, wait=True)
+
+    tm_hip, tm_llvm = [], []
+    for i in range(5):
+      tm_hip.append(hip_runner(bufs, {}, wait=True))
+      tm_llvm.append(llvm_runner(bufs, {}, wait=True))
+    avg_tm_hip += min(tm_hip)
+    avg_tm_llvm += min(tm_llvm)
+    ratio = min(tm_llvm)/min(tm_hip)
+    print(f"{avg_tm_llvm/avg_tm_hip:5.2f}x -- {num:4d} {colorize_float(ratio)}  {min(tm_llvm)*1e6:7.2f}(hip={min(tm_hip)*1e6:7.2f}) us", lin.name)

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -526,7 +526,8 @@ class Kernel:
         if self.first_reduce < self.first_upcast and s <= 3 and isinstance(s2:=self.full_unupcasted_shape[-1], int) and s2 <= 3:
           self.apply_opt(Opt(OptOps.UNROLL, len(self.full_unupcasted_shape)-1-self.first_reduce, 0))
       else:
-        for splits in [4]:
+        # for r_30522n1 (NUM=269)
+        for splits in [6, 4]:
           if self.full_unupcasted_shape[-1]%splits == 0:
             self.apply_opt(Opt(OptOps.UNROLL, len(self.full_unupcasted_shape)-1-self.first_reduce, splits))
             break

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -242,9 +242,9 @@ class AMDLLVMRenderer(LLVMRenderer):
   ]) + base_rewrite
   extra_matcher = PatternMatcher([
     # double intrinsics missing for sqrt/exp2/log2
-    ((UPat(Ops.SQRT, dtype=dtypes.double, name="x"), lambda x: xpow(x.src[0], x.src[0].const_like(0.5)))),
-    ((UPat(Ops.EXP2, dtype=dtypes.double, name="x"), lambda x: xexp2(x.src[0]))),
-    ((UPat(Ops.LOG2, dtype=dtypes.double, name="x"), lambda x: xlog2(x.src[0]))),
+    (UPat(Ops.SQRT, dtype=dtypes.double, name="x"), lambda x: xpow(x.src[0], x.src[0].const_like(0.5))),
+    (UPat(Ops.EXP2, dtype=dtypes.double, name="x"), lambda x: xexp2(x.src[0])),
+    (UPat(Ops.LOG2, dtype=dtypes.double, name="x"), lambda x: xlog2(x.src[0])),
     (UPat(Ops.WMMA, name="x", dtype=dtypes.half.vec(8)),
      lambda x: UOp(Ops.WMMA, dtypes.half.vec(16), (x.src[0], x.src[1], x.src[2].cast(dtypes.half.vec(16))), (*x.arg,)).cast(dtypes.half.vec(8)))
   ]) + LLVMRenderer.extra_matcher

--- a/tinygrad/runtime/support/compiler_amd.py
+++ b/tinygrad/runtime/support/compiler_amd.py
@@ -75,7 +75,7 @@ class AMDLLVMCompiler(LLVMCompiler):
   target_arch = "AMDGPU"
   def __init__(self, arch: str):
     self.arch = arch
-    super().__init__(self.arch, "+cumode")
+    super().__init__(self.arch, "")
   def __reduce__(self): return (AMDLLVMCompiler, (self.arch,))
   def compile(self, src:str) -> bytes:
     try: return super().compile(src)


### PR DESCRIPTION
disable cumode give a speedup, CI failed with remu `remu does not support the new instruction introduced in this kernel`, tests succeeded on tinybox

compare with AMD backend(3h10m), 10%(3h29m) slower after this change

test with: `BERT_LAYERS=2 DISABLE_COMPILER_CACHE=1 DEFAULT_FLOAT=HALF BENCHMARK=10 BS=66 GPUS=6 MODEL=bert python3 examples/mlperf/model_train.py`

