### PR TITLE
GROUP/GROUPTOP support with TC

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -2027,7 +2027,13 @@ class TestKernelOpts(unittest.TestCase):
         [Opt(OptOps.UNROLL, 0, 2), Opt(OptOps.UPCAST, 0, 4)],
         [Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.UNROLL, 0, 2), Opt(OptOps.UPCAST, 1, 4)],
         [Opt(OptOps.UNROLL, 0, 2), Opt(OptOps.UPCAST, 1, 4), Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.UNROLL, 0, 4)],
-        # [Opt(OptOps.GROUP, 0, 2)] # doesn't work because group_for_reduce dims become early locals (conflicting with TC)
+        [Opt(OptOps.GROUP, 0, 2)],
+        [Opt(OptOps.GROUPTOP, 0, 4)],
+        [Opt(OptOps.UPCAST, 0, 4), Opt(OptOps.GROUP, 0, 2)],
+        [Opt(OptOps.LOCAL, 0, 4), Opt(OptOps.GROUP, 0, 2)],
+        [Opt(OptOps.UNROLL, 0, 4), Opt(OptOps.GROUP, 0, 2)],
+        [Opt(OptOps.UPCAST, 0, 2), Opt(OptOps.LOCAL, 0, 2), Opt(OptOps.GROUP, 0, 2)],
+        [Opt(OptOps.LOCAL, 0, 2), Opt(OptOps.GROUPTOP, 0, 8), Opt(OptOps.UNROLL, 0, 2), Opt(OptOps.UPCAST, 1, 2)],
       ], apply_tc=True, atol=atol, rtol=rtol)
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.tensor_cores, "test requires tensor cores")

--- a/tinygrad/opt/kernel.py
+++ b/tinygrad/opt/kernel.py
@@ -380,7 +380,7 @@ class Kernel:
     elif opt.op in {OptOps.GROUP, OptOps.GROUPTOP}:   # green
       check(self.opts.has_local and self.opts.has_shared, "target does not support local or shared mem")
       check(self.first_reduce + self.group_for_reduces <= axis < self.first_upcast, "must be reduce axis to group")
-      check(not self.tensor_core, "can't group with tensor cores")
+      check(self.use_tensor_cores != 3, "can't group with tensor cores emulation")
       check(len(reduce_axes:=[i for r in self.reduceops for i in r.axis_arg]) == len(set(reduce_axes)), "can't group with parallel reduces")
       self.shift_to(axis, amt, top=(opt.op is OptOps.GROUPTOP), insert_before=self.first_reduce + self.group_for_reduces)
       self.group_for_reduces += 1
@@ -507,9 +507,11 @@ class Kernel:
           else: # for TC=3 MUL/SUM instead of WMMA
             tc_uop = UOp(Ops.REDUCE_AXIS, tc.dtype_out, ((srcs[0] * srcs[1]).cast(tc.dtype_out),), (Ops.ADD, tc_reduce_axes))
 
-          return ret.replace(src=(tc_uop,), arg=(Ops.ADD, new_axes)) if (new_axes := tuple(i for i in axes if i not in tc_reduce_axes)) else tc_uop
+          ret = ret.replace(src=(tc_uop,), arg=(Ops.ADD, new_axes)) if (new_axes := tuple(i for i in axes if i not in tc_reduce_axes)) else tc_uop
 
