### PR TITLE
add kernel count to grouper process replay differ [pr]

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -34,7 +34,9 @@ class ProcessReplayWarning(Warning): pass
 def replay_kernelize(ret:dict[UOp, UOp], big_sink:UOp) -> tuple[str, str, tuple[Any, ...]]:
   UOp.unique_num = itertools.count(max([u.arg for u in big_sink.toposort() if u.op is Ops.UNIQUE], default=0)+1)
   new_sink = big_sink.substitute(get_kernelize_map(big_sink))
-  def to_str(ret:UOp): return "\n".join([repr(u.arg.ast) for u in ret.toposort() if u.op is Ops.KERNEL])
+  def to_str(ret:UOp):
+    asts = [repr(u.arg.ast) for u in ret.toposort() if u.op is Ops.KERNEL]
+    return "\n".join([f"{len(asts)} kernels", *asts])
   return to_str(new_sink), to_str(ret[big_sink]), (big_sink,)
 
 def replay_linearize(k:Kernel, _:Kernel, name_override=None, ast_transform=None) -> tuple[str, str, tuple[Any, ...]]:


### PR DESCRIPTION
Some PRs like #10609 change total number of scheduled kernels, it's useful to know by how many:
![image](https://github.com/user-attachments/assets/ca9958a3-5e5f-41e6-b54c-483567f4e8d0)
Things that just change structure of ASTs will look the same:
![image](https://github.com/user-attachments/assets/717866a6-b965-4758-b845-7c6882bb20c9)