### PR TITLE
Add missing js files in python package data for viz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name='tinygrad',
       packages = ['tinygrad', 'tinygrad.runtime.autogen', 'tinygrad.runtime.autogen.am', 'tinygrad.codegen', 'tinygrad.nn',
                   'tinygrad.renderer', 'tinygrad.engine', 'tinygrad.viz', 'tinygrad.runtime', 'tinygrad.runtime.support',
                   'tinygrad.runtime.support.am', 'tinygrad.runtime.graph', 'tinygrad.shape', 'tinygrad.uop'],
-      package_data = {'tinygrad': ['py.typed'], 'tinygrad.viz': ['index.html', 'perfetto.html', 'assets/**/*', 'lib/**/*']},
+      package_data = {'tinygrad': ['py.typed'], 'tinygrad.viz': ['index.html', 'perfetto.html', 'assets/**/*', 'js/*', 'lib/**/*']},
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License"


### PR DESCRIPTION
I installed tinygrad with uv to try it out

```bash
uv add tinygrad
```

Then wrote a simple tinygrad program and run it with the VIZ web tool:

```bash
VIZ=1 NOOPT=1 uv run python hello.py
```

But the web UI is not working. I looked into Chrome console and noticed that the `index.js` cannot be found:

![image](https://github.com/user-attachments/assets/70794ab0-5fd2-44c9-9481-8bd0d083ff7b)

I looked at the package installed by uv at my virtualenv folder, and realized that the js files in the `viz/js` are not there. Checked with the `setup.py` file, it turns out that the js folder is missing there. This PR adds the missing path.

I just tried it with `python setup.py sdist`:

```
...
copying tinygrad/viz/assets/unpkg.com/@highlightjs/cdn-assets@11.10.0/styles/tokyo-night-dark.min.css -> tinygrad-0.1.0/tinygrad/viz/assets/unpkg.com/@highlightjs/cdn-assets@11.10.0/styles
copying tinygrad/viz/js/index.js -> tinygrad-0.1.0/tinygrad/viz/js
copying tinygrad/viz/js/worker.js -> tinygrad-0.1.0/tinygrad/viz/js
copying tinygrad.egg-info/SOURCES.txt -> tinygrad-0.1.0/tinygrad.egg-info
Writing tinygrad-0.1.0/setup.cfg
creating dist
Creating tar archive
```

Then run

```bash
tar -tf dist/tinygrad-0.1.0.tar.gz
```

And can confirm now the missing js files are included

```
...
tinygrad-0.1.0/tinygrad/viz/assets/unpkg.com/@highlightjs/cdn-assets@11.10.0/styles/tokyo-night-dark.min.css
tinygrad-0.1.0/tinygrad/viz/index.html
tinygrad-0.1.0/tinygrad/viz/js/
tinygrad-0.1.0/tinygrad/viz/js/index.js
tinygrad-0.1.0/tinygrad/viz/js/worker.js
tinygrad-0.1.0/tinygrad/viz/perfetto.html
...
```