### PR TITLE
[Bounty][WIP] BLAKE3 Hash Implementation

### DIFF
--- a/extra/crypto/hash.py
+++ b/extra/crypto/hash.py
@@ -1,0 +1,144 @@
+from tinygrad.dtype import DType
+from tinygrad.ops import sint
+from tinygrad import Tensor, dtypes
+
+# TODO: Remove
+import numpy as np
+np.set_printoptions(formatter={'int':lambda x:hex(int(x))})
+
+# TODO: Get rid of useless contiguous
+# TODO: Get rid of the comments
+# TODO: Reduce LOC
+# TODO: Optional, other modes, out_len, not for ml
+# TODO: Op reduction
+# TODO: Better log test + Graph maybe
+# TODO: Bandwidth test/analysis (TinyJit warmup)
+
+# **************** Constants ****************
+
+# *** Blake3 ***
+
+IV = Tensor([0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
+            0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19], dtype=dtypes.uint32)
+MSG_PERM = Tensor([2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8], dtype=dtypes.uint32)
+CHUNK_START, CHUNK_END = 0x01, 0x02
+NODE_PARENT, NODE_ROOT = 0x04, 0x08
+COLUMNS = [(0,4,8,12,0,1), (1,5,9,13,2,3), (2,6,10,14,4,5), (3,7,11,15,6,7)]
+DIAGONALS = [(0,5,10,15,8,9), (1,6,11,12,10,11), (2,7,8,13,12,13), (3,4,9,14,14,15)]
+
+# **************** Helper Functions ****************
+
+# *** Blake3 ***
+
+def check_tensor(*requirements:tuple[Tensor, tuple[sint, ...], DType, str]) -> None:
+  def check(x, shape, dtype, name): assert x.shape == shape and x.dtype == dtype, f"{name} requirements: {shape}.{dtype} does not match {x.shape}.{x.dtype}"
+  list(map(lambda r: check(r[0], r[1], r[2], r[3]), requirements))
+def rotate_right(x:Tensor, bits:int) -> Tensor: return (x.rshift(bits)) | (x.lshift(x.dtype.itemsize * 8 - bits))
+
+def g(state:Tensor, a:int, b:int, c:int, d:int, x:Tensor, y:Tensor) -> Tensor:
+  assert len(state.shape); check_tensor((state, (bsize:=state.shape[0], 16), dtypes.uint32, "state"),
+    (x, (bsize,), dtypes.uint32, "x"), (y, (bsize,), dtypes.uint32, "y"))
+
+  for z in (x, y):
+    state[:, a] = state[:, a] + state[:, b] + z
+    state[:, d] = rotate_right(state[:, d] ^ state[:, a], 16 if z is x else 8)
+    state[:, c] = state[:, c] + state[:, d]
+    state[:, b] = rotate_right(state[:, b] ^ state[:, c], 12 if z is x else 7)
+  return state # (bsize,16).uint32
+
+def compress_block(block:Tensor, chain_val:Tensor, counter_low:Tensor, counter_high:Tensor, block_len:Tensor, flags:Tensor) -> Tensor:
+  assert len(block.shape); check_tensor((block, (bsize:=block.shape[0], 16), dtypes.uint32, "block"), (chain_val, (bsize, 8), dtypes.uint32, "chain_val"),
+    (counter_low, (bsize,), dtypes.uint32, "counter_low"), (counter_high, (bsize,), dtypes.uint32, "counter_high"),
+    (block_len, (bsize,), dtypes.uint32, "block_len"), (flags, (bsize,), dtypes.uint32, "flags"))
+
+  initials, configs = IV[:4].reshape(1, 4).expand(bsize,4), Tensor.stack(counter_low, counter_high, block_len, flags, dim=1)
+  state = Tensor.cat(chain_val, initials, configs, dim=1).cast(dtypes.uint32)
+  for r in range(7):
+    for qr, (a,b,c,d,xi,yi) in enumerate([*COLUMNS, *DIAGONALS]): state = g(state, a, b, c, d, block[:, xi], block[:, yi])
+    block = block[:, MSG_PERM]
+  state[:, :8] = state[:, :8] ^ state[:, 8:16]
+  state[:, 8:16] = state[:, 8:16] ^ chain_val
+  return state.contiguous() # (bsize,16).uint32
+
+def pack_blocks(blocks:Tensor) -> Tensor:
+  assert len(blocks.shape); check_tensor((blocks, (num_blocks:=blocks.shape[0], 64), dtypes.uint8, "blocks"))
+
+  block_words = Tensor.zeros(num_blocks, 16, dtype=dtypes.uint32).contiguous()
+  for j in range(64): k = j//4; block_words[:, k] = block_words[:, k] | blocks[:, j].lshift((j % 4) * 8)
+  return block_words # (num_blocks,16).uint32
+
+def process_chunk(chunk:Tensor, chain_val:Tensor, chunk_idx:Tensor, flags:Tensor, root:bool=False) -> Tensor:
+  assert len(chunk.shape) == 2 and (csize:=chunk.shape[1]) <= 1024
+  check_tensor((chunk, (bsize:=chunk.shape[0], csize), dtypes.uint8, "chunk"), (chain_val, (bsize, 8), dtypes.uint32, "chain_val"),
+    (chunk_idx, (bsize,), dtypes.uint32, "chunk_idx"), (flags, (bsize,), dtypes.uint32, "flags"))
+
+  padding_size = (64 - csize % 64) % 64  # This gives 0 when csize is a multiple of 64
+  # padded_chunk = chunk.pad((0, 0, 0, padding_size), value=0)
+  padded_chunk = chunk.pad((0, padding_size), value=0)
+  num_blocks = padded_chunk.shape[1] // 64
+  block_words = pack_blocks(padded_chunk.reshape(bsize * num_blocks, 64)).reshape(bsize, num_blocks, 16)
+  chain_val_out = chain_val.clone() # TODO: Consider reassigning chain_val instead (cache, mem, and kernel advantage ?)
+  for i in range(num_blocks):
+    block_flags = flags
+    if root and i == num_blocks - 1: block_flags = block_flags | NODE_ROOT
+    block_flags = block_flags | (CHUNK_START if i == 0 else 0)
+    block_flags = block_flags | (CHUNK_END if i == num_blocks - 1 else 0)
+    block_len = Tensor.full((bsize,), min(64, csize - i * 64), dtype=dtypes.uint32)
+    chain_val_out = compress_block(block_words[:, i], chain_val_out, chunk_idx, Tensor.zeros(bsize, dtype=dtypes.uint32), block_len, block_flags)[:, :8]
+  return chain_val_out # (bsize,8).uint32
+
+def process_parent(left:Tensor, right:Tensor, flags:Tensor) -> Tensor:
+  check_tensor((left, (bsize:=left.shape[0], 8), dtypes.uint32, "left"), (right, (bsize, 8), dtypes.uint32, "right"), (flags, (bsize,), dtypes.uint32, "flags"))
+
+  blocks = Tensor.cat(left, right, dim=1).cast(dtypes.uint32)
+  return compress_block(blocks, IV.expand(bsize, 8), Tensor.zeros(bsize, dtype=dtypes.uint32), Tensor.zeros(bsize, dtype=dtypes.uint32),
+                        Tensor.full((bsize,), 64, dtype=dtypes.uint32), flags | NODE_PARENT)[:, :8].contiguous() # (bsize,8).uint32
+
+# **************** Hash Functions ****************
+
+def blake3(msg:Tensor, max_batch_size:int=None) -> Tensor:
+  if not isinstance(msg, Tensor): msg = Tensor(np.frombuffer(msg, dtype=np.uint8))
+  if msg.dtype != dtypes.uint8: msg = msg.cast(dtypes.uint8)
+  assert len(msg.shape) == 1, "blake3 does not support batched inputs"
+
+  num_chunks = (msg.shape[0] + 1023) // 1024
+  chunks = msg.pad((0, num_chunks * 1024 - msg.shape[0]), value=0).reshape(num_chunks, 1024)
+  chunk_hashes = Tensor.zeros((num_chunks, 8), dtype=dtypes.uint32).contiguous()
+  chunk_flags = Tensor.zeros((num_chunks,), dtype=dtypes.uint32)
+  chunk_indices = Tensor.arange(num_chunks, dtype=dtypes.uint32)
+
+  last_chunk_complete = (msg.shape[0] % 1024 == 0)
+  last_chunk_idx = num_chunks - 1
+
+  if max_batch_size is None: batch_size = num_chunks if last_chunk_complete and num_chunks > 1 else last_chunk_idx
+  else: batch_size = min(max_batch_size, num_chunks if last_chunk_complete and num_chunks > 1 else last_chunk_idx)
+
+  for i in range(0, last_chunk_idx if batch_size else 0, batch_size if batch_size else 1):
+    batch_end = min(i + batch_size, last_chunk_idx)
+    batch_chunks = chunks[i:batch_end]
+    batch_indices = chunk_indices[i:batch_end]
+    batch_flags = chunk_flags[i:batch_end]
+    batch_chain_vals = IV.expand(batch_end - i, 8)
+    chunk_hashes[i:batch_end] = process_chunk(batch_chunks, batch_chain_vals, batch_indices, batch_flags)
+
+  if (not last_chunk_complete and num_chunks > 0) or num_chunks == 1:
+    last_chunk_size = msg.shape[0] % 1024 if not last_chunk_complete else 1024
+    last_chunk = chunks[last_chunk_idx:last_chunk_idx+1, :last_chunk_size]
+    last_index = chunk_indices[last_chunk_idx:last_chunk_idx+1]
+    last_flag = chunk_flags[last_chunk_idx:last_chunk_idx+1]
+    last_chain_val = IV.expand(1, 8)
+    chunk_hashes[last_chunk_idx:last_chunk_idx+1] = process_chunk(last_chunk, last_chain_val, last_index, last_flag, num_chunks==1)#[0] TODO: Enable when only one chunk?
+
+  while chunk_hashes.shape[0] > 1:
+    num_parents = (chunk_hashes.shape[0] + 1) // 2
+    parents = Tensor.zeros((num_parents, 8), dtype=dtypes.uint32).contiguous()
+    pair_count = chunk_hashes.shape[0] // 2
+    batch_left = chunk_hashes[0:-1:2] if chunk_hashes.shape[0] % 2 else chunk_hashes[::2]
+    batch_right = chunk_hashes[1::2]
+    parent_flags = Tensor.full((pair_count,), NODE_ROOT if num_parents == 1 else 0, dtype=dtypes.uint32)
+    parents[:pair_count] = process_parent(batch_left, batch_right, parent_flags)
+    if chunk_hashes.shape[0] % 2: parents[-1] = chunk_hashes[-1]
+    chunk_hashes = parents
+
+  assert chunk_hashes.shape[0] == 1, "Final result should be a single hash"
+  return chunk_hashes[0]

