### PR TITLE
ramp.py: correct UOp and Ops import path from tinygrad.uop to tinygrad.uop.ops

### DIFF
--- a/docs/ramp.py
+++ b/docs/ramp.py
@@ -239,7 +239,7 @@ print("******* PART 3 *******")
 # it's much simpler than what's in LLVM or MLIR
 
 from tinygrad import dtypes
-from tinygrad.uop import UOp, Ops
+from tinygrad.uop.ops import UOp, Ops
 
 # first, we'll construct some const UOps
 a = UOp(Ops.CONST, dtypes.int, arg=2)


### PR DESCRIPTION
This fixes the following error: 
```
ImportError: cannot import name 'UOp' from 'tinygrad.uop' (/tinygrad/tinygrad/uop/__init__.py). Did you mean: 'uop'?
```
in `ramp.py`.