### PR TITLE
AMD: fix USB auto-detection

### DIFF
--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -841,7 +841,7 @@ class AMDDevice(HCQCompiled):
     errs:str = ""
     for iface_t in (KFDIface, PCIIface, USBIface):
       try: return iface_t(self, self.device_id)
-      except (RuntimeError, FileNotFoundError, BlockingIOError) as e: errs += f"\n{iface_t.__name__}: {type(e).__name__}: {e}"
+      except (RuntimeError, FileNotFoundError, BlockingIOError, IndexError) as e: errs += f"\n{iface_t.__name__}: {type(e).__name__}: {e}"
     raise RuntimeError(f"Cannot find a usable interface for AMD:{self.device_id}:{errs}")
 
   def __init__(self, device:str=""):


### PR DESCRIPTION
Fixes this on my workstation:
```bash
(openpilot) batman@workstation-adeeb:~/sixpilot$ ipython -c "from tinygrad import Device; print(list(Device.get_available_devices()))"
['CUDA', 'GPU', 'CPU', 'LLVM', 'DSP']
(openpilot) batman@workstation-adeeb:~/sixpilot$ AMD=1 AMD_IFACE=USB ipython -c "from tinygrad import Device; print(list(Device.get_available_devices()))"
['AMD', 'CUDA', 'GPU', 'CPU', 'LLVM', 'DSP']
(openpilot) batman@workstation-adeeb:~/sixpilot$ AMD=1 ipython -c "from tinygrad import Device; print(list(Device.get_available_devices()))"
['CUDA', 'GPU', 'CPU', 'LLVM', 'DSP']
```

---

Here's the exception it was hitting.
```python
Traceback (most recent call last):
  File "/home/batman/sixpilot/tinygrad/device.py", line 39, in get_available_devices
    yield self[device].device
          ~~~~^^^^^^^^
  File "/home/batman/sixpilot/tinygrad/device.py", line 22, in __getitem__
    def __getitem__(self, ix:str) -> Compiled: return self.__get_canonicalized_item(self.canonicalize(ix))
                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/sixpilot/tinygrad/device.py", line 28, in __get_canonicalized_item
    ret = [cls for cname, cls in inspect.getmembers(importlib.import_module(f'tinygrad.runtime.ops_{x.lower()}')) \
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/sixpilot/tinygrad/runtime/ops_amd.py", line 849, in __init__
    self.dev_iface = self._select_iface()
                     ^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/sixpilot/tinygrad/runtime/ops_amd.py", line 843, in _select_iface
    try: return iface_t(self, self.device_id)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/sixpilot/tinygrad/runtime/ops_amd.py", line 659, in __init__
    self.pcibus = PCIIface.gpus[dev_id]
                  ~~~~~~~~~~~~~^^^^^^^^
IndexError: list index out of range
```