### PR TITLE
Add macos CLOUD tests 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -761,6 +761,30 @@ jobs:
     - name: Run WEBGPU Efficientnet
       run: node test/web/test_webgpu.js
 
+  osxcloud:
+    name: MacOS (cloud)
+    runs-on: macos-15
+    timeout-minutes: 10
+    env:
+      CLOUD: 1
+      CLOUDDEV: METAL
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Setup Environment
+        uses: ./.github/actions/setup-tinygrad
+        with:
+          key: macos-cloud
+          deps: testing_minimal
+      - name: Check Device.DEFAULT and print some source
+        run: |
+          python -c "from tinygrad import Device; assert Device.DEFAULT == 'CLOUD', Device.DEFAULT"
+          python -c "from tinygrad import Device; assert Device.default.properties['clouddev'] == 'METAL', Device.default.properties['clouddev']"
+          DEBUG=4 python3 test/test_tiny.py TestTiny.test_plus
+      - name: Run CLOUD=1 Test
+        run: |
+          python3 -m pytest test/test_tiny.py test/test_jit.py
+
   osxtests:
     strategy:
       fail-fast: false


### PR DESCRIPTION
A lot more work is required to enable all of them and move into osxtests matrix, for now i created a separate runner for them (copied from WebGPU)

~~Will add test/test_graph.py to those tests in #9876~~

Hm, `@unittest.skipIf(CI and Device.DEFAULT=="METAL", "no ICB in CI, creation of graph fails")` on graph tests, looks like i'll have to use another device for cloud graph tests.