### PR TITLE
OptOps.LDS

### DIFF
--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -1,0 +1,175 @@
+from typing import Union
+import numpy as np
+import unittest
+from dataclasses import replace
+
+from tinygrad.codegen.kernel import Opt, OptOps, KernelOptError, Kernel
+from tinygrad.ops import UOp, Ops
+from tinygrad.device import Device, Buffer
+from tinygrad.tensor import Tensor
+from tinygrad.engine.realize import run_schedule, CompiledRunner
+from tinygrad.helpers import Context
+from tinygrad.dtype import dtypes
+
+def helper_realized_ast(r:Union[Tensor, list[Tensor]]) -> tuple[UOp, list[Buffer]]:
+  if isinstance(r, Tensor): r = [r]
+  s = Tensor.schedule(*r)
+  run_schedule(s[:-1])
+  assert s[-1].ast.op is Ops.SINK, f"helper_realized_ast expects a SINK {s[-1]}"
+  bufs = [Buffer((x).device, x.size, x.dtype).allocate() if i < len(s[-1].ast.src) else x for i,x in enumerate(s[-1].bufs)]
+  return s[-1].ast, bufs
+
+def helper_lds_allclose(opts:list[Opt], expected_bufs, N=16, M=16, K=16, dtype_in=dtypes.float, acc_dtype=dtypes.float, append_lds_opts=True):
+  with Context(DEBUG=0): a, b = Tensor.rand(M, K, dtype=dtype_in).realize(), Tensor.rand(K, N, dtype=dtype_in).realize()
+  realized_ast, bufs = helper_realized_ast(a.matmul(b, dtype=acc_dtype))
+  k = Kernel(realized_ast)
+  if append_lds_opts: opts += [Opt(OptOps.LDS, 0, None), Opt(OptOps.LDS, 1, None), Opt(OptOps.LDS, 2, None)]
+  for opt in opts:
+    k.apply_opt(opt)
+  prg = k.to_program()
+  CompiledRunner(replace(prg, device=Device.DEFAULT)).exec(bufs)
+
+  atol, rtol = 1e-4, 1e-4
+  if dtype_in == dtypes.half: atol, rtol = 1e-2, 1e-2
+  np.testing.assert_allclose(bufs[0].numpy().reshape((M,N)), a.numpy() @ b.numpy(), atol=atol, rtol=rtol)
+
+  local_buffers = [uop for uop in k.uops if uop.op is Ops.DEFINE_LOCAL]
+  assert len(local_buffers) == len(expected_bufs), f"Expected exactly {len(expected_bufs)} local buffers, got {len(local_buffers)}"
+  for i,(buf, sz) in enumerate(expected_bufs):
+    assert local_buffers[i].arg == f"lds{buf}", f"Expected buffer argument index {buf}, got {local_buffers[i].arg}"
+    expected_dtype = (acc_dtype if buf == 0 else dtype_in).ptr(sz, local=True)
+    assert local_buffers[i].dtype == expected_dtype, f"Expected buffer dtype {expected_dtype}, got {local_buffers[i].dtype} for {opts=}"
+    # TODO: check all access to the global buffer are proxied through the local buffer
+
+@unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")
+class TestLDS(unittest.TestCase):
+#   @unittest.expectedFailure
+  def test_lds_args(self):
+    realized_ast, _ = helper_realized_ast(Tensor.rand(4, 4) @ Tensor.rand(4, 4))
+    k = Kernel(realized_ast)
+    valid_opts = [Opt(OptOps.LDS, 0, None),
+                  Opt(OptOps.LDS, 1, None),
+                  Opt(OptOps.LDS, 2, None)]
+    for opt in valid_opts:
+      k = Kernel(realized_ast)
+      k.apply_opt(opt)
+
+    invalid_opts = [Opt(OptOps.LDS, -1, None),
+                    Opt(OptOps.LDS, 3, None)]
+    for opt in invalid_opts:
+      k = Kernel(realized_ast)
+      with self.assertRaises(KernelOptError):
+        k.apply_opt(opt)
+
+#   @unittest.expectedFailure
+  def test_lds_basic(self):
+    # output
+    helper_lds_allclose(opts=[Opt(OptOps.LDS, 0, None)], expected_bufs=[(0,1)], append_lds_opts=False)
+    # input
+    helper_lds_allclose(opts=[Opt(OptOps.LDS, 1, None)], expected_bufs=[(1,1)], append_lds_opts=False)
+    helper_lds_allclose(opts=[Opt(OptOps.LDS, 2, None)], expected_bufs=[(2,1)], append_lds_opts=False)
+    # multi
+    helper_lds_allclose(opts=[Opt(OptOps.LDS, 0, None), Opt(OptOps.LDS, 1, None)], expected_bufs=[(0,1),(1,1)], append_lds_opts=False)
+    helper_lds_allclose(opts=[], expected_bufs=[(0,1),(1,1),(2,1)])
+
+#   @unittest.expectedFailure
+  def test_lds_unroll(self):
+    # unroll doesn't change local output buffer size
+    for sz in [2,4,8]:
+      helper_lds_allclose(opts=[Opt(OptOps.UNROLL, 0, sz)], expected_bufs=[(0,1),(1,sz),(2,sz)])
+
+#   @unittest.expectedFailure
+  @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
+  def test_lds_local(self):
+    # if only locals are applied, local buffer size for output should be prod(locals)
+
+    basic_local_opts = [Opt(OptOps.LOCAL, 0, 2)]
+    helper_lds_allclose(opts=basic_local_opts, expected_bufs=[(0,2),(1,2),(2,1)])
+
+    multi_local_opts = [Opt(OptOps.LOCAL, 0, 2),
+                        Opt(OptOps.LOCAL, 0, 8)]
+    helper_lds_allclose(opts=multi_local_opts, expected_bufs=[(0,16),(1,16),(2,1)])
+
+    multi_axis_local_opts = [Opt(OptOps.LOCAL, 1, 4),
+                             Opt(OptOps.LOCAL, 0, 2)]
+    helper_lds_allclose(opts=multi_axis_local_opts, expected_bufs=[(0,8),(1,2),(2,4)])
+
+    full_local_opts = [Opt(OptOps.LOCAL, 0, 16),
+                       Opt(OptOps.LOCAL, 0, 16)]
+    helper_lds_allclose(opts=full_local_opts, expected_bufs=[(0,256),(1,16),(2,16)])
+
+#   @unittest.expectedFailure
+  def test_lds_upcast(self):
+    # if only upcasts are applied, local buffer size for output should be prod(upcast)
+
+    basic_upcast_opts = [Opt(OptOps.UPCAST, 0, 2)]
+    helper_lds_allclose(opts=basic_upcast_opts, expected_bufs=[(0,2),(1,2),(2,1)])
+
+    multi_upcast_opts = [Opt(OptOps.UPCAST, 0, 2),
+                         Opt(OptOps.UPCAST, 0, 8)]
+    helper_lds_allclose(opts=multi_upcast_opts, expected_bufs=[(0,16),(1,16),(2,1)])
+
+    multi_axis_upcast_opts = [Opt(OptOps.UPCAST, 1, 4),
+                              Opt(OptOps.UPCAST, 0, 2)]
+    helper_lds_allclose(opts=multi_axis_upcast_opts, expected_bufs=[(0,8),(1,2),(2,4)])
+
+    full_upcast_opts = [Opt(OptOps.UPCAST, 0, 16),
+                        Opt(OptOps.UPCAST, 0, 16)]
+    helper_lds_allclose(opts=full_upcast_opts, expected_bufs=[(0,256),(1,16),(2,16)])
+
+#   @unittest.expectedFailure
+  @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test requires tensor cores")
+  def test_lds_tc(self):
+    for tc in Device[Device.DEFAULT].renderer.tensor_cores:
+      if tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16: continue
+      (N, M, K) = tc.dims
+      sz = 64
+
+      opts = [Opt(OptOps.TC, 0, (-1, 0))]
+      helper_lds_allclose(opts=opts, expected_bufs=[(0,M*N),(1,K*N),(2,M*K)], N=N, M=M, K=K, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+
+      opts = [Opt(OptOps.TC, 0, (-1, 0)),
+              Opt(OptOps.LOCAL, 0, 2),
+              Opt(OptOps.UPCAST, 1, 2)]
+      helper_lds_allclose(opts=opts, expected_bufs=[(0,M*N*4),(1,K*N*2),(2,M*K*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+
+      opts = [Opt(OptOps.TC, 0, (-1, 0)),
+              Opt(OptOps.UNROLL, 0, 2)]
+      helper_lds_allclose(opts=opts, expected_bufs=[(0,M*N),(1,K*N*2),(2,M*K*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+
+      opts = [Opt(OptOps.TC, 0, (-1, 0)),
+              Opt(OptOps.UNROLL, 0, 2),
+              Opt(OptOps.UPCAST, 1, 2)]
+      helper_lds_allclose(opts=opts, expected_bufs=[(0,M*N*2),(1,K*N*2),(2,M*K*4)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+
+#   @unittest.expectedFailure
+  @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
+  def test_lds_full(self):
+    opts = [Opt(OptOps.LOCAL, 0, 2),
+            Opt(OptOps.UPCAST, 1, 2)]
+    helper_lds_allclose(opts=opts, expected_bufs=[(0,4),(1,2),(2,2)])
+
+    opts = [Opt(OptOps.LOCAL, 0, 2),
+            Opt(OptOps.UPCAST, 0, 4),
+            Opt(OptOps.LOCAL, 1, 8)]
+    helper_lds_allclose(opts=opts, expected_bufs=[(0,64),(1,8),(2,8)])
+
+    opts = [Opt(OptOps.LOCAL, 0, 16),
+            Opt(OptOps.UPCAST, 1, 2)]
+    helper_lds_allclose(opts=opts, expected_bufs=[(0,16),(1,16),(2,1)]) # upcasting local dim
+
+    opts = [Opt(OptOps.LOCAL, 0, 16),
+            Opt(OptOps.UPCAST, 0, 16)]
+    helper_lds_allclose(opts=opts, expected_bufs=[(0,256),(1,16),(2,16)])
+
+    opts = [Opt(OptOps.LOCAL, 1, 16),
+            Opt(OptOps.UPCAST, 1, 16)]
+    helper_lds_allclose(opts=opts, expected_bufs=[(0,16),(1,1),(2,16)])
+
+    opts = [Opt(OptOps.LOCAL, 1, 4),
+            Opt(OptOps.UNROLL, 0, 2),
+            Opt(OptOps.UPCAST, 0, 2)]
+    helper_lds_allclose(opts=opts, expected_bufs=[(0,8),(1,4),(2,8)])
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -152,21 +152,21 @@ class TestLDS(unittest.TestCase):
       sz = 64
 
       opts = [Opt(OptOps.TC, 0, (i, 0))]
-      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N),(1,K*N),(2,M*K)], N=N, M=M, K=K, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N),(1,M*K),(2,K*N)], N=N, M=M, K=K, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
       opts = [Opt(OptOps.TC, 0, (i, 0)),
               Opt(OptOps.LOCAL, 0, 2),
               Opt(OptOps.UPCAST, 1, 2)]
-      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N*4),(1,K*N*2),(2,M*K*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N*4),(1,M*K*2),(2,K*N*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
       opts = [Opt(OptOps.TC, 0, (i, 0)),
               Opt(OptOps.UNROLL, 0, 2)]
-      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N),(1,K*N*2),(2,M*K*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N),(1,M*K*2),(2,K*N*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
       opts = [Opt(OptOps.TC, 0, (i, 0)),
               Opt(OptOps.UNROLL, 0, 2),
               Opt(OptOps.UPCAST, 1, 2)]
-      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N*2),(1,K*N*2),(2,M*K*4)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N*2),(1,M*K*2),(2,K*N*4)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   def test_lds_full(self):

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -54,7 +54,7 @@ def helper_lds_matmul(opts:list[Opt], expected_bufs, N=16, M=16, K=16, dtype_in=
     expected_dtype = (acc_dtype if buf == 0 else dtype_in).ptr(sz, local=True)
     assert local_buffers[i].dtype == expected_dtype, f"Expected buffer dtype {expected_dtype}, got {local_buffers[i].dtype} for {opts=}"
 
-@unittest.skipIf(Device.DEFAULT == "PTX", "shared memory is broken in PTX")
+@unittest.skipIf(Device.DEFAULT == "PTX", "shared memory is broken in PTX") # TODO: fix, TC=3 is also broken
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "tests require shared")
 class TestLDS(unittest.TestCase):
   def test_lds_args(self):

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -195,6 +195,7 @@ class TestLDSOps(unittest.TestCase):
       a = Tensor.rand((sz:=4096), sz).realize()
       b = Tensor.rand(sz, 1).realize()
     opts = [Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.LOCAL, 1, 8), Opt(OptOps.LOCAL, 0, 4)]
+    # b is broadcasted so local buffer shape only depends on locals/upcasts to dim 0
     helper_lds_allclose(a + b, opts, a.numpy() + b.numpy(), (sz,sz), [(0,128),(1,128),(2,16)], rtol=1e-4, atol=1e-4)
 
 if __name__ == '__main__':

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -54,8 +54,7 @@ def helper_lds_matmul(opts:list[Opt], expected_bufs, N=32, M=64, K=16, dtype_in=
     expected_dtype = (acc_dtype if buf == 0 else dtype_in).ptr(sz, local=True)
     assert local_buffers[i].dtype == expected_dtype, f"Expected buffer dtype {expected_dtype}, got {local_buffers[i].dtype} for {opts=}"
 
-# TODO: fix, TC=3 is also broken
-@unittest.skipIf(Device[Device.DEFAULT].renderer.suffix == "PTX", "shared memory is broken in PTX")
+@unittest.skipIf(Device[Device.DEFAULT].renderer.suffix == "PTX", "shared memory is broken in PTX") # TODO: fix, TC=3 is also broken
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "tests require shared")
 class TestLDS(unittest.TestCase):
   def test_lds_args(self):
@@ -200,7 +199,6 @@ class TestLDS(unittest.TestCase):
             Opt(OptOps.UPCAST, 0, 2)]
     helper_lds_matmul(opts=opts, expected_bufs=[(0,8),(1,4),(2,8)])
 
-# TODO: fix, TC=3 is also broken
 @unittest.skipIf(Device[Device.DEFAULT].renderer.suffix == "PTX", "shared memory is broken in PTX")
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "tests require shared")
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "tests require local")

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -126,24 +126,24 @@ class TestLDS(unittest.TestCase):
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test requires tensor cores")
   def test_lds_tc(self):
