### PR TITLE
proper error for device mismatch

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -76,6 +76,7 @@ class TestSchedule(unittest.TestCase):
     c = a+b
     with self.assertRaisesRegex(RuntimeError, "all buffers must be on the same device"): check_schedule(c, 1)
 
+  @unittest.skipIf(Device.DEFAULT == "CPU", "devices must mismatch")
   def test_error_on_device_mismatch_alt(self):
     a = Tensor.empty(10)
     b = Tensor.empty((1,), device="CPU").expand(10).contiguous()

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -74,7 +74,13 @@ class TestSchedule(unittest.TestCase):
     a = Tensor.empty(10)
     b = Tensor.empty(10, device="CPU")
     c = a+b
-    with self.assertRaises(RuntimeError): check_schedule(c, 1)
+    with self.assertRaisesRegex(RuntimeError, "all buffers must be on the same device"): check_schedule(c, 1)
+
+  def test_error_on_device_mismatch_alt(self):
+    a = Tensor.empty(10)
+    b = Tensor.empty((1,), device="CPU").expand(10).contiguous()
+    c = a+b
+    with self.assertRaisesRegex(RuntimeError, "all buffers must be on the same device"): check_schedule(c, 1)
 
   @unittest.skipUnless(is_dtype_supported(dtypes.half) and getenv("CAST_AFTER_EXPAND"), "need half and CAST_AFTER_EXPAND=1")
   @unittest.skip("CAST_AFTER_EXPAND is not supported")

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -413,8 +413,8 @@ def fix_kernel_ast(k:UOp) -> UOp|None:
   # replace buffer with define_global + add load/store last
   bufs = tuple(s.buf_uop if s.op is not Ops.MSELECT else s.src[0].buf_uop for s in k.src)
   ast = graph_rewrite(ast, merge_views+add_buffer_ops+fix_kernel_ops, bufs, bottom_up=True, name="replace buffer")
-  if ast.op is Ops.SINK and not all_same([x.device for x in k.src]):
-    raise RuntimeError(f"all buffers must be on the same device: {tuple(b.buffer for b in k.src)}")
+  if ast.op is Ops.SINK and not all_same([x.device for x in bufs]):
+    raise RuntimeError(f"all buffers must be on the same device: {tuple(b.buffer for b in bufs)}")
   return k.replace(arg=Kernel(ast, k.arg.metadata))
 
 create_ast = PatternMatcher([(UPat(Ops.KERNEL, name="k"), fix_kernel_ast),])

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -413,8 +413,8 @@ def fix_kernel_ast(k:UOp) -> UOp|None:
   # replace buffer with define_global + add load/store last
   bufs = tuple(s.buf_uop if s.op is not Ops.MSELECT else s.src[0].buf_uop for s in k.src)
   ast = graph_rewrite(ast, merge_views+add_buffer_ops+fix_kernel_ops, bufs, bottom_up=True, name="replace buffer")
-  if ast.op is Ops.SINK and not all_same([x.device for x in bufs]):
-    raise RuntimeError(f"all buffers must be on the same device: {tuple(b.buffer for b in bufs)}")
+  if ast.op is Ops.SINK and not all_same([x.device for x in k.src]):
+    raise RuntimeError(f"all buffers must be on the same device: {tuple(b.buf_uop.buffer for b in k.src)}")
   return k.replace(arg=Kernel(ast, k.arg.metadata))
 
 create_ast = PatternMatcher([(UPat(Ops.KERNEL, name="k"), fix_kernel_ast),])


### PR DESCRIPTION
This changed to k.src https://github.com/tinygrad/tinygrad/pull/10494/files, ASSIGN/MSELECT do not define a Buffer directly, it should only be for BUFFER UOps.
![image](https://github.com/user-attachments/assets/60e862df-9181-45aa-b5f4-5ae9706e7dcb)