### PR TITLE
fix: llama gsm8k eval

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -3,9 +3,6 @@
 #import typeguard.importhook
 #typeguard.importhook.install_import_hook('tinygrad')
 
-import sys
-sys.path.append(".")
-
 from pathlib import Path
 from typing import List, Optional
 import argparse, json

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -194,7 +194,7 @@ def load(fn:str):
 
 class LLaMa:
   @staticmethod
-  def build(model_path, tokenizer_path, model_gen="1", model_size="7B", quantize=None, device=None):
+  def build(model_path, tokenizer_path, model_gen="1", model_size="7B", quantize=None, device=None, MODEL_PARAMS=None):
     params = MODEL_PARAMS[model_gen][model_size]
     tokenizer = MODEL_PARAMS[model_gen]['tokenizer'](model_file=str(tokenizer_path))
     assert tokenizer.vocab_size() == params["args"]["vocab_size"], f"{tokenizer.vocab_size()=} not equal to {params['args']['vocab_size']}"
@@ -449,7 +449,7 @@ After you are done speaking, output [EOS]. You are not Chad.
   TOKENIZER_PATH = (MODEL_PATH if MODEL_PATH.is_dir() else MODEL_PATH.parent) / "tokenizer.model"
   print(f"using LLaMA{LLAMA_SUFFIX}-{args.size} model")
   device = tuple(f"{Device.DEFAULT}:{i}" for i in range(args.shard)) if args.shard > 1 else Device.DEFAULT
-  llama = LLaMa.build(MODEL_PATH, TOKENIZER_PATH, model_gen=args.gen, model_size=args.size, quantize=args.quantize, device=device)
+  llama = LLaMa.build(MODEL_PATH, TOKENIZER_PATH, model_gen=args.gen, model_size=args.size, quantize=args.quantize, device=device, MODEL_PARAMS=MODEL_PARAMS)
   param_bytes = sum(x.lazydata.size * x.dtype.itemsize for x in get_parameters(llama.model))
 
   outputted = pre_prompt if chatbot else args.prompt

--- a/examples/llama.py
+++ b/examples/llama.py
@@ -3,6 +3,9 @@
 #import typeguard.importhook
 #typeguard.importhook.install_import_hook('tinygrad')
 
