### PR TITLE
Remote multi (graph)

### DIFF
--- a/tinygrad/runtime/graph/remote.py
+++ b/tinygrad/runtime/graph/remote.py
@@ -1,28 +1,35 @@
 from tinygrad.ops import Variable
-from tinygrad.engine.jit import GraphRunner
+from tinygrad.engine.jit import GraphRunner, MultiGraphRunner, GraphException
 from tinygrad.engine.realize import CompiledRunner, ExecItem
 from tinygrad.device import Device, Buffer
-from tinygrad.runtime.ops_remote import GraphComputeItem, GraphAlloc, GraphFree, GraphExec
+from tinygrad.runtime.ops_remote import RemoteDevice, GraphComputeItem, GraphAlloc, GraphFree, GraphExec
 from tinygrad.helpers import unwrap, flatten, dedup, all_same
+from typing import cast
 
 class RemoteGraph(GraphRunner):
   def __init__(self, jit_cache: list[ExecItem], rawbufs: list[Buffer], var_vals: dict[Variable, int]):
     super().__init__(jit_cache, rawbufs, var_vals)
     self.devices = dedup(flatten([[Device[unwrap(buf).device] for buf in ji.bufs] for ji in jit_cache]))
-    assert all_same(self.devices), self.devices
+    if not all_same([d.conn for d in self.devices]): raise GraphException(f"Cross-host remote graph is not supported ({self.devices})")
     self.iids = sorted(self.input_replace.values())
     def _process_ji(ji: ExecItem):
       assert isinstance(ji.prg, CompiledRunner), f'Only compiled runners are supported: {ji.prg}'
