### PR TITLE
Less verbose cloud multiprocessing start

### DIFF
--- a/tinygrad/runtime/ops_cloud.py
+++ b/tinygrad/runtime/ops_cloud.py
@@ -124,7 +124,6 @@ class CloudHandler(BaseHTTPRequestHandler):
   def do_POST(self): return self._do("POST")
 
 def cloud_server(port:int):
-  multiprocessing.current_process().name = "MainProcess"
   CloudHandler.device = getenv("CLOUDDEV", "METAL") if Device.DEFAULT == "CLOUD" else Device.DEFAULT
   print(f"start cloud server on {port} with device {CloudHandler.device}")
   server = HTTPServer(('', port), CloudHandler)
@@ -166,9 +165,7 @@ class CloudDevice(Compiled):
   def __init__(self, device:str):
     if (host:=getenv("HOST", "")) != "": self.host = host
     else:
-      p = multiprocessing.Process(target=cloud_server, args=(6667,))
-      p.daemon = True
-      p.start()
+      multiprocessing.Process(target=cloud_server, args=(6667,), name="MainProcess", daemon=True).start()
       self.host = "127.0.0.1:6667"
 
     # state for the connection


### PR DESCRIPTION
The set name before starting part used to be required for #9935 when CLOUDDEV was a global variable, now just readability improvement