### PR TITLE
kernelize llama

### DIFF
--- a/examples/tinychat/tinychat-browser/compile.py
+++ b/examples/tinychat/tinychat-browser/compile.py
@@ -2,7 +2,7 @@ import os, json, hashlib, math, sys
 from extra.export_model import export_model
 from examples.llama3 import build_transformer, Tokenizer
 from tinygrad.nn.state import get_state_dict, load_state_dict
-from tinygrad import Device, Variable, Tensor, dtypes, TinyJit
+from tinygrad import Device, Variable, Tensor, dtypes
 from tinygrad.helpers import fetch, Context
 from tiktoken.load import load_tiktoken_bpe, dump_tiktoken_bpe
 
@@ -86,7 +86,8 @@ def validate_model(model, tokenizer):
   toks += tokenizer.encode(prompt) + [tokenizer.special_tokens["<|eot_id|>"]]
   toks += [tokenizer.special_tokens["<|start_header_id|>"]] + tokenizer.encode("assistant") + [tokenizer.special_tokens["<|end_header_id|>"]] + tokenizer.encode("\n\n")
   start_pos = 0
-  run = TinyJit(model.forward)
+  #run = TinyJit(model.forward)
+  run = model.forward
   for tok in toks[:-1]:
     run(Tensor([[tok]]), Variable("start_pos", 0, model.max_context).bind(start_pos), 0.0, 0, 0.0, 0.0, 0.0).realize()
     start_pos += 1

--- a/examples/tinychat/tinychat-browser/compile.py
+++ b/examples/tinychat/tinychat-browser/compile.py
@@ -1,4 +1,4 @@
-import os, json, hashlib, math
+import os, json, hashlib, math, sys
 from extra.export_model import export_model
 from examples.llama3 import build_transformer, Tokenizer
 from tinygrad.nn.state import get_state_dict, load_state_dict
@@ -119,9 +119,10 @@ if __name__=="__main__":
   Device.DEFAULT="CPU"
   model = build_transformer(model_path, model_size="1B", quantize="int8", scale_dtype=dtypes.float32, device=Device.DEFAULT, max_context=max_context)
   state_dict = get_state_dict(model)
-  validate_model(model, tokenizer)
+  #validate_model(model, tokenizer)
   model_name = "transformer"
 
+  """
   with Context(BEAM=3):
     cprog, js_wrapper = export_model(model, "wasm", *model_input(), model_name=model_name)
     # ensure consistency with exported weights
@@ -129,6 +130,7 @@ if __name__=="__main__":
 
   with open(os.path.join(os.path.dirname(__file__), f"{model_name}.c"), "w") as f: f.write(cprog)
   with open(os.path.join(os.path.dirname(__file__), "net_clang.js"), "w") as f: f.write(js_wrapper)
+  """
 
   Device.DEFAULT="WEBGPU"
   # float16 is not yet supported for dawn/Vulkan/NVIDIA stack, see: https://issues.chromium.org/issues/42251215
@@ -139,6 +141,7 @@ if __name__=="__main__":
   model.output.weight, model.output.scale = model.tok_embeddings.weight, model.tok_embeddings.scale
 
   validate_model(model, tokenizer)
+  sys.exit()
   metadata = prepare_browser_chunks(model) # export weights to disk
 
   with Context(BEAM=3):

--- a/examples/tinychat/tinychat-browser/compile.py
+++ b/examples/tinychat/tinychat-browser/compile.py
@@ -89,13 +89,13 @@ def validate_model(model, tokenizer):
   #run = TinyJit(model.forward)
   run = model.forward
   for tok in toks[:-1]:
-    run(Tensor([[tok]]), Variable("start_pos", 0, model.max_context).bind(start_pos), 0.0, 0, 0.0, 0.0, 0.0).realize()
+    run(Tensor([[tok]]), Variable("start_pos", 0, model.max_context - 1).bind(start_pos), 0.0, 0, 0.0, 0.0, 0.0).realize()
     start_pos += 1
   tok = toks[-1]
   result = ""
   expected = "How's it going?"
   while True:
-    tok = run(Tensor([[tok]]), Variable("start_pos", 0, model.max_context).bind(start_pos), 0.0, 0, 0.0, 0.0, 0.0).item()
+    tok = run(Tensor([[tok]]), Variable("start_pos", 0, model.max_context - 1).bind(start_pos), 0.0, 0, 0.0, 0.0, 0.0).item()
     start_pos += 1
     if tok in tokenizer.stop_tokens or len(result) > len(expected): break
     result += tokenizer.decode([tok])

--- a/extra/models/llama.py
+++ b/extra/models/llama.py
@@ -78,7 +78,7 @@ class Attention:
     # update the cache
     assert xk.dtype == xv.dtype == self.cache_kv.dtype, f"{xk.dtype=}, {xv.dtype=}, {self.cache_kv.dtype=}"
     #self.cache_kv.shrink((None, None, (start_pos, start_pos+seqlen), None, None)).assign(Tensor.stack(xk, xv)).realize()