--- a/test/testextra/crypto/test_hash.py
+++ b/test/testextra/crypto/test_hash.py
@@ -1,0 +1,57 @@
+import unittest
+# from hypothesis import given, strategies as st, settings, example
+from extra.crypto.hash import blake3
+from tinygrad import Tensor, TinyJit, dtypes
+# from tinygrad.helpers import GlobalCounters
+# import math
+
+class TestBlake3(unittest.TestCase):
+  """Test against official test vectors from: https://github.com/BLAKE3-team/BLAKE3"""
+
+  TEST_VECTORS = {
+    0: ("af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262", TinyJit(blake3)),
+    1: ("2d3adedff11b61f14c886e35afa036736dcd87a74d27b5c1510225d0f592e213", TinyJit(blake3)),
+    2: ("7b7015bb92cf0b318037702a6cdd81dee41224f734684c2c122cd6359cb1ee63", TinyJit(blake3)),
+    3: ("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f", TinyJit(blake3)),
+    4: ("f30f5ab28fe047904037f77b6da4fea1e27241c5d132638d8bedce9d40494f32", TinyJit(blake3)),
+    5: ("b40b44dfd97e7a84a996a91af8b85188c66c126940ba7aad2e7ae6b385402aa2", TinyJit(blake3)),
+    6: ("06c4e8ffb6872fad96f9aaca5eee1553eb62aed0ad7198cef42e87f6a616c844", TinyJit(blake3)),
+    7: ("3f8770f387faad08faa9d8414e9f449ac68e6ff0417f673f602a646a891419fe", TinyJit(blake3)),
+    8: ("2351207d04fc16ade43ccab08600939c7c1fa70a5c0aaca76063d04c3228eaeb", TinyJit(blake3)),
+    63: ("e9bc37a594daad83be9470df7f7b3798297c3d834ce80ba85d6e207627b7db7b", TinyJit(blake3)),
+    64: ("4eed7141ea4a5cd4b788606bd23f46e212af9cacebacdc7d1f4c6dc7f2511b98", TinyJit(blake3)),
+    65: ("de1e5fa0be70df6d2be8fffd0e99ceaa8eb6e8c93a63f2d8d1c30ecb6b263dee", TinyJit(blake3)),
+    127: ("d81293fda863f008c09e92fc382a81f5a0b4a1251cba1634016a0f86a6bd640d", TinyJit(blake3)),
+    128: ("f17e570564b26578c33bb7f44643f539624b05df1a76c81f30acd548c44b45ef", TinyJit(blake3)),
+    129: ("683aaae9f3c5ba37eaaf072aed0f9e30bac0865137bae68b1fde4ca2aebdcb12", TinyJit(blake3)),
+    1023: ("10108970eeda3eb932baac1428c7a2163b0e924c9a9e25b35bba72b28f70bd11", TinyJit(blake3)),
+    1024: ("42214739f095a406f3fc83deb889744ac00df831c10daa55189b5d121c855af7", TinyJit(blake3)),
+    2048: ("e776b6028c7cd22a4d0ba182a8bf62205d2ef576467e838ed6f2529b85fba24a", TinyJit(blake3)),
+    2049: ("5f4d72f40d7a5f82b15ca2b2e44b1de3c2ef86c426c95c1af0b6879522563030", TinyJit(blake3)),
+    3072: ("b98cb0ff3623be03326b373de6b9095218513e64f1ee2edd2525c7ad1e5cffd2", TinyJit(blake3)),
+    3073: ("7124b49501012f81cc7f11ca069ec9226cecb8a2c850cfe644e327d22d3e1cd3", TinyJit(blake3)),
+    4096: ("015094013f57a5277b59d8475c0501042c0b642e531b0a1c8f58d2163229e969", TinyJit(blake3)),
+    4097: ("9b4052b38f1c5fc8b1f9ff7ac7b27cd242487b3d890d15c96a1c25b8aa0fb995", TinyJit(blake3)),
+    5120: ("9cadc15fed8b5d854562b26a9536d9707cadeda9b143978f319ab34230535833", TinyJit(blake3)),
+    5121: ("628bd2cb2004694adaab7bbd778a25df25c47b9d4155a55f8fbd79f2fe154cff", TinyJit(blake3)),
+    6144: ("3e2e5b74e048f3add6d21faab3f83aa44d3b2278afb83b80b3c35164ebeca205", TinyJit(blake3)),
+    6145: ("f1323a8631446cc50536a9f705ee5cb619424d46887f3c376c695b70e0f0507f", TinyJit(blake3)),
+    7168: ("61da957ec2499a95d6b8023e2b0e604ec7f6b50e80a9678b89d2628e99ada77a", TinyJit(blake3)),
+    7169: ("a003fc7a51754a9b3c7fae0367ab3d782dccf28855a03d435f8cfe74605e7817", TinyJit(blake3)),
+    8192: ("aae792484c8efe4f19e2ca7d371d8c467ffb10748d8a5a1ae579948f718a2a63", TinyJit(blake3)),
+    8193: ("bab6c09cb8ce8cf459261398d2e7aef35700bf488116ceb94a36d0f5f1b7bc3b", TinyJit(blake3)),
+    16384: ("f875d6646de28985646f34ee13be9a576fd515f76b5b0a26bb324735041ddde4", TinyJit(blake3)),
+    31744: ("62b6960e1a44bcc1eb1a611a8d6235b6b4b78f32e7abc4fb4c6cdcce94895c47", TinyJit(blake3)),
+    102400: ("bc3e3d41a1146b069abffad3c0d44860cf664390afce4d9661f7902e7943e085", TinyJit(blake3)),
+  }
+
+  def test_vectors(self):
+    for length, (expected_hex, blake3_func) in self.TEST_VECTORS.items():
+      with self.subTest(length=length):
+        input_data = bytes(i & 0xFF for i in range(length))
+        input_tensor = Tensor(input_data, dtype=dtypes.uint8)
+        hash_output = blake3_func(input_tensor).realize().numpy().tobytes().hex()
+        self.assertEqual(hash_output, expected_hex, f"Failed for length {length}")
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Parallel BLAKE3 Implementation

Implements parallel BLAKE3 in `extra/crypto/hash.py` with O(log(n)) kernel complexity for length-n messages.

## TODOs

- [ ] Clean up
- [ ] Reduce LOC
- [ ] Add quick kernel log scaling analysis
- [ ] Add bandwidth test for performance analysis with `TinyJit` warmup
- [ ] Bug, wrong hash when last block of last chunk is full and more than one chunk