### PR TITLE
Hlb cifar10 random_crop and cutmix (numpy to tinygrad)

### DIFF
--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -243,7 +243,7 @@ def train_cifar():
       st = time.monotonic()
       X, Y = X_in, Y_in
       if is_train:
-        X, Y = data_augmentation(X, Y, step, crop_size=32, mask_size=hyp['net']['cutmix_size'])
+        X, Y = data_augmentation_jitted(X, Y, step, crop_size=32, mask_size=hyp['net']['cutmix_size'])
       et = time.monotonic()
       print(f"shuffling {'training' if is_train else 'test'} dataset in {(et-st)*1e3:.2f} ms ({epoch=})")
       for i in range(0, X.shape[0], BS):


### PR DESCRIPTION
BOUNTY: Move "examples/hlb_cifar10.py" each epoch data processing from numpy into tinygrad (random_crop + cutmix)

Only printing shuffling print statements below

Before (with numpy):

```bash
$ python3 examples/hlb_cifar10.py
shuffling training dataset in 2142.32 ms (epoch=0)
shuffling training dataset in 1546.26 ms (epoch=1)
shuffling training dataset in 1362.65 ms (epoch=2)
shuffling training dataset in 1383.80 ms (epoch=3)
shuffling training dataset in 2078.21 ms (epoch=4)
shuffling training dataset in 1330.54 ms (epoch=5)
shuffling training dataset in 1949.68 ms (epoch=6)
shuffling training dataset in 2012.85 ms (epoch=7)
shuffling training dataset in 2419.86 ms (epoch=8)
shuffling training dataset in 2706.02 ms (epoch=9)
shuffling training dataset in 1818.96 ms (epoch=10)
shuffling test dataset in 180.85 ms (epoch=0)
eval     9590/10240 93.65%,    0.40 val_loss STEP=1000 (in 3545.62 ms)
```

After (with tinygrad ops):
```bash
$ python3 examples/hlb_cifar10.py
shuffling training dataset in 114.91 ms (epoch=0)
shuffling training dataset in 118.82 ms (epoch=1)
shuffling training dataset in 128.38 ms (epoch=2)
shuffling training dataset in 120.11 ms (epoch=3)
shuffling training dataset in 118.67 ms (epoch=4)
shuffling training dataset in 125.63 ms (epoch=5)
shuffling training dataset in 366.39 ms (epoch=6)
shuffling training dataset in 231.46 ms (epoch=7)
shuffling training dataset in 242.67 ms (epoch=8)
shuffling training dataset in 234.92 ms (epoch=9)
shuffling training dataset in 237.13 ms (epoch=10)
shuffling test dataset in 0.00 ms (epoch=0)
eval     9605/10240 93.80%,    0.40 val_loss STEP=1000 (in 3760.51 ms)
```

After (with tinygrad ops + jit)
```bash
$ python3 examples/hlb_cifar10.py
shuffling training dataset in 10893.02 ms (epoch=0)
shuffling training dataset in 568.47 ms (epoch=1)
shuffling training dataset in 6.49 ms (epoch=2)
shuffling training dataset in 0.33 ms (epoch=3)
shuffling training dataset in 0.64 ms (epoch=4)
shuffling training dataset in 0.20 ms (epoch=5)
shuffling training dataset in 0.17 ms (epoch=6)
shuffling training dataset in 0.20 ms (epoch=7)
shuffling training dataset in 0.23 ms (epoch=8)
shuffling training dataset in 0.18 ms (epoch=9)
shuffling training dataset in 0.24 ms (epoch=10)
shuffling test dataset in 0.00 ms (epoch=0)
eval     9602/10240 93.77%,    0.40 val_loss STEP=1000 (in 3804.26 ms)
```