### PR TITLE
add test_multitensor_jit_input [pr]

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -210,6 +210,14 @@ class TestMultiTensor(unittest.TestCase):
         a,b = jit_allreduce(Tensor.rand(256, 256))
         np.testing.assert_almost_equal(a.numpy(), b.numpy(), decimal=5)
 
+  def test_multitensor_jit_input(self):
+    @TinyJit
+    def f(x): return (x+1).contiguous().sum()
+    for _ in range(5):
+      tt = Tensor.arange(0, 4).contiguous().realize().shard((d1,d2), 0).realize()
+      out = f(tt)
+      assert out.item() == 1+2+3+4
+
   @unittest.skip("slow")
   def test_fuzz_allreduce(self):
     random.seed(41)


### PR DESCRIPTION
@nimlgen `AMD=1 MOCKGPU=1 PYTHONPATH="." python3 test/test_multitensor.py TestMultiTensor.test_multitensor_jit_input` doesn't work on mac (works on real device)

```
light@blak:~/tinygrad$ AMD=1 MOCKGPU=1 PYTHONPATH="." python3 test/test_multitensor.py TestMultiTensor.test_multitensor_jit_input
F
======================================================================
FAIL: test_multitensor_jit_input (__main__.TestMultiTensor.test_multitensor_jit_input)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/light/tinygrad/test/test_multitensor.py", line 218, in test_multitensor_jit_input
    out = f(tt)
          ^^^^^
  File "/Users/light/tinygrad/tinygrad/engine/jit.py", line 328, in __call__
    ret = self.captured(input_buffers, var_vals)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/light/tinygrad/tinygrad/engine/jit.py", line 206, in __call__
    for ei in self._jit_cache: ei.run(var_vals, jit=True)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/light/tinygrad/tinygrad/engine/realize.py", line 127, in run
    et = self.prg(bufs, var_vals, wait=wait or DEBUG >= 2)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/light/tinygrad/tinygrad/runtime/graph/hcq.py", line 190, in __call__
    self.comp_queues[dev].submit(dev, hcq_var_vals_local:=hcq_var_vals|self.fixedvars[dev])
  File "/Users/light/tinygrad/tinygrad/runtime/support/hcq.py", line 209, in submit
    self._submit(dev)
  File "/Users/light/tinygrad/tinygrad/runtime/ops_amd.py", line 330, in _submit
    dev.compute_queue.signal_doorbell(dev)
  File "/Users/light/tinygrad/tinygrad/runtime/ops_amd.py", line 509, in signal_doorbell
    for doorbell in self.doorbells: doorbell[0] = self.put_value
                                    ~~~~~~~~^^^
  File "/Users/light/tinygrad/tinygrad/runtime/support/hcq.py", line 14, in __setitem__
    def __setitem__(self, k, v): self.mv[k] = v
                                 ~~~~~~~^^^
  File "/Users/light/tinygrad/test/mockgpu/mockgpu.py", line 27, in __setitem__
    self.wcb(self.mv, index)
  File "/Users/light/tinygrad/test/mockgpu/amd/amddriver.py", line 148, in <lambda>
    self.track_address(struct.doorbell_offset, struct.doorbell_offset + 8, lambda mv,off: None, lambda mv, off: self._emulate_execute())
                                                                                                                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/light/tinygrad/test/mockgpu/amd/amddriver.py", line 171, in _emulate_execute
    q.execute()
  File "/Users/light/tinygrad/test/mockgpu/amd/amdgpu.py", line 88, in execute
    elif op == amd_gpu.PACKET3_INDIRECT_BUFFER: self._exec_indirect_buffer(n)
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/light/tinygrad/test/mockgpu/amd/amdgpu.py", line 175, in _exec_indirect_buffer
    assert rptr[0] == wptr[0], "not everything executed in amdgpu"
           ^^^^^^^^^^^^^^^^^^
AssertionError: not everything executed in amdgpu

----------------------------------------------------------------------
Ran 1 test in 0.703s

FAILED (failures=1)
```

Is anything testing HCQ multigraph with JIT?