### PR TITLE
Flash attention

### DIFF
--- a/test/models/test_real_world.py
+++ b/test/models/test_real_world.py
@@ -165,7 +165,7 @@ class TestRealWorld(unittest.TestCase):
       for v in data.values(): v.to_(Device.DEFAULT)
 
       helper_test("train_bert", lambda: (data["input_ids"], data["segment_ids"], data["input_mask"], data["masked_lm_positions"], \
-          data["masked_lm_ids"], data["masked_lm_weights"], data["next_sentence_labels"]), train, 0.25, 346)
+          data["masked_lm_ids"], data["masked_lm_weights"], data["next_sentence_labels"]), train, 0.25, 1332)
 
   def test_bert_fuse_arange(self):
     with Context(FUSE_ARANGE=1):

--- a/tinygrad/codegen/symbolic.py
+++ b/tinygrad/codegen/symbolic.py
@@ -55,6 +55,8 @@ symbolic_simple = PatternMatcher([
    lambda a: a.const_like(exec_alu(a.op, a.dtype, [a.src[0].arg, a.src[1].arg], False))),
   (UPat(GroupOp.Ternary, src=(UPat((Ops.VCONST, Ops.CONST)),)*3, name="a"),
    lambda a: a.const_like(exec_alu(a.op, a.dtype, [a.src[0].arg, a.src[1].arg, a.src[2].arg], False))),
+  (UPat(Ops.MAX, src=[UPat.var("x"), UPat.cvar("y", vec=False)], dtype=dtypes.floats), lambda x,y: x if y.arg == float("-inf") else None),
+  (UPat.var("x") + UPat.var("x") * -1, lambda x: x.const_like(0)),
   # bool MUL is AND, ADD/MAX is OR. prevents other rules to rewrite bool ADD/MUL incorrectly
   (UPat.var('x', dtype=dtypes.bool) * UPat.var('y', dtype=dtypes.bool), lambda x,y: x&y),
   (UPat.var('x', dtype=dtypes.bool) + UPat.var('y', dtype=dtypes.bool), lambda x,y: x|y),

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3886,8 +3886,8 @@ class Tensor(MathTrait):
     assert all_int(self.shape), f"does not support symbolic shape {self.shape}"
     if _flash_att and not is_causal:
       assert not is_causal
-      assert all_int(key.shape), f"does not support symbolic shape {key.shape}"
-      assert all_int(value.shape), f"does not support symbolic shape {value.shape}"
+      assert isinstance(key.shape[-2], int), f"does not support symbolic shape {key.shape}"
+      assert isinstance(value.shape[-2], int), f"does not support symbolic shape {value.shape}"
       return self.flash_attention(key, value, attn_mask=attn_mask, dropout_p=dropout_p)
     qk = self.matmul(key.transpose(-2,-1), dtype=least_upper_dtype(self.dtype, key.dtype, dtypes.float32)) / math.sqrt(self.shape[-1])
     # handle attention mask

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3886,7 +3886,7 @@ class Tensor(MathTrait):
     assert all_int(self.shape), f"does not support symbolic shape {self.shape}"
     if is_causal:
       if attn_mask is not None: raise RuntimeError("cannot set attn_mask when is_causal=True")
-      attn_mask = qk.ones_like(requires_grad=False, device=self.device, dtype=dtypes.bool).tril()
+      attn_mask = Tensor.ones(self.shape[:-1]+(key.shape[-2],), requires_grad=False, device=self.device, dtype=dtypes.bool).tril()
     if _flash_att:
       assert isinstance(key.shape[-2], int), f"does not support symbolic shape {key.shape}"
       assert isinstance(value.shape[-2], int), f"does not support symbolic shape {value.shape}"

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3886,7 +3886,7 @@ class Tensor(MathTrait):
     """
     # NOTE: it also works when `key` and `value` have symbolic shape.
     assert all_int(self.shape), f"does not support symbolic shape {self.shape}"
-    if _flash_att:
+    if _flash_att and not is_causal:
       assert not is_causal
       assert all_int(key.shape), f"does not support symbolic shape {key.shape}"
       assert all_int(value.shape), f"does not support symbolic shape {value.shape}"

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3887,8 +3887,8 @@ class Tensor(MathTrait):
       if attn_mask is not None: raise RuntimeError("cannot set attn_mask when is_causal=True")
       attn_mask = Tensor.ones(self.shape[:-1]+(key.shape[-2],), requires_grad=False, device=self.device, dtype=dtypes.bool).tril()
     if _flash_att:
-      assert isinstance(key.shape[-2], int), f"does not support symbolic shape {key.shape}"
-      assert isinstance(value.shape[-2], int), f"does not support symbolic shape {value.shape}"
+      assert isinstance(key.shape[-1], int), f"does not support symbolic shape {key.shape}"
+      assert isinstance(value.shape[-1], int), f"does not support symbolic shape {value.shape}"
       return self.flash_attention(key, value, attn_mask=attn_mask, dropout_p=dropout_p)
     qk = self.matmul(key.transpose(-2,-1), dtype=least_upper_dtype(self.dtype, key.dtype, dtypes.float32)) / math.sqrt(self.shape[-1])
     # handle attention mask

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3820,7 +3820,6 @@ class Tensor(MathTrait):
     if num_classes == -1: num_classes = (self.max()+1).item()
     return self[..., None]._one_hot_along_dim(num_classes).where(1, 0)
 
-
   def flash_attention(self, key:Tensor, value:Tensor, attn_mask:Tensor|None=None, dropout_p:float=0.0) -> Tensor:
     if attn_mask is not None:
       if attn_mask.dtype == dtypes.bool: attn_mask = attn_mask.where(0, -float("inf"))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3819,8 +3819,57 @@ class Tensor(MathTrait):
     if not dtypes.is_int(self.dtype): raise RuntimeError(f"expect integer dtype, getting {self.dtype=}")
     if num_classes == -1: num_classes = (self.max()+1).item()
     return self[..., None]._one_hot_along_dim(num_classes).where(1, 0)
+  
+  
+  def flash_attention(self, key:Tensor, value:Tensor, attn_mask:Tensor|None=None, dropout_p:float=0.0) -> Tensor:
+      if attn_mask is not None:
+        if attn_mask.dtype == dtypes.bool: attn_mask = attn_mask.where(0, -float("inf"))
+      
+      M = 96*1024 # TODO: make device specific
 
-  def scaled_dot_product_attention(self, key:Tensor, value:Tensor, attn_mask:Tensor|None=None, dropout_p:float=0.0, is_causal:bool=False) -> Tensor:
+      Bc = round_up(M // (4*self.shape[-1]*self.dtype.itemsize), 1)
+      Br = min(Bc, self.shape[-1])
+
+      full_output = []
+      for ri in range(0, self.shape[-2], Br):
+        qi = self[..., ri:ri+Br, :]
+        m = Tensor.full(ml_shape:=qi.shape[:-1]+(1,), -float('inf'), dtype=self.dtype, device=self.device)
+        l = Tensor.zeros(ml_shape, dtype=self.dtype, device=self.device)
+        O = qi.zeros_like()
+        #O = UOp.new_buffer(self.device, qi.numel(), self.dtype)
+        for ci in range(0, key.shape[-2], Bc):
+          k_chunk = key[..., ci:ci+Bc, :]
+          v_chunk = value[..., ci:ci+Bc, :]
+
+          S_chunk = (qi.matmul(k_chunk.transpose(-2, -1), dtype=least_upper_dtype(self.dtype, k_chunk.dtype, dtypes.float32)) / math.sqrt(self.shape[-1]))
+
+          if attn_mask is not None:
+            S_chunk = S_chunk + (attn_mask[..., ri:ri+Br, ci:ci+Bc] if attn_mask.shape[-2]!=1 else attn_mask[..., ci:ci+Bc])
+          S_chunk = S_chunk.cast(self.dtype)
+          m_chunk = S_chunk.max(-1, keepdim=True).detach()
+          e_chunk = (S_chunk - m_chunk).exp().dropout(dropout_p)
+
+          l_chunk = e_chunk.sum(-1, keepdim=True)
+          o_chunk = e_chunk @ v_chunk
+
+          m_new = Tensor.maximum(m, m_chunk)
+          exp_m_diff = (m - m_new).exp()
+          exp_mc_diff = (m_chunk - m_new).exp()
+
+          m = m_new
+          l = l * exp_m_diff + l_chunk * exp_mc_diff
+          # TODO: this should be an in-place edit of O
+          O = O * exp_m_diff + o_chunk * exp_mc_diff
+          #O.assign(O * exp_m_diff.lazydata + o_chunk.lazydata * exp_mc_diff.lazydata)
+
+          # TODO: Get a bunch of the above to fuse
+          #O = O.fuse()
+        #full_output.append(Tensor(O/l.lazydata))
+        full_output.append(O/l)
+
+      return Tensor.cat(*full_output, dim=-2)
+
+  def scaled_dot_product_attention(self, key:Tensor, value:Tensor, attn_mask:Tensor|None=None, dropout_p:float=0.0, is_causal:bool=False, _flash_att=getenv("FLASH_ATTENTION", 1)) -> Tensor:
     """
     Computes scaled dot-product attention.
     `self` is the query tensor, `key` is the key tensor, and `value` is the value tensor.
@@ -3837,6 +3886,11 @@ class Tensor(MathTrait):
     """
     # NOTE: it also works when `key` and `value` have symbolic shape.
     assert all_int(self.shape), f"does not support symbolic shape {self.shape}"
+    if _flash_att:
+      assert not is_causal
+      assert all_int(key.shape), f"does not support symbolic shape {key.shape}"
+      assert all_int(value.shape), f"does not support symbolic shape {value.shape}"
+      return self.flash_attention(key, value, attn_mask=attn_mask, dropout_p=dropout_p)
     qk = self.matmul(key.transpose(-2,-1), dtype=least_upper_dtype(self.dtype, key.dtype, dtypes.float32)) / math.sqrt(self.shape[-1])
     # handle attention mask
     if is_causal:


### PR DESCRIPTION
This is very much an early draft, I'm sharing this to maybe avoid a bit of double work, and to have a good place to outline the areas of this work I'm struggling with to hopefully get some pointers in the right direction.

What is implemented so far: basic outline of flash attention. When running with FLASH_ATTENTION=1 (default right now for testing only) all calls to scaled_dot_product_attention will be handled via the flash attention implementation.

Next steps for this to actually be an improvement:
- [ ] Fuse the intermediate steps into one kernel, right now there is an explosion in number of kernels
- [ ] Flash attention paper slices the output buffer, and reads+writes to the same memory locations of it multiple times. I've tried to emulate that by assigning a UOp buffer to itself (see commented out code), but that leads to compile failures.
- [ ] The additions in symbolic should be removed again, they're there to eliminate part of the first kernel layers (first computation of m_new and first update of O)
- [x] is_causal is not yet supported
- [ ] Test/fix symbolic shapes for key/value (and attn_mask?)
- [ ] Size of cache memory is hardcoded, should be made device-specific or maybe best sizes discovered via beam search?
- [ ] The backwards pass can be made more efficient by using `l` to recompute softmax more efficiently. I think this needs a custom backwards pass, not autodiscovered via compute_gradient(). Not sure how to include that.