### PR TITLE
add `ds_load_b96` and `ds_store_b96` instructions to remu

### DIFF
--- a/extra/remu/src/thread.rs
+++ b/extra/remu/src/thread.rs
@@ -1396,9 +1396,10 @@ impl<'a> Thread<'a> {
 
             match op {
                 // load
-                54 | 118 | 255 => {
+                54 | 118 | 254 | 255 => {
                     let dwords = match op {
                         255 => 4,
+                        254 => 3,
                         118 => 2,
                         _ => 1,
                     };
@@ -1419,9 +1420,10 @@ impl<'a> Thread<'a> {
                     self.vec_reg.write64(vdst + 2, self.lds.read64(addr1));
                 }
                 // store
-                13 | 77 | 223 => {
+                13 | 77 | 222 | 223 => {
                     let dwords = match op {
                         223 => 4,
+                        222 => 3,
                         77 => 2,
                         _ => 1,
                     };


### PR DESCRIPTION
both instructions are required by `test_mid_dim_multireduce`

<img width="494" alt="image" src="https://github.com/user-attachments/assets/a9541402-d5cf-4c31-b5ab-efd9062bcea4" />


 