### PR TITLE
RetinaNet time estimation fix

### DIFF
--- a/extra/datasets/openimages.py
+++ b/extra/datasets/openimages.py
@@ -1,3 +1,4 @@
+import glob
 import sys
 import json
 import numpy as np
@@ -198,6 +199,10 @@ def normalize(img:Tensor, device:list[str]|None = None):
   std = Tensor([0.229, 0.224, 0.225], device=device, dtype=dtypes.float32).reshape(1, -1, 1, 1)
   img = ((img.permute([0, 3, 1, 2]) / 255.0) - mean) / std
   return img.cast(dtypes.default_float)
+
+def get_dataset_count(base_dir:Path, val:bool) -> int:
+  if not (files:=glob.glob(p:=str(base_dir / f"{'validation' if val else 'train'}/data/*.jpg"))): raise FileNotFoundError(f"No files in {p}")
+  return len(files)
 
 if __name__ == "__main__":
   download_dataset(base_dir:=getenv("BASE_DIR", BASEDIR), "train")


### PR DESCRIPTION
# Overview
As pointed out in #9950, the estimated training time is incorrect. The core issue was that with `INITMLPERF=1`, both `steps_in_train_epoch` and `steps_in_val_epoch` are set to `BS` and `EVAL_BS`, respectively.

Since this is not representative of the actual dataset count, the estimations are going to be incorrect. This PR now looks through the actual number of images and uses that as the dataset count, regardless of the value of `INITMLPERF`.

Here's an actual run of the following command: 
```bash
INITMLPERF=1 BENCHMARK=10 MODEL=retinanet BASE_DIR=/raid/datasets/openimages/ BS=48 GPUS=6 python3 examples/mlperf/model_train.py
```

<img width="1072" alt="Screenshot 2025-04-21 at 11 20 49" src="https://github.com/user-attachments/assets/7c5fb959-01cc-409e-849e-a8240360478b" />

For comparison, here's the same run without `INITMLPERF`:
```bash
BENCHMARK=10 MODEL=retinanet BASE_DIR=/raid/datasets/openimages/ BS=48 GPUS=6 python3 examples/mlperf/model_train.py
```
<img width="1074" alt="Screenshot 2025-04-21 at 11 26 48" src="https://github.com/user-attachments/assets/199b66ed-ba43-4508-9a1e-1ee428966ef4" />