### PR TITLE
xor self folding

### DIFF
--- a/test/unit/test_uop_symbolic.py
+++ b/test/unit/test_uop_symbolic.py
@@ -110,6 +110,9 @@ class TestSymbolic(unittest.TestCase):
   def test_neg(self):
     self.helper_test_variable(-Variable("a", 0, 8), -8, 0, "(a*-1)")
 
+  def test_xor_0(self):
+    self.helper_test_variable(Variable("a", 0, 8) ^ 0, 0, 8, "a")
+
   def test_add_1(self):
     self.helper_test_variable(Variable("a", 0, 8)+1, 1, 9, "(a+1)")
 

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -25,6 +25,8 @@ try:
     (UPat(Ops.LOAD, name="x"), lambda x,ctx: UOp(Ops.NOOP, arg=create_bounded(f"load{ctx[1].setdefault(x, len(ctx[1]))}", x.vmin, x.vmax, ctx[0]))),
     (UPat(Ops.CONST, name="x"), lambda x,ctx: UOp(Ops.NOOP, arg=(z3.BoolVal if dtypes.is_bool(x.dtype) else z3.IntVal)(x.arg, ctx=ctx[0].ctx))),
     (UPat(Ops.CAST, name="x"), lambda x: x.src[0]),
+    (UPat(Ops.XOR, src=UPat(Ops.NOOP), name="x"),
+      lambda x: UOp(Ops.NOOP, arg=z3.BV2Int(z3_alu[x.op](*(z3.Int2BV(s.arg, x.dtype.itemsize*8) for s in x.src))))),
     (UPat(GroupOp.ALU, src=UPat(Ops.NOOP), name="x"), lambda x: UOp(Ops.NOOP, arg=z3_alu[x.op](*(s.arg for s in x.src)))),
   ])
 

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -25,6 +25,7 @@ symbolic_simple = PatternMatcher([
   # ** self folding **
   (UPat.var("x") + 0, lambda x: x),    # x+0 -> x
   (UPat.var("x") * 1, lambda x: x),    # x*1 -> x
+  (UPat.var("x", dtype=dtypes.ints) ^ 0, lambda x: x), # x^0 -> x
   (UPat.var("x") // UPat.var("x"), lambda x: x.const_like(1)), # x//x -> 1
   (UPat.var("x") // 1, lambda x: x),   # x//1 -> x
   (UPat.var("x") // -1, lambda x: -x), # x//-1 -> -x


### PR DESCRIPTION
relevant for keccak. Reduces scheduling time a bit (2900ms -> 2200ms on my machine).

example:
```python
from tinygrad import Tensor, dtypes

a = Tensor([ 1, 2 ], dtype=dtypes.int)
b = Tensor([ 1337 ], dtype=dtypes.int).pad((0, 1))

(a ^ b).realize()
```

before:
```c
void E_2(int* restrict data0, int* restrict data1, int* restrict data2) {
  int val0 = *(data1+0);
  int val1 = *(data2+0);
  int val2 = *(data1+1);
  *(data0+0) = (val0^val1);
  *(data0+1) = (val2^0);
}
```
after:
```c
void E_2(int* restrict data0, int* restrict data1, int* restrict data2) {
  int val0 = *(data1+0);
  int val1 = *(data2+0);
  int val2 = *(data1+1);
  *(data0+1) = val2;
  *(data0+0) = (val0^val1);
}
```
