### PR TITLE
don't run linearize().uop tests in get_action_space test

### DIFF
--- a/extra/optimization/get_action_space.py
+++ b/extra/optimization/get_action_space.py
@@ -26,15 +26,6 @@ if __name__ == "__main__":
     #if not lin.apply_tensor_cores():
     lin.apply_opts(hand_coded_optimizations(lin))
     test_rebuild(lin)
-    # confirm linearize can be called twice
-    uops1 = lin.linearize().uops
-    uops2 = lin.linearize().uops
-    for x,y in zip(uops1, uops2):
-      # for some reason DEFINE_ACC is changing the arg
-      if x.op != y.op or x.dtype != y.dtype: # or x.arg != y.arg:
-        uops1.print()
-        uops2.print()
-        raise Exception(f"UOPS MISMATCH {x} {y}")
 
   print(len(tactions), len(actions))
   print(sorted(list(tactions)))


### PR DESCRIPTION
this part takes 2 minutes in CI and has nothing to do with action space. also not sure if the "for some reason" comment is still relevant