### PR TITLE
add TestSchedule.test_realize_means_realize [pr]

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -151,6 +151,17 @@ class TestSchedule(unittest.TestCase):
     a.realize()
     assert not a.lazydata.is_realized
 
+  def test_realize_means_realize(self):
+    a = Tensor.empty(10)
+    a.kernelize()
+    # no allocation in kernelize
+    assert not a.lazydata.buffer.is_allocated()
+    self.assertIs(a.lazydata.op, Ops.BUFFER)
+    a.realize()
+    # after realize, even if there aren't ExecItems the sinked buffers should be allocated
+    with self.assertRaises(AssertionError):
+      assert a.lazydata.buffer.is_allocated()
+
   def test_simplify_padded_const(self):
     a = Tensor.empty(1022).cummax(axis=0)
     sched = check_schedule(a, 5)


### PR DESCRIPTION
Currently it fails because realize only runs ExecItems, if there are SINK(...BUFFER) in the schedule graph, none of the BUFFERs get allocated.
![image](https://github.com/user-attachments/assets/48012fd1-6ea9-4bf6-bc48-c5ffb9ae17e2)