### PR TITLE
Allow TYPED=1

### DIFF
--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, replace
 from collections import defaultdict
-from typing import Optional, Any, Iterator, Generator
+from typing import Optional, Any, Iterator, Generator, Optional
 import multiprocessing, importlib, inspect, functools, pathlib, os, ctypes, ctypes.util, platform, contextlib, sys, re, atexit, pickle, decimal, time
 from tinygrad.helpers import CI, OSX, LRU, getenv, diskcache_get, diskcache_put, DEBUG, GlobalCounters, flat_mv, from_mv, PROFILE, temp, mv_address, \
                              cpu_time_execution, colored, Context, round_up
@@ -327,7 +327,7 @@ class Compiled:
     # override this in your device implementation
 
 # TODO: move this to each Device
-def is_dtype_supported(dtype:DType, device:Optional[str]=None) -> bool:
+def is_dtype_supported(dtype:Optional[DType], device:Optional[str]=None) -> bool:
   if device is None: device = Device.DEFAULT
   if dtype == dtypes.bfloat16:
     # NOTE: this requires bf16 buffer support

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Final, Optional, ClassVar, Union, Callable, Literal
+from typing import Final, Optional, ClassVar, Union, Callable, Literal,TYPE_CHECKING
 import math, struct, ctypes, functools
 from dataclasses import dataclass, fields
 from tinygrad.helpers import getenv, prod
@@ -7,6 +7,13 @@ from tinygrad.helpers import getenv, prod
 ConstType = Union[float, int, bool]
 
 FmtStr = Literal['?', 'b', 'B', 'h', 'H', 'i', 'I', 'q', 'Q', 'e', 'f', 'd']
+if TYPE_CHECKING:
+  import numpy.typing as npt
+  npArrayType = npt.NDArray
+  npDTypeLike = npt.DTypeLike
+else:
+  npArrayType = "np.ndarray"
+  npDTypeLike = "np.dtype"
 
 # all DTypes should only be created once
 class DTypeMetaClass(type):
