### PR TITLE
Move "examples/hlb_cifar10.py" each epoch data processing from numpy into tinygrad

### DIFF
--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -3,7 +3,7 @@
 # tinygrad implementation of https://github.com/tysam-code/hlb-CIFAR10/blob/main/main.py
 # https://myrtle.ai/learn/how-to-train-your-resnet-8-bag-of-tricks/
 # https://siboehm.com/articles/22/CUDA-MMM
-import random, time
+import time
 import numpy as np
 from typing import Optional
 from extra.lr_scheduler import OneCycleLR
@@ -149,7 +149,6 @@ def train_cifar():
 
   def set_seed(seed):
     Tensor.manual_seed(seed)
-    random.seed(seed)
 
   # ========== Model ==========
   def whitening(X, kernel_size=hyp['net']['kernel_size']):


### PR DESCRIPTION
- replaced `random.shuffle` with `Tensor.randperm` in `fetch_batches` and `cutmix`
- tried to migrate `random_crop` numpy masking into `Tensor.masked_select`.
  - found that it works correctly for small tensors, but for large tensors, it is much slower and can fail.
  - For example, I tested and compared both value and process time. See: [test code(not in this pr)](https://github.com/currybab/tinygrad/blob/test-random-crop/examples/test_hlb_cifar10.py)
 - test result(m1 pro 32GB)   
```
➜ python examples/test_hlb_cifar10.py
Tensor size: 38880
Numpy masking time: 173.892 ms
Tinygrad masking time: 141.244 ms
check operation result: True


Tensor size: 194400
Numpy masking time: 149.374 ms
Tinygrad masking time: 181.097 ms
check operation result: True


Tensor size: 388800
Numpy masking time: 180.275 ms
Tinygrad masking time: 324.488 ms
check operation result: True


Tensor size: 777600
Numpy masking time: 220.358 ms
Tinygrad masking time: 1077.976 ms
check operation result: True


Tensor size: 1944000
Numpy masking time: 193.766 ms
Tinygrad masking time: 6040.181 ms
check operation result: True


Tensor size: 3888000
Numpy masking time: 229.063 ms
Tinygrad masking time: 23818.370 ms
check operation result: True
```
  - all outputs match
  - tinygrad was much slower than numpy for large tensors.
  - For sizes at 194,400,000 elements, tinygrad implementation hangs or fails with an error.
- Suggest to keep random_crop in numpy for now, and will move this after performance and stability issues in `masked_select` are addressed.