### PR TITLE
Change type hint for init_c_struct_t and to_struct [pr]

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -298,7 +298,7 @@ def mv_address(mv): return ctypes.addressof(ctypes.c_char.from_buffer(mv))
 def to_char_p_p(options: list[bytes], to_type=ctypes.c_char):
   return (ctypes.POINTER(to_type) * len(options))(*[ctypes.cast(ctypes.create_string_buffer(o), ctypes.POINTER(to_type)) for o in options])
 @functools.cache
-def init_c_struct_t(fields: tuple[tuple[str, ctypes._SimpleCData], ...]):
+def init_c_struct_t(fields: tuple[tuple[str, type[ctypes._SimpleCData]], ...]):
   class CStruct(ctypes.Structure):
     _pack_, _fields_ = 1, fields
   return CStruct

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -47,7 +47,8 @@ def msg(selector: str, restype: type[T] = objc_id):  # type: ignore [assignment]
 def to_ns_str(s: str): return msg("stringWithUTF8String:", objc_instance)(libobjc.objc_getClass(b"NSString"), s.encode())
 def from_ns_str(s): return bytes(msg("UTF8String", ctypes.c_char_p)(s)).decode()
 
-def to_struct(*t: int, _type: type = ctypes.c_ulong): return init_c_struct_t(tuple([(f"field{i}", _type) for i in range(len(t))]))(*t)
+def to_struct(*t: int, _type: type[ctypes._SimpleCData] = ctypes.c_ulong):
+  return init_c_struct_t(tuple([(f"field{i}", _type) for i in range(len(t))]))(*t)
 
 def wait_check(cbuf: Any):
   msg("waitUntilCompleted")(cbuf)


### PR DESCRIPTION
I’m working on issue #7889 and need to ensure the unit tests run with TYPED=1. To simplify the review process, I’m splitting the necessary changes into several PRs. See also #10848, #10859, #10864, #10866 and #10876.

Right now, `init_c_struct_t` gets called eight times, and we always pass it a type, never an instance. To stop Typeguard from throwing errors at runtime, I updated its type hint. I've modified the type hint in `to_struct` accordingly.
