### PR TITLE
unbind variables when creating ScheduleItems [pr]

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from collections import deque
-from tinygrad.ops import UOp, Variable, Ops, buffers
+from tinygrad.ops import UOp, Variable, Ops, UPat, PatternMatcher, graph_rewrite, buffers
 from tinygrad.device import Buffer
 from tinygrad.helpers import Metadata, DEBUG, unwrap
 from tinygrad.engine.grouper import get_becomes_map
@@ -13,10 +13,29 @@ class ScheduleItem:
   bufs: tuple[Buffer, ...]
   metadata: tuple[Metadata, ...] = ()
 
+# **** unbind Variables
+
+def unbind_view(ctx:dict[Variable, int], x:UOp):
+  st = unwrap(x.st).simplify()
+  if any(x.op is Ops.BIND for x in st.vars()):
+    st, var_vals = st.unbind()
+    ctx.update(var_vals)
+  return x.replace(arg=st) if st != x.st else None
+
+def unbind_bind(ctx:dict[Variable, int], x:UOp):
+  var, val = x.unbind()
+  ctx[var.replace(src=())] = val
+  return var
+
+pm_unbind = PatternMatcher([
+  (UPat(Ops.VIEW, name="x"), unbind_view),
+  (UPat(Ops.BIND, name="x"), unbind_bind),
+])
+
 # **** schedule linearizer
 
 def create_schedule_with_vars(big_sink:UOp) -> tuple[list[ScheduleItem], dict[Variable, int], dict[UOp, UOp]]:
-  becomes_map, var_vals = get_becomes_map(big_sink)
+  becomes_map = get_becomes_map(big_sink)
   sched_sink = becomes_map.pop(big_sink)
 
   # bfs toposort
@@ -32,12 +51,13 @@ def create_schedule_with_vars(big_sink:UOp) -> tuple[list[ScheduleItem], dict[Va
 
   queue = deque(k for k,v in in_degree.items() if v == 0)
   schedule: list[ScheduleItem] = []
+  var_vals: dict[Variable, int] = {}
   while queue:
     u = queue.popleft()
     # map the BUFFER UOp to a subbuffer if it's a BUFFER_VIEW
     if (k:=u.src[1]).arg.ast.op is Ops.BUFFER_VIEW:
       buffers[k.src[0]] = (base:=k.src[1].buf_uop.buffer).view(k.size, k.arg.ast.dtype, k.arg.ast.arg[1]*base.dtype.itemsize)
-    schedule.append(ScheduleItem(k.arg.ast, tuple(s.buf_uop.buffer for s in k.src), k.arg.metadata))
+    schedule.append(ScheduleItem(graph_rewrite(k.arg.ast, pm_unbind, ctx=var_vals), tuple(s.buf_uop.buffer for s in k.src), k.arg.metadata))
     for x in children.get(u, []):
       in_degree[x] -= 1
       if in_degree[x] == 0: queue.append(x)


### PR DESCRIPTION
Grouper has nothing to do with var_vals, it's a ScheduleItem concern,
This enables Tensor.kernelize to just rewrite the Tensors graph instead of having to also return a var_vals dictionary.
The unbinding happens later when we actually want to run the ASTs.

eg BIND in Tensor -> DEFINE_VAR in ScheduleItem + mapping `{a:4}`.
![image](https://github.com/user-attachments/assets/9d76c942-c146-46d2-aa1f-235807469649)
![image](https://github.com/user-attachments/assets/89203be5-dc7d-493a-9111-1f3fc90fe5d8)
