### PR TITLE
[Bounty] Add guide for using tinygrad backend with pytorch-cifar10

### DIFF
--- a/docs/cifar10_torch_tiny_backend.md
+++ b/docs/cifar10_torch_tiny_backend.md
@@ -1,0 +1,96 @@
+# How to Use `tinygrad` as a Backend for `pytorch-cifar` Training
+
+This guide explains how to configure and run the `pytorch-cifar` training example using `tinygrad` as the backend, after installing `tinygrad`.
+
+## 1. Clone the Repository
+
+First, clone the `pytorch-cifar` repository:
+
+```shell
+git clone https://github.com/kuangliu/pytorch-cifar.git
+cd pytorch-cifar # Navigate into the directory
+```
+
+## 2. Modify `main.py`
+
+Next, modify the `main.py` file within the cloned repository to enable the `tinygrad` backend. Apply the following changes:
+
+```diff
+ import torch.optim as optim
+ import torch.nn.functional as F
+ import torch.backends.cudnn as cudnn
++from tinygrad import getenv
+
+ import torchvision
+ import torchvision.transforms as transforms
+@@ -21,7 +22,12 @@ parser.add_argument('--resume', '-r', action='store_true',
+                     help='resume from checkpoint')
+ args = parser.parse_args()
+
+-device = 'cuda' if torch.cuda.is_available() else 'cpu'
++if getenv("TINY_BACKEND"):
++    # Import the tinygrad frontend for torch
++    import tinygrad.frontend.torch
++    # Set the device to "tiny" to use the tinygrad backend
++    device = torch.device("tiny")
++else:
++    device = 'cuda' if torch.cuda.is_available() else 'cpu'
++
+ best_acc = 0  # best test accuracy
+ start_epoch = 0  # start from epoch 0 or last checkpoint epoch
+
+@@ -55,7 +61,8 @@ classes = ('plane', 'car', 'bird', 'cat', 'deer',
+ # Model
+ print('==> Building model..')
+ # net = VGG('VGG19')
+-# net = ResNet18()
++# Use ResNet18 for this example
++net = ResNet18()
+ # net = PreActResNet18()
+ # net = GoogLeNet()
+ # net = DenseNet121()
+@@ -68,7 +75,7 @@ print('==> Building model..')
+ # net = ShuffleNetV2(1)
+ # net = EfficientNetB0()
+ # net = RegNetX_200MF()
+-net = SimpleDLA()
++# net = SimpleDLA() # Comment out SimpleDLA if you uncommented ResNet18
+ net = net.to(device)
+ if device == 'cuda':
+     net = torch.nn.DataParallel(net)
+```
+
+**Note:** This diff enables `ResNet18`. Ensure other models like `SimpleDLA` are commented out.
+
+## 3. Run the Training
+
+Execute the training script using the following command. Make sure to replace `path-to-tinygrad` with the actual path to your `tinygrad` installation if it's not in the standard Python path.
+
+```shell
+PYTHONPATH=path-to-tinygrad TINY_BACKEND=1 python3 main.py
+```
+
+## 4. Expected Output
+
+You should observe output similar to the following, indicating the training progress with the `tinygrad` backend:
+
+```text
+==> Preparing data..
+==> Building model..
+
+Epoch: 0
+/workspace/.python/tinygrad/lib/python3.10/site-packages/torch/nn/modules/module.py:1830: FutureWarning: Using a non-full backward hook when the forward contains multiple autograd Nodes is deprecated and will be removed in future versions. This hook will be missing some grad_input. Please use register_full_backward_hook to get the documented behavior.
+  self._maybe_warn_non_full_backward_hook(args, result, grad_fn)
+ [=========================== 391/391 ============================>]  Step: 20s974ms | Tot: 9m27s | Loss: 1.990 | Acc: 29.360% (14680/50000)
+ [=========================== 100/100 ============================>]  Step: 204ms | Tot: 20s660ms | Loss: 1.688 | Acc: 40.040% (4004/10000)
+Saving..
+
+Epoch: 1
+ [=========================== 391/391 ============================>]  Step: 1s298ms | Tot: 9m17s | Loss: 1.483 | Acc: 45.402% (22701/50000)
+ [=========================== 100/100 ============================>]  Step: 209ms | Tot: 21s330ms | Loss: 1.289 | Acc: 52.780% (5278/10000)
+Saving..
+...
+```
+```
+
+This revised version uses headings (`##`) to structure the steps, specifies the language for code blocks (`shell`, `diff`, `text`), adds a `cd` command after cloning, and includes minor clarifications.


### PR DESCRIPTION
This PR modifies the CIFAR-10 training script to allow using `tinygrad` as a backend.

**Changes:**
*   Added necessary imports and logic to switch to the `tinygrad` backend.

**Results:**
The script runs successfully using `tinygrad`.

*   Standard Output:

<img width="1146" alt="image" src="https://github.com/user-attachments/assets/cd77cc32-0b96-4026-873a-b74ad4356083" />

*   Debug Output (`DEBUG=2`): Shows detailed `tinygrad` operations

