### PR TITLE
Fix comment typo in spec.py

### DIFF
--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -16,7 +16,7 @@ try:
 
   # ctx is (solver, load_number_dict)
   z3_renderer = PatternMatcher([
-    # Ops.SPECIAL can have symbolic arg but it wont be in the toposort beacuse its not a src, we need to add it manually
+    # Ops.SPECIAL can have symbolic arg but it won't be in the toposort because it's not a src; we need to add it manually
     (UPat(Ops.SPECIAL, src=(), name="x"), lambda x: UOp(Ops.SPECIAL, arg=x.arg[0], src=(x.ufix(x.arg[1]),))),
     (UPat(Ops.SPECIAL, src=UPat(Ops.NOOP), name="x"), lambda x,ctx: UOp(Ops.NOOP, arg=create_bounded(x.arg, 0, x.src[0].arg-1, ctx[0]))),
     (UPat(Ops.DEFINE_VAR, name="x"), lambda x,ctx: UOp(Ops.NOOP, arg=create_bounded(x.arg[0], x.arg[1], x.arg[2], ctx[0]))),


### PR DESCRIPTION
## Summary
- correct misspelling in tinygrad/spec.py comment
- adjust punctuation for clarity

## Testing
- `python3 -m ruff check tinygrad/spec.py`