### PR TITLE
add support for `ds_load_u8` in remu

### DIFF
--- a/extra/remu/src/rdna3.rs
+++ b/extra/remu/src/rdna3.rs
@@ -218,5 +218,6 @@ mod test_rdna3 {
     fn test_decode_ds() {
         assert_eq!(test_decode("ds_add_u32 v2, v4 offset:16"), Instruction::DS { op: 0, gds: false, offset1: 0, offset0: 0x10, vdst: 0, data1: 0, data0: 4, addr: 2 });
         assert_eq!(test_decode("ds_store_b32 v0, v1, offset: 0x04 gds"), Instruction::DS { op: 13, gds: true, offset1: 0, offset0: 0x04, vdst: 0, data1: 0, data0: 1, addr: 0 });
+        assert_eq!(test_decode("ds_load_u8 v1, v0 offset:16"), Instruction::DS { op: 58, gds: false, offset1: 0, offset0: 16, vdst: 1, data1: 0, data0: 0, addr: 0 });
     }
 }

--- a/extra/remu/src/thread.rs
+++ b/extra/remu/src/thread.rs
@@ -1407,6 +1407,7 @@ impl<'a> Thread<'a> {
                         self.vec_reg[vdst + i] = self.lds.read(single_addr() + 4 * i);
                     });
                 }
+                58 => self.vec_reg[vdst] = self.lds.read(single_addr()) as u8 as u32,
                 60 => self.vec_reg[vdst] = self.lds.read(single_addr()) as u16 as u32,
                 55 => {
                     let (addr0, addr1) = double_addr(4);

--- a/extra/remu/src/thread.rs
+++ b/extra/remu/src/thread.rs
@@ -3607,6 +3607,30 @@ mod test_lds {
     }
 
     #[test]
+    fn test_ds_load_u8() {
+        let mut thread = _helper_test_thread();
+        thread.lds.write(0, 17);
+        thread.vec_reg[0] = 0;
+        r(&vec![0xD8E80000, 0x00000100, END_PRG], &mut thread);
+        assert_eq!(thread.vec_reg[0], 17);
+
+        thread.lds.write(0, 264);
+        thread.vec_reg[0] = 0;
+        r(&vec![0xD8E80000, 0x00000100, END_PRG], &mut thread);
+        assert_eq!(thread.vec_reg[0], 8);
+
+        thread.lds.write(8, 23);
+        thread.vec_reg[0] = 0;
+        r(&vec![0xD8E80008, 0x00000100, END_PRG], &mut thread);
+        assert_eq!(thread.vec_reg[0], 23);
+
+        thread.lds.write(16, 29);
+        thread.vec_reg[0] = 0;
+        r(&vec![0xD8E80010, 0x00000100, END_PRG], &mut thread);
+        assert_eq!(thread.vec_reg[0], 29);
+    }
+
+    #[test]
     fn test_ds_store_dwords() {
         let mut thread = _helper_test_thread();
         thread.vec_reg[9] = 69;


### PR DESCRIPTION
Fixes _RuntimeError: remu does not support the new instruction introduced in this kernel_ for https://github.com/tinygrad/tinygrad/pull/9771

Walkthrough docs are pending

Whenever you have time, feedback is much appreciated @Qazalin 