### PR TITLE
even spacing in viz nodes

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -43,8 +43,8 @@ async function renderDag(graph, additions, recenter=false) {
       const x = (d.width-d.padding*2)/2;
       const y = (d.height-d.padding*2)/2;
       return `translate(-${x}, -${y})`;
-     }).selectAll("text").data(d => [d.label.split("\n")]).join("text").selectAll("tspan").data(d => d).join("tspan").text(d => d).attr("x", "1")
-       .attr("dy", 14).attr("xml:space", "preserve");
+     }).selectAll("text").data(d => [d.label.split("\n")]).join("text").selectAll("tspan").data(d => d).join("tspan").text(d => d).attr("x", "0")
+      .attr("dy", (_, i) => i === 0 ? 12 : 14).attr("xml:space", "preserve");
     // draw edges
     const line = d3.line().x(d => d.x).y(d => d.y).curve(d3.curveBasis);
     d3.select("#edges").selectAll("path.edgePath").data(g.edges()).join("path").attr("class", "edgePath").attr("d", (e) => {

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -44,7 +44,7 @@ async function renderDag(graph, additions, recenter=false) {
       const y = (d.height-d.padding*2)/2;
       return `translate(-${x}, -${y})`;
      }).selectAll("text").data(d => [d.label.split("\n")]).join("text").selectAll("tspan").data(d => d).join("tspan").text(d => d).attr("x", "0")
-      .attr("dy", (_, i) => i === 0 ? 12 : 14).attr("xml:space", "preserve");
+      .attr("dy", (_, i) => i === 0 ? 14-2.1 : 14).attr("xml:space", "preserve");
     // draw edges
     const line = d3.line().x(d => d.x).y(d => d.y).curve(d3.curveBasis);
     d3.select("#edges").selectAll("path.edgePath").data(g.edges()).join("path").attr("class", "edgePath").attr("d", (e) => {

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -35,15 +35,16 @@ async function renderDag(graph, additions, recenter=false) {
     d3.select("#bars").html("");
     const g = dagre.graphlib.json.read(e.data);
     // draw nodes
+    const STROKE_WIDTH = 1.4;
     const nodes = d3.select("#nodes").selectAll("g").data(g.nodes().map(id => g.node(id)), d => d).join("g")
       .attr("transform", d => `translate(${d.x},${d.y})`);
     nodes.selectAll("rect").data(d => [d]).join("rect").attr("width", d => d.width).attr("height", d => d.height).attr("fill", d => d.color)
-      .attr("x", d => -d.width/2).attr("y", d => -d.height/2).attr("style", d => "stroke:#4a4b57; stroke-width:1.4px;"+d.style);
-    nodes.selectAll("g.label").data(d => [d]).join("g").attr("class", "label").attr("dominant-baseline", "text-after-edge").attr("transform", d => {
+      .attr("x", d => -d.width/2).attr("y", d => -d.height/2).attr("style", d => `stroke:#4a4b57; stroke-width:${STROKE_WIDTH}px; ${d.style}`);
+    nodes.selectAll("g.label").data(d => [d]).join("g").attr("class", "label").attr("transform", d => {
       const x = (d.width-d.padding*2)/2;
-      const y = (d.height-d.padding*2)/2-1.4;
+      const y = (d.height-d.padding*2)/2+STROKE_WIDTH;
       return `translate(-${x}, -${y})`;
-     }).selectAll("text").data(d => [d.label.split("\n")]).join("text").selectAll("tspan").data(d => d).join("tspan").text(d => d).attr("x", "0")
+    }).selectAll("text").data(d => [d.label.split("\n")]).join("text").selectAll("tspan").data(d => d).join("tspan").text(d => d).attr("x", "0")
       .attr("dy", 14).attr("xml:space", "preserve");
     // draw edges
     const line = d3.line().x(d => d.x).y(d => d.y).curve(d3.curveBasis);

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -39,12 +39,12 @@ async function renderDag(graph, additions, recenter=false) {
       .attr("transform", d => `translate(${d.x},${d.y})`);
     nodes.selectAll("rect").data(d => [d]).join("rect").attr("width", d => d.width).attr("height", d => d.height).attr("fill", d => d.color)
       .attr("x", d => -d.width/2).attr("y", d => -d.height/2).attr("style", d => "stroke:#4a4b57; stroke-width:1.4px;"+d.style);
-    nodes.selectAll("g.label").data(d => [d]).join("g").attr("class", "label").attr("transform", d => {
+    nodes.selectAll("g.label").data(d => [d]).join("g").attr("class", "label").attr("dominant-baseline", "text-after-edge").attr("transform", d => {
       const x = (d.width-d.padding*2)/2;
-      const y = (d.height-d.padding*2)/2;
+      const y = (d.height-d.padding*2)/2-1.4;
       return `translate(-${x}, -${y})`;
      }).selectAll("text").data(d => [d.label.split("\n")]).join("text").selectAll("tspan").data(d => d).join("tspan").text(d => d).attr("x", "0")
-      .attr("dy", (_, i) => i === 0 ? 14-2.1 : 14).attr("xml:space", "preserve");
+      .attr("dy", 14).attr("xml:space", "preserve");
     // draw edges
     const line = d3.line().x(d => d.x).y(d => d.y).curve(d3.curveBasis);
     d3.select("#edges").selectAll("path.edgePath").data(g.edges()).join("path").attr("class", "edgePath").attr("d", (e) => {


### PR DESCRIPTION
The spacing inside of the VIZ=1 nodes seem to be a few pixels too much on the top and left side. I changed x to 0 and set the first line's dy to 12, and the rest to 14. The change is especially noticeable in the SINK node shown below, it looks centered now.

Before:
<img width="868" alt="Screenshot 2025-05-05 at 10 27 54 PM" src="https://github.com/user-attachments/assets/ceaf3528-418c-48a9-9d9b-0c0443dd51f2" />

After:
<img width="945" alt="Screenshot 2025-05-05 at 10 26 30 PM" src="https://github.com/user-attachments/assets/cea01edd-2b1a-4eb0-9c2a-33b59e7408e0" />