@@ -206,7 +213,7 @@ truncate: dict[DType, Callable] = {dtypes.bool: bool,
 def _to_np_dtype(dtype:DType) -> Optional[type]:
   import numpy as np
   return np.dtype(dtype.fmt).type if dtype.fmt is not None else None
-def _from_np_dtype(npdtype:'np.dtype') -> DType: # type: ignore [name-defined] # noqa: F821
+def _from_np_dtype(npdtype:npDTypeLike) -> DType: # type: ignore [name-defined] # noqa: F821
   import numpy as np
   return dtypes.fields()[np.dtype(npdtype).name]
 

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -63,7 +63,7 @@ def partition(itr:Iterable[T], fxn:Callable[[T],bool]) -> tuple[list[T], list[T]
 def unwrap(x:Optional[T]) -> T:
   assert x is not None
   return x
-def get_single_element(x:list[T]) -> T:
+def get_single_element(x:Union[list[T], tuple[T, ...]]) -> T:
   assert len(x) == 1, f"list {x} must only have 1 element"
   return x[0]
 def get_child(obj, key):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -749,7 +749,7 @@ class UPat(MathTrait):
   def var(name:Optional[str]=None, dtype:Optional[Union[DType, tuple[DType, ...]]]=None): return UPat(dtype=dtype, name=name)
   @staticmethod
   @functools.cache
-  def cvar(name:Optional[str]=None, dtype:Optional[DType]=None, vec=True): return UPat((Ops.CONST,Ops.VCONST) if vec else Ops.CONST, dtype, name=name)
+  def cvar(name:Optional[str]=None, dtype:Optional[Union[DType, tuple[DType, ...]]]=None, vec=True): return UPat((Ops.CONST,Ops.VCONST) if vec else Ops.CONST, dtype, name=name)
   @staticmethod
   def const(dtype:Optional[Union[DType, tuple[DType, ...]]], b:ConstType): return UPat(Ops.CONST, dtype=dtype, arg=b)
 
@@ -845,7 +845,7 @@ class PatternMatcher:
   @functools.cache  # pylint: disable=method-cache-max-size-none
   def __add__(self, more:PatternMatcher): return PatternMatcher(self.patterns+more.patterns)
 
-  def rewrite(self, uop:UOp, ctx=None) -> UOp|None:
+  def rewrite(self, uop:UOp, ctx=None) -> UOp|None|bool|tuple|str:
     ler = {u.op for u in uop.src}
     for _,match,early_reject in self.pdict.get(uop.op, []):
       if not early_reject.issubset(ler): continue

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -112,7 +112,7 @@ class CStyleLanguage(Renderer):
     [") {\n" + tmp] + ['\n'.join(kernel), "\n}"])
     return prg if prefix is None else "\n".join(prefix)+f"\n{prg}"
 
-  def render_cast(self, dt:DType, val: str) -> str: return f"({self.render_dtype(dt)})({val})"
+  def render_cast(self, dt:DType, val: int|str) -> str: return f"({self.render_dtype(dt)})({val})"
   def render_dtype(self, dt:DType, mutable=True) -> str:
     if isinstance(dt, ImageDType): return f"{'write_only' if mutable else 'read_only'} image2d_t"
     if isinstance(dt, PtrDType):

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -44,7 +44,7 @@ class CLProgram:
     with contextlib.suppress(TypeError, AttributeError): check(cl.clReleaseKernel(self.kernel))
     with contextlib.suppress(TypeError, AttributeError): check(cl.clReleaseProgram(self.program))
 
-  def __call__(self, *bufs:tuple[ctypes._CData, BufferSpec], global_size:tuple[int,int,int]=(1,1,1), local_size:Optional[tuple[int,int,int]]=None, vals:tuple[int, ...]=(), wait=False) -> Optional[float]:  # noqa: E501
+  def __call__(self, *bufs:tuple[ctypes._SimpleCData, BufferSpec], global_size:tuple[int,int,int]=(1,1,1), local_size:Optional[tuple[int,int,int]]=None, vals:tuple[int, ...]=(), wait=False) -> Optional[float]:  # noqa: E501
     for i,(b,_) in enumerate(bufs): cl.clSetKernelArg(self.kernel, i, ctypes.sizeof(b), ctypes.byref(b))
     for i,v in enumerate(vals,start=len(bufs)): cl.clSetKernelArg(self.kernel, i, 4, ctypes.byref(ctypes.c_int32(v)))
     if local_size is not None: global_size = cast(tuple[int,int,int], tuple(int(g*l) for g,l in zip(global_size, local_size)))
@@ -62,14 +62,14 @@ class CLAllocator(LRUAllocator):
   def __init__(self, dev:CLDevice):
     self.dev = dev
     super().__init__()
-  def _alloc(self, size:int, options:BufferSpec) -> tuple[ctypes._CData, BufferSpec]:
+  def _alloc(self, size:int, options:BufferSpec) -> tuple[ctypes._Pointer, BufferSpec]:
     if options.image is not None:
       return (checked(cl.clCreateImage2D(self.dev.context, cl.CL_MEM_READ_WRITE,
                                         cl.cl_image_format(cl.CL_RGBA, {2: cl.CL_HALF_FLOAT, 4: cl.CL_FLOAT}[options.image.itemsize]),
                                         options.image.shape[1], options.image.shape[0], 0, None, status := ctypes.c_int32()), status), options)
     return (checked(cl.clCreateBuffer(self.dev.context, cl.CL_MEM_READ_WRITE, size, None, status := ctypes.c_int32()), status), options)
-  def _free(self, opaque:tuple[ctypes._CData, BufferSpec], options:BufferSpec): check(cl.clReleaseMemObject(opaque[0]))
-  def _copyin(self, dest:tuple[ctypes._CData, BufferSpec], src:memoryview):
+  def _free(self, opaque:tuple[ctypes._SimpleCData, BufferSpec], options:BufferSpec): check(cl.clReleaseMemObject(opaque[0]))
+  def _copyin(self, dest:tuple[ctypes._SimpleCData, BufferSpec], src:memoryview):
     if dest[1].image is not None:
       check(cl.clEnqueueWriteImage(self.dev.queue, dest[0], False, (ctypes.c_size_t * 3)(0,0,0),
                                    (ctypes.c_size_t * 3)(dest[1].image.shape[1],dest[1].image.shape[0],1), 0, 0, from_mv(src), 0, None, None))
@@ -77,7 +77,7 @@ class CLAllocator(LRUAllocator):
       if mv_address(src) % 16: src = memoryview(bytearray(src))
       check(cl.clEnqueueWriteBuffer(self.dev.queue, dest[0], False, 0, len(src)*src.itemsize, from_mv(src), 0, None, None))
     self.dev.pending_copyin.append(src)    # NOTE: these can't be freed until the GPU actually executes this command
-  def _copyout(self, dest:memoryview, src:tuple[ctypes._CData, BufferSpec]):
+  def _copyout(self, dest:memoryview, src:tuple[ctypes._SimpleCData, BufferSpec]):
     if src[1].image is not None:
       check(cl.clEnqueueReadImage(self.dev.queue, src[0], False, (ctypes.c_size_t * 3)(0,0,0),
                                   (ctypes.c_size_t * 3)(src[1].image.shape[1],src[1].image.shape[0],1), 0, 0, from_mv(dest), 0, None, None))

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import cast, Union
 from tinygrad.ops import PatternMatcher, UPat, GroupOp, Ops, UOp, print_uops
 from tinygrad.dtype import DType, ImageDType, dtypes, PtrDType
 from tinygrad.helpers import all_same, dedup, prod, getenv, DEBUG
@@ -168,7 +168,7 @@ shape_spec = PatternMatcher([
 
 # ***** uop helpers *****
 
-def type_verify(uops:list[UOp], *extra_specs:PatternMatcher):
+def type_verify(uops:Union[list[UOp], tuple[UOp, ...]], *extra_specs:PatternMatcher):
   specs = [spec, *extra_specs]
   for i,u in enumerate(uops):
     spec_ret = [cast(bool|None, s.rewrite(u)) for s in specs]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time, math, itertools, functools, struct, sys, inspect, pathlib, string, hashlib, weakref
 from contextlib import ContextDecorator
 from typing import Callable, ClassVar, Optional, Sequence, cast, get_args, Literal, SupportsIndex, ParamSpec, TypeVar
-from tinygrad.dtype import DType, DTypeLike, dtypes, ImageDType, ConstType, least_upper_float, least_upper_dtype, sum_acc_dtype, to_dtype, truncate
+from tinygrad.dtype import DType, DTypeLike, dtypes, ImageDType, ConstType, npArrayType, least_upper_float, least_upper_dtype, sum_acc_dtype, to_dtype, truncate
 from tinygrad.dtype import _from_np_dtype, _to_np_dtype
 from tinygrad.helpers import argfix, make_tuple, flatten, prod, all_int, round_up, merge_dicts, argsort, getenv, all_same, fully_flatten, dedup
 from tinygrad.helpers import IMAGE, WINO, _METADATA, Metadata, TRACEMETA, ceildiv, fetch, polyN, unwrap
@@ -50,7 +50,7 @@ def _metaop(op, shape:tuple[sint,...], dtype:DType, device:str|tuple[str, ...], 
   if isinstance(device, str): return UOp.metaop(op, shape, dtype, device, arg)
   return UOp.multi(*[UOp.metaop(op, shape, dtype, d, arg) for d in device], axis=None)
 
-def _fromnp(x: 'np.ndarray') -> UOp:  # type: ignore [name-defined] # noqa: F821
+def _fromnp(x: npArrayType) -> UOp:  # type: ignore [name-defined] # noqa: F821
   ret = UOp.new_buffer("NPY", x.size, _from_np_dtype(x.dtype))
   # fake realize
   ret.buffer.allocate(x)
@@ -125,7 +125,7 @@ class Tensor(SimpleMathTrait):
   training: ClassVar[bool] = False
   no_grad: ClassVar[bool] = False
 
-  def __init__(self, data:ConstType|bytes|list|tuple|UOp|'np.ndarray'|pathlib.Path|None,  # type: ignore [name-defined] # noqa: F821
+  def __init__(self, data:ConstType|bytes|list|tuple|UOp|npArrayType|pathlib.Path|None,  # type: ignore [name-defined] # noqa: F821
                device:str|tuple|list|None=None, dtype:DTypeLike|None=None, requires_grad:bool|None=None):
     if dtype is not None: dtype = to_dtype(dtype)
     if device is None and isinstance(data, pathlib.Path): device = f"DISK:{data.resolve()}"  # keep it on the disk if device is None
@@ -333,7 +333,7 @@ class Tensor(SimpleMathTrait):
     """
     return self.data().tolist()
 
-  def numpy(self) -> 'np.ndarray':  # type: ignore [name-defined] # noqa: F821
+  def numpy(self) -> npArrayType:  # type: ignore [name-defined] # noqa: F821
     """
     Returns the value of this tensor as a `numpy.ndarray`.
 


### PR DESCRIPTION
This is a work in progress that addresses #7889! I will be updating my notes below, but I wanted to document things live in case someone has thoughts. Some things I noted and would like to get feedback on:

Main: 
-  numpy types are currently handled with annotations, which I assume is done to avoid importing numpy. Runtime type checking doesn't play well with this. Potential solution: we use annotations when not type checking, otherwise use [numpy's typing module](https://numpy.org/devdocs/reference/typing.html). I think I have a gap in my understanding and may be doing something silly here.

- Some tests cannot pass with runtime type checking because they are _designed_ to have an error. (I think!) this is is a thorn for runtime type checking because we should be passing in `TypeCheckError` for the expected error, but we need to import the typeguard library for that. This was alluded to in #6520.
e.g.
```
self.helper_test_exception(None, lambda x,y: x.div(y, rounding_mode="typo"), lambda x,y: x.div(y, rounding_mode="typo"), forward_only=True, vals=[[5], [0]], expected=RuntimeError)
```
Could a potential solution be to somehow [xfail](https://docs.pytest.org/en/7.1.x/how-to/skipping.html) them when TYPED=1?

- The tests did not seem to like `ctypes._CData`. I cannot seem to import that class either, although the documentation shows that it definitely exists. I started replacing them with `_SimpleCData` and `_Pointer` and potentially others, but I'm not sold on this approach yet. I have yet to do more digging around here.

Minor: 
- Looks like the codebase is split between using `Union` and `|`; `| None` and `Optional[]`. I'm assuming there is a preference towards the modern version of doing things and maybe moving away from `typing.List` to `list`, etc, since the project expects >3.10? If there is a consensus, I can zap those as I come across them! As of now, I follow what neighboring functions are doing.
