### PR TITLE
Fix NBIO 7.2.0 error on Steam Deck

### DIFF
--- a/autogen_stubs.sh
+++ b/autogen_stubs.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash 
+set -e
 
 # setup instructions for clang2py
 if [[ ! $(clang2py -V) ]]; then
@@ -431,6 +432,12 @@ generate_am() {
     $AMKERN_INC/asic_reg/nbio/nbio_2_3_sh_mask.h \
     -o $BASE/am/nbio_2_3_0.py
   fixup $BASE/am/nbio_2_3_0.py
+
+  clang2py -k cdefstum \
+    $AMKERN_INC/asic_reg/nbio/nbio_7_2_0_offset.h \
+    $AMKERN_INC/asic_reg/nbio/nbio_7_2_0_sh_mask.h \
+    -o $BASE/am/nbio_7_2_0.py
+  fixup $BASE/am/nbio_7_2_0.py
 
   clang2py -k cdefstum \
     $AMKERN_INC/asic_reg/mmhub/mmhub_4_1_0_offset.h \

--- a/autogen_stubs.sh
+++ b/autogen_stubs.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env bash 
-set -e
+#!/bin/bash -e
 
 # setup instructions for clang2py
 if [[ ! $(clang2py -V) ]]; then


### PR DESCRIPTION
Any operations on Steam Deck with `AMD=1` were giving the following error regarding NBIO 7.2.0 not being found, the fix is expands the RDNA2 fix (#9700) to handle Steam Deck as well.

```
['f644a68c-7d33-48df-8588-9652319edbef(WiFi (wlo1))', '6dcccf8a-84a7-4f7e-b897-9c21a77b4ef5(Ethernet (eno1))']})
Task exception was never retrieved
future: <Task finished name='Task-217' coro=<TinygradDynamicShardInferenceEngine.ensure_shard() done, defined at /nix/store/yqs9w5kkzd7rlj6a3agbgxc729s5d9qm-exo-0.0.16-intelarc/lib/python3.12/site-packages/exo/inference/tinygrad/inference.py:143> exception=ImportError('Failed
to load autogen module for NBIO 7.2.0')>
Traceback (most recent call last):
  File "/nix/store/yqs9w5kkzd7rlj6a3agbgxc729s5d9qm-exo-0.0.16-intelarc/lib/python3.12/site-packages/exo/inference/tinygrad/inference.py", line 152, in ensure_shard
    model_shard = await loop.run_in_executor(self.executor, build_transformer, model_path, shard, parameters)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/f2krmq3iv5nibcvn4rw7nrnrciqprdkh-python3-3.12.9/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/yqs9w5kkzd7rlj6a3agbgxc729s5d9qm-exo-0.0.16-intelarc/lib/python3.12/site-packages/exo/inference/tinygrad/inference.py", line 45, in build_transformer
    model = Transformer(**MODEL_PARAMS[model_size]["args"], linear=linear, max_context=8192, jit=True, shard=shard)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/yqs9w5kkzd7rlj6a3agbgxc729s5d9qm-exo-0.0.16-intelarc/lib/python3.12/site-packages/exo/inference/tinygrad/models/llama.py", line 198, in __init__
    self.freqs_cis = precompute_freqs_cis(dim // n_heads, self.max_context*2, rope_theta, rope_scaling=rope_scaling).contiguous()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/yqs9w5kkzd7rlj6a3agbgxc729s5d9qm-exo-0.0.16-intelarc/lib/python3.12/site-packages/exo/inference/tinygrad/models/llama.py", line 17, in precompute_freqs_cis
    freqs[:dim // 4] *= low_freq_factor
    ~~~~~^^^^^^^^^^^
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/tensor.py", line 4193, in _wrapper
    ret = fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/tensor.py", line 1213, in __setitem__
    res = self.realize()._getitem(indices, v)
          ^^^^^^^^^^^^^^
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/tensor.py", line 4168, in _wrapper
    if _METADATA.get() is not None: return fn(*args, **kwargs)
                                           ^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/tensor.py", line 255, in realize
    run_schedule(*self.schedule_with_vars(*lst), do_update_stats=do_update_stats)
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 183, in run_schedule
    ei.run(var_vals, do_update_stats=do_update_stats)
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 125, in run
    et = self.prg(bufs, var_vals, wait=wait or DEBUG >= 2)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/engine/realize.py", line 65, in __call__
    return self._prg(*[x._buf for x in rawbufs], **lra, vals=tuple(var_vals[k] for k in self.p.vars), wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/runtime/support/hcq.py", line 325, in __call__
    q = self.dev.hw_compute_queue_t().wait(self.dev.timeline_signal, self.dev.timeline_value - 1).memory_barrier()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/runtime/ops_amd.py", line 125, in memory_barrier
    self.wait_reg_mem(reg_req=getattr(self.nbio, f'regBIF_BX_PF{pf}_GPU_HDP_FLUSH_REQ').addr,
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/runtime/ops_amd.py", line 505, in __getattr__
    if name in self.regs: return self.regs[name]
               ^^^^^^^^^
  File "/nix/store/f2krmq3iv5nibcvn4rw7nrnrciqprdkh-python3-3.12.9/lib/python3.12/functools.py", line 998, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/runtime/ops_amd.py", line 503, in regs
    def regs(self): return collect_registers(self.module, cls=functools.partial(AMDReg, ip=self))
                                             ^^^^^^^^^^^
  File "/nix/store/f2krmq3iv5nibcvn4rw7nrnrciqprdkh-python3-3.12.9/lib/python3.12/functools.py", line 998, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/runtime/ops_amd.py", line 501, in module
    def module(self): return import_module(self.name, self.version)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ph9d3a1ixn6bgh8psw502q6j6rpmysw4-python3.12-tinygrad-0.10.2-unstable-2025-04-10/lib/python3.12/site-packages/tinygrad/runtime/support/amd.py", line 32, in import_module
    raise ImportError(f"Failed to load autogen module for {name.upper()} {'.'.join(map(str, version))}")
ImportError: Failed to load autogen module for NBIO 7.2.0
```