### PR TITLE
use AM driver in bert mlperf

### DIFF
--- a/examples/mlperf/training_submission_v5.0/tinycorp/benchmarks/bert/implementations/tinybox_red/run_and_time.sh
+++ b/examples/mlperf/training_submission_v5.0/tinycorp/benchmarks/bert/implementations/tinybox_red/run_and_time.sh
@@ -21,7 +21,4 @@ sudo rmmod amdgpu || true
 BENCHMARK=10 INITMLPERF=1 BERT_LAYERS=2 python3 examples/mlperf/model_train.py | tee $LOGFILE
 
 # run
-# TODO: AMD driver hangs during init, but is 5% faster per step in real run.
-sudo modprobe amdgpu
 PARALLEL=0 RUNMLPERF=1 python3 examples/mlperf/model_train.py | tee -a $LOGFILE
-sudo rmmod amdgpu || true


### PR DESCRIPTION
we should commit to use AM. it's 7ms slower python time now