### PR TITLE
ensure edge labels are always on top

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -191,6 +191,7 @@
       <svg id="graph-svg" preserveAspectRatio="xMidYMid meet">
         <g id="render">
           <g id="edges"></g>
+          <g id="edge-labels"></g> <!-- NOTE: this ensures edge labels are always on top -->
           <g id="nodes"></g>
           <g id="bars"></g>
         </g>

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -54,7 +54,7 @@ async function renderDag(graph, additions, recenter=false) {
       points.push(intersectRect(g.node(e.w), points[points.length-1]));
       return line(points);
     }).attr("marker-end", "url(#arrowhead)");
-    const edgeLabels = d3.select("#edges").selectAll("g").data(g.edges().filter(e => g.edge(e).label != null)).join("g").attr("transform", (e) => {
+    const edgeLabels = d3.select("#edge-labels").selectAll("g").data(g.edges().filter(e => g.edge(e).label != null)).join("g").attr("transform", (e) => {
       // get a point near the end
       const [p1, p2] = g.edge(e).points.slice(-2);
       const dx = p2.x-p1.x;


### PR DESCRIPTION
Rendering in DOM insertion order.
The labels would go below the edge paths once D3 re-rendered the edges: (eg, if you step forward, then walk back the rewrites)
![image](https://github.com/user-attachments/assets/11526581-5366-4974-b76b-9ba5877ccc40)

Now it's always in a separate group above the edges:
![image](https://github.com/user-attachments/assets/2cbb91ef-c1e0-4fae-bf73-dd7528073431)
