### PR TITLE
multi sync support in remu

### DIFF
--- a/extra/remu/src/thread.rs
+++ b/extra/remu/src/thread.rs
@@ -1396,9 +1396,10 @@ impl<'a> Thread<'a> {
 
             match op {
                 // load
-                54 | 118 | 255 => {
+                54 | 118 | 254 | 255 => {
                     let dwords = match op {
                         255 => 4,
+                        254 => 3,
                         118 => 2,
                         _ => 1,
                     };
@@ -1419,9 +1420,10 @@ impl<'a> Thread<'a> {
                     self.vec_reg.write64(vdst + 2, self.lds.read64(addr1));
                 }
                 // store
-                13 | 77 | 223 => {
+                13 | 77 | 222 | 223 => {
                     let dwords = match op {
                         223 => 4,
+                        222 => 3,
                         77 => 2,
                         _ => 1,
                     };

--- a/extra/remu/src/work_group.rs
+++ b/extra/remu/src/work_group.rs
@@ -2,6 +2,7 @@ use crate::helpers::{colored, DEBUG};
 use crate::state::{Register, VecDataStore, WaveValue, VGPR};
 use crate::thread::{Thread, END_PRG, SGPR_COUNT};
 use std::collections::HashMap;
+use std::ptr;
 
 pub const WAVE_SIZE: usize = 32;
 
@@ -27,13 +28,7 @@ struct WaveState {
 }
 
 const SYNCS: [u32; 5] = [0xBF89FC07, 0xBFBD0000, 0xBC7C0000, 0xBF890007, 0xbFB60003];
-const BARRIERS: [[u32; 2]; 5] = [
-    [SYNCS[0], SYNCS[0]],
-    [SYNCS[0], SYNCS[1]],
-    [SYNCS[0], SYNCS[2]],
-    [SYNCS[3], SYNCS[1]],
-    [SYNCS[1], SYNCS[0]],
-];
+const S_BARRIER: u32 = 0xBFBD0000;
 impl<'a> WorkGroup<'a> {
     pub fn new(dispatch_dim: u32, id: [u32; 3], launch_bounds: [u32; 3], kernel: &'a Vec<u32>, kernel_args: *const u64) -> Self {
         Self { dispatch_dim, id, kernel, launch_bounds, kernel_args, lds: VecDataStore::new(), wave_state: HashMap::new() }
@@ -50,23 +45,25 @@ impl<'a> WorkGroup<'a> {
         }
         let waves = threads.chunks(WAVE_SIZE).collect::<Vec<_>>();
 
-        let mut sync = false;
-        for (i, x) in self.kernel.iter().enumerate() {
-            if i != 0 && BARRIERS.contains(&[*x, self.kernel[i - 1]]) {
-                sync = true;
-                break;
-            }
-        }
+        // Lock-step wave scheduling: Drive waves forward in cooperative-multitasking fashion,
+        // where each wave yields control when encountering a barrier or finishing the program
+        loop {
+            let mut all_done = true;
 
-        for _ in 0..=(sync as usize) {
-            for w in waves.iter().enumerate() {
-                self.exec_wave(w)?
+            for (idx, wave) in waves.iter().enumerate() {
+                if !self.exec_wave((idx, wave))? {
+                    all_done = false;
+                }
+            }
+
+            if all_done {
+                break;
             }
         }
         Ok(())
     }
 
-    fn exec_wave(&mut self, (wave_id, threads): (usize, &&[[u32; 3]])) -> Result<(), i32> {
+    fn exec_wave(&mut self, (wave_id, threads): (usize, &&[[u32; 3]])) -> Result<bool, i32> {
         let (mut scalar_reg, mut scc, mut pc, mut vec_reg, mut vcc, mut exec, mut sds) = match self.wave_state.get(&wave_id) {
           None => {
             let mut scalar_reg = [0; SGPR_COUNT];
@@ -102,12 +99,20 @@ impl<'a> WorkGroup<'a> {
         };
 
         loop {
+            let [id0, id1, id2] = self.id;
             if self.kernel[pc] == END_PRG {
-                break Ok(());
+                if *DEBUG {
+                    println!("[{id0:<3} {id1:<3} {id2:<3}] [_   _   _  ] __ BFB00000 SOPP {{ wave: {wave_id} }}");
+                }
+                break Ok(true);
             }
-            if BARRIERS.contains(&[self.kernel[pc], self.kernel[pc + 1]]) && self.wave_state.get(&wave_id).is_none() {
+            if self.kernel[pc] == S_BARRIER {
+                if *DEBUG {
+                    println!("[{id0:<3} {id1:<3} {id2:<3}] [_   _   _  ] __ BFBD0000 SOPP {{ wave: {wave_id}, pc: {pc} }}");
+                }
+                pc += 1;
                 self.wave_state.insert(wave_id, WaveState { scalar_reg, scc, vec_reg, vcc, exec, pc, sds });
-                break Ok(());
+                break Ok(false);
             }
             if SYNCS.contains(&self.kernel[pc]) || self.kernel[pc] >> 20 == 0xbf8 || self.kernel[pc] == 0x7E000000 {
                 pc += 1;
@@ -235,5 +240,35 @@ mod test_workgroup {
         let mut wg = WorkGroup::new(1, [0, 0, 0], [5, 1, 1], &kernel, [addr].as_ptr());
         wg.exec_waves().unwrap();
         assert_eq!(ret, 0b11110);
+    }
+
+    fn make_wave_slices<const X: usize>(
+        launch_bounds: [u32; 3],
+    ) -> Vec<Vec<[u32; 3]>> {
+        let mut threads = Vec::<[u32; 3]>::new();
+        for z in 0..launch_bounds[2] {
+            for y in 0..launch_bounds[1] {
+                for x in 0..launch_bounds[0] {
+                    threads.push([x, y, z]);
+                }
+            }
+        }
+        threads.chunks(WAVE_SIZE).map(|c| c.to_vec()).collect::<Vec<_>>()
+    }
+
+    #[test]
+    fn test_multi_barrier_basic() {
+        let kernel = vec![0xBFBD0000, 0xBFBD0000, END_PRG];
+        let launch_bounds = [64, 1, 1];
+        let mut wg = WorkGroup::new(1, [0, 0, 0], launch_bounds, &kernel, ptr::null());
+
+        let waves = make_wave_slices::<64>(launch_bounds);
+
+        assert_eq!(wg.exec_wave((0, &waves[0].as_slice())).unwrap(), false); // Wave 0 stops at the barrier 1.
+        assert_eq!(wg.exec_wave((1, &waves[1].as_slice())).unwrap(), false); // Wave 1 now reaches the barrier 1 and stops.
+        assert_eq!(wg.exec_wave((0, &waves[0].as_slice())).unwrap(), false); // Wave 0 stops at the barrier 2.
+        assert_eq!(wg.exec_wave((1, &waves[1].as_slice())).unwrap(), false); // Wave 1 now reaches the barrier 2 and stops.
+        assert_eq!(wg.exec_wave((0, &waves[0].as_slice())).unwrap(), true);  // All waves have arrived so wave 0 should be able to finish.
+        assert_eq!(wg.exec_wave((1, &waves[1].as_slice())).unwrap(), true);  // Wave 1 should also be able to finish now.
     }
 }

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -134,7 +134,6 @@ class TestLinearizer(unittest.TestCase):
     x = Tensor.randn(4,).realize()
     helper_linearizer_ast(store.sink(), [x], wanna_output=[x.numpy()+1], opts=[])
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")
   def test_multireduce(self):
@@ -166,7 +165,6 @@ class TestLinearizer(unittest.TestCase):
     lins = helper_linearizer_ast(sink, [x], wanna_output=[wanna_output], opts=opts)
     self._test_no_nested_ranges(lins, [0])
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")
   def test_mid_dim_multireduce(self):
@@ -246,7 +244,6 @@ class TestLinearizer(unittest.TestCase):
     lins = helper_linearizer_ast(sink, [x0,x1,x2], wanna_output=[wanna_output])
     self._test_no_nested_ranges(lins, [0])
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")
   @unittest.skip("this is not supported, it worked by luck")
@@ -294,7 +291,6 @@ class TestLinearizer(unittest.TestCase):
     lins = helper_linearizer_ast(sink, [x], wanna_output=[wanna_output], opts=opts)
     self._test_no_nested_ranges(lins, [0, 1])
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")
   def test_partial_opt_multireduce(self):
@@ -321,7 +317,6 @@ class TestLinearizer(unittest.TestCase):
     lins = helper_linearizer_ast(sink, [x], wanna_output=[wanna_output], opts=opts)
     self._test_no_nested_ranges(lins, [0])
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")
   def test_multireduce_with_parallel(self):
@@ -355,7 +350,6 @@ class TestLinearizer(unittest.TestCase):
     lins = helper_linearizer_ast(sink, [x,x_p], wanna_output=[wanna_output], opts=opts)
     self._test_no_nested_ranges(lins, [0])
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   def test_multiout_multireduce(self):
     # check how multireduce works with multioutput
     Tensor.manual_seed(0)
@@ -374,7 +368,6 @@ class TestLinearizer(unittest.TestCase):
 
     helper_linearizer_ast(sink, [x], wanna_output=[wanna_output, wanna_output/15])
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   def test_multiout_intermediate_multireduce(self):
     # check how it outputing at different stages of the multireduce works
     # TODO: Fails because the stores shapes do not match: store1.shape = (27,15,1,5) != store0.shape = (27,1,1,5)
@@ -397,7 +390,6 @@ class TestLinearizer(unittest.TestCase):
     with self.assertRaises(RuntimeError): # AST is invalid
       helper_linearizer_ast(sink, [x], wanna_output=[wanna_output0, wanna_output1])
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   def test_complete_unroll_multireduce(self):
     Tensor.manual_seed(0)
     x = Tensor.randn(27, 3, 5, dtype=dtypes.float).realize()
@@ -413,7 +405,6 @@ class TestLinearizer(unittest.TestCase):
     wanna_output = (x.numpy()-x.numpy().sum(axis=1, keepdims=True)).sum(axis=1).reshape(27,1,1,5)
     helper_linearizer_ast(sink, [x], wanna_output=[wanna_output], opts=opts)
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   def test_upcast_multireduce(self):
     Tensor.manual_seed(0)
     x = Tensor.randn(27, 3, 5, dtype=dtypes.float).realize()
@@ -429,7 +420,6 @@ class TestLinearizer(unittest.TestCase):
     wanna_output = (x.numpy()-x.numpy().sum(axis=1, keepdims=True)).sum(axis=1).reshape(27,1,1,5)
     helper_linearizer_ast(sink, [x], wanna_output=[wanna_output], opts=opts)
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skip("can't group with multiple reduces yet")
   def test_early_endif(self):
@@ -448,7 +438,6 @@ class TestLinearizer(unittest.TestCase):
     wanna_output = (x.numpy()-x.numpy().sum(axis=1, keepdims=True)).sum(axis=1).reshape(27,1,1,5)
     helper_linearizer_ast(sink, [x], wanna_output=[wanna_output], opts=opts)
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   def test_mean_std_multireduce(self):
     Tensor.manual_seed(0)
     x = Tensor.randn(15, 25, 35, dtype=dtypes.float).realize()
@@ -466,7 +455,6 @@ class TestLinearizer(unittest.TestCase):
     wanna_output = x.numpy().std(axis=2, ddof=0).reshape((15,25,1,1))
     helper_linearizer_ast(sink, [x], wanna_output=[wanna_output])
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   def test_mean_std_multireduce_mid_dim(self):
     Tensor.manual_seed(0)
     x = Tensor.randn(15, 25, 35, dtype=dtypes.float).realize()
@@ -484,7 +472,6 @@ class TestLinearizer(unittest.TestCase):
     wanna_output = x.numpy().std(axis=1, ddof=0).reshape((15,1,1,35))
     helper_linearizer_ast(sink, [x], wanna_output=[wanna_output])
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   @unittest.expectedFailure
   def test_mean_std_multireduce_multiout(self):
     # TODO: Similar error to test_multiout_intermediate_multireduce (implicit expand vs shape mismatch)
@@ -508,7 +495,7 @@ class TestLinearizer(unittest.TestCase):
     for k in lins:
       assert len([u for u in k.uops if u.op is Ops.DEFINE_ACC]) == 2, "got more than two accs (implies the kernel didn't reuse the mean reduce)"
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"PTX", "AMD", "NV"}, "ocelot/remu doesn't have multiple wave syncs yet")
+  @unittest.skipIf(CI and Device.DEFAULT in {"PTX", "NV"}, "ocelot doesn't have multiple wave syncs yet")
   def test_var_multireduce(self):
     Tensor.manual_seed(0)
     x = Tensor.randn(3, 27, 32, dtype=dtypes.float).realize()
@@ -531,7 +518,6 @@ class TestLinearizer(unittest.TestCase):
     y_tiny = x.var(axis=2, correction=0).reshape(3,27,1,1)
     np.testing.assert_allclose(y_tiny.numpy(), wanna_output, atol=1e-4, rtol=1e-4)
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   def test_softmax_multireduce(self):
     x = Tensor.rand(4, 32).realize()
     g0, g1 = [UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(), arg=i) for i in range(2)]
@@ -660,7 +646,6 @@ class TestLinearizer(unittest.TestCase):
           ast_const(dtypes.int, -1, (1, 1)),)),)),))
     helper_linearizer_ast(ast, [t, t_max], wanna_output=[real_argmax])
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   def test_padto_sum_multireduce(self):
     Tensor.manual_seed(0)
     N = 17
@@ -690,7 +675,6 @@ class TestLinearizer(unittest.TestCase):
     sink = UOp(Ops.SINK, src=(store,))
     helper_linearizer_ast(sink, [x], wanna_output=[(x.numpy()-x.numpy().sum(axis=1, keepdims=True)).sum(axis=1).reshape(N,1,1)], opts=opts)
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   def test_padto_max_multireduce(self):
     Tensor.manual_seed(0)
     N = 17
@@ -717,7 +701,6 @@ class TestLinearizer(unittest.TestCase):
     sink = UOp(Ops.SINK, src=(store,))
     helper_linearizer_ast(sink, [x], wanna_output=[(x.numpy()-x.numpy().max(axis=1, keepdims=True)).max(axis=1).reshape(N,1,1)], opts=opts)
 
-  @unittest.skipIf(CI and Device.DEFAULT in {"AMD"}, "AMD CI doesn't support multiple sync threads yet")
   def test_padto_where_multireduce(self):
     # ternary operators try to use both ridxs
 


### PR DESCRIPTION
This pull request adds support for `DS_LOAD_B96` and `DS_STORE_B96`, which are required by `test_mid_dim_multireduce`. 

### multi sync

The first approach I took extended the existing implementation. Before executing wave passes, I counted the number of barriers present in the kernel and executed exactly that many passes. However, this approach doesn't handle cases where barriers are placed inside loops, as these barriers may be encountered multiple times.

The second approach addresses this limitation by continuing to execute wave passes until all waves complete. I modified the `exec_wave` API to return `true` if it reaches the end of the program, and `false` if it encounters a barrier. Consequently, `exec_waves` now repeatedly runs wave passes until every wave has finished executing.

Additionally, I simplified barrier synchronization to support only the `s_barrier` instruction, as I couldn't make it reliably work for the multi synchronization instruction matching.

I added basic tests directly to remu. More extensive testing will be incorporated from the frontend using OptOps.LDS.