### PR TITLE
readable COPY(VIEW) reordering [pr]

### DIFF
--- a/test/test_symbolic_ops.py
+++ b/test/test_symbolic_ops.py
@@ -1,5 +1,5 @@
 import unittest
-from tinygrad import Tensor, Variable, Device
+from tinygrad import Tensor, Variable
 from tinygrad.shape.shapetracker import View
 from tinygrad.helpers import Context, GlobalCounters
 from tinygrad.uop.ops import sym_infer
@@ -177,16 +177,6 @@ class TestSymbolicOps(unittest.TestCase):
     for i in range(1, 5):
       vi = Variable("i", 1, 10).bind(i)
       t = Tensor.ones(i)
-      symbolic = t.reshape(vi).sum().item()
-      expected = t.sum().item()
-      np.testing.assert_equal(symbolic, expected)
-
-  @unittest.skipIf(Device.DEFAULT == "CPU", "test copy from external device to CPU")
-  def test_ones_sum_cpu(self):
-    for i in range(1, 5):
-      vi = Variable("i", 1, 10).bind(i)
-      vj = Variable("i", 1, 20).bind(i*2)
-      t = Tensor.ones(vj).contiguous().shrink(((0, vi),)).to("CPU")
       symbolic = t.reshape(vi).sum().item()
       expected = t.sum().item()
       np.testing.assert_equal(symbolic, expected)

--- a/test/test_symbolic_ops.py
+++ b/test/test_symbolic_ops.py
@@ -1,5 +1,5 @@
 import unittest
-from tinygrad import Tensor, Variable
+from tinygrad import Tensor, Variable, Device
 from tinygrad.shape.shapetracker import View
 from tinygrad.helpers import Context, GlobalCounters
 from tinygrad.uop.ops import sym_infer
@@ -177,6 +177,16 @@ class TestSymbolicOps(unittest.TestCase):
     for i in range(1, 5):
       vi = Variable("i", 1, 10).bind(i)
       t = Tensor.ones(i)
+      symbolic = t.reshape(vi).sum().item()
+      expected = t.sum().item()
+      np.testing.assert_equal(symbolic, expected)
+
+  @unittest.skipIf(Device.DEFAULT == "CPU", "test copy from external device to CPU")
+  def test_ones_sum_cpu(self):
+    for i in range(1, 5):
+      vi = Variable("i", 1, 10).bind(i)
+      vj = Variable("i", 1, 20).bind(i*2)
+      t = Tensor.ones(vj).contiguous().shrink(((0, vi),)).to("CPU")
       symbolic = t.reshape(vi).sum().item()
       expected = t.sum().item()
       np.testing.assert_equal(symbolic, expected)

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -68,7 +68,7 @@ def split_reduceop(reduce:UOp, x:UOp):
   return splitted.r(*reduce.arg).r(reduce.arg[0], (len(reduce.shape),)).reshape(reduce.shape)
 
 def copy_reorder_view(copy:UOp, view:UOp, base:UOp):
-  if resolve(prod(view.shape) < prod(base.shape)): return view.contiguous().copy_to_device(copy.device)
+  if prod(view.shape) < prod(base.shape): return view.contiguous().copy_to_device(copy.device)
   return base.copy_to_device(copy.device, arg=copy.arg).view(view.arg)
 
 ALWAYS_CONTIGUOUS = {Ops.CONTIGUOUS, Ops.ASSIGN, Ops.COPY, Ops.BUFFER, Ops.BUFFER_VIEW, Ops.CONST, Ops.BIND, Ops.DEVICE, Ops.MSELECT}

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -68,7 +68,7 @@ def split_reduceop(reduce:UOp, x:UOp):
   return splitted.r(*reduce.arg).r(reduce.arg[0], (len(reduce.shape),)).reshape(reduce.shape)
 
 def copy_reorder_view(copy:UOp, view:UOp, base:UOp):
-  if prod(view.shape) < prod(base.shape): return view.contiguous().copy_to_device(copy.device)
+  if resolve(prod(view.shape) < prod(base.shape)): return view.contiguous().copy_to_device(copy.device)
   return base.copy_to_device(copy.device, arg=copy.arg).view(view.arg)
 
 ALWAYS_CONTIGUOUS = {Ops.CONTIGUOUS, Ops.ASSIGN, Ops.COPY, Ops.BUFFER, Ops.BUFFER_VIEW, Ops.CONST, Ops.BIND, Ops.DEVICE, Ops.MSELECT}

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -68,6 +68,7 @@ def split_reduceop(reduce:UOp, x:UOp):
   return splitted.r(*reduce.arg).r(reduce.arg[0], (len(reduce.shape),)).reshape(reduce.shape)
 
 def copy_reorder_view(copy:UOp, view:UOp, base:UOp):
