### PR TITLE
fix kernelize usage with pm_gradient

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -606,16 +606,25 @@ class TestSchedule(unittest.TestCase):
     e = c.kernelize()+d.kernelize()
     check_schedule(e, 3)
 
-  @unittest.expectedFailure # TODO: this should pass
   def test_kernelize_bw(self):
     a = Tensor.full((3,), 2.0, requires_grad=True).contiguous()
     b = Tensor.full((3,), 3.0, requires_grad=True).contiguous()
     x = (a*b).kernelize()
     y = Tensor.eye(3, requires_grad=True)
     z = y.matmul(x).sum()
-    if getenv("VIZ"):
-      graph_rewrite(z.lazydata, PatternMatcher([]), name="y.matmul(x).sum()")
     z.backward()
+    self.assertEqual(z.item(), 18.0)
+    self.assertEqual(z.grad.item(), 1.0)
+
+  def test_kernelize_bw_view(self):
+    a = Tensor.full((3,1), 2.0, requires_grad=True).contiguous()
+    b = Tensor.full((3,1), 3.0, requires_grad=True).contiguous()
+    x = (a*b).kernelize()
+    y = Tensor.eye(6, requires_grad=True)
+    z = y.matmul(x.expand(3,2).reshape(6)).sum()
+    z.backward()
+    self.assertEqual(z.item(), 36.0)
+    self.assertEqual(z.grad.item(), 1.0)
 
   @unittest.skip("no longer supported")
   def test_double_from(self):

--- a/tinygrad/gradient.py
+++ b/tinygrad/gradient.py
@@ -41,8 +41,8 @@ pm_gradient = PatternMatcher([
   (UPat(Ops.EXPAND, name="ret"), lambda ctx, ret:
     (ctx.cast(sum_acc_dtype(ctx.dtype)).r(Ops.ADD, tuple(i for i,(si,so) in enumerate(zip(ret.src[0].shape, ret.arg)) if si!=so)).cast(ctx.dtype),)),
   (UPat(Ops.MULTI, name="ret"), lambda ctx, ret: ctx.shard(ret.device, ret.axis).src),
-  # there's no gradient for bitcast or assign
-  (UPat((Ops.BITCAST, Ops.ASSIGN)), lambda ctx: (None,)),
+  # there's no gradient for bitcast
+  (UPat(Ops.BITCAST), lambda ctx: (None,)),
 ])
 
 # copied from tensor.py, get relevant toposort of gradients

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -35,7 +35,7 @@ tensor_uop_spec = buffer_spec+assign_spec+PatternMatcher([
    # "make things that can't be images not images" can change the buffer dtype
    # this is fine as long as it's a realized buffer and base dtypes match.
    ((isinstance(mv.dtype, ImageDType) or isinstance(x.dtype, ImageDType)) and x.dtype.base == mv.dtype.base and x.base.op is Ops.BUFFER)),
-  (UPat(Ops.VIEW, src=(UPat(GroupOp.All-{Ops.BUFFER, Ops.BUFFER_VIEW, Ops.CONST, Ops.DEVICE}),)), lambda: False),
+  (UPat(Ops.VIEW, src=(UPat(GroupOp.All-{Ops.BUFFER, Ops.ASSIGN, Ops.BUFFER_VIEW, Ops.CONST, Ops.DEVICE}),)), lambda: False),
 
   # Tensor variable bindings
   (UPat(Ops.BIND, dtypes.int, (UPat(Ops.DEFINE_VAR), UPat.cvar(dtype=dtypes.int)), arg=None), lambda: True),


### PR DESCRIPTION
ASSIGNs are treated like DETACH in the graph, gradients do not flow through ASSIGN.

Currently the logic for picking if a Tensor uses replace or constructs ASSIGN(BUFFER, value) is in tensor.py. Any UOp children for an ASSIGN simply loads the BUFFER value, so it's behavior is similar to a BUFFER UOp.