### PR TITLE
Fold constant variable

### DIFF
--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -110,6 +110,9 @@ class TestSymbolic(unittest.TestCase):
   def test_sub_1(self):
     self.helper_test_variable(Variable("a", 0, 8)-1, -1, 7, "(a+-1)")
 
+  def test_const_var(self):
+    self.helper_test_variable(Variable("fake", 1, 1), 1, 1, "1")
+
   def test_add_self(self):
     a = Variable("a", 0, 8)
     b = Variable("b", 0, 8)

--- a/tinygrad/codegen/symbolic.py
+++ b/tinygrad/codegen/symbolic.py
@@ -29,6 +29,7 @@ symbolic_simple = PatternMatcher([
   (UPat.var("x") // 1, lambda x: x),   # x//1 -> x
   (UPat.var("x") // -1, lambda x: -x), # x//-1 -> -x
   (UPat.var("x") / UPat.var("x"), lambda x: x.const_like(1)), # x/x -> 1
+  (UPat(GroupOp.Irreducible-{Ops.CONST}, name="x"), lambda x: x.const_like(x.vmin) if x.vmin == x.vmax else None),
   ((UPat.var("x") * UPat.var("x2")) / UPat.var("x2"), lambda x,x2: x), # (x*x2)/x2 -> x
   ((UPat.var() % UPat.var("y")).named("base") % UPat.var("y"), lambda base,y: base),  # (x%y)%y = -> x%y (rewritten with base for speed)
   (UPat.var("x")%UPat.cvar("c")+(UPat.var("x")//UPat.cvar("c"))*UPat.cvar("c"), lambda x,c: x), # (x%c)+(x//c)*c = x

--- a/tinygrad/codegen/symbolic.py
+++ b/tinygrad/codegen/symbolic.py
@@ -29,7 +29,7 @@ symbolic_simple = PatternMatcher([
   (UPat.var("x") // 1, lambda x: x),   # x//1 -> x
   (UPat.var("x") // -1, lambda x: -x), # x//-1 -> -x
   (UPat.var("x") / UPat.var("x"), lambda x: x.const_like(1)), # x/x -> 1
-  (UPat(GroupOp.Irreducible-{Ops.CONST}, name="x"), lambda x: x.const_like(x.vmin) if x.vmin == x.vmax else None),
+  (UPat(GroupOp.Irreducible-{Ops.CONST}, name="x"), lambda x: x.const_like(x.vmin) if x.vmin == x.vmax else None), # fold constant variable
   ((UPat.var("x") * UPat.var("x2")) / UPat.var("x2"), lambda x,x2: x), # (x*x2)/x2 -> x
   ((UPat.var() % UPat.var("y")).named("base") % UPat.var("y"), lambda base,y: base),  # (x%y)%y = -> x%y (rewritten with base for speed)
   (UPat.var("x")%UPat.cvar("c")+(UPat.var("x")//UPat.cvar("c"))*UPat.cvar("c"), lambda x,c: x), # (x%c)+(x//c)*c = x


### PR DESCRIPTION
#10178 fails on process replay I think because there is a 'fake' variable with vmin==vmax=1 which happens to only get folded if its in an alu with a const. 
Just seeing what happens