-      return GraphComputeItem(ji.prg._prg.name, ji.prg._prg.datahash, tuple(unwrap(buf)._buf for buf in ji.bufs), tuple(ji.prg.p.vars),
+      return GraphComputeItem(ji.prg.dev.session, ji.prg._prg.name, ji.prg._prg.datahash,
+                              tuple(unwrap(buf)._buf for buf in ji.bufs), tuple(ji.prg.p.vars), tuple(ji.prg.p.ins), tuple(ji.prg.p.outs),
                               tuple(ji.prg.p.global_size) if ji.prg.p.global_size is not None else None,
                               tuple(ji.prg.p.local_size) if ji.prg.p.local_size is not None else None)
     self.graph_num = self.devices[0].graph_num
     self.devices[0].graph_num += 1
-    self.devices[0].q(GraphAlloc(self.graph_num, tuple(_process_ji(ji) for ji in jit_cache), tuple(rawbufs[i]._buf for i in self.iids), var_vals))
+    self.devices[0].q(GraphAlloc(self.graph_num, tuple(_process_ji(ji) for ji in jit_cache), self.map_rawbufs(rawbufs), var_vals))
 
   def __del__(self):
     self.devices[0].q(GraphFree(self.graph_num))
 
+  def map_rawbufs(self, rawbufs:list[Buffer]):
+    return tuple((cast(RemoteDevice, Device[rawbufs[i].device]).session, rawbufs[i]._buf) for i in self.iids)
+
   def __call__(self, rawbufs: list[Buffer], var_vals: dict[Variable, int], wait=False):
-    self.devices[0].q(GraphExec(self.graph_num, tuple(rawbufs[i]._buf for i in self.iids), var_vals, wait))
-    if wait: return float(self.devices[0].batch_submit())
+    self.devices[0].q(GraphExec(self.graph_num, self.map_rawbufs(rawbufs), var_vals, wait))
+    if wait: return float(self.devices[0].conn.batch_submit())
+
+class RemoteMultiGraph(RemoteGraph, MultiGraphRunner): pass

--- a/tinygrad/runtime/ops_remote.py
+++ b/tinygrad/runtime/ops_remote.py
@@ -13,7 +13,7 @@ from tinygrad.renderer import Renderer, ProgramSpec
 from tinygrad.dtype import DTYPES_DICT, dtypes
 from tinygrad.ops import UOp, Ops, Variable, sint
 from tinygrad.helpers import getenv, DEBUG, fromimport, unwrap, Timing
-from tinygrad.engine.jit import GraphRunner, ExecItem, graph_class
+from tinygrad.engine.jit import GraphRunner, MultiGraphRunner, ExecItem, graph_class
 from tinygrad.engine.realize import CompiledRunner
 from tinygrad.device import Compiled, Buffer, Allocator, Compiler, Device, BufferSpec
 from tinygrad.runtime.graph.cpu import CPUGraph
@@ -28,6 +28,7 @@ class RemoteProperties:
   real_device: str
   renderer: tuple[str, str, tuple[Any, ...]]
   graph_supported: bool
+  graph_supports_multi: bool
   transfer_supported: bool
 
 @dataclass(frozen=True)
@@ -61,10 +62,13 @@ class ProgramExec(RemoteRequest):
 
 @dataclass(frozen=True)
 class GraphComputeItem:
+  session: tuple[str, int]
   name: str
   datahash: str
   bufs: tuple[int, ...]
   vars: tuple[Variable, ...]
+  ins: tuple[int, ...]
+  outs: tuple[int, ...]
   global_size: tuple[sint, ...]|None
   local_size: tuple[sint, ...]|None
 
@@ -72,7 +76,7 @@ class GraphComputeItem:
 class GraphAlloc(RemoteRequest):
   graph_num: int
   jit_cache: tuple[GraphComputeItem, ...]
-  bufs: tuple[int, ...]
+  bufs: tuple[tuple[tuple[str, int], int], ...]
   var_vals: dict[Variable, int]
 
 @dataclass(frozen=True)
@@ -82,7 +86,7 @@ class GraphFree(RemoteRequest):
 @dataclass(frozen=True)
 class GraphExec(RemoteRequest):
   graph_num: int
-  bufs: tuple[int, ...]
+  bufs: tuple[tuple[tuple[str, int], int], ...]
   var_vals: dict[Variable, int]
   wait: bool
 
@@ -158,7 +162,11 @@ class RemoteHandler:
             cls, args = dev.renderer.__reduce__()
             # CPUGraph re-renders kernel from uops specified in CompiledRunner, this is not supported
             graph_cls = gt if (gt:=graph_class(Device[self.base_device])) is not CPUGraph else None
-            rp = RemoteProperties(dev.device, (cls.__module__, cls.__name__, args), graph_cls is not None, hasattr(dev.allocator, '_transfer'))
+            rp = RemoteProperties(
+              real_device=dev.device, renderer=(cls.__module__, cls.__name__, args),
+              graph_supported=graph_cls is not None, graph_supports_multi=graph_cls is not None and issubclass(graph_cls, MultiGraphRunner),
+              transfer_supported=hasattr(dev.allocator, '_transfer'),
+            )
             ret = repr(rp).encode()
           case BufferAlloc():
             assert c.buffer_num not in session.buffers, f"buffer {c.buffer_num} already allocated"
@@ -184,16 +192,17 @@ class RemoteHandler:
           case GraphAlloc():
             graph_fn: Callable = unwrap(dev.graph)
             def _parse_ji(gi: GraphComputeItem):
-              prg = session.programs[(gi.name, gi.datahash)]
-              ps = ProgramSpec(gi.name, '', dev.device, UOp(Ops.NOOP), vars=list(gi.vars),
+              prg = self.sessions[gi.session].programs[(gi.name, gi.datahash)]
+              ps = ProgramSpec(gi.name, '', f"{self.base_device}:{gi.session[1]}", UOp(Ops.NOOP),
+                               vars=list(gi.vars), ins=list(gi.ins), outs=list(gi.outs),
                                global_size=list(cast(tuple[int], gi.global_size)) if gi.global_size is not None else None,
                                local_size=list(cast(tuple[int], gi.local_size)) if gi.local_size is not None else None)
-              return ExecItem(CompiledRunner(ps, precompiled=b'', prg=prg), [session.buffers[buf] for buf in gi.bufs])
+              return ExecItem(CompiledRunner(ps, precompiled=b'', prg=prg), [self.sessions[gi.session].buffers[buf] for buf in gi.bufs])
             assert c.graph_num not in session.graphs, f"graph {c.graph_num} already allocated"
-            session.graphs[c.graph_num] = graph_fn(list(map(_parse_ji, c.jit_cache)), [session.buffers[buf] for buf in c.bufs], c.var_vals)
+            session.graphs[c.graph_num] = graph_fn(list(map(_parse_ji, c.jit_cache)), [self.sessions[s].buffers[i] for s,i in c.bufs], c.var_vals)
           case GraphFree(): del session.graphs[c.graph_num]
           case GraphExec():
-            r = session.graphs[c.graph_num]([session.buffers[buf] for buf in c.bufs], c.var_vals, wait=c.wait)
+            r = session.graphs[c.graph_num]([self.sessions[s].buffers[i] for s,i in c.bufs], c.var_vals, wait=c.wait)
             if r is not None: ret = str(r).encode()
     else: status, ret = http.HTTPStatus.NOT_FOUND, b"Not Found"
     return status, ret
@@ -281,7 +290,8 @@ class RemoteDevice(Compiled):
     if not renderer[0].startswith("tinygrad.renderer.") or not renderer[1].endswith("Renderer"): raise RuntimeError(f"bad renderer {renderer}")
     renderer_class = fromimport(renderer[0], renderer[1])  # TODO: is this secure?
     if not issubclass(renderer_class, Renderer): raise RuntimeError(f"renderer isn't a Renderer {renderer}")
-    graph = fromimport('tinygrad.runtime.graph.remote', 'RemoteGraph') if self.properties.graph_supported else None
+    graph_supported, graph_multi = self.properties.graph_supported, self.properties.graph_supports_multi
+    graph = fromimport('tinygrad.runtime.graph.remote', f"Remote{'Multi' if graph_multi else ''}Graph") if graph_supported else None
     super().__init__(device, RemoteAllocator(self), renderer_class(*renderer[2]), Compiler(), functools.partial(RemoteProgram, self), graph)
 
   def __del__(self):


### PR DESCRIPTION
```
    3 1183.79 ms run,   26.31 ms python,   0.47 ms fetch data, 1157.01 ms AMD * 6,  0.69 loss, 0.000175 LR, 134.22 GB used,  92125.82 GFLOPS
    4 1179.94 ms run,   23.27 ms python,   0.44 ms fetch data, 1156.23 ms AMD * 6,  0.69 loss, 0.000175 LR, 134.22 GB used,  92426.82 GFLOPS
    5 1181.35 ms run,   23.33 ms python,   0.46 ms fetch data, 1157.56 ms AMD * 6,  0.69 loss, 0.000175 LR, 134.22 GB used,  92316.49 GFLOPS
    6 1176.95 ms run,   23.15 ms python,   0.45 ms fetch data, 1153.34 ms AMD * 6,  0.69 loss, 0.000175 LR, 134.22 GB used,  92661.54 GFLOPS
```

```
    3 1180.47 ms run,    5.21 ms python,   0.33 ms fetch data, 1174.92 ms REMOTE * 6,  0.69 loss, 0.000175 LR, 137.38 GB used,  92385.46 GFLOPS
    4 1191.75 ms run,    8.59 ms python,   0.54 ms fetch data, 1182.62 ms REMOTE * 6,  0.69 loss, 0.000175 LR, 137.38 GB used,  91510.34 GFLOPS
    5 1197.44 ms run,   11.65 ms python,   0.72 ms fetch data, 1185.07 ms REMOTE * 6,  0.69 loss, 0.000175 LR, 137.38 GB used,  91075.74 GFLOPS
    6 1195.43 ms run,   11.41 ms python,   0.72 ms fetch data, 1183.30 ms REMOTE * 6,  0.69 loss, 0.000175 LR, 137.38 GB used,  91229.02 GFLOPS
```

