### PR TITLE
Increase `TestPTXFailures::test_gated_define_acc_with_half_dtype` atol and rtol

### DIFF
--- a/test/test_renderer_failures.py
+++ b/test/test_renderer_failures.py
@@ -71,7 +71,7 @@ class TestPTXFailures(unittest.TestCase):
     b = Tensor.randn(34, 32, dtype=dtypes.half).realize()
     result = a.pad((1,1)).matmul(b, dtype=dtypes.half).numpy()
     reference = a.pad((1,1)).matmul(b, dtype=dtypes.float).numpy()
-    np.testing.assert_allclose(result, reference)
+    np.testing.assert_allclose(result, reference, atol=1e-2, rtol=1e-2)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
test was failing due to tolerance

<img width="1379" alt="image" src="https://github.com/user-attachments/assets/b89327d3-0dcd-49ff-9cb2-e06d9db5f64c" />
