### PR TITLE
backend/aco-amd-nak-nvidia-mesa

### DIFF
--- a/tinygrad/runtime/nvcuvid.py
+++ b/tinygrad/runtime/nvcuvid.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import ctypes, ctypes.util
+
+class NVHevcDecoder:
+  def __init__(self, width:int, height:int):
+    libpath = ctypes.util.find_library('nvcuvid')
+    if libpath is None:
+      raise RuntimeError('libnvcuvid not found')
+    self.lib = ctypes.CDLL(libpath)
+    # Only include fields needed for basic decoder init
+    class CUVIDDECODECREATEINFO(ctypes.Structure):
+      _fields_ = [
+        ('ulWidth', ctypes.c_uint),
+        ('ulHeight', ctypes.c_uint),
+        ('ulNumDecodeSurfaces', ctypes.c_uint),
+        ('CodecType', ctypes.c_int),
+        ('ChromaFormat', ctypes.c_int),
+        ('ulCreationFlags', ctypes.c_uint),
+      ]
+    self._info = CUVIDDECODECREATEINFO(ulWidth=width, ulHeight=height,
+      ulNumDecodeSurfaces=1, CodecType=8, ChromaFormat=1, ulCreationFlags=0)
+    self.decoder = ctypes.c_void_p()
+    res = self.lib.cuvidCreateDecoder(ctypes.byref(self.decoder),
+      ctypes.byref(self._info))
+    if res != 0:
+      raise RuntimeError(f'cuvidCreateDecoder failed: {res}')
+
+  def decode(self, bitstream:bytes):
+    raise NotImplementedError('Decoding not implemented')
+
+  def close(self):
+    if self.decoder:
+      self.lib.cuvidDestroyDecoder(self.decoder)
+      self.decoder = None

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -13,6 +13,7 @@ from tinygrad.renderer.cstyle import NVRenderer
 from tinygrad.runtime.support.compiler_cuda import CUDACompiler, PTXCompiler, PTX, NVPTXCompiler, NVCompiler
 from tinygrad.runtime.autogen import nv_gpu
 from tinygrad.runtime.support.elf import elf_loader
+from tinygrad.runtime.nvcuvid import NVHevcDecoder
 if getenv("IOCTL"): import extra.nv_gpu_driver.nv_ioctl # noqa: F401 # pylint: disable=unused-import
 
 def get_error_str(status): return f"{status}: {nv_gpu.nv_status_codes.get(status, 'Unknown error')}"
@@ -339,6 +340,9 @@ class NVDevice(HCQCompiled[NVSignal]):
     fd_dev = FileIOInterface(f"/dev/nvidia{NVDevice.gpus_info[self.device_id].minor_number}", os.O_RDWR | os.O_CLOEXEC)
     nv_iowr(fd_dev, nv_gpu.NV_ESC_REGISTER_FD, nv_gpu.nv_ioctl_register_fd_t(ctl_fd=self.fd_ctl.fd))
     return fd_dev
+
+  def create_hevc_decoder(self, width:int, height:int) -> NVHevcDecoder:
+    return NVHevcDecoder(width, height)
 
   def _gpu_map_to_cpu(self, memory_handle, size, target=None, flags=0, system=False):
     fd_dev = self._new_gpu_fd() if not system else FileIOInterface("/dev/nvidiactl", os.O_RDWR | os.O_CLOEXEC)


### PR DESCRIPTION
### Description

This PR introduces initial support for HEVC (H.265) video decoding through NVIDIA’s CUVID interface in the Tinygrad NV runtime.

### Changes Made

* Added a new module `nvcuvid.py` with the `NVHevcDecoder` class that sets up and initializes a CUVID decoder.
* Integrated the decoder into the NVIDIA runtime driver by exposing a `create_hevc_decoder` method in the `NVDevice` class.

### Implementation Details

* The `NVHevcDecoder` class loads `libnvcuvid` using `ctypes` and initializes the decoder via `cuvidCreateDecoder`.
* The actual decoding logic (`decode()` method) is currently unimplemented and raises `NotImplementedError`.
* Proper cleanup is handled via `cuvidDestroyDecoder` in the `close()` method.

### Testing

* `ruff` lint checks pass on both modified and new files.
* `pytest` passes for `test/test_tiny.py` with the default configuration.
