### PR TITLE
fix amdgpu_disassemble on mac [pr]

### DIFF
--- a/tinygrad/runtime/support/compiler_amd.py
+++ b/tinygrad/runtime/support/compiler_amd.py
@@ -2,9 +2,10 @@ import ctypes, subprocess
 import tinygrad.runtime.autogen.comgr as comgr
 from tinygrad.device import Compiler, CompileError
 from tinygrad.runtime.ops_llvm import LLVMCompiler
+from tinygrad.helpers import OSX
 
 def amdgpu_disassemble(lib:bytes):
-  asm = subprocess.check_output(["/opt/rocm/llvm/bin/llvm-objdump", '-d', '-'], input=lib)
+  asm = subprocess.check_output(["llvm-objdump" if OSX else "/opt/rocm/llvm/bin/llvm-objdump", '-d', '-'], input=lib)
   print('\n'.join([x for x in asm.decode('utf-8').split("\n") if 's_code_end' not in x]))
 
 def check(status):


### PR DESCRIPTION
`DEBUG=7 MOCKGPU=1 AMD=1  PYTHONPATH=. python test/test_tiny.py TestTiny.test_plus` does not work on mac with error: `FileNotFoundError: [Errno 2] No such file or directory: '/opt/rocm/llvm/bin/llvm-objdump'`.

It shouldn't need rocm to run the disassembler on newer LLVM versions. I tested this on the red boxes and llvm@14 still requires the rocm path.