### PR TITLE
mlperf ci uses its own cache

### DIFF
--- a/.github/workflows/mlperf.yml
+++ b/.github/workflows/mlperf.yml
@@ -24,4 +24,6 @@ jobs:
         ln -s /raid/datasets/imagenet extra/datasets/imagenet
     - name: Run resnet
       run: |
-        BENCHMARK_LOG=mlpert_train_resnet LOGMLPERF=0 examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/resnet/implementations/tinybox_red/run_and_time.sh
+        rm "~/.cache/tinygrad/cache_mlperf.db" || true
+        BENCHMARK_LOG=mlpert_train_resnet LOGMLPERF=0 CACHEDB="~/.cache/tinygrad/cache_mlperf.db" examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/resnet/implementations/tinybox_red/run_and_time.sh
+        rm "~/.cache/tinygrad/cache_mlperf.db"


### PR DESCRIPTION
not to interfere with regular cache which is used by benchmark