### PR TITLE
Print real device behind cloud instead of an array of renderer properties

### DIFF
--- a/tinygrad/runtime/ops_cloud.py
+++ b/tinygrad/runtime/ops_cloud.py
@@ -113,7 +113,7 @@ class CloudHandler(BaseHTTPRequestHandler):
             if r is not None: ret = str(r).encode()
     elif self.path == "/properties" and method == "GET":
       cls, args = Device[CloudHandler.device].renderer.__reduce__()
-      ret = json.dumps({'renderer': (cls.__module__, cls.__name__, args)}).encode()
+      ret = json.dumps({'clouddev': CloudHandler.device, 'renderer': (cls.__module__, cls.__name__, args)}).encode()
     else: status_code = 404
     self.send_response(status_code)
     self.send_header('Content-Length', str(len(ret)))
@@ -182,7 +182,7 @@ class CloudDevice(Compiled):
       except Exception as e:
         print(e)
         time.sleep(0.1)
-    if DEBUG >= 1: print(f"remote has device {self.properties['renderer']}")
+    if DEBUG >= 1: print(f"remote has device {self.properties['clouddev']}")
     # TODO: how to we have BEAM be cached on the backend? this should just send a specification of the compute. rethink what goes in Renderer
     renderer = self.properties['renderer']
     if not renderer[0].startswith("tinygrad.renderer.") or not renderer[1].endswith("Renderer"): raise RuntimeError(f"bad renderer {renderer}")


### PR DESCRIPTION
(the first commit of this pr is #10021)

This is kind of a bug because currently with DEBUG>=1 it will say that
remote has device and then an array of renderer props instead of a real
device name which doesn't make sense:

```
127.0.0.1 - - [24/Apr/2025 16:50:44] "GET /properties HTTP/1.1" 200 -
remote has device ['tinygrad.renderer.cstyle', 'MetalRenderer', []]
opened device CLOUD from pid:20210
```

Now it will actually print the name of device behind cloud:

```
127.0.0.1 - - [24/Apr/2025 16:56:29] "GET /properties HTTP/1.1" 200 -
remote has device METAL
opened device CLOUD from pid:20315
```