### PR TITLE
perf: ~9% on schedule bench [pr]

### DIFF
--- a/tinygrad/codegen/symbolic.py
+++ b/tinygrad/codegen/symbolic.py
@@ -300,6 +300,7 @@ def parse_valid(valid:UOp) -> tuple[UOp, bool, int]:
   if valid.op is Ops.CMPLT and valid.src[1].op is Ops.CONST and dtypes.is_int(valid.src[0].dtype): return valid.src[0], True, valid.src[1].arg-1
   raise ValueError(f"not able to parse {valid=}")
 
+@functools.cache
 def uop_given_valid(valid:UOp, uop:UOp) -> UOp|None:
   # return None if valid is always False, otherwise the simplified uop (might be the same as input)
 

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -100,6 +100,9 @@ class dtypes:
     return int(val) if dtypes.is_int(dtype) else float(val) if dtypes.is_float(dtype) else bool(val)
   @staticmethod
   @functools.cache
+  def minmax(dtype:DType): return dtypes.min(dtype), dtypes.max(dtype)
+  @staticmethod
+  @functools.cache
   def min(dtype:DType):
     if dtypes.is_int(dtype): return 0 if dtypes.is_unsigned(dtype) else -2**(dtype.itemsize*8-1)
     return -float("inf") if dtypes.is_float(dtype) else False

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -406,6 +406,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     out_dtype = (self, *src)[-1].dtype
     if arg in {Ops.CMPLT, Ops.CMPNE}: out_dtype = dtypes.bool.vec(out_dtype.count) if out_dtype.count > 1 else dtypes.bool
     return UOp(arg, out_dtype, (self,)+src)
+  @functools.cache
   @staticmethod
   def const(dtype:DType, b:ConstLike):
     if isinstance(b, UOp): return b.unbind()[0] if b.op is Ops.BIND else b
@@ -652,7 +653,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     if self.op is Ops.CONST: return self.arg, self.arg
     if self.op is Ops.VCONST: return (min(self.arg), max(self.arg))
     if self.op is Ops.CAST: return max(dtypes.min(self.dtype), self.src[0].vmin), min(self.src[0].vmax, dtypes.max(self.dtype))
-    return dtypes.min(self.dtype), dtypes.max(self.dtype)
+    return dtypes.minmax(self.dtype)
 
   @functools.cached_property
   def _sym_fxn(self):


### PR DESCRIPTION
* list comprehension into tuple for some busy lambdas
* some specific lru-caches


`python test/external/external_benchmark_schedule.py` best of 5, python 3.12 M3 Pro

branch
```
***** model tensor in     22.48 ms
***** model schedule in   64.39 ms
***** model opts(32) in   72.84 ms
***** model lower in      65.42 ms
***** model rewrite in   349.28 ms
***** model linearize in  88.81 ms
20089
all 664.33 ms
```

master
```
***** model tensor in     22.42 ms
***** model schedule in   64.44 ms
***** model opts(32) in   84.02 ms
***** model lower in      68.04 ms
***** model rewrite in   380.23 ms
***** model linearize in 108.50 ms
20089
all 728.78 ms
```


