### PR TITLE
linearizer failure from FUSE_ARANGE default diff

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -84,6 +84,7 @@ class TestSchedule(unittest.TestCase):
     with Context(FUSE_ARANGE=1, NOOPT=1): self.test_arange_avgpool2d(kcount=1)
 
   # linearizer error
+  @unittest.skipUnless(Device[Device.DEFAULT].renderer.supports_float4, "needs supports_float4 to fail")
   def test_arange_avgpool2d_fused(self):
     with self.assertRaises(RecursionError):
       with Context(FUSE_ARANGE=1, NOOPT=0): self.test_arange_avgpool2d(kcount=1)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -74,8 +74,8 @@ class TestSchedule(unittest.TestCase):
   def test_arange_sum(self):
     a = Tensor.arange(6).reshape(3, 2).sum(axis=1)
     with Context(FUSE_ARANGE=1):
-      a.realize()
-    self.assertEqual(a.numpy(), np.arange(6).reshape(3,2).sum(axis=1))
+      run_schedule(check_schedule(a, 1))
+    self.assertListEqual(a.tolist(), [1, 5, 9])
 
   @unittest.skipIf(Device.DEFAULT == "CPU", "devices must mismatch")
   def test_error_on_device_mismatch(self):


### PR DESCRIPTION
The linearizer seems to be fine without the CAST.
The real avg_pool2d kernel does not lower properly:
![image](https://github.com/user-attachments/assets/64120f62-1778-4aff-85dc-f47551c345bc)
without CAST, this loop structure is fine, suggests there's a missing or_casted in the linearizer matchers?
![image](https://github.com/user-attachments/assets/9761ed56-550e-47b0-ae8a-f0f5c2cac273)
