### PR TITLE
raise error non float tensors & updated test to verify it.

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -493,12 +493,11 @@ class TestTinygrad(unittest.TestCase):
     with self.assertRaises(TypeError):
       _a = Tensor([3]) in [Tensor([3]), Tensor([4]), Tensor([5])]
 
-  def test_repr_with_grad(self):
-    a = Tensor([1], requires_grad=True)
-    b = Tensor([1])
-    c = (a + b).sum().backward()
-    print(a)
-    print(c)
+  def test_int_with_grad(self):
+    with self.assertRaises(RuntimeError,msg='Only Tensors of floating point and complex dtype can require gradients.'):
+      a = Tensor([1], requires_grad=True)
+    with self.assertRaises(RuntimeError,msg='Only Tensors of floating point and complex dtype can require gradients.'):
+      b= Tensor([1], requires_grad=True, dtype=dtypes.int)
 
   def test_env_overwrite_default_device(self):
     subprocess.run(['DISK=1 python3 -c "from tinygrad import Device; assert Device.DEFAULT != \\"DISK\\""'],

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -160,6 +160,10 @@ class Tensor(SimpleMathTrait):
       dtype = dtype or dtypes.uint8
       data = UOp.new_buffer(f"DISK:{data.resolve()}", data.stat().st_size // dtype.itemsize, dtype)
 
+    if dtype in dtypes.ints and bool(self.requires_grad):
+      del data
+      raise RuntimeError("Only Tensors of floating point and complex dtype can require gradients.")
+
     # by this point, it has to be a UOp
     if not isinstance(data, UOp): raise RuntimeError(f"can't create Tensor from {data!r} with type {type(data)}")
 


### PR DESCRIPTION
Fixes https://github.com/tinygrad/tinygrad/issues/9723
- Updated the Tensor __init__ function with the required checks, and raise RuntimeError when it fails.
- Updated test/test_tensor.py to check for the above changes. 
- Test cases 
   - when dtype is inferred 
   - when dtype is explicitly mentioned