### PR TITLE
fix test logcumsumexp broken devectorize=0

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -3,7 +3,7 @@ import numpy as np
 from typing import List, Callable
 import torch
 import warnings
-from tinygrad.helpers import getenv, IMAGE, DEBUG, CI, Context, TRANSCENDENTAL, DEVECTORIZE, OSX
+from tinygrad.helpers import getenv, IMAGE, DEBUG, CI, Context, TRANSCENDENTAL, OSX
 from tinygrad import Tensor, Device, dtypes
 from tinygrad.tensor import _to_np_dtype
 from tinygrad.device import is_dtype_supported

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1546,7 +1546,6 @@ class TestOps(unittest.TestCase):
     helper_test_op([()], lambda x: torch.logcumsumexp(x, dim=0), lambda x: x.logcumsumexp(), atol=1e-7, grad_atol=1e-7)
     helper_test_op([()], lambda x: torch.logcumsumexp(x, dim=-1), lambda x: x.logcumsumexp(-1), atol=1e-7, grad_atol=1e-7)
 
-  @unittest.skipIf(not DEVECTORIZE, "broken without DEVECTORIZE. TODO: fix this")
   def test_logcumsumexp_numerical(self):
     helper_test_op(None, lambda x: torch.logcumsumexp(x, dim=0), lambda x: x.logcumsumexp(), atol=1e-7, grad_atol=1e-7, vals=[[0.0, 100.0]])
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2073,7 +2073,7 @@ class Tensor(MathTrait):
     m = self.max(axis=axis, keepdim=True)
     return (self - m).exp().sum(axis=axis, keepdim=keepdim).log() + m.squeeze(axis)
 
-  def logcumsumexp(self, axis=0, mask_val:float=-1e4) -> Tensor:
+  def logcumsumexp(self, axis=0) -> Tensor:
     """
     Computes the log-cumsum-exp of the tensor along the specified axis or axes.
 
@@ -2105,7 +2105,7 @@ class Tensor(MathTrait):
     x_cummax = x_reshaped.cummax(-1).unsqueeze(-1)
     x_expand = x_reshaped.unsqueeze(1).expand(*x_reshaped.shape, last_dim_size)
     mask = Tensor.ones(last_dim_size, last_dim_size, requires_grad=False, device=self.device).tril().unsqueeze(0)
-    ret = mask.where(x_expand - x_cummax, mask_val).exp().sum(-1).log() + x_cummax.squeeze(-1)
+    ret = mask.where(x_expand - x_cummax, dtypes.min(self.dtype)).exp().sum(-1).log() + x_cummax.squeeze(-1)
     return ret.reshape(*x.shape).transpose(-1, axis)
 
   def argmax(self, axis=None, keepdim=False) -> Tensor:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2073,7 +2073,7 @@ class Tensor(MathTrait):
     m = self.max(axis=axis, keepdim=True)
     return (self - m).exp().sum(axis=axis, keepdim=keepdim).log() + m.squeeze(axis)
 
-  def logcumsumexp(self, axis=0) -> Tensor:
+  def logcumsumexp(self, axis=0, mask_val:float=-1e4) -> Tensor:
     """
     Computes the log-cumsum-exp of the tensor along the specified axis or axes.
 
@@ -2105,7 +2105,7 @@ class Tensor(MathTrait):
     x_cummax = x_reshaped.cummax(-1).unsqueeze(-1)
     x_expand = x_reshaped.unsqueeze(1).expand(*x_reshaped.shape, last_dim_size)
     mask = Tensor.ones(last_dim_size, last_dim_size, requires_grad=False, device=self.device).tril().unsqueeze(0)
-    ret = ((x_expand - x_cummax).exp() * mask).sum(-1).log() + x_cummax.squeeze(-1)
+    ret = mask.where(x_expand - x_cummax, mask_val).exp().sum(-1).log() + x_cummax.squeeze(-1)
     return ret.reshape(*x.shape).transpose(-1, axis)
 
   def argmax(self, axis=None, keepdim=False) -> Tensor:


### PR DESCRIPTION
my attempt to fix the broken devectorize=0 which failed because of nan values. I propose a fix by applying the mask before the exponential rather than after, with mask value 1e4. 