```
==> Preparing data..
==> Building model..
opened device CUDA from pid:1481353
opened device NPY from pid:1481353

Epoch: 0
*** CUDA       1 copy    1.57M,    CUDA <- NPY             arg  2 mem  0.05 GB tm   6749.19us/     6.75ms (     0.00 GFLOPS    0.2|0.2     GB/s) 
*** CUDA       2 copy     6912,    CUDA <- NPY             arg  2 mem  0.05 GB tm    138.67us/     6.89ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA       3 r_128_16_2_16_8_3_4_4_3_3                 arg  3 mem  0.08 GB tm    123.78us/     7.01ms (  3659.71 GFLOPS  283.9|3015.9  GB/s) ['conv2d']
*** CUDA       4 r_8_8_8_16_256_4                          arg  2 mem  0.08 GB tm     53.38us/     7.07ms (   157.16 GFLOPS  629.3|629.3   GB/s) 
*** CUDA       5 copy      256,    CUDA <- NPY             arg  2 mem  0.08 GB tm    107.00us/     7.17ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA       6 copy      256,    CUDA <- NPY             arg  2 mem  0.08 GB tm     31.72us/     7.20ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA       7 copy   147456,    CUDA <- NPY             arg  2 mem  0.08 GB tm    103.53us/     7.31ms (     0.00 GFLOPS    1.4|1.4     GB/s) 
*** CUDA       8 r_64_16_8                                 arg  2 mem  0.08 GB tm     17.02us/     7.32ms (     1.50 GFLOPS    1.9|6.3     GB/s) ['var_mean']
*** CUDA       9 r_8_2_8_16_256_4_4                        arg  3 mem  0.08 GB tm     93.79us/     7.42ms (   268.32 GFLOPS  358.1|358.2   GB/s) ['var_mean', '__sub__', 'realize']
*** CUDA      10 r_64_16_8n1                               arg  2 mem  0.08 GB tm     22.82us/     7.44ms (     1.26 GFLOPS    1.4|4.7     GB/s) ['rsqrt', '__add__', 'var_mean']
*** CUDA      11 E_128_8_16_8_16_4                         arg  6 mem  0.11 GB tm     49.25us/     7.49ms (  1022.00 GFLOPS 1362.7|2044.0  GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA      12 r_128_16_2_16_8_64_4_4_3_3                arg  3 mem  0.15 GB tm   1650.50us/     9.14ms (  5855.01 GFLOPS   40.7|4411.6  GB/s) ['conv2d']
*** CUDA      13 r_8_8_8_16_256_4                          arg  2 mem  0.15 GB tm     59.04us/     9.20ms (   142.08 GFLOPS  568.9|568.9   GB/s) 
*** CUDA      14 copy      256,    CUDA <- NPY             arg  2 mem  0.15 GB tm     53.58us/     9.25ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      15 copy      256,    CUDA <- NPY             arg  2 mem  0.15 GB tm     28.71us/     9.28ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      16 copy   147456,    CUDA <- NPY             arg  2 mem  0.15 GB tm     62.92us/     9.34ms (     0.00 GFLOPS    2.3|2.3     GB/s) 
*** CUDA      17 r_64_16_8                                 arg  2 mem  0.15 GB tm     16.06us/     9.36ms (     1.59 GFLOPS    2.1|6.6     GB/s) ['var_mean']
*** CUDA      18 r_8_2_8_16_256_4_4                        arg  3 mem  0.15 GB tm     93.15us/     9.45ms (   270.16 GFLOPS  360.6|360.7   GB/s) ['var_mean', '__sub__', 'realize']
*** CUDA      19 r_64_16_8n1                               arg  2 mem  0.15 GB tm      8.38us/     9.46ms (     3.42 GFLOPS    3.9|12.7    GB/s) ['rsqrt', '__add__', 'var_mean']
*** CUDA      20 E_128_8_16_8_16_4                         arg  6 mem  0.18 GB tm     42.98us/     9.51ms (  1171.16 GFLOPS 1561.6|2342.3  GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA      21 r_128_16_2_16_8_64_4_4_3_3                arg  3 mem  0.21 GB tm   1642.69us/    11.15ms (  5882.84 GFLOPS   40.9|4432.6  GB/s) ['conv2d']
/workspace/.python/tinygrad/lib/python3.10/site-packages/torch/nn/modules/module.py:1830: FutureWarning: Using a non-full backward hook when the forward contains multiple autograd Nodes is deprecated and will be removed in future versions. This hook will be missing some grad_input. Please use register_full_backward_hook to get the documented behavior.
  self._maybe_warn_non_full_backward_hook(args, result, grad_fn)
*** CUDA      22 r_8_8_8_16_256_4                          arg  2 mem  0.21 GB tm     59.33us/    11.21ms (   141.39 GFLOPS  566.1|566.1   GB/s) 
*** CUDA      23 copy      256,    CUDA <- NPY             arg  2 mem  0.21 GB tm     53.29us/    11.26ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      24 copy      256,    CUDA <- NPY             arg  2 mem  0.21 GB tm     27.99us/    11.29ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      25 copy   147456,    CUDA <- NPY             arg  2 mem  0.21 GB tm     59.95us/    11.35ms (     0.00 GFLOPS    2.5|2.5     GB/s) 
*** CUDA      26 r_64_16_8                                 arg  2 mem  0.21 GB tm     14.82us/    11.36ms (     1.73 GFLOPS    2.2|7.2     GB/s) ['var_mean']
*** CUDA      27 r_8_2_8_16_256_4_4                        arg  3 mem  0.21 GB tm     91.33us/    11.45ms (   275.55 GFLOPS  367.8|367.9   GB/s) ['var_mean', '__sub__', 'realize']
*** CUDA      28 r_64_16_8n1                               arg  2 mem  0.21 GB tm      8.22us/    11.46ms (     3.49 GFLOPS    4.0|12.9    GB/s) ['rsqrt', '__add__', 'var_mean']
*** CUDA      29 E_128_8_16_8_16_4n1                       arg  7 mem  0.25 GB tm     63.23us/    11.53ms (   928.65 GFLOPS 1592.0|2122.6  GB/s) ['relu', '__add__', 'realize', '__mul__', '__sub__']
*** CUDA      30 r_128_16_2_16_8_64_4_4_3_3                arg  3 mem  0.28 GB tm   1647.81us/    13.17ms (  5864.56 GFLOPS   40.8|4418.8  GB/s) ['conv2d']
*** CUDA      31 r_8_8_8_16_256_4                          arg  2 mem  0.28 GB tm     58.02us/    13.23ms (   144.59 GFLOPS  578.9|578.9   GB/s) 
*** CUDA      32 copy      256,    CUDA <- NPY             arg  2 mem  0.28 GB tm     52.91us/    13.29ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      33 copy      256,    CUDA <- NPY             arg  2 mem  0.28 GB tm     31.30us/    13.32ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      34 copy   147456,    CUDA <- NPY             arg  2 mem  0.28 GB tm     63.64us/    13.38ms (     0.00 GFLOPS    2.3|2.3     GB/s) 
*** CUDA      35 r_64_16_8                                 arg  2 mem  0.28 GB tm     18.24us/    13.40ms (     1.40 GFLOPS    1.8|5.8     GB/s) ['var_mean']
*** CUDA      36 r_8_2_8_16_256_4_4                        arg  3 mem  0.28 GB tm     92.93us/    13.49ms (   270.81 GFLOPS  361.4|361.5   GB/s) ['var_mean', '__sub__', 'realize']
*** CUDA      37 r_64_16_8n1                               arg  2 mem  0.28 GB tm      9.57us/    13.50ms (     3.00 GFLOPS    3.5|11.1    GB/s) ['rsqrt', '__add__', 'var_mean']
*** CUDA      38 E_128_8_16_8_16_4                         arg  6 mem  0.31 GB tm     43.04us/    13.54ms (  1169.42 GFLOPS 1559.2|2338.8  GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA      39 r_128_16_2_16_8_64_4_4_3_3                arg  3 mem  0.35 GB tm   1642.14us/    15.19ms (  5884.79 GFLOPS   41.0|4434.0  GB/s) ['conv2d']
*** CUDA      40 r_8_8_8_16_256_4                          arg  2 mem  0.35 GB tm     59.49us/    15.25ms (   141.01 GFLOPS  564.6|564.6   GB/s) 
*** CUDA      41 copy      256,    CUDA <- NPY             arg  2 mem  0.35 GB tm     53.14us/    15.30ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      42 copy      256,    CUDA <- NPY             arg  2 mem  0.35 GB tm     30.56us/    15.33ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      43 copy   294912,    CUDA <- NPY             arg  2 mem  0.35 GB tm    148.70us/    15.48ms (     0.00 GFLOPS    2.0|2.0     GB/s) 
*** CUDA      44 r_64_16_8                                 arg  2 mem  0.35 GB tm     15.04us/    15.49ms (     1.70 GFLOPS    2.2|7.1     GB/s) ['var_mean']
*** CUDA      45 r_8_2_8_16_256_4_4                        arg  3 mem  0.35 GB tm     93.89us/    15.59ms (   268.04 GFLOPS  357.7|357.8   GB/s) ['var_mean', '__sub__', 'realize']
*** CUDA      46 r_64_16_8n1                               arg  2 mem  0.35 GB tm      9.31us/    15.60ms (     3.08 GFLOPS    3.5|11.4    GB/s) ['rsqrt', '__add__', 'var_mean']
*** CUDA      47 E_128_8_16_8_16_4n1                       arg  7 mem  0.38 GB tm     55.97us/    15.65ms (  1049.18 GFLOPS 1798.6|2398.1  GB/s) ['relu', '__add__', 'realize', '__mul__', '__sub__']
*** CUDA      48 r_128_16_2_16_4_64_4_4_3_3                arg  3 mem  0.40 GB tm    745.98us/    16.40ms (  6477.13 GFLOPS   67.9|5690.0  GB/s) ['conv2d']
*** CUDA      49 r_16_8_8_16_64_4                          arg  2 mem  0.40 GB tm     25.44us/    16.42ms (   164.87 GFLOPS  662.1|662.1   GB/s) 
*** CUDA      50 copy      512,    CUDA <- NPY             arg  2 mem  0.40 GB tm    105.94us/    16.53ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      51 copy      512,    CUDA <- NPY             arg  2 mem  0.40 GB tm     32.13us/    16.56ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      52 copy   589824,    CUDA <- NPY             arg  2 mem  0.40 GB tm   1071.73us/    17.63ms (     0.00 GFLOPS    0.6|0.6     GB/s) 
*** CUDA      53 r_128_16_8                                arg  2 mem  0.40 GB tm     17.50us/    17.65ms (     2.93 GFLOPS    3.8|12.2    GB/s) ['var_mean']
*** CUDA      54 r_16_2_8_16_64_4_4                        arg  3 mem  0.40 GB tm     36.61us/    17.69ms (   343.72 GFLOPS  460.1|460.5   GB/s) ['var_mean', '__sub__', 'realize']
*** CUDA      55 r_128_16_8n1                              arg  2 mem  0.40 GB tm     16.64us/    17.70ms (     3.45 GFLOPS    4.0|12.8    GB/s) ['rsqrt', '__add__', 'var_mean']
*** CUDA      56 E_128_16_4_8_16_4                         arg  6 mem  0.42 GB tm     33.02us/    17.74ms (   762.05 GFLOPS 1016.1|1524.1  GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA      57 r_128_16_2_16_4_128_4_4_3_3               arg  3 mem  0.43 GB tm   1034.40us/    18.77ms (  9342.30 GFLOPS   33.0|7022.9  GB/s) ['conv2d']
*** CUDA      58 copy    32768,    CUDA <- NPY             arg  2 mem  0.43 GB tm    138.17us/    18.91ms (     0.00 GFLOPS    0.2|0.2     GB/s) 
*** CUDA      59 r_128_16_2_16_4_16_4_4_4                  arg  3 mem  0.45 GB tm    284.38us/    19.19ms (  1887.84 GFLOPS  177.1|1946.8  GB/s) ['conv2d']
scheduled 15 kernels
*** CUDA      60 r_16_8_8_16_64_4                          arg  2 mem  0.45 GB tm     31.30us/    19.23ms (   134.02 GFLOPS  538.2|538.2   GB/s) 
*** CUDA      61 copy      512,    CUDA <- NPY             arg  2 mem  0.45 GB tm     55.86us/    19.28ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      62 copy      512,    CUDA <- NPY             arg  2 mem  0.45 GB tm     29.72us/    19.31ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      63 r_16_8_8_16_64_4                          arg  2 mem  0.45 GB tm     22.82us/    19.33ms (   183.83 GFLOPS  738.2|738.2   GB/s) 
*** CUDA      64 copy      512,    CUDA <- NPY             arg  2 mem  0.45 GB tm     28.90us/    19.36ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      65 copy      512,    CUDA <- NPY             arg  2 mem  0.45 GB tm     24.52us/    19.39ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      66 copy   589824,    CUDA <- NPY             arg  2 mem  0.45 GB tm    129.54us/    19.52ms (     0.00 GFLOPS    4.6|4.6     GB/s) 
*** CUDA      67 r_128_16_8                                arg  2 mem  0.45 GB tm     14.14us/    19.53ms (     3.62 GFLOPS    4.7|15.1    GB/s) ['var_mean']
*** CUDA      68 r_128_16_8                                arg  2 mem  0.45 GB tm      9.57us/    19.54ms (     5.35 GFLOPS    6.9|22.3    GB/s) ['var_mean']
*** CUDA      69 r_16_2_8_16_64_4_4                        arg  3 mem  0.45 GB tm     30.14us/    19.57ms (   417.43 GFLOPS  558.8|559.3   GB/s) ['var_mean', '__sub__', 'realize']
*** CUDA      70 r_16_2_8_16_64_4_4                        arg  3 mem  0.45 GB tm     29.12us/    19.60ms (   432.11 GFLOPS  578.4|579.0   GB/s) ['var_mean', '__sub__', 'realize']
*** CUDA      71 r_128_16_8n1                              arg  2 mem  0.45 GB tm      7.94us/    19.61ms (     7.23 GFLOPS    8.3|26.8    GB/s) ['rsqrt', '__add__', 'var_mean']
*** CUDA      72 r_128_16_8n1                              arg  2 mem  0.45 GB tm      8.61us/    19.62ms (     6.66 GFLOPS    7.7|24.7    GB/s) ['rsqrt', '__add__', 'var_mean']
*** CUDA      73 E_128_16_4_8_16_4n1                       arg 11 mem  0.47 GB tm     41.79us/    19.66ms (  1103.98 GFLOPS 1204.4|2007.2  GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA      74 r_128_16_2_16_4_128_4_4_3_3               arg  3 mem  0.48 GB tm   1024.29us/    20.68ms (  9434.53 GFLOPS   33.3|7092.3  GB/s) ['conv2d']
*** CUDA      75 r_16_8_8_16_64_4                          arg  2 mem  0.48 GB tm     29.82us/    20.71ms (   140.64 GFLOPS  564.7|564.7   GB/s) 
*** CUDA      76 copy      512,    CUDA <- NPY             arg  2 mem  0.48 GB tm     54.48us/    20.77ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      77 copy      512,    CUDA <- NPY             arg  2 mem  0.48 GB tm     31.34us/    20.80ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      78 copy   589824,    CUDA <- NPY             arg  2 mem  0.48 GB tm    128.93us/    20.93ms (     0.00 GFLOPS    4.6|4.6     GB/s) 
*** CUDA      79 r_128_16_8                                arg  2 mem  0.48 GB tm     17.57us/    20.94ms (     2.91 GFLOPS    3.8|12.1    GB/s) ['var_mean']
*** CUDA      80 r_16_2_8_16_64_4_4                        arg  3 mem  0.48 GB tm     28.13us/    20.97ms (   447.34 GFLOPS  598.8|599.4   GB/s) ['var_mean', '__sub__', 'realize']
*** CUDA      81 r_128_16_8n1                              arg  2 mem  0.48 GB tm     10.11us/    20.98ms (     5.67 GFLOPS    6.5|21.1    GB/s) ['rsqrt', '__add__', 'var_mean']
*** CUDA      82 E_128_16_4_8_16_4                         arg  6 mem  0.50 GB tm     25.82us/    21.01ms (   974.51 GFLOPS 1299.4|1949.0  GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA      83 r_128_16_2_16_4_128_4_4_3_3               arg  3 mem  0.52 GB tm   1026.72us/    22.04ms (  9412.18 GFLOPS   33.3|7075.5  GB/s) ['conv2d']
*** CUDA      84 r_16_8_8_16_64_4                          arg  2 mem  0.52 GB tm     27.04us/    22.06ms (   155.11 GFLOPS  622.9|622.9   GB/s) 
*** CUDA      85 copy      512,    CUDA <- NPY             arg  2 mem  0.52 GB tm     53.55us/    22.12ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      86 copy      512,    CUDA <- NPY             arg  2 mem  0.52 GB tm     30.13us/    22.15ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      87 copy    1.18M,    CUDA <- NPY             arg  2 mem  0.52 GB tm    277.25us/    22.42ms (     0.00 GFLOPS    4.3|4.3     GB/s) 
*** CUDA      88 r_128_16_8                                arg  2 mem  0.52 GB tm     17.22us/    22.44ms (     2.97 GFLOPS    3.8|12.4    GB/s) ['var_mean']
*** CUDA      89 r_16_2_8_16_64_4_4                        arg  3 mem  0.52 GB tm     28.26us/    22.47ms (   445.32 GFLOPS  596.1|596.7   GB/s) ['var_mean', '__sub__', 'realize']
*** CUDA      90 r_128_16_8n1                              arg  2 mem  0.52 GB tm      8.90us/    22.48ms (     6.45 GFLOPS    7.4|23.9    GB/s) ['rsqrt', '__add__', 'var_mean']
*** CUDA      91 E_128_16_4_8_16_4n2                       arg  7 mem  0.53 GB tm     39.97us/    22.52ms (   734.59 GFLOPS 1259.3|1679.1  GB/s) ['relu', '__add__', 'realize', '__mul__', '__sub__']
*** CUDA      92 r_128_8_8_8_2_128_4_4_3_3                 arg  3 mem  0.54 GB tm   1183.10us/    23.70ms (  4084.03 GFLOPS   22.3|3580.6  GB/s) ['conv2d']
*** CUDA      93 r_256_16_8_64                             arg  2 mem  0.54 GB tm     33.57us/    23.73ms (    64.55 GFLOPS  249.9|258.7   GB/s) ['var_mean', 'realize']
*** CUDA      94 copy     1024,    CUDA <- NPY             arg  2 mem  0.54 GB tm    104.50us/    23.84ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      95 copy     1024,    CUDA <- NPY             arg  2 mem  0.54 GB tm     32.61us/    23.87ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA      96 copy    2.36M,    CUDA <- NPY             arg  2 mem  0.54 GB tm   1363.93us/    25.24ms (     0.00 GFLOPS    1.7|1.7     GB/s) 
*** CUDA      97 r_256_16_8_64n1                           arg  3 mem  0.54 GB tm     33.79us/    25.27ms (   188.61 GFLOPS  248.3|257.5   GB/s) ['rsqrt', '__add__', 'var_mean', '__sub__', 'realize']
*** CUDA      98 E_128_32_8_16_4                           arg  6 mem  0.55 GB tm     50.24us/    25.32ms (   250.46 GFLOPS  334.0|500.9   GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA      99 r_128_8_8_8_2_256_4_4_3_3                 arg  3 mem  0.56 GB tm   2249.76us/    27.57ms (  4295.43 GFLOPS    8.5|3225.3  GB/s) ['conv2d']
*** CUDA     100 copy   131072,    CUDA <- NPY             arg  2 mem  0.56 GB tm    167.40us/    27.74ms (     0.00 GFLOPS    0.8|0.8     GB/s) 
*** CUDA     101 r_128_8_8_8_2_32_4_4_4                    arg  3 mem  0.57 GB tm    197.28us/    27.93ms (  2721.37 GFLOPS  128.2|2763.9  GB/s) ['conv2d']
scheduled 11 kernels
*** CUDA     102 r_256_16_8_64                             arg  2 mem  0.57 GB tm     36.51us/    27.97ms (    59.34 GFLOPS  229.8|237.8   GB/s) ['var_mean', 'realize']
*** CUDA     103 copy     1024,    CUDA <- NPY             arg  2 mem  0.57 GB tm     57.04us/    28.03ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     104 copy     1024,    CUDA <- NPY             arg  2 mem  0.57 GB tm     30.80us/    28.06ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     105 r_256_16_8_64                             arg  2 mem  0.57 GB tm     29.41us/    28.09ms (    73.68 GFLOPS  285.3|295.3   GB/s) ['var_mean', 'realize']
*** CUDA     106 copy     1024,    CUDA <- NPY             arg  2 mem  0.57 GB tm     29.46us/    28.12ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     107 copy     1024,    CUDA <- NPY             arg  2 mem  0.57 GB tm     25.57us/    28.14ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     108 copy    2.36M,    CUDA <- NPY             arg  2 mem  0.57 GB tm    313.48us/    28.46ms (     0.00 GFLOPS    7.5|7.5     GB/s) 
*** CUDA     109 r_256_16_8_64n1                           arg  3 mem  0.57 GB tm     33.95us/    28.49ms (   187.72 GFLOPS  247.1|256.2   GB/s) ['rsqrt', '__add__', 'var_mean', '__sub__', 'realize']
*** CUDA     110 r_256_16_8_64n1                           arg  3 mem  0.57 GB tm     25.95us/    28.52ms (   245.58 GFLOPS  323.3|335.2   GB/s) ['rsqrt', '__add__', 'var_mean', '__sub__', 'realize']
*** CUDA     111 E_128_32_8_16_4n1                         arg 11 mem  0.57 GB tm     36.83us/    28.55ms (   626.32 GFLOPS  683.5|1138.8  GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA     112 r_128_8_8_8_2_256_4_4_3_3                 arg  3 mem  0.58 GB tm   2243.68us/    30.80ms (  4307.07 GFLOPS    8.5|3234.0  GB/s) ['conv2d']
*** CUDA     113 r_256_16_8_64                             arg  2 mem  0.58 GB tm     35.42us/    30.83ms (    61.17 GFLOPS  236.8|245.1   GB/s) ['var_mean', 'realize']
*** CUDA     114 copy     1024,    CUDA <- NPY             arg  2 mem  0.58 GB tm     55.77us/    30.89ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     115 copy     1024,    CUDA <- NPY             arg  2 mem  0.58 GB tm     30.89us/    30.92ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     116 copy    2.36M,    CUDA <- NPY             arg  2 mem  0.59 GB tm    321.40us/    31.24ms (     0.00 GFLOPS    7.3|7.3     GB/s) 
*** CUDA     117 r_256_16_8_64n1                           arg  3 mem  0.58 GB tm     34.34us/    31.27ms (   185.62 GFLOPS  244.4|253.4   GB/s) ['rsqrt', '__add__', 'var_mean', '__sub__', 'realize']
*** CUDA     118 E_128_32_8_16_4                           arg  6 mem  0.59 GB tm     21.12us/    31.30ms (   595.78 GFLOPS  794.6|1191.6  GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA     119 r_128_8_8_8_2_256_4_4_3_3                 arg  3 mem  0.60 GB tm   2242.56us/    33.54ms (  4309.22 GFLOPS    8.5|3235.7  GB/s) ['conv2d']
*** CUDA     120 r_256_16_8_64                             arg  2 mem  0.60 GB tm     35.78us/    33.57ms (    60.57 GFLOPS  234.5|242.7   GB/s) ['var_mean', 'realize']
*** CUDA     121 copy     1024,    CUDA <- NPY             arg  2 mem  0.60 GB tm     54.35us/    33.63ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     122 copy     1024,    CUDA <- NPY             arg  2 mem  0.60 GB tm     30.04us/    33.66ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     123 copy    4.72M,    CUDA <- NPY             arg  2 mem  0.60 GB tm   2400.85us/    36.06ms (     0.00 GFLOPS    2.0|2.0     GB/s) 
*** CUDA     124 r_256_16_8_64n1                           arg  3 mem  0.60 GB tm     35.39us/    36.09ms (   180.08 GFLOPS  237.1|245.8   GB/s) ['rsqrt', '__add__', 'var_mean', '__sub__', 'realize']
*** CUDA     125 E_128_32_8_16_4n2                         arg  7 mem  0.61 GB tm     28.19us/    36.12ms (   520.72 GFLOPS  892.8|1190.2  GB/s) ['relu', '__add__', 'realize', '__mul__', '__sub__']
*** CUDA     126 r_16_8_8_16_256_3_3_4_4_4                 arg  3 mem  0.61 GB tm   1249.12us/    37.37ms (  3868.19 GFLOPS   13.9|2421.0  GB/s) ['conv2d']
*** CUDA     127 r_512_16_8_16                             arg  2 mem  0.61 GB tm     24.38us/    37.40ms (    48.71 GFLOPS  172.1|196.2   GB/s) ['var_mean', 'realize']
*** CUDA     128 copy     2048,    CUDA <- NPY             arg  2 mem  0.61 GB tm     89.70us/    37.49ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     129 copy     2048,    CUDA <- NPY             arg  2 mem  0.61 GB tm     30.95us/    37.52ms (     0.00 GFLOPS    0.1|0.1     GB/s) 
*** CUDA     130 copy    9.44M,    CUDA <- NPY             arg  2 mem  0.62 GB tm   4359.56us/    41.88ms (     0.00 GFLOPS    2.2|2.2     GB/s) 
*** CUDA     131 r_512_16_8_16n1                           arg  3 mem  0.61 GB tm     23.97us/    41.90ms (   138.08 GFLOPS  175.2|201.0   GB/s) ['rsqrt', '__add__', 'var_mean', '__sub__', 'realize']
*** CUDA     132 E_64_32_2_16_4_4                          arg  6 mem  0.62 GB tm     20.03us/    41.92ms (   314.07 GFLOPS  419.2|628.1   GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA     133 r_16_8_8_16_512_3_3_4_4_4                 arg  3 mem  0.62 GB tm   1125.60us/    43.05ms (  8585.36 GFLOPS   15.8|5369.6  GB/s) ['conv2d']
*** CUDA     134 copy   524288,    CUDA <- NPY             arg  2 mem  0.62 GB tm   1069.42us/    44.12ms (     0.00 GFLOPS    0.5|0.5     GB/s) 
*** CUDA     135 r_64_8_2_16_4_64_4_4_4                    arg  3 mem  0.63 GB tm    114.62us/    44.23ms (  4683.76 GFLOPS  114.3|4720.3  GB/s) ['conv2d']
scheduled 11 kernels
*** CUDA     136 r_512_16_8_16                             arg  2 mem  0.63 GB tm     26.59us/    44.26ms (    44.67 GFLOPS  157.8|179.9   GB/s) ['var_mean', 'realize']
*** CUDA     137 copy     2048,    CUDA <- NPY             arg  2 mem  0.63 GB tm     54.30us/    44.31ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     138 copy     2048,    CUDA <- NPY             arg  2 mem  0.63 GB tm     29.79us/    44.34ms (     0.00 GFLOPS    0.1|0.1     GB/s) 
*** CUDA     139 r_512_16_8_16                             arg  2 mem  0.63 GB tm     19.84us/    44.36ms (    59.87 GFLOPS  211.5|241.1   GB/s) ['var_mean', 'realize']
*** CUDA     140 copy     2048,    CUDA <- NPY             arg  2 mem  0.63 GB tm     30.43us/    44.39ms (     0.00 GFLOPS    0.1|0.1     GB/s) 
*** CUDA     141 copy     2048,    CUDA <- NPY             arg  2 mem  0.63 GB tm     26.88us/    44.42ms (     0.00 GFLOPS    0.1|0.1     GB/s) 
*** CUDA     142 copy    9.44M,    CUDA <- NPY             arg  2 mem  0.63 GB tm   1136.66us/    45.55ms (     0.00 GFLOPS    8.3|8.3     GB/s) 
*** CUDA     143 r_512_16_8_16n1                           arg  3 mem  0.63 GB tm     24.80us/    45.58ms (   133.45 GFLOPS  169.3|194.2   GB/s) ['rsqrt', '__add__', 'var_mean', '__sub__', 'realize']
*** CUDA     144 r_512_16_8_16n1                           arg  3 mem  0.63 GB tm     16.51us/    45.60ms (   200.43 GFLOPS  254.3|291.7   GB/s) ['rsqrt', '__add__', 'var_mean', '__sub__', 'realize']
*** CUDA     145 E_64_32_2_16_4_4n1                        arg 11 mem  0.63 GB tm     20.38us/    45.62ms (   565.85 GFLOPS  618.1|1028.8  GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA     146 r_16_8_8_16_512_3_3_4_4_4                 arg  3 mem  0.63 GB tm   1111.39us/    46.73ms (  8695.11 GFLOPS   16.0|5438.2  GB/s) ['conv2d']
*** CUDA     147 r_512_16_8_16                             arg  2 mem  0.63 GB tm     25.22us/    46.75ms (    47.11 GFLOPS  166.4|189.7   GB/s) ['var_mean', 'realize']
*** CUDA     148 copy     2048,    CUDA <- NPY             arg  2 mem  0.63 GB tm     55.75us/    46.81ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     149 copy     2048,    CUDA <- NPY             arg  2 mem  0.63 GB tm     29.73us/    46.84ms (     0.00 GFLOPS    0.1|0.1     GB/s) 
*** CUDA     150 copy    9.44M,    CUDA <- NPY             arg  2 mem  0.64 GB tm   1134.86us/    47.97ms (     0.00 GFLOPS    8.3|8.3     GB/s) 
*** CUDA     151 r_512_16_8_16n1                           arg  3 mem  0.63 GB tm     24.29us/    48.00ms (   136.26 GFLOPS  172.9|198.3   GB/s) ['rsqrt', '__add__', 'var_mean', '__sub__', 'realize']
*** CUDA     152 E_64_32_2_16_4_4                          arg  6 mem  0.64 GB tm     15.52us/    48.01ms (   405.38 GFLOPS  541.0|810.8   GB/s) ['relu', '__add__', '__mul__', '__sub__', 'realize']
*** CUDA     153 r_16_8_8_16_512_3_3_4_4_4                 arg  3 mem  0.64 GB tm   1096.74us/    49.11ms (  8811.31 GFLOPS   16.3|5510.9  GB/s) ['conv2d']
*** CUDA     154 xfer     6912,    CUDA <- CUDA            arg  2 mem  0.64 GB tm     55.38us/    49.16ms (     0.00 GFLOPS    0.1|0.1     GB/s) 
scheduled 157 kernels
*** CUDA     155 E_                                        arg  1 mem  0.64 GB tm     17.38us/    49.18ms (     0.00 GFLOPS    0.0|0.0     GB/s) ['contiguous']
*** CUDA     156 r_512_16_8_16                             arg  2 mem  0.64 GB tm     19.33us/    49.20ms (    61.46 GFLOPS  217.1|247.5   GB/s) ['var_mean', 'realize']
*** CUDA     157 copy     2048,    CUDA <- NPY             arg  2 mem  0.64 GB tm     53.77us/    49.26ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     158 copy     2048,    CUDA <- NPY             arg  2 mem  0.64 GB tm     31.32us/    49.29ms (     0.00 GFLOPS    0.1|0.1     GB/s) 
*** CUDA     159 copy     1024,    CUDA <- NPY             arg  2 mem  0.64 GB tm     34.16us/    49.32ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     160 E_n1                                      arg  1 mem  0.64 GB tm     15.97us/    49.34ms (     0.00 GFLOPS    0.0|0.0     GB/s) ['contiguous']
*** CUDA     161 r_5_2_10                                  arg  1 mem  0.64 GB tm     16.70us/    49.35ms (     0.02 GFLOPS    0.0|0.0     GB/s) ['scatter', 'gather']
*** CUDA     162 E_10_32_4                                 arg  1 mem  0.64 GB tm     16.16us/    49.37ms (     0.00 GFLOPS    0.3|0.3     GB/s) ['contiguous']
*** CUDA     163 copy    20480,    CUDA <- NPY             arg  2 mem  0.64 GB tm    110.61us/    49.48ms (     0.00 GFLOPS    0.2|0.2     GB/s) 
*** CUDA     164 copy       40,    CUDA <- NPY             arg  2 mem  0.64 GB tm     65.89us/    49.55ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** CUDA     165 E_4_32_4                                  arg  3 mem  0.64 GB tm     17.15us/    49.56ms (     0.03 GFLOPS    0.4|0.4     GB/s) ['__mul__']
*** CUDA     166 E_4_32_4                                  arg  3 mem  0.64 GB tm     11.04us/    49.57ms (     0.05 GFLOPS    0.6|0.6     GB/s) ['__mul__']
*** CUDA     167 E_4_32_4                                  arg  3 mem  0.64 GB tm      8.99us/    49.58ms (     0.06 GFLOPS    0.7|0.7     GB/s) ['__mul__']
*** CUDA     168 E_4_32_4                                  arg  3 mem  0.64 GB tm      8.61us/    49.59ms (     0.06 GFLOPS    0.7|0.7     GB/s) ['__mul__']
*** CUDA     169 E_2_32_4                                  arg  3 mem  0.64 GB tm     14.72us/    49.61ms (     0.02 GFLOPS    0.2|0.2     GB/s) ['__mul__']
*** CUDA     170 E_2_32_4                                  arg  3 mem  0.64 GB tm     11.23us/    49.62ms (     0.02 GFLOPS    0.3|0.3     GB/s) ['__mul__']
*** CUDA     171 E_2_32_4                                  arg  3 mem  0.64 GB tm      8.80us/    49.63ms (     0.03 GFLOPS    0.3|0.3     GB/s) ['__mul__']
*** CUDA     172 E_2_32_4                                  arg  3 mem  0.64 GB tm      8.42us/    49.64ms (     0.03 GFLOPS    0.4|0.4     GB/s) ['__mul__']
*** CUDA     173 E_2_32_4                                  arg  3 mem  0.64 GB tm      7.65us/    49.64ms (     0.03 GFLOPS    0.4|0.4     GB/s) ['__mul__']
*** CUDA     174 E_32_4                                    arg  3 mem  0.64 GB tm     15.74us/    49.66ms (     0.01 GFLOPS    0.1|0.1     GB/s) ['__mul__']
*** CUDA     175 E_32_4                                    arg  3 mem  0.64 GB tm     10.66us/    49.67ms (     0.01 GFLOPS    0.1|0.1     GB/s) ['__mul__']
*** CUDA     176 E_32_4                                    arg  3 mem  0.64 GB tm      8.19us/    49.68ms (     0.02 GFLOPS    0.2|0.2     GB/s) ['__mul__']
*** CUDA     177 E_32_4                                    arg  3 mem  0.64 GB tm      8.22us/    49.69ms (     0.02 GFLOPS    0.2|0.2     GB/s) ['__mul__']
*** CUDA     178 E_32_4                                    arg  3 mem  0.64 GB tm      7.74us/    49.69ms (     0.02 GFLOPS    0.2|0.2     GB/s) ['__mul__']
*** CUDA     179 E_16_4                                    arg  3 mem  0.64 GB tm     15.14us/    49.71ms (     0.00 GFLOPS    0.1|0.1     GB/s) ['__mul__']
*** CUDA     180 E_16_4                                    arg  3 mem  0.64 GB tm     10.72us/    49.72ms (     0.01 GFLOPS    0.1|0.1     GB/s) ['__mul__']
*** CUDA     181 E_16_4                                    arg  3 mem  0.64 GB tm      8.61us/    49.73ms (     0.01 GFLOPS    0.1|0.1     GB/s) ['__mul__']
*** CUDA     182 E_16_4                                    arg  3 mem  0.64 GB tm      8.86us/    49.74ms (     0.01 GFLOPS    0.1|0.1     GB/s) ['__mul__']
*** CUDA     183 E_16_4                                    arg  3 mem  0.64 GB tm      8.03us/    49.74ms (     0.01 GFLOPS    0.1|0.1     GB/s) ['__mul__']
*** CUDA     184 r_512_16_8_16n1                           arg  3 mem  0.64 GB tm     23.78us/    49.77ms (   139.20 GFLOPS  176.6|202.6   GB/s) ['rsqrt', '__add__', 'var_mean', '__sub__', 'realize']
*** CUDA     185 r_16_8                                    arg  2 mem  0.64 GB tm     16.10us/    49.78ms (     0.03 GFLOPS    0.1|0.1     GB/s) ['contiguous', 'cast', 'sum', 'ne']
*** CUDA     186 E_32_4n1                                  arg  3 mem  0.64 GB tm     15.39us/    49.80ms (     0.02 GFLOPS    0.1|0.1     GB/s) ['where', 'ne', 'unsqueeze']
*** CUDA     187 r_4_32_8_16_4_16                          arg  7 mem  0.64 GB tm     20.29us/    49.82ms (   413.48 GFLOPS  426.8|439.3   GB/s) ['avg_pool2d', 'relu', '__add__', 'realize', '__mul__', '__sub__']
*** CUDA     188 E_4_32_4                                  arg  3 mem  0.64 GB tm     11.07us/    49.83ms (     0.05 GFLOPS    0.6|0.6     GB/s) ['__mul__', 'reshape']
*** CUDA     189 E_n2                                      arg  2 mem  0.64 GB tm     15.90us/    49.85ms (     0.00 GFLOPS    0.0|0.0     GB/s) ['div', 'cast']
*** CUDA     190 r_128_10_16_32                            arg  4 mem  0.64 GB tm     25.12us/    49.87ms (    66.04 GFLOPS   11.5|270.7   GB/s) ['__add__', 'matmul']
*** CUDA     191 E_32_4n2                                  arg  4 mem  0.64 GB tm     16.58us/    49.89ms (     0.02 GFLOPS    0.1|0.1     GB/s) ['where', 'ne', 'unsqueeze']
*** CUDA     192 r_4_32_10                                 arg  2 mem  0.64 GB tm     16.35us/    49.91ms (     0.14 GFLOPS    0.3|0.3     GB/s) ['log_softmax']
*** CUDA     193 r_4_32_10n1                               arg  5 mem  0.64 GB tm     15.42us/    49.92ms (     0.49 GFLOPS    0.5|1.1     GB/s) ['sum', '__mul__', 'scatter']
*** CUDA     194 r_4_32_10n2                               arg  3 mem  0.64 GB tm     16.16us/    49.94ms (     0.32 GFLOPS    0.4|0.4     GB/s) ['log_softmax']
*** CUDA     195 E_5_32_2_4                                arg  9 mem  0.64 GB tm     17.54us/    49.95ms (     0.80 GFLOPS    1.1|2.8     GB/s) ['__sub__', '__mul__', 'scatter', 'exp', 'log_softmax']
*** CUDA     196 r_4_8_8_16_4_4_10                         arg  3 mem  0.64 GB tm     18.14us/    49.97ms (    72.24 GFLOPS   15.9|86.7    GB/s) ['avg_pool2d bw', 'reshape', 'matmul']
*** CUDA     197 r_512_16_8_16n2                           arg  9 mem  0.64 GB tm     31.30us/    50.00ms (   373.53 GFLOPS  276.8|300.5   GB/s) ['__mul__', 'sum', 'reshape', 'where', '__sub__', '__le__', 'avg_pool2d bw', 'realize', 'relu', '__add__']
*** CUDA     198 r_512_16_8_16n3                           arg  9 mem  0.64 GB tm     31.81us/    50.04ms (   334.04 GFLOPS  272.3|295.7   GB/s) ['__mul__', 'sum', 'where', '__le__', 'avg_pool2d bw', 'relu', '__add__', 'realize', '__sub__']
*** CUDA     199 E_64_32_2_16_4_4n2                        arg 12 mem  0.65 GB tm     20.19us/    50.06ms (   675.09 GFLOPS  636.9|1090.5  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', 'avg_pool2d bw', 'relu', 'realize', '__add__']
*** CUDA     200 r_128_64_8_4_3_128_3_4_4                  arg  3 mem  0.68 GB tm    830.98us/    50.89ms ( 11629.31 GFLOPS   61.8|13613.0 GB/s) ['conv2d bw', 'conv2d']
*** CUDA     201 r_2048_32_4_6_6_4                         arg  2 mem  0.69 GB tm     64.64us/    50.95ms (   291.99 GFLOPS  730.0|1314.0  GB/s) ['conv2d bw']
*** CUDA     202 r_512_16_8_4_4                            arg  7 mem  0.66 GB tm     38.53us/    50.99ms (   140.12 GFLOPS  344.5|344.5   GB/s) ['__mul__', 'sum', 'where', '__sub__', '__le__', 'conv2d bw', 'realize']
*** CUDA     203 r_512_16_8_4_4n1                          arg  4 mem  0.66 GB tm     31.20us/    51.02ms (   105.29 GFLOPS  288.8|288.8   GB/s) ['__mul__', 'sum', 'where', '__le__', 'conv2d bw', 'realize']
*** CUDA     204 E_64_32_2_16_4_4n3                        arg  9 mem  0.66 GB tm     23.07us/    51.04ms (   318.14 GFLOPS  954.4|954.4   GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', 'realize']
*** CUDA     205 r_128_64_8_4_3_128_3_4_4                  arg  3 mem  0.70 GB tm    825.44us/    51.87ms ( 11707.30 GFLOPS   62.2|13704.3 GB/s) ['conv2d bw', 'conv2d']
*** CUDA     206 r_2048_32_4_6_6_4                         arg  2 mem  0.71 GB tm     58.53us/    51.93ms (   322.48 GFLOPS  806.2|1451.2  GB/s) ['conv2d bw']
*** CUDA     207 r_512_16_8_4_4n2                          arg 13 mem  0.67 GB tm     46.56us/    51.97ms (   341.16 GFLOPS  383.6|383.6   GB/s) ['__mul__', 'sum', 'where', '__sub__', '__le__', '__add__', 'realize', 'conv2d bw', 'avg_pool2d bw', 'relu']
*** CUDA     208 r_512_16_8_4_4n3                          arg 10 mem  0.67 GB tm     38.91us/    52.01ms (   353.89 GFLOPS  349.5|349.5   GB/s) ['__mul__', 'sum', 'where', '__le__', '__add__', 'conv2d bw', 'realize', 'avg_pool2d bw', 'relu', '__sub__']
*** CUDA     209 r_512_16_8_4_4n2                          arg 13 mem  0.67 GB tm     40.86us/    52.05ms (   388.71 GFLOPS  437.0|437.0   GB/s) ['__mul__', 'sum', 'where', '__sub__', '__le__', '__add__', 'realize', 'conv2d bw', 'avg_pool2d bw', 'relu']
*** CUDA     210 E_64_32_2_16_4_4n4                        arg 15 mem  0.67 GB tm     25.47us/    52.08ms (   699.82 GFLOPS 1040.1|1235.0  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', '__add__', 'realize', 'avg_pool2d bw', 'relu']
*** CUDA     211 E_64_32_2_16_4_4n4                        arg 15 mem  0.68 GB tm     21.31us/    52.10ms (   836.42 GFLOPS 1243.1|1476.0  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', '__add__', 'realize', 'avg_pool2d bw', 'relu']
*** CUDA     212 r_64_4_2_16_4_128_4_4_4                   arg  3 mem  0.68 GB tm    115.36us/    52.22ms (  4653.87 GFLOPS   59.1|4672.1  GB/s) ['conv2d bw', 'conv2d']
*** CUDA     213 r_128_64_8_4_3_128_3_4_4                  arg  3 mem  0.72 GB tm    853.15us/    53.07ms ( 11327.03 GFLOPS   60.2|13259.1 GB/s) ['conv2d bw', 'conv2d']
*** CUDA     214 r_2048_32_4_6_6_4                         arg  2 mem  0.73 GB tm     59.01us/    53.13ms (   319.86 GFLOPS  799.7|1439.4  GB/s) ['conv2d bw']
*** CUDA     215 r_512_16_8_4_4                            arg  7 mem  0.69 GB tm     30.43us/    53.16ms (   177.40 GFLOPS  436.1|436.1   GB/s) ['__mul__', 'sum', 'where', '__sub__', '__le__', 'conv2d bw', 'realize']
*** CUDA     216 r_512_16_8_4_4n1                          arg  4 mem  0.69 GB tm     23.20us/    53.18ms (   141.59 GFLOPS  388.4|388.4   GB/s) ['__mul__', 'sum', 'where', '__le__', 'conv2d bw', 'realize']
*** CUDA     217 E_64_32_2_16_4_4n3                        arg  9 mem  0.69 GB tm     16.10us/    53.20ms (   456.02 GFLOPS 1368.0|1368.0  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', 'realize']
*** CUDA     218 r_128_32_8_4_3_128_3_4_4                  arg  3 mem  0.71 GB tm    434.40us/    53.63ms ( 11123.02 GFLOPS   64.0|13020.3 GB/s) ['conv2d bw', 'conv2d']
*** CUDA     219 r_1024_5_5_32_2_2_4_4                     arg  2 mem  0.73 GB tm     83.58us/    53.72ms (   470.44 GFLOPS  382.6|2038.6  GB/s) ['conv2d bw']
*** CUDA     220 r_256_16_8_8_8                            arg  8 mem  0.71 GB tm     75.36us/    53.79ms (   168.00 GFLOPS  424.4|449.8   GB/s) ['__mul__', 'sum', 'where', '__sub__', '__le__', '__add__', 'realize', 'conv2d bw']
*** CUDA     221 r_256_16_8_8_8n1                          arg  5 mem  0.71 GB tm     55.23us/    53.85ms (   153.14 GFLOPS  427.2|461.3   GB/s) ['__mul__', 'sum', 'where', '__le__', '__add__', 'conv2d bw', 'realize']
*** CUDA     222 E_128_32_8_8_2_4                          arg 10 mem  0.72 GB tm     33.25us/    53.88ms (   473.07 GFLOPS 1214.3|1450.7  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', '__add__', 'realize']
*** CUDA     223 r_128_128_2_16_3_64_3_4_4                 arg  3 mem  0.79 GB tm    980.48us/    54.86ms (  9856.07 GFLOPS   88.0|11575.7 GB/s) ['conv2d bw', 'conv2d']
*** CUDA     224 r_1024_5_5_32_2_2_4_4n1                   arg  2 mem  0.80 GB tm    186.75us/    55.05ms (   210.56 GFLOPS  474.5|912.4   GB/s) ['conv2d bw']
*** CUDA     225 r_256_16_8_8_8n2                          arg  7 mem  0.73 GB tm     73.60us/    55.12ms (   143.53 GFLOPS  346.6|346.6   GB/s) ['__mul__', 'sum', 'where', '__sub__', '__le__', 'conv2d bw', 'realize']
*** CUDA     226 r_256_16_8_8_8n3                          arg  4 mem  0.73 GB tm     50.50us/    55.17ms (   125.97 GFLOPS  338.4|338.4   GB/s) ['__mul__', 'sum', 'where', '__le__', 'conv2d bw', 'realize']
*** CUDA     227 E_128_32_8_8_2_4n1                        arg  9 mem  0.74 GB tm     30.82us/    55.20ms (   476.38 GFLOPS 1242.1|1429.1  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', 'realize']
*** CUDA     228 r_128_128_2_16_3_64_3_4_4                 arg  3 mem  0.81 GB tm    949.41us/    56.15ms ( 10178.63 GFLOPS   90.8|11954.6 GB/s) ['conv2d bw', 'conv2d']
*** CUDA     229 r_1024_5_5_32_2_2_4_4n1                   arg  2 mem  0.83 GB tm    179.97us/    56.33ms (   218.49 GFLOPS  492.3|946.8   GB/s) ['conv2d bw']
*** CUDA     230 r_256_16_8_8_8n4                          arg 10 mem  0.75 GB tm    114.46us/    56.45ms (   165.57 GFLOPS  442.7|442.7   GB/s) ['__mul__', 'sum', 'where', '__sub__', '__le__', '__add__', 'realize', 'conv2d bw']
*** CUDA     231 r_256_16_8_8_8n5                          arg  7 mem  0.75 GB tm     90.66us/    56.54ms (   162.70 GFLOPS  466.1|466.1   GB/s) ['__mul__', 'sum', 'where', '__le__', '__add__', 'conv2d bw', 'realize']
*** CUDA     232 r_256_16_8_8_8n4                          arg 10 mem  0.75 GB tm    107.36us/    56.64ms (   176.53 GFLOPS  472.0|472.0   GB/s) ['__mul__', 'sum', 'where', '__sub__', '__le__', '__add__', 'realize', 'conv2d bw']
*** CUDA     233 E_128_32_8_8_2_4n2                        arg 12 mem  0.76 GB tm     40.13us/    56.68ms (   548.75 GFLOPS 1541.8|1620.1  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', '__add__', 'realize']
*** CUDA     234 E_128_32_8_8_2_4n2                        arg 12 mem  0.77 GB tm     58.40us/    56.74ms (   377.06 GFLOPS 1059.4|1113.2  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', '__add__', 'realize']
*** CUDA     235 r_128_4_8_16_64_4_4_4                     arg  3 mem  0.77 GB tm     69.70us/    56.81ms (  7703.04 GFLOPS  182.4|7763.2  GB/s) ['conv2d bw', 'conv2d']
*** CUDA     236 r_128_128_2_16_3_64_3_4_4                 arg  3 mem  0.85 GB tm   1053.41us/    57.87ms (  9173.73 GFLOPS   81.9|10774.3 GB/s) ['conv2d bw', 'conv2d']
*** CUDA     237 r_1024_5_5_32_2_2_4_4n1                   arg  2 mem  0.86 GB tm    180.61us/    58.05ms (   217.72 GFLOPS  490.6|943.4   GB/s) ['conv2d bw']
*** CUDA     238 r_256_16_8_8_8n2                          arg  7 mem  0.78 GB tm     66.59us/    58.11ms (   158.63 GFLOPS  383.1|383.1   GB/s) ['__mul__', 'sum', 'where', '__sub__', '__le__', 'conv2d bw', 'realize']
*** CUDA     239 r_256_16_8_8_8n3                          arg  4 mem  0.78 GB tm     42.02us/    58.16ms (   151.40 GFLOPS  406.7|406.7   GB/s) ['__mul__', 'sum', 'where', '__le__', 'conv2d bw', 'realize']
*** CUDA     240 E_128_32_8_8_2_4n1                        arg  9 mem  0.79 GB tm     24.58us/    58.18ms (   597.33 GFLOPS 1557.5|1792.0  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', 'realize']
*** CUDA     241 r_128_64_2_16_3_64_3_4_4                  arg  3 mem  0.83 GB tm    464.83us/    58.64ms ( 10394.81 GFLOPS  101.8|12208.5 GB/s) ['conv2d bw', 'conv2d']
*** CUDA     242 r_2048_6_6_8_3_3_4_4                      arg  2 mem  0.85 GB tm    182.78us/    58.83ms (   348.50 GFLOPS  322.7|1510.2  GB/s) ['conv2d bw']
*** CUDA     243 r_16_2_8_16_16_4_16                       arg  7 mem  0.81 GB tm    224.19us/    59.05ms (   102.90 GFLOPS  262.4|262.4   GB/s) ['__mul__', 'where', '__sub__', '__le__', '__add__', 'realize', 'conv2d bw']
*** CUDA     244 r_4_8_8_16_16_4_16                        arg  5 mem  0.81 GB tm    123.68us/    59.18ms (   118.69 GFLOPS  339.8|339.8   GB/s) ['where', '__le__', '__add__', 'conv2d bw', 'realize']
*** CUDA     245 r_128_16_8n2                              arg  3 mem  0.81 GB tm     18.02us/    59.19ms (     3.07 GFLOPS    3.7|12.3    GB/s) ['__mul__', 'sum']
*** CUDA     246 r_128_16_8                                arg  2 mem  0.81 GB tm     11.90us/    59.21ms (     4.30 GFLOPS    5.5|17.9    GB/s) ['__mul__', 'sum']
*** CUDA     247 E_128_64_2_16_4_4                         arg 10 mem  0.83 GB tm     39.10us/    59.24ms (   804.45 GFLOPS 1937.4|2467.0  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', '__add__', 'realize']
*** CUDA     248 r_128_64_4_2_16_3_32_3_4_4                arg  3 mem  0.98 GB tm   1233.34us/    60.48ms (  7835.35 GFLOPS  136.5|9263.7  GB/s) ['conv2d bw', 'conv2d']
*** CUDA     249 r_2048_6_6_8_3_3_4_4n1                    arg  2 mem  1.00 GB tm    195.20us/    60.67ms (   326.34 GFLOPS  882.3|1414.1  GB/s) ['conv2d bw']
*** CUDA     250 r_16_2_8_16_16_4_16n1                     arg  6 mem  0.85 GB tm    145.57us/    60.82ms (   144.07 GFLOPS  346.4|346.4   GB/s) ['__mul__', 'where', '__sub__', '__le__', 'conv2d bw', 'realize']
*** CUDA     251 r_4_8_8_16_16_4_16n1                      arg  4 mem  0.85 GB tm     94.37us/    60.91ms (   133.34 GFLOPS  356.4|356.4   GB/s) ['where', '__le__', 'conv2d bw', 'realize']
*** CUDA     252 r_128_16_8n2                              arg  3 mem  0.85 GB tm     11.30us/    60.92ms (     4.90 GFLOPS    5.9|19.6    GB/s) ['__mul__', 'sum']
*** CUDA     253 r_128_16_8                                arg  2 mem  0.85 GB tm      9.70us/    60.93ms (     5.28 GFLOPS    6.8|22.0    GB/s) ['__mul__', 'sum']
*** CUDA     254 E_128_64_2_16_4_4n1                       arg  9 mem  0.87 GB tm     36.90us/    60.97ms (   795.75 GFLOPS 1939.7|2387.3  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', 'realize']
*** CUDA     255 r_128_64_4_2_16_3_32_3_4_4                arg  3 mem  1.02 GB tm   1217.18us/    62.19ms (  7939.37 GFLOPS  138.3|9386.7  GB/s) ['conv2d bw', 'conv2d']
*** CUDA     256 r_2048_6_6_8_3_3_4_4n1                    arg  2 mem  1.04 GB tm    188.83us/    62.38ms (   337.34 GFLOPS  912.1|1461.8  GB/s) ['conv2d bw']
*** CUDA     257 r_16_2_8_16_16_4_16n2                     arg  9 mem  0.89 GB tm    275.87us/    62.65ms (   129.23 GFLOPS  334.8|334.8   GB/s) ['__mul__', 'where', '__sub__', '__le__', '__add__', 'realize', 'conv2d bw']
*** CUDA     258 r_4_8_8_16_16_4_16n2                      arg  7 mem  0.89 GB tm    224.26us/    62.88ms (   121.57 GFLOPS  337.0|337.0   GB/s) ['where', '__le__', '__add__', 'conv2d bw', 'realize']
*** CUDA     259 r_16_2_8_16_16_4_16n2                     arg  9 mem  0.89 GB tm    255.87us/    63.13ms (   139.33 GFLOPS  361.0|361.0   GB/s) ['__mul__', 'where', '__sub__', '__le__', '__add__', 'realize', 'conv2d bw']
*** CUDA     260 r_128_16_8n2                              arg  3 mem  0.89 GB tm      9.63us/    63.14ms (     5.74 GFLOPS    6.9|23.0    GB/s) ['__mul__', 'sum']
*** CUDA     261 r_128_16_8                                arg  2 mem  0.89 GB tm      9.82us/    63.15ms (     5.21 GFLOPS    6.7|21.7    GB/s) ['__mul__', 'sum']
*** CUDA     262 r_128_16_8n2                              arg  3 mem  0.89 GB tm      8.80us/    63.16ms (     6.28 GFLOPS    7.6|25.1    GB/s) ['__mul__', 'sum']
*** CUDA     263 E_128_64_2_16_4_4n2                       arg 12 mem  0.91 GB tm     48.16us/    63.21ms (   914.46 GFLOPS 2362.4|2699.8  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', '__add__', 'realize']
*** CUDA     264 E_128_64_2_16_4_4n2                       arg 12 mem  0.92 GB tm     44.06us/    63.25ms (   999.46 GFLOPS 2582.0|2950.8  GB/s) ['conv2d bw', '__sub__', '__mul__', 'where', '__le__', '__add__', 'realize']
```