### PR TITLE
set fail-fast behavior

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 20
     defaults:
       run:
-        shell: bash -o pipefail {0}
+        shell: bash -e -o pipefail {0}
     if: github.repository_owner == 'tinygrad'
     steps:
     - name: Checkout Code
@@ -161,7 +161,7 @@ jobs:
     timeout-minutes: 30
     defaults:
       run:
-        shell: bash -o pipefail {0}
+        shell: bash -e -o pipefail {0}
     if: github.repository_owner == 'tinygrad'
     steps:
     - name: Checkout Code
@@ -275,7 +275,7 @@ jobs:
     timeout-minutes: 20
     defaults:
       run:
-        shell: bash -o pipefail {0}
+        shell: bash -e -o pipefail {0}
     if: github.repository_owner == 'tinygrad'
     steps:
     - name: Checkout Code
@@ -347,7 +347,7 @@ jobs:
     timeout-minutes: 20
     defaults:
       run:
-        shell: bash -o pipefail {0}
+        shell: bash -e -o pipefail {0}
     if: github.repository_owner == 'tinygrad'
     steps:
     - name: Checkout Code
@@ -473,7 +473,7 @@ jobs:
     timeout-minutes: 30
     defaults:
       run:
-        shell: bash -o pipefail {0}
+        shell: bash -e -o pipefail {0}
     if: github.repository_owner == 'tinygrad'
     steps:
     - name: Checkout Code
@@ -543,7 +543,7 @@ jobs:
     timeout-minutes: 20
     defaults:
       run:
-        shell: bash -o pipefail {0}
+        shell: bash -e -o pipefail {0}
     if: github.repository_owner == 'tinygrad'
     steps:
     - name: Checkout Code


### PR DESCRIPTION
example of benchmark job [silently failing](https://github.com/tinygrad/tinygrad/actions/runs/14975260718/job/42065838943#step:18:13)
same benchmark job after this change [failing](https://github.com/tinygrad/tinygrad/actions/runs/14975260718/job/42065838943#step:18:13)


exit codes and error action preference [(reference)](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference)