### PR TITLE
Cast ptr to int in test_from_mv_to_mv

### DIFF
--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -1,4 +1,4 @@
-import gzip, unittest
+import ctypes, gzip, unittest
 from tinygrad import Variable
 from tinygrad.helpers import Context, ContextVar, argfix
 from tinygrad.helpers import merge_dicts, strip_parens, prod, round_up, fetch, fully_flatten, from_mv, to_mv, polyN, time_to_str, cdiv, cmod, getbits
@@ -182,7 +182,7 @@ class TestMemoryview(unittest.TestCase):
   def test_from_mv_to_mv(self):
     base = memoryview(bytearray(b"\x11\x22\x33"*40))
     ct = from_mv(base)
-    mv = to_mv(ct, len(base))
+    mv = to_mv(ctypes.addressof(ct), len(base))
     mv[0] = 2
     assert base[0] == 2
 

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -291,7 +291,7 @@ def capstone_flatdump(lib: bytes):
 # *** ctypes helpers
 
 # TODO: make this work with read only memoryviews (if possible)
-def from_mv(mv:memoryview, to_type=ctypes.c_char):
+def from_mv(mv:memoryview, to_type:type[ctypes._SimpleCData]=ctypes.c_char) -> ctypes.Array:
   return ctypes.cast(ctypes.addressof(to_type.from_buffer(mv)), ctypes.POINTER(to_type * len(mv))).contents
 def to_mv(ptr:int, sz:int) -> memoryview: return memoryview(ctypes.cast(ptr, ctypes.POINTER(ctypes.c_uint8 * sz)).contents).cast("B")
 def mv_address(mv): return ctypes.addressof(ctypes.c_char.from_buffer(mv))


### PR DESCRIPTION
I’m working on issue #7889 and need to ensure the unit tests run with TYPED=1. To simplify the review process, I’m splitting the necessary changes into several PRs. See also #10848, #10859, #10864 and #10866.

`to_mv` expects `ct` to be of type `int`. If you don’t cast it, `ct` is a `ctypes.Array` and causes a Typeguard error.