### PR TITLE
Set FUSE_ARANGE default

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -40,6 +40,7 @@ METAL_XCODE         | [1]        | enable Metal using macOS Xcode SDK
 CPU                 | [1]        | enable CPU (Clang) backend
 LLVM                | [1]        | enable LLVM backend
 BEAM                | [#]        | number of beams in kernel beam search
+FUSE_ARANGE         | [0-1]      | fuse arange operations into upstream kernels (default 1)
 DEFAULT_FLOAT       | [HALF, ...]| specify the default float dtype (FLOAT32, HALF, BFLOAT16, FLOAT64, ...), default to FLOAT32
 IMAGE               | [1-2]      | enable 2d specific optimizations
 FLOAT16             | [1]        | use float16 for images instead of float32

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -111,7 +111,7 @@ JIT = ContextVar("JIT", 2 if platform.system() == 'Darwin' and ('Intel' in platf
 WINO, CAPTURING, TRACEMETA = ContextVar("WINO", 0), ContextVar("CAPTURING", 1), ContextVar("TRACEMETA", 1)
 USE_TC, TC_SELECT, TC_OPT, AMX = ContextVar("TC", 1), ContextVar("TC_SELECT", -1), ContextVar("TC_OPT", 0), ContextVar("AMX", 0)
 TRANSCENDENTAL, TC_SEARCH_OVER_SHAPE = ContextVar("TRANSCENDENTAL", 1), ContextVar("TC_SEARCH_OVER_SHAPE", 1)
-FUSE_ARANGE, FUSE_CONV_BW = ContextVar("FUSE_ARANGE", 0), ContextVar("FUSE_CONV_BW", 0)
+FUSE_ARANGE, FUSE_CONV_BW = ContextVar("FUSE_ARANGE", 1), ContextVar("FUSE_CONV_BW", 0)
 SPLIT_REDUCEOP, NO_MEMORY_PLANNER, RING = ContextVar("SPLIT_REDUCEOP", 1), ContextVar("NO_MEMORY_PLANNER", 0), ContextVar("RING", 1)
 PICKLE_BUFFERS, PROFILE, LRU = ContextVar("PICKLE_BUFFERS", 1), ContextVar("PROFILE", getenv("VIZ")), ContextVar("LRU", 1)
 CACHELEVEL, IGNORE_BEAM_CACHE, DEVECTORIZE = ContextVar("CACHELEVEL", 2), ContextVar("IGNORE_BEAM_CACHE", 0), ContextVar("DEVECTORIZE", 1)


### PR DESCRIPTION
## Summary
- enable FUSE_ARANGE by default
- document the environment variable

## Testing
- `python3 -m ruff check tinygrad/helpers.py`
- `python3 -m mypy tinygrad/helpers.py --strict-equality` *(fails: Cannot determine type of "opts")*
- `python3 -m pytest test/test_tiny.py` *(fails: No module named pytest)*
- `python3 test/external/external_test_example.py` *(fails: ModuleNotFoundError: No module named 'tinygrad')*
