### PR TITLE
mmapeak implementation for 7900 XTX

### DIFF
--- a/extra/mmapeak/mmapeak.py
+++ b/extra/mmapeak/mmapeak.py
@@ -1,0 +1,31 @@
+import pathlib
+from tinygrad.device import Device
+from tinygrad.runtime.ops_amd import AMDProgram, HIPCompiler
+import time
+
+NUM_WORKGROUPS = 96
+WAVE_SIZE = 32
+NUM_WAVES = 2
+FLOPS_PER_MATMUL =  (16*16*16*2 + 16*16)
+INTERNAL_LOOP  = 1_000_000_000
+
+DEV = Device['AMD']
+
+def launchBenchmark(fileName):
+    src = (pathlib.Path(__file__).parent / fileName).read_text()
+    lib = HIPCompiler("gfx1100").compile(src)
+    fxn = AMDProgram(DEV, "matmul", lib)
+    start = time.perf_counter()
+    fxn(global_size=(NUM_WORKGROUPS,1,1), local_size=(WAVE_SIZE*NUM_WAVES,1,1), wait=True) #For some reason the returned time is very small after the first kernel execution
+    end = time.perf_counter()
+    elapsed = end-start
+    FLOPs = FLOPS_PER_MATMUL * NUM_WAVES * NUM_WORKGROUPS * INTERNAL_LOOP
+    print(fileName, " : ", round(FLOPs/elapsed/10**12, 2), "T(FL)OPS")
+
+if __name__=="__main__":
+    launchBenchmark("v_wmma_bf16_16x16x16_bf16.s")
+    launchBenchmark("v_wmma_f16_16x16x16_f16.s")
+    launchBenchmark("v_wmma_f32_16x16x16_bf16.s")
+    launchBenchmark("v_wmma_f32_16x16x16_f16.s")
+    launchBenchmark("v_wmma_i32_16x16x16_iu4.s")
+    launchBenchmark("v_wmma_i32_16x16x16_iu8.s")

--- a/extra/mmapeak/v_wmma_bf16_16x16x16_bf16.s
+++ b/extra/mmapeak/v_wmma_bf16_16x16x16_bf16.s
@@ -1,0 +1,40 @@
+    .text
+    .globl matmul
+    .p2align 8 
+    .type matmul,@function
+matmul:
+    s_mov_b32 s1, 1000000000
+    inner_loop:
+        v_wmma_bf16_16x16x16_bf16 v[0:7], v[8:15], v[16:23], v[24:31]
+        s_sub_u32 s1, s1, 1
+        s_cmpk_lg_i32 s1, 0
+        s_cbranch_scc1 inner_loop
+    s_endpgm
+
+.rodata
+.p2align 6
+.amdhsa_kernel matmul
+  .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: matmul
+    .symbol: matmul.kd
+    .kernarg_segment_size:  0
+    .group_segment_fixed_size: 0
+    .private_segment_fixed_size: 0
+    .kernarg_segment_align: 4
+    .wavefront_size: 32
+    .sgpr_count: 8
+    .vgpr_count: 32
+    .max_flat_workgroup_size: 1024
+    .args:
+...
+.end_amdgpu_metadata

--- a/extra/mmapeak/v_wmma_f16_16x16x16_f16.s
+++ b/extra/mmapeak/v_wmma_f16_16x16x16_f16.s
@@ -1,0 +1,40 @@
+    .text
+    .globl matmul
+    .p2align 8 
+    .type matmul,@function
+matmul:
+    s_mov_b32 s1, 1000000000
+    inner_loop:
+        v_wmma_f16_16x16x16_f16 v[0:7], v[8:15], v[16:23], v[24:31]
+        s_sub_u32 s1, s1, 1
+        s_cmpk_lg_i32 s1, 0
+        s_cbranch_scc1 inner_loop
+    s_endpgm
+
+.rodata
+.p2align 6
+.amdhsa_kernel matmul
+  .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: matmul
+    .symbol: matmul.kd
+    .kernarg_segment_size:  0
+    .group_segment_fixed_size: 0
+    .private_segment_fixed_size: 0
+    .kernarg_segment_align: 4
+    .wavefront_size: 32
+    .sgpr_count: 8
+    .vgpr_count: 32
+    .max_flat_workgroup_size: 1024
+    .args:
+...
+.end_amdgpu_metadata

