### PR TITLE
fix TestLinearizerFailures.test_failure_53

### DIFF
--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1254,7 +1254,6 @@ class TestLinearizerFailures(unittest.TestCase):
     helper_test_lin(Kernel(ast, opts=Device[Device.DEFAULT].renderer), opts=opts, failed_platforms=[])
 
   def test_failure_53(self):
-    # COMPILE_ERROR, val scope issue
     ast = UOp(Ops.SINK, dtypes.void, arg=None, src=(
       UOp(Ops.STORE, dtypes.void, arg=None, src=(
         UOp(Ops.DEFINE_GLOBAL, dtypes.uchar.ptr(), arg=0, src=()),
@@ -1284,7 +1283,7 @@ class TestLinearizerFailures(unittest.TestCase):
                 UOp(Ops.CONST, dtypes.bool, arg=True, src=(
                    x23,)),)),)),)),)),)),))
     opts = [Opt(op=OptOps.GROUPTOP, axis=1, arg=16)]
-    helper_test_lin(Kernel(ast, opts=Device[Device.DEFAULT].renderer), opts=opts, failed_platforms=["AMD", "GPU", "METAL", "NV", "CUDA"])
+    helper_test_lin(Kernel(ast, opts=Device[Device.DEFAULT].renderer), opts=opts, failed_platforms=["AMD", "METAL"])
 
   @unittest.skipIf(CI and Device.DEFAULT in {"METAL"}, "hangs metal gpu CI")
   def test_failure_54(self):

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1283,7 +1283,7 @@ class TestLinearizerFailures(unittest.TestCase):
                 UOp(Ops.CONST, dtypes.bool, arg=True, src=(
                    x23,)),)),)),)),)),)),))
     opts = [Opt(op=OptOps.GROUPTOP, axis=1, arg=16)]
-    helper_test_lin(Kernel(ast, opts=Device[Device.DEFAULT].renderer), opts=opts, failed_platforms=["AMD"])
+    helper_test_lin(Kernel(ast, opts=Device[Device.DEFAULT].renderer), opts=opts, failed_platforms=[])
 
   @unittest.skipIf(CI and Device.DEFAULT in {"METAL"}, "hangs metal gpu CI")
   def test_failure_54(self):

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1283,7 +1283,7 @@ class TestLinearizerFailures(unittest.TestCase):
                 UOp(Ops.CONST, dtypes.bool, arg=True, src=(
                    x23,)),)),)),)),)),)),))
     opts = [Opt(op=OptOps.GROUPTOP, axis=1, arg=16)]
-    helper_test_lin(Kernel(ast, opts=Device[Device.DEFAULT].renderer), opts=opts, failed_platforms=["AMD", "METAL"])
+    helper_test_lin(Kernel(ast, opts=Device[Device.DEFAULT].renderer), opts=opts, failed_platforms=["AMD"])
 
   @unittest.skipIf(CI and Device.DEFAULT in {"METAL"}, "hangs metal gpu CI")
   def test_failure_54(self):


### PR DESCRIPTION
handled Ops.VALID correctly

the last graph rewrite before and after change

<div style="display: flex; justify-content: space-between;">
  <img src="https://github.com/user-attachments/assets/75d176f2-4aaf-4c72-8e5f-7ba2ba88d203" width="48%" />
  <img src="https://github.com/user-attachments/assets/f10b3c14-569e-4294-bfc4-eb579515c125" width="48%" />
</div>

test passing on : NV , GPU and CUDA
![Screenshot from 2025-04-25 17-31-00](https://github.com/user-attachments/assets/d6f58e24-2392-4259-91fc-28fd5689b954)
![Screenshot from 2025-04-25 17-30-31](https://github.com/user-attachments/assets/64b05f27-11ad-4aa3-9edd-7fcb89c38cee)
![Screenshot from 2025-04-25 17-31-28](https://github.com/user-attachments/assets/ca6c604b-a838-402c-a46a-cdef8da9f447)

let me know if im doing the linearize.py bug fix the wrong way 
