### PR TITLE
am: fix speed of ring copies

### DIFF
--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -662,6 +662,7 @@ class PCIIface:
         vendor = int(HWInterface(f"/sys/bus/pci/devices/{pcibus}/vendor").read(), 16)
         device = int(HWInterface(f"/sys/bus/pci/devices/{pcibus}/device").read(), 16)
         if vendor == 0x1002 and device in PCIIface.supported_devs: PCIIface.gpus.append(pcibus)
+      PCIIface.gpus = sorted(PCIIface.gpus)
 
       # TODO: visible_devices should be handled layer above this?
       visible_devices = [int(x) for x in (getenv('VISIBLE_DEVICES', getenv('HIP_VISIBLE_DEVICES', ''))).split(',') if x.strip()]


### PR DESCRIPTION
tinyboxes have the following pci tree:
```
-+-[0000:c0]
 |           +-01.1-[c1-c3]----00.0-[c2-c3]----00.0-[c3]--+-00.0  AMD/ATI Navi 31 [Radeon RX 7900 XT/7900 XTX/7900M]
 |           |                                            \-00.1  AMD/ATI Navi 31 HDMI/DP Audio
 |           +-03.1-[c4-c6]----00.0-[c5-c6]----00.0-[c6]--+-00.0  AMD/ATI Navi 31 [Radeon RX 7900 XT/7900 XTX/7900M]
 |           |                                            \-00.1  AMD/ATI Navi 31 HDMI/DP Audio
 +-[0000:80]
 |           +-01.1-[81-83]----00.0-[82-83]----00.0-[83]--+-00.0  AMD/ATI Navi 31 [Radeon RX 7900 XT/7900 XTX/7900M]
 |           |                                            \-00.1  AMD/ATI Navi 31 HDMI/DP Audio
 |           +-03.1-[84-86]----00.0-[85-86]----00.0-[86]--+-00.0  AMD/ATI Navi 31 [Radeon RX 7900 XT/7900 XTX/7900M]
 |           |                                            \-00.1  AMD/ATI Navi 31 HDMI/DP Audio
 +-[0000:40]
 |           +-03.1-[42-44]----00.0-[43-44]----00.0-[44]--+-00.0  AMD/ATI Navi 31 [Radeon RX 7900 XT/7900 XTX/7900M]
 |           |                                            \-00.1  AMD/ATI Navi 31 HDMI/DP Audio
 \-[0000:00]
             +-01.1-[01-03]----00.0-[02-03]----00.0-[03]--+-00.0  AMD/ATI Navi 31 [Radeon RX 7900 XT/7900 XTX/7900M]
             |                                            \-00.1  AMD/ATI Navi 31 HDMI/DP Audio
```

the unordered selection of gpus could oversaturate the pci lanes when performing ring reduction (e.g. `VISIBLE_DEVICES=0,4,2,5`), so sorting them in order by default.