### PR TITLE
split kernel graph into insert and finalize stages [pr]

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -15,7 +15,7 @@ from tinygrad.ops import PatternMatcher, UOp, Ops, GroupOp, UPat, graph_rewrite,
 from tinygrad.codegen.symbolic import symbolic_simple
 from tinygrad.spec import type_verify, shape_spec
 from tinygrad.helpers import CI, DEBUG, FUSE_ARANGE, SPLIT_REDUCEOP, GlobalCounters, Context, getenv, all_same, temp
-from tinygrad.engine.grouper import view_left, view_right, sym, get_becomes_map, Kernel, create_ast, merge_views
+from tinygrad.engine.grouper import view_left, view_right, sym, get_becomes_map, Kernel, finalize_kernels, merge_views
 from tinygrad.engine.schedule import ScheduleItem, create_schedule_with_vars
 from tinygrad.engine.realize import CompiledRunner, run_schedule, lower_schedule
 from extra.models.llama import precompute_freqs_cis
@@ -605,7 +605,7 @@ class TestSchedule(unittest.TestCase):
     b = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize().lazydata
     c = Tensor.arange(4).realize().lazydata
     kernel = UOp(Ops.KERNEL, src=(a, b, c), arg=Kernel(UOp.sink(c.r(Ops.ADD, (0,))+1, c.r(Ops.ADD, (0,))*2)))
-    kernel = graph_rewrite(kernel, create_ast)
+    kernel = graph_rewrite(kernel, finalize_kernels)
     run_schedule(check_schedule(UOp.sink(a.assign(kernel), b.assign(kernel)), 1))
     self.assertEqual(a.buffer.numpy(), [7])
     self.assertEqual(b.buffer.numpy(), [12])


### PR DESCRIPTION
Kernelize in master goes through:

1. merge_views+fuse: Reorder views and finalize the shape of UOps
2. group_realizes: Put UOps that will go to memory to a dict
3. create_kernels+append_to_kernels: Based on the realizes dict, create the kernel graph
4. fixup assign dependancies
5. create_asts: Create the local graph per kernel.

This diff is toward merging step 2 and first half of step 3. Then step 5 and second half of 3 can merge:

1. Same merge_views+fuse
2. insert_kernels: Insert KERNEL UOps immediately after ops that should realize
3. finalize_kernels: Either fuse KERNEL sources or load from global memory.
4. fixup ASSIGN edges