### PR TITLE
viz: color by kernel names in profiler

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -298,7 +298,7 @@ async function renderProfiler() {
   }
   // draw events on a timeline
   const dpr = window.devicePixelRatio || 1;
-  const ellipseWidth = ctx.measureText("...").width;
+  const ellipsisWidth = ctx.measureText("...").width;
   const rectLst = [];
   function render(transform=null) {
     if (transform != null) zoomLevel = transform;
@@ -342,7 +342,7 @@ async function renderProfiler() {
       let [labelX, labelWidth] = [x+2, 0];
       const labelY = e.y+e.height/2;
       for (const [i,l] of e.labelParts.entries()) {
-        if (labelWidth+l.width+(i===e.labelParts.length-1 ? 0 : ellipseWidth) > width) {
+        if (labelWidth+l.width+(i===e.labelParts.length-1 ? 0 : ellipsisWidth)+2 > width) {
           if (labelWidth !== 0) ctx.fillText("...", labelX, labelY);
           break;
         }

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -217,6 +217,10 @@ function renderMemoryGraph(graph) {
   document.getElementById("zoom-to-fit-btn").click();
 }
 
+const ANSI_COLORS = ["#b3b3b3", "#ff6666", "#66b366", "#ffff66", "#6666ff", "#ff66ff", "#66ffff", "#ffffff"];
+const parseColors = (name) => [...name.matchAll(/(?:\u001b\[(\d+)m([\s\S]*?)\u001b\[0m)|([^\u001b]+)/g)].map(([_, code, colored_st, st]) =>
+  ({ st: colored_st ?? st, color: code != null ? ANSI_COLORS[(parseInt(code)-30+60)%60] : "#ffffff" }));
+
 // ** profiler graph
 
 function formatTime(ts, dur) {
@@ -225,13 +229,7 @@ function formatTime(ts, dur) {
   return `${(ts*1e-6).toFixed(2)}s`;
 }
 
-const colors = [
-  "#b6ccfe", "#74c69d", "#f1c0e8", "#90dbf4", "#5ca98c",
-  "#adc3f5", "#fde4cf", "#8eecf5", "#85c9a7", "#cfbaf0",
-  "#9eb8f0", "#52b788", "#ffcfd2", "#98f5e1", "#4c8d6e",
-  "#b6ceea", "#e7e2b6", "#96e5a5", "#3a5f4a", "#d8f3dc",
-  "#c3d2ee", "#3d6c5b", "#cfdaf0", "#c1d3fe"
-];
+const colors = ["#1D1F2A", "#2A2D3D", "#373B4F", "#444862", "#12131A", "#2F3244", "#3B3F54", "#4A4E65", "#181A23", "#232532", "#313548", "#404459"];
 
 var data, canvasZoom, zoomLevel = d3.zoomIdentity;
 async function renderProfiler() {
@@ -290,8 +288,8 @@ async function renderProfiler() {
       const height = baseHeight-padding;
       const y = (baseY-canvasTop+padding/2)+height*depth;
       if (!nameMap.has(e.name)) {
-        const color = colors[i%colors.length];
-        nameMap.set(e.name, { color, labelWidth:ctx.measureText(e.name).width });
+        const labelParts = parseColors(kernelMap.get(e.name)?.name ?? e.name).map(({ color, st }) => ({ color, st, width:ctx.measureText(st).width }));
+        nameMap.set(e.name, { bgColor:colors[i%colors.length], labelParts });
       }
       data.push({ x:start, dur:e.dur, name:e.name, height, y, ...nameMap.get(e.name) });
     }
@@ -300,6 +298,7 @@ async function renderProfiler() {
   }
   // draw events on a timeline
   const dpr = window.devicePixelRatio || 1;
+  const ellipseWidth = ctx.measureText("...").width;
   const rectLst = [];
   function render(transform=null) {
     if (transform != null) zoomLevel = transform;
@@ -334,14 +333,23 @@ async function renderProfiler() {
       // zoom only changes x and width
       const x = scale(e.x);
       const width = scale(e.x+e.dur)-x;
-      ctx.fillStyle = e.color;
+      ctx.fillStyle = e.bgColor;
       ctx.fillRect(x, e.y, width, e.height);
       rectLst.push({ y0:e.y, y1:e.y+e.height, x0:x, x1:x+width, name:e.name })
-      if (width > e.labelWidth) {
-        ctx.fillStyle = "black";
-        ctx.textAlign = "left";
-        ctx.textBaseline = "middle";
-        ctx.fillText(e.name, x+2, e.y+e.height/2);
+      // add labels
+      ctx.textAlign = "left";
+      ctx.textBaseline = "middle";
+      let [labelX, labelWidth] = [x+2, 0];
+      const labelY = e.y+e.height/2;
+      for (const [i,l] of e.labelParts.entries()) {
+        if (labelWidth+l.width+(i===e.labelParts.length-1 ? 0 : ellipseWidth) > width) {
+          if (labelWidth !== 0) ctx.fillText("...", labelX, labelY);
+          break;
+        }
+        ctx.fillStyle = l.color;
+        ctx.fillText(l.st, labelX, labelY);
+        labelWidth += l.width;
+        labelX += l.width;
       }
     }
     ctx.restore();
@@ -492,10 +500,7 @@ async function main() {
       const ul = ctxList.appendChild(document.createElement("ul"));
       ul.id = `ctx-${i}`;
       const p = ul.appendChild(document.createElement("p"));
-      p.innerHTML = name.replace(/\u001b\[(\d+)m(.*?)\u001b\[0m/g, (_, code, st) => {
-        const colors = ['gray','red','green','yellow','blue','magenta','cyan','white'];
-        return `<span style="${`color: color-mix(in srgb, ${colors[(parseInt(code)-30+60)%60]} 60%, white)`}">${st}</span>`;
-      });
+      p.innerHTML = parseColors(name).map(c => `<span style="color: ${c.color}">${c.st}</span>`).join("");
       p.onclick = () => {
         setState(i === state.currentCtx ? { expandSteps:!state.expandSteps } : { expandSteps:true, currentCtx:i, currentStep:0, currentRewrite:0 });
       }


### PR DESCRIPTION
I think this makes the UI more consistent:
![image](https://github.com/user-attachments/assets/3a9a37a6-f7c5-4f3e-b228-88ea33554a8e)
Same kernels on different GPUs have the same tint, but emphasis is on shape colors.