### PR TITLE
move TestOpsFp8s skipTest

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -3003,10 +3003,11 @@ class TestOpsUint8(unittest.TestCase):
       lambda x: x.type(torch.uint8).min(),
       lambda x: x.cast(dtypes.uint8).min(), forward_only=True, vals=[[0, 128, 255, 64, 32, 16]])
 
-@unittest.skipUnless("CUDA" in Device.get_available_devices() and Device.DEFAULT == "PYTHON" and getenv("EMULATE_CUDA_SM89"),
-                     "only for emulated CUDA")
 class TestOpsFp8s(unittest.TestCase):
   def _compare_to_cuda(self, shp_a, shp_b, op, dtype):
+    if not ("CUDA" in Device.get_available_devices() and Device.DEFAULT == "PYTHON" and getenv("EMULATE_CUDA_SM89")):
+      self.skipTest("only for emulated CUDA")
+
     a = Tensor.rand(shp_a, dtype=dtype)
     b = Tensor.rand(shp_b, dtype=dtype)
     np.testing.assert_equal(op(a, b).numpy(), op(a.to("CUDA"), b.to("CUDA")).numpy())


### PR DESCRIPTION
so get_available_devices is not called when running other tests