### PR TITLE
push permutes through fused reduces

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -70,12 +70,11 @@ def _test_conv2d(allowed:int, dtype:DType=dtypes.float, **kwargs):
 def schedule_graph_rewrite(big_sink:UOp): return graph_rewrite(big_sink, merge_views+sym, {})
 
 class TestSchedule(unittest.TestCase):
-  @unittest.expectedFailure
   def test_arange_sum(self):
     a = Tensor.arange(6).reshape(3, 2).sum(axis=1)
     with Context(FUSE_ARANGE=1):
       a.realize()
-    self.assertEqual(a.numpy(), np.arange(6).reshape(3,2).sum(axis=1))
+    np.testing.assert_equal(a.numpy(), np.arange(6).reshape(3,2).sum(axis=1))
 
   @unittest.skipIf(Device.DEFAULT == "CPU", "devices must mismatch")
   def test_error_on_device_mismatch(self):

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -89,11 +89,19 @@ class TestSchedule(unittest.TestCase):
     with self.assertRaises(RecursionError):
       with Context(FUSE_ARANGE=1, NOOPT=0): self.test_arange_avgpool2d(kcount=1)
 
+  # when we're fusing a reduce, all ReduceOps must have the same N in the dimensions
+  # all permutes, reshapes, expands and shrinks push through the reduce
   def test_arange_sum(self):
     a = Tensor.arange(6).reshape(3, 2).sum(axis=1)
     with Context(FUSE_ARANGE=1):
       run_schedule(check_schedule(a, 1))
     self.assertListEqual(a.tolist(), [1, 5, 9])
+
+  def test_permute_arange(self):
+    a = Tensor.arange(6).reshape(6, 1, 1).permute(2, 0, 1).sum(axis=1)
+    with Context(FUSE_ARANGE=1):
+      run_schedule(check_schedule(a, 1))
+    self.assertListEqual(a.tolist(), [[15]])
 
   @unittest.skipIf(Device.DEFAULT == "CPU", "devices must mismatch")
   def test_error_on_device_mismatch(self):

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from tinygrad.uop.ops import UOp, Ops, GroupOp, PatternMatcher, UPat, graph_rewrite, graph_rewrite_map, identity_element, resolve, can_pad, sint
 from tinygrad.uop.ops import track_rewrites, _substitute
 from tinygrad.uop.spec import type_verify, tensor_uop_spec
-from tinygrad.codegen.lowerer import get_contraction_with_reduce, get_contraction
+from tinygrad.codegen.lowerer import get_contraction_with_reduce
 from tinygrad.codegen.symbolic import symbolic_simple
 from tinygrad.helpers import Metadata, all_int, all_same, colored, prod, dedup, unwrap, getenv, pluralize
 from tinygrad.helpers import FUSE_CONV_BW, FUSE_ARANGE, DEBUG, DONT_REALIZE_EXPAND, DONT_GROUP_REDUCES, SPLIT_REDUCEOP
