### PR TITLE
[BOUNTY] Fix TestLinearizerFailures.test_failure_53

### DIFF
--- a/tinygrad/codegen/linearize.py
+++ b/tinygrad/codegen/linearize.py
@@ -201,7 +201,7 @@ def remove_blockend(x:UOp):
       late_ops = [UOp(Ops.BARRIER)] + late_ops
     arg = BasicBlock2(tuple(early_ops)+parent_block.arg.lst+tuple(late_ops), tuple([y for y in x.arg.ctx if y is not x.arg.end]), cnt=x.arg.cnt)
     return UOp(Ops.BLOCK, src=tuple(y for y in x.src if y is not parent_block)+parent_block.src, arg=arg)
-  elif x.arg.end.op is Ops.IF and x.arg.end in x.arg.lst: # case for if already present in blockend
+  if x.arg.end.op is Ops.IF and x.arg.end in x.arg.lst: # case for if already present in blockend
     arg = BasicBlock2(x.arg.lst, tuple([y for y in x.arg.ctx if y is not x.arg.end]), cnt=x.arg.cnt)
     return UOp(Ops.BLOCK, src=x.src, arg=arg)
 

--- a/tinygrad/codegen/linearize.py
+++ b/tinygrad/codegen/linearize.py
@@ -201,6 +201,9 @@ def remove_blockend(x:UOp):
       late_ops = [UOp(Ops.BARRIER)] + late_ops
     arg = BasicBlock2(tuple(early_ops)+parent_block.arg.lst+tuple(late_ops), tuple([y for y in x.arg.ctx if y is not x.arg.end]), cnt=x.arg.cnt)
     return UOp(Ops.BLOCK, src=tuple(y for y in x.src if y is not parent_block)+parent_block.src, arg=arg)
+  elif x.arg.end.op is Ops.IF and x.arg.end in x.arg.lst: # case for if already present in blockend
+    arg = BasicBlock2(x.arg.lst, tuple([y for y in x.arg.ctx if y is not x.arg.end]), cnt=x.arg.cnt)
+    return UOp(Ops.BLOCK, src=x.src, arg=arg)
 
 block_merge = PatternMatcher([
   (UPat((Ops.BLOCK, Ops.BLOCKEND), name="x"), merge_block),


### PR DESCRIPTION
The problem seems to be that, 
when Ops.IF is already present in the BLOCKEND lst, the remove_blockend() func does not work and merge blockends rewrite ends there raising this,

if sink.op is not Ops.BLOCK or not all(x.op in DONT_PLACE_IN_BLOCK for x in sink.src): raise RuntimeError("linearize failure")

So, added an if statement in the remove_blockend() func to look for such cases and make that BLOCKEND a BLOCK, then linearizer continues from there.

Test passes on CUDA