### PR TITLE
jit: rename optimize_weights -> replan_buffers_memory_layout

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -617,8 +617,8 @@ class TestJitFree(unittest.TestCase):
     fxn(Tensor([2]))
     self.assertEqual(x.item(), 8)
 
-  def test_optimize_weights(self):
-    if not hasattr(Device[Device.DEFAULT].allocator, '_offset'): raise unittest.SkipTest("optimize_weights useless")
+  def test_replan_buffers_memory_layout(self):
+    if not hasattr(Device[Device.DEFAULT].allocator, '_offset'): raise unittest.SkipTest("replan_buffers_memory_layout useless")
 
     ext_tensor = Tensor([1,24,23,45,1])
     ext_tensor_2 = Tensor([2,2,2,2,2])
@@ -630,7 +630,7 @@ class TestJitFree(unittest.TestCase):
       out = fxn(Tensor([i,1,2,3,4]))
       self.assertEqual(out.item(), 11400+200*i)
     assert len(set([b.base for item in fxn.captured.jit_cache for b in item.bufs if b is not None])) == 4
-    fxn.captured.optimize_weights()
+    fxn.captured.replan_buffers_memory_layout()
     assert len(set([b.base for item in fxn.captured.jit_cache for b in item.bufs if b is not None])) == 2
 
     out = fxn(Tensor([11,1,2,3,4]))


### PR DESCRIPTION
`optimize_weights` was a poor name from the beginning. `replan_buffers_memory_layout` should better describe what's happening in the function