### PR TITLE
enable process replay assert for schedule [pr]

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # compare kernels created by HEAD against master
-import os, multiprocessing, logging, pickle, sqlite3, difflib, functools, warnings
+import os, multiprocessing, logging, pickle, sqlite3, difflib, functools, warnings, itertools
 from typing import Callable, cast
 from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connection, getenv, tqdm, dedup
 from tinygrad.engine.grouper import get_becomes_map
@@ -34,6 +34,7 @@ class ProcessReplayWarning(Warning): pass
 # *** recreators
 
 def recreate_sched(big_sink:UOp) -> list[UOp]:
+  UOp.unique_num = itertools.count(max([u.arg for u in big_sink.toposort() if u.op is Ops.UNIQUE], default=0))
   becomes_map = get_becomes_map(big_sink)
   sched_sink = big_sink.substitute(becomes_map)
   return dedup(u.arg.ast for u in sched_sink.toposort() if u.op is Ops.KERNEL)
@@ -47,8 +48,6 @@ def recreate_kernel(ast:UOp, opts:Renderer, applied_opts:list[Opt], name:str, _)
 # *** diff a "good" recreation against the generated version
 
 def diff(offset:int, name:str, fxn:Callable) -> None:
-  # TODO: add this assert back for schedule
-  if ASSERT_DIFF and name != "schedule": warnings.filterwarnings("error", category=ProcessReplayWarning)
   if early_stop.is_set(): return None
   conn = db_connection()
   cur = conn.cursor()

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -34,7 +34,7 @@ class ProcessReplayWarning(Warning): pass
 # *** recreators
 
 def recreate_sched(big_sink:UOp) -> list[UOp]:
-  UOp.unique_num = itertools.count(max([u.arg for u in big_sink.toposort() if u.op is Ops.UNIQUE], default=0))
+  UOp.unique_num = itertools.count(max([u.arg for u in big_sink.toposort() if u.op is Ops.UNIQUE], default=0)+1)
   becomes_map = get_becomes_map(big_sink)
   sched_sink = big_sink.substitute(becomes_map)
   return dedup(u.arg.ast for u in sched_sink.toposort() if u.op is Ops.KERNEL)


### PR DESCRIPTION
To correctly replicate scheduling we also need to start the UNIQUE counter at number of total "known" buffers in that capture.

Process replay in scheduling asserted with "Cycle detected in graph" because it did not account for known ASSIGN targets in the schedule graph. If the BUFFER counter counts up to n (from a 0 base), and there is also an ASSIGN to BUFFER n captured, the replayed graph can have a cycle.

If we base the counter at max(N) of the local UNIQUEs, all new buffers enumerate correctly independent of which process replay threads get to replay first.

One other way to solve this is to rebase all BUFFER numbers to 0 before scheduling.