### PR TITLE
hack for VIZ=1 with examples/llama

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -442,7 +442,10 @@ After you are done speaking, output [EOS]. You are not Chad.
   TOKENIZER_PATH = (MODEL_PATH if MODEL_PATH.is_dir() else MODEL_PATH.parent) / "tokenizer.model"
   print(f"using LLaMA{LLAMA_SUFFIX}-{args.size} model")
   device = tuple(f"{Device.DEFAULT}:{i}" for i in range(args.shard)) if args.shard > 1 else Device.DEFAULT
-  llama = LLaMa.build(MODEL_PATH, TOKENIZER_PATH, model_gen=args.gen, model_size=args.size, quantize=args.quantize, device=device)
+  # prevent tracking model weights
+  # TODO: this is a part of a larger problem with BUFFER UOps and gc in TRACK_MATCH_STATS=2
+  with Context(TRACK_MATCH_STATS=0):
+    llama = LLaMa.build(MODEL_PATH, TOKENIZER_PATH, model_gen=args.gen, model_size=args.size, quantize=args.quantize, device=device)
   param_bytes = sum(x.lazydata.size * x.dtype.itemsize for x in get_parameters(llama.model))
 
   outputted = pre_prompt if chatbot else args.prompt


### PR DESCRIPTION
The "Make sure buffers are GCed on CPU and with VIZ, with good tests" bounty should actually fix the root cause of this. Viewing the VIZ for model forward is still useful for kernelize and FUSE_ARANGE development.
![image](https://github.com/user-attachments/assets/51a031e8-d456-48f2-ad9d-bde89a1ac46f)