### PR TITLE
[bounty] move "examples/hlb_cifar10.py" each epoch data processing from numpy into tinygrad (random_crop + cutmix)

### DIFF
--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -188,8 +188,10 @@ def train_cifar():
 
   # ========== Preprocessing ==========
   # NOTE: this only works for RGB in format of NxCxHxW and pads the HxW
-  def pad_reflect(X:Tensor, size=2) -> Tensor:
-    return X.pad(((0,0), (0,0), (size,size), (size,size)), mode='reflect')
+  def pad_reflect(X, size=2) -> Tensor:
+    X = X[...,:,1:size+1].flip(-1).cat(X, X[...,:,-(size+1):-1].flip(-1), dim=-1)
+    X = X[...,1:size+1,:].flip(-2).cat(X, X[...,-(size+1):-1,:].flip(-2), dim=-2)
+    return X
 
   # return a binary mask in the format of BS x C x H x W where H x W contains a random square mask
   def make_square_mask(shape, mask_size) -> Tensor:

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -188,10 +188,8 @@ def train_cifar():
 
   # ========== Preprocessing ==========
   # NOTE: this only works for RGB in format of NxCxHxW and pads the HxW
-  def pad_reflect(X, size=2) -> Tensor:
-    X = X[...,:,1:size+1].flip(-1).cat(X, X[...,:,-(size+1):-1].flip(-1), dim=-1)
-    X = X[...,1:size+1,:].flip(-2).cat(X, X[...,-(size+1):-1,:].flip(-2), dim=-2)
-    return X
+  def pad_reflect(X:Tensor, size=2) -> Tensor:
+    return X.pad(((0,0), (0,0), (size,size), (size,size)), mode='reflect')
 
   # return a binary mask in the format of BS x C x H x W where H x W contains a random square mask
   def make_square_mask(shape, mask_size) -> Tensor:


### PR DESCRIPTION
On METAL, with FUSE_ARANGE=1 and WINO=1, entire training runtime:

BEFORE:  
First 20 steps
```
shuffling training dataset in 3023.95 ms (epoch=0)
  0 8793.29 ms run, 8790.37 ms python,    2.91 ms METAL, 1185.91 loss, 0.000015 LR, 0.89 GB used,     74.86 GFLOPS,    658.26 GOPS
  1 2888.95 ms run, 1937.29 ms python,  951.67 ms METAL, 1182.59 loss, 0.000030 LR, 2.09 GB used,    226.68 GFLOPS,    654.88 GOPS
  2 2539.12 ms run,   31.76 ms python, 2507.36 ms METAL, 1179.59 loss, 0.000045 LR, 2.09 GB used,    257.92 GFLOPS,    654.88 GOPS
  3 1994.70 ms run,   89.32 ms python, 1905.39 ms METAL, 1174.88 loss, 0.000060 LR, 2.09 GB used,    328.31 GFLOPS,    654.88 GOPS
  4 1845.78 ms run,   30.53 ms python, 1815.25 ms METAL, 1160.90 loss, 0.000075 LR, 2.09 GB used,    354.80 GFLOPS,    654.88 GOPS
  5 1854.35 ms run,   23.99 ms python, 1830.36 ms METAL, 1169.61 loss, 0.000090 LR, 2.09 GB used,    353.16 GFLOPS,    654.88 GOPS
  6 2259.68 ms run,  109.63 ms python, 2150.05 ms METAL, 1169.31 loss, 0.000105 LR, 2.09 GB used,    289.81 GFLOPS,    654.88 GOPS
  7 2870.21 ms run,   92.22 ms python, 2778.00 ms METAL, 1168.00 loss, 0.000120 LR, 2.09 GB used,    228.16 GFLOPS,    654.88 GOPS
  8 2854.63 ms run,  156.78 ms python, 2697.84 ms METAL, 1143.29 loss, 0.000135 LR, 2.09 GB used,    229.41 GFLOPS,    654.88 GOPS
  9 2200.26 ms run,   59.62 ms python, 2140.64 ms METAL, 1145.82 loss, 0.000149 LR, 2.09 GB used,    297.64 GFLOPS,    654.88 GOPS
 10 3274.19 ms run,  140.58 ms python, 3133.61 ms METAL, 1129.64 loss, 0.000164 LR, 2.09 GB used,    200.01 GFLOPS,    654.88 GOPS
 11 3492.81 ms run,   60.71 ms python, 3432.10 ms METAL, 1115.49 loss, 0.000179 LR, 2.09 GB used,    187.49 GFLOPS,    654.88 GOPS
 12 3291.58 ms run,  135.35 ms python, 3156.23 ms METAL, 1111.54 loss, 0.000194 LR, 2.09 GB used,    198.96 GFLOPS,    654.88 GOPS
 13 3120.79 ms run,   55.01 ms python, 3065.78 ms METAL, 1095.44 loss, 0.000209 LR, 2.09 GB used,    209.84 GFLOPS,    654.88 GOPS
 14 3580.10 ms run,   61.22 ms python, 3518.88 ms METAL, 1070.99 loss, 0.000224 LR, 2.09 GB used,    182.92 GFLOPS,    654.88 GOPS
 15 3731.26 ms run,  161.72 ms python, 3569.54 ms METAL, 1056.04 loss, 0.000239 LR, 2.09 GB used,    175.51 GFLOPS,    654.88 GOPS
 16 3032.41 ms run,   56.57 ms python, 2975.84 ms METAL, 1018.90 loss, 0.000254 LR, 2.09 GB used,    215.96 GFLOPS,    654.88 GOPS
 17 3037.56 ms run,   57.75 ms python, 2979.81 ms METAL, 1009.53 loss, 0.000269 LR, 2.09 GB used,    215.59 GFLOPS,    654.88 GOPS
 18 2560.99 ms run,   60.92 ms python, 2500.07 ms METAL,  982.36 loss, 0.000284 LR, 2.09 GB used,    255.71 GFLOPS,    654.88 GOPS
 19 3194.96 ms run,  145.62 ms python, 3049.34 ms METAL,  968.06 loss, 0.000299 LR, 2.09 GB used,    204.97 GFLOPS,    654.88 GOPS
 20 3418.47 ms run,   67.75 ms python, 3350.71 ms METAL,  969.21 loss, 0.000314 LR, 2.09 GB used,    191.57 GFLOPS,    654.88 GOPS
```
Total time ```2256.95 seconds```

