### PR TITLE
Generalize type hint for get_single_element [pr]

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -63,8 +63,8 @@ def partition(itr:Iterable[T], fxn:Callable[[T],bool]) -> tuple[list[T], list[T]
 def unwrap(x:Optional[T]) -> T:
   assert x is not None
   return x
-def get_single_element(x:list[T]) -> T:
-  assert len(x) == 1, f"list {x} must only have 1 element"
+def get_single_element(x:Sequence[T]) -> T:
+  assert len(x) == 1, f"sequence {x} must only have 1 element"
   return x[0]
 def get_child(obj, key):
   for k in key.split('.'):


### PR DESCRIPTION
I’m working on issue #7889 and need to ensure the unit tests run with TYPED=1. To simplify the review process, I’m splitting the necessary changes into several PRs. See also #10848, #10859 and #10864.

`get_single_element` is often called with a `tuple[T]`. I've relaxed the type hint to `Sequence[T]` such that `typeguard` does not throw an error.