### PR TITLE
[Bounty] CPUGraph on ClangDevice

### DIFF
--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -108,7 +108,8 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_order_copy_writed(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+      self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0 = Device.DEFAULT
     b0 = [helper_alloc_rawbuffer(d0, fill=True) for _ in range(4)]
@@ -120,7 +121,8 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_order_copy_then_read(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+      self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0 = Device.DEFAULT
     b0 = [helper_alloc_rawbuffer(d0, fill=True) for _ in range(4)]
@@ -151,7 +153,8 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_copies_2_devs(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+      self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0, d1 = Device.DEFAULT, f"{Device.DEFAULT}:1"
     b0 = [helper_alloc_rawbuffer(d0, fill=True) for _ in range(3)]
@@ -164,7 +167,8 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_copies_after_graph_global(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+      self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0, d1, d2, d3 = Device.DEFAULT, f"{Device.DEFAULT}:1", f"{Device.DEFAULT}:2", f"{Device.DEFAULT}:3"
     b0 = [helper_alloc_rawbuffer(d0, fill=True) for _ in range(8)]
@@ -212,7 +216,8 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_graph_after_copies_devs(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+      self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0, d1, d2, d3 = Device.DEFAULT, f"{Device.DEFAULT}:1", f"{Device.DEFAULT}:2", f"{Device.DEFAULT}:3"
     b0 = [helper_alloc_rawbuffer(d0, fill=True) for _ in range(8)]
@@ -241,7 +246,8 @@ class TestGraph(unittest.TestCase):
 
   @unittest.skipUnless(Device.DEFAULT in {"CUDA", "NV", "AMD"}, "mutidevice graph required")
   def test_graph_offset_bufs(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+      self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0 = Device.DEFAULT
     if not hasattr(Device[d0].allocator, "_offset"): self.skipTest("device does not support _offset")

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -13,8 +13,6 @@ Tensor.manual_seed(1337)
 BUF_SIZE = 4096 if CI else 4096 * 128
 RUN_CNT = 4 if CI else 32
 
-Device.DEFAULT = "CPU"
-
 cached_prgs = {}
 def helper_exec_op(device, outbuf, inbufs):
   if (device, len(inbufs)) not in cached_prgs:

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -110,7 +110,7 @@ class TestGraph(unittest.TestCase):
   def test_order_copy_writed(self):
     default_graph = Device[Device.DEFAULT].graph
     graph_runner = getattr(default_graph, 'func', default_graph)
-  
+
     if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
@@ -126,7 +126,7 @@ class TestGraph(unittest.TestCase):
   def test_order_copy_then_read(self):
     default_graph = Device[Device.DEFAULT].graph
     graph_runner = getattr(default_graph, 'func', default_graph)
-  
+
     if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
@@ -161,7 +161,7 @@ class TestGraph(unittest.TestCase):
   def test_copies_2_devs(self):
     default_graph = Device[Device.DEFAULT].graph
     graph_runner = getattr(default_graph, 'func', default_graph)
-  
+
     if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
@@ -178,7 +178,7 @@ class TestGraph(unittest.TestCase):
   def test_copies_after_graph_global(self):
     default_graph = Device[Device.DEFAULT].graph
     graph_runner = getattr(default_graph, 'func', default_graph)
-  
+
     if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
@@ -230,7 +230,7 @@ class TestGraph(unittest.TestCase):
   def test_graph_after_copies_devs(self):
     default_graph = Device[Device.DEFAULT].graph
     graph_runner = getattr(default_graph, 'func', default_graph)
-  
+
     if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
@@ -263,7 +263,7 @@ class TestGraph(unittest.TestCase):
   def test_graph_offset_bufs(self):
     default_graph = Device[Device.DEFAULT].graph
     graph_runner = getattr(default_graph, 'func', default_graph)
-  
+
     if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -13,6 +13,8 @@ Tensor.manual_seed(1337)
 BUF_SIZE = 4096 if CI else 4096 * 128
 RUN_CNT = 4 if CI else 32
 
+Device.DEFAULT = "CPU"
+
 cached_prgs = {}
 def helper_exec_op(device, outbuf, inbufs):
   if (device, len(inbufs)) not in cached_prgs:
@@ -239,6 +241,7 @@ class TestGraph(unittest.TestCase):
 
     helper_test_graphs(Device[d0].graph, graphs)
 
+  @unittest.skipUnless(Device.DEFAULT in {"CUDA", "NV", "AMD"}, "mutidevice graph required")
   def test_graph_offset_bufs(self):
     if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -108,7 +108,10 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_order_copy_writed(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
+    default_graph = Device[Device.DEFAULT].graph
+    graph_runner = getattr(default_graph, 'func', default_graph)
+  
+    if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0 = Device.DEFAULT
@@ -121,7 +124,10 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_order_copy_then_read(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
+    default_graph = Device[Device.DEFAULT].graph
+    graph_runner = getattr(default_graph, 'func', default_graph)
+  
+    if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0 = Device.DEFAULT
@@ -153,7 +159,10 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_copies_2_devs(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
+    default_graph = Device[Device.DEFAULT].graph
+    graph_runner = getattr(default_graph, 'func', default_graph)
+  
+    if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0, d1 = Device.DEFAULT, f"{Device.DEFAULT}:1"
@@ -167,7 +176,10 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_copies_after_graph_global(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
+    default_graph = Device[Device.DEFAULT].graph
+    graph_runner = getattr(default_graph, 'func', default_graph)
+  
+    if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0, d1, d2, d3 = Device.DEFAULT, f"{Device.DEFAULT}:1", f"{Device.DEFAULT}:2", f"{Device.DEFAULT}:3"
@@ -216,7 +228,10 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_graph_after_copies_devs(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
+    default_graph = Device[Device.DEFAULT].graph
+    graph_runner = getattr(default_graph, 'func', default_graph)
+  
+    if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0, d1, d2, d3 = Device.DEFAULT, f"{Device.DEFAULT}:1", f"{Device.DEFAULT}:2", f"{Device.DEFAULT}:3"
@@ -246,7 +261,10 @@ class TestGraph(unittest.TestCase):
 
   @unittest.skipUnless(Device.DEFAULT in {"CUDA", "NV", "AMD"}, "mutidevice graph required")
   def test_graph_offset_bufs(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
+    default_graph = Device[Device.DEFAULT].graph
+    graph_runner = getattr(default_graph, 'func', default_graph)
+  
+    if not issubclass(graph_runner, MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0 = Device.DEFAULT

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -108,7 +108,7 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_order_copy_writed(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0 = Device.DEFAULT
@@ -121,7 +121,7 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_order_copy_then_read(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0 = Device.DEFAULT
@@ -153,7 +153,7 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_copies_2_devs(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0, d1 = Device.DEFAULT, f"{Device.DEFAULT}:1"
@@ -167,7 +167,7 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_copies_after_graph_global(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0, d1, d2, d3 = Device.DEFAULT, f"{Device.DEFAULT}:1", f"{Device.DEFAULT}:2", f"{Device.DEFAULT}:3"
@@ -216,7 +216,7 @@ class TestGraph(unittest.TestCase):
     helper_test_graphs(Device[d0].graph, graphs)
 
   def test_graph_after_copies_devs(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0, d1, d2, d3 = Device.DEFAULT, f"{Device.DEFAULT}:1", f"{Device.DEFAULT}:2", f"{Device.DEFAULT}:3"
@@ -246,7 +246,7 @@ class TestGraph(unittest.TestCase):
 
   @unittest.skipUnless(Device.DEFAULT in {"CUDA", "NV", "AMD"}, "mutidevice graph required")
   def test_graph_offset_bufs(self):
-    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner): 
+    if not issubclass(getattr(Device[Device.DEFAULT].graph, 'func', Device[Device.DEFAULT].graph), MultiGraphRunner):
       self.skipTest("graph does not supported (not MultiGraphRunner)")
 
     d0 = Device.DEFAULT

--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -36,7 +36,7 @@ class CPUGraph(GraphRunner):
     defines = dedup(itertools.chain.from_iterable(device.renderer._render_defines(cast(CompiledRunner, ji.prg).p.uops) for ji in jit_cache))
     entry = device.renderer._render_entry("batched", targs)
     code = '\n'.join(defines) + '\n' + '\n'.join([''.join(f) for f in funcs]) + '\n'.join(batched) + '\n' + entry
-    code = code.replace('void batched', '__attribute__((section(".text.last"))) void batched')
+    code = code.replace('void batched', '\n__attribute__((section(".text.last"))) void batched')
 
     if DEBUG >= 4: print(code)
     self.clprg = device.runtime("batched", device.compiler.compile_cached(code))

--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -36,6 +36,7 @@ class CPUGraph(GraphRunner):
     defines = dedup(itertools.chain.from_iterable(device.renderer._render_defines(cast(CompiledRunner, ji.prg).p.uops) for ji in jit_cache))
     entry = device.renderer._render_entry("batched", targs)
     code = '\n'.join(defines) + '\n' + '\n'.join([''.join(f) for f in funcs]) + '\n'.join(batched) + '\n' + entry
+    code = code.replace('void batched', '__attribute__((section(".text.last"))) void batched')
 
     if DEBUG >= 4: print(code)
     self.clprg = device.runtime("batched", device.compiler.compile_cached(code))

--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -10,9 +10,7 @@ from tinygrad.renderer.cstyle import ClangRenderer
 from tinygrad.device import Device
 
 class CPUGraph(GraphRunner):
-  def __init__(self, jit_cache: list[ExecItem], input_rawbuffers: list[Buffer], var_vals: dict[Variable, int]):
-    device = Device[Device.DEFAULT]
-
+  def __init__(self, device, jit_cache: list[ExecItem], input_rawbuffers: list[Buffer], var_vals: dict[Variable, int]):
     if not issubclass(type(device.renderer), ClangRenderer) and not isinstance(device.renderer, ClangRenderer): raise GraphException
     super().__init__(jit_cache, input_rawbuffers, var_vals)
 

--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -7,9 +7,12 @@ from tinygrad.engine.realize import ExecItem, CompiledRunner
 from tinygrad.ops import Variable
 from tinygrad.dtype import dtypes
 from tinygrad.renderer.cstyle import ClangRenderer
+from tinygrad.device import Device
 
 class CPUGraph(GraphRunner):
-  def __init__(self, device, jit_cache: list[ExecItem], input_rawbuffers: list[Buffer], var_vals: dict[Variable, int]):
+  def __init__(self, jit_cache: list[ExecItem], input_rawbuffers: list[Buffer], var_vals: dict[Variable, int]):
+    device = Device[Device.DEFAULT]
+
     if not issubclass(type(device.renderer), ClangRenderer) and not isinstance(device.renderer, ClangRenderer): raise GraphException
     super().__init__(jit_cache, input_rawbuffers, var_vals)
 

--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -7,7 +7,6 @@ from tinygrad.engine.realize import ExecItem, CompiledRunner
 from tinygrad.ops import Variable
 from tinygrad.dtype import dtypes
 from tinygrad.renderer.cstyle import ClangRenderer
-from tinygrad.device import Device
 
 class CPUGraph(GraphRunner):
   def __init__(self, device, jit_cache: list[ExecItem], input_rawbuffers: list[Buffer], var_vals: dict[Variable, int]):

--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -31,12 +31,11 @@ class CPUGraph(GraphRunner):
     batched.append("}")
 
     prep = [device.renderer._render(cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache)]
-    funcs = dedup(device.renderer._render_body(prep[i][0], *prep[i][1:], cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache))
+    funcs = dedup(device.renderer._render_body(prep[i][0], *prep[i][1:], cast(CompiledRunner, ji.prg).p.uops).replace('void', 'static void') for i,ji in enumerate(jit_cache))
 
     defines = dedup(itertools.chain.from_iterable(device.renderer._render_defines(cast(CompiledRunner, ji.prg).p.uops) for ji in jit_cache))
     entry = device.renderer._render_entry("batched", targs)
     code = '\n'.join(defines) + '\n' + '\n'.join([''.join(f) for f in funcs]) + '\n'.join(batched) + '\n' + entry
-    code = code.replace('void batched', '\n__attribute__((section(".text.last"))) void batched')
 
     if DEBUG >= 4: print(code)
     self.clprg = device.runtime("batched", device.compiler.compile_cached(code))

--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -31,7 +31,10 @@ class CPUGraph(GraphRunner):
     batched.append("}")
 
     prep = [device.renderer._render(cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache)]
-    funcs = dedup(device.renderer._render_body(prep[i][0], *prep[i][1:], cast(CompiledRunner, ji.prg).p.uops).replace('void', 'static void') for i,ji in enumerate(jit_cache))
+    funcs = dedup(
+        device.renderer._render_body(prep[i][0], *prep[i][1:], cast(CompiledRunner, ji.prg).p.uops).replace('void', 'static void')
+        for i, ji in enumerate(jit_cache)
+      )
 
     defines = dedup(itertools.chain.from_iterable(device.renderer._render_defines(cast(CompiledRunner, ji.prg).p.uops) for ji in jit_cache))
     entry = device.renderer._render_entry("batched", targs)

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -4,7 +4,6 @@ from tinygrad.device import Compiled, Compiler, MallocAllocator, CPUProgram
 from tinygrad.runtime.support.elf import jit_loader
 from tinygrad.renderer.cstyle import ClangRenderer
 from tinygrad.runtime.graph.cpu import CPUGraph
-import functools
 
 class ClangJITCompiler(Compiler):
   def __init__(self, cachekey="compile_clang_jit"): super().__init__(cachekey)

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -1,8 +1,10 @@
 import platform, subprocess, sys
-from tinygrad.helpers import capstone_flatdump, getenv
+from tinygrad.helpers import capstone_flatdump, getenv, OSX
 from tinygrad.device import Compiled, Compiler, MallocAllocator, CPUProgram
 from tinygrad.runtime.support.elf import jit_loader
 from tinygrad.renderer.cstyle import ClangRenderer
+from tinygrad.runtime.graph.cpu import CPUGraph
+import functools
 
 class ClangJITCompiler(Compiler):
   def __init__(self, cachekey="compile_clang_jit"): super().__init__(cachekey)
@@ -11,7 +13,8 @@ class ClangJITCompiler(Compiler):
     # -fno-math-errno is required for __builtin_sqrt to become an instruction instead of a function call
     # x18 is a reserved platform register. It is clobbered on context switch in macos and is used to store TEB pointer in windows on arm, don't use it
     target = 'x86_64' if sys.platform == 'win32' else platform.machine()
-    args = ['-march=native', f'--target={target}-none-unknown-elf', '-O2', '-fPIC', '-ffreestanding', '-fno-math-errno', '-nostdlib']
+    args = [f'--target={target}-none-unknown-elf', '-O2', '-fPIC', '-ffreestanding', '-fno-math-errno', '-nostdlib']
+    if not OSX: args.insert(0, '-march=native')
     arch_args = ['-ffixed-x18'] if target == 'arm64' else []
     obj = subprocess.check_output([getenv("CC", 'clang'), '-c', '-x', 'c', *args, *arch_args, '-', '-o', '-'], input=src.encode('utf-8'))
     return jit_loader(obj)
@@ -19,6 +22,6 @@ class ClangJITCompiler(Compiler):
   def disassemble(self, lib:bytes): return capstone_flatdump(lib)
 
 class ClangDevice(Compiled):
-  def __init__(self, device:str): super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram)
+  def __init__(self, device:str): super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram, functools.partial(CPUGraph, self))
 
 CPUDevice = ClangDevice

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -1,10 +1,8 @@
-import platform, subprocess, sys
+import platform, subprocess, sys, functools
 from tinygrad.helpers import capstone_flatdump, getenv
 from tinygrad.device import Compiled, Compiler, MallocAllocator, CPUProgram
 from tinygrad.runtime.support.elf import jit_loader
 from tinygrad.renderer.cstyle import ClangRenderer
-from tinygrad.runtime.graph.cpu import CPUGraph
-import functools
 
 class ClangJITCompiler(Compiler):
   def __init__(self, cachekey="compile_clang_jit"): super().__init__(cachekey)
@@ -21,7 +19,8 @@ class ClangJITCompiler(Compiler):
   def disassemble(self, lib:bytes): return capstone_flatdump(lib)
 
 class ClangDevice(Compiled):
-  def __init__(self, device:str): super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram,
-                                                   functools.partial(CPUGraph, self))
+  def __init__(self, device:str):
+    from tinygrad.runtime.graph.cpu import CPUGraph
+    super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram, functools.partial(CPUGraph, self))
 
 CPUDevice = ClangDevice

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -1,5 +1,5 @@
 import platform, subprocess, sys
-from tinygrad.helpers import capstone_flatdump, getenv, OSX
+from tinygrad.helpers import capstone_flatdump, getenv
 from tinygrad.device import Compiled, Compiler, MallocAllocator, CPUProgram
 from tinygrad.runtime.support.elf import jit_loader
 from tinygrad.renderer.cstyle import ClangRenderer
@@ -13,8 +13,7 @@ class ClangJITCompiler(Compiler):
     # -fno-math-errno is required for __builtin_sqrt to become an instruction instead of a function call
     # x18 is a reserved platform register. It is clobbered on context switch in macos and is used to store TEB pointer in windows on arm, don't use it
     target = 'x86_64' if sys.platform == 'win32' else platform.machine()
-    args = [f'--target={target}-none-unknown-elf', '-O2', '-fPIC', '-ffreestanding', '-fno-math-errno', '-nostdlib']
-    if not OSX: args.insert(0, '-march=native')
+    args = ['-march=native', f'--target={target}-none-unknown-elf', '-O2', '-fPIC', '-ffreestanding', '-fno-math-errno', '-nostdlib']
     arch_args = ['-ffixed-x18'] if target == 'arm64' else []
     obj = subprocess.check_output([getenv("CC", 'clang'), '-c', '-x', 'c', *args, *arch_args, '-', '-o', '-'], input=src.encode('utf-8'))
     return jit_loader(obj)
@@ -22,6 +21,7 @@ class ClangJITCompiler(Compiler):
   def disassemble(self, lib:bytes): return capstone_flatdump(lib)
 
 class ClangDevice(Compiled):
-  def __init__(self, device:str): super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram, functools.partial(CPUGraph, self))
+  def __init__(self, device:str): super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram,
+                                                   functools.partial(CPUGraph, self))
 
 CPUDevice = ClangDevice

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -21,7 +21,6 @@ class ClangJITCompiler(Compiler):
   def disassemble(self, lib:bytes): return capstone_flatdump(lib)
 
 class ClangDevice(Compiled):
-  def __init__(self, device:str): super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram,
-                                                   functools.partial(CPUGraph, self))
+  def __init__(self, device:str): super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram, CPUGraph)
 
 CPUDevice = ClangDevice

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -4,6 +4,7 @@ from tinygrad.device import Compiled, Compiler, MallocAllocator, CPUProgram
 from tinygrad.runtime.support.elf import jit_loader
 from tinygrad.renderer.cstyle import ClangRenderer
 from tinygrad.runtime.graph.cpu import CPUGraph
+import functools
 
 class ClangJITCompiler(Compiler):
   def __init__(self, cachekey="compile_clang_jit"): super().__init__(cachekey)
@@ -20,6 +21,7 @@ class ClangJITCompiler(Compiler):
   def disassemble(self, lib:bytes): return capstone_flatdump(lib)
 
 class ClangDevice(Compiled):
-  def __init__(self, device:str): super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram, CPUGraph)
+  def __init__(self, device:str): super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram,
+                                                   functools.partial(CPUGraph, self))
 
 CPUDevice = ClangDevice

--- a/tinygrad/runtime/support/elf.py
+++ b/tinygrad/runtime/support/elf.py
@@ -49,11 +49,9 @@ def relocate(instr: int, ploc: int, tgt: int, r_type: int):
   match r_type:
     # https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.95.pdf
     case libc.R_X86_64_PC32: return i2u(32, tgt-ploc)
+    case libc.R_X86_64_PLT32: return i2u(32, tgt-ploc)  # PC-relative offset to PLT entry
     # https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst for definitions of relocations
     # https://www.scs.stanford.edu/~zyedidia/arm64/index.html for instruction encodings
-    case libc.R_AARCH64_ADR_PREL_LO21:  # Type 4: PC-relative address calculation
-      offset = tgt - ploc
-      return instr | (getbits(offset, 0, 20) << 5) | (getbits(offset, 20, 21) << 29)
     case libc.R_AARCH64_ADR_PREL_PG_HI21:
       rel_pg = (tgt & ~0xFFF) - (ploc & ~0xFFF)
       return instr | (getbits(rel_pg, 12, 13) << 29) | (getbits(rel_pg, 14, 32) << 5)

--- a/tinygrad/runtime/support/elf.py
+++ b/tinygrad/runtime/support/elf.py
@@ -59,6 +59,13 @@ def relocate(instr: int, ploc: int, tgt: int, r_type: int):
     case libc.R_AARCH64_LDST32_ABS_LO12_NC: return instr | (getbits(tgt, 2, 11) << 10)
     case libc.R_AARCH64_LDST64_ABS_LO12_NC: return instr | (getbits(tgt, 3, 11) << 10)
     case libc.R_AARCH64_LDST128_ABS_LO12_NC: return instr | (getbits(tgt, 4, 11) << 10)
+    case libc.R_AARCH64_COPY: return instr  # For COPY relocation, we just return the instruction as is
+    case libc.R_AARCH64_CALL26:  # For CALL26 relocation, calculate the PC-relative offset
+      offset = (tgt - ploc) >> 2  # Divide by 4 since instructions are 4 bytes aligned
+      return instr | (getbits(offset, 0, 25) << 0)  # Encode the 26-bit offset
+    case libc.R_AARCH64_JUMP26:  # For JUMP26 relocation, same as CALL26 but for unconditional jumps
+      offset = (tgt - ploc) >> 2  # Divide by 4 since instructions are 4 bytes aligned
+      return instr | (getbits(offset, 0, 25) << 0)  # Encode the 26-bit offset
   raise NotImplementedError(f"Encountered unknown relocation type {r_type}")
 
 def jit_loader(obj: bytes) -> bytes:

--- a/tinygrad/runtime/support/elf.py
+++ b/tinygrad/runtime/support/elf.py
@@ -51,6 +51,9 @@ def relocate(instr: int, ploc: int, tgt: int, r_type: int):
     case libc.R_X86_64_PC32: return i2u(32, tgt-ploc)
     # https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst for definitions of relocations
     # https://www.scs.stanford.edu/~zyedidia/arm64/index.html for instruction encodings
+    case libc.R_AARCH64_ADR_PREL_LO21:  # Type 4: PC-relative address calculation
+      offset = tgt - ploc
+      return instr | (getbits(offset, 0, 20) << 5) | (getbits(offset, 20, 21) << 29)
     case libc.R_AARCH64_ADR_PREL_PG_HI21:
       rel_pg = (tgt & ~0xFFF) - (ploc & ~0xFFF)
       return instr | (getbits(rel_pg, 12, 13) << 29) | (getbits(rel_pg, 14, 32) << 5)
@@ -59,7 +62,6 @@ def relocate(instr: int, ploc: int, tgt: int, r_type: int):
     case libc.R_AARCH64_LDST32_ABS_LO12_NC: return instr | (getbits(tgt, 2, 11) << 10)
     case libc.R_AARCH64_LDST64_ABS_LO12_NC: return instr | (getbits(tgt, 3, 11) << 10)
     case libc.R_AARCH64_LDST128_ABS_LO12_NC: return instr | (getbits(tgt, 4, 11) << 10)
-    case libc.R_AARCH64_COPY: return instr  # For COPY relocation, we just return the instruction as is
     case libc.R_AARCH64_CALL26:  # For CALL26 relocation, calculate the PC-relative offset
       offset = (tgt - ploc) >> 2  # Divide by 4 since instructions are 4 bytes aligned
       return instr | (getbits(offset, 0, 25) << 0)  # Encode the 26-bit offset


### PR DESCRIPTION
Work in progress for "CPUGraph working with CLANG+LLVM" bounty.

In CPUGraph, the batched function is rendered at the very bottom of the C program. However, when we compile and load it, the memory pointer points to the very beginning of the shared library (ie. the first function).

from device.py:
` self.mem = mmap(-1, len(lib), MAP_ANON | MAP_PRIVATE | (MAP_JIT if OSX else 0), PROT_READ | PROT_WRITE | PROT_EXEC)
`

then we create a function pointer using this memory address, which is then not pointing to the batched function:

from device.py:
`self.fxn = ctypes.CFUNCTYPE(None)(mv_address(self.mem))
`

Therefore, when we run the JIT, it is not batched function that gets run.

My change labels the batched function with an attribute and when assembling the elf we manually relocate the function that's labeled to the top.