+import sys
+sys.path.append(".")
+
 from pathlib import Path
 from typing import List, Optional
 import argparse, json

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ setup(name='tinygrad',
             "pycocotools",
             "boto3",
             "pandas",
-            "influxdb3-python"
+            "influxdb3-python",
+            "lm_eval"
         ],
         'docs': [
             "mkdocs",

--- a/test/external/external_llama_eval.py
+++ b/test/external/external_llama_eval.py
@@ -2,9 +2,7 @@ from lm_eval.api.model import LM
 from lm_eval.api.instance import Instance
 from lm_eval.evaluator import simple_evaluate
 import torch, json, argparse
-import sys
-sys.path.append("examples")
-from llama import LLaMa, MODEL_PARAMS
+from examples.llama import LLaMa, MODEL_PARAMS
 from tinygrad.tensor import Tensor
 from tinygrad import Device
 from pathlib import Path
@@ -70,7 +68,6 @@ class LLaMaAdaptor(LM):
     return torch.Tensor(self.llama.model(Tensor(inps.numpy()), 0).numpy())
 
   def generate_until(self, requests: list[Instance]) -> list[str]:
-    # TODO: use params in requests
     continuations = []
     for request in requests:
       prompt, until = request[0], request[1]['until']

--- a/test/external/external_llama_eval.py
+++ b/test/external/external_llama_eval.py
@@ -7,6 +7,7 @@ sys.path.append("examples")
 from llama import LLaMa, MODEL_PARAMS
 from tinygrad.tensor import Tensor
 from tinygrad import Device
+from pathlib import Path
 
 # https://github.com/EleutherAI/lm-evaluation-harness/blob/main/docs/model_guide.md
 class LLaMaAdaptor(LM):
@@ -30,13 +31,6 @@ class LLaMaAdaptor(LM):
     self.do_sample = do_sample
     self.temperature = temperature
     self._device = device
-
-    assert isinstance(model_gen, str)
-    assert isinstance(model_size, str)
-    assert isinstance(batch_size, int)
-    assert isinstance(checkpoint_path, str)
-    assert isinstance(tokenizer_path, str)
-
     self.llama = LLaMa.build(checkpoint_path, tokenizer_path, model_gen, model_size, quantize, MODEL_PARAMS=MODEL_PARAMS)
 
   @classmethod
@@ -99,8 +93,8 @@ if __name__ == '__main__':
   parser.add_argument('--quantize', action='store_true', help="Quantize the weights to int8 in memory")
   parser.add_argument('--eval', type=str, default="arc_easy", help="Run in evaluation mode")
   parser.add_argument('--limit', type=int, default=None, help="Limit tests in eval")
-  parser.add_argument('--weights', type=str, default="./weights/LLaMa/", help="Location of the weights")
-  parser.add_argument('--tokenizer', type=str, default="./weights/LLaMa/tokenizer.model", help="Location of the tokenizer")
+  parser.add_argument('--weights', type=Path, default="./weights/LLaMa/", help="Location of the weights")
+  parser.add_argument('--tokenizer', type=Path, default="./weights/LLaMa/tokenizer.model", help="Location of the tokenizer")
   args = parser.parse_args()
 
   # run eval and exit

--- a/test/external/external_llama_eval.py
+++ b/test/external/external_llama_eval.py
@@ -31,7 +31,7 @@ class LLaMaAdaptor(LM):
     self.do_sample = do_sample
     self.temperature = temperature
     self._device = device
-    self.llama = LLaMa.build(checkpoint_path, tokenizer_path, model_gen, model_size, quantize, MODEL_PARAMS=MODEL_PARAMS)
+    self.llama = LLaMa.build(checkpoint_path, tokenizer_path, model_gen, model_size, MODEL_PARAMS=MODEL_PARAMS)
 
   @classmethod
   def create_from_arg_string(cls, arg_string, additional_config=None):

--- a/test/external/external_llama_eval.py
+++ b/test/external/external_llama_eval.py
@@ -1,9 +1,10 @@
 from lm_eval.api.model import LM
+from lm_eval.api.instance import Instance
 from lm_eval.evaluator import simple_evaluate
 import torch, json, argparse
 import sys
 sys.path.append("examples")
-from llama import LLaMa
+from llama import LLaMa, MODEL_PARAMS
 from tinygrad.tensor import Tensor
 from tinygrad import Device
 
@@ -30,13 +31,13 @@ class LLaMaAdaptor(LM):
     self.temperature = temperature
     self._device = device
 
-    assert isinstance(model_gen, int)
+    assert isinstance(model_gen, str)
     assert isinstance(model_size, str)
     assert isinstance(batch_size, int)
     assert isinstance(checkpoint_path, str)
     assert isinstance(tokenizer_path, str)
 
-    self.llama = LLaMa.build(checkpoint_path, tokenizer_path, model_gen, model_size, quantize)
+    self.llama = LLaMa.build(checkpoint_path, tokenizer_path, model_gen, model_size, quantize, MODEL_PARAMS=MODEL_PARAMS)
 
   @classmethod
   def create_from_arg_string(cls, arg_string, additional_config=None):
@@ -94,7 +95,7 @@ if __name__ == '__main__':
 
   parser = argparse.ArgumentParser(description='Run LLaMA evals in tinygrad', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
   parser.add_argument('--size', type=str, default="7B", help="Size of model to use [7B, 13B, 30B, 65B] for Gen 1, [7B, 13B] for Gen 2")
-  parser.add_argument('--gen', type=int, default="1", help="Generation of the model to use [1, 2]")
+  parser.add_argument('--gen', type=str, default="1", help="Generation of the model to use [1, 2]")
   parser.add_argument('--quantize', action='store_true', help="Quantize the weights to int8 in memory")
   parser.add_argument('--eval', type=str, default="arc_easy", help="Run in evaluation mode")
   parser.add_argument('--limit', type=int, default=None, help="Limit tests in eval")

--- a/test/external/external_llama_eval.py
+++ b/test/external/external_llama_eval.py
@@ -98,8 +98,7 @@ if __name__ == '__main__':
   args = parser.parse_args()
 
   # run eval and exit
-  adaptor = LLaMaAdaptor(model_gen=args.gen, model_size=args.size, quantize=args.quantize,
+  model = LLaMaAdaptor(model_gen=args.gen, model_size=args.size, quantize=args.quantize,
                          checkpoint_path=args.weights, tokenizer_path=args.tokenizer, device="cpu")
-  #results = evaluator.evaluate(adaptor, tasks.get_task_dict(args.eval.split(",")), False, 0, args.limit)
-  results = evaluator.simple_evaluate(model, tasks='gsm8k', device='cuda:0', batch_size=1, limit=2)
+  results = simple_evaluate(model, tasks='gsm8k', device='cuda:0', batch_size=1, limit=2)
   print(json.dumps(results, indent=2))

--- a/test/external/external_llama_eval.py
+++ b/test/external/external_llama_eval.py
@@ -1,8 +1,9 @@
 from lm_eval.api.model import LM
 from lm_eval.evaluator import simple_evaluate
 import torch, json, argparse
-
-from examples.llama import LLaMa
+import sys
+sys.path.append("examples")
+from llama import LLaMa
 from tinygrad.tensor import Tensor
 from tinygrad import Device
 
@@ -74,6 +75,7 @@ class LLaMaAdaptor(LM):
     return torch.Tensor(self.llama.model(Tensor(inps.numpy()), 0).numpy())
 
   def generate_until(self, requests: list[Instance]) -> list[str]:
+    # TODO: use params in requests
     continuations = []
     for request in requests:
       prompt, until = request[0], request[1]['until']


### PR DESCRIPTION
Since 0.4.0 EleutherAI's `lm_eval` `api.model.LM` replaces `BaseLM` with following abstract methods:

1. `def generate_until(self, requests: list[Instance]) -> list[str]`
2. `def loglikelihood(self, requests: list[Instance]) -> list[tuple[float, bool]`
3. `def loglikelihood_rolling(self, requests: list[Instance]) -> list[tuple[float, bool]]`

We only have to implement the first, since the gsm8k eval extracts the answer from the generation. The latter two are for categorical outputs.

Runs with `PYTHONPATH=. uv run python3 test/external/external_llama_eval.py`