--- a/extra/mmapeak/v_wmma_f32_16x16x16_bf16.s
+++ b/extra/mmapeak/v_wmma_f32_16x16x16_bf16.s
@@ -1,0 +1,40 @@
+    .text
+    .globl matmul
+    .p2align 8 
+    .type matmul,@function
+matmul:
+    s_mov_b32 s1, 1000000000
+    inner_loop:
+        v_wmma_f32_16x16x16_bf16 v[0:7], v[8:15], v[16:23], v[24:31]
+        s_sub_u32 s1, s1, 1
+        s_cmpk_lg_i32 s1, 0
+        s_cbranch_scc1 inner_loop
+    s_endpgm
+
+.rodata
+.p2align 6
+.amdhsa_kernel matmul
+  .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: matmul
+    .symbol: matmul.kd
+    .kernarg_segment_size:  0
+    .group_segment_fixed_size: 0
+    .private_segment_fixed_size: 0
+    .kernarg_segment_align: 4
+    .wavefront_size: 32
+    .sgpr_count: 8
+    .vgpr_count: 32
+    .max_flat_workgroup_size: 1024
+    .args:
+...
+.end_amdgpu_metadata

--- a/extra/mmapeak/v_wmma_f32_16x16x16_f16.s
+++ b/extra/mmapeak/v_wmma_f32_16x16x16_f16.s
@@ -1,0 +1,40 @@
+    .text
+    .globl matmul
+    .p2align 8 
+    .type matmul,@function
+matmul:
+    s_mov_b32 s1, 1000000000
+    inner_loop:
+        v_wmma_f32_16x16x16_f16 v[0:7], v[8:15], v[16:23], v[24:31]
+        s_sub_u32 s1, s1, 1
+        s_cmpk_lg_i32 s1, 0
+        s_cbranch_scc1 inner_loop
+    s_endpgm
+
+.rodata
+.p2align 6
+.amdhsa_kernel matmul
+  .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: matmul
+    .symbol: matmul.kd
+    .kernarg_segment_size:  0
+    .group_segment_fixed_size: 0
+    .private_segment_fixed_size: 0
+    .kernarg_segment_align: 4
+    .wavefront_size: 32
+    .sgpr_count: 8
+    .vgpr_count: 32
+    .max_flat_workgroup_size: 1024
+    .args:
+...
+.end_amdgpu_metadata

--- a/extra/mmapeak/v_wmma_i32_16x16x16_iu4.s
+++ b/extra/mmapeak/v_wmma_i32_16x16x16_iu4.s
@@ -1,0 +1,40 @@
+    .text
+    .globl matmul
+    .p2align 8 
+    .type matmul,@function
+matmul:
+    s_mov_b32 s1, 1000000000
+    inner_loop:
+        v_wmma_i32_16x16x16_iu4 v[0:7], v[8:9], v[9:10], v[11:18]
+        s_sub_u32 s1, s1, 1
+        s_cmpk_lg_i32 s1, 0
+        s_cbranch_scc1 inner_loop
+    s_endpgm
+
+.rodata
+.p2align 6
+.amdhsa_kernel matmul
+  .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: matmul
+    .symbol: matmul.kd
+    .kernarg_segment_size:  0
+    .group_segment_fixed_size: 0
+    .private_segment_fixed_size: 0
+    .kernarg_segment_align: 4
+    .wavefront_size: 32
+    .sgpr_count: 8
+    .vgpr_count: 32
+    .max_flat_workgroup_size: 1024
+    .args:
+...
+.end_amdgpu_metadata

--- a/extra/mmapeak/v_wmma_i32_16x16x16_iu8.s
+++ b/extra/mmapeak/v_wmma_i32_16x16x16_iu8.s
@@ -1,0 +1,40 @@
+    .text
+    .globl matmul
+    .p2align 8 
+    .type matmul,@function
+matmul:
+    s_mov_b32 s1, 1000000000
+    inner_loop:
+        v_wmma_i32_16x16x16_iu8 v[0:7], v[8:11], v[12:15], v[16:23]
+        s_sub_u32 s1, s1, 1
+        s_cmpk_lg_i32 s1, 0
+        s_cbranch_scc1 inner_loop
+    s_endpgm
+
+.rodata
+.p2align 6
+.amdhsa_kernel matmul
+  .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
+  .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: matmul
+    .symbol: matmul.kd
+    .kernarg_segment_size:  0
+    .group_segment_fixed_size: 0
+    .private_segment_fixed_size: 0
+    .kernarg_segment_align: 4
+    .wavefront_size: 32
+    .sgpr_count: 8
+    .vgpr_count: 32
+    .max_flat_workgroup_size: 1024
+    .args:
+...
+.end_amdgpu_metadata


### PR DESCRIPTION
This adds a script similar to mmapeak using tinygrad infrastructure. I used tinygrad's "runtime layer" as outlined in abstractions2.py.