### PR TITLE
Remove unused env var doc

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -36,7 +36,6 @@ CUDA                | [1]        | enable CUDA backend
 AMD                 | [1]        | enable AMD backend
 NV                  | [1]        | enable NV backend
 METAL               | [1]        | enable Metal backend (for Mac M1 and after)
-METAL_XCODE         | [1]        | enable Metal using macOS Xcode SDK
 CPU                 | [1]        | enable CPU (Clang) backend
 LLVM                | [1]        | enable LLVM backend
 BEAM                | [#]        | number of beams in kernel beam search


### PR DESCRIPTION
## Summary
- remove `METAL_XCODE` from env vars table

## Testing
- `ruff check docs/env_vars.md` *(fails: SyntaxError in docs)*