-    for tc in Device[Device.DEFAULT].renderer.tensor_cores:
+    for i, tc in enumerate(Device[Device.DEFAULT].renderer.tensor_cores):
       if tc.dtype_in == dtypes.bfloat16 or tc.dtype_out == dtypes.bfloat16: continue
       (N, M, K) = tc.dims
       sz = 64
 
-      opts = [Opt(OptOps.TC, 0, (-1, 0))]
+      opts = [Opt(OptOps.TC, 0, (i, 0))]
       helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N),(1,K*N),(2,M*K)], N=N, M=M, K=K, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
-      opts = [Opt(OptOps.TC, 0, (-1, 0)),
+      opts = [Opt(OptOps.TC, 0, (i, 0)),
               Opt(OptOps.LOCAL, 0, 2),
               Opt(OptOps.UPCAST, 1, 2)]
       helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N*4),(1,K*N*2),(2,M*K*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
-      opts = [Opt(OptOps.TC, 0, (-1, 0)),
+      opts = [Opt(OptOps.TC, 0, (i, 0)),
               Opt(OptOps.UNROLL, 0, 2)]
       helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N),(1,K*N*2),(2,M*K*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
-      opts = [Opt(OptOps.TC, 0, (-1, 0)),
+      opts = [Opt(OptOps.TC, 0, (i, 0)),
               Opt(OptOps.UNROLL, 0, 2),
               Opt(OptOps.UPCAST, 1, 2)]
       helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N*2),(1,K*N*2),(2,M*K*4)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -171,7 +171,8 @@ class TestLDS(unittest.TestCase):
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   def test_lds_full(self):
     opts = [Opt(OptOps.LOCAL, 0, 2),
-            Opt(OptOps.UPCAST, 1, 2)]
+            Opt(OptOps.UPCAST, 1, 2),
+            Opt(OptOps.SWAP, 0, 1)]
     helper_lds_matmul(opts=opts, expected_bufs=[(0,4),(1,2),(2,2)])
 
     opts = [Opt(OptOps.LOCAL, 0, 2),

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -46,7 +46,6 @@ def helper_lds_allclose(opts:list[Opt], expected_bufs, N=16, M=16, K=16, dtype_i
 
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")
 class TestLDS(unittest.TestCase):
-#   @unittest.expectedFailure
   def test_lds_args(self):
     realized_ast, _ = helper_realized_ast(Tensor.rand(4, 4) @ Tensor.rand(4, 4))
     k = Kernel(realized_ast)
@@ -64,7 +63,6 @@ class TestLDS(unittest.TestCase):
       with self.assertRaises(KernelOptError):
         k.apply_opt(opt)
 
-#   @unittest.expectedFailure
   def test_lds_basic(self):
     # output
     helper_lds_allclose(opts=[Opt(OptOps.LDS, 0, None)], expected_bufs=[(0,1)], append_lds_opts=False)
@@ -75,13 +73,11 @@ class TestLDS(unittest.TestCase):
     helper_lds_allclose(opts=[Opt(OptOps.LDS, 0, None), Opt(OptOps.LDS, 1, None)], expected_bufs=[(0,1),(1,1)], append_lds_opts=False)
     helper_lds_allclose(opts=[], expected_bufs=[(0,1),(1,1),(2,1)])
 
-#   @unittest.expectedFailure
   def test_lds_unroll(self):
     # unroll doesn't change local output buffer size
     for sz in [2,4,8]:
       helper_lds_allclose(opts=[Opt(OptOps.UNROLL, 0, sz)], expected_bufs=[(0,1),(1,sz),(2,sz)])
 
-#   @unittest.expectedFailure
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   def test_lds_local(self):
     # if only locals are applied, local buffer size for output should be prod(locals)
@@ -101,7 +97,6 @@ class TestLDS(unittest.TestCase):
                        Opt(OptOps.LOCAL, 0, 16)]
     helper_lds_allclose(opts=full_local_opts, expected_bufs=[(0,256),(1,16),(2,16)])
 
-#   @unittest.expectedFailure
   def test_lds_upcast(self):
     # if only upcasts are applied, local buffer size for output should be prod(upcast)
 
@@ -120,7 +115,6 @@ class TestLDS(unittest.TestCase):
                         Opt(OptOps.UPCAST, 0, 16)]
     helper_lds_allclose(opts=full_upcast_opts, expected_bufs=[(0,256),(1,16),(2,16)])
 
-#   @unittest.expectedFailure
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test requires tensor cores")
   def test_lds_tc(self):
     for tc in Device[Device.DEFAULT].renderer.tensor_cores:
@@ -145,7 +139,6 @@ class TestLDS(unittest.TestCase):
               Opt(OptOps.UPCAST, 1, 2)]
       helper_lds_allclose(opts=opts, expected_bufs=[(0,M*N*2),(1,K*N*2),(2,M*K*4)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
-#   @unittest.expectedFailure
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   def test_lds_full(self):
     opts = [Opt(OptOps.LOCAL, 0, 2),

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -73,6 +73,24 @@ class TestLDS(unittest.TestCase):
       with self.assertRaises(KernelOptError):
         k.apply_opt(opt)
 
+  def test_invalid_lds(self):
+    realized_ast, _ = helper_realized_ast(Tensor.rand(4, 4) @ Tensor.rand(4, 4))
+    invalid_opts = [
+      [Opt(OptOps.PADTO, 1, 7), Opt(OptOps.LDS, 2, None)],
+      [Opt(OptOps.LDS, 2, None), Opt(OptOps.PADTO, 1, 7)],
+      [Opt(OptOps.LDS, 2, None), Opt(OptOps.UPCAST, 2, 2)],
+      [Opt(OptOps.LDS, 0, None), Opt(OptOps.LOCAL, 2, 2)],
+      [Opt(OptOps.LDS, 0, None), Opt(OptOps.UNROLL, 0, 2)],
+      [Opt(OptOps.GROUPTOP, 0, 2), Opt(OptOps.LDS, 0, None)],
+      [Opt(OptOps.LDS, 0, None), Opt(OptOps.GROUPTOP, 0, 2)],
+      [Opt(OptOps.GROUP, 0, 2), Opt(OptOps.LDS, 0, None)],
+      [Opt(OptOps.LDS, 0, None), Opt(OptOps.GROUP, 0, 2)],
+    ]
+    for opts in invalid_opts:
+      k = Kernel(realized_ast)
+      with self.assertRaises(KernelOptError):
+        for opt in opts: k.apply_opt(opt)
+
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   def test_lds_basic(self):
     # output

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -54,7 +54,8 @@ def helper_lds_matmul(opts:list[Opt], expected_bufs, N=32, M=64, K=16, dtype_in=
     expected_dtype = (acc_dtype if buf == 0 else dtype_in).ptr(sz, local=True)
     assert local_buffers[i].dtype == expected_dtype, f"Expected buffer dtype {expected_dtype}, got {local_buffers[i].dtype} for {opts=}"
 
-@unittest.skipIf(Device.DEFAULT == "PTX", "shared memory is broken in PTX") # TODO: fix, TC=3 is also broken
+# TODO: fix, TC=3 is also broken
+@unittest.skipIf(Device[Device.DEFAULT].renderer.suffix == "PTX", "shared memory is broken in PTX")
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "tests require shared")
 class TestLDS(unittest.TestCase):
   def test_lds_args(self):
@@ -199,7 +200,8 @@ class TestLDS(unittest.TestCase):
             Opt(OptOps.UPCAST, 0, 2)]
     helper_lds_matmul(opts=opts, expected_bufs=[(0,8),(1,4),(2,8)])
 
-@unittest.skipIf(Device.DEFAULT == "PTX", "shared memory is broken in PTX")
+# TODO: fix, TC=3 is also broken
+@unittest.skipIf(Device[Device.DEFAULT].renderer.suffix == "PTX", "shared memory is broken in PTX")
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "tests require shared")
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "tests require local")
 class TestLDSOps(unittest.TestCase):

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -53,7 +53,7 @@ def helper_lds_matmul(opts:list[Opt], expected_bufs, N=16, M=16, K=16, dtype_in=
     expected_dtype = (acc_dtype if buf == 0 else dtype_in).ptr(sz, local=True)
     assert local_buffers[i].dtype == expected_dtype, f"Expected buffer dtype {expected_dtype}, got {local_buffers[i].dtype} for {opts=}"
 
-@unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")
+@unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "tests require shared")
 class TestLDS(unittest.TestCase):
   def test_lds_args(self):
     realized_ast, _ = helper_realized_ast(Tensor.rand(4, 4) @ Tensor.rand(4, 4))
