### PR TITLE
tensor: raise error when setting requires_grad=True on non-float tensors

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -166,6 +166,10 @@ class Tensor(SimpleMathTrait):
     # by this point, it has to be a UOp
     if not isinstance(data, UOp): raise RuntimeError(f"can't create Tensor from {data!r} with type {type(data)}")
 
+    # check that requires_grad=True is only set on float tensors
+    if requires_grad and not dtypes.is_float(data.dtype):
+      raise RuntimeError(f"Only Tensors of floating point dtype can require gradients")
+
     # data might be on a different device
     if isinstance(device, str): self.lazydata:UOp = data if data.device == device else data.copy_to_device(device)
     # if device is a tuple, we should have/construct a MultiLazyBuffer


### PR DESCRIPTION
fixes issue #9723 

This PR adds a runtime check in the Tensor constructor to raise a RuntimeError when requires_grad=True is set on a non-floating point tensor.

```
from tinygrad import Tensor
print(Tensor([1.0, 2.0, 3.0], requires_grad=True).tolist())  
print(Tensor([1, 2, 3], requires_grad=False).tolist())       
print(Tensor([1, 2, 3], requires_grad=True).tolist())        
```
out:
```
[1.0, 2.0, 3.0]
[1, 2, 3]
Traceback (most recent call last):
  File "/mnt/z/work/tinygrad/tt.py", line 5, in <module>
    print(Tensor([1, 2, 3], requires_grad=True).tolist())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/z/work/tinygrad/tinygrad/tensor.py", line 171, in __init__
    raise RuntimeError(f"Only Tensors of floating point dtype can require gradients")
RuntimeError: Only Tensors of floating point dtype can require gradients
```