### PR TITLE
Pass list to block_reorder in test_loads

### DIFF
--- a/test/unit/test_block_reorder.py
+++ b/test/unit/test_block_reorder.py
@@ -54,7 +54,7 @@ class TestBlockReorder(unittest.TestCase):
     sink = c.store(sum(loads)).sink()
 
     # determine golden order
-    golden = block_reorder(sink.toposort())
+    golden = block_reorder(list(sink.toposort()))
 
     # render for test
     print(self._test_render(golden))


### PR DESCRIPTION
I’m working on issue #7889 and need to ensure the unit tests run with TYPED=1. To simplify the review process, I’m splitting the necessary changes into several PRs. See also #10848, #10859, #10864, #10866, #10876 and #10878.

`block_reorder` expects a `list`. The return value of `toposort` is `dict[UOp, None]`. I am casting the value to avoid Typeguard errors.