### PR TITLE
Fix my pre commit tests

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -50,6 +50,7 @@ JIT                 | [0-2]      | 0=disabled, 1=[jit enabled](quickstart.md#jit
 VIZ                 | [1]        | 0=disabled, 1=[viz enabled](https://github.com/tinygrad/tinygrad/tree/master/tinygrad/viz)
 ALLOW_TF32          | [1]        | enable TensorFloat-32 tensor cores on Ampere or newer GPUs.
 WEBGPU_BACKEND      | [WGPUBackendType_Metal, ...]          | Force select a backend for WebGPU (Metal, DirectX, OpenGL, Vulkan...)
+CUDA_INC            | str        | Path to the CUDA headers (CUDA and NV backends). If not set, TinyGrad looks in `/usr/local/cuda/include`, `/usr/include` and `/opt/cuda/include`.
 
 ## Debug breakdown
 

--- a/test/external/external_test_example.py
+++ b/test/external/external_test_example.py
@@ -7,7 +7,7 @@ def multidevice_test(fxn):
   exclude_devices = getenv("EXCLUDE_DEVICES", "").split(",")
   def ret(self):
     for device in Device._devices:
-      if device in ["DISK", "NPY", "FAKE", "DSP", "NULL"]: continue
+      if device in ["CLOUD", "DISK", "NPY", "FAKE", "DSP", "NULL"]: continue
       if not CI: print(device)
       if device in exclude_devices:
         if not CI: print(f"WARNING: {device} test is excluded")

--- a/tinygrad/runtime/support/compiler_cuda.py
+++ b/tinygrad/runtime/support/compiler_cuda.py
@@ -4,7 +4,7 @@ from tinygrad.helpers import to_char_p_p, colored, init_c_var, getenv
 import tinygrad.runtime.autogen.nvrtc as nvrtc
 from tinygrad.device import Compiler, CompileError
 
-PTX = getenv("PTX")  # this shouldn't be here, in fact, it shouldn't exist
+PTX, CUDA_INC = getenv("PTX"), getenv("CUDA_INC", "")  # PTX shouldn't be here, in fact, it shouldn't exist
 
 def _get_bytes(arg, get_str, get_sz, check) -> bytes:
   sz = init_c_var(ctypes.c_size_t(), lambda x: check(get_sz(arg, ctypes.byref(x))))
@@ -40,7 +40,8 @@ def cuda_disassemble(lib, arch):
 
 class CUDACompiler(Compiler):
   def __init__(self, arch:str, cache_key:str="cuda"):
-    self.arch, self.compile_options = arch, [f'--gpu-architecture={arch}', "-I/usr/local/cuda/include", "-I/usr/include", "-I/opt/cuda/include/"]
+    self.arch, self.compile_options = arch, [f'--gpu-architecture={arch}']
+    self.compile_options += [f"-I{CUDA_INC}"] if CUDA_INC else ["-I/usr/local/cuda/include", "-I/usr/include", "-I/opt/cuda/include"]
     nvrtc_check(nvrtc.nvrtcVersion((nvrtcMajor := ctypes.c_int()), (nvrtcMinor := ctypes.c_int())))
     if (nvrtcMajor.value, nvrtcMinor.value) >= (12, 4): self.compile_options.append("--minimal")
     super().__init__(f"compile_{cache_key}_{self.arch}")


### PR DESCRIPTION
I had a few failures when runnign the pre-commit tests:

- test_allreduce fails when less than 6 GPUS are available, at least with NV/CUDA
    - Make N dynamic (up to 8), test is skipped if less than 2.

- compiler_cuda will look for CUDA headers in pre-determined locations, fails with mamba/conda if the system CUDA version is different/missing, see #7038
   - Prepend CUDA_HOME to the -Is if set in environment.

- external_test_example.py fails at least on NV/CUDA for the CLOUD device, see #9814
   -  Exclude CLOUD from the test

Please let me know if you want any of them done differently/dropped.