### PR TITLE
ONNX add tests against ORT

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -290,13 +290,8 @@ def get_onnx_ops():
   def HardSigmoid(x:Tensor, alpha:float=0.2, beta:float=0.5): return (alpha*x + beta).clip(0, 1)
   def Gelu(x:Tensor, approximate:str|None=None): return x.gelu() if approximate == "tanh" else 0.5 * x * (1 + (x/math.sqrt(2)).erf())
   def BiasGelu(x: Tensor, bias: Tensor, approximate: str | None = None) -> Tensor: return Gelu(x + bias, approximate)
-  def FastGelu(x:Tensor, bias:Tensor|None=None):
-    # this is tanh approximated
-    return (x + bias).gelu() if bias is not None else x.gelu()
-  # TODO: fix this
-  def PRelu(X:Tensor, slope:Tensor):
-    slope = slope[0] if slope.shape[-1] != X.shape[-1] else slope
-    return (X > 0).where(X, X * slope)
+  def FastGelu(x:Tensor, bias:Tensor|None=None): return (x + bias).gelu() if bias is not None else x.gelu() # this is tanh approximated
+  def PRelu(X:Tensor, slope:Tensor): return (X > 0).where(X, X * slope)
   def LeakyRelu(X:Tensor, alpha:float=0.01): return X.leaky_relu(alpha)
   def ThresholdedRelu(X:Tensor, alpha:float=1.0): return (X > alpha).where(X, 0)
   def LogSoftmax(x: Tensor, axis:int=-1): return x.log_softmax(axis)
@@ -366,7 +361,6 @@ def get_onnx_ops():
   def Shrink(x:Tensor, bias:float=0.0, lambd:float=0.5): return (x < -lambd)*(x+bias) + (x > lambd)*(x-bias)
   def Transpose(x:Tensor, perm:list[int]|None=None): return x.permute(order=perm or list(range(x.ndim)[::-1]))
 
-  # TODO: add test for when axes is None
   def Squeeze(data:Tensor, axes:list[int]|None=None):
     return data.squeeze() if axes is None else functools.reduce(lambda d, dim: d.squeeze(dim), sorted(axes, reverse=True), data)
   def Unsqueeze(data:Tensor, axes:list[int]): return functools.reduce(lambda d, dim: d.unsqueeze(dim), sorted(axes), data)

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -44,18 +44,27 @@ backend_test = onnx.backend.test.BackendTest(TinygradBackend, __name__)
 backend_test.exclude('test_adam_multiple_cpu')
 backend_test.exclude('test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True_cpu')
 
-# BUG: onnxruntime 1.20.1 fails these tests too
-backend_test.exclude('test_qlinearmatmul_2D_int8_float16_cpu')
-backend_test.exclude('test_qlinearmatmul_3D_int8_float16_cpu')
-backend_test.exclude('test_qlinearmatmul_2D_int8_float32_cpu')
-backend_test.exclude('test_qlinearmatmul_3D_int8_float32_cpu')
+# BUG: ORT fails these tests
+backend_test.exclude('test_PReLU_1d_multiparam_cpu')
+backend_test.exclude('test_PReLU_2d_multiparam_cpu')
+backend_test.exclude('test_PReLU_3d_multiparam_cpu')
 
 # BUG: we don't match ORT here due to some div inaccuracy with floats
 backend_test.exclude('test_dynamicquantizelinear_cpu')
 backend_test.exclude('test_dynamicquantizelinear_expanded_cpu')
 
-# BUG: we match ORT, tested in TestMainOnnxOps.test_maxunpool
+# tested in TestMainOnnxOps.test_qlinearmatmul_2D_int8_float16, ORT fails
+backend_test.exclude('test_qlinearmatmul_2D_int8_float16_cpu')
+# tested in TestMainOnnxOps.test_qlinearmatmul_3D_int8_float16, ORT fails
+backend_test.exclude('test_qlinearmatmul_3D_int8_float16_cpu')
+# tested in TestMainOnnxOps.test_qlinearmatmul_2D_int8_float32, ORT fails
+backend_test.exclude('test_qlinearmatmul_2D_int8_float32_cpu')
+# tested in TestMainOnnxOps.test_qlinearmatmul_3D_int8_float32, ORT fails
+backend_test.exclude('test_qlinearmatmul_3D_int8_float32_cpu')
+# tested in TestMainOnnxOps.test_maxunpool_export_with_output_shape
 backend_test.exclude('test_maxunpool_export_with_output_shape_cpu')
