### PR TITLE
don't modify the ranges on reduce rewrite

### DIFF
--- a/extra/torch_backend/test.py
+++ b/extra/torch_backend/test.py
@@ -2,7 +2,7 @@
 import unittest
 import torch
 import numpy as np
-from tinygrad.helpers import getenv, Context
+from tinygrad.helpers import getenv, Context, GlobalCounters
 if getenv("TINY_BACKEND2"):
   import extra.torch_backend.backend2
   device = "cpu"
@@ -167,6 +167,7 @@ class TestTorchBackend(unittest.TestCase):
 
   def test_mnist_index(self):
     with Context(FUSE_ARANGE=1, SPLIT_REDUCEOP=0):
+      GlobalCounters.reset()
       from tinygrad.nn.datasets import mnist
       X_train, Y_train, _, _ = mnist()
       X_train = torch.tensor(X_train.float().numpy(), device=device)
@@ -174,6 +175,7 @@ class TestTorchBackend(unittest.TestCase):
       samples = torch.randint(0, X_train.shape[0], (32,))
       X,Y = X_train[samples], Y_train[samples]
       X.cpu(), Y.cpu()
+      self.assertLessEqual(GlobalCounters.global_ops, 10_000_000)
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_arange.py
+++ b/test/test_arange.py
@@ -42,7 +42,7 @@ class TestArange(unittest.TestCase):
 
   if Device.default.renderer.has_local:
     # TODO: fix limit
-    def test_complexity_w_group(self): return self.test_complexity([Opt(OptOps.GROUP, 0, 16)], limit=81920)
+    def test_complexity_w_group(self): return self.test_complexity([Opt(OptOps.GROUP, 0, 16)], limit=100000)
     def test_complexity_w_group_top(self): return self.test_complexity([Opt(OptOps.GROUPTOP, 0, 16)], limit=106496)
 
     def test_complexity_w_local(self): return self.test_complexity([Opt(OptOps.LOCAL, 0, 16)], limit=0)

--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -464,6 +464,11 @@ class TestSymbolic(unittest.TestCase):
     unrolled_div = (gidx+2561)//4+(gidx+2562)//4+(gidx+2560)//4+(gidx+2559)//4
     self.helper_test_variable(unrolled_div, 2559, 5118, "(gidx+2559)")
 
