### PR TITLE
feat/amd-mi300x-runtime-refactor

### DIFF
--- a/test/test_parse_xccs.py
+++ b/test/test_parse_xccs.py
@@ -1,0 +1,31 @@
+import os, unittest
+from tinygrad.runtime.ops_amd import parse_xccs
+from tinygrad.helpers import getenv
+
+class TestParseXCCS(unittest.TestCase):
+  def test_default(self):
+    os.environ.pop('XCCS', None)
+    getenv.cache_clear()
+    self.assertEqual(parse_xccs({'num_xcc':8}), 8)
+
+  def test_override(self):
+    os.environ['XCCS'] = '4'
+    getenv.cache_clear()
+    self.assertEqual(parse_xccs({'num_xcc':8}), 4)
+    os.environ.pop('XCCS')
+
+  def test_cap_and_invalid(self):
+    os.environ['XCCS'] = '12'
+    getenv.cache_clear()
+    self.assertEqual(parse_xccs({'num_xcc':8}), 8)
+    os.environ['XCCS'] = 'abc'
+    getenv.cache_clear()
+    self.assertEqual(parse_xccs({'num_xcc':8}), 8)
+    os.environ['XCCS'] = '-1'
+    getenv.cache_clear()
+    self.assertEqual(parse_xccs({'num_xcc':8}), 1)
+    os.environ.pop('XCCS')
+
+if __name__ == '__main__':
+  unittest.main()
+


### PR DESCRIPTION
### Description

This PR refactors the AMD MI300X runtime by introducing a flexible way to override the number of XCCs (Shader Core Complexes) through an environment variable. This change improves configurability when working with different MI300X hardware configurations.

### Changes Made

* Added a new helper function `parse_xccs` to safely parse the `XCCS` environment variable with boundary checks and default handling.
* Updated the `AMDDevice` initialization to use `parse_xccs` for determining the number of XCCs.
* Introduced a new unit test file `test_parse_xccs.py` to validate override behavior, including:

  * Default fallback
  * Proper override within limits
  * Graceful fallback on invalid or excessive values
