### PR TITLE
Fix getbits mask calculation

### DIFF
--- a/test/unit/test_getbits.py
+++ b/test/unit/test_getbits.py
@@ -1,0 +1,21 @@
+import unittest
+from tinygrad.helpers import getbits
+
+class TestGetBits(unittest.TestCase):
+  def test_low_bits(self):
+    self.assertEqual(getbits(0b11010110, 0, 3), 0b0110)
+
+  def test_high_bits(self):
+    self.assertEqual(getbits(0b11010110, 4, 7), 0b1101)
+
+  def test_middle_bits(self):
+    self.assertEqual(getbits(0b11010110, 3, 5), 0b010)
+
+  def test_full_range(self):
+    self.assertEqual(getbits(0b11010110, 0, 7), 0b11010110)
+
+  def test_single_bit(self):
+    self.assertEqual(getbits(0b100000000, 8, 8), 1)
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -50,7 +50,7 @@ def lo32(x:Any) -> Any: return x & 0xFFFFFFFF # Any is sint
 def hi32(x:Any) -> Any: return x >> 32 # Any is sint
 def data64(data:Any) -> tuple[Any, Any]: return (data >> 32, data & 0xFFFFFFFF) # Any is sint
 def data64_le(data:Any) -> tuple[Any, Any]: return (data & 0xFFFFFFFF, data >> 32) # Any is sint
-def getbits(value: int, start: int, end: int): return (value >> start) & ((1 << end-start+1) - 1)
+def getbits(value: int, start: int, end: int): return (value >> start) & ((1 << (end-start+1)) - 1)
 def i2u(bits: int, value: int): return value if value >= 0 else (1<<bits)+value
 def merge_dicts(ds:Iterable[dict[T,U]]) -> dict[T,U]:
   kvs = set([(k,v) for d in ds for k,v in d.items()])


### PR DESCRIPTION
## Summary
- update `getbits` mask formula
- add unit tests for various start/end ranges
- keep `getbits` on one line

## Testing
- `ruff check tinygrad/helpers.py test/unit/test_getbits.py`
- `PYTHONPATH=. python3 test/unit/test_getbits.py -v`
