### PR TITLE
fixing bug in transformer training example

### DIFF
--- a/examples/transformer.py
+++ b/examples/transformer.py
@@ -17,7 +17,7 @@ def make_dataset():
   random.shuffle(ds)
   ds = np.array(ds).astype(np.float32)
   ds_X = ds[:, 0:6]
-  ds_Y = np.copy(ds[:, 1:])
+  ds_Y = np.copy(ds[:, 1:]).astype(np.int32)
   ds_X_train, ds_X_test = ds_X[0:8000], ds_X[8000:]
   ds_Y_train, ds_Y_test = ds_Y[0:8000], ds_Y[8000:]
   return ds_X_train, ds_Y_train, ds_X_test, ds_Y_test


### PR DESCRIPTION
The y labels are expected to be of type int however the original supplied type is float. i have cast the original numpy arrays to int32 to fix the bug.

Steps to reproduce bug>

```python examples/transformer.py```


<img width="1347" alt="Screenshot 2025-04-13 at 3 50 48 PM" src="https://github.com/user-attachments/assets/6e095a04-4a07-4f72-83fe-d2fbd5e4b080" />
