### PR TITLE
usbgpu: tiny changes in setup pci bars to match spec

### DIFF
--- a/tinygrad/runtime/support/amd.py
+++ b/tinygrad/runtime/support/amd.py
@@ -1,4 +1,4 @@
-import functools, importlib, time
+import functools, importlib
 from collections import defaultdict
 from dataclasses import dataclass
 from tinygrad.helpers import getbits, round_up, getenv

--- a/tinygrad/runtime/support/amd.py
+++ b/tinygrad/runtime/support/amd.py
@@ -38,16 +38,15 @@ def setup_pci_bars(usb:ASM24Controller, gpu_bus:int, mem_base:int, pref_mem_base
 
   if need_reset or getenv("USB_RESCAN_BUS", 0) == 1:
     for bus in range(gpu_bus):
-      usb.pcie_cfg_req(pci.PCI_SUBORDINATE_BUS, bus=bus, dev=0, fn=0, value=gpu_bus, size=1)
-      usb.pcie_cfg_req(pci.PCI_SECONDARY_BUS, bus=bus, dev=0, fn=0, value=bus+1, size=1)
-      usb.pcie_cfg_req(pci.PCI_PRIMARY_BUS, bus=bus, dev=0, fn=0, value=max(0, bus-1), size=1)
+      # All 3 values must be written at the same time.
+      buses = (0 << 0) | ((bus+1) << 8) | ((gpu_bus) << 16)
+      usb.pcie_cfg_req(pci.PCI_PRIMARY_BUS, bus=bus, dev=0, fn=0, value=buses, size=4)
+
       usb.pcie_cfg_req(pci.PCI_MEMORY_BASE, bus=bus, dev=0, fn=0, value=mem_base>>16, size=2)
       usb.pcie_cfg_req(pci.PCI_MEMORY_LIMIT, bus=bus, dev=0, fn=0, value=0xf000, size=2)
       usb.pcie_cfg_req(pci.PCI_PREF_MEMORY_BASE, bus=bus, dev=0, fn=0, value=pref_mem_base>>16, size=2)
       usb.pcie_cfg_req(pci.PCI_PREF_MEMORY_LIMIT, bus=bus, dev=0, fn=0, value=mem_base>>16, size=2)
-      usb.pcie_cfg_req(pci.PCI_BRIDGE_CONTROL, bus=bus, dev=0, fn=0, value=pci.PCI_BRIDGE_CTL_BUS_RESET, size=1)
-      time.sleep(0.1)
-      usb.pcie_cfg_req(pci.PCI_BRIDGE_CONTROL, bus=bus, dev=0, fn=0, value=0x0, size=1)
+
       usb.pcie_cfg_req(pci.PCI_COMMAND, bus=bus, dev=0, fn=0, value=pci.PCI_COMMAND_IO | pci.PCI_COMMAND_MEMORY | pci.PCI_COMMAND_MASTER, size=1)
 
   mem_space_addr, bar_off, bars = [mem_base, pref_mem_base], 0, {}


### PR DESCRIPTION
do not see linux's `pci_scan_bridge_extend` does anything special. it never resets bus (my controllers work without reset). spec also requires to write buses as dword.