### PR TITLE
Explicitly use CUDA_KERNEL_NODE_PARAMS v1

### DIFF
--- a/tinygrad/runtime/graph/cuda.py
+++ b/tinygrad/runtime/graph/cuda.py
@@ -29,7 +29,7 @@ class CUDAGraph(MultiGraphRunner):
         c_deps = (cuda.CUgraphNode*len(deps))(*deps) if deps else None
 
         c_args, vargs = encode_args([cast(Buffer, x)._buf for x in ji.bufs], [var_vals.get(x, ji.fixedvars.get(x)) for x in ji.prg.p.vars])
-        kern_params = cuda.CUDA_KERNEL_NODE_PARAMS(ji.prg._prg.prg, *global_size, *local_size, 0, None, vargs)
+        kern_params = cuda.CUDA_KERNEL_NODE_PARAMS_v1(ji.prg._prg.prg, *global_size, *local_size, 0, None, vargs)
         check(cuda.cuGraphAddKernelNode(ctypes.byref(new_node), self.graph, c_deps, len(deps), ctypes.byref(kern_params)))
 
         if j in self.launch_dims_replace or j in self.var_vals_replace or j in self.jc_idx_with_updatable_rawbufs:


### PR DESCRIPTION
CUDA 12 changed `CUDA_KERNEL_NODE_PARAMS` to always be an alias to `CUDA_KERNEL_NODE_PARAMS_v2` instead of `CUDA_KERNEL_NODE_PARAMS_v1`

(looks like `__CUDA_API_VERSION_INTERNAL` hack only fixes functions)

Also it looks like there is no cuda tests that trigger graph even in benchmark???