### PR TITLE
merge process replay and viz captures [pr]

### DIFF
--- a/test/external/process_replay/local.sh
+++ b/test/external/process_replay/local.sh
@@ -3,7 +3,7 @@
 HEAD=$(git rev-parse --abbrev-ref HEAD)
 python test/external/process_replay/reset.py
 CAPTURE_PROCESS_REPLAY=1 python test/test_ops.py TestOps.test_add
-git checkout master
-git checkout $HEAD -- test/external/process_replay/process_replay.py
+#git checkout master
+#git checkout $HEAD -- test/external/process_replay/process_replay.py
 ASSERT_PROCESS_REPLAY=1 python test/external/process_replay/process_replay.py
-git checkout $HEAD
+#git checkout $HEAD

--- a/test/external/process_replay/local.sh
+++ b/test/external/process_replay/local.sh
@@ -3,7 +3,7 @@
 HEAD=$(git rev-parse --abbrev-ref HEAD)
 python test/external/process_replay/reset.py
 CAPTURE_PROCESS_REPLAY=1 python test/test_ops.py TestOps.test_add
-#git checkout master
-#git checkout $HEAD -- test/external/process_replay/process_replay.py
+git checkout master
+git checkout $HEAD -- test/external/process_replay/process_replay.py
 ASSERT_PROCESS_REPLAY=1 python test/external/process_replay/process_replay.py
-#git checkout $HEAD
+git checkout $HEAD

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -2,7 +2,7 @@
 # compare kernels created by HEAD against master
 import os, multiprocessing, logging, pickle, sqlite3, difflib, warnings, itertools
 from typing import Callable, Any
-from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connection, getenv, tqdm, to_function_name
+from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connection, getenv, tqdm
 from tinygrad.engine.grouper import get_kernelize_map
 from tinygrad.codegen.kernel import Kernel
 from tinygrad.uop.ops import UOp, Ops

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -66,6 +66,7 @@ def diff(offset:int) -> None:
       with Context(**ctx_vars): good, compare, metadata = replayer(ret, *args, **kwargs)
       if good != compare:
         for m in metadata: trunc_log(m)
+        logging.info(loc)
         for line in difflib.unified_diff(good.splitlines(), compare.splitlines()):
           logging.info(colored(line, "red" if line.startswith("-") else "green" if line.startswith("+") else None))
         if ctx_vars: logging.info(ctx_vars)

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -2,7 +2,7 @@
 # compare kernels created by HEAD against master
 import os, multiprocessing, logging, pickle, sqlite3, difflib, warnings, itertools
 from typing import Callable, Any
-from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connection, getenv, tqdm
+from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connection, getenv, tqdm, to_function_name
 from tinygrad.engine.grouper import get_kernelize_map
 from tinygrad.codegen.kernel import Kernel
 from tinygrad.uop.ops import UOp, Ops
@@ -41,7 +41,7 @@ def replay_linearize(k:Kernel, _:Kernel, name_override=None, ast_transform=None)
   # create a copy because the Kernel class contains optimization parameters (other than applied_opts) in its state
   # this should be made fully functional. It's fine for process replay since copy returns a fresh instance
   k2 = k.copy()
-  k2.linearize(name_override=name_override, ast_transform=ast_transform)
+  k2.linearize(name_override=name_override or to_function_name(k.name), ast_transform=ast_transform)
   def to_str(ret:Kernel): return ret.opts.render(ret.uops)
   return to_str(k2), to_str(k), (k.ast, k.opts, k.applied_opts)
 

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -20,7 +20,7 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 MAX_LINES = 500
 def trunc_log(x):
   if len(lines:=repr(x).splitlines()) > MAX_LINES: lines = lines[:MAX_LINES]+[f"WARN: truncated string with {len(lines)} lines"]