-    self.cache_kv.shrink((None, None, (start_pos, start_pos+seqlen), None, None)).assign(Tensor.stack(xk, xv)).kernelize()
+    self.cache_kv.shrink((None, None, (start_pos, start_pos+seqlen), None, None)).assign(Tensor.stack(xk, xv)).kernelize().realize()
 
     keys = self.cache_kv[0].shrink((None, (0, start_pos+seqlen), None, None))
     values = self.cache_kv[1].shrink((None, (0, start_pos+seqlen), None, None))

--- a/extra/models/llama.py
+++ b/extra/models/llama.py
@@ -188,11 +188,11 @@ class Transformer:
     self.freqs_cis = self.freqs_cis.cast(h.dtype).kernelize()
     freqs_cis = self.freqs_cis.shrink((None, (start_pos, start_pos+seqlen),None,None,None))
 
-    mask = Tensor.full((1, 1, seqlen, start_pos+seqlen), float("-inf"), dtype=h.dtype, device=h.device).triu(start_pos+1).realize() if seqlen > 1 else None
+    mask = Tensor.full((1, 1, seqlen, start_pos+seqlen), float("-inf"), dtype=h.dtype, device=h.device).triu(start_pos+1).kernelize() if seqlen > 1 else None
     for layer in self.layers: h = layer(h, start_pos, freqs_cis, mask)
     logits = self.output(self.norm(h)).float()[:, -1, :]
 
-    return sample(logits.flatten(), temperature, top_k, top_p, alpha_f, alpha_p).realize()
+    return sample(logits.flatten(), temperature, top_k, top_p, alpha_f, alpha_p).kernelize()
 
   def __call__(self, tokens:Tensor, start_pos:int, temperature:float=0.0, top_k:int=0, top_p:float=0.8, alpha_f:float=0.0, alpha_p:float=0.0):
     # TODO: better way to handle the first call v.s. the rest?

--- a/extra/models/llama.py
+++ b/extra/models/llama.py
@@ -175,7 +175,8 @@ class Transformer:
     _bsz, seqlen = tokens.shape
     h = self.tok_embeddings(tokens)
 
-    self.freqs_cis = self.freqs_cis.cast(h.dtype).realize()
+    #self.freqs_cis = self.freqs_cis.cast(h.dtype).realize()
+    self.freqs_cis = self.freqs_cis.cast(h.dtype).kernelize()
     freqs_cis = self.freqs_cis.shrink((None, (start_pos, start_pos+seqlen),None,None,None))
 
     mask = Tensor.full((1, 1, seqlen, start_pos+seqlen), float("-inf"), dtype=h.dtype, device=h.device).triu(start_pos+1).realize() if seqlen > 1 else None

--- a/extra/models/llama.py
+++ b/extra/models/llama.py
@@ -78,7 +78,15 @@ class Attention:
     # update the cache
     assert xk.dtype == xv.dtype == self.cache_kv.dtype, f"{xk.dtype=}, {xv.dtype=}, {self.cache_kv.dtype=}"
     #self.cache_kv.shrink((None, None, (start_pos, start_pos+seqlen), None, None)).assign(Tensor.stack(xk, xv)).realize()
-    self.cache_kv.shrink((None, None, (start_pos, start_pos+seqlen), None, None)).assign(Tensor.stack(xk, xv)).kernelize().realize()
+    #self.cache_kv.shrink((None, None, (start_pos, start_pos+seqlen), None, None)).assign(Tensor.stack(xk, xv)).kernelize().realize()
+    self.cache_kv.assign(
+      Tensor.cat(
+        self.cache_kv.shrink((None, None, (0, start_pos), None, None)),
+        Tensor.stack(xk, xv),
+        self.cache_kv.shrink((None, None, (start_pos+seqlen, self.max_context), None, None)),
+        dim=2
+      ).contiguous()
+    ).kernelize()
 
     keys = self.cache_kv[0].shrink((None, (0, start_pos+seqlen), None, None))
     values = self.cache_kv[1].shrink((None, (0, start_pos+seqlen), None, None))

--- a/extra/models/llama.py
+++ b/extra/models/llama.py
@@ -77,7 +77,8 @@ class Attention:
 
     # update the cache
     assert xk.dtype == xv.dtype == self.cache_kv.dtype, f"{xk.dtype=}, {xv.dtype=}, {self.cache_kv.dtype=}"
-    self.cache_kv.shrink((None, None, (start_pos, start_pos+seqlen), None, None)).assign(Tensor.stack(xk, xv)).realize()
+    #self.cache_kv.shrink((None, None, (start_pos, start_pos+seqlen), None, None)).assign(Tensor.stack(xk, xv)).realize()
+    self.cache_kv.shrink((None, None, (start_pos, start_pos+seqlen), None, None)).assign(Tensor.stack(xk, xv)).kernelize()
 
     keys = self.cache_kv[0].shrink((None, (0, start_pos+seqlen), None, None))
     values = self.cache_kv[1].shrink((None, (0, start_pos+seqlen), None, None))


### PR DESCRIPTION
The goal is to export tinychat to browser without the jit, replacing calls to `realize` with `kernelize` throughout `extra/models/llama.py`.

To start, the tinychat browser prep script has been simplified to only run model validation on WEBGPU:
`PYTHONPATH=. python examples/tinychat/tinychat-browser/compile.py`