### PR TITLE
Raise error when setting requires_grad=True on non-float tensors

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -132,5 +132,15 @@ class TestOptim(unittest.TestCase):
     optimizer.step()
     Tensor.training = old_state
 
+  def test_requires_grad_non_float(self):
+    # Test that optimizer raises an error when a non-float tensor with requires_grad=None is passed
+    x = Tensor([1, 2, 3], dtype=dtypes.int32)  # Non-float tensor with default requires_grad=None
+    with self.assertRaises(RuntimeError):
+      Adam([x])
+    with self.assertRaises(RuntimeError):
+      SGD([x])
+    with self.assertRaises(RuntimeError):
+      AdamW([x])
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -350,6 +350,25 @@ class TestTinygrad(unittest.TestCase):
     assert Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32 # check if ndarray correctly casts to Tensor dtype
     assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64 # check that it works for something else
 
+  def test_requires_grad_non_float(self):
+    # Test that requires_grad=True raises error for non-float tensors at init
+    with self.assertRaises(RuntimeError):
+      Tensor([1, 2, 3], dtype=dtypes.int32, requires_grad=True)
+    with self.assertRaises(RuntimeError):
+      Tensor([True, False], dtype=dtypes.bool, requires_grad=True)
+
+    # Test that requires_grad_() raises error for non-float tensors
+    t1 = Tensor([1, 2, 3], dtype=dtypes.int32)
+    with self.assertRaises(RuntimeError):
+      t1.requires_grad_(True)
+
+    # Verify that float tensors still work fine
+    t2 = Tensor([1.0, 2.0, 3.0], dtype=dtypes.float32, requires_grad=True)
+    assert t2.requires_grad == True
+    t3 = Tensor([1.0, 2.0, 3.0], dtype=dtypes.float32)
+    t3.requires_grad_(True)
+    assert t3.requires_grad == True
+
   def test_tensor_from_blob(self):
     x = memoryview(bytearray(16)).cast('I')
 

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -10,7 +10,11 @@ class Optimizer:
   def __init__(self, params: list[Tensor], lr: float):
     # if it's None, but being put into an optimizer, set it to True
     for x in params:
-      if x.requires_grad is None: x.requires_grad = True
+      if x.requires_grad is None:
+        # Check if the tensor is of floating point type before enabling requires_grad
+        if not dtypes.is_float(x.dtype):
+          raise RuntimeError("only Tensors of floating point dtype can require gradients")
+        x.requires_grad = True
 
     self.params: list[Tensor] = dedup([x for x in params if x.requires_grad])
     assert len(self.params) != 0, "optimizer must have at least one param"

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -139,6 +139,9 @@ class Tensor(SimpleMathTrait):
     # None (the default) will be updated to True if it's put in an optimizer
     self.requires_grad:bool|None = requires_grad
 
+    if requires_grad and not dtypes.is_float(dtype or (data.dtype if isinstance(data, UOp) else dtypes.from_py(data))):
+      raise RuntimeError("only Tensors of floating point dtype can require gradients")
+
     # create a UOp from the different types of inputs
     if isinstance(data, UOp):
       assert dtype is None or dtype==data.dtype, "dtype doesn't match, and casting isn't supported"
@@ -187,6 +190,8 @@ class Tensor(SimpleMathTrait):
     return lhs._apply_uop(fxn, rhs)
 
   def requires_grad_(self, requires_grad=True) -> Tensor:
+    if requires_grad and not dtypes.is_float(self.dtype):
+      raise RuntimeError("only Tensors of floating point dtype can require gradients")
     self.requires_grad = requires_grad
     return self
 


### PR DESCRIPTION
## Description
This PR addresses issue #9723 by adding checks that raise appropriate error messages when attempting to set `requires_grad=True` on non-float tensors.

## Changes
1. Added a check in `Tensor.__init__()` to prevent creating non-float tensors with `requires_grad=True`
2. Added a check in `Tensor.requires_grad_()` to prevent modifying existing non-float tensors to have `requires_grad=True` 
3. Added a check in `Optimizer.__init__()` to prevent optimizers from enabling `requires_grad` on non-float tensors
4. Added appropriate tests in `test_tensor.py` and `test_optim.py`

This behavior now matches PyTorch, which also raises an error when trying to enable gradients on non-floating point tensors.

## Testing
Added tests that verify:
- Creating a non-float tensor with `requires_grad=True` raises an error
- Setting `requires_grad_(True)` on a non-float tensor raises an error
- Passing a non-float tensor to an optimizer raises an error when trying to set `requires_grad=True`
- Float tensors still work properly with `requires_grad=True`

Fixes #9723