### PR TITLE
RetinaNet INITMLPERF support

### DIFF
--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -385,7 +385,7 @@ def train_retinanet():
     x = Tensor.zeros(bs, 800, 800, 3, dtype=dtypes.uint8).contiguous()
     if val:
       img_ids, img_sizes = [0] * bs, [(800, 800)] * bs
-      return x.shard(GPUS, axis=0).realize(), img_ids, img_sizes
+      return x.shard(GPUS, axis=0).realize(), img_ids, img_sizes, None
 
     y_boxes = Tensor.zeros(bs, 120087, 4, dtype=dtypes.float32).contiguous()
     y_labels = Tensor.zeros(bs, 120087, dtype=dtypes.int64).contiguous()
@@ -395,24 +395,22 @@ def train_retinanet():
 
   @TinyJit
   def _train_step(model, optim, loss_scaler, x, **kwargs):
-    with Context(BEAM=TRAIN_BEAM):
-      optim.zero_grad()
+    optim.zero_grad()
 
-      losses = model(normalize(x, GPUS), **kwargs)
-      loss = sum([l for l in losses.values()])
+    losses = model(normalize(x, GPUS), **kwargs)
+    loss = sum([l for l in losses.values()])
 
-      (loss * loss_scaler).backward()
-      for t in optim.params: t.grad = t.grad / loss_scaler
+    (loss * loss_scaler).backward()
+    for t in optim.params: t.grad = t.grad / loss_scaler
 
-      optim.step()
+    optim.step()
 
-      return loss.realize(), losses
+    return loss.realize(), losses
   
   @TinyJit
   def _eval_step(model, x, **kwargs):
-    with Context(BEAM=EVAL_BEAM):
-      out = model(normalize(x, GPUS), **kwargs)
-      return out.realize()
+    out = model(normalize(x, GPUS), **kwargs)
+    return out.realize()
 
   # ** hyperparameters **
   config["seed"] = SEED = getenv("SEED", random.SystemRandom().randint(0, 2**32 - 1))
@@ -474,6 +472,8 @@ def train_retinanet():
 
   for e in range(start_epoch, EPOCHS):
     # ** training loop **
+    BEAM.value = TRAIN_BEAM
+
     if INITMLPERF:
       i, proc = 0, _fake_data_get(BS)
     else:
@@ -542,6 +542,8 @@ def train_retinanet():
       
     # ** eval loop **
     if (e + 1) % eval_freq == 0:
+      BEAM.value = EVAL_BEAM
+
       if getenv("RESET_STEP", 1): _train_step.reset()
 
       with Tensor.train(mode=False), Tensor.test():
@@ -551,9 +553,9 @@ def train_retinanet():
           val_dataloader = batch_load_retinanet(val_dataset, (val:=True), Path(BASE_DIR), batch_size=EVAL_BS, shuffle=False, seed=SEED)
           it = iter(tqdm(val_dataloader, total=steps_in_val_epoch))
           i, proc = 0, _data_get(it, val=val)
+          val_img_ids, val_imgs, ncats, narea = [], [], len(coco_val.params.catIds), len(coco_val.params.areaRng)
 
         eval_times, prev_cookies = [], []
-        val_img_ids, val_imgs, ncats, narea = [], [], len(coco_val.params.catIds), len(coco_val.params.areaRng)
 
         while proc is not None:
           GlobalCounters.reset()
@@ -561,16 +563,18 @@ def train_retinanet():
 
           out, img_ids, img_sizes, proc = _eval_step(model, (x:=proc[0])).numpy(), proc[1], proc[2], proc[3]
           out = model.postprocess_detections(out, input_size=x.shape[1:3], orig_image_sizes=img_sizes)
-          coco_results  = [{"image_id": img_ids[i], "category_id": label, "bbox": box.tolist(), "score": score}
-            for i, prediction in enumerate(out) for box, score, label in zip(*prediction.values())]
 
-          with redirect_stdout(None):
-            coco_val.cocoDt = val_dataset.loadRes(coco_results)
-            coco_val.params.imgIds = img_ids
-            coco_val.evaluate()
+          if not INITMLPERF:
+            coco_results  = [{"image_id": img_ids[i], "category_id": label, "bbox": box.tolist(), "score": score}
+              for i, prediction in enumerate(out) for box, score, label in zip(*prediction.values())]
 
