### PR TITLE
 [bounty] Fix TestOps.test_avg_pool3d_failure by fixing the issue in the linearizer, not with workarounds

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2474,7 +2474,6 @@ class TestOps(unittest.TestCase):
       lambda x: Tensor.avg_pool2d(x, kernel_size=(111,28)), rtol=1e-5)
 
   # TODO: linearizer block error
-  @unittest.expectedFailure
   def test_avg_pool3d_failure(self):
     with Context(NOOPT=0):
       helper_test_op([(1,1,16,16,16)],

--- a/tinygrad/codegen/symbolic.py
+++ b/tinygrad/codegen/symbolic.py
@@ -406,6 +406,7 @@ def index_collapse(idx:UOp,rng:UOp,buf:UOp,ld:UOp,acc:UOp,add=UOp.const(dtypes.i
 def reduce_collapse(acc:UOp, ret:UOp, alu:UOp):
   reduce_parented, reduce_unparented = partition(acc.src[1:], lambda x: x in ret.toposort())
   if len(reduce_unparented) == 0: return None
+  if reduce_unparented and reduce_parented and min(x.arg for x in reduce_parented) > max(x.arg for x in reduce_unparented): return None
   new_acc = acc.replace(src=acc.src[0:1]+tuple(reduce_parented))
   ret = new_acc.assign(new_acc.alu(alu.op, ret))
   if alu.op is Ops.ADD:


### PR DESCRIPTION
# dedup blockend

- only count current level
- remove cross level blockend from sink

example:
input:
```
1 f1 ['0'] - 1 ---- 0 f1 [] - 1 ---- sink
1 f1 [] - 1 -------------------------|
```

before dedup:
```
1 f2 ['0'] - 1 ---- 0 f1 [] - 1 ---- sink
             |-----------------------|
```

after dedup:
```
1 f1 ['0'] - 1 ---- 0 f1 [] - 1 ---- sink
```

test:
```
~/tinygrad (git)-[guanhua/bounty-1] % VIZ=1 DEBUG=4 python3 -c "
from tinygrad import Tensor

t = Tensor.rand(16, 16, 16)
t.avg_pool2d(kernel_size=(8, 8, 8), stride=5, padding=1, count_include_pad=False).realize()"

tinygrad.device.CompileError: program_source:83:45: error: use of undeclared identifier 'acc22'
```

# fix reduce_collapse

- scope

```
~/tinygrad (git)-[guanhua/bounty-1] % VIZ=1 DEBUG=4 python3 -c "
from tinygrad import Tensor

t = Tensor.rand(16, 16, 16)
t.avg_pool2d(kernel_size=(8, 8, 8), stride=5, padding=1, count_include_pad=False).realize()"

kernel void r_8_8_3_3_3_8(device float* data0, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {

  for (int ridx0 = 0; ridx0 < 8; ridx0++) {

    float acc22 = 0.0f;

    for (int ridx1 = 0; ridx1 < 8; ridx1++) {

      acc22 = (acc22+(alu6*8.0f));

    }

  }

  *((device float4*)((data0+16))) = float4((acc22*8.0f),acc14,acc1,acc7);

}

tinygrad.device.CompileError: program_source:83:45: error: use of undeclared identifier 'acc22'
```

reduce_collapse should consider scope
reduce low level range and collapse top level range = scope error
after reduce, new parent range is the new top level

perf:
```
~/tinygrad2 (git)-[master] % PYTHONPATH=. python3 test/external/external_benchmark_schedule.py
***** model tensor in     34.43 ms
***** model schedule in  116.04 ms
***** model opts(32) in  132.39 ms
***** model lower in     125.12 ms
***** model rewrite in   415.54 ms
***** model linearize in 157.68 ms
20089
all 982.90 ms

~/tinygrad (git)-[guanhua/bounty-1] % PYTHONPATH=. python3 test/external/external_benchmark_schedule.py
***** model tensor in     34.63 ms
***** model schedule in  116.46 ms
***** model opts(32) in  166.76 ms
***** model lower in     125.07 ms
***** model rewrite in   415.74 ms
***** model linearize in 157.50 ms
20089
all 1017.86 ms
```

test:
```
~/tinygrad (git)-[guanhua/bounty-1] % VIZ=1 DEBUG=4 python3 -c "
from tinygrad import Tensor

t = Tensor.rand(16, 16, 16)
t.avg_pool2d(kernel_size=(8, 8, 8), stride=5, padding=1, count_include_pad=False).realize()"

~/tinygrad (git)-[guanhua/bounty-1] % python3 -m pytest test/test_ops.py::TestOps::test_avg_pool3d_failure

================================ 1 passed in 3.61s ================================

~/tinygrad (git)-[guanhua/bounty-1] % python3 -m pytest test/test_linearizer.py::TestLinearizer::test_three_nested_range

================================ 1 passed in 0.63s ================================
```