### PR TITLE
Fix METAL virtual device sync issue 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -92,8 +92,8 @@ jobs:
       run: |
         BENCHMARK_LOG=llama3_int8 python3.11 examples/llama3.py --size 8B --temperature 0 --benchmark --quantize int8 | tee llama3_int8.txt
         BENCHMARK_LOG=llama3_nf4 python3.11 examples/llama3.py --size 8B --temperature 0 --benchmark --quantize nf4 | tee llama3_nf4.txt
-    #- name: Run LLaMA 7B on 4 (virtual) GPUs
-    #  run: python3.11 examples/llama.py --gen 1 --size 7B --shard 4 --prompt "Hello." --count 10 --temperature 0  --timing | tee llama_four_gpu.txt
+    - name: Run LLaMA 7B on 4 (virtual) GPUs
+      run: python3.11 examples/llama.py --gen 1 --size 7B --shard 4 --prompt "Hello." --count 10 --temperature 0  --timing | tee llama_four_gpu.txt
     - name: Run GPT2
       run: |
         BENCHMARK_LOG=gpt2_nojit JIT=0 python3.11 examples/gpt2.py --prompt "Hello." --count 10 --temperature 0 --timing | tee gpt2_unjitted.txt

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -1,5 +1,8 @@
 import unittest
 from tinygrad.device import CompileError, Device, Compiler
+from tinygrad.tensor import Tensor
+import random
+import numpy as np
 if Device.DEFAULT=="METAL":
   from tinygrad.runtime.ops_metal import MetalDevice, MetalCompiler, MetalProgram
 @unittest.skipIf(Device.DEFAULT!="METAL", "Metal support required")
@@ -73,3 +76,49 @@ kernel void r_5(device int* data0, const device int* data1, uint3 gid [[threadgr
 """)
     with self.assertRaises(RuntimeError):
       MetalProgram(device, "r_5", compiled)
+
+@unittest.skipIf(Device.DEFAULT != "METAL", "Metal support required")
+class TestTensorDeviceTransfers(unittest.TestCase):
+  @staticmethod
+  def _generate_devices(count):
+    return [f"METAL:{i}" for i in range(count)]
+
+  @staticmethod
+  def _check_tensor_match(src, dst, tol=1e-6):
+    np.testing.assert_allclose(
+      src.numpy(), dst.numpy(), rtol=1e-5, atol=tol,
+      err_msg="Tensor values diverged on transfer"
+    )
+
+  def _prepare_random_tensors(self, device_list, size=(100, 100), seed=42):
+    random.seed(seed)
+    created = []
+    for dev in device_list:
+      t = Tensor.randn(*size, device=dev)
+      t = t.matmul(t).realize()
+      created.append(t)
+    return created
+
+  def test_fill_pairwise_transfers(self):
+    devs = self._generate_devices(4)
+    filled = {
+      dev: Tensor.full((10, 10), float(i + 1), device=dev)
+      for i, dev in enumerate(devs)
+    }
+
+    for src_dev in devs:
+      original = filled[src_dev]
+      expected_value = float(devs.index(src_dev) + 1)
+      for dst_dev in devs:
+        if dst_dev == src_dev:
+          continue
+        moved = original.to(device=dst_dev).realize()
+        self.assertEqual(
+          moved.shape, original.shape,
+          f"Shape mismatch transferring from {src_dev} to {dst_dev}"
+        )
+        arr = moved.numpy()
+        np.testing.assert_array_equal(
+          arr, np.full_like(arr, expected_value),
+          err_msg=f"Values not preserved from {src_dev} to {dst_dev}"
+        )


### PR DESCRIPTION
## Issue
   - Metal virtual devices need to be properly synchronized when tensors are transferred between devices (e.g. METAL:0 → METAL:1), the destination can read data before the source finishes writing 

## Fix
   - Add explicit cross-device synchronization using MTLSharedEvent timeline events
   - Use encodeSignalEvent at end of command buffer on source device and on destination device create wait buffer with encodeWaitForEvent:value: before any dependent work. 
   - Track and increment timeline_value per device to ensure ordered signalling so work on the source device completes before the destination proceeds.
   
   More Details on [Synchronizing Events Across Multiple Devices](https://developer.apple.com/documentation/metal/synchronizing-events-across-multiple-devices-or-processes)