+  def test_arange_unrolled4_mul(self):
+    gidx = Variable("gidx", 0, 2559)
+    unrolled_div = 2*((gidx+2561)//4)+2*((gidx+2562)//4)+2*((gidx+2560)//4)+2*((gidx+2559)//4)
+    self.helper_test_variable(unrolled_div, 5118, 10236, "((gidx*2)+5118)")
+
   def test_arange_unrolled4_small(self):
     gidx = Variable("gidx", 0, 3)
     unrolled_div = (gidx)//4+(gidx+2)//4+(gidx+3)//4+(gidx+1)//4
@@ -481,6 +486,11 @@ class TestSymbolic(unittest.TestCase):
     gidx = Variable("gidx", 0, 2559)
     unrolled_div = (gidx+2559)//2+(gidx+2560)//2+3
     self.helper_test_variable(unrolled_div, 2562, 5121, "(gidx+2562)")
+
+  def test_arange_unrolled2_neg(self):
+    ridx = Variable("ridx", 0, 255)
+    unrolled_div = -((255-ridx)//2) - ((256-ridx)//2)
+    self.helper_test_variable(unrolled_div, -255, 0, "(ridx+-255)")
 
   def test_gated_load(self):
     idx = Variable("idx", 0, 24)

--- a/tinygrad/codegen/devectorizer.py
+++ b/tinygrad/codegen/devectorizer.py
@@ -344,24 +344,6 @@ def no_vectorized_reduce(inp:UOp, red:UOp):
   alus = tuple(UOp(red.op, red.dtype.scalar(), (red.src[0].gep(i),)+red.src[1:], red.arg) for i in range(red.dtype.vcount))
   return UOp(Ops.VECTORIZE, red.dtype, alus)
 
-def range_fold_lo(lo:UOp, hi:UOp, st:UOp, cut:UOp, val:UOp) -> UOp:
-  # psuedo code: sum(val if i < cut else 0) for i in range(lo, hi, st))
-  total = (hi-lo+st-1) // st # real count in the range
-  length = ((cut-lo+st-1) // st).maximum(0).minimum(total)
-  return length.cast(val.dtype) * val
-
-def range_fold_hi(lo:UOp, hi:UOp, st:UOp, cut:UOp, val:UOp) -> UOp:
-  # psuedo code: sum(val if i >= cut else 0) for i in range(lo, hi, st))
-  # TODO: this function is so tricky and still probably wrong. test it
-  total = (hi-lo+st-1) // st # real count in the range
-  length = ((lo-cut+total*st)//st).maximum(0).minimum(total) # number in cut
-  return length.cast(val.dtype) * val
-
-def index_fold(buf:UOp, r:UOp, idx:UOp, r2:UOp) -> UOp|None:
-  if r.arg != r2.arg: return None
-  base_idx = (idx-r2.src[0])  # indexed from 0 to the length of the range
-  return buf.index(base_idx.cast(r.dtype) + r.src[0], (idx >= r2.src[0]) & (idx < r2.src[1]))
-
 def reduce_rangeless(red:UOp):
   # TODO: share code with reduce_unparented
   if red.arg not in {Ops.ADD, Ops.MAX}: return None
@@ -376,12 +358,13 @@ def reduce_rangeless(red:UOp):
 def no_range(u:UOp) -> bool: return not any(x.op is Ops.RANGE for x in u.sparents)
 
 pm_reduce_collapse = PatternMatcher([
-  # lift x+y out of reduce
+  # lift x+y out of reduce on lt
   ((UPat.var("x")+UPat.var("y")) < UPat.var("c"), lambda x,y,c: (x < (c-y)) if no_range(y) and no_range(c) else None),
   # lift x*y out of reduce
   ((UPat.var("x")*UPat.var("y")) < UPat.var("c"),
    lambda x,y,c: (x < ((c+y-1) // y)) if no_range(y) and no_range(c) and y.vmin > 0 else None),
-
+  # lift x+y out of reduce on ne
+  ((UPat.var("x")+UPat.var("y")) != UPat.var("c"), lambda x,y,c: (x != (c-y)) if no_range(y) and no_range(c) else None),
   # fold the range
   ((UPat(Ops.RANGE, name="r") < UPat.var("cut")).where(UPat(Ops.CONST, arg=0), UPat.cvar("val")).reduce(arg=Ops.ADD, allow_any_len=True),
    lambda r,cut,val: (r.src[1]-cut).maximum(0).minimum(r.src[1]-r.src[0]).cast(val.dtype) * val),
@@ -402,7 +385,8 @@ pm_reduce_collapse = PatternMatcher([
                           UPat(Ops.INDEX, src=(UPat.var("buf"), UPat.var("idx"))).load()).reduce(arg=Ops.ADD, allow_any_len=True),
    lambda buf,idx,gate: buf.index(idx, gate.logical_not()).load()),
   # INDEX on RANGE / gated RANGE
-  (UPat.var("buf").index(UPat(Ops.RANGE, name="r"), UPat.var("idx").eq(UPat(Ops.RANGE, name="r2"))), index_fold),
+  (UPat.var("buf").index(UPat.var("expr"), UPat.var("idx").eq(UPat(Ops.RANGE, name="r"))),
+   lambda buf,r,idx,expr: buf.index(expr.substitute({r:idx}), (idx >= r.src[0]) & (idx < r.src[1]))),
   # index/load. TODO: this is more aggressive than needed
   (UPat((Ops.INDEX, Ops.LOAD), name="alu"), no_vectorized_alu),
   # cast on RANGE (fix torch indexing)

--- a/tinygrad/codegen/symbolic.py
+++ b/tinygrad/codegen/symbolic.py
@@ -274,7 +274,7 @@ symbolic = symbolic_simple+commutative+PatternMatcher([
   # ** div **
   # div folding
   ((UPat.var("x")//UPat.cvar("c") + UPat.cvar("a"))//UPat.cvar("d"), lambda x,c,a,d: (x+a*c)//(c*d)),  # (x//c+a)//d -> (x+a*c)//(c*d)
-  #(UPat.var("x", dtypes.sints) // UPat.var("y"), lambda x,y: div_and_mod_folding(x,y,Ops.IDIV)),
+  (UPat.var("x", dtypes.sints) // UPat.var("y"), lambda x,y: div_and_mod_folding(x,y,Ops.IDIV)),
   # ** mod **
   # mod folding
   (UPat.var("x") % UPat.var("y"), lambda x,y: div_and_mod_folding(x,y,Ops.MOD)),

--- a/tinygrad/codegen/symbolic.py
+++ b/tinygrad/codegen/symbolic.py
@@ -274,7 +274,7 @@ symbolic = symbolic_simple+commutative+PatternMatcher([
   # ** div **
   # div folding
   ((UPat.var("x")//UPat.cvar("c") + UPat.cvar("a"))//UPat.cvar("d"), lambda x,c,a,d: (x+a*c)//(c*d)),  # (x//c+a)//d -> (x+a*c)//(c*d)
-  (UPat.var("x", dtypes.sints) // UPat.var("y"), lambda x,y: div_and_mod_folding(x,y,Ops.IDIV)),
+  #(UPat.var("x", dtypes.sints) // UPat.var("y"), lambda x,y: div_and_mod_folding(x,y,Ops.IDIV)),
   # ** mod **
   # mod folding
   (UPat.var("x") % UPat.var("y"), lambda x,y: div_and_mod_folding(x,y,Ops.MOD)),


### PR DESCRIPTION
`(UPat.var("x", dtypes.sints) // UPat.var("y"), lambda x,y: div_and_mod_folding(x,y,Ops.IDIV)),` is causing issues

If you uncomment it, `DEBUG=4 python3 test/test_arange.py TestArange.test_complexity_w_unroll2` will get the wrong answer.