### PR TITLE
Revert 9720 and remove symbolic dim check for ONNX

### DIFF
--- a/extra/onnx_helpers.py
+++ b/extra/onnx_helpers.py
@@ -40,7 +40,7 @@ def get_example_inputs(graph_inputs:dict[str, OnnxValue], config={}):
 
   ret: dict[str, Tensor] = {}
   for name, spec in graph_inputs.items():
-    assert not spec.is_optional, "only allow tensor input for now"
+    assert not spec.is_optional and not spec.is_sequence, "only allow tensor input for now"
     shape = _get_shape(spec.shape)
     value = _get_value(name, shape, spec.dtype)
     ret.update({name:value})

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -175,12 +175,6 @@ backend_test.exclude('test_resize_downsample_sizes_linear_antialias_cpu') # anti
 backend_test.exclude('test_ai_onnx_ml_label_encoder_tensor_value_only_mapping_cpu') # bad data type string
 backend_test.exclude('test_ai_onnx_ml_label_encoder_tensor_mapping_cpu') # bad data type string
 
-# no support for sequence
-backend_test.exclude('test_identity_opt_cpu')
-backend_test.exclude('test_identity_sequence_cpu')
-backend_test.exclude('test_optional_get_element_optional_sequence_cpu')
-backend_test.exclude('test_optional_get_element_sequence_cpu')
-
 backend_test.exclude('test_scatternd_min_cpu') # min not yet supported
 backend_test.exclude('test_scatternd_max_cpu') # max not yet supported
 


### PR DESCRIPTION
I misunderstood "A dimension variable “N” represents the same value across the entire graph in a model." to mean outputs too.

model from `HuggingFaceTB/SmolLM-135M/onnx/model.onnx` from #9785
has symbolic dim for output but has a different value than the symbolic value specified at input. (result is validated to ORT to be correct)

It appears that ORT does not check symbolic dims for both input and output.
ORT checks at runtime:
 - explicit static input shapes dims
 - input dtype
 - output dtype

after this revert and removing the symbolic dim check, we are currently only checking `static input shapes`

ORT has options ilke [add_free_dimension_override_by_denotation](https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.add_free_dimension_override_by_denotation) and [tools](https://onnxruntime.ai/docs/tutorials/mobile/helpers/make-dynamic-shape-fixed.html) to make symbolic shapes static.

I think they just leave validation out in case people want to tamper with the symbolic shapes. I think it is fine if we don't check this? And trust the user to identify the shapes and input the intended dim size for symbolic dimensions.

There are also some other peculiarities I found from ORT while running random tests for this. 
Was pretty puzzled on how to resolve this. Decided to revert.
I think moving on we try to do little hand written validation. Just let the model run with flexibility. It's a little hard to know which validation is absolutely expected and which isn't due to the lack of documentation and the ORT weirdness. 