### PR TITLE
[bounty] Don't use numpy inside hlb_cifar10 training loop

### DIFF
--- a/.github/workflows/benchmark_search.yml
+++ b/.github/workflows/benchmark_search.yml
@@ -27,7 +27,7 @@ jobs:
         BENCHMARK_LOG=search_sdxl_cached PYTHONPATH=. AMD=1 JITBEAM=2 python examples/sdxl.py --noshow --timing --seed 0
     - name: Run winograd cifar with new search
       run: |
-        BENCHMARK_LOG=search_wino_cifar WINO=1 DEFAULT_FLOAT=HALF FUSE_ARANGE=1 JITBEAM=4 IGNORE_BEAM_CACHE=1 DISABLE_COMPILER_CACHE=1 BS=1024 STEPS=500 python examples/hlb_cifar10.py
+        BENCHMARK_LOG=search_wino_cifar WINO=1 DEFAULT_FLOAT=HALF JITBEAM=4 IGNORE_BEAM_CACHE=1 DISABLE_COMPILER_CACHE=1 BS=1024 STEPS=500 python examples/hlb_cifar10.py
     - name: Run winograd cifar with cached search
       run: |
-        BENCHMARK_LOG=search_wino_cifar_cached WINO=1 DEFAULT_FLOAT=HALF FUSE_ARANGE=1 JITBEAM=4 BS=1024 STEPS=500 python examples/hlb_cifar10.py
+        BENCHMARK_LOG=search_wino_cifar_cached WINO=1 DEFAULT_FLOAT=HALF JITBEAM=4 BS=1024 STEPS=500 python examples/hlb_cifar10.py

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -244,10 +244,10 @@ def train_cifar():
         if getenv("CUTMIX", 1) and step >= hyp['net']['cutmix_steps']: X, Y = X_cm, Y_cm
       et = time.monotonic()
       print(f"shuffling {'training' if is_train else 'test'} dataset in {(et-st)*1e3:.2f} ms ({epoch=})")
