### PR TITLE
setitem tests (some failing) from kernelize

### DIFF
--- a/test/test_setitem.py
+++ b/test/test_setitem.py
@@ -25,6 +25,17 @@ class TestSetitem(unittest.TestCase):
       n[slc] = val.numpy() if isinstance(val, Tensor) else val
       np.testing.assert_allclose(t.numpy(), n)
 
+  def test_padded_setitem(self):
+    t = Tensor.arange(10)
+    t[4:1:-2] = 11
+    self.assertListEqual(t.tolist(), [0, 1, 11, 3, 11, 5, 6, 7, 8, 9])
+
+  @unittest.expectedFailure # TODO: fix double ASSIGN in scheduler
+  def test_setitem_inplace_mul(self):
+    t = Tensor.arange(10).realize()
+    t[:3] *= 10
+    self.assertListEqual(t.tolist(), [0, 10, 20, 3, 4, 5, 6, 7, 8, 9])
+
   def test_setitem_into_unrealized(self):
     t = Tensor.arange(4).reshape(2, 2)
     t[1] = 5

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -266,6 +266,14 @@ class TestDiskTensor(unittest.TestCase):
     reloaded = Tensor.empty(10, 10, device=f"disk:{temp('dt_write_ones')}")
     np.testing.assert_almost_equal(reloaded.numpy(), np.ones((10, 10)))
 
+  def test_simple_setitem(self):
+    pathlib.Path(temp(fn:="dt_simple_setitem")).unlink(missing_ok=True)
+    data = [[1],[2]]
+    src = Tensor(data)
+    dt = src.to(f"disk:{temp(fn)}")
+    dt[1] = [3]
+    self.assertEqual(dt.tolist(), [[1], [3]])
+
   def test_assign_slice(self):
     def assign(x,s,y): x[s] = y
     helper_test_disk_tensor("dt_assign_slice_1", [0,1,2,3], lambda x: assign(x, slice(0,2), [13, 12]))


### PR DESCRIPTION
subtle bug in inplace setitem, `t[:3] *= 10` creates two ASSIGNs in the graph, when it's really one assign
![image](https://github.com/user-attachments/assets/1b904f62-8d48-4980-983e-eecbc07c6e85)
