### PR TITLE
keep UOp tags if sources are replaced

### DIFF
--- a/test/unit/test_graph_rewrite.py
+++ b/test/unit/test_graph_rewrite.py
@@ -276,6 +276,13 @@ class TestSubstitute(unittest.TestCase):
     ret = substitute(ret, {a.sin():a.sqrt(), n1.sin():n1.sqrt()})
     self.assertIs(ret, a.sqrt().sqrt())
 
+  def test_tagged_replace(self):
+    a = UOp.variable('a', 0, 10)
+    b = UOp.variable('b', 0, 10)
+    ret = (a+4).replace(tag=1)
+    ret = substitute(ret, {a:b})
+    # the srcs are rewritten but we keep tag
+    self.assertIs(ret, (b+4).replace(tag=1))
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -91,8 +91,9 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
   @functools.cached_property
   def key(self) -> bytes:
     return hashlib.sha256(str((self.op, self.dtype, self.arg)).encode() + b"".join([s.key for s in self.src])).digest()
-  def __repr__(self): return pretty_print(self, lambda x: f"{type(self).__name__}({x.op}, {x.dtype}, arg={x.argstr()}, src=(%s))")
+  def __repr__(self): return pretty_print(self, lambda x: f"{type(self).__name__}({x.op}, {x.dtype}, arg={x.argstr()}{x.tagstr()}, src=(%s))")
   def argstr(self): return f'({", ".join(map(str, self.arg))})' if self.op is Ops.REDUCE_AXIS else repr(self.arg)
+  def tagstr(self): return f", tag={self.tag}" if self.tag is not None else ""
 
   @functools.cached_property
   def parents(self:UOp) -> dict[UOp, None]:

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -843,7 +843,7 @@ class RewriteContext:
             continue
         else:
           # if srcs changed from rewrites, construct a new UOp with the new srcs
-          new_src_n = UOp(new_n.op, new_n.dtype, new_src, new_n.arg)
+          new_src_n = UOp(new_n.op, new_n.dtype, new_src, new_n.arg, new_n.tag)
         # trigger a rewrite of new_src_n, then after that rewrite is done, link it back to n
         stack.append((n, 2, new_src_n))
         stack.append((new_src_n, 0, new_src_n))

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -91,9 +91,8 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
   @functools.cached_property
   def key(self) -> bytes:
     return hashlib.sha256(str((self.op, self.dtype, self.arg)).encode() + b"".join([s.key for s in self.src])).digest()
-  def __repr__(self): return pretty_print(self, lambda x: f"{type(self).__name__}({x.op}, {x.dtype}, arg={x.argstr()}{x.tagstr()}, src=(%s))")
+  def __repr__(self): return pretty_print(self, lambda x: f"{type(self).__name__}({x.op}, {x.dtype}, arg={x.argstr()}, src=(%s))")
   def argstr(self): return f'({", ".join(map(str, self.arg))})' if self.op is Ops.REDUCE_AXIS else repr(self.arg)
-  def tagstr(self): return f", tag={self.tag}" if self.tag is not None else ""
 
   @functools.cached_property
   def parents(self:UOp) -> dict[UOp, None]:


### PR DESCRIPTION
Noticed this while adding UOp tags to VIZ. In master, we drop the UOp tag if sources are replaced.
`VIZ=1 python test/test_tiny.py TestTiny.test_plus`
1. insert_gbarrier has 4 rewrites, remove_tags only has 2.
2. Only nodes with no rewritten sources keep tags:
![image](https://github.com/user-attachments/assets/67d88e4e-3afa-4f47-a000-dcd8c354c167)

This was okay for correctness of a single pass, as we've already moved past the rightmost nodes in bottom_up rewrite.

With the tags kept, rewrite counts match and we can see the full representation in VIZ:
![image](https://github.com/user-attachments/assets/99e48f2c-4dd9-4def-b492-d89f3eda5981)
