### PR TITLE
add double gemm fuse beam failure

### DIFF
--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1430,6 +1430,7 @@ class TestLinearizerFailures(unittest.TestCase):
     opts = [Opt(op=OptOps.GROUPTOP, axis=0, arg=29), Opt(op=OptOps.PADTO, axis=0, arg=32)]
     helper_test_lin(Kernel(ast, opts=Device[Device.DEFAULT].renderer), opts=opts, failed_platforms=["METAL", "GPU", "AMD", "NV"])
 
+  # from BEAM=2 python test/test_softmax_fusion.py TestFuse.test_double_gemm
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test needs TC")
   def test_failure_59(self):
     ast = UOp(Ops.SINK, dtypes.void, arg=None, src=(
@@ -1454,7 +1455,7 @@ class TestLinearizerFailures(unittest.TestCase):
     try:
       lin.apply_opts(opts)
     except AssertionError:
-      # AssertionError from `assert all_same(tensor_core_opts)` in kernel.py
+      # AssertionError is from `assert all_same(tensor_core_opts)` in kernel.py
       # only fails with metal TC
       assert Device.DEFAULT == "METAL"
 

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1430,7 +1430,7 @@ class TestLinearizerFailures(unittest.TestCase):
     opts = [Opt(op=OptOps.GROUPTOP, axis=0, arg=29), Opt(op=OptOps.PADTO, axis=0, arg=32)]
     helper_test_lin(Kernel(ast, opts=Device[Device.DEFAULT].renderer), opts=opts, failed_platforms=["METAL", "GPU", "AMD", "NV"])
 
-  # from BEAM=2 python test/test_softmax_fusion.py TestFuse.test_double_gemm
+  # from IGNORE_BEAM_CACHE=1 BEAM=2 python test/test_softmax_fusion.py TestFuse.test_double_gemm
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test needs TC")
   def test_failure_59(self):
     ast = UOp(Ops.SINK, dtypes.void, arg=None, src=(

--- a/test/test_softmax_fusion.py
+++ b/test/test_softmax_fusion.py
@@ -67,6 +67,11 @@ class TestFuse(unittest.TestCase):
       c = (Tensor.rand(N,N)-0.5).realize()
     self._test_fuse(lambda a,b,c: a@b@c, a, b, c, atol=1e-5)
 
+  @unittest.expectedFailure
+  def test_double_gemm_beam(self):
+    with Context(BEAM=2):
+      self.test_double_gemm()
+
   def test_embedding(self):
     with Context(TRACK_MATCH_STATS=0, DEBUG=0):
       vocab_sz = 123

--- a/test/test_softmax_fusion.py
+++ b/test/test_softmax_fusion.py
@@ -67,6 +67,7 @@ class TestFuse(unittest.TestCase):
       c = (Tensor.rand(N,N)-0.5).realize()
     self._test_fuse(lambda a,b,c: a@b@c, a, b, c, atol=1e-5)
 
+  @unittest.skipUnless(Device.DEFAULT == "METAL", "fails only with METAL TC")
   @unittest.expectedFailure
   def test_double_gemm_beam(self):
     with Context(BEAM=2):

--- a/test/test_softmax_fusion.py
+++ b/test/test_softmax_fusion.py
@@ -67,12 +67,6 @@ class TestFuse(unittest.TestCase):
       c = (Tensor.rand(N,N)-0.5).realize()
     self._test_fuse(lambda a,b,c: a@b@c, a, b, c, atol=1e-5)
 
-  @unittest.skipUnless(Device.DEFAULT == "METAL", "fails only with METAL TC")
-  @unittest.expectedFailure
-  def test_double_gemm_beam(self):
-    with Context(BEAM=2):
-      self.test_double_gemm()
-
   def test_embedding(self):
     with Context(TRACK_MATCH_STATS=0, DEBUG=0):
       vocab_sz = 123


### PR DESCRIPTION
hits this assert in `kernel.py line:278`
```python
        # can only fuse reduces with the same tc options
        assert all_same(tensor_core_opts)
```
I changed that assert to a `if not all_same(tensor_core_opts): continue` just for the double gemm fuse in olmoe to run and it became real sloooow. 
So maybe it's my fault.
Dunno if it's necessarily a linearizer failure.