### PR TITLE
Make sure clang always inline batched functions

### DIFF
--- a/tinygrad/runtime/graph/cpu.py
+++ b/tinygrad/runtime/graph/cpu.py
@@ -31,8 +31,8 @@ class CPUGraph(GraphRunner):
     batched.append("}")
 
     prep = [device.renderer._render(cast(CompiledRunner, ji.prg).p.uops) for i,ji in enumerate(jit_cache)]
-    funcs = dedup(device.renderer._render_body(prep[i][0], *prep[i][1:], cast(CompiledRunner, ji.prg).p.uops, ["static"])
-                  for i,ji in enumerate(jit_cache))
+    funcs = dedup(device.renderer._render_body(prep[i][0], *prep[i][1:], cast(CompiledRunner, ji.prg).p.uops,
+                                               ["static", "__attribute__((always_inline))"]) for i,ji in enumerate(jit_cache))
 
     defines = dedup(itertools.chain.from_iterable(device.renderer._render_defines(cast(CompiledRunner, ji.prg).p.uops) for ji in jit_cache))
     entry = device.renderer._render_entry("batched", targs)


### PR DESCRIPTION
Makes #10014 more robust.
While working on LLVM graph (#10029) I found two tests (one was test_jit_multiple_random_regen in test_jit.py) where LLVM did not inlined functions with just linkage modifier (most likely because of the size).
I think there is a good chance that this can happen with clang backend too so it's better to force function inlining.