### PR TITLE
fix display of kernel args in viz [pr]

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -362,11 +362,13 @@ async function main() {
       if (s > 0 && s === currentRewrite) {
         const { upat, diff } = ret[s];
         metadata.appendChild(codeBlock(upat[1], "python", { loc:upat[0], wrap:true }));
-        const diffCode = metadata.appendChild(document.createElement("pre"));
-        diffCode.innerHTML = `<code>`+diff.map((line) => {
-          const color = line.startsWith("+") ? "#3aa56d" : line.startsWith("-") ? "#d14b4b" : "#f0f0f5";
-          return `<span style="color: ${color};">${line}</span>`;
-        }).join("<br>")+`</code>`;
+        const diffCode = metadata.appendChild(document.createElement("pre")).appendChild(document.createElement("code"));
+        for (const line of diff) {
+          const span = diffCode.appendChild(document.createElement("span"));
+          span.style.color = line.startsWith("+") ? "#3aa56d" : line.startsWith("-") ? "#d14b4b" : "#f0f0f5";
+          span.innerText = line;
+          diffCode.appendChild(document.createElement("br"));
+        }
         diffCode.className = "wrap";
       }
     }


### PR DESCRIPTION
setting innerHTML doesn't escape `<` characters correctly:
![image](https://github.com/user-attachments/assets/a5a1ff8a-39d6-4b73-b42d-1edeba753cc2)
setting innerText renders correctly as plain text
![image](https://github.com/user-attachments/assets/687bafa9-2533-4607-81b2-ddac0c448684)
