### PR TITLE
add FLAT formats to remu

### DIFF
--- a/extra/remu/src/thread.rs
+++ b/extra/remu/src/thread.rs
@@ -1505,8 +1505,12 @@ impl<'a> Thread<'a> {
             if !self.exec.read() {
                 return Ok(());
             }
-            let offset = sign_ext(instr & 0x1fff, 13);
             let seg = (instr >> 16) & 0x3;
+            let offset_bits = match seg {
+                0 => 12,
+                _ => 13
+            };
+            let offset = sign_ext(instr & 0x1fff, offset_bits);
             let op = ((instr >> 18) & 0x7f) as usize;
             let addr = ((instr >> 32) & 0xff) as usize;
             let data = ((instr >> 40) & 0xff) as usize;
@@ -1539,7 +1543,7 @@ impl<'a> Thread<'a> {
                         _ => todo_instr!(instruction)?,
                     }
                 }
-                2 => {
+                0 | 2 => {
                     print_instr!("GLOBAL", offset, op, addr, data, saddr, vdst);
 
                     let addr = match saddr_off {


### PR DESCRIPTION
rebase from #9982. The FLAT format is very complex actually, it "may" fall into global memory space or local memory space, depending on a scalar register that is different per wave. This resolves all FLAT instructions to the GDS. But the addresses can fall into SDS as well, I'll need to hand write some tests that use the scratch address space next and resolve those correctly too.
https://www.amd.com/content/dam/amd/en/documents/radeon-tech-docs/instruction-set-architectures/rdna3-shader-instruction-set-architecture-feb-2023_0.pdf#page=120