### PR TITLE
Change z3 cdiv to euclidian division

### DIFF
--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -6,7 +6,7 @@ try:
   import z3
 
   # IDIV is truncated division but z3 does euclidian division (floor if b>0 ceil otherwise); mod by power of two sometimes uses Ops.AND
-  def z3_cdiv(a, b):return z3.If(0<b, z3.If((a<0), (a+(b-1))/b, a/b), z3.If((a<0),(a-(b+1))/b, a/b))
+  def z3_cdiv(a, b):return z3.If((a<0), z3.If(0<b, (a+(b-1))/b, (a-(b+1))/b), a/b)
   z3_alu: dict[Ops, Callable] = python_alu | {Ops.MOD: lambda a,b: a-z3_cdiv(a,b)*b, Ops.IDIV: z3_cdiv, Ops.SHR: lambda a,b: a/(2**b.as_long()),
     Ops.SHL: lambda a,b: a*(2**b.as_long()), Ops.AND: lambda a,b: a%(b+1) if isinstance(b, z3.ArithRef) else a&b, Ops.WHERE: z3.If,
     Ops.MAX: lambda a,b: z3.If(a<b, b, a)}

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -5,8 +5,8 @@ from tinygrad.helpers import all_same, prod, DEBUG, ContextVar, Context
 try:
   import z3
 
-  # IDIV is truncated division but z3 does floored division; mod by power of two sometimes uses Ops.AND
-  def z3_cdiv(a,b): return z3.If(a<0, (a+(b-1))/b, a/b)
+  # IDIV is truncated division but z3 does euclidian division (floor if b>0 ceil otherwise); mod by power of two sometimes uses Ops.AND
+  def z3_cdiv(a, b):return z3.If(0<b, z3.If((a<0), (a+(b-1))/b, a/b), z3.If((a<0),(a-(b+1))/b, a/b))
   z3_alu: dict[Ops, Callable] = python_alu | {Ops.MOD: lambda a,b: a-z3_cdiv(a,b)*b, Ops.IDIV: z3_cdiv, Ops.SHR: lambda a,b: a/(2**b.as_long()),
     Ops.SHL: lambda a,b: a*(2**b.as_long()), Ops.AND: lambda a,b: a%(b+1) if isinstance(b, z3.ArithRef) else a&b, Ops.WHERE: z3.If,
     Ops.MAX: lambda a,b: z3.If(a<b, b, a)}


### PR DESCRIPTION
So the z3 divison operator is actually euclidian division, which is floored division if d is positive. I added the rule:
```
(UPat.var("x") // UPat.var("d"), lambda x,d: -(x//(-d)) if d.vmax <=0 else None),
```
So that d was always positive and I could treat z3 division as floored division for the index validation.
But now for the symbolic fuzzing bounty I need to deal with negative divisors as well.