### PR TITLE
remove view_supported_devices, check allocator instead [pr]

### DIFF
--- a/test/test_subbuffer.py
+++ b/test/test_subbuffer.py
@@ -1,10 +1,9 @@
 import unittest
 from tinygrad import Device, dtypes, Tensor
 from tinygrad.device import Buffer
-from tinygrad.ops import view_supported_devices
 from tinygrad.helpers import Context
 
-@unittest.skipIf(Device.DEFAULT not in view_supported_devices, "subbuffer not supported")
+@unittest.skipUnless(hasattr(Device[Device.DEFAULT].allocator, "_offset"), "subbuffer not supported")
 class TestSubBuffer(unittest.TestCase):
   def setUp(self):
     self.buf = Buffer(Device.DEFAULT, 10, dtypes.uint8).ensure_allocated()

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -185,9 +185,6 @@ class GroupOp:
 
   All = set(Ops)
 
-# some BUFFER ops can be processed with only a view
-view_supported_devices = {"LLVM", "CPU", "CUDA", "NV", "AMD", "METAL", "QCOM", "DSP", "DISK"}
-
 # https://en.wikipedia.org/wiki/Identity_element
 def identity_element(op:Ops, dt:DType) -> ConstType: return dtypes.as_const({Ops.ADD:0, Ops.MUL:1, Ops.MAX:dtypes.min(dt)}[op], dt)
 


### PR DESCRIPTION
Currently it's only used in test_subbuffer. Once we add subbuffers for CONTIGUOUS and BITCAST in grouper, this needs to check a device attribute (without opening devices), it shouldn't be duplicated between ops and runtime.