### PR TITLE
Fix argsort returning wrong type

### DIFF
--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -1,7 +1,7 @@
 import gzip, unittest
 from tinygrad import Variable
 from tinygrad.helpers import Context, ContextVar
-from tinygrad.helpers import merge_dicts, strip_parens, prod, round_up, fetch, fully_flatten, from_mv, to_mv, polyN, time_to_str, cdiv, cmod
+from tinygrad.helpers import merge_dicts, strip_parens, prod, round_up, fetch, fully_flatten, from_mv, to_mv, polyN, time_to_str, cdiv, cmod, argsort
 from tinygrad.tensor import get_shape
 from tinygrad.codegen.lowerer import get_contraction, get_contraction_with_reduce
 import numpy as np
@@ -331,6 +331,12 @@ class TestCStyleDivMod(unittest.TestCase):
     self.assertEqual(cmod(0, -5), 0)
     self.assertEqual(cmod(4, -5), 4)
     self.assertEqual(cmod(9, -5), 4)
+
+class TestArgsort(unittest.TestCase):
+  def test_range(self):
+    self.assertEqual(argsort(range(5)), [0,1,2,3,4])
+  def test_descending(self):
+    self.assertEqual(argsort([5,4,3,2,1]), [4,3,2,1,0])
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -22,7 +22,7 @@ def argfix(*x):
     if len(x) != 1: raise ValueError(f"bad arg {x}")
     return tuple(x[0])
   return x
-def argsort(x): return type(x)(sorted(range(len(x)), key=x.__getitem__)) # https://stackoverflow.com/questions/3382352/equivalent-of-numpy-argsort-in-basic-python
+def argsort(x: Sequence[Any]) -> list[int]: return sorted(range(len(x)), key=x.__getitem__)  # https://stackoverflow.com/questions/3382352/equivalent-of-numpy-argsort-in-basic-python
 def all_same(items:Union[tuple[T, ...], list[T]]): return all(x == items[0] for x in items)
 def all_int(t: Sequence[Any]) -> TypeGuard[tuple[int, ...]]: return all(isinstance(s, int) for s in t)
 def colored(st, color:Optional[str], background=False): return f"\u001b[{10*background+60*(color.upper() == color)+30+['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'].index(color.lower())}m{st}\u001b[0m" if color is not None else st  # replace the termcolor library with one line  # noqa: E501


### PR DESCRIPTION
## Summary
- improve `argsort` helper to return list of indices for any sequence
- add unit tests for `argsort`
- keep original comment style

## Testing
- `python3 -m ruff check tinygrad/helpers.py test/unit/test_helpers.py`