@@ -314,7 +314,7 @@ def apply_swizzle(u:UOp) -> UOp: return graph_rewrite(u, view_left, name="Sub Vi
 def swizzle_reduceop(r:UOp, src:UOp, view:UOp, fuse=False):
   # don't swizzle if we can push the view to children
   if unwrap(view.st).contiguous and view.size == r.size and \
-      (not fuse or tuple(x for x in r.shape if resolve(x != 1)) == tuple(x for x in view.shape if resolve(x != 1))):
+      (not (len(r.arg) == 3 and r.arg[2]) or tuple(x for x in r.shape if resolve(x != 1)) == tuple(x for x in view.shape if resolve(x != 1))):
     return None
   # swizzle the input
   input_st = ShapeTracker.from_shape(src.shape)
@@ -332,11 +332,8 @@ def swizzle_reduceop(r:UOp, src:UOp, view:UOp, fuse=False):
   return red.reshape(view.shape)
 
 def reduceop_view_right(src:UOp, v:UOp, r:UOp):
-  assert unwrap(v.st).contiguous and v.size == src.size, f"can't compute new axis for {src.shape} -> {r.shape}"
-  if (contraction:=get_contraction(v.shape, src.shape)) is None: return None
-  new_axis: list[int] = []
-  for i,pairs in enumerate(contraction):
-    if any(x in r.axis_arg for x in pairs): new_axis.append(i)
+  assert unwrap(v.st).contiguous and set(v.shape) == set(r.shape), f"can't compute new axis for {src.shape} -> {r.shape}"
+  new_axis = [i for i,(s,u) in enumerate(zip(src.shape, r.shape)) if s != u]
   return src.r(r.arg[0], tuple(new_axis)).reshape(r.shape)
 
 def elementwise_view_right(root:UOp):

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -332,7 +332,7 @@ def swizzle_reduceop(r:UOp, src:UOp, view:UOp, fuse=False):
   return red.reshape(view.shape)
 
 def reduceop_view_right(src:UOp, v:UOp, r:UOp):
-  assert unwrap(v.st).contiguous and set(v.shape) == set(r.shape), f"can't compute new axis for {src.shape} -> {r.shape}"
+  assert unwrap(v.st).contiguous and v.size == src.size, f"can't compute new axis for {src.shape} -> {r.shape}"
   new_axis = [i for i,(s,u) in enumerate(zip(src.shape, r.shape)) if s != u]
   return src.r(r.arg[0], tuple(new_axis)).reshape(r.shape)
 

--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -311,7 +311,7 @@ view_left = merge_views+PatternMatcher([
 def apply_swizzle(u:UOp) -> UOp: return graph_rewrite(u, view_left, name="Sub View Left")
 
 def swizzle_reduceop(r:UOp, src:UOp, view:UOp, fuse=False):
-  if (st:=unwrap(view.st)).contiguous and st.size == r.size: return None
+  if (st:=unwrap(view.st)).contiguous and tuple(x for x in r.shape if resolve(x != 1)) == tuple(x for x in view.shape if resolve(x != 1)): return None
   input_st = ShapeTracker.from_shape(src.shape)
   tmp = input_st.permute(tuple(i for i in range(len(input_st.shape)) if i not in r.axis_arg)+r.axis_arg)
   prshape = prod(rshape:=tmp.shape[-len(r.axis_arg):])
@@ -345,7 +345,7 @@ def elementwise_view_right(root:UOp):
 
 # push VIEW to children
 view_right = merge_views+PatternMatcher([
-  # push a non contiguous ShapeTracker through reduceop
+  # push view through reduceops
   (UPat(Ops.VIEW, src=(UPat(Ops.REDUCE_AXIS, src=(UPat.var("src"),), name="r"),), name="view"), swizzle_reduceop),
   # apply view after reduceops
   (UPat(Ops.REDUCE_AXIS, src=(UPat(Ops.VIEW, src=(UPat(GroupOp.All-ALWAYS_CONTIGUOUS, name="src"),), name="v"),), name="r"), reduceop_view_right),


### PR DESCRIPTION
The FUSE_ARANGE default diff revealed this bug, but it's a generic issue when pushing a reshape/permute before REDUCE_AXIS.

For example, in `python test/test_schedule.py TestSchedule.test_arange_sum`, we change the output dimensions from (6,1) to (3,2)
![image](https://github.com/user-attachments/assets/6a454557-78d3-4f30-9970-ebd0d99cf2e3)
To fuse this reduce while keeping the output shape the same, the swizzler needs to change the reduce source's shape:
![image](https://github.com/user-attachments/assets/1903add6-2393-4bd8-b628-939a293b7de7)


<br />

This gets at the heart of the swizzler, thought about this in porting DSP stuff to master too, when do we push MovementOps before ReduceOps and when do we decide to push it after?

Pushing it before will change the structure of ReduceOp ([10638](https://github.com/tinygrad/tinygrad/pull/10638)), pushing it after will change how it's stored in memory.

Currently we only change the reduceop if it's a non-contiguous / shrink, since that is required for correctness.
Everything else pushes to the STORE ShapeTracker.

The REDUCE_AXIS stays exactly as the user described it before downstream MovementOps. This is fine as long as all children are elementwise. The moment there is a second REDUCE_AXIS, the ndims mismatch becomes a problem.

How do we push a RESHAPE (6, 1) -> (3, 2) past the second reduce? There is no known axis. If we're fusing the REDUCE_AXIS, it's required that the N dims match exactly.