-        ret = ret.replace(arg = (op.arg[0], axes))
+        else:
+          ret = ret.replace(arg = (op.arg[0], axes))
+
         if self.group_for_reduces and grouped_axes:
           local_shape = (1,) * self.global_dims + self.full_shape[self.global_dims:self.global_dims+self.local_dims] + \
             tuple([self.full_shape[i] if self.sts[reduce_idx].shape[i] != self.sts[reduce_idx+1].shape[i] else 1 \


### PR DESCRIPTION
I questioned why this didn't worked as current tensor cores are computationally equivalent to a sequence of defined optimizations (locals, upcasts and unrolls) and GROUP already worked with any combination of those. I tested and GROUP indeed worked out of the box TC=2 so there was no particular reason (apart from maybe hidden implementation quirks) real tensor cores wouldn't work. I was surprised that only a really minor adjustment was needed to make it work for real tensor cores! 

I still check for no emulated tensor cores (TC=3) as there is check in `lowerer -> lower_load_store` that decides whether to use idxs or ridxs. This check currently breaks the indexing for the local buffers of the emulated tensor core. I think with a minor refactor this could be fixed, but decided to leave it for a subsequent pr.

I need to investigate the failing test in METAL CI job. As I can't replicate the error in my local machine I am inclined to believe this might be again a compiler error of some sense.

### BEAM generated kernel
``` python
UOp(Ops.SINK, dtypes.void, arg=None, src=(
  UOp(Ops.STORE, dtypes.void, arg=None, src=(
    UOp(Ops.VIEW, dtypes.float.ptr(16777216), arg=ShapeTracker(views=(View(shape=(4096, 4096, 1), strides=(4096, 1, 0), offset=0, mask=None, contiguous=True),)), src=(
      UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(16777216), arg=0, src=()),)),
    UOp(Ops.REDUCE_AXIS, dtypes.float, arg=(Ops.ADD, (2,)), src=(
      UOp(Ops.MUL, dtypes.float, arg=None, src=(
        UOp(Ops.LOAD, dtypes.float, arg=None, src=(
          UOp(Ops.VIEW, dtypes.float.ptr(16777216), arg=ShapeTracker(views=(View(shape=(4096, 4096, 4096), strides=(4096, 0, 1), offset=0, mask=None, contiguous=False),)), src=(
            UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(16777216), arg=1, src=()),)),)),
        UOp(Ops.LOAD, dtypes.float, arg=None, src=(
          UOp(Ops.VIEW, dtypes.float.ptr(16777216), arg=ShapeTracker(views=(View(shape=(4096, 4096, 4096), strides=(0, 1, 4096), offset=0, mask=None, contiguous=False),)), src=(
            UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(16777216), arg=2, src=()),)),)),)),)),)),))

   0.00s:                from   1 ->   1 actions 4096 4096 4096
   1.93s:        85.14ms from  24 ->  23 actions  512  512    2    2    2    2    2  512    2    2    2    2
  19.26s:        57.76ms from  94 ->  94 actions  256  512    2    2    2    2    2  512    2    2    2    2    2
  34.83s:        50.81ms from  57 ->  56 actions  512  256    2    2    2    2    2    2   16   32    2    2    2    2
  41.72s:        31.54ms from  42 ->  40 actions  128  256    2    2    2    2    2    2   16   32    2    2    2    2    4
  42.82s:        25.85ms from  10 ->  10 actions  128  128    2    2    2    2    2    2    8   64    2    2    2    2    4    2
  43.30s:        25.77ms from   4 ->   4 actions  128  128    2    2    2    2    2    2    8   64    2    2    2    2    4    2
  43.35s:        25.77ms from   4 ->   0 actions  128  128    2    2    2    2    2    2    8   64    2    2    2    2    4    2

[Opt(op=OptOps.TC, axis=0, arg=(0, 2, 1)), Opt(op=OptOps.LOCAL, axis=1, arg=2), Opt(op=OptOps.GROUP, axis=0, arg=8), Opt(op=OptOps.UPCAST, axis=0, arg=4), Opt(op=OptOps.UPCAST, axis=1, arg=2), Opt(op=OptOps.SWAP, axis=0, arg=1)]

*** METAL      3 r_128_128_2_2_2_2_2_2_8_64_2_2_2_2_4_2    arg  3 mem  0.20 GB tm     32.05ms/    40.45ms (  4321.83 GFLOPS    6.3|971.6   GB/s) ['matmul']
*** METAL      4 r_128_128_2_2_2_2_2_2_8_64_2_2_2_2_4_2    arg  3 mem  0.27 GB tm     27.44ms/    67.89ms (  5048.28 GFLOPS    7.3|1134.9  GB/s) ['matmul']
*** METAL      5 r_128_128_2_2_2_2_2_2_8_64_2_2_2_2_4_2    arg  3 mem  0.27 GB tm     27.32ms/    95.21ms (  5070.91 GFLOPS    7.4|1140.0  GB/s) ['matmul']
*** METAL      6 r_128_128_2_2_2_2_2_2_8_64_2_2_2_2_4_2    arg  3 mem  0.27 GB tm     27.17ms/   122.38ms (  5098.00 GFLOPS    7.4|1146.1  GB/s) ['matmul']
*** METAL      7 r_128_128_2_2_2_2_2_2_8_64_2_2_2_2_4_2    arg  3 mem  0.27 GB tm     27.19ms/   149.57ms (  5093.51 GFLOPS    7.4|1145.1  GB/s) ['matmul']
*** METAL      8 r_128_128_2_2_2_2_2_2_8_64_2_2_2_2_4_2    arg  3 mem  0.27 GB tm     27.40ms/   176.97ms (  5054.56 GFLOPS    7.3|1136.3  GB/s) ['matmul']
*** METAL      9 r_128_128_2_2_2_2_2_2_8_64_2_2_2_2_4_2    arg  3 mem  0.27 GB tm     27.38ms/   204.35ms (  5059.49 GFLOPS    7.4|1137.4  GB/s) ['matmul']
*** METAL     10 r_128_128_2_2_2_2_2_2_8_64_2_2_2_2_4_2    arg  3 mem  0.27 GB tm     27.89ms/   232.24ms (  4966.01 GFLOPS    7.2|1116.4  GB/s) ['matmul']
*** METAL     11 r_128_128_2_2_2_2_2_2_8_64_2_2_2_2_4_2    arg  3 mem  0.27 GB tm     27.22ms/   259.47ms (  5088.31 GFLOPS    7.4|1143.9  GB/s) ['matmul']
*** METAL     12 r_128_128_2_2_2_2_2_2_8_64_2_2_2_2_4_2    arg  3 mem  0.27 GB tm     29.04ms/   288.50ms (  4770.44 GFLOPS    6.9|1072.4  GB/s) ['matmul']
```
```c
#include <metal_stdlib>
using namespace metal;
float2 __WMMA_8_8_8_float_float(float2 a, float2 b, float2 c){
  simdgroup_float8x8 mat_a, mat_b; simdgroup_float8x8 mat_c;
  mat_a.thread_elements()[0] = a[0]; mat_b.thread_elements()[0] = b[0]; mat_c.thread_elements()[0] = c[0];
  mat_a.thread_elements()[1] = a[1]; mat_b.thread_elements()[1] = b[1]; mat_c.thread_elements()[1] = c[1];
  simdgroup_multiply_accumulate(mat_c, mat_a, mat_b, mat_c);
  return float2(mat_c.thread_elements()[0], mat_c.thread_elements()[1]);
}
kernel void r_128_128_2_2_2_2_2_2_8_64_2_2_2_2_4_2(device float* data0, device float* data1, device float* data2, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  threadgroup __attribute__((aligned(16))) float temp0[8192];
  int gidx0 = gid.x; /* 128 */
  int gidx1 = gid.y; /* 128 */
  int lidx0 = lid.x; /* 32 */
  int lidx1 = lid.y; /* 2 */
  int lidx2 = lid.z; /* 8 */
  int alu0 = (lidx0>>4);
  int alu1 = ((lidx0>>3)&1);
  int alu2 = ((lidx0>>2)&1);
  int alu3 = ((lidx0>>1)&1);
  int alu4 = (lidx0&1);
  int alu5 = (lidx1<<3);
  int alu6 = (alu0<<14);
  int alu7 = (alu1<<2);
  int alu8 = (alu2<<13);
  int alu9 = (alu3<<12);
  int alu10 = (alu4<<1);
  int alu11 = (gidx1<<5);
  int alu12 = (gidx0<<17);
  int alu13 = ((alu4<<12)+(alu3<<11)+(alu2<<10)+(alu1<<9)+(alu0<<8)+(lidx1<<7));
  int alu14 = (alu12+alu11+alu10+alu9+alu8+alu7+alu6+alu5);
  float acc0 = 0.0f;
  float acc1 = 0.0f;
  float acc2 = 0.0f;
  float acc3 = 0.0f;
  float acc4 = 0.0f;
  float acc5 = 0.0f;
  float acc6 = 0.0f;
  float acc7 = 0.0f;
  float acc8 = 0.0f;
  float acc9 = 0.0f;
  float acc10 = 0.0f;
  float acc11 = 0.0f;
  float acc12 = 0.0f;
  float acc13 = 0.0f;
  float acc14 = 0.0f;
  float acc15 = 0.0f;
  for (int ridx9 = 0; ridx9 < 64; ridx9++) {
    int alu15 = (alu12+alu10+alu9+alu8+alu7+alu6+(lidx2<<3)+(ridx9<<6));
    float2 val0 = *((device float2*)((data1+alu15)));
    float2 val1 = *((device float2*)((data1+(alu15+32768))));
    float2 val2 = *((device float2*)((data1+(alu15+65536))));
    float2 val3 = *((device float2*)((data1+(alu15+98304))));
    int alu16 = (alu11+alu10+alu9+alu8+alu7+alu6+alu5+(lidx2<<15)+(ridx9<<18));
    float2 val4 = *((device float2*)((data2+alu16)));
    float2 val5 = *((device float2*)((data2+(alu16+16))));
    float2 wmma0 = __WMMA_8_8_8_float_float(val1, val5, float2(acc6,acc7));
    float2 wmma1 = __WMMA_8_8_8_float_float(val1, val4, float2(acc4,acc5));
    float2 wmma2 = __WMMA_8_8_8_float_float(val2, val5, float2(acc10,acc11));
    float2 wmma3 = __WMMA_8_8_8_float_float(val2, val4, float2(acc8,acc9));
    float2 wmma4 = __WMMA_8_8_8_float_float(val3, val5, float2(acc14,acc15));
    float2 wmma5 = __WMMA_8_8_8_float_float(val3, val4, float2(acc12,acc13));
    float2 wmma6 = __WMMA_8_8_8_float_float(val0, val5, float2(acc2,acc3));
    float2 wmma7 = __WMMA_8_8_8_float_float(val0, val4, float2(acc0,acc1));
    acc0 = wmma7.x;
    acc1 = wmma7.y;
    acc2 = wmma6.x;
    acc3 = wmma6.y;
    acc4 = wmma1.x;
    acc5 = wmma1.y;
    acc6 = wmma0.x;
    acc7 = wmma0.y;
    acc8 = wmma3.x;
    acc9 = wmma3.y;
    acc10 = wmma2.x;
    acc11 = wmma2.y;
    acc12 = wmma5.x;
    acc13 = wmma5.y;
    acc14 = wmma4.x;
    acc15 = wmma4.y;
  }
  int alu34 = (alu13+(lidx2<<4));
  *((threadgroup __attribute__((aligned(16))) float4*)((temp0+alu34))) = float4(acc0,acc2,acc4,acc6);
  *((threadgroup __attribute__((aligned(16))) float4*)((temp0+(alu34+4)))) = float4(acc8,acc10,acc12,acc14);
  *((threadgroup __attribute__((aligned(16))) float4*)((temp0+(alu34+8)))) = float4(acc1,acc3,acc5,acc7);
  *((threadgroup __attribute__((aligned(16))) float4*)((temp0+(alu34+12)))) = float4(acc9,acc11,acc13,acc15);
  threadgroup_barrier(mem_flags::mem_threadgroup);
  if ((((bool)(lidx2))!=1)) {
    float acc16 = 0.0f;
    float acc17 = 0.0f;
    float acc18 = 0.0f;
    float acc19 = 0.0f;
    float acc20 = 0.0f;
    float acc21 = 0.0f;
    float acc22 = 0.0f;
    float acc23 = 0.0f;
    float acc24 = 0.0f;
    float acc25 = 0.0f;
    float acc26 = 0.0f;
    float acc27 = 0.0f;
    float acc28 = 0.0f;
    float acc29 = 0.0f;
    float acc30 = 0.0f;
    float acc31 = 0.0f;
    for (int ridx1008 = 0; ridx1008 < 8; ridx1008++) {
      int alu41 = (alu13+(ridx1008<<4));
      float4 val6 = *((threadgroup __attribute__((aligned(16))) float4*)((temp0+(alu41+4))));
      float4 val7 = *((threadgroup __attribute__((aligned(16))) float4*)((temp0+(alu41+8))));
      float4 val8 = *((threadgroup __attribute__((aligned(16))) float4*)((temp0+(alu41+12))));
      float4 val9 = *((threadgroup __attribute__((aligned(16))) float4*)((temp0+alu41)));
      acc16 = (acc16+val9.x);
      acc17 = (acc17+val9.y);
      acc18 = (acc18+val9.z);
      acc19 = (acc19+val9.w);
      acc20 = (acc20+val6.x);
      acc21 = (acc21+val6.y);
      acc22 = (acc22+val6.z);
      acc23 = (acc23+val6.w);
      acc24 = (acc24+val7.x);
      acc25 = (acc25+val7.y);
      acc26 = (acc26+val7.z);
      acc27 = (acc27+val7.w);
      acc28 = (acc28+val8.x);
      acc29 = (acc29+val8.y);
      acc30 = (acc30+val8.z);
      acc31 = (acc31+val8.w);
    }
    *((device float2*)((data0+(alu14+16)))) = float2(acc17,acc25);
    *((device float2*)((data0+(alu14+32768)))) = float2(acc18,acc26);
    *((device float2*)((data0+(alu14+32784)))) = float2(acc19,acc27);
    *((device float2*)((data0+(alu14+65536)))) = float2(acc20,acc28);
    *((device float2*)((data0+(alu14+65552)))) = float2(acc21,acc29);
    *((device float2*)((data0+(alu14+98304)))) = float2(acc22,acc30);
    *((device float2*)((data0+(alu14+98320)))) = float2(acc23,acc31);
    *((device float2*)((data0+alu14))) = float2(acc16,acc24);
  }
}
```