+# tested in TestMainOnnxOps.test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True
+backend_test.exclude('test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True_cpu')
 
 # about different dtypes
 if not is_dtype_supported(dtypes.float64):

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -42,9 +42,8 @@ backend_test = onnx.backend.test.BackendTest(TinygradBackend, __name__)
 
 # BUG: buggy onnx tests
 backend_test.exclude('test_adam_multiple_cpu')
-backend_test.exclude('test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True_cpu')
 
-# BUG: ORT fails these tests
+# BUG: ORT fails these with runtime error
 backend_test.exclude('test_PReLU_1d_multiparam_cpu')
 backend_test.exclude('test_PReLU_2d_multiparam_cpu')
 backend_test.exclude('test_PReLU_3d_multiparam_cpu')
@@ -53,13 +52,14 @@ backend_test.exclude('test_PReLU_3d_multiparam_cpu')
 backend_test.exclude('test_dynamicquantizelinear_cpu')
 backend_test.exclude('test_dynamicquantizelinear_expanded_cpu')
 
-# tested in TestMainOnnxOps.test_qlinearmatmul_2D_int8_float16, ORT fails
+# BUG: ORT fails these with numerical error but we match ORT numerically
+# tested in TestMainOnnxOps.test_qlinearmatmul_2D_int8_float16
 backend_test.exclude('test_qlinearmatmul_2D_int8_float16_cpu')
-# tested in TestMainOnnxOps.test_qlinearmatmul_3D_int8_float16, ORT fails
+# tested in TestMainOnnxOps.test_qlinearmatmul_3D_int8_float16
 backend_test.exclude('test_qlinearmatmul_3D_int8_float16_cpu')
-# tested in TestMainOnnxOps.test_qlinearmatmul_2D_int8_float32, ORT fails
+# tested in TestMainOnnxOps.test_qlinearmatmul_2D_int8_float32
 backend_test.exclude('test_qlinearmatmul_2D_int8_float32_cpu')
-# tested in TestMainOnnxOps.test_qlinearmatmul_3D_int8_float32, ORT fails
+# tested in TestMainOnnxOps.test_qlinearmatmul_3D_int8_float32
 backend_test.exclude('test_qlinearmatmul_3D_int8_float32_cpu')
 # tested in TestMainOnnxOps.test_maxunpool_export_with_output_shape
 backend_test.exclude('test_maxunpool_export_with_output_shape_cpu')

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -53,17 +53,17 @@ backend_test.exclude('test_dynamicquantizelinear_cpu')
 backend_test.exclude('test_dynamicquantizelinear_expanded_cpu')
 
 # BUG: ORT fails these with numerical error but we match ORT numerically
-# tested in TestMainOnnxOps.test_qlinearmatmul_2D_int8_float16
+# tested in external_test_onnx_ops.py::TestMainOnnxOps.test_qlinearmatmul_2D_int8_float16
 backend_test.exclude('test_qlinearmatmul_2D_int8_float16_cpu')
-# tested in TestMainOnnxOps.test_qlinearmatmul_3D_int8_float16
+# tested in external_test_onnx_ops.py::TestMainOnnxOps.test_qlinearmatmul_3D_int8_float16
 backend_test.exclude('test_qlinearmatmul_3D_int8_float16_cpu')
-# tested in TestMainOnnxOps.test_qlinearmatmul_2D_int8_float32
+# tested in external_test_onnx_ops.py::TestMainOnnxOps.test_qlinearmatmul_2D_int8_float32
 backend_test.exclude('test_qlinearmatmul_2D_int8_float32_cpu')