AFTER: 
First 20 steps
```
shuffling training dataset in 115.53 ms (epoch=0)
  0 33105.38 ms run, 33102.44 ms python,    2.94 ms METAL, 1186.34 loss, 0.000015 LR, 1.47 GB used,     12.77 GFLOPS,    422.69 GOPS
  1 3918.00 ms run, 3854.59 ms python,   63.41 ms METAL, 1184.87 loss, 0.000030 LR, 3.03 GB used,     52.90 GFLOPS,    207.27 GOPS
  2 1076.21 ms run,   15.97 ms python, 1060.24 ms METAL, 1180.90 loss, 0.000045 LR, 3.03 GB used,    192.60 GFLOPS,    207.27 GOPS
  3  683.50 ms run,  153.07 ms python,  530.43 ms METAL, 1174.70 loss, 0.000060 LR, 3.03 GB used,    303.25 GFLOPS,    207.27 GOPS
  4 1115.59 ms run,   15.78 ms python, 1099.81 ms METAL, 1166.12 loss, 0.000075 LR, 3.03 GB used,    185.80 GFLOPS,    207.27 GOPS
  5  920.60 ms run,   16.64 ms python,  903.95 ms METAL, 1161.46 loss, 0.000090 LR, 3.03 GB used,    225.15 GFLOPS,    207.27 GOPS
  6  917.06 ms run,   12.71 ms python,  904.34 ms METAL, 1161.46 loss, 0.000105 LR, 3.03 GB used,    226.02 GFLOPS,    207.27 GOPS
  7  890.99 ms run,   11.37 ms python,  879.62 ms METAL, 1149.46 loss, 0.000120 LR, 3.03 GB used,    232.63 GFLOPS,    207.27 GOPS
  8 1166.17 ms run,   15.50 ms python, 1150.67 ms METAL, 1151.63 loss, 0.000135 LR, 3.03 GB used,    177.74 GFLOPS,    207.27 GOPS
  9  939.36 ms run,   15.94 ms python,  923.42 ms METAL, 1146.55 loss, 0.000149 LR, 3.03 GB used,    220.66 GFLOPS,    207.27 GOPS
 10  957.69 ms run,   13.77 ms python,  943.92 ms METAL, 1137.31 loss, 0.000164 LR, 3.03 GB used,    216.43 GFLOPS,    207.27 GOPS
 11  887.51 ms run,   15.11 ms python,  872.40 ms METAL, 1121.26 loss, 0.000179 LR, 3.03 GB used,    233.55 GFLOPS,    207.27 GOPS
 12  885.47 ms run,   21.43 ms python,  864.04 ms METAL, 1114.67 loss, 0.000194 LR, 3.03 GB used,    234.09 GFLOPS,    207.27 GOPS
 13  877.75 ms run,   10.98 ms python,  866.77 ms METAL, 1088.33 loss, 0.000209 LR, 3.03 GB used,    236.14 GFLOPS,    207.27 GOPS
 14  918.54 ms run,   11.34 ms python,  907.20 ms METAL, 1063.63 loss, 0.000224 LR, 3.03 GB used,    225.66 GFLOPS,    207.27 GOPS
 15  871.53 ms run,   12.17 ms python,  859.35 ms METAL, 1046.91 loss, 0.000239 LR, 3.03 GB used,    237.83 GFLOPS,    207.27 GOPS
 16  880.26 ms run,   12.81 ms python,  867.45 ms METAL, 1041.77 loss, 0.000254 LR, 3.03 GB used,    235.47 GFLOPS,    207.27 GOPS
 17  886.72 ms run,   11.81 ms python,  874.91 ms METAL, 1010.21 loss, 0.000269 LR, 3.03 GB used,    233.75 GFLOPS,    207.27 GOPS
 18  900.25 ms run,   14.49 ms python,  885.76 ms METAL,  984.77 loss, 0.000284 LR, 3.03 GB used,    230.24 GFLOPS,    207.27 GOPS
 19  871.91 ms run,   12.21 ms python,  859.70 ms METAL,  984.16 loss, 0.000299 LR, 3.03 GB used,    237.73 GFLOPS,    207.27 GOPS
 20  880.89 ms run,   19.16 ms python,  861.73 ms METAL,  967.18 loss, 0.000314 LR, 3.03 GB used,    235.30 GFLOPS,    207.27 GOPS
```
Total time ```1225.61 seconds```


