### PR TITLE
openpilot: test LLVM compile in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,7 +441,7 @@ jobs:
       - name: Test openpilot fastvits model correctness (float32)
         run: PYTHONPATH="." FLOAT16=0 DEBUGCL=1 GPU=1 IMAGE=2 python examples/openpilot/compile3.py https://github.com/commaai/openpilot/raw/9118973ed03c1ae1d40cf69a29507ec2cc78efd7/selfdrive/modeld/models/supercombo.onnx
       - name: Test openpilot LLVM compile
-        run: PYTHONPATH="." LLVM=1 LLVMOPT=1 BEAM=0 IMAGE=0 python examples/openpilot/compile3.py https://github.com/commaai/openpilot/raw/9118973ed03c1ae1d40cf69a29507ec2cc78efd7/selfdrive/modeld/models/supercombo.onnx
+        run: PYTHONPATH="." LLVM=1 LLVMOPT=1 JIT=2 BEAM=0 IMAGE=0 python examples/openpilot/compile3.py https://github.com/commaai/openpilot/raw/9118973ed03c1ae1d40cf69a29507ec2cc78efd7/selfdrive/modeld/models/supercombo.onnx
       - name: Run process replay tests
         uses: ./.github/actions/process-replay
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -440,6 +440,8 @@ jobs:
         run: PYTHONPATH="." FLOAT16=0 DEBUGCL=1 GPU=1 IMAGE=2 python examples/openpilot/compile3.py https://github.com/commaai/openpilot/raw/3799fe46b3a629e491d4b8498b8ae83e4c88c304/selfdrive/modeld/models/supercombo.onnx
       - name: Test openpilot fastvits model correctness (float32)
         run: PYTHONPATH="." FLOAT16=0 DEBUGCL=1 GPU=1 IMAGE=2 python examples/openpilot/compile3.py https://github.com/commaai/openpilot/raw/9118973ed03c1ae1d40cf69a29507ec2cc78efd7/selfdrive/modeld/models/supercombo.onnx
+      - name: Test openpilot LLVM compile
+        run: PYTHONPATH="." LLVM=1 LLVMOPT=1 BEAM=0 IMAGE=0 python examples/openpilot/compile3.py https://github.com/commaai/openpilot/raw/9118973ed03c1ae1d40cf69a29507ec2cc78efd7/selfdrive/modeld/models/supercombo.onnx
       - name: Run process replay tests
         uses: ./.github/actions/process-replay
 


### PR DESCRIPTION
Can't bump tinygrad in openpilot at the moment due to this issue. Can also switch the existing tests from `GPU` since we don't use that in openpilot anymore?
```python
Traceback (most recent call last):
  File "/home/batman/threepilot/tinygrad_repo/examples/openpilot/compile3.py", line 136, in <module>
    test_val = compile(onnx_file) if not getenv("RUN") else None
               ^^^^^^^^^^^^^^^^^^
  File "/home/batman/threepilot/tinygrad_repo/examples/openpilot/compile3.py", line 42, in compile
    ret = run_onnx_jit(**inputs).numpy()
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/threepilot/tinygrad_repo/tinygrad/engine/jit.py", line 328, in __call__
    ret = self.captured(input_buffers, var_vals)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/threepilot/tinygrad_repo/tinygrad/engine/jit.py", line 206, in __call__
    for ei in self._jit_cache: ei.run(var_vals, jit=True)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/threepilot/tinygrad_repo/tinygrad/engine/realize.py", line 127, in run
    et = self.prg(bufs, var_vals, wait=wait or DEBUG >= 2)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/threepilot/tinygrad_repo/tinygrad/runtime/graph/cpu.py", line 31, in __call__
    return self.clprg(*[x._buf for x in rawbufs], *self.base_rawbufs, *[x[1] for x in sorted(var_vals.items(), key=lambda x: x[0].expr)], wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/threepilot/tinygrad_repo/tinygrad/device.py", line 287, in __call__
    return cpu_time_execution(lambda: self.fxn(*args), enable=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/threepilot/tinygrad_repo/tinygrad/helpers.py", line 270, in cpu_time_execution
    cb()
  File "/home/batman/threepilot/tinygrad_repo/tinygrad/device.py", line 287, in <lambda>
    return cpu_time_execution(lambda: self.fxn(*args), enable=wait)
                                      ^^^^^^^^^^^^^^^
ctypes.ArgumentError: argument 2: TypeError: Don't know how to convert parameter 2
```