-          val_img_ids.extend(img_ids)
-          val_imgs.append(np.array(coco_val.evalImgs).reshape(ncats, narea, len(img_ids)))
+            with redirect_stdout(None):
+              coco_val.cocoDt = val_dataset.loadRes(coco_results)
+              coco_val.params.imgIds = img_ids
+              coco_val.evaluate()
+
+            val_img_ids.extend(img_ids)
+            val_imgs.append(np.array(coco_val.evalImgs).reshape(ncats, narea, len(img_ids)))
 
           if len(prev_cookies) == getenv("STORE_COOKIES", 1): prev_cookies = []  # free previous cookies after gpu work has been enqueued
           try:
@@ -594,22 +598,23 @@ def train_retinanet():
         if getenv("RESET_STEP", 1): _eval_step.reset()
         total_fw_time = sum(eval_times) / len(eval_times)
 
-        coco_val.params.imgIds = val_img_ids
-        coco_val._paramsEval.imgIds = val_img_ids
-        coco_val.evalImgs = list(np.concatenate(val_imgs, -1).flatten())
-        coco_val.accumulate()
-        coco_val.summarize()
+        if not INITMLPERF:
+          coco_val.params.imgIds = val_img_ids
+          coco_val._paramsEval.imgIds = val_img_ids
+          coco_val.evalImgs = list(np.concatenate(val_imgs, -1).flatten())
+          coco_val.accumulate()
+          coco_val.summarize()
 
-        val_metric = coco_val.stats[0]
+          val_metric = coco_val.stats[0]
 
-        tqdm.write(f"eval time: {total_fw_time:.2f}, eval metric: {val_metric:.4f}")
+          tqdm.write(f"eval time: {total_fw_time:.2f}, eval metric: {val_metric:.4f}")
 
-        if WANDB:
-          wandb.log({"eval/forward_time": total_fw_time, "eval/metric": val_metric, "epoch": e + 1})
+          if WANDB:
+            wandb.log({"eval/forward_time": total_fw_time, "eval/metric": val_metric, "epoch": e + 1})
 
-        if val_metric >= target_metric:
-          print(colored(f"target metric reached: {val_metric:.2f}/{target_metric:.2f}", color="green"))
-          break
+          if val_metric >= target_metric:
+            print(colored(f"target metric reached: {val_metric:.2f}/{target_metric:.2f}", color="green"))
+            break
 
 def train_unet3d():
   """

--- a/extra/models/retinanet.py
+++ b/extra/models/retinanet.py
@@ -160,7 +160,7 @@ class RegressionHead:
     self.bbox_reg = ConvHead(in_channels, num_anchors * 4, kernel_size=3, padding=1)
 
     if box_coder is None:
-      box_coder = BoxCoder((1.0, 1.0, 1.0, 1.0), apply_to_remove=False)
+      box_coder = BoxCoder((1.0, 1.0, 1.0, 1.0), apply_to_remove=True)
     self.box_coder = box_coder
 
   def __call__(self, x:Tensor, bboxes:Tensor|None=None, matches:Tensor|None=None, anchors:Tensor|None=None):

--- a/extra/models/retinanet.py
+++ b/extra/models/retinanet.py
@@ -160,7 +160,7 @@ class RegressionHead:
     self.bbox_reg = ConvHead(in_channels, num_anchors * 4, kernel_size=3, padding=1)
 
     if box_coder is None:
-      box_coder = BoxCoder((1.0, 1.0, 1.0, 1.0), apply_to_remove=True)
+      box_coder = BoxCoder((1.0, 1.0, 1.0, 1.0))
     self.box_coder = box_coder
 
   def __call__(self, x:Tensor, bboxes:Tensor|None=None, matches:Tensor|None=None, anchors:Tensor|None=None):


### PR DESCRIPTION
# Overview
This PR adds support for `INITMLPERF` that can be used to run beam searches by using an empty dataset.

Note that the validation loop is updated so that it does not trigger the `pycocotools` related operations as it is not important for applying beam search on it.

Here's a screenshot of how it looks like when running the following command:
```bash
INITMLPERF=1 BENCHMARK=10 MODEL=retinanet BASE_DIR=/raid/datasets/openimages/ BS=48 GPUS=6 python3 examples/mlperf/model_train.py
```
<img width="1066" alt="Screenshot 2025-04-20 at 14 03 21" src="https://github.com/user-attachments/assets/f035c91a-90f1-42a2-b464-5b0684fc5621" />