### PR TITLE
only reorder expand if it can fuse with input

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2482,7 +2482,7 @@ class TestUOpBecome(unittest.TestCase):
     b = a.expand(4, 4).reciprocal()
     check_schedule(b, 1)
     self.assertEqual(b.lazydata.base.buffer.size, 16)
-    self.assertEqual(b.lazydata.st, ShapeTracker.from_shape((16, 1)))
+    self.assertEqual(b.lazydata.st, ShapeTracker.from_shape((4, 4)))
 
   def test_reorder_expand_alt(self):
     x = Tensor.empty(4, 1)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2476,12 +2476,13 @@ class TestUOpBecome(unittest.TestCase):
 
   # sometimes we prefer to perform an op before movement ops, in this case we should stack the mops on top of the new buffer
 
+  # NOTE: this expand is not reordered because there's before it to fuse
   def test_reorder_expand(self):
     a = Tensor.empty(4, 1)
     b = a.expand(4, 4).reciprocal()
     check_schedule(b, 1)
-    self.assertEqual(b.lazydata.base.buffer.size, 4)
-    self.assertEqual(b.lazydata.st, ShapeTracker.from_shape((4, 1)).expand((4, 4)))
+    self.assertEqual(b.lazydata.base.buffer.size, 16)
+    self.assertEqual(b.lazydata.st, ShapeTracker.from_shape((16, 1)))
 
   def test_reorder_expand_alt(self):
     x = Tensor.empty(4, 1)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2483,6 +2483,13 @@ class TestUOpBecome(unittest.TestCase):
     self.assertEqual(b.lazydata.base.buffer.size, 4)
     self.assertEqual(b.lazydata.st, ShapeTracker.from_shape((4, 1)).expand((4, 4)))
 
+  def test_reorder_expand_alt(self):
+    x = Tensor.empty(4, 1)
+    y = Tensor.empty(4, 1)
+    img = Tensor.empty(4, 4)
+    z = (img*x) / y
+    check_schedule(z, 1)
+
   def test_become_existing_buffer(self):
     a = Tensor.empty(4, 4)
     b = a*1


### PR DESCRIPTION
In the master version of grouper.py https://github.com/tinygrad/tinygrad/pull/10186/commits/f05a508fd8a9ef7c5b4ada2737a36d75e6fdc45e, `VIZ=1 python test/test_schedule.py TestUOpBecome.test_reorder_expand_alt` creates two kernels.
![image](https://github.com/user-attachments/assets/ad2a670f-f93f-4e69-85f5-c0a89bab7fd7)

It is not worth it to push the EXPAND after a UnaryOp if it costs an extra memory roundtrip. This is why generating quantized ONNX in #9682 required DONT_REALIZE_EXPAND =1.

Now just `DEBUG=2 QUANT=1 python3 examples/test_onnx_imagenet.py https://github.com/xamcat/mobcat-samples/raw/refs/heads/master/onnx_runtime/InferencingSample/InferencingSample/mobilenetv2-7.onnx` is enough to create the faster schedule.