### PR TITLE
don't sort dims in verify_sink_dims [pr]

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -72,9 +72,9 @@ def diff(offset:int, name:str, fxn:Callable) -> None:
       if good is None: continue
     except Exception as e:
       changed += 1
-      warnings.warn(f"FAILED TO RECREATE KERNEL {e}", ProcessReplayWarning)
       if ctx_vars: logging.info(ctx_vars)
       for x in args[:-2]: trunc_log(x)
+      warnings.warn(f"FAILED TO RECREATE KERNEL {e}", ProcessReplayWarning)
       continue
     # diff kernels
     try: assert str(args[-1]) == str(good)

--- a/test/unit/test_verify_ast.py
+++ b/test/unit/test_verify_ast.py
@@ -34,12 +34,12 @@ class TestVerifyAST(unittest.TestCase):
     store = UOp(Ops.STORE, dtypes.void, (buf_0, ShapeTracker.from_shape((32, 1)).to_uop(), a+b))
     helper_test_verify_ast(store)
 
-  def test_exactly_one_ndim(self):
+  def test_exactly_one_full_shape(self):
     dtype = dtypes.int
     bufs = [UOp(Ops.DEFINE_GLOBAL, dtype.ptr(), (), i) for i in range(6)]
-    a = UOp(Ops.LOAD, dtype, (bufs[2], ShapeTracker.from_shape((32, 4)).to_uop()))
-    b = UOp(Ops.LOAD, dtype, (bufs[3], ShapeTracker.from_shape((32, 4)).to_uop()))
-    st0 = UOp.store(bufs[0], ShapeTracker.from_shape((32, 4)).to_uop(), a+b)
+    a = UOp(Ops.LOAD, dtype, (bufs[2], ShapeTracker.from_shape((32, 1)).to_uop()))
+    b = UOp(Ops.LOAD, dtype, (bufs[3], ShapeTracker.from_shape((32, 1)).to_uop()))
+    st0 = UOp.store(bufs[0], ShapeTracker.from_shape((32, 1)).to_uop(), a+b)
     a = UOp(Ops.LOAD, dtype, (bufs[4], ShapeTracker.from_shape((32, 32)).to_uop()))
     b = UOp(Ops.LOAD, dtype, (bufs[5], ShapeTracker.from_shape((32, 32)).to_uop()))
     st1 = UOp.store(bufs[1], ShapeTracker.from_shape((32, 32)).to_uop(), a+b)

--- a/test/unit/test_verify_ast.py
+++ b/test/unit/test_verify_ast.py
@@ -34,12 +34,12 @@ class TestVerifyAST(unittest.TestCase):
     store = UOp(Ops.STORE, dtypes.void, (buf_0, ShapeTracker.from_shape((32, 1)).to_uop(), a+b))
     helper_test_verify_ast(store)
 
-  def test_exactly_one_full_shape(self):
+  def test_exactly_one_ndim(self):
     dtype = dtypes.int
     bufs = [UOp(Ops.DEFINE_GLOBAL, dtype.ptr(), (), i) for i in range(6)]
-    a = UOp(Ops.LOAD, dtype, (bufs[2], ShapeTracker.from_shape((32, 1)).to_uop()))
-    b = UOp(Ops.LOAD, dtype, (bufs[3], ShapeTracker.from_shape((32, 1)).to_uop()))
-    st0 = UOp.store(bufs[0], ShapeTracker.from_shape((32, 1)).to_uop(), a+b)
+    a = UOp(Ops.LOAD, dtype, (bufs[2], ShapeTracker.from_shape((32, 4)).to_uop()))
+    b = UOp(Ops.LOAD, dtype, (bufs[3], ShapeTracker.from_shape((32, 4)).to_uop()))
+    st0 = UOp.store(bufs[0], ShapeTracker.from_shape((32, 4)).to_uop(), a+b)
     a = UOp(Ops.LOAD, dtype, (bufs[4], ShapeTracker.from_shape((32, 32)).to_uop()))
     b = UOp(Ops.LOAD, dtype, (bufs[5], ShapeTracker.from_shape((32, 32)).to_uop()))
     st1 = UOp.store(bufs[1], ShapeTracker.from_shape((32, 32)).to_uop(), a+b)

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -192,7 +192,8 @@ sched_spec = buffer_spec+assign_spec+PatternMatcher([
 # *** this is the UOp shape spec ***
 
 def verify_sink_dims(sink:UOp):
-  for dims in zip(*[x.shape for x in sink.toposort() if x.op is not Ops.SINK and x.st is not None]):
+  if not all_same([s.shape for s in sink.src]): return False
+  for dims in zip(*[x.shape for x in sink.toposort() if x.st is not None]):
     if len(n_dims:={s for s in dims if resolve(s!=1)}) > 1:
       print(f"# INVALID KERNEL DIMS: can only have 1 or n in each dimension: {n_dims}")
       return False

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -1,7 +1,7 @@
 from typing import cast, Callable
-from tinygrad.ops import PatternMatcher, UPat, GroupOp, Ops, UOp, print_uops, python_alu, graph_rewrite
+from tinygrad.ops import PatternMatcher, UPat, GroupOp, Ops, UOp, print_uops, python_alu, graph_rewrite, resolve
 from tinygrad.dtype import DType, ImageDType, dtypes, PtrDType
-from tinygrad.helpers import all_same, dedup, prod, DEBUG, IGNORE_OOB
+from tinygrad.helpers import all_same, prod, DEBUG, IGNORE_OOB
 try:
   import z3
 
@@ -192,8 +192,10 @@ sched_spec = buffer_spec+assign_spec+PatternMatcher([
 # *** this is the UOp shape spec ***
 
 def verify_sink_dims(sink:UOp):
-  shape_dims = [sorted(dedup(dims)) for dims in zip(*[x.shape for x in sink.toposort() if x.op is not Ops.SINK and x.st is not None])]
-  return all_same([x.st_arg.size for x in sink.src]) and all(len(x) == 1 or (len(x) == 2 and x[0] == 1) for x in shape_dims)
+  for dims in zip(*[x.shape for x in sink.toposort() if x.op is not Ops.SINK and x.st is not None]):
+    if len(n_dims:={s for s in dims if resolve(s!=1)}) > 1:
+      print(f"# INVALID KERNEL DIMS: can only have 1 or n in each dimension: {n_dims}")
+      return False
 
 shape_spec = PatternMatcher([
   # shapes must have either 1 or n in each dimension


### PR DESCRIPTION
This dedup already checks for sizes too, if you store a (3, 5) and a (4, 5) in the same kernel it is invalid.