### PR TITLE
add_contiguous in grouper

### DIFF
--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -517,10 +517,12 @@ def get_kernelize_map(big_sink:UOp) -> dict[UOp, UOp]:
   # make contiguous and src[0] the same thing
   # NOTE: this has to exist becase graph_rewrite_map does not map src[0] -> contiguous directly, if you do, it's an infinite loop!
   for k,v in tensor_map.copy().items():
-    if k.op is not v.op: continue # TODO: this is a fragile check for if we should looks for contigs in this op for contig parents
+    if k.op is not v.op: continue # TODO: this is a fragile check for if we should look for contig srcs in this op
     assert len(k.src) == len(v.src), "source length changed while inserting contiguous?"
     for s0,s1 in zip(k.src, v.src):
-      if s1.op is Ops.CONTIGUOUS: tensor_map[s0] = s1
+      if s1.op is Ops.CONTIGUOUS:
+        # map src0 to contiguous
+        tensor_map[s0] = s1
   tensor_map = graph_rewrite_map(tensor_map[big_sink], create_kernels+create_ast, input_map=tensor_map, name="create_kernels")
 
   # if a kernel depends on a buffer, and that buffer is later assigned to, make the assign depend on the kernel's assign

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -248,7 +248,7 @@ def create_kernel(x:UOp, b:UOp|None=None):
   return buffer.assign(kernel).reshape(x.shape)
 
 DONT_PLACE_IN_KERNEL = {Ops.KERNEL, Ops.ASSIGN, Ops.BUFFER}
-def append_to_kernel(ctx:dict[UOp, None], x:UOp):
+def append_to_kernel(x:UOp):
   new_srcs: list[UOp] = []
   metadata = dict.fromkeys(x.arg.metadata)
   for s in x.src:


### PR DESCRIPTION
Failing tests in BUFFER_VIEW/DISK tensor

BUFFER_VIEW should not be a kernel. It's a LOAD of subbuffer.

```
=========================== short test summary info ============================
FAILED test/test_conv_shapetracker.py::TestConvShapetracker::test_conv_3x3_one_view - AssertionError: conv should only have one kernel, getting 3
assert 3 == 1
 +  where 3 = len([ScheduleItem(ast=UOp(Ops.SINK, dtypes.void, arg=None, src=(\n  UOp(Ops.STORE, dtypes.void, arg=None, src=(\n    UOp(Ops...4608 dtype:dtypes.float>, <buf real:False device:METAL size:32 dtype:dtypes.float>), metadata=(conv2d,), fixedvars={})])
FAILED test/test_arange.py::TestIndexing::test_index_mnist - AssertionError: buffer copy mismatch, 47040000 != 47040016, dtypes.uchar != dtypes.uchar
FAILED test/test_arange.py::TestIndexing::test_index_mnist_opt - AssertionError: buffer copy mismatch, 47040000 != 47040016, dtypes.uchar != dtypes.uchar
FAILED test/test_arange.py::TestIndexing::test_index_mnist_opt_split - AssertionError: buffer copy mismatch, 47040000 != 47040016, dtypes.uchar != dtypes.uchar
FAILED test/test_arange.py::TestIndexing::test_index_mnist_split - AssertionError: buffer copy mismatch, 47040000 != 47040016, dtypes.uchar != dtypes.uchar
FAILED test/test_multitensor.py::TestMultiTensor::test_data_parallel_resnet - AssertionError: buffer copy mismatch, 22 != 46827520, dtypes.uchar != dtypes.uchar
FAILED test/test_multitensor.py::TestMultiTensor::test_data_parallel_resnet_train_step - AssertionError: buffer copy mismatch, 22 != 46827520, dtypes.uchar != dtypes.uchar
FAILED test/test_multitensor.py::TestMultiTensor::test_rmsnorm - AssertionError: 
Not equal to tolerance rtol=1e-06, atol=1e-06

(shapes (4, 10, 20), (4, 10, 10) mismatch)
 ACTUAL: array([[[1.225271e+00, 3.724281e-01, 5.091330e-01, 1.094762e+00, 6.284181e-01, 6.203892e-01, 1.551779e+00, 8.530937e-01, 6.898670e-01, 1.331356e+00,
         1.577904e+00, 1.513512e+00, 1.395560e+00, 4.062609e-01, 2.545260e-01, 2.041801e-01, 1.242008e+00, 1.316516e+00, 3.782687e-01, 5.654534e-01],
        [1.975244e+00, 4.437606e-01, 1.241732e+00, 8.598182e-01, 1.372883e+00, 5.204374e-01, 2.472579e-01, 1.173816e+00, 1.614728e+00, 7.553883e-02,...
 DESIRED: array([[[1.225271, 0.372428, 0.509133, 1.094762, 0.628418, 0.620389, 1.551779, 0.853094, 0.689867, 1.331356],
        [1.975244, 0.443761, 1.241732, 0.859818, 1.372883, 0.520437, 0.247258, 1.173816, 1.614728, 0.075539],
        [1.679304, 0.907129, 0.687743, 0.038277, 1.670196, 0.281965, 0.693665, 0.55413 , 1.299488, 0.[618](https://github.com/tinygrad/tinygrad/actions/runs/15197755495/job/42745817619?pr=10470#step:6:619)201],...
FAILED test/test_schedule.py::TestIndexing::test_mnist_val - AssertionError: buffer copy mismatch, 60000 != 60008, dtypes.uchar != dtypes.uchar
FAILED test/test_tensor.py::TestTensorMetadata::test_complex - AssertionError: 0 != 3
FAILED test/test_tensor.py::TestTensorMetadata::test_matmul - AssertionError: 0 != 1
FAILED test/test_tensor.py::TestTensorMetadata::test_relu - AssertionError: 0 != 1
FAILED test/test_tensor.py::TestTinygrad::test_copy_from_disk - AssertionError: buffer copy mismatch, 10 != 30, dtypes.float != dtypes.float
= 13 failed, 1930 passed, 309 skipped, 67 xfailed, 11 warnings in 180.93s (0:03:00) =
```