-  logging.info(repr(x))
+  logging.info("\n".join(lines))
 
 # user config
 ASSERT_DIFF = int((flag:="[pr]") in os.getenv("COMMIT_MESSAGE", flag) or flag in os.getenv("PR_TITLE", flag))

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -45,7 +45,7 @@ def replay_linearize(ret:Kernel, s:Kernel, name_override=None, ast_transform=Non
 
 differs: dict[str, Callable[..., tuple[str, str]]] = {"get_kernelize_map":replay_kernelize, "linearize":replay_linearize}
 
-# *** Run replayers on captured rows starting from offset and print generated diff
+# *** run replayers on captured rows and print diffs
 
 def diff(offset:int) -> None:
   if ASSERT_DIFF: warnings.filterwarnings("error", category=ProcessReplayWarning)
@@ -59,7 +59,7 @@ def diff(offset:int) -> None:
       warnings.warn(f"detected changes in over {MAX_DIFF_PCT}%. skipping further diff generation.", ProcessReplayWarning)
       early_stop.set()
       break
-    # try unpickle and unpack
+    # try unpickle
     try: name, args, kwargs, ctx_vals, loc, ret = pickle.loads(row[0])
     except Exception as e:
       changed += 1

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -106,7 +106,6 @@ if __name__ == "__main__":
 
   print(f"running process replay with {ASSERT_DIFF=}")
   try: _pmap()
-  except ProcessReplayWarning: exit(1)
   except Exception as e:
     if ASSERT_DIFF: raise e
     logging.error(f"diff err {e}")

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -39,7 +39,7 @@ def replay_kernelize(ret:dict[UOp, UOp], big_sink:UOp) -> tuple[str, str, tuple[
 
 def replay_linearize(k:Kernel, _:Kernel, name_override=None, ast_transform=None) -> tuple[str, str, tuple[Any, ...]]:
   k2 = k.copy()
-  k2.linearize(name_override=to_function_name(k.name), ast_transform=ast_transform)
+  k2.linearize(name_override=name_override, ast_transform=ast_transform)
   def to_str(ret:Kernel): return ret.opts.render(ret.uops)
   return to_str(k2), to_str(k), (k.ast, k.opts, k.applied_opts)
 

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -37,11 +37,11 @@ def replay_kernelize(ret:dict[UOp, UOp], big_sink:UOp) -> tuple[str, str, tuple[
   def to_str(ret:UOp): return "\n".join([repr(u.arg.ast) for u in ret.toposort() if u.op is Ops.KERNEL])
   return to_str(new_sink), to_str(ret[big_sink]), (big_sink,)
 
-def replay_linearize(ret:Kernel, s:Kernel, name_override=None, ast_transform=None) -> tuple[str, str, tuple[Any, ...]]:
-  k = Kernel(s.ast, opts=s.opts).apply_opts(s.applied_opts)
-  k.to_program(name_override=to_function_name(ret.name))
+def replay_linearize(k:Kernel, _:Kernel, name_override=None, ast_transform=None) -> tuple[str, str, tuple[Any, ...]]:
+  k2 = Kernel(k.ast, opts=k.opts).apply_opts(k.applied_opts)
+  k2.to_program(name_override=to_function_name(k.name))
   def to_str(ret:Kernel): return ret.opts.render(ret.uops)
-  return to_str(k), to_str(ret), (s.ast, s.opts, s.applied_opts)
+  return to_str(k2), to_str(k), (k.ast, k.opts, k.applied_opts)
 
 replayers: dict[str, Callable[..., tuple[str, str, tuple[Any, ...]]]] = {"get_kernelize_map":replay_kernelize, "linearize":replay_linearize}
 
@@ -104,7 +104,7 @@ if __name__ == "__main__":
 
   print(f"running process replay with {ASSERT_DIFF=}")
   try: _pmap()
-  except ProcessReplayWarning: exit(1)
+  except ProcessReplayWarning: exit(0)
   except Exception as e:
     if ASSERT_DIFF: raise e
     logging.error(f"diff err {e}")

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -38,6 +38,8 @@ def replay_kernelize(ret:dict[UOp, UOp], big_sink:UOp) -> tuple[str, str, tuple[
   return to_str(new_sink), to_str(ret[big_sink]), (big_sink,)
 
 def replay_linearize(k:Kernel, _:Kernel, name_override=None, ast_transform=None) -> tuple[str, str, tuple[Any, ...]]:
+  # create a copy because the Kernel class contains optimization parameters (other than applied_opts) in its state
+  # this should be made fully functional. It's fine for process replay since copy returns a fresh instance
   k2 = k.copy()
   k2.linearize(name_override=name_override, ast_transform=ast_transform)
   def to_str(ret:Kernel): return ret.opts.render(ret.uops)

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 # compare kernels created by HEAD against master
-import os, multiprocessing, logging, pickle, sqlite3, difflib, functools, warnings, itertools
+import os, multiprocessing, logging, pickle, sqlite3, difflib, warnings, itertools
 from typing import Callable, cast
-from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connection, getenv, tqdm
+from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connection, getenv, tqdm, to_function_name
 from tinygrad.engine.grouper import get_kernelize_map
-from tinygrad.codegen.kernel import Kernel, Opt
-from tinygrad.renderer import Renderer
+from tinygrad.codegen.kernel import Kernel
 from tinygrad.uop.ops import UOp, Ops
 
 # *** process replay settings
@@ -32,56 +31,62 @@ class ProcessReplayWarning(Warning): pass
 
 # *** recreators
 
-def recreate_sched(big_sink:UOp) -> list[UOp]:
+def recreate_sched(ret:dict[UOp, UOp], big_sink:UOp) -> bool:
   UOp.unique_num = itertools.count(max([u.arg for u in big_sink.toposort() if u.op is Ops.UNIQUE], default=0)+1)
-  becomes_map = get_kernelize_map(big_sink)
-  sched_sink = big_sink.substitute(becomes_map)
-  return [u.arg.ast for u in sched_sink.toposort() if u.op is Ops.KERNEL]
+  new_sink = big_sink.substitute(get_kernelize_map(big_sink))
+  new_asts = "\n".join([repr(u.arg.ast) for u in new_sink.toposort() if u.op is Ops.KERNEL])
+  old_asts = "\n".join([repr(u.arg.ast) for u in ret[big_sink].toposort() if u.op is Ops.KERNEL])
+  return new_asts, old_asts
 
-def recreate_kernel(ast:UOp, opts:Renderer, applied_opts:list[Opt], name:str, _) -> str:
-  k = Kernel(ast, opts=opts)
-  for opt in applied_opts: k.apply_opt(opt)
+def recreate_kernel(ret:Kernel, s:Kernel, name_override=None, ast_transform=None) -> bool:
+  k = Kernel(s.ast, opts=s.opts).apply_opts(s.applied_opts)
   # NOTE: replay with the captured renderer, not the one in master
-  return k.opts.render(cast(list,k.to_program(name).uops))
+  new_src = k.opts.render(cast(list,k.to_program(to_function_name(ret.name)).uops))
+  old_src = ret.opts.render(ret.uops)
+  return new_src, old_src
 
-# *** diff a "good" recreation against the generated version
+differs: dict[str, Callable[..., tuple[str, str]]] = {"get_kernelize_map":recreate_sched, "linearize":recreate_kernel}
 
-def diff(offset:int, name:str, fxn:Callable) -> None:
+# *** replay all rows starting from the offset and print generated diff
+
+def diff(offset:int) -> None:
   if ASSERT_DIFF: warnings.filterwarnings("error", category=ProcessReplayWarning)
   if early_stop.is_set(): return None
   conn = db_connection()
   cur = conn.cursor()
-  cur.execute(f"SELECT val FROM '{name}_{TABLE_NAME}' LIMIT ? OFFSET ?", (PAGE_SIZE, offset))
+  cur.execute(f"SELECT val FROM '{TABLE_NAME}' LIMIT ? OFFSET ?", (PAGE_SIZE, offset))
   changed = 0
   for row in cur.fetchall():
     if changed > MAX_DIFF_PCT:
-      warnings.warn(f"detected changes in over {MAX_DIFF_PCT}% of {name}s. skipping further diff generation.")
+      warnings.warn(f"detected changes in over {MAX_DIFF_PCT}%. skipping further diff generation.", ProcessReplayWarning)
       early_stop.set()
       break
-    # try unpickle
-    try: args = pickle.loads(row[0])
+    # try unpickle and unpack
+    try: name, args, kwargs, ctx_vals, loc, ret = pickle.loads(row[0])
     except Exception as e:
       changed += 1
       warnings.warn(f"FAILED TO UNPICKLE OBJECTS {e}", ProcessReplayWarning)
       continue
+    if (differ:=differs.get(name)) is None: continue
     # try recreate
     try:
-      ctx_vars = {k:v.value for k,v in args[-2].items() if k != "DEBUG" and (var:=ContextVar._cache.get(k)) is not None and var.value != v.value}
-      with Context(**ctx_vars): good = fxn(*args[:-2])
-      if good is None: continue
+      ctx_vars = {k:v.value for k,v in ctx_vals.items() if k != "DEBUG" and (var:=ContextVar._cache.get(k)) is not None and var.value != v.value}
+      with Context(**ctx_vars): good, compare = differ(ret, *args, **kwargs)
     except Exception as e:
       changed += 1
       if ctx_vars: logging.info(ctx_vars)
-      for x in args[:-2]: trunc_log(x)
+      for x in args: trunc_log(x)
+      for k,v in kwargs.items(): trunc_log((k, v))
       warnings.warn(f"FAILED TO RECREATE KERNEL {e}", ProcessReplayWarning)
       continue
     # diff kernels
-    try: assert str(args[-1]) == str(good)
+    try: assert good == compare
     except AssertionError:
       changed += 1
       if ctx_vars: logging.info(ctx_vars)
-      for x in args[:-2]: trunc_log(x)
-      changes = list(difflib.unified_diff(str(good).splitlines(), str(args[-1]).splitlines()))
+      for x in args: trunc_log(x)
+      for k,v in kwargs.items(): trunc_log((k, v))
+      changes = list(difflib.unified_diff(good.splitlines(), compare.splitlines()))
       logging.info("\n".join(colored(line, "red" if line.startswith("-") else "green" if line.startswith("+") else None) for line in changes))
       warnings.warn("PROCESS REPLAY DETECTED CHANGE", ProcessReplayWarning)
   conn.commit()
@@ -89,18 +94,18 @@ def diff(offset:int, name:str, fxn:Callable) -> None:
 
 # *** generic runner for executing fxn across all rows of a table in parallel
 
-def _pmap(name:str, fxn:Callable, maxtasksperchild:int=16) -> None:
+def _pmap(maxtasksperchild:int=16) -> None:
   conn = db_connection()
   cur = conn.cursor()
-  try: row_count = cur.execute(f"select count(*) from '{name}_{TABLE_NAME}'").fetchone()[0]
+  try: row_count = cur.execute(f"select count(*) from '{TABLE_NAME}'").fetchone()[0]
   except sqlite3.OperationalError:
-    warnings.warn(f"{name}_{TABLE_NAME} isn't accessible in master, did DB_VERSION change?", ProcessReplayWarning)
+    warnings.warn(f"{TABLE_NAME} isn't accessible in master, did DB_VERSION change?", ProcessReplayWarning)
     return None
   conn.commit()
   cur.close()
   with multiprocessing.get_context("spawn").Pool(multiprocessing.cpu_count(), maxtasksperchild=maxtasksperchild) as pool:
     inputs = list(range(0, row_count, PAGE_SIZE))
-    list(tqdm(pool.imap_unordered(functools.partial(diff, name=name, fxn=fxn), inputs), total=len(inputs)))
+    list(tqdm(pool.imap_unordered(diff, inputs), total=len(inputs)))
     pool.close()
     pool.join()
     pool.terminate()
@@ -113,10 +118,8 @@ if __name__ == "__main__":
     exit(0)
 
   print(f"running process replay with {ASSERT_DIFF=}")
-  for name,fxn in [("schedule", recreate_sched), ("kernel", recreate_kernel)]:
-    logging.info(f"***** {name} diff")
-    try: _pmap(name, fxn)
-    except ProcessReplayWarning: exit(1)
-    except Exception as e:
-      if ASSERT_DIFF: raise e
-      logging.error(f"{name} diff err {e}")
+  try: _pmap()
+  except ProcessReplayWarning: exit(1)
+  except Exception as e:
+    if ASSERT_DIFF: raise e
+    logging.error(f"diff err {e}")

--- a/test/external/process_replay/reset.py
+++ b/test/external/process_replay/reset.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
 from tinygrad.helpers import db_connection, VERSION
 cur = db_connection()
-cur.execute(f"drop table if exists kernel_process_replay_{VERSION}")
-cur.execute(f"drop table if exists schedule_process_replay_{VERSION}")
+cur.execute(f"drop table if exists process_replay_{VERSION}")

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -227,10 +227,6 @@ def diskcache(func:Callable[..., T]):
     return diskcache_put(table, key, func(*args, **kwargs))
   return wrapper
 
-# *** process replay ***
-
-CAPTURE_PROCESS_REPLAY = getenv("CAPTURE_PROCESS_REPLAY")
-
 # *** http support ***
 
 def _ensure_downloads_dir() -> pathlib.Path:

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -5,7 +5,7 @@ from enum import auto, IntEnum, Enum
 from dataclasses import dataclass, field
 from tinygrad.dtype import ConstType, ImageDType, dtypes, DType, truncate
 from tinygrad.helpers import ContextVar, all_int, prod, getenv, all_same, Context, partition, temp, unwrap, T, argfix, Metadata, flatten
-from tinygrad.helpers import PICKLE_BUFFERS, dedup, cdiv, cmod
+from tinygrad.helpers import PICKLE_BUFFERS, dedup, cdiv, cmod, diskcache_put
 if TYPE_CHECKING:
   from tinygrad.shape.shapetracker import ShapeTracker
   from tinygrad.device import Buffer, MultiBuffer
@@ -892,6 +892,14 @@ class TrackedGraphRewrite:
 tracked_keys:list[Any] = []
 tracked_ctxs:list[list[TrackedGraphRewrite]] = []
 _name_cnt:dict[str, int] = {}
+
+if getenv("CAPTURE_PROCESS_REPLAY"):
+  replay_capture: dict[str, bytes] = {}
+  import atexit
+  @atexit.register
+  def save_to_diskcache():
+    for k,v in replay_capture.items(): diskcache_put("process_replay", k, v, prepickled=True)
+
 def track_rewrites(named=False, name_fxn:Callable|None=None):
   def _decorator(func):
     def __wrapper(*args, **kwargs):
@@ -901,6 +909,15 @@ def track_rewrites(named=False, name_fxn:Callable|None=None):
         tracked_ctxs.append([])
       ret = func(*args, **kwargs)
       if TRACK_MATCH_STATS >= 2 and name_fxn is not None: tracked_keys[-1] = f"{name_fxn(ret)} n{_name_cnt[func.__name__]}"
+      if getenv("CAPTURE_PROCESS_REPLAY"):
+        # find the unittest frame we're capturing in
+        frm = sys._getframe(1)
+        while (f_back:=frm.f_back) is not None and "unittest" not in f_back.f_code.co_filename: frm = f_back
+        loc = f"{frm.f_code.co_filename.split('/')[-1]}:{frm.f_lineno} {frm.f_code.co_name}"
+        # capture global context vars and all the args passed in
+        with Context(PICKLE_BUFFERS=0):
+          inputs = (func.__name__, args, kwargs, ContextVar._cache)
+          replay_capture[hashlib.sha256(pickle.dumps(inputs)).hexdigest()] = pickle.dumps(inputs+(loc, ret))
       return ret
     return __wrapper
   return _decorator


### PR DESCRIPTION
Process replay capturing shouldn't exist in the main loop of the process. It lives on the VIZ capturing decorator now.
The behavior and functionality for users stays exactly as it was before. It's just less lines and factored out.

Turns out if we capture linearize instead of to_program, it reveals test cases where the a Kernel is not reproducible from only its AST, opts and applied_opts. For example, test_float4_expanded calls`.upcast()`, changing self.upcasted, instead of appending an OptOp to applied_opts.