### PR TITLE
refactor `CUDA`, `NV` & `PTX` disassemble [pr]

### DIFF
--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -5,7 +5,7 @@ from tinygrad.device import Compiled, BufferSpec, LRUAllocator
 from tinygrad.renderer.cstyle import CUDARenderer
 from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.runtime.autogen import cuda
-from tinygrad.runtime.support.compiler_cuda import cuda_disassemble, pretty_ptx, CUDACompiler, PTXCompiler, PTX
+from tinygrad.runtime.support.compiler_cuda import pretty_ptx, CUDACompiler, PTXCompiler, PTX
 if getenv("IOCTL"): import extra.nv_gpu_driver.nv_ioctl  # noqa: F401  # pylint: disable=unused-import
 if MOCKGPU:=getenv("MOCKGPU"): from test.mockgpu.cuda import cuda # type: ignore # pylint: disable=reimported
 
@@ -34,14 +34,12 @@ class CUDAProgram:
   def __init__(self, dev:CUDADevice, name:str, lib:bytes, smem:int=0):
     self.dev, self.name, self.lib, self.smem = dev, name, lib, smem
     if DEBUG >= 5: print("\n".join([f"{i+1:>3} {line}" for i, line in enumerate(pretty_ptx(lib.decode('utf-8')).split("\n"))]))
-    if DEBUG >= 7: cuda_disassemble(lib, dev.arch)
 
     check(cuda.cuCtxSetCurrent(self.dev.context))
     self.module = cuda.CUmodule()
     status = cuda.cuModuleLoadData(ctypes.byref(self.module), lib)
     if status != 0:
       del self.module
-      cuda_disassemble(lib, dev.arch)
       raise RuntimeError(f"module load failed with status code {status}: {cuda.cudaError_enum__enumvalues[status]}")
     check(cuda.cuModuleGetFunction(ctypes.byref(prg := cuda.CUfunction()), self.module, name.encode("utf-8")))
     self.prg = prg


### PR DESCRIPTION
unify CUDA/NV/PTX disassemble pipeline

before, it was quite a mess how it worked; the `disassemble` function from `CUDACompiler` was not working for itself as `nvdisam` expects a `cubin` lib, but the `compile` outputs `ptx`. That `disassemble` function did work for `NVCompiler` that inherited it as the compile function from it does generate `cubin` lib.

`CUDA=1 PTX=0` and `CUDA=1 PTX=1` were disassembled by `cuda_disassemble` helper fun that introduced a step using ptxas for ptx into sass compilation.

Added disassemble to NVPTX that before was a noop.

Removed extra disassembling happening in `cuda_ops` as it was already triggered with `DEBUG >= 7` in realize.

https://github.com/tinygrad/tinygrad/blob/475a7583b38458e5addf74e15026f0888c1feaf9/tinygrad/engine/realize.py#L45

Now disassemble works for all cuda backend/renderer combinations
- `CUDA=1 PTX=1`
- `CUDA=1 PTX=0`
- `NV=1 PTX=1`
- `NV=1 PTX=0`