-      vi = Variable("i", 0, X.shape[0]-1)
-      for i in range(0, X.shape[0], BS):
+
+      vi = Variable("i", 0, (full_batches := (X.shape[0] // BS) * BS) - BS)
+      for i in range(0, full_batches, BS):
         step += 1
-        if i+BS > X.shape[0]: break
         vib = vi.bind(i)
         yield X[vib:vib+BS], Y[vib:vib+BS]
       epoch += 1

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -245,15 +245,14 @@ def train_cifar():
       if is_train:
         X, Y = jittable_transforms(X, Y)
         if getenv("CUTMIX", 1) and step >= hyp['net']['cutmix_steps']:
-            X, Y = cutmix(X, Y, mask_size=hyp['net']['cutmix_size'])
+          X, Y = cutmix(X, Y, mask_size=hyp['net']['cutmix_size'])
       et = time.monotonic()
       print(f"shuffling {'training' if is_train else 'test'} dataset in {(et-st)*1e3:.2f} ms ({epoch=})")
       for i in range(0, X.shape[0], BS):
-        # pad the last batch  # TODO: not correct for test
-        batch_end = min(i+BS, Y.shape[0])
         step += 1
+        if i+BS > X.shape[0]: break
         # This needs to be contiguous, or the jitted consumer will fail.
-        yield X[batch_end-BS:batch_end].contiguous(), Y[batch_end-BS:batch_end].contiguous()
+        yield X[i:i+BS].contiguous(), Y[i:i+BS].contiguous()
       epoch += 1
       if not is_train: break
 

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -201,19 +201,25 @@ def train_cifar():
     idx_y = Tensor.arange(H, dtype=dtypes.int32).reshape((1,1,H,1))
     return (idx_x >= low_x) * (idx_x < (low_x + mask_size)) * (idx_y >= low_y) * (idx_y < (low_y + mask_size))
 
-  def random_crop(X:Tensor, crop_size=32):
-    mask = make_square_mask(X.shape, crop_size)
-    mask = mask.expand((-1,3,-1,-1))
-    X_cropped = Tensor(X.numpy()[mask.numpy()])
-    return X_cropped.reshape((-1, 3, crop_size, crop_size))
 
-  def cutmix(X:Tensor, Y:Tensor, mask_size=3):
-    # fill the square with randomly selected images from the same batch
+  def negative_pad_grid(n=4):
+      # Generate all possible padding combinations that sum to biting n elements from h and w.
+      pad_options = [(-i, i-n) for i in range(n+1)]
+
+      # Create all possible combinations of padding for left/right and top/bottom
+      return [(pad_options[x % len(pad_options)], pad_options[y % len(pad_options)])
+              for x in range(n) for y in range(n)]
+
+  def random_crop(X:Tensor, crop_size:int=32) -> Tensor:
+      assert X.shape[-1] >= crop_size
+      Xl = X.split(X.shape[0]//16) # XXX This results in B=3125, which is prob not great for performance, not sure if matters.
+      Xp = [ x.pad(((0,0),(0, 0), *npad)) for x, npad in zip(Xl, negative_pad_grid(X.shape[-1] - crop_size)) ]
+      return Tensor.cat(*Xp)
+
+  def cutmix(X, Y, mask_size=3):
     mask = make_square_mask(X.shape, mask_size)
-    order = list(range(0, X.shape[0]))
-    random.shuffle(order)
-    X_patch = Tensor(X.numpy()[order], device=X.device, dtype=X.dtype)
-    Y_patch = Tensor(Y.numpy()[order], device=Y.device, dtype=Y.dtype)
+    order = Tensor.randperm(X.shape[0], device=X.device)
+    X_patch, Y_patch = X[order], Y[order]
     X_cutmix = mask.where(X_patch, X)
     mix_portion = float(mask_size**2)/(X.shape[-2]*X.shape[-1])
     Y_cutmix = mix_portion * Y_patch + (1. - mix_portion) * Y
@@ -226,28 +232,25 @@ def train_cifar():
       st = time.monotonic()
       X, Y = X_in, Y_in
       if is_train:
+        perms = Tensor.randperm(X.shape[0], device=X.device)
         # TODO: these are not jitted
         if getenv("RANDOM_CROP", 1):
+          X, Y = X[perms], Y[perms]
           X = random_crop(X, crop_size=32)
         if getenv("RANDOM_FLIP", 1):
           X = (Tensor.rand(X.shape[0],1,1,1) < 0.5).where(X.flip(-1), X) # flip LR
         if getenv("CUTMIX", 1):
           if step >= hyp['net']['cutmix_steps']:
             X, Y = cutmix(X, Y, mask_size=hyp['net']['cutmix_size'])
-        order = list(range(0, X.shape[0]))
-        random.shuffle(order)
-        X, Y = X.numpy()[order], Y.numpy()[order]
-      else:
-        X, Y = X.numpy(), Y.numpy()
+        X, Y = X[perms], Y[perms]
       et = time.monotonic()
       print(f"shuffling {'training' if is_train else 'test'} dataset in {(et-st)*1e3:.2f} ms ({epoch=})")
       for i in range(0, X.shape[0], BS):
         # pad the last batch  # TODO: not correct for test
         batch_end = min(i+BS, Y.shape[0])
-        x = Tensor(X[batch_end-BS:batch_end], device=X_in.device, dtype=X_in.dtype)
-        y = Tensor(Y[batch_end-BS:batch_end], device=Y_in.device, dtype=Y_in.dtype)
         step += 1
-        yield x, y
+        # This needs to be contiguous, or the jitted consumer will fail.
+        yield X[batch_end-BS:batch_end].contiguous(), Y[batch_end-BS:batch_end].contiguous()
       epoch += 1
       if not is_train: break
 

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -203,18 +203,18 @@ def train_cifar():
 
 
   def negative_pad_grid(n=4):
-      # Generate all possible padding combinations that sum to biting n elements from h and w.
-      pad_options = [(-i, i-n) for i in range(n+1)]
+    # Generate all possible padding combinations that sum to biting n elements from h and w.
+    pad_options = [(-i, i-n) for i in range(n+1)]
 
-      # Create all possible combinations of padding for left/right and top/bottom
-      return [(pad_options[x % len(pad_options)], pad_options[y % len(pad_options)])
-              for x in range(n) for y in range(n)]
+    # Create all possible combinations of padding for left/right and top/bottom
+    return [(pad_options[x % len(pad_options)], pad_options[y % len(pad_options)])
+            for x in range(n) for y in range(n)]
 
   def random_crop(X:Tensor, crop_size:int=32) -> Tensor:
-      assert X.shape[-1] >= crop_size
-      Xl = X.split(X.shape[0]//16) # XXX This results in B=3125, which is prob not great for performance, not sure if matters.
-      Xp = [ x.pad(((0,0),(0, 0), *npad)) for x, npad in zip(Xl, negative_pad_grid(X.shape[-1] - crop_size)) ]
-      return Tensor.cat(*Xp)
+    assert X.shape[-1] >= crop_size
+    Xl = X.split(X.shape[0]//16) # XXX This results in B=3125, which is prob not great for performance, not sure if matters.
+    Xp = [ x.pad(((0,0),(0, 0), *npad)) for x, npad in zip(Xl, negative_pad_grid(X.shape[-1] - crop_size)) ]
+    return Tensor.cat(*Xp)
 
   def cutmix(X, Y, mask_size=3):
     mask = make_square_mask(X.shape, mask_size)

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -145,6 +145,7 @@ hyp = {
   },
 }
 
+@Context(FUSE_ARANGE=getenv("FUSE_ARANGE", 1))
 def train_cifar():
 
   def set_seed(seed):


### PR DESCRIPTION
A deep dive: https://xl0.github.io/tinygrad-notes/bounty1.html

So the main issue here was the fact that `Tensor.masked_select()` is so slow that it's unusable. It's a natural choice for implementing `random_crop`, but not the only option.

Since `random_crop` picks a 32x32 rectangle from a 36x36 source image, there are only 16 possible crops. So I shuffle the dataset, split it 16-way, apply all possible crops using `.pad()` with negative padding, put it togeher and shuffle it again.

The result is not as straight-forward as `X.masked_select(mask)`, but it is actually fast - faster than the numpy implementation at least. Maybe we can use `.masked_select()` once it get good.

Another issue - indexing the dataset with a large 1-dim tensor to shuffle it is super slow, unless done with FUSE_ARANGE. Then it's actually quite fast.

@geohot do you want me to add FUSE_ARANGE to the CI flows for this example? Without it it gets slower.

`cutmix` did not pose difficulty, and I also removed any numpy from the trainig loop. There is still numpy in `whitening()`, and I can remove it too. @geohot do you want all trace of numpy gone, or should I do it in another PR?

In total, on my machine, I get 110s -> 102s, so ~7% performance improvement. No difference in training accuracy.

I also noticed that @IntendedConsequence made a good effort in #10728. I'm not sure how to best handle the situation, because I saw his half-way through. I like the training loop cleanup he did, but feel it's a separate PR.