### PR TITLE
Fixing metal compile errors in extra/gemm (similar to #3365)

### DIFF
--- a/extra/gemm/metal_matmul.py
+++ b/extra/gemm/metal_matmul.py
@@ -26,7 +26,7 @@ metalalloc._copyin(c,nc.tobytes())
 FLOPS = N*N*N*2
 BW = N*N*3*4
 
-prog = MetalProgram(device, "test", MetalCompiler(device).compile(f"""
+prog = MetalProgram(device, "test", MetalCompiler().compile(f"""
 #include <metal_stdlib>
 #include <metal_simdgroup_matrix>  // Available from Metal version 2.3 released with OS X 11.0+
 using namespace metal;

--- a/extra/gemm/metal_matvec.py
+++ b/extra/gemm/metal_matvec.py
@@ -30,7 +30,7 @@ WORKSIZE_ROW = 16
 WORKSIZE_COL = 1
 LOCAL_SIZE = [32, WORKSIZE_COL, WORKSIZE_ROW]
 GLOBAL_SIZE = [M//(LOCAL_SIZE[0]*LOCAL_SIZE[1]*4), 1, 1]
-prog = MetalProgram(device, "test", MetalCompiler(device).compile(f"""
+prog = MetalProgram(device, "test", MetalCompiler().compile(f"""
 #include <metal_stdlib>
 using namespace metal;
 kernel void test(device float* data0, const device float* data1, const device float* data2, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {{


### PR DESCRIPTION
`extra/gemm/metal_matmul.py` and `extra/gemm/metal_matvec.py` both failed to run on M2 Macbook target. 
This slight tweak resolves the issue.