-# tested in TestMainOnnxOps.test_qlinearmatmul_3D_int8_float32
+# tested in external_test_onnx_ops.py::TestMainOnnxOps.test_qlinearmatmul_3D_int8_float32
 backend_test.exclude('test_qlinearmatmul_3D_int8_float32_cpu')
-# tested in TestMainOnnxOps.test_maxunpool_export_with_output_shape
+# tested in external_test_onnx_ops.py::TestMainOnnxOps.test_maxunpool_export_with_output_shape
 backend_test.exclude('test_maxunpool_export_with_output_shape_cpu')
-# tested in TestMainOnnxOps.test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True
+# tested in external_test_onnx_ops.py::TestMainOnnxOps.test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True
 backend_test.exclude('test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True_cpu')
 
 # about different dtypes

--- a/test/external/external_test_onnx_ops.py
+++ b/test/external/external_test_onnx_ops.py
@@ -33,6 +33,13 @@ class TestMainOnnxOps(TestOnnxOps):
     outputs = ["out"]
     self.helper_test_single_op("Reshape", inputs, attributes, outputs)
 
+  def test_squeeze(self):
+    # axes is None
+    inputs = {"data": np.random.randn(1, 3, 1, 1).astype(np.float32)}
+    attributes = {}
+    outputs = ["squeezed"]
+    self.helper_test_single_op("Squeeze", inputs, attributes, outputs)
+
   def test_conv(self):
     # test VALID auto_pad
     inputs = {
@@ -54,8 +61,8 @@ class TestMainOnnxOps(TestOnnxOps):
     outputs = ["y"]
     self.helper_test_single_op("Gather", inputs, attributes, outputs)
 
-  def test_maxunpool(self):
-    # test_maxunpool_export_with_output_shape_cpu
+  def test_maxunpool_export_with_output_shape(self):
+    # https://github.com/onnx/onnx/blob/main/docs/Operators.md#examples-91
     xT = np.array([[[[5, 6], [7, 8]]]], dtype=np.float32)
     xI = np.array([[[[5, 7], [13, 15]]]], dtype=np.int64)
     output_shape = np.array((1, 1, 5, 5), dtype=np.int64)
@@ -63,6 +70,13 @@ class TestMainOnnxOps(TestOnnxOps):
     attributes = {"kernel_shape": [2, 2], "strides": [2, 2]}
     outputs = ["y"]
     self.helper_test_single_op("MaxUnpool", inputs, attributes, outputs)
+
+  def test_averagepool_3d_dilations_large_count_include_pad_is_1_ceil_mode_is_True(self):
+    # https://github.com/onnx/onnx/blob/main/docs/Operators.md#examples-13
+    inputs = {"x": np.random.randn(1, 1, 32, 32, 32).astype(np.float32)}
+    attributes = {"kernel_shape": (5, 5, 5), "strides": (3, 3, 3), "dilations": (2, 2, 2), "count_include_pad": 1, "ceil_mode": True}
+    outputs = ["y"]
+    self.helper_test_single_op("AveragePool", inputs, attributes, outputs)
 
   def test_isinf(self):
     # https://github.com/onnx/onnx/blob/main/docs/Operators.md#isinf
@@ -155,6 +169,30 @@ class TestMainOnnxOps(TestOnnxOps):
         attributes = {}
         outputs = ["Y"]
         self.helper_test_single_op("QLinearMatMul", inputs, attributes, outputs)
+
+  def _run_qlinearmatmul_test(self, quant_type, dtype, dims):
+    # https://github.com/onnx/onnx/blob/main/docs/Operators.md#examples-111
+    if dims == 2:
+      a = np.array([[208, 236, 0, 238], [3, 214, 255, 29]])
+      b = np.array([[152, 51, 244], [60, 26, 255], [0, 127, 246], [127, 254, 247]])
+    else:
+      a = np.array([[[208, 236, 0, 238], [3, 214, 255, 29]], [[208, 236, 0, 238], [3, 214, 255, 29]]])
+      b = np.array([[[152, 51, 244], [60, 26, 255], [0, 127, 246], [127, 254, 247]], [[152, 51, 244], [60, 26, 255], [0, 127, 246], [127, 254, 247]]])
+    if quant_type == np.int8:
+      a = a - 127
+      b = b - 127
+    a = a.astype(quant_type)
+    b = b.astype(quant_type)
+    inputs = {
+      "a": a, "a_scale": np.array([0.0066], dtype=dtype), "a_zero_point": np.array([113-127] if quant_type == np.int8 else [113], dtype=quant_type),
+      "b": b, "b_scale": np.array([0.00705], dtype=dtype), "b_zero_point": np.array([114-127] if quant_type == np.int8 else [114], dtype=quant_type),
+      "y_scale": np.array([0.0107], dtype=dtype), "y_zero_point": np.array([118 - 127] if quant_type == np.int8 else [118], dtype=quant_type)
+    }
+    self.helper_test_single_op("QLinearMatMul", inputs, {}, ["y"],)
+  def test_qlinearmatmul_2D_int8_float16(self): self._run_qlinearmatmul_test(np.int8, np.float16, 2)
+  def test_qlinearmatmul_3D_int8_float16(self): self._run_qlinearmatmul_test(np.int8, np.float16, 3)
+  def test_qlinearmatmul_2D_int8_float32(self): self._run_qlinearmatmul_test(np.int8, np.float32, 2)
+  def test_qlinearmatmul_3D_int8_float32(self): self._run_qlinearmatmul_test(np.int8, np.float32, 3)
 
 class TestContribOnnxOps(TestOnnxOps):
   DOMAIN = "com.microsoft"

--- a/test/external/external_test_onnx_ops.py
+++ b/test/external/external_test_onnx_ops.py
@@ -178,15 +178,16 @@ class TestMainOnnxOps(TestOnnxOps):
     else:
       a = np.array([[[208, 236, 0, 238], [3, 214, 255, 29]], [[208, 236, 0, 238], [3, 214, 255, 29]]])
       b = np.array([[[152, 51, 244], [60, 26, 255], [0, 127, 246], [127, 254, 247]], [[152, 51, 244], [60, 26, 255], [0, 127, 246], [127, 254, 247]]])
+    a_zero_point = np.array([113])
+    b_zero_point = np.array([114])
+    y_zero_point = np.array([118])
     if quant_type == np.int8:
-      a = a - 127
-      b = b - 127
-    a = a.astype(quant_type)
-    b = b.astype(quant_type)
+      a, b, a_zero_point, b_zero_point, y_zero_point = (x - 127 for x in (a, b, a_zero_point, b_zero_point, y_zero_point))
+    a, b, a_zero_point, b_zero_point, y_zero_point = (x.astype(quant_type) for x in (a, b, a_zero_point, b_zero_point, y_zero_point))
     inputs = {
-      "a": a, "a_scale": np.array([0.0066], dtype=dtype), "a_zero_point": np.array([113-127] if quant_type == np.int8 else [113], dtype=quant_type),
-      "b": b, "b_scale": np.array([0.00705], dtype=dtype), "b_zero_point": np.array([114-127] if quant_type == np.int8 else [114], dtype=quant_type),
-      "y_scale": np.array([0.0107], dtype=dtype), "y_zero_point": np.array([118 - 127] if quant_type == np.int8 else [118], dtype=quant_type)
+      "a": a, "a_scale": np.array([0.0066], dtype=dtype), "a_zero_point": a_zero_point,
+      "b": b, "b_scale": np.array([0.00705], dtype=dtype), "b_zero_point": b_zero_point,
+      "y_scale": np.array([0.0107], dtype=dtype), "y_zero_point": y_zero_point
     }
     self.helper_test_single_op("QLinearMatMul", inputs, {}, ["y"],)
   def test_qlinearmatmul_2D_int8_float16(self): self._run_qlinearmatmul_test(np.int8, np.float16, 2)


### PR DESCRIPTION
split from #9609 
 - added missing test to cover Squeeze op when axes is None
 - resolved PRelu to match ORT
 - added test coverage for tests in `test/external/external_test_onnx_ops.py` where both we and ORT fails at but we match ORT behavior