@@ -72,6 +72,7 @@ class TestLDS(unittest.TestCase):
       with self.assertRaises(KernelOptError):
         k.apply_opt(opt)
 
+  @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   def test_lds_basic(self):
     # output
     helper_lds_matmul(opts=[Opt(OptOps.LDS, 0, None)], expected_bufs=[(0,1)], append_lds_opts=False)
@@ -176,6 +177,8 @@ class TestLDS(unittest.TestCase):
             Opt(OptOps.UPCAST, 0, 2)]
     helper_lds_matmul(opts=opts, expected_bufs=[(0,8),(1,4),(2,8)])
 
+@unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "tests require shared")
+@unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "tests require local")
 class TestLDSOps(unittest.TestCase):
   def test_lds_transpose(self):
     with Context(DEBUG=0): a = Tensor.rand((sz:=4096), sz).realize()

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -210,7 +210,9 @@ class TestLDSOps(unittest.TestCase):
     ta, tb = torch.from_numpy(a.numpy()).to("cpu"), torch.from_numpy(b.numpy()).to("cpu")
     tc = torch.nn.functional.conv2d(ta, tb).numpy()
 
-    helper_lds_allclose(a.conv2d(b), [], tc, (16, 64, 62, 62), [(0,1),(1,1),(2,1)], rtol=1e-4, atol=1e-4)
+    opts = [Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.UPCAST, 2, 2), Opt(OptOps.LOCAL, 0, 2), Opt(OptOps.LOCAL, 1, 4)]
+
+    helper_lds_allclose(a.conv2d(b), opts, tc, (16, 64, 62, 62), [(0,64),(1,16),(2,4)], rtol=1e-4, atol=1e-4)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -54,6 +54,7 @@ def helper_lds_matmul(opts:list[Opt], expected_bufs, N=16, M=16, K=16, dtype_in=
     expected_dtype = (acc_dtype if buf == 0 else dtype_in).ptr(sz, local=True)
     assert local_buffers[i].dtype == expected_dtype, f"Expected buffer dtype {expected_dtype}, got {local_buffers[i].dtype} for {opts=}"
 
+@unittest.skipIf(Device.DEFAULT == "PTX", "shared memory is broken in PTX")
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "tests require shared")
 class TestLDS(unittest.TestCase):
   def test_lds_args(self):
