### PR TITLE
don't raise Exception in process replay [pr]

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -47,7 +47,7 @@ def recreate_kernel(ast:UOp, opts:Renderer, applied_opts:list[Opt], name:str, _)
 # *** diff a "good" recreation against the generated version
 
 def diff(offset:int, name:str, fxn:Callable) -> None:
-  warnings.filterwarnings("error", category=ProcessReplayWarning)
+  if ASSERT_DIFF: warnings.filterwarnings("error", category=ProcessReplayWarning)
   if early_stop.is_set(): return None
   conn = db_connection()
   cur = conn.cursor()
@@ -116,8 +116,7 @@ if __name__ == "__main__":
   for name,fxn in [("schedule", recreate_sched), ("kernel", recreate_kernel)]:
     logging.info(f"***** {name} diff")
     try: _pmap(name, fxn)
+    except ProcessReplayWarning: exit(1)
     except Exception as e:
-      if ASSERT_DIFF:
-        print(e)
-        exit(1)
+      if ASSERT_DIFF: raise e
       logging.error(f"{name} diff err {e}")

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -33,7 +33,7 @@ class ProcessReplayWarning(Warning): pass
 # *** recreators
 
 def recreate_sched(big_sink:UOp) -> list[UOp]:
-  UOp.unique_num = itertools.count(max([u.arg for u in big_sink.toposort() if u.op is Ops.UNIQUE], default=0)+1)
+  #UOp.unique_num = itertools.count(max([u.arg for u in big_sink.toposort() if u.op is Ops.UNIQUE], default=0)+1)
   becomes_map = get_becomes_map(big_sink)
   sched_sink = big_sink.substitute(becomes_map)
   return [u.arg.ast for u in sched_sink.toposort() if u.op is Ops.KERNEL]

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -33,7 +33,7 @@ class ProcessReplayWarning(Warning): pass
 # *** recreators
 
 def recreate_sched(big_sink:UOp) -> list[UOp]:
-  #UOp.unique_num = itertools.count(max([u.arg for u in big_sink.toposort() if u.op is Ops.UNIQUE], default=0)+1)
+  UOp.unique_num = itertools.count(max([u.arg for u in big_sink.toposort() if u.op is Ops.UNIQUE], default=0)+1)
   becomes_map = get_becomes_map(big_sink)
   sched_sink = big_sink.substitute(becomes_map)
   return [u.arg.ast for u in sched_sink.toposort() if u.op is Ops.KERNEL]

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -117,5 +117,7 @@ if __name__ == "__main__":
     logging.info(f"***** {name} diff")
     try: _pmap(name, fxn)
     except Exception as e:
-      if ASSERT_DIFF: raise e
+      if ASSERT_DIFF:
+        print(e)
+        exit(1)
       logging.error(f"{name} diff err {e}")


### PR DESCRIPTION
Exit is a much cleaner experience when running locally. Stacktrace isn't useful when we're printing the diff:

Compare
![image](https://github.com/user-attachments/assets/46fc5d6a-f360-41c4-acfb-4995b58e5a6e)
![image](https://github.com/user-attachments/assets/6ea65549-74e1-4881-869b-bd508ce894d8)

It'll still raise Exception for generic errors.