### PR TITLE
CPUGraph for LLVM+CLANG

### DIFF
--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -74,6 +74,10 @@ def helper_test_graphs(graph_impl, graphs, runs=RUN_CNT):
     test_bufs_np = [np.frombuffer(x, _to_np_dtype(bufs[i].dtype)) for i,x in enumerate(test_bufs)]
     for i in range(len(ground_thruth_bufs)): np.testing.assert_equal(ground_truth_np[i], test_bufs_np[i])
 
+multi_graph_runner_only = unittest.skipIf(
+  not isinstance(Device[Device.DEFAULT].graph, type) or not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner),
+  "graph does not supported (not MultiGraphRunner)")
+
 @unittest.skipUnless(Device[Device.DEFAULT].graph is not None, "graph support required")
 @unittest.skipIf(CI and Device.DEFAULT=="METAL", "no ICB in CI, creation of graph fails")
 class TestGraph(unittest.TestCase):
@@ -107,9 +111,8 @@ class TestGraph(unittest.TestCase):
 
     helper_test_graphs(Device[d0].graph, graphs)
 
+  @multi_graph_runner_only
   def test_order_copy_writed(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
-
     d0 = Device.DEFAULT
     b0 = [helper_alloc_rawbuffer(d0, fill=True) for _ in range(4)]
 
@@ -119,9 +122,8 @@ class TestGraph(unittest.TestCase):
 
     helper_test_graphs(Device[d0].graph, graphs)
 
+  @multi_graph_runner_only
   def test_order_copy_then_read(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
-
     d0 = Device.DEFAULT
     b0 = [helper_alloc_rawbuffer(d0, fill=True) for _ in range(4)]
 
@@ -150,9 +152,8 @@ class TestGraph(unittest.TestCase):
 
     helper_test_graphs(Device[d0].graph, graphs)
 
+  @multi_graph_runner_only
   def test_copies_2_devs(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
-
     d0, d1 = Device.DEFAULT, f"{Device.DEFAULT}:1"
     b0 = [helper_alloc_rawbuffer(d0, fill=True) for _ in range(3)]
     b1 = [helper_alloc_rawbuffer(d1, fill=True) for _ in range(1)]
@@ -163,9 +164,8 @@ class TestGraph(unittest.TestCase):
 
     helper_test_graphs(Device[d0].graph, graphs)
 
+  @multi_graph_runner_only
   def test_copies_after_graph_global(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
-
     d0, d1, d2, d3 = Device.DEFAULT, f"{Device.DEFAULT}:1", f"{Device.DEFAULT}:2", f"{Device.DEFAULT}:3"
     b0 = [helper_alloc_rawbuffer(d0, fill=True) for _ in range(8)]
     b1 = [helper_alloc_rawbuffer(d1, fill=True) for _ in range(6)]
@@ -211,9 +211,8 @@ class TestGraph(unittest.TestCase):
 
     helper_test_graphs(Device[d0].graph, graphs)
 
+  @multi_graph_runner_only
   def test_graph_after_copies_devs(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
-
     d0, d1, d2, d3 = Device.DEFAULT, f"{Device.DEFAULT}:1", f"{Device.DEFAULT}:2", f"{Device.DEFAULT}:3"
     b0 = [helper_alloc_rawbuffer(d0, fill=True) for _ in range(8)]
     b1 = [helper_alloc_rawbuffer(d1, fill=True) for _ in range(1)]
@@ -239,9 +238,8 @@ class TestGraph(unittest.TestCase):
 
     helper_test_graphs(Device[d0].graph, graphs)
 
+  @multi_graph_runner_only
   def test_graph_offset_bufs(self):
-    if not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner): self.skipTest("graph does not supported (not MultiGraphRunner)")
-
     d0 = Device.DEFAULT
     if not hasattr(Device[d0].allocator, "_offset"): self.skipTest("device does not support _offset")
 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -76,7 +76,7 @@ def helper_test_graphs(graph_impl, graphs, runs=RUN_CNT):
 
 multi_graph_runner_only = unittest.skipIf(
   not isinstance(Device[Device.DEFAULT].graph, type) or not issubclass(Device[Device.DEFAULT].graph, MultiGraphRunner),
-  "graph does not supported (not MultiGraphRunner)")
+  "graph is not supported (not MultiGraphRunner)")
 
 @unittest.skipUnless(Device[Device.DEFAULT].graph is not None, "graph support required")
 @unittest.skipIf(CI and Device.DEFAULT=="METAL", "no ICB in CI, creation of graph fails")

--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -10,13 +10,12 @@ from tinygrad.renderer.cstyle import ClangRenderer
 
 class CPUGraph(GraphRunner):
   def __init__(self, device, jit_cache: list[ExecItem], input_rawbuffers: list[Buffer], var_vals: dict[Variable, int]):
-    super().__init__(jit_cache, input_rawbuffers, var_vals)
-
     cpu_progs: list[ExecItem] = []
     if issubclass(device.runtime, CPUProgram):
       device = Device["CPU"]
       cpu_progs.extend(dict((cast(CompiledRunner, item.prg).p.name, item) for item in jit_cache).values()) # dedupe by name
     elif not isinstance(device.renderer, ClangRenderer): raise GraphException
+    super().__init__(jit_cache, input_rawbuffers, var_vals)
 
     self.base_bufs = dedup(b.base for ji in jit_cache for b in ji.bufs if b is not None and b not in input_rawbuffers)
     self.base_rawbufs = [b._buf for b in self.base_bufs] + [cast(CompiledRunner, ji.prg)._prg.fxn for ji in cpu_progs]

--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -10,47 +10,44 @@ from tinygrad.renderer.cstyle import ClangRenderer
 
 class CPUGraph(GraphRunner):
   def __init__(self, device, jit_cache: list[ExecItem], input_rawbuffers: list[Buffer], var_vals: dict[Variable, int]):
-    n_cpu_prog = len([ item for item in jit_cache if isinstance(item.prg._prg, CPUProgram) ])
-    if n_cpu_prog > 0:
-      if n_cpu_prog != len(jit_cache): raise GraphException
+    cpu_progs = [ item for item in jit_cache if isinstance(item.prg._prg, CPUProgram) ]
+    if cpu_progs:
+      if len(cpu_progs) != len(jit_cache): raise GraphException
       device = Device["CPU"]
     elif not isinstance(device.renderer, ClangRenderer): raise GraphException
     super().__init__(jit_cache, input_rawbuffers, var_vals)
 
     self.base_bufs = dedup(b.base for ji in jit_cache for b in ji.bufs if b is not None and b not in input_rawbuffers)
-    self.base_rawbufs = [b._buf for b in self.base_bufs]
-    cbuf_fn_casts: list[str] = []
-    for idx, ji in enumerate(jit_cache):
-      if isinstance(ji.prg._prg, CPUProgram):
-        p_args = [(f"arg{i}", (buf.dtype.ptr(), False)) for i, buf in enumerate(ji.bufs) if buf is not None] + \
-          [(f"{v.expr}", (dtypes.int, False)) for v in cast(CompiledRunner, ji.prg).p.vars]
-        s_args = ','.join([f"{device.renderer.render_dtype(x[1][0])}" for x in p_args])
-        fn_name = to_function_name(cast(CompiledRunner, ji.prg).p.name)
-        cbuf_fn_casts.append(f"  void (*{fn_name})({s_args}) = (void (*)({s_args}))fxnp{idx};")
-        self.base_rawbufs.append(ji.prg._prg.fxn)
+    self.base_rawbufs = [b._buf for b in self.base_bufs] + [ji.prg._prg.fxn for ji in cpu_progs]
+    init_lines: list[str] = []
+    for i, ji in enumerate(cpu_progs):
+      arg_dtypes = tuple(buf.dtype.ptr() for buf in ji.bufs if buf is not None) + tuple(v.dtype for v in cast(CompiledRunner, ji.prg).p.vars)
+      s_args = ','.join([device.renderer.render_dtype(dt) for dt in arg_dtypes])
+      fn_name = to_function_name(cast(CompiledRunner, ji.prg).p.name)
+      init_lines.append(f"  void (*{fn_name})({s_args}) = (void (*)({s_args}))fxnp{i};")
 
     targs = [(f"arg{i}", (x.dtype.ptr(), False)) for i,x in enumerate(input_rawbuffers)] + \
             [(f"cbuf{i}", (dtypes.char.ptr(), False)) for i in range(len(self.base_bufs))] + \
-            [(f"fxnp{i}", (dtypes.void.ptr(), False)) for i in range(n_cpu_prog)] + \
+            [(f"fxnp{i}", (dtypes.void.ptr(), False)) for i in range(len(cpu_progs))] + \
             sorted([(f"{v.expr}", (dtypes.int, False)) for v in var_vals])
 
     def render_arg(buf):
       if buf in input_rawbuffers: return f"arg{input_rawbuffers.index(buf)}"
       return f"({device.renderer.render_dtype(buf.dtype)}*)(cbuf{self.base_bufs.index(buf.base)} + {buf.offset})"
 
-    batched = ["void batched("+','.join([f"{device.renderer.render_dtype(x[1][0])} {x[0]}" for x in targs])+") {"] + cbuf_fn_casts
+    batched = ["void batched("+','.join([f"{device.renderer.render_dtype(x[1][0])} {x[0]}" for x in targs])+") {"] + init_lines
     for i, ji in enumerate(jit_cache):
       args = [render_arg(buf) for buf in ji.bufs] + [x.expr for x in cast(CompiledRunner, ji.prg).p.vars]
       batched.append(f"  {to_function_name(cast(CompiledRunner, ji.prg).p.name)}({','.join(args)});")
     batched.append("}")
 
-    if n_cpu_prog == 0:
+    if not cpu_progs:
       prep = [device.renderer._render(cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache)]
       funcs = dedup(device.renderer._render_body(prep[i][0], *prep[i][1:], cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache))
       defines = dedup(itertools.chain.from_iterable(device.renderer._render_defines(cast(CompiledRunner, ji.prg).p.uops) for ji in jit_cache))
     else: funcs, defines = [], []
     entry = device.renderer._render_entry("batched", targs)
-    code = '\n'.join(defines) + '\n' + '\n'.join([''.join(f) for f in funcs]) + '\n' + '\n'.join(batched) + '\n' + entry
+    code = '\n'.join(itertools.chain(defines, funcs, batched, (entry,)))
 
     if DEBUG >= 4: print(code)
     self.clprg = device.runtime("batched", device.compiler.compile_cached(code))

--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -10,47 +10,47 @@ from tinygrad.renderer.cstyle import ClangRenderer
 
 class CPUGraph(GraphRunner):
   def __init__(self, device, jit_cache: list[ExecItem], input_rawbuffers: list[Buffer], var_vals: dict[Variable, int]):
-    cpu_progs: list[ExecItem] = []
-    if issubclass(device.runtime, CPUProgram):
-      device = Device["CPU"]
-      cpu_progs.extend(dict((cast(CompiledRunner, item.prg).p.name, item) for item in jit_cache).values()) # dedupe by name
+    if issubclass(device.runtime, CPUProgram): device = Device["CPU"]
     elif not isinstance(device.renderer, ClangRenderer): raise GraphException
     super().__init__(jit_cache, input_rawbuffers, var_vals)
 
     self.base_bufs = dedup(b.base for ji in jit_cache for b in ji.bufs if b is not None and b not in input_rawbuffers)
-    self.base_rawbufs = [b._buf for b in self.base_bufs] + [cast(CompiledRunner, ji.prg)._prg.fxn for ji in cpu_progs]
-
-    targs = [(f"arg{i}", (x.dtype.ptr(), False)) for i,x in enumerate(input_rawbuffers)] + \
-            [(f"cbuf{i}", (dtypes.char.ptr(), False)) for i in range(len(self.base_bufs))] + \
-            [(f"fxnp{i}", (dtypes.void.ptr(), False)) for i in range(len(cpu_progs))] + \
-            sorted([(f"{v.expr}", (dtypes.int, False)) for v in var_vals])
+    self.rawbufs = [b._buf for b in self.base_bufs]
 
     def render_arg(buf):
       if buf in input_rawbuffers: return f"arg{input_rawbuffers.index(buf)}"
       return f"({device.renderer.render_dtype(buf.dtype)}*)(cbuf{self.base_bufs.index(buf.base)} + {buf.offset})"
 
-    batched = ["void batched("+','.join([f"{device.renderer.render_dtype(x[1][0])} {x[0]}" for x in targs])+") {"]
-    for i, ji in enumerate(cpu_progs):
-      runner = cast(CompiledRunner, ji.prg)
-      arg_dtypes = tuple(buf.dtype.ptr() for buf in ji.bufs if buf is not None) + tuple(v.dtype for v in runner.p.vars)
-      s_args = ','.join([device.renderer.render_dtype(dt) for dt in arg_dtypes])
-      batched.append(f"  void (*{to_function_name(runner.p.name)})({s_args}) = (void (*)({s_args}))fxnp{i};")
-
+    defines, funcs, batched_inner  = [], [], []
+    rendered_casts: set[str] = set()
     for i, ji in enumerate(jit_cache):
-      args = [render_arg(buf) for buf in ji.bufs] + [x.expr for x in cast(CompiledRunner, ji.prg).p.vars]
-      batched.append(f"  {to_function_name(cast(CompiledRunner, ji.prg).p.name)}({','.join(args)});")
-    batched.append("}")
+      runner = cast(CompiledRunner, ji.prg)
+      fn_name = to_function_name(runner.p.name)
 
-    if not cpu_progs:
-      prep = [device.renderer._render(cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache)]
-      funcs = dedup(device.renderer._render_body(prep[i][0], *prep[i][1:], cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache))
-      defines = dedup(itertools.chain.from_iterable(device.renderer._render_defines(cast(CompiledRunner, ji.prg).p.uops) for ji in jit_cache))
-    else: funcs, defines = [], []
+      if isinstance(runner._prg, CPUProgram) and fn_name not in rendered_casts:
+        arg_dtypes = tuple(buf.dtype.ptr() for buf in ji.bufs if buf is not None) + tuple(v.dtype for v in runner.p.vars)
+        s_args = ','.join([device.renderer.render_dtype(dt) for dt in arg_dtypes])
+        batched_inner.append(f"  void (*{fn_name})({s_args}) = (void (*)({s_args}))fxnp{len(rendered_casts)};")
+        self.rawbufs.append(runner._prg.fxn)
+        rendered_casts.add(fn_name)
+
+      if not isinstance(runner._prg, CPUProgram):
+        defines.extend(device.renderer._render_defines(runner.p.uops))
+        funcs.append(device.renderer._render_body(*device.renderer._render(runner.p.uops), runner.p.uops))
+
+      batched_inner.append(f"  {fn_name}({','.join([render_arg(buf) for buf in ji.bufs] + [x.expr for x in runner.p.vars])});")
+
+    targs = [(f"arg{i}", (x.dtype.ptr(), False)) for i,x in enumerate(input_rawbuffers)] + \
+            [(f"cbuf{i}", (dtypes.char.ptr(), False)) for i in range(len(self.base_bufs))] + \
+            [(f"fxnp{i}", (dtypes.void.ptr(), False)) for i in range(len(rendered_casts))] + \
+            sorted([(f"{v.expr}", (dtypes.int, False)) for v in var_vals])
+
+    batched = ["void batched("+','.join([f"{device.renderer.render_dtype(x[1][0])} {x[0]}" for x in targs])+") {", *batched_inner, "}"]
     entry = device.renderer._render_entry("batched", targs)
-    code = '\n'.join(itertools.chain(defines, funcs, batched, (entry,)))
+    code = '\n'.join(itertools.chain(dedup(defines), dedup(funcs), batched, (entry,)))
 
     if DEBUG >= 4: print(code)
     self.clprg = device.runtime("batched", device.compiler.compile_cached(code))
 
   def __call__(self, rawbufs: list[Buffer], var_vals: dict[Variable, int], wait=False):
-    return self.clprg(*[x._buf for x in rawbufs], *self.base_rawbufs, *[x[1] for x in sorted(var_vals.items(), key=lambda x: x[0].expr)], wait=wait)
+    return self.clprg(*[x._buf for x in rawbufs], *self.rawbufs, *[x[1] for x in sorted(var_vals.items(), key=lambda x: x[0].expr)], wait=wait)

--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -2,7 +2,7 @@ from typing import cast
 import itertools
 from tinygrad.helpers import dedup, DEBUG, to_function_name
 from tinygrad.engine.jit import GraphRunner, GraphException
-from tinygrad.device import Buffer
+from tinygrad.device import Buffer, CPUProgram, Device
 from tinygrad.engine.realize import ExecItem, CompiledRunner
 from tinygrad.ops import Variable
 from tinygrad.dtype import dtypes
@@ -10,32 +10,47 @@ from tinygrad.renderer.cstyle import ClangRenderer
 
 class CPUGraph(GraphRunner):
   def __init__(self, device, jit_cache: list[ExecItem], input_rawbuffers: list[Buffer], var_vals: dict[Variable, int]):
-    if not issubclass(type(device.renderer), ClangRenderer) and not isinstance(device.renderer, ClangRenderer): raise GraphException
+    n_cpu_prog = len([ item for item in jit_cache if isinstance(item.prg._prg, CPUProgram) ])
+    if n_cpu_prog > 0:
+      if n_cpu_prog != len(jit_cache): raise GraphException
+      device = Device["CPU"]
+    elif not isinstance(device.renderer, ClangRenderer): raise GraphException
     super().__init__(jit_cache, input_rawbuffers, var_vals)
 
     self.base_bufs = dedup(b.base for ji in jit_cache for b in ji.bufs if b is not None and b not in input_rawbuffers)
     self.base_rawbufs = [b._buf for b in self.base_bufs]
+    cbuf_fn_casts: list[str] = []
+    for idx, ji in enumerate(jit_cache):
+      if isinstance(ji.prg._prg, CPUProgram):
+        p_args = [(f"arg{i}", (buf.dtype.ptr(), False)) for i, buf in enumerate(ji.bufs) if buf is not None] + \
+          [(f"{v.expr}", (dtypes.int, False)) for v in cast(CompiledRunner, ji.prg).p.vars]
+        s_args = ','.join([f"{device.renderer.render_dtype(x[1][0])}" for x in p_args])
+        fn_name = to_function_name(cast(CompiledRunner, ji.prg).p.name)
+        cbuf_fn_casts.append(f"  void (*{fn_name})({s_args}) = (void (*)({s_args}))fxnp{idx};")
+        self.base_rawbufs.append(ji.prg._prg.fxn)
 
     targs = [(f"arg{i}", (x.dtype.ptr(), False)) for i,x in enumerate(input_rawbuffers)] + \
             [(f"cbuf{i}", (dtypes.char.ptr(), False)) for i in range(len(self.base_bufs))] + \
+            [(f"fxnp{i}", (dtypes.void.ptr(), False)) for i in range(n_cpu_prog)] + \
             sorted([(f"{v.expr}", (dtypes.int, False)) for v in var_vals])
 
     def render_arg(buf):
       if buf in input_rawbuffers: return f"arg{input_rawbuffers.index(buf)}"
       return f"({device.renderer.render_dtype(buf.dtype)}*)(cbuf{self.base_bufs.index(buf.base)} + {buf.offset})"
 
-    batched = ["void batched("+','.join([f"{device.renderer.render_dtype(x[1][0])} {x[0]}" for x in targs])+") {"]
+    batched = ["void batched("+','.join([f"{device.renderer.render_dtype(x[1][0])} {x[0]}" for x in targs])+") {"] + cbuf_fn_casts
     for i, ji in enumerate(jit_cache):
       args = [render_arg(buf) for buf in ji.bufs] + [x.expr for x in cast(CompiledRunner, ji.prg).p.vars]
       batched.append(f"  {to_function_name(cast(CompiledRunner, ji.prg).p.name)}({','.join(args)});")
     batched.append("}")
 
-    prep = [device.renderer._render(cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache)]
-    funcs = dedup(device.renderer._render_body(prep[i][0], *prep[i][1:], cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache))
-
-    defines = dedup(itertools.chain.from_iterable(device.renderer._render_defines(cast(CompiledRunner, ji.prg).p.uops) for ji in jit_cache))
+    if n_cpu_prog == 0:
+      prep = [device.renderer._render(cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache)]
+      funcs = dedup(device.renderer._render_body(prep[i][0], *prep[i][1:], cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache))
+      defines = dedup(itertools.chain.from_iterable(device.renderer._render_defines(cast(CompiledRunner, ji.prg).p.uops) for ji in jit_cache))
+    else: funcs, defines = [], []
     entry = device.renderer._render_entry("batched", targs)
-    code = '\n'.join(defines) + '\n' + '\n'.join([''.join(f) for f in funcs]) + '\n'.join(batched) + '\n' + entry
+    code = '\n'.join(defines) + '\n' + '\n'.join([''.join(f) for f in funcs]) + '\n' + '\n'.join(batched) + '\n' + entry
 
     if DEBUG >= 4: print(code)
     self.clprg = device.runtime("batched", device.compiler.compile_cached(code))

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -1,6 +1,7 @@
-import platform, subprocess, sys
+import platform, subprocess, sys, functools
 from tinygrad.helpers import capstone_flatdump, getenv
 from tinygrad.device import Compiled, Compiler, MallocAllocator, CPUProgram
+from tinygrad.runtime.graph.cpu import CPUGraph
 from tinygrad.runtime.support.elf import jit_loader
 from tinygrad.renderer.cstyle import ClangRenderer
 
@@ -19,6 +20,7 @@ class ClangJITCompiler(Compiler):
   def disassemble(self, lib:bytes): return capstone_flatdump(lib)
 
 class ClangDevice(Compiled):
-  def __init__(self, device:str): super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram)
+  def __init__(self, device:str):
+    super().__init__(device, MallocAllocator, ClangRenderer(), ClangJITCompiler(), CPUProgram, functools.partial(CPUGraph, self))
 
 CPUDevice = ClangDevice

--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -1,8 +1,9 @@
-import ctypes, platform
+import ctypes, platform, functools
 from tinygrad.device import Compiled, Compiler, MallocAllocator, CPUProgram
 from tinygrad.helpers import OSX, getenv, capstone_flatdump, DEBUG
 from tinygrad.renderer.llvmir import LLVMRenderer
 import tinygrad.runtime.autogen.llvm as llvm
+from tinygrad.runtime.graph.cpu import CPUGraph
 from tinygrad.runtime.support.elf import jit_loader
 
 def cerr(): return ctypes.pointer(ctypes.pointer(ctypes.c_char()))
@@ -60,4 +61,4 @@ class HostLLVMCompiler(LLVMCompiler):
 
 class LLVMDevice(Compiled):
   def __init__(self, device:str):
-    super().__init__(device, MallocAllocator, LLVMRenderer(), HostLLVMCompiler(), CPUProgram)
+    super().__init__(device, MallocAllocator, LLVMRenderer(), HostLLVMCompiler(), CPUProgram, functools.partial(CPUGraph, self))


### PR DESCRIPTION
Reuses the compiled CPUProgram for both LLVM and CLANG.

I have decided to pass in the functions as void pointers, to make sure `device.renderer._render_entry("batched", targs)` works correctly.

Running `test_order_2_writes_to_same_buf` produces:

```python
void batched(signed char* cbuf0,signed char* cbuf1,signed char* cbuf2,signed char* cbuf3,signed char* cbuf4,void* fxnp0) {
  void (*E_131072_4n2)(int*,int*,int*) = (void (*)(int*,int*,int*))fxnp0;
  E_131072_4n2((int*)(cbuf0 + 0),(int*)(cbuf1 + 0),(int*)(cbuf2 + 0));
  E_131072_4n2((int*)(cbuf0 + 0),(int*)(cbuf3 + 0),(int*)(cbuf4 + 0));
}
```