+  assert copy.arg is None, "copy arg is not allowed here"
   if prod(view.shape) < prod(base.shape): return view.contiguous().copy_to_device(copy.device)
   return base.copy_to_device(copy.device, arg=copy.arg).view(view.arg)
 

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -69,7 +69,7 @@ def split_reduceop(reduce:UOp, x:UOp):
 
 def copy_reorder_view(copy:UOp, view:UOp, base:UOp):
   if prod(view.shape) < prod(base.shape): return view.contiguous().copy_to_device(copy.device)
-  return base.copy_to_device(copy.device, arg=copy.arg).view(view.arg)
+  return base.copy_to_device(copy.device).view(view.arg)
 
 ALWAYS_CONTIGUOUS = {Ops.CONTIGUOUS, Ops.ASSIGN, Ops.COPY, Ops.BUFFER, Ops.BUFFER_VIEW, Ops.CONST, Ops.BIND, Ops.DEVICE, Ops.MSELECT}
 

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -68,7 +68,6 @@ def split_reduceop(reduce:UOp, x:UOp):
   return splitted.r(*reduce.arg).r(reduce.arg[0], (len(reduce.shape),)).reshape(reduce.shape)
 
 def copy_reorder_view(copy:UOp, view:UOp, base:UOp):
-  assert copy.arg is None, "copy arg is not allowed here"
   if prod(view.shape) < prod(base.shape): return view.contiguous().copy_to_device(copy.device)
   return base.copy_to_device(copy.device, arg=copy.arg).view(view.arg)
 

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -67,6 +67,10 @@ def split_reduceop(reduce:UOp, x:UOp):
   # reduce original axes, then split
   return splitted.r(*reduce.arg).r(reduce.arg[0], (len(reduce.shape),)).reshape(reduce.shape)
 
+def copy_reorder_view(copy:UOp, view:UOp, base:UOp):
+  if prod(view.shape) < prod(base.shape): return view.contiguous().copy_to_device(copy.device)
+  return base.copy_to_device(copy.device, arg=copy.arg).view(view.arg)
+
 ALWAYS_CONTIGUOUS = {Ops.CONTIGUOUS, Ops.ASSIGN, Ops.COPY, Ops.BUFFER, Ops.BUFFER_VIEW, Ops.CONST, Ops.BIND, Ops.DEVICE, Ops.MSELECT}
 
 sym = symbolic_simple+PatternMatcher([
@@ -90,9 +94,7 @@ sym = symbolic_simple+PatternMatcher([
   # non device changing COPY is a NOOP
   (UPat(Ops.COPY, name="c", src=(UPat.var("x"), UPat(Ops.DEVICE))), lambda c,x: x if c.device == x.device else None),
   # store a shrink before COPY, otherwise view after the COPY
-  (UPat(Ops.COPY, src=(UPat(Ops.VIEW, name="v"), UPat(Ops.DEVICE)), name="copy"), lambda copy,v:
-    v.contiguous().copy_to_device(copy.device, arg=copy.arg) if prod(v.shape) < prod(v.base.shape) else \
-    v.base.copy_to_device(copy.device, arg=copy.arg).view(v.st)),
+  (UPat(Ops.COPY, src=(UPat(Ops.VIEW, src=(UPat.var("base"),), name="view"), UPat(Ops.DEVICE)), name="copy"), copy_reorder_view),
   # remove cast to image when it's already a contiguous image
   (UPat(Ops.CAST, name="cast", src=(UPat(Ops.VIEW, name="vm", src=(UPat(Ops.CONTIGUOUS, name="base"),)),)),
    lambda cast,base,vm: base.view(vm.st) if isinstance(cast.dtype, ImageDType) and isinstance(base.dtype, ImageDType) else None),

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -81,7 +81,7 @@ tensor_uop_spec = buffer_spec+assign_spec+PatternMatcher([
    lambda root,x: root.dtype == x.dtype),
 
   # COPY/ALLREDUCE/MULTI
-  (UPat(Ops.COPY, name="copy", src=(UPat.var("x"), UPat(Ops.DEVICE))), lambda copy,x: copy.dtype == x.dtype),
+  (UPat(Ops.COPY, name="copy", src=(UPat.var("x"), UPat(Ops.DEVICE)), arg=None), lambda copy,x: copy.dtype == x.dtype),
   (UPat(Ops.ALLREDUCE, name="red", src=(UPat.var("x"), UPat(Ops.DEVICE))), lambda red,x: red.dtype == x.dtype and isinstance(red.arg, Ops)),
   (UPat(Ops.MULTI, name="multi"), lambda multi: all(x.dtype == multi.dtype for x in multi.src) and isinstance(multi.arg, int)),
 ])


### PR DESCRIPTION
COPY with a VIEW source should either make the VIEW contiguous or move the base and apply VIEW on the other device.

This is similar to how MSELECT(VIEW) will look like after https://github.com/tinygrad/tinygrad/pull/10496.

Also removed arg from the implementation. It is useless after MSELECT and clone fixes.