### PR TITLE
new schedule linearizer enqueues KERNEL UOps [pr]

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -604,14 +604,13 @@ class TestSchedule(unittest.TestCase):
     c = b.kernelize()+Tensor.empty(4,4)
     check_schedule(c, 2)
 
-  @unittest.skip("this fails because it's toposorting the ASSIGN")
   def test_multioutput_ast(self):
     a = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize().lazydata
     b = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize().lazydata
     c = Tensor.arange(4).realize().lazydata
     kernel = UOp(Ops.KERNEL, src=(a, b, c), arg=Kernel(UOp.sink(c.r(Ops.ADD, (0,))+1, c.r(Ops.ADD, (0,))*2)))
     kernel = graph_rewrite(kernel, create_ast)
-    run_schedule(check_schedule(UOp.sink(a.assign(kernel), b.assign(kernel)), 2))
+    run_schedule(check_schedule(UOp.sink(a.assign(kernel), b.assign(kernel)), 1))
     self.assertEqual(a.buffer.numpy(), [7])
     self.assertEqual(b.buffer.numpy(), [12])
 

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -34,7 +34,7 @@ pm_unbind = PatternMatcher([
 # **** schedule linearizer
 
 def create_schedule_with_vars(sched_sink:UOp) -> tuple[list[ScheduleItem], dict[Variable, int], dict[UOp, UOp]]:
-  # construnct the KERNEL children graph based on ASSIGNs
+  # construnct the KERNEL children graph based on assigns
   children: defaultdict[UOp, list[UOp]] = defaultdict(list)
   in_degree: dict[UOp, int] = {}
   for u in (toposort:=sched_sink.toposort):

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from collections import deque, defaultdict
+from collections import deque
 from tinygrad.ops import UOp, Variable, Ops, UPat, PatternMatcher, graph_rewrite, buffers
 from tinygrad.device import Buffer
 from tinygrad.helpers import Metadata, DEBUG, unwrap
@@ -46,7 +46,7 @@ def create_schedule_with_vars(sched_sink:UOp) -> tuple[list[ScheduleItem], dict[
       children.setdefault(s.src[1], []).append(k)
       in_degree[k] += 1
 
-  # bfs algorithm
+  # linearize KERNEL UOps into ScheduleItems in BFS order
   queue = deque(k for k,v in in_degree.items() if v == 0)
   schedule: list[ScheduleItem] = []
   var_vals: dict[Variable, int] = {}

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -34,31 +34,33 @@ pm_unbind = PatternMatcher([
 # **** schedule linearizer
 
 def create_schedule_with_vars(sched_sink:UOp) -> tuple[list[ScheduleItem], dict[Variable, int], dict[UOp, UOp]]:
-  # bfs toposort
-  children: defaultdict[UOp, list[UOp]] = defaultdict(list)
-  in_degree: defaultdict[UOp, int] = defaultdict(int)
+  # construnct the KERNEL children graph based on ASSIGNs
+  children: dict[UOp, list[UOp]] = {}
+  in_degree: dict[UOp, int] = {}
   for u in (toposort:=sched_sink.toposort):
     if u.op is not Ops.ASSIGN: continue
-    for s in u.src[1].src:
+    k = u.src[1]
+    in_degree.setdefault(k, 0)
+    for s in k.src:
       if s.op is not Ops.ASSIGN: continue
-      children[s].append(u)
-      in_degree[u] += 1
+      children.setdefault(s.src[1], []).append(k)
+      in_degree[k] += 1
 
-  queue = deque(u for u in toposort if u.op is Ops.ASSIGN and u not in in_degree)
+  # bfs algorithm
+  queue = deque(k for k,v in in_degree.items() if v == 0)
   schedule: list[ScheduleItem] = []
   var_vals: dict[Variable, int] = {}
   while queue:
-    u = queue.popleft()
-    # map the BUFFER UOp to a subbuffer if it's a BUFFER_VIEW
-    if (k:=u.src[1]).arg.ast.op is Ops.BUFFER_VIEW:
+    k = queue.popleft()
+    if k.arg.ast.op is Ops.BUFFER_VIEW:
       buffers[k.src[0]] = (base:=k.src[1].buf_uop.buffer).view(k.size, k.arg.ast.dtype, k.arg.ast.arg[1]*base.dtype.itemsize)
     schedule.append(ScheduleItem(graph_rewrite(k.arg.ast, pm_unbind, ctx=var_vals), tuple(s.buf_uop.buffer for s in k.src), k.arg.metadata))
-    for x in children[u]:
+    for x in children.get(k, []):
       in_degree[x] -= 1
       if in_degree[x] == 0: queue.append(x)
 
   # confirm everything was scheduled correctly
-  assert len(schedule) == len([u for u in toposort if u.op is Ops.KERNEL]), f"Schedule length mistmatch {len(schedule)}"
+  assert len(schedule) == len(in_degree), f"Schedule length mistmatch {len(schedule)} != {len(in_degree)}"
   if DEBUG >= 1 and len(schedule) >= 10: print(f"scheduled {len(schedule)} kernels")
 
   # map ASSIGN to BUFFER after ScheduleItems are constructed


### PR DESCRIPTION
The linearizer used to put ASSIGN in the queue, this did not work with multi output because multiple ASSIGNs can share a KERNEL. 
`VIZ=1 python test/test_schedule.py TestSchedule.test_multioutput_ast`:
![image](https://github.com/user-attachments/assets/3ded5440-61a4-4258-bb33-2c1495e2f646)