### PR TITLE
Device: Allow DEVICE=X from instead of X=1

### DIFF
--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -42,7 +42,7 @@ class _Device:
     from_env = [d for d in from_env if d not in ["DISK", "NPY"]]
     assert len(from_env) < 2, f"multiple devices set in env: {from_env}"
     if len(from_env) > 0:
-       device = from_env[0]
+      device = from_env[0]
     else:
       try: device = next(self.get_available_devices())
       except StopIteration as exc: raise RuntimeError("no usable devices") from exc

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -10,7 +10,7 @@ from tinygrad.renderer import Renderer
 
 # **************** Device ****************
 
-ALL_DEVICES = ["METAL", "AMD", "NV", "CUDA", "QCOM", "GPU", "CPU", "LLVM", "DSP", "WEBGPU"]
+ALL_DEVICES = ["METAL", "AMD", "NV", "CUDA", "QCOM", "GPU", "CPU", "LLVM", "DSP", "WEBGPU", "NULL"]
 class _Device:
   def __init__(self) -> None:
     self._devices = [x.stem[len("ops_"):].upper() for x in (pathlib.Path(__file__).parent/"runtime").iterdir() if x.stem.startswith("ops_")]
@@ -37,8 +37,9 @@ class _Device:
       with contextlib.suppress(Exception): yield self[device].device
   @functools.cached_property
   def DEFAULT(self) -> str:
-    from_env = [d for d in ALL_DEVICES if getenv(d) == 1]
-    if (env_device:=getenv("DEVICE", '')) in ALL_DEVICES: from_env.append(env_device)
+    from_env = [d for d in self._devices if getenv(d) == 1]
+    if (env_device:=getenv("DEVICE", '')) in self._devices: from_env.append(env_device)
+    from_env = [d for d in from_env if d not in ["DISK", "NPY"]]
     assert len(from_env) < 2, f"multiple devices set in env: {from_env}"
     if len(from_env) == 0:
       try: device = next(self.get_available_devices())

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -10,7 +10,7 @@ from tinygrad.renderer import Renderer
 
 # **************** Device ****************
 
-ALL_DEVICES = ["METAL", "AMD", "NV", "CUDA", "QCOM", "GPU", "CPU", "LLVM", "DSP", "WEBGPU", "NULL"]
+ALL_DEVICES = ["METAL", "AMD", "NV", "CUDA", "QCOM", "GPU", "CPU", "LLVM", "DSP", "WEBGPU"]
 class _Device:
   def __init__(self) -> None:
     self._devices = [x.stem[len("ops_"):].upper() for x in (pathlib.Path(__file__).parent/"runtime").iterdir() if x.stem.startswith("ops_")]

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -41,11 +41,11 @@ class _Device:
     if (env_device:=getenv("DEVICE", '')) in self._devices: from_env.append(env_device)
     from_env = [d for d in from_env if d not in ["DISK", "NPY"]]
     assert len(from_env) < 2, f"multiple devices set in env: {from_env}"
-    if len(from_env) == 0:
+    if len(from_env) > 0:
+       device = from_env[0]
+    else:
       try: device = next(self.get_available_devices())
       except StopIteration as exc: raise RuntimeError("no usable devices") from exc
-    else:
-      device = from_env[0]
     os.environ[device] = "1"   # we set this in environment for spawned children
     return device
 Device = _Device()


### PR DESCRIPTION
This PR isn't very clean. I tried to keep behavior the same, but not clear to me what the differences are between the following groups and whether they are handled well:

- ALL_DEVICES
- Device._devices
- Device._devices - ['DISK', 'NPY']
- Device.get_available_devices()

Should `Device._devices - ['DISK', 'NPY']` be named? Also seems confusing that `NPY=1` will silently switch to another device?