### PR TITLE
do not create kernels with more inputs than the backend allows

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1750,7 +1750,7 @@ class TestHandCodedOpts(unittest.TestCase):
     # float4/other hcopt shouldn't upcast last axis, since we already have 7 upcast, and the last axis is not very contiguous
     assert k.upcasted == 1 and k.full_shape[-1] == 7
 
-  @unittest.skipIf(Device.DEFAULT == "METAL", "METAL can only run kernels with up to 32 buffers")
+  @unittest.skipIf(Device.DEFAULT in {"METAL", "WEBGPU"}, "METAL/WEBGPU split this kernel since it has 37 buffers")
   def test_masked_upcast_wino(self):
     monster = Tensor.stack(*[Tensor.stack(*[Tensor.empty(16) for _ in range(6)]) for _ in range(6)])
 

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -83,6 +83,31 @@ class TestSchedule(unittest.TestCase):
     c = a+b
     with self.assertRaisesRegex(RuntimeError, "all buffers must be on the same device"): check_schedule(c, 1)
 
+  def test_limit_buffers(self):
+    a = Tensor(0).contiguous().realize()
+    N = 31
+    for i in range(1,N):
+      a = a + Tensor(i).contiguous()
+    self.assertEqual(a.item(), sum(range(N)))
+
+  def test_limit_buffers_prerealized(self):
+    a = Tensor(0).contiguous().realize()
+    N = 31
+    bufs = [Tensor(i).contiguous().realize() for i in range(1,N)]
+    for b in bufs:
+      a = a + b
+    self.assertEqual(a.item(), sum(range(N)))
+
+  def test_limit_buffers_split(self):
+    a = Tensor(0).contiguous().realize()
+    N = 31
+    bufs = [Tensor(i).contiguous().realize() for i in range(1,N//2)]
+    for i in range(N//2,N):
+      a = a + Tensor(i).contiguous()
+    for b in bufs:
+      a = a + b
+    self.assertEqual(a.item(), sum(range(N)))
+
   @unittest.skipUnless(is_dtype_supported(dtypes.half) and getenv("CAST_AFTER_EXPAND"), "need half and CAST_AFTER_EXPAND=1")
   @unittest.skip("CAST_AFTER_EXPAND is not supported")
   def test_expand_buffer_before_cast(self):

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -100,7 +100,7 @@ class TestSchedule(unittest.TestCase):
   def test_limit_buffers_prerealized(self):
     a = Tensor(0).contiguous().realize()
     N = 31
-    with Context(TRACK_MATCH_STATS=0):
+    with Context(TRACK_MATCH_STATS=0, DEBUG=0):
       bufs = [Tensor(i).contiguous().realize() for i in range(1,N)]
     for b in bufs:
       a = a + b

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -98,12 +98,12 @@ class TestSchedule(unittest.TestCase):
       run_schedule(check_schedule(xt, 2))
     np.testing.assert_equal(xt.numpy(), X.numpy()[1][0])
 
+  @unittest.skipIf(CI and Device.DEFAULT == "NV", "crashes on NV CI")
   def test_add_chain_buffers(self):
     N = 31
     with Context(TRACK_MATCH_STATS=0, DEBUG=0):
       bufs = [Tensor(i).reshape((1,)).contiguous().realize() for i in range(N)]
     for X in range(1,N):
-      print("--------")
       root = bufs[0]
       for i in range(1,N,X):
         root = root + functools.reduce(lambda a,b:a+b, bufs[i:i+X])

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -90,10 +90,18 @@ class TestSchedule(unittest.TestCase):
       a = a + Tensor(i).contiguous()
     self.assertEqual(a.item(), sum(range(N)))
 
+  def test_limit_buffers_double(self):
+    a = Tensor(0).contiguous().realize()
+    N = 31
+    for i in range(1,N*2):
+      a = a + Tensor(i).contiguous()
+    self.assertEqual(a.item(), sum(range(N*2)))
+
   def test_limit_buffers_prerealized(self):
     a = Tensor(0).contiguous().realize()
     N = 31
-    bufs = [Tensor(i).contiguous().realize() for i in range(1,N)]
+    with Context(TRACK_MATCH_STATS=0):
+      bufs = [Tensor(i).contiguous().realize() for i in range(1,N)]
     for b in bufs:
       a = a + b
     self.assertEqual(a.item(), sum(range(N)))

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -99,12 +99,13 @@ class TestSchedule(unittest.TestCase):
     np.testing.assert_equal(xt.numpy(), X.numpy()[1][0])
 
   def test_add_chain_buffers(self):
-    N = 36
-    with Context(DEBUG=0, TRACK_MATCH_STATS=0):
-      bufs = [Tensor((i,)).contiguous().realize() for i in range(N)]
+    N = 31
+    with Context(TRACK_MATCH_STATS=0, DEBUG=0):
+      bufs = [Tensor(i).reshape((1,)).contiguous().realize() for i in range(N)]
     for X in range(1,N):
+      print("--------")
       root = bufs[0]
-      for i in range(0,N,X):
+      for i in range(1,N,X):
         root = root + functools.reduce(lambda a,b:a+b, bufs[i:i+X])
       self.assertEqual(root.item(), sum(range(N)))
 

--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -440,21 +440,6 @@ class TestUOpMethod(unittest.TestCase):
     self.assertEqual(const._device, None)
     with self.assertRaises(AssertionError): const.device
 
-  def test_gated_toposort(self):
-    seen = {}
-    def gate_a(u:UOp):
-      if u.op is Ops.DEFINE_VAR:
-        seen[u] = seen.setdefault(u,0)+1
-        if u.arg[0] == "a": return False
-      return True
-    a = UOp.variable("a", 0, 8)
-    b = UOp.variable("b", 0, 8)
-    root = (a+b)*(a*b)
-    ts = root.toposort(gate_a)
-    self.assertEqual(seen[b], 1)
-    # this should've been 1 like b
-    self.assertEqual(seen[a], 2)
-
 class TestUOpStr(unittest.TestCase):
   def test_uop_str(self):
     a = UOp(Ops.CONST, dtypes.float, (), 2.0) + UOp(Ops.CONST, dtypes.float, (), 3.0)

--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -440,6 +440,21 @@ class TestUOpMethod(unittest.TestCase):
     self.assertEqual(const._device, None)
     with self.assertRaises(AssertionError): const.device
 
+  def test_gated_toposort(self):
+    seen = {}
+    def gate_a(u:UOp):
+      if u.op is Ops.DEFINE_VAR:
+        seen[u] = seen.setdefault(u,0)+1
+        if u.arg[0] == "a": return False
+      return True
+    a = UOp.variable("a", 0, 8)
+    b = UOp.variable("b", 0, 8)
+    root = (a+b)*(a*b)
+    ts = root.toposort(gate_a)
+    self.assertEqual(seen[b], 1)
+    # this should've been 1 like b
+    self.assertEqual(seen[a], 2)
+
 class TestUOpStr(unittest.TestCase):
   def test_uop_str(self):
     a = UOp(Ops.CONST, dtypes.float, (), 2.0) + UOp(Ops.CONST, dtypes.float, (), 3.0)

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -504,7 +504,7 @@ add_gbarrier = PatternMatcher([(UPat(GroupOp.All-{Ops.GBARRIER, Ops.ASSIGN}, nam
                                 lambda ctx,x: x.replace(tag=1).gbarrier() if x in ctx and x.tag is None else None)])
 
 def _limit_inputs(x:UOp):
-  if x.tag is not None or not (MAX_BUFS:=getenv("MAX_KERNEL_BUFFERS",{"METAL":32}.get(x.device,0))): return None
+  if x.tag is not None or not (MAX_BUFS:=getenv("MAX_KERNEL_BUFFERS",{"METAL":32}.get(x._device,0))): return None
   assert MAX_BUFS > 2, "MAX_KERNEL_BUFFERS must be greater than 2"
   cnt = 1
   def gate_buffer(u:UOp):
@@ -514,7 +514,7 @@ def _limit_inputs(x:UOp):
   x.toposort(gate=gate_buffer)
   if cnt >= MAX_BUFS-1: return x.replace(tag=1).gbarrier()
 
-limit_inputs = PatternMatcher([(UPat(GroupOp.All-{Ops.SINK, Ops.GBARRIER, Ops.ASSIGN, Ops.UNIQUE}, name="x"), _limit_inputs),])
+limit_inputs = PatternMatcher([(UPat(GroupOp.All-{Ops.SINK, Ops.GBARRIER, Ops.ASSIGN}, name="x"), _limit_inputs),])
 
 remove_tags = PatternMatcher([(UPat(GroupOp.All, name="x"), lambda x: x.replace(tag=None) if x.tag is not None else None)])
 

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -517,11 +517,11 @@ def limit_inputs(x:UOp):
     if (is_buffer:=(u.op in {Ops.BUFFER, Ops.GBARRIER, Ops.ASSIGN})): bufs.add(u)
     return not is_buffer
   x.toposort(gate=gate_buffer)
-  if len(bufs) >= MAX_BUFS-1: return x.replace(tag=1).gbarrier()
+  if len(bufs) >= MAX_BUFS-2: return x.replace(tag=1).gbarrier()
 
 split_kernels = PatternMatcher([
   (UPat(GroupOp.All-{Ops.SINK, Ops.GBARRIER, Ops.ASSIGN, Ops.UNIQUE}, name="x"), limit_inputs),
-  (UPat(Ops.GBARRIER, src=(UPat(Ops.GBARRIER),), name="x"), lambda x: x.src[0]),
+  (UPat((Ops.GBARRIER, Ops.CONTIGUOUS), src=(UPat(Ops.GBARRIER),), name="x"), lambda x: x.src[0]),
 ])
 
 remove_tags = PatternMatcher([(UPat(GroupOp.All, name="x"), lambda x: x.replace(tag=None) if x.tag is not None else None)])

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -503,7 +503,7 @@ def get_name(becomes_map:dict[UOp, UOp]) -> str:
 add_gbarrier = PatternMatcher([(UPat(GroupOp.All-{Ops.GBARRIER, Ops.ASSIGN}, name="x"),
                                 lambda ctx,x: x.replace(tag=1).gbarrier() if x in ctx and x.tag is None else None)])
 
-def limit_buffer_inputs(x:UOp):
+def limit_inputs(x:UOp):
   # skip if this is already tagged
   if x.tag is not None: return None
   # check if backend has a buffer limit
@@ -520,7 +520,7 @@ def limit_buffer_inputs(x:UOp):
   if len(bufs) >= MAX_BUFS-2: return x.replace(tag=1).gbarrier()
 
 split_kernels = PatternMatcher([
-  (UPat(GroupOp.Binary, name="x"), limit_buffer_inputs),
+  (UPat(GroupOp.All-{Ops.SINK, Ops.GBARRIER, Ops.ASSIGN, Ops.UNIQUE}, name="x"), limit_inputs),
   (UPat((Ops.GBARRIER, Ops.CONTIGUOUS), src=(UPat(Ops.GBARRIER),), name="x"), lambda x: x.src[0]),
 ])
 

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -503,7 +503,7 @@ def get_name(becomes_map:dict[UOp, UOp]) -> str:
 add_gbarrier = PatternMatcher([(UPat(GroupOp.All-{Ops.GBARRIER, Ops.ASSIGN}, name="x"),
                                 lambda ctx,x: x.replace(tag=1).gbarrier() if x in ctx and x.tag is None else None)])
 
-def limit_inputs(x:UOp):
+def limit_buffer_inputs(x:UOp):
   # skip if this is already tagged
   if x.tag is not None: return None
   # check if backend has a buffer limit
@@ -520,7 +520,7 @@ def limit_inputs(x:UOp):
   if len(bufs) >= MAX_BUFS-2: return x.replace(tag=1).gbarrier()
 
 split_kernels = PatternMatcher([
-  (UPat(GroupOp.All-{Ops.SINK, Ops.GBARRIER, Ops.ASSIGN, Ops.UNIQUE}, name="x"), limit_inputs),
+  (UPat(GroupOp.Binary, name="x"), limit_buffer_inputs),
   (UPat((Ops.GBARRIER, Ops.CONTIGUOUS), src=(UPat(Ops.GBARRIER),), name="x"), lambda x: x.src[0]),
 ])
 

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -503,10 +503,10 @@ def get_name(becomes_map:dict[UOp, UOp]) -> str:
 add_gbarrier = PatternMatcher([(UPat(GroupOp.All-{Ops.GBARRIER, Ops.ASSIGN}, name="x"),
                                 lambda ctx,x: x.replace(tag=1).gbarrier() if x in ctx and x.tag is None else None)])
 
-# TODO: verify webgpu
+# TODO: get this from the device through GrouperOpts
 DEVICE_MAX_BUFS = {"METAL":32, "WEBGPU":8}
+
 def limit_bufs(root:UOp):
-  if root.tag is not None: return None
   # check if backend has a buffer limit
   device = root.device if isinstance(root.device, str) else root.device[0].split(":")[0]
   if not (MAX_BUFS:=getenv("MAX_KERNEL_BUFFERS", DEVICE_MAX_BUFS.get(device, 0))): return None
@@ -514,7 +514,7 @@ def limit_bufs(root:UOp):
   bufs: set[UOp] = set()
   def gate_input(u:UOp):
     if (is_buffer:=(u.op in {Ops.BUFFER, Ops.GBARRIER, Ops.ASSIGN})): bufs.add(u)
-    return u is root or not is_buffer
+    return not is_buffer
   root.toposort(gate=gate_input)
   # NOTE: this -1 is for the output buffer
   if len(bufs)>=MAX_BUFS-1:

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -504,7 +504,8 @@ add_gbarrier = PatternMatcher([(UPat(GroupOp.All-{Ops.GBARRIER, Ops.ASSIGN}, nam
                                 lambda ctx,x: x.replace(tag=1).gbarrier() if x in ctx and x.tag is None else None)])
 
 def _limit_inputs(x:UOp):
-  if x.tag is not None or not (MAX_BUFS:=getenv("MAX_KERNEL_BUFFERS",{"METAL":32}.get(x._device,0))): return None
+  # TODO: webgpu is actually 10 on a mac
+  if x.tag is not None or not (MAX_BUFS:=getenv("MAX_KERNEL_BUFFERS",{"METAL":32, "WEBGPU":8}.get(x._device,0))): return None
   assert MAX_BUFS > 2, "MAX_KERNEL_BUFFERS must be greater than 2"
   cnt = 1
   def gate_buffer(u:UOp):


### PR DESCRIPTION
resolves #1461, there should be a way to get this value per backend without opening devices. 

Fixes running driver monitoring on METAL=1
```
PYTHONPATH="." METAL=1 IMAGE=0 NOLOCALS=0 python3 examples/openpilot/compile3.py https://github.com/commaai/openpilot/raw/v0.9.7/selfdrive/modeld/models/dmonitoring_model.onnx
```
and issues with backward pass in examples/minrf.py.

Python time:
```
~/code/tinygrad (32_buffer) > SCHEDULE_ONLY=1 PYTHONPATH=. python ./test/external/external_benchmark_schedule.py
***** model tensor in     23.16 ms
***** model schedule in   87.94 ms
all 111.15 ms

~/code/tinygrad (master) > SCHEDULE_ONLY=1 PYTHONPATH=. python ./test/external/external_benchmark_schedule.py
***** model tensor in     23.12 ms
***** model schedule in   81.22 ms
all 104.37 ms
```