@@ -197,6 +198,7 @@ class TestLDS(unittest.TestCase):
             Opt(OptOps.UPCAST, 0, 2)]
     helper_lds_matmul(opts=opts, expected_bufs=[(0,8),(1,4),(2,8)])
 
+@unittest.skipIf(Device.DEFAULT == "PTX", "shared memory is broken in PTX")
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "tests require shared")
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "tests require local")
 class TestLDSOps(unittest.TestCase):

--- a/test/test_lds.py
+++ b/test/test_lds.py
@@ -19,19 +19,17 @@ def helper_realized_ast(r:Union[Tensor, list[Tensor]]) -> tuple[UOp, list[Buffer
   bufs = [Buffer((x).device, x.size, x.dtype).allocate() if i < len(s[-1].ast.src) else x for i,x in enumerate(s[-1].bufs)]
   return s[-1].ast, bufs
 
-def helper_lds_allclose(opts:list[Opt], expected_bufs, N=16, M=16, K=16, dtype_in=dtypes.float, acc_dtype=dtypes.float, append_lds_opts=True):
-  with Context(DEBUG=0): a, b = Tensor.rand(M, K, dtype=dtype_in).realize(), Tensor.rand(K, N, dtype=dtype_in).realize()
-  realized_ast, bufs = helper_realized_ast(a.matmul(b, dtype=acc_dtype))
+def helper_lds_allclose(r:Tensor, opts:list[Opt], desired:np.ndarray, output_shape:tuple[int], expected_bufs:list[tuple[int, int]],
+                        rtol:float=1e-7, atol:float=0, append_lds_opts=True) -> Kernel:
+  realized_ast, bufs = helper_realized_ast(r)
   k = Kernel(realized_ast)
-  if append_lds_opts: opts += [Opt(OptOps.LDS, 0, None), Opt(OptOps.LDS, 1, None), Opt(OptOps.LDS, 2, None)]
+  if append_lds_opts: opts += [Opt(OptOps.LDS, i, None) for i in range(len(bufs))]
   for opt in opts:
     k.apply_opt(opt)
   prg = k.to_program()
   CompiledRunner(replace(prg, device=Device.DEFAULT)).exec(bufs)
 
-  atol, rtol = 1e-4, 1e-4
-  if dtype_in == dtypes.half: atol, rtol = 1e-2, 1e-2
-  np.testing.assert_allclose(bufs[0].numpy().reshape((M,N)), a.numpy() @ b.numpy(), atol=atol, rtol=rtol)
+  np.testing.assert_allclose(bufs[0].numpy().reshape(output_shape), desired, atol=atol, rtol=rtol)
 
   assert k.smem_usage == sum([sz for _, sz in expected_bufs]), f"{k.smem_usage=} != {sum([sz for _, sz in expected_bufs])=}"
   assert k.smem_usage <= k.opts.shared_max, f"{k.smem_usage} > {k.opts.shared_max}"
@@ -39,10 +37,21 @@ def helper_lds_allclose(opts:list[Opt], expected_bufs, N=16, M=16, K=16, dtype_i
   local_buffers = [uop for uop in k.uops if uop.op is Ops.DEFINE_LOCAL]
   assert len(local_buffers) == len(expected_bufs), f"Expected exactly {len(expected_bufs)} local buffers, got {len(local_buffers)}"
   for i,(buf, sz) in enumerate(expected_bufs):
-    assert local_buffers[i].arg == f"lds{buf}", f"Expected buffer argument index {buf}, got {local_buffers[i].arg}"
+    assert local_buffers[i].arg == f"lds{buf}", f"Expected buffer argument index lds{buf}, got {local_buffers[i].arg}"
+    assert local_buffers[i].dtype.size == sz, f"Expected buffer sz {sz}, got {local_buffers[i].dtype.size=} for {opts=}"
+    # TODO: check all access to the global buffer are proxied through the local buffer
+  return k
+
+def helper_lds_matmul(opts:list[Opt], expected_bufs, N=16, M=16, K=16, dtype_in=dtypes.float, acc_dtype=dtypes.float, append_lds_opts=True):
+  with Context(DEBUG=0): a, b = Tensor.rand(M, K, dtype=dtype_in).realize(), Tensor.rand(K, N, dtype=dtype_in).realize()
+  atol, rtol = 1e-4, 1e-4
+  if dtype_in == dtypes.half: atol, rtol = 1e-2, 1e-2
+  k = helper_lds_allclose(a.matmul(b, dtype=acc_dtype), opts, a.numpy() @ b.numpy(), (M,N), expected_bufs, rtol, atol, append_lds_opts)
+
+  local_buffers = [uop for uop in k.uops if uop.op is Ops.DEFINE_LOCAL]
+  for i,(buf, sz) in enumerate(expected_bufs):
     expected_dtype = (acc_dtype if buf == 0 else dtype_in).ptr(sz, local=True)
     assert local_buffers[i].dtype == expected_dtype, f"Expected buffer dtype {expected_dtype}, got {local_buffers[i].dtype} for {opts=}"
-    # TODO: check all access to the global buffer are proxied through the local buffer
 
 @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")
 class TestLDS(unittest.TestCase):
@@ -65,55 +74,55 @@ class TestLDS(unittest.TestCase):
 
   def test_lds_basic(self):
     # output
-    helper_lds_allclose(opts=[Opt(OptOps.LDS, 0, None)], expected_bufs=[(0,1)], append_lds_opts=False)
+    helper_lds_matmul(opts=[Opt(OptOps.LDS, 0, None)], expected_bufs=[(0,1)], append_lds_opts=False)
     # input
-    helper_lds_allclose(opts=[Opt(OptOps.LOCAL, 0, 4), Opt(OptOps.LDS, 1, None)], expected_bufs=[(1,4)], append_lds_opts=False)
-    helper_lds_allclose(opts=[Opt(OptOps.UNROLL, 0, 4),Opt(OptOps.LDS, 2, None)], expected_bufs=[(2,4)], append_lds_opts=False)
+    helper_lds_matmul(opts=[Opt(OptOps.LOCAL, 0, 4), Opt(OptOps.LDS, 1, None)], expected_bufs=[(1,4)], append_lds_opts=False)
+    helper_lds_matmul(opts=[Opt(OptOps.UNROLL, 0, 4),Opt(OptOps.LDS, 2, None)], expected_bufs=[(2,4)], append_lds_opts=False)
     # multi
-    helper_lds_allclose(opts=[Opt(OptOps.LDS, 0, None), Opt(OptOps.LDS, 1, None)], expected_bufs=[(0,1),(1,1)], append_lds_opts=False)
-    helper_lds_allclose(opts=[], expected_bufs=[(0,1),(1,1),(2,1)])
+    helper_lds_matmul(opts=[Opt(OptOps.LDS, 0, None), Opt(OptOps.LDS, 1, None)], expected_bufs=[(0,1),(1,1)], append_lds_opts=False)
+    helper_lds_matmul(opts=[], expected_bufs=[(0,1),(1,1),(2,1)])
 
   def test_lds_unroll(self):
     # unroll doesn't change local output buffer size
     for sz in [2,4,8]:
-      helper_lds_allclose(opts=[Opt(OptOps.UNROLL, 0, sz)], expected_bufs=[(0,1),(1,sz),(2,sz)])
+      helper_lds_matmul(opts=[Opt(OptOps.UNROLL, 0, sz)], expected_bufs=[(0,1),(1,sz),(2,sz)])
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   def test_lds_local(self):
     # if only locals are applied, local buffer size for output should be prod(locals)
 
     basic_local_opts = [Opt(OptOps.LOCAL, 0, 2)]
-    helper_lds_allclose(opts=basic_local_opts, expected_bufs=[(0,2),(1,2),(2,1)])
+    helper_lds_matmul(opts=basic_local_opts, expected_bufs=[(0,2),(1,2),(2,1)])
 
     multi_local_opts = [Opt(OptOps.LOCAL, 0, 2),
                         Opt(OptOps.LOCAL, 0, 8)]
-    helper_lds_allclose(opts=multi_local_opts, expected_bufs=[(0,16),(1,16),(2,1)])
+    helper_lds_matmul(opts=multi_local_opts, expected_bufs=[(0,16),(1,16),(2,1)])
 
     multi_axis_local_opts = [Opt(OptOps.LOCAL, 1, 4),
                              Opt(OptOps.LOCAL, 0, 2)]
-    helper_lds_allclose(opts=multi_axis_local_opts, expected_bufs=[(0,8),(1,2),(2,4)])
+    helper_lds_matmul(opts=multi_axis_local_opts, expected_bufs=[(0,8),(1,2),(2,4)])
 
     full_local_opts = [Opt(OptOps.LOCAL, 0, 16),
                        Opt(OptOps.LOCAL, 0, 16)]
-    helper_lds_allclose(opts=full_local_opts, expected_bufs=[(0,256),(1,16),(2,16)])
+    helper_lds_matmul(opts=full_local_opts, expected_bufs=[(0,256),(1,16),(2,16)])
 
   def test_lds_upcast(self):
     # if only upcasts are applied, local buffer size for output should be prod(upcast)
 
     basic_upcast_opts = [Opt(OptOps.UPCAST, 0, 2)]
-    helper_lds_allclose(opts=basic_upcast_opts, expected_bufs=[(0,2),(1,2),(2,1)])
+    helper_lds_matmul(opts=basic_upcast_opts, expected_bufs=[(0,2),(1,2),(2,1)])
 
     multi_upcast_opts = [Opt(OptOps.UPCAST, 0, 2),
                          Opt(OptOps.UPCAST, 0, 8)]
-    helper_lds_allclose(opts=multi_upcast_opts, expected_bufs=[(0,16),(1,16),(2,1)])
+    helper_lds_matmul(opts=multi_upcast_opts, expected_bufs=[(0,16),(1,16),(2,1)])
 
     multi_axis_upcast_opts = [Opt(OptOps.UPCAST, 1, 4),
                               Opt(OptOps.UPCAST, 0, 2)]
-    helper_lds_allclose(opts=multi_axis_upcast_opts, expected_bufs=[(0,8),(1,2),(2,4)])
+    helper_lds_matmul(opts=multi_axis_upcast_opts, expected_bufs=[(0,8),(1,2),(2,4)])
 
     full_upcast_opts = [Opt(OptOps.UPCAST, 0, 16),
                         Opt(OptOps.UPCAST, 0, 16)]
-    helper_lds_allclose(opts=full_upcast_opts, expected_bufs=[(0,256),(1,16),(2,16)])
+    helper_lds_matmul(opts=full_upcast_opts, expected_bufs=[(0,256),(1,16),(2,16)])
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test requires tensor cores")
   def test_lds_tc(self):
@@ -123,49 +132,67 @@ class TestLDS(unittest.TestCase):
       sz = 64
 
       opts = [Opt(OptOps.TC, 0, (-1, 0))]
-      helper_lds_allclose(opts=opts, expected_bufs=[(0,M*N),(1,K*N),(2,M*K)], N=N, M=M, K=K, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N),(1,K*N),(2,M*K)], N=N, M=M, K=K, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
       opts = [Opt(OptOps.TC, 0, (-1, 0)),
               Opt(OptOps.LOCAL, 0, 2),
               Opt(OptOps.UPCAST, 1, 2)]
-      helper_lds_allclose(opts=opts, expected_bufs=[(0,M*N*4),(1,K*N*2),(2,M*K*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N*4),(1,K*N*2),(2,M*K*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
       opts = [Opt(OptOps.TC, 0, (-1, 0)),
               Opt(OptOps.UNROLL, 0, 2)]
-      helper_lds_allclose(opts=opts, expected_bufs=[(0,M*N),(1,K*N*2),(2,M*K*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N),(1,K*N*2),(2,M*K*2)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
       opts = [Opt(OptOps.TC, 0, (-1, 0)),
               Opt(OptOps.UNROLL, 0, 2),
               Opt(OptOps.UPCAST, 1, 2)]
-      helper_lds_allclose(opts=opts, expected_bufs=[(0,M*N*2),(1,K*N*2),(2,M*K*4)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
+      helper_lds_matmul(opts=opts, expected_bufs=[(0,M*N*2),(1,K*N*2),(2,M*K*4)], N=sz, M=sz, K=sz, dtype_in=tc.dtype_in, acc_dtype=tc.dtype_out)
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   def test_lds_full(self):
     opts = [Opt(OptOps.LOCAL, 0, 2),
             Opt(OptOps.UPCAST, 1, 2)]
-    helper_lds_allclose(opts=opts, expected_bufs=[(0,4),(1,2),(2,2)])
+    helper_lds_matmul(opts=opts, expected_bufs=[(0,4),(1,2),(2,2)])
 
     opts = [Opt(OptOps.LOCAL, 0, 2),
             Opt(OptOps.UPCAST, 0, 4),
             Opt(OptOps.LOCAL, 1, 8)]
-    helper_lds_allclose(opts=opts, expected_bufs=[(0,64),(1,8),(2,8)])
+    helper_lds_matmul(opts=opts, expected_bufs=[(0,64),(1,8),(2,8)])
 
     opts = [Opt(OptOps.LOCAL, 0, 16),
             Opt(OptOps.UPCAST, 1, 2)]
-    helper_lds_allclose(opts=opts, expected_bufs=[(0,16),(1,16),(2,1)]) # upcasting local dim
+    helper_lds_matmul(opts=opts, expected_bufs=[(0,16),(1,16),(2,1)]) # upcasting local dim
 
     opts = [Opt(OptOps.LOCAL, 0, 16),
             Opt(OptOps.UPCAST, 0, 16)]
-    helper_lds_allclose(opts=opts, expected_bufs=[(0,256),(1,16),(2,16)])
+    helper_lds_matmul(opts=opts, expected_bufs=[(0,256),(1,16),(2,16)])
 
     opts = [Opt(OptOps.LOCAL, 1, 16),
             Opt(OptOps.UPCAST, 1, 16)]
-    helper_lds_allclose(opts=opts, expected_bufs=[(0,16),(1,1),(2,16)])
+    helper_lds_matmul(opts=opts, expected_bufs=[(0,16),(1,1),(2,16)])
 
     opts = [Opt(OptOps.LOCAL, 1, 4),
             Opt(OptOps.UNROLL, 0, 2),
             Opt(OptOps.UPCAST, 0, 2)]
-    helper_lds_allclose(opts=opts, expected_bufs=[(0,8),(1,4),(2,8)])
+    helper_lds_matmul(opts=opts, expected_bufs=[(0,8),(1,4),(2,8)])
+
+class TestLDSOps(unittest.TestCase):
+  def test_lds_transpose(self):
+    with Context(DEBUG=0): a = Tensor.rand((sz:=4096), sz).realize()
+    opts = [Opt(OptOps.UPCAST, 1, 4), Opt(OptOps.LOCAL, 0, 8), Opt(OptOps.LOCAL, 1, 4)]
+    helper_lds_allclose(a.transpose().contiguous(), opts, a.numpy().T, (sz,sz), [(0,128), (1,128)])
+
+  def test_lds_reduce_sum(self):
+    with Context(DEBUG=0): a = Tensor.rand((sz:=4096), sz).realize()
+    opts = [Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.LOCAL, 0, 8), Opt(OptOps.LOCAL, 0, 4)]
+    helper_lds_allclose(a.sum(axis=1), opts, a.numpy().sum(axis=1), (sz), [(0,128), (1,128)], rtol=1e-4, atol=1e-4)
+
+  def test_lds_elementwise_broadcast(self):
+    with Context(DEBUG=0):
+      a = Tensor.rand((sz:=4096), sz).realize()
+      b = Tensor.rand(sz, 1).realize()
+    opts = [Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.LOCAL, 1, 8), Opt(OptOps.LOCAL, 0, 4)]
+    helper_lds_allclose(a + b, opts, a.numpy() + b.numpy(), (sz,sz), [(0,128),(1,128),(2,16)], rtol=1e-4, atol=1e-4)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -357,7 +357,7 @@ class Kernel:
 
     axis = self.real_axis(opt)
     if opt.op is not OptOps.LDS:
-      if opt.op != OptOps.SWAP: check(not any(self.lds), f"cant reshape after LDS {self.applied_opts=} {opt=}")
+      if opt.op != OptOps.SWAP: check(not any(self.lds), f"can't reshape after LDS {self.applied_opts=} {opt=}")
       check(axis < len(self.full_shape), "invalid axis")
 
     if opt.op is OptOps.SWAP: amt = cast(int, opt.arg)  # arg is an axis in the SWAPs

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -356,7 +356,7 @@ class Kernel:
       return
 
     axis = self.real_axis(opt)
-    if opt.op != OptOps.LDS:
+    if opt.op is not OptOps.LDS:
       check(not any(self.lds), f"cant reshape after LDS {self.applied_opts=} {opt=}")
       check(axis < len(self.full_shape), "invalid axis")
 

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -673,7 +673,6 @@ class Kernel:
     del fixup_ast
     return graph_rewrite(fixed_ast, view_left)
 
-
   def apply_lds(self, ast) -> UOp:
     def transform(ctx:tuple[Kernel, set[UOp]], global_access:UOp):
       if (buf:=global_access.src[0]).arg in ctx[1] or global_access.src[0].op is not Ops.DEFINE_GLOBAL: return None
@@ -698,7 +697,6 @@ class Kernel:
       return None
 
     return graph_rewrite(ast, PatternMatcher([(UPat((Ops.LOAD, Ops.STORE), name="global_access"), transform)]), ctx=(self, set()))
-
 
   # **** this is the lowerer ****
 

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -704,9 +704,7 @@ class Kernel:
     if getenv("VIZ"): graph_rewrite(self.ast, PatternMatcher([]), name="View Base AST")
 
     modified_ast = self.get_optimized_ast(name_override)
-    assert modified_ast.arg.dont_use_locals == self.dont_use_locals
     modified_ast = self.apply_lds(modified_ast)
-    assert modified_ast.arg.dont_use_locals == self.dont_use_locals
     if ast_transform is not None: modified_ast = ast_transform(self, modified_ast)
 
     if DEBUG >= 3:

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -675,7 +675,7 @@ class Kernel:
 
   def apply_lds(self, ast) -> UOp:
     def transform(ctx:tuple[Kernel, set[UOp]], global_access:UOp):
-      if (buf:=global_access.src[0]).op is not Ops.DEFINE_GLOBAL or buf.arg in ctx[1] or not (k := ctx[0]).lds[buf.arg]: return None
+      if (buf := global_access.src[0]).op is not Ops.DEFINE_GLOBAL or buf.arg in ctx[1] or not (k := ctx[0]).lds[buf.arg]: return None
       ctx[1].add(buf.arg)
       global_st: ShapeTracker = global_access.src[1].arg
       gd, fr, fu, shape = k.global_dims, k.first_reduce, k.first_upcast, []

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Optional, cast, Final, Callable, Sequence
 
 from tinygrad.ops import GroupOp, KernelInfo, UOp, Ops, can_pad, resolve, Variable, sint, graph_rewrite, track_rewrites, view_left, print_uops
-from tinygrad.ops import PatternMatcher
+from tinygrad.ops import PatternMatcher, UPat
 from tinygrad.spec import type_verify, shape_spec
 from tinygrad.device import Device
 from tinygrad.renderer import Renderer, TensorCore, ProgramSpec, Opt, OptOps
@@ -78,6 +78,8 @@ class Kernel:
     self.tensor_core_opts: Optional[TensorCoreOptions] = None
     self.use_tensor_cores: int = 0
     self.dont_use_locals: bool = False
+    self.lds: list[bool] = [False] * len(self.bufs)
+    self.smem_usage:int = 0
 
     # group simplifies
     self.simplify_ones()
@@ -97,6 +99,7 @@ class Kernel:
     ret.applied_opts, ret.group_for_reduces, ret.upcasted, ret.local_dims, ret.dont_use_locals = \
       self.applied_opts[:], self.group_for_reduces, self.upcasted, self.local_dims, self.dont_use_locals
     ret.tensor_core, ret.tensor_core_opts, ret.use_tensor_cores = self.tensor_core, self.tensor_core_opts, self.use_tensor_cores
+    ret.lds, ret.smem_usage = self.lds[:], self.smem_usage
 
     return ret
 
@@ -353,7 +356,9 @@ class Kernel:
       return
 
     axis = self.real_axis(opt)
-    check(axis < len(self.full_shape), "invalid axis")
+    if opt.op is not OptOps.LDS:
+      check(not any(self.lds), f"cant reshape after LDS {self.applied_opts=} {opt=}")
+      check(axis < len(self.full_shape), "invalid axis")
 
     if opt.op is OptOps.SWAP: amt = cast(int, opt.arg)  # arg is an axis in the SWAPs
     elif opt.arg is not None:
@@ -424,6 +429,16 @@ class Kernel:
           self.sts[i] = st.pad(((0,0),) * axis + ((0,ru),) + ((0,0),) * (len(st.shape)-axis-1))
           padded = True
       check(padded, "nothing was padded")
+    elif opt.op is OptOps.LDS:
+      check(0 <= axis < len(self.bufs), f"invalid buffer {axis}")
+      check(not self.lds[axis], f"already applied lds on buffer {axis}")
+      ops = [op.op for op in self.applied_opts]
+      check(OptOps.PADTO not in ops and OptOps.GROUPTOP not in ops, "cant apply lds with padto/grouptop")
+      buf_index = axis if axis == 0 else (1 if axis == 2 else 2)
+      self.smem_usage += prod(sz for i,(sz,st) in enumerate(zip(self.sts[buf_index].shape,self.sts[buf_index].real_strides(True)))
+                              if st != 0 and ((self.global_dims <= i < self.first_reduce) or self.first_upcast <= i))
+      check(self.smem_usage <= self.opts.shared_max, f"exceeds maximum shared memory size: needs {self.smem_usage}, max {self.opts.shared_max}")
+      self.lds[axis] = True
 
     if append_opt: self.applied_opts.append(opt)
     if self.simplify_ones() and self.tensor_core_opts:
@@ -656,6 +671,33 @@ class Kernel:
     del fixup_ast
     return graph_rewrite(fixed_ast, view_left)
 
+
+  def apply_lds(self, ast) -> UOp:
+    def transform(ctx:tuple[Kernel, set[UOp]], global_access:UOp):
+      if (buf:=global_access.src[0]).arg in ctx[1] or global_access.src[0].op is not Ops.DEFINE_GLOBAL: return None
+      ctx[1].add(buf.arg)
+      if (k := ctx[0]).lds[buf.arg]:
+        global_st: ShapeTracker = global_access.src[1].arg
+        gd, fr, fu, shape = k.global_dims, k.first_reduce, k.first_upcast, []
+        for i, st in enumerate(global_st.real_strides(True)): shape.append(global_st.shape[i] if i >= gd and st != 0 and (i < fr or i >= fu) else 1)
+
+        store_st = load_st = ShapeTracker.from_shape(tuple(shape))
+        if DEBUG>=4: print(f"\n{buf.arg=} [{k.smem_usage}]\n {store_st=}\n  {load_st=}\n{global_st=}\n")
+
+        local_buffer = UOp(Ops.DEFINE_LOCAL, buf.dtype.base.ptr(size=store_st.real_size(), local=True), (), f"lds{buf.arg}")
+        if global_access.op == Ops.LOAD:
+          global_access = global_access.replace(src=(global_access.src[0], global_st.to_uop()))
+          local_store = UOp.store(local_buffer, store_st.to_uop(), global_access)
+          return UOp(Ops.LOAD, global_access.dtype, (local_buffer, load_st.to_uop(), local_store))
+        if global_access.op == Ops.STORE:
+          local_store = UOp.store(local_buffer, store_st.to_uop(), global_access.src[2])
+          local_load = UOp(Ops.LOAD, local_buffer.dtype.base, (local_buffer, load_st.to_uop(), local_store))
+          return global_access.replace(src=(global_access.src[0], global_st.to_uop(), local_load))
+      return None
+
+    return graph_rewrite(ast, PatternMatcher([(UPat((Ops.LOAD, Ops.STORE), name="global_access"), transform)]), ctx=(self, set()))
+
+
   # **** this is the lowerer ****
 
   @track_rewrites()
@@ -664,6 +706,7 @@ class Kernel:
     if getenv("VIZ"): graph_rewrite(self.ast, PatternMatcher([]), name="View Base AST")
 
     modified_ast = self.get_optimized_ast(name_override)
+    modified_ast = self.apply_lds(modified_ast)
     if ast_transform is not None: modified_ast = ast_transform(self, modified_ast)
 
     if DEBUG >= 3:

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -434,7 +434,9 @@ class Kernel:
       check(not self.lds[axis], f"already applied lds on buffer {axis}")
       ops = [op.op for op in self.applied_opts]
       check(OptOps.PADTO not in ops and OptOps.GROUPTOP not in ops, "cant apply lds with padto/grouptop")
-      buf_index = axis if axis == 0 else (1 if axis == 2 else 2)
+      # TODO: remove buf_index hack
+      if len(self.bufs) == 3: buf_index = axis if axis == 0 else (1 if axis == 2 else 2)
+      else: buf_index = axis
       self.smem_usage += prod(sz for i,(sz,st) in enumerate(zip(self.sts[buf_index].shape,self.sts[buf_index].real_strides(True)))
                               if st != 0 and ((self.global_dims <= i < self.first_reduce) or self.first_upcast <= i))
       check(self.smem_usage <= self.opts.shared_max, f"exceeds maximum shared memory size: needs {self.smem_usage}, max {self.opts.shared_max}")

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -79,7 +79,7 @@ class Kernel:
     self.use_tensor_cores: int = 0
     self.dont_use_locals: bool = False
     self.lds: list[bool] = [False] * len(self.bufs)
-    self.smem_usage:int = 0
+    self.smem_usage: int = 0
 
     # group simplifies
     self.simplify_ones()
@@ -356,7 +356,7 @@ class Kernel:
       return
 
     axis = self.real_axis(opt)
-    if opt.op is not OptOps.LDS:
+    if opt.op != OptOps.LDS:
       check(not any(self.lds), f"cant reshape after LDS {self.applied_opts=} {opt=}")
       check(axis < len(self.full_shape), "invalid axis")
 

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -704,7 +704,9 @@ class Kernel:
     if getenv("VIZ"): graph_rewrite(self.ast, PatternMatcher([]), name="View Base AST")
 
     modified_ast = self.get_optimized_ast(name_override)
+    assert modified_ast.arg.dont_use_locals == self.dont_use_locals
     modified_ast = self.apply_lds(modified_ast)
+    assert modified_ast.arg.dont_use_locals == self.dont_use_locals
     if ast_transform is not None: modified_ast = ast_transform(self, modified_ast)
 
     if DEBUG >= 3:

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -9,7 +9,7 @@ from tinygrad.dtype import DType
 
 class OptOps(Enum):
   TC = auto(); UPCAST = auto(); UNROLL = auto(); LOCAL = auto() # noqa: E702
-  GROUP = auto(); GROUPTOP = auto(); NOLOCALS = auto(); PADTO = auto(); SWAP = auto(); LDS = auto()  # noqa: E702
+  GROUP = auto(); GROUPTOP = auto(); NOLOCALS = auto(); PADTO = auto(); SWAP = auto(); LDS = auto() # noqa: E702
   def __lt__(self, x:OptOps): return self.value < x.value
 
 @dataclass(frozen=True, order=True)

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -8,8 +8,8 @@ from tinygrad.ops import Ops, UOp, sym_infer, sint, Variable, ssimplify, GroupOp
 from tinygrad.dtype import DType
 
 class OptOps(Enum):
-  TC = auto(); UPCAST = auto(); UNROLL = auto(); LOCAL = auto(); LDS = auto() # noqa: E702
-  GROUP = auto(); GROUPTOP = auto(); NOLOCALS = auto(); PADTO = auto(); SWAP = auto() # noqa: E702
+  TC = auto(); UPCAST = auto(); UNROLL = auto(); LOCAL = auto() # noqa: E702
+  GROUP = auto(); GROUPTOP = auto(); NOLOCALS = auto(); PADTO = auto(); SWAP = auto(); LDS = auto()  # noqa: E702
   def __lt__(self, x:OptOps): return self.value < x.value
 
 @dataclass(frozen=True, order=True)

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -8,7 +8,7 @@ from tinygrad.ops import Ops, UOp, sym_infer, sint, Variable, ssimplify, GroupOp
 from tinygrad.dtype import DType
 
 class OptOps(Enum):
-  TC = auto(); UPCAST = auto(); UNROLL = auto(); LOCAL = auto() # noqa: E702
+  TC = auto(); UPCAST = auto(); UNROLL = auto(); LOCAL = auto(); LDS = auto() # noqa: E702
   GROUP = auto(); GROUPTOP = auto(); NOLOCALS = auto(); PADTO = auto(); SWAP = auto() # noqa: E702
   def __lt__(self, x:OptOps): return self.value < x.value
 


### PR DESCRIPTION
Use of shared memory is broken for PTX. (LDS test fails with `RecursionError: maximum recursion depth exceeded`, same as for TC=3 emulation, probably there is a bug on how `Ops.DEFINE_LOCAL` is handled). Will try to address this before merging this pr. 

Can't run with `process replay` as the addition of a new item in `OptOps` enum breaks pickle.

I don't know why NV won't finish the job, it passes all the tests fairly quickly on the real device (tiny19).
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/e7a79f7f-5a3b-4b19-a2c3-d9574468a4fd" />

If added to BEAM, it makes matmul for 4096x4096 more fast on my computer. Right now it only makes it fast for large matmuls. For matmuls of smaller sizes, as the hit rate for the cache is good already good, so it does not actually make it faster.
<img width="2002" alt="image" src="https://github.com/user-attachments/assets/911fe3f5-526c-4ef5-8b18-4e89880ffd13" />
BEAM=4 is faster on this branch vs BEAM=16 on master.
<img width="2002" alt="image" src="https://github.com/user-attachments/assets/e548bc43-54e1-4eed-9a32-f74e2da73e8f" />

This is not addressing thread access pattern to local (LDS_SWAP) and local layout(LDS_LAYOUT) yet. Those are going to be independent kernel opts. 

I've already been trying the former, named. I actually could make the search space quite good, quickly rejecting invalid permutations, but the way BEAM works right now makes it hard for it to end up using it, as it usually needs 3/4 consecutive opts to actually make it good (local and unroll of the same size, LDS on the buffer(that is usually discarded for input buffers as without correcting the thread pattern it makes it slower) and then the LDS_SWAP opt that corrects the thread pattern (only one permutation at a time))
