### PR TITLE
fix kernelize with VIEW children

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -597,6 +597,12 @@ class TestSchedule(unittest.TestCase):
     d = c+2
     check_schedule(d, 2)
 
+  def test_kernelize_view(self):
+    a = Tensor.empty(4,1)
+    b = a*2
+    c = b.kernelize()+Tensor.empty(4,4)
+    check_schedule(c, 2)
+
   # unlike schedule, kernelize can be called multiple times on a Tensor
   def test_double_kerenlize(self):
     a = Tensor.empty(10)

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -35,7 +35,7 @@ tensor_uop_spec = buffer_spec+assign_spec+PatternMatcher([
    # "make things that can't be images not images" can change the buffer dtype
    # this is fine as long as it's a realized buffer and base dtypes match.
    ((isinstance(mv.dtype, ImageDType) or isinstance(x.dtype, ImageDType)) and x.dtype.base == mv.dtype.base and x.base.op is Ops.BUFFER)),
-  (UPat(Ops.VIEW, src=(UPat(GroupOp.All-{Ops.BUFFER, Ops.BUFFER_VIEW, Ops.CONST, Ops.DEVICE}),)), lambda: False),
+  (UPat(Ops.VIEW, src=(UPat(GroupOp.All-{Ops.BUFFER, Ops.BUFFER_VIEW, Ops.ASSIGN, Ops.CONST, Ops.DEVICE}),)), lambda: False),
 
   # Tensor variable bindings
   (UPat(Ops.BIND, dtypes.int, (UPat(Ops.DEFINE_VAR), UPat.cvar(dtype=dtypes.int)), arg=None), lambda: True),


### PR DESCRIPTION
Prereq for the gradient diff https://github.com/tinygrad/tinygrad/pull/9953

The Tensor UOp spec asserts views mid graph because we have not yet defined the gradient of a VIEW.

Since gradients do not flow through ASSIGNs, having a VIEW(ASSIGN) in the graph is fine, similar to a VIEW(BUFFER).