### PR TITLE
Perform index validation on load/store, not on the index

### DIFF
--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1452,7 +1452,7 @@ class TestLinearizerFailures(unittest.TestCase):
             UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(50257, 1), strides=(0, 0), offset=0, mask=None, contiguous=False),)), src=()),)),)),)),))
     opts = [Opt(op=OptOps.GROUPTOP, axis=0, arg=29), Opt(op=OptOps.PADTO, axis=0, arg=32)]
     with Context(IGNORE_OOB=0):
-      helper_test_lin(Kernel(ast, opts=Device[Device.DEFAULT].renderer), opts=opts, failed_platforms=["METAL", "GPU", "AMD", "NV", "CUDA"])
+      helper_test_lin(Kernel(ast, opts=Device[Device.DEFAULT].renderer), opts=opts, failed_platforms=[])
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test needs local")
   def test_failure_59(self):

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1725,6 +1725,7 @@ class TestLinearizerFailures(unittest.TestCase):
 
   def test_failure_63(self):
     # BEAM=2 python3 examples/beautiful_mnist.py
+    # fails index_validation if implicit gate on store is not considered
     ast = UOp(Ops.SINK, dtypes.void, arg=None, src=(
       UOp(Ops.STORE, dtypes.void, arg=None, src=(
         UOp(Ops.VIEW, dtypes.uint.ptr(400), arg=ShapeTracker(views=(View(shape=(400, 1), strides=(1, 0), offset=0, mask=None, contiguous=True),)), src=(

--- a/test/test_linearizer_failures.py
+++ b/test/test_linearizer_failures.py
@@ -1723,5 +1723,23 @@ class TestLinearizerFailures(unittest.TestCase):
     opts = [Opt(op=OptOps.LOCAL, axis=1, arg=4), Opt(op=OptOps.LOCAL, axis=1, arg=3), Opt(op=OptOps.LOCAL, axis=0, arg=8), Opt(op=OptOps.PADTO, axis=2, arg=32), Opt(op=OptOps.UPCAST, axis=2, arg=4), Opt(op=OptOps.UPCAST, axis=2, arg=0), Opt(op=OptOps.GROUP, axis=0, arg=0)]
     helper_test_lin(Kernel(ast), opts, failed_platforms=["AMD", "HIP", "NV", "CUDA"])
 
+  def test_failure_63(self):
+    # BEAM=2 python3 examples/beautiful_mnist.py
+    ast = UOp(Ops.SINK, dtypes.void, arg=None, src=(
+      UOp(Ops.STORE, dtypes.void, arg=None, src=(
+        UOp(Ops.VIEW, dtypes.uint.ptr(400), arg=ShapeTracker(views=(View(shape=(400, 1), strides=(1, 0), offset=0, mask=None, contiguous=True),)), src=(
+          UOp(Ops.DEFINE_GLOBAL, dtypes.uint.ptr(400), arg=0, src=()),)),
+        UOp(Ops.REDUCE_AXIS, dtypes.uint, arg=(Ops.ADD, (1,)), src=(
+          UOp(Ops.WHERE, dtypes.uint, arg=None, src=(
+            UOp(Ops.VALID, dtypes.bool, arg=None, src=(
+              UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(401, 799), strides=(0, 0), offset=0, mask=((0, 401), (399, 799)), contiguous=False), View(shape=(400, 400), strides=(1, 800), offset=0, mask=None, contiguous=False))), src=()),)),
+            UOp(Ops.CONST, dtypes.uint, arg=1, src=(
+              x8:=UOp(Ops.VIEW, dtypes.void, arg=ShapeTracker(views=(View(shape=(400, 400), strides=(0, 0), offset=0, mask=None, contiguous=False),)), src=()),)),
+            UOp(Ops.CONST, dtypes.uint, arg=0, src=(
+              x8,)),)),)),)),))
+    opts = [Opt(op=OptOps.GROUP, axis=0, arg=8), Opt(op=OptOps.PADTO, axis=0, arg=32)]
+    helper_test_lin(Kernel(ast), opts, failed_platforms=[])
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -423,6 +423,16 @@ class TestUOpGraph(unittest.TestCase):
       ld0 = UOp(Ops.LOAD, dtypes.int, (glbl0.index(Variable("i", 0, 20)),))
       with self.assertRaises(RuntimeError): to_uops_list([ld0])
 
+  def test_in_out_of_bounds_access_gated_store(self):
+    with Context(IGNORE_OOB=0):
+      glbl0 = UOp(Ops.DEFINE_GLOBAL, dtypes.int.ptr(16), (), 0)
+      v = Variable("v", 0, 20)
+      st0 = UOp(Ops.STORE, dtypes.void, (glbl0.index(v), UOp.const(dtypes.int, 0), v<16))
+      to_uops_list([st0])
+
+      st1 = UOp(Ops.STORE, dtypes.void, (glbl0.index(v), v, v<20))
+      with self.assertRaises(RuntimeError): to_uops_list([st1])
+
   def test_out_of_bounds_off_by_one_access(self):
     with Context(IGNORE_OOB=0):
       glbl0 = UOp(Ops.DEFINE_GLOBAL, dtypes.int.ptr(16), (), 0)

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -116,7 +116,7 @@ def validate_index(idx:UOp, cond:UOp=UOp.const(dtypes.bool, True)):
   solver.add(z3_sink.src[1].arg)
   if solver.check((z3_idx<0)|(sz<=z3_idx)) == z3.sat:
     print(f"idx={idx.src[1].render(simplify=False)}")
-    print(f"mask & if-cond={mask.render(simplify=False)}")
+    print(f"mask & cond={mask.render(simplify=False)}")
     print(f"# OUT OF BOUNDS ACCESS: at {solver.model()} INDEX not in 0 - {sz}\nconstraints = {solver}")
     return False
   return True
@@ -165,7 +165,7 @@ spec = PatternMatcher([
   # STORE takes a <bufidx, val, gate?>
   (UPat(Ops.STORE, dtype=dtypes.void, src=(index_pat, UPat())), validate_index),
   (UPat(Ops.STORE, dtype=dtypes.void, src=(index_pat, UPat(), UPat(dtype=dtypes.bool, name="cond"))), validate_index),
-  (UPat(Ops.STORE, dtype=dtypes.void, src=(index_pat, UPat(), UPat(Ops.IF))), lambda idx,cond: validate_index(idx,cond.src[0])),
+  (UPat(Ops.STORE, dtype=dtypes.void, src=(index_pat, UPat(), UPat(Ops.IF, name="cond"))), lambda idx,cond: validate_index(idx,cond.src[0])),
 
   # most ALUs have all matching dtypes, except CMPLT, CMPNE, and WHERE
   (UPat(Ops.WHERE, name="w", src=(UPat(dtype=dtypes.bool), UPat.var("x"), UPat.var("y"))), lambda w,x,y: w.dtype == x.dtype == y.dtype),

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -100,11 +100,11 @@ tensor_uop_spec = buffer_spec+assign_spec+PatternMatcher([
 
 # ***** uop type spec *****
 
-def validate_index(idx:UOp, cond:UOp=UOp.const(dtypes.bool, True)):
+def validate_index(idx:UOp, gate:UOp=UOp.const(dtypes.bool, True)):
   if IGNORE_OOB or isinstance(idx.dtype, ImageDType) or (sz := cast(PtrDType, idx.src[0].dtype).size) == -1: return True
   # We can use UOp min/max to do a faster check, but it can give false positive since its not an exact bound and doesn't consider the mask
   if 0<=idx.src[1].vmin and idx.src[1].vmax<sz: return True
-  mask = idx.src[2]&cond if len(idx.src)==3 else cond
+  mask = idx.src[2]&gate if len(idx.src)==3 else gate
 
   # WEBGPU has a BITCAST in the index. TODO: fix
   if any(x.op is Ops.BITCAST for x in idx.toposort()): return True
@@ -116,7 +116,7 @@ def validate_index(idx:UOp, cond:UOp=UOp.const(dtypes.bool, True)):
   solver.add(z3_sink.src[1].arg)
   if solver.check((z3_idx<0)|(sz<=z3_idx)) == z3.sat:
     print(f"idx={idx.src[1].render(simplify=False)}")
-    print(f"mask & cond={mask.render(simplify=False)}")
+    print(f"mask & gate={mask.render(simplify=False)}")
     print(f"# OUT OF BOUNDS ACCESS: at {solver.model()} INDEX not in 0 - {sz}\nconstraints = {solver}")
     return False
   return True


### PR DESCRIPTION
@geohot this is what was causing OOB failures in beautiful_mnist. Problem was that the gates of the load/stores were not being considered in index validation.

