### PR TITLE
Add ensure_supported_dtype to ONNX

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -70,11 +70,11 @@ def buffer_parse(onnx_tensor: TensorProto) -> Tensor:
     return prepare_data(data.cast(dtype).reshape(shape))
   if has_field(onnx_tensor, "raw_data"):
     if onnx_tensor.data_type == TensorProto.FLOAT16:
-      ret = onnx_tensor.raw_data.bitcast(dtypes.float16).reshape(shape)
+      ret = onnx_tensor.raw_data.bitcast(dtypes.float16).reshape(shape).to(Device.DEFAULT)
       if shape == (): return Tensor(ret.item(), dtype=dtypes.float32)
       if not is_dtype_supported(dtypes.float16): return ret.to("CPU").cast(dtypes.float32).to(Device.DEFAULT)
-      return ret.to(Device.DEFAULT).cast(dtypes.float32)
-    ret = onnx_tensor.raw_data.bitcast(dtype).reshape(shape)
+      return ret.cast(dtypes.float32)
+    ret = onnx_tensor.raw_data.bitcast(dtype).reshape(shape).to(Device.DEFAULT)
     if shape == (): ret = Tensor(ret.item(), dtype=dtype).reshape(shape)
     return prepare_data(ret)
   return Tensor(None)

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -72,7 +72,8 @@ def buffer_parse(onnx_tensor: TensorProto) -> Tensor:
     if onnx_tensor.data_type == TensorProto.FLOAT16:
       ret = onnx_tensor.raw_data.bitcast(dtypes.float16).reshape(shape)
       if shape == (): return Tensor(ret.item(), dtype=dtypes.float32)
-      return ret.to("CPU").cast(dtypes.float32).to(Device.DEFAULT)
+      if not is_dtype_supported(dtypes.float16): return ret.to("CPU").cast(dtypes.float32).to(Device.DEFAULT)
+      return ret.to(Device.DEFAULT).cast(dtypes.float32)
     ret = onnx_tensor.raw_data.bitcast(dtype).reshape(shape)
     if shape == (): ret = Tensor(ret.item(), dtype=dtype).reshape(shape)
     return prepare_data(ret)


### PR DESCRIPTION
- Ensures that dtypes of tensors internal to the graph is supported on device for the FP and issues warnings when dtype is defaulting to a default dtype.
- Removes the numpy in buffer load and instead use:
`DISK (bitcast, reshape) -> DEVICE (optionally -> CPU cast to device supported dtype -> back to DEVICE, if dtype not support on device)` if on DISK, or `DEVICE (cast, reshape) and -> CPU cast -> back to DEVICE if dtype not supported` if already on DEVICE

split from #10694 