### PR TITLE
Revert "ONNX add output shape validation (#9720)"

### DIFF
--- a/extra/onnx_helpers.py
+++ b/extra/onnx_helpers.py
@@ -40,7 +40,7 @@ def get_example_inputs(graph_inputs:dict[str, OnnxValue], config={}):
 
   ret: dict[str, Tensor] = {}
   for name, spec in graph_inputs.items():
-    assert not spec.is_optional, "only allow tensor input for now"
+    assert not spec.is_optional and not spec.is_sequence, "only allow tensor input for now"
     shape = _get_shape(spec.shape)
     value = _get_value(name, shape, spec.dtype)
     ret.update({name:value})

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -175,12 +175,6 @@ backend_test.exclude('test_resize_downsample_sizes_linear_antialias_cpu') # anti
 backend_test.exclude('test_ai_onnx_ml_label_encoder_tensor_value_only_mapping_cpu') # bad data type string
 backend_test.exclude('test_ai_onnx_ml_label_encoder_tensor_mapping_cpu') # bad data type string
 
-# no support for sequence
-backend_test.exclude('test_identity_opt_cpu')
-backend_test.exclude('test_identity_sequence_cpu')
-backend_test.exclude('test_optional_get_element_optional_sequence_cpu')
-backend_test.exclude('test_optional_get_element_sequence_cpu')
-
 backend_test.exclude('test_scatternd_min_cpu') # min not yet supported
 backend_test.exclude('test_scatternd_max_cpu') # max not yet supported
 


### PR DESCRIPTION
This reverts commit ac713e04db4e7989740674ab52e00dbc745793fe.

This broke model from `HuggingFaceTB/SmolLM-135M/onnx/model.onnx` from #9785
That model has symbolic dim for output but has a different value than the symbolic value specified at input. (result is validated to ORT to be correct however)

I think moving on we try to do little hand written validation. Just let the model run with flexibility. 