### PR TITLE
Bounty: Fix METAL virtual device sync issue and reenable "Run LLaMA 7B on 4 virtual GPUs"

### DIFF
--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -1,7 +1,12 @@
 import unittest
+import os
+import time
+from unittest.mock import patch
 from tinygrad.device import CompileError, Device, Compiler
+from tinygrad.helpers import getenv
 if Device.DEFAULT=="METAL":
-  from tinygrad.runtime.ops_metal import MetalDevice, MetalCompiler, MetalProgram
+  from tinygrad.runtime.ops_metal import MetalDevice, MetalCompiler, MetalProgram, MetalBuffer, msg, libobjc
+
 @unittest.skipIf(Device.DEFAULT!="METAL", "Metal support required")
 class TestMetal(unittest.TestCase):
   def test_alloc_oom(self):
@@ -73,3 +78,262 @@ kernel void r_5(device int* data0, const device int* data1, uint3 gid [[threadgr
 """)
     with self.assertRaises(RuntimeError):
       MetalProgram(device, "r_5", compiled)
+
+  # New tests for virtual device synchronization improvements
+  def test_virtual_device_detection(self):
+    """Test that virtual devices are properly detected"""
+    device = MetalDevice("metal")
+    # Test should work regardless of whether device is virtual or not
+    self.assertIsInstance(device.is_virtual, bool)
+    self.assertIsInstance(device.max_buffers_in_flight, int)
+    self.assertGreater(device.max_buffers_in_flight, 0)
+
+    # Virtual devices should have smaller buffer limits
+    if device.is_virtual:
+      self.assertEqual(device.max_buffers_in_flight, 64)
+      self.assertIsNotNone(device.virtual_sync_event)
+    else:
+      self.assertEqual(device.max_buffers_in_flight, 1024)
+      self.assertIsNone(device.virtual_sync_event)
+
+  @patch('tinygrad.runtime.ops_metal.from_ns_str')
+  def test_virtual_device_mock_detection(self, mock_from_ns_str):
+    """Test virtual device detection with mocked device names"""
+    # Test virtual device detection
+    mock_from_ns_str.return_value = "Apple Virtual GPU"
+    device = MetalDevice("metal")
+    self.assertTrue(device.is_virtual)
+    self.assertEqual(device.max_buffers_in_flight, 64)
+    self.assertIsNotNone(device.virtual_sync_event)
+
+    # Test paravirtualized device detection
+    mock_from_ns_str.return_value = "Apple Paravirtualized GPU"
+    device2 = MetalDevice("metal")
+    self.assertTrue(device2.is_virtual)
+
+    # Test normal device
+    mock_from_ns_str.return_value = "Apple M1"
+    device3 = MetalDevice("metal")
+    self.assertFalse(device3.is_virtual)
+    self.assertEqual(device3.max_buffers_in_flight, 1024)
+
+  def test_sync_capacity_management(self):
+    """Test that sync capacity management works correctly"""
+    device = MetalDevice("metal")
+
+    # Test ensure_sync_capacity with empty buffer list
+    initial_count = len(device.mtl_buffers_in_flight)
+    device.ensure_sync_capacity()
+    self.assertEqual(len(device.mtl_buffers_in_flight), initial_count)
+
+    # Test _sync_oldest_buffers with empty list
+    device._sync_oldest_buffers(5)
+    self.assertEqual(len(device.mtl_buffers_in_flight), 0)
+
+  def test_buffer_capacity_enforcement(self):
+    """Test that buffer capacity is enforced for virtual devices"""
+    device = MetalDevice("metal")
+    compiler = MetalCompiler()
+
+    # Create a simple kernel for testing
+    compiled = compiler.compile("""
+#include <metal_stdlib>
+kernel void test_kernel(device int* data, uint3 gid [[threadgroup_position_in_grid]]){
+  data[gid.x] = gid.x;
+}
+""")
+    program = MetalProgram(device, "test_kernel", compiled)
+
+    # Allocate a test buffer
+    test_buf = device.allocator.alloc(64)
+
+    # Simulate filling up the buffer queue (but not beyond capacity)
+    max_test_buffers = min(10, device.max_buffers_in_flight // 2)
+
+    for i in range(max_test_buffers):
+      # Call program without waiting to fill the buffer queue
+      program(test_buf, global_size=(1,1,1), local_size=(1,1,1), wait=False)
+
+    # Verify buffers are tracked
+    self.assertLessEqual(len(device.mtl_buffers_in_flight), device.max_buffers_in_flight)
+
+    # Clean up
+    device.synchronize()
+    device.allocator.free(test_buf, None)
+
+  def test_virtual_device_transfer_sync(self):
+    """Test enhanced synchronization during transfers for virtual devices"""
+    device1 = MetalDevice("metal:0")
+    device2 = MetalDevice("metal:1") if getenv("METAL_MULTI_GPU", 0) else device1
+
+    # Allocate buffers on both devices
+    buf1 = device1.allocator.alloc(1024)
+    buf2 = device2.allocator.alloc(1024)
+
+    try:
+      # Test transfer between devices (or same device)
+      device1.allocator._transfer(buf2, buf1, 1024, device1, device2)
+
+      # Verify synchronization occurred
+      # For virtual devices, additional sync should happen
+      if device1.is_virtual or device2.is_virtual:
+        # Virtual device transfers should be more conservative
+        self.assertLessEqual(len(device1.mtl_buffers_in_flight), device1.max_buffers_in_flight)
+        self.assertLessEqual(len(device2.mtl_buffers_in_flight), device2.max_buffers_in_flight)
+
+      # Clean up
+      device1.synchronize()
+      device2.synchronize()
+
+    finally:
+      device1.allocator.free(buf1, None)
+      device2.allocator.free(buf2, None)
+
+  def test_virtual_graph_environment_variable(self):
+    """Test that METAL_ENABLE_VIRTUAL_GRAPH controls graph usage"""
+    # Test with graph enabled for virtual devices
+    with patch.dict(os.environ, {'METAL_ENABLE_VIRTUAL_GRAPH': '1'}):
+      with patch('tinygrad.runtime.ops_metal.from_ns_str', return_value="Apple Virtual GPU"):
+        device = MetalDevice("metal")
+        # Should have graph enabled even for virtual device
+        # Note: We can't directly test graph creation due to import dependencies,
+        # but we can verify the device was created successfully
+        self.assertTrue(device.is_virtual)
+
+  def test_synchronization_performance(self):
+    """Test that synchronization doesn't cause significant performance degradation"""
+    device = MetalDevice("metal")
+    compiler = MetalCompiler()
+
+    # Create a simple kernel
+    compiled = compiler.compile("""
+#include <metal_stdlib>
+kernel void perf_test(device int* data, uint3 gid [[threadgroup_position_in_grid]]){
+  data[gid.x] = gid.x * 2;
+}
+""")
+    program = MetalProgram(device, "perf_test", compiled)
+
+    # Allocate test buffer
+    test_buf = device.allocator.alloc(1024)
+
+    try:
+      # Time multiple kernel executions
+      start_time = time.time()
+
+      num_iterations = 10
+      for i in range(num_iterations):
+        program(test_buf, global_size=(256,1,1), local_size=(1,1,1), wait=True)
+
+      end_time = time.time()
+      avg_time = (end_time - start_time) / num_iterations
+
+      # Verify execution completed (basic sanity check)
+      self.assertGreater(avg_time, 0)
+      self.assertLess(avg_time, 1.0)  # Should complete within reasonable time
+
+      # Verify final synchronization
+      device.synchronize()
+      self.assertEqual(len(device.mtl_buffers_in_flight), 0)
+
+    finally:
+      device.allocator.free(test_buf, None)
+
+  def test_multi_buffer_synchronization_stress(self):
+    """Stress test for multiple buffer management in virtual devices"""
+    device = MetalDevice("metal")
+    compiler = MetalCompiler()
+
+    # Create a simple kernel
+    compiled = compiler.compile("""
+#include <metal_stdlib>
+kernel void stress_test(device int* data, uint3 gid [[threadgroup_position_in_grid]]){
+  data[gid.x] = gid.x + 1;
+}
+""")
+    program = MetalProgram(device, "stress_test", compiled)
+
+    # Create multiple buffers
+    num_buffers = 5
+    buffers = []
+
+    try:
+      for i in range(num_buffers):
+        buf = device.allocator.alloc(256)
+        buffers.append(buf)
+
+      # Execute multiple operations to stress the synchronization system
+      stress_iterations = min(20, device.max_buffers_in_flight // 4)
+
+      for i in range(stress_iterations):
+        buf_idx = i % num_buffers
+        program(buffers[buf_idx], global_size=(64,1,1), local_size=(1,1,1), wait=False)
+
+        # Occasionally force synchronization
+        if i % 5 == 4:
+          device.synchronize()
+
+      # Final synchronization
+      device.synchronize()
+      self.assertEqual(len(device.mtl_buffers_in_flight), 0)
+
+    finally:
+      # Clean up all buffers
+      for buf in buffers:
+        device.allocator.free(buf, None)
+
+  def test_virtual_sync_event_functionality(self):
+    """Test virtual device sync event creation and usage"""
+    device = MetalDevice("metal")
+
+    if device.is_virtual:
+      # Virtual devices should have sync events
+      self.assertIsNotNone(device.virtual_sync_event)
+      self.assertEqual(device.virtual_sync_value, 0)
+
+      # Test that sync values increment during operations
+      compiler = MetalCompiler()
+      compiled = compiler.compile("""
+#include <metal_stdlib>
+kernel void sync_test(device int* data, uint3 gid [[threadgroup_position_in_grid]]){
+  data[0] = 42;
+}
+""")
+      program = MetalProgram(device, "sync_test", compiled)
+      test_buf = device.allocator.alloc(64)
+
+      try:
+        initial_sync_value = device.virtual_sync_value
+        program(test_buf, global_size=(1,1,1), local_size=(1,1,1), wait=False)
+
+        # Sync value should increment for virtual devices
+        self.assertGreater(device.virtual_sync_value, initial_sync_value)
+
+        device.synchronize()
+
+      finally:
+        device.allocator.free(test_buf, None)
+    else:
+      # Physical devices should not have virtual sync events
+      self.assertIsNone(device.virtual_sync_event)
+      self.assertEqual(device.virtual_sync_value, 0)
+
+  def test_error_handling_with_sync_improvements(self):
+    """Test that error handling still works correctly with sync improvements"""
+    device = MetalDevice("metal")
+
+    # Test that OOM still raises MemoryError
+    with self.assertRaises(MemoryError):
+      device.allocator.alloc(10000000000000000000)
+
+    # Test that device remains functional after error
+    test_buf = device.allocator.alloc(64)
+    try:
+      # Should still work normally
+      self.assertIsInstance(test_buf, MetalBuffer)
+      self.assertEqual(test_buf.size, 64)
+    finally:
+      device.allocator.free(test_buf, None)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from tinygrad.device import CompileError, Device, Compiler
 from tinygrad.helpers import getenv
 if Device.DEFAULT=="METAL":
-  from tinygrad.runtime.ops_metal import MetalDevice, MetalCompiler, MetalProgram, MetalBuffer, msg, libobjc
+  from tinygrad.runtime.ops_metal import MetalDevice, MetalCompiler, MetalProgram, MetalBuffer
 
 @unittest.skipIf(Device.DEFAULT!="METAL", "Metal support required")
 class TestMetal(unittest.TestCase):
@@ -336,4 +336,4 @@ kernel void sync_test(device int* data, uint3 gid [[threadgroup_position_in_grid
       device.allocator.free(test_buf, None)
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -288,11 +288,9 @@ class MetalAllocator(LRUAllocator[MetalDevice]):
       msg("commit")(dest_command_buffer)
       dest_dev.mtl_buffers_in_flight.append(dest_command_buffer)
       src_dev.timeline_value += 1
-
     msg("setLabel:")(src_command_buffer, to_ns_str(f"COPY {src_dev.device} -> {dest_dev.device}"))
     msg("commit")(src_command_buffer)
     src_dev.mtl_buffers_in_flight.append(src_command_buffer)
-
   def _cp_mv(self, dst, src, prof_desc):
     with cpu_profile(prof_desc, self.dev.device, is_copy=True): dst[:] = src
   def _as_buffer(self, src:MetalBuffer) -> memoryview:

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -69,22 +69,68 @@ class MetalDevice(Compiled):
     self.mtl_buffers_in_flight: list[Any] = []
     self.timeline_signal = msg("newSharedEvent", objc_instance)(self.sysdevice)
     self.timeline_value = 0
+    
+    # Check if this is a virtual device
+    device_name = from_ns_str(msg('name')(self.sysdevice)).lower()
+    self.is_virtual = 'virtual' in device_name or 'paravirtualized' in device_name
+    
+    # Enhanced synchronization for virtual devices
+    if self.is_virtual:
+      # Create additional synchronization primitives for virtual devices
+      self.virtual_sync_event = msg("newSharedEvent", objc_instance)(self.sysdevice)
+      self.virtual_sync_value = 0
+      # Use a smaller command buffer pool for virtual devices to reduce memory pressure
+      self.max_buffers_in_flight = 64
+    else:
+      self.virtual_sync_event = None
+      self.virtual_sync_value = 0
+      self.max_buffers_in_flight = 1024
 
     Compiled.profile_events += [ProfileDeviceEvent(device)]
 
     from tinygrad.runtime.graph.metal import MetalGraph
     # NOTE: GitHub CI macOS runners use paravirtualized metal which is broken with graph.
     # This can be reproduced locally with any virtualization software (like utm) that can create macOS VMs with apple's own virtualization framework.
+    # Enable MetalGraph for virtual devices with enhanced synchronization
+    # instead of completely disabling it
+    graph_class = MetalGraph if not self.is_virtual or getenv("METAL_ENABLE_VIRTUAL_GRAPH", 0) else None
+    
     super().__init__(device, MetalAllocator(self), MetalRenderer(), MetalCompiler() if getenv("METAL_DIRECT", 1) else Compiler(),
-                     functools.partial(MetalProgram, self), MetalGraph if 'virtual' not in from_ns_str(msg('name')(self.sysdevice)).lower() else None)
+                     functools.partial(MetalProgram, self), graph_class)
 
   def synchronize(self):
+    # Enhanced synchronization for virtual devices
+    if self.is_virtual and len(self.mtl_buffers_in_flight) > self.max_buffers_in_flight // 2:
+      # More aggressive synchronization for virtual devices
+      self._sync_oldest_buffers(len(self.mtl_buffers_in_flight) // 2)
+    
     for cbuf in self.mtl_buffers_in_flight:
       wait_check(cbuf)
       st, en = decimal.Decimal(cmdbuf_st_time(cbuf)) * 1000000, decimal.Decimal(cmdbuf_en_time(cbuf)) * 1000000
       if PROFILE and (lb:=cmdbuf_label(cbuf)) is not None:
         Compiled.profile_events += [ProfileRangeEvent(self.device, lb, st, en, is_copy=lb.startswith("COPY"))]
     self.mtl_buffers_in_flight.clear()
+
+  def _sync_oldest_buffers(self, count: int):
+    """Synchronize the oldest command buffers to prevent memory pressure in virtual devices"""
+    if count <= 0 or count >= len(self.mtl_buffers_in_flight):
+      return
+    
+    buffers_to_sync = self.mtl_buffers_in_flight[:count]
+    for cbuf in buffers_to_sync:
+      wait_check(cbuf)
+      st, en = decimal.Decimal(cmdbuf_st_time(cbuf)) * 1000000, decimal.Decimal(cmdbuf_en_time(cbuf)) * 1000000
+      if PROFILE and (lb:=cmdbuf_label(cbuf)) is not None:
+        Compiled.profile_events += [ProfileRangeEvent(self.device, lb, st, en, is_copy=lb.startswith("COPY"))]
+    
+    # Remove synced buffers from the list
+    self.mtl_buffers_in_flight = self.mtl_buffers_in_flight[count:]
+
+  def ensure_sync_capacity(self):
+    """Ensure we don't exceed the maximum number of in-flight buffers"""
+    if len(self.mtl_buffers_in_flight) >= self.max_buffers_in_flight:
+      # Force synchronization of half the buffers
+      self._sync_oldest_buffers(self.max_buffers_in_flight // 2)
 
 def metal_src_to_library(device:MetalDevice, src:str) -> objc_instance:
   options = msg("new", objc_instance)(libobjc.objc_getClass(b"MTLCompileOptions"))
@@ -172,6 +218,10 @@ class MetalProgram:
       exec_width = msg("threadExecutionWidth", ctypes.c_ulong)(self.pipeline_state)
       memory_length = msg("staticThreadgroupMemoryLength", ctypes.c_ulong)(self.pipeline_state)
       raise RuntimeError(f"local size {local_size} bigger than {self.max_total_threads} with exec width {exec_width} memory length {memory_length}")
+    
+    # Ensure we don't exceed buffer capacity before creating new command buffer
+    self.dev.ensure_sync_capacity()
+    
     command_buffer = msg("commandBuffer", objc_instance)(self.dev.mtl_queue)
     encoder = msg("computeCommandEncoder", objc_instance)(command_buffer)
     msg("setComputePipelineState:")(encoder, self.pipeline_state)
@@ -179,9 +229,16 @@ class MetalProgram:
     for i,a in enumerate(vals, start=len(bufs)): msg("setBytes:length:atIndex:")(encoder, bytes(ctypes.c_int(a)), 4, i)
     msg("dispatchThreadgroups:threadsPerThreadgroup:")(encoder, to_struct(*global_size), to_struct(*local_size))
     msg("endEncoding")(encoder)
+    
+    # Enhanced synchronization for virtual devices
+    if self.dev.is_virtual and self.dev.virtual_sync_event:
+      msg("encodeSignalEvent:value:")(command_buffer, self.dev.virtual_sync_event, self.dev.virtual_sync_value)
+      self.dev.virtual_sync_value += 1
+    
     msg("setLabel:")(command_buffer, to_ns_str(self.name)) # TODO: is this always needed?
     msg("commit")(command_buffer)
     self.dev.mtl_buffers_in_flight.append(command_buffer)
+    
     if wait:
       wait_check(command_buffer)
       return cmdbuf_en_time(command_buffer) - cmdbuf_st_time(command_buffer)
@@ -199,7 +256,20 @@ class MetalAllocator(LRUAllocator[MetalDevice]):
     return MetalBuffer(ret, size)
   def _free(self, opaque:MetalBuffer, options): msg("release")(opaque.buf)
   def _transfer(self, dest:MetalBuffer, src:MetalBuffer, sz:int, src_dev:MetalDevice, dest_dev:MetalDevice):
-    dest_dev.synchronize()
+    # Enhanced synchronization for virtual devices during transfers
+    if src_dev.is_virtual or dest_dev.is_virtual:
+      # More conservative synchronization for virtual devices
+      dest_dev.synchronize()
+      if src_dev != dest_dev:
+        src_dev.synchronize()
+    else:
+      dest_dev.synchronize()
+    
+    # Ensure capacity before creating command buffers
+    src_dev.ensure_sync_capacity()
+    if src_dev != dest_dev:
+      dest_dev.ensure_sync_capacity()
+    
     src_command_buffer = msg("commandBuffer", objc_instance)(src_dev.mtl_queue)
     encoder = msg("blitCommandEncoder", objc_instance)(src_command_buffer)
     msg("copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:")(encoder, src.buf, ctypes.c_ulong(src.offset),
@@ -209,12 +279,20 @@ class MetalAllocator(LRUAllocator[MetalDevice]):
       msg("encodeSignalEvent:value:")(src_command_buffer, src_dev.timeline_signal, src_dev.timeline_value)
       dest_command_buffer = msg("commandBuffer", objc_instance)(dest_dev.mtl_queue)
       msg("encodeWaitForEvent:value:")(dest_command_buffer, src_dev.timeline_signal, src_dev.timeline_value)
+      
+      # Additional virtual device synchronization
+      if dest_dev.is_virtual and dest_dev.virtual_sync_event:
+        msg("encodeSignalEvent:value:")(dest_command_buffer, dest_dev.virtual_sync_event, dest_dev.virtual_sync_value)
+        dest_dev.virtual_sync_value += 1
+      
       msg("commit")(dest_command_buffer)
       dest_dev.mtl_buffers_in_flight.append(dest_command_buffer)
       src_dev.timeline_value += 1
+    
     msg("setLabel:")(src_command_buffer, to_ns_str(f"COPY {src_dev.device} -> {dest_dev.device}"))
     msg("commit")(src_command_buffer)
     src_dev.mtl_buffers_in_flight.append(src_command_buffer)
+    
   def _cp_mv(self, dst, src, prof_desc):
     with cpu_profile(prof_desc, self.dev.device, is_copy=True): dst[:] = src
   def _as_buffer(self, src:MetalBuffer) -> memoryview:


### PR DESCRIPTION
Key Changes:

- added is_virtual variable to the function and additional synchronization primitives for virtual devices
- using a smaller command buffer pool for virtual devices to reduce memory pressure
- added aggressive synchronisation for virtual devices
