### PR TITLE
Fix/hcqfuzz harnesss bug

### DIFF
--- a/extra/hcqfuzz/readme
+++ b/extra/hcqfuzz/readme
@@ -4,9 +4,9 @@ To add a new test, define a `TestSpec`-based class in a file in the `tests/` fol
 
 You can choose which tests to load from which file:
 ```bash
-RUN_FILES="hcq,allocator" python3 extra/hcqfuzz/fuzzer.py
+PYTHONPATH=. RUN_FILES="hcq,allocator" python3 extra/hcqfuzz/fuzzer.py
 ```
 Or skip tests from any file:
 ```bash
-SKIP_FILES="allocator" python3 extra/hcqfuzz/fuzzer.py
+PYTHONPATH=. SKIP_FILES="allocator" python3 extra/hcqfuzz/fuzzer.py
 ```

--- a/test/external/external_fuzz_ampt.py
+++ b/test/external/external_fuzz_ampt.py
@@ -1,4 +1,5 @@
 import random
+from typing import Optional
 from tinygrad.helpers import round_up
 from tinygrad.runtime.support.am.amdev import AMPageTableTraverseContext
 from test.external.external_test_am import helper_read_entry_components, FakeAM

--- a/test/external/external_fuzz_ampt.py
+++ b/test/external/external_fuzz_ampt.py
@@ -59,7 +59,7 @@ class AMPTFuzzer:
 
     return True
 
-  def random_alloc(self):
+  def random_alloc(self) -> Optional[int]:
     if self.total_size - self.alloc_payload < self.min_alloc_size: return None
 
     size = random.randint(self.min_alloc_size, min(self.max_alloc_size, self.total_size - self.alloc_payload))

--- a/test/external/external_fuzz_tlsf.py
+++ b/test/external/external_fuzz_tlsf.py
@@ -31,7 +31,7 @@ class AllocatorFuzzer:
 
   def random_alloc(self) -> Optional[int]:
     if self.total_size - self.alloc_payload < self.min_alloc_size: return None
-    
+
     size = random.randint(self.min_alloc_size, min(self.max_alloc_size, self.total_size - self.alloc_payload))
 
     try:

--- a/test/external/external_fuzz_tlsf.py
+++ b/test/external/external_fuzz_tlsf.py
@@ -30,6 +30,8 @@ class AllocatorFuzzer:
     return True
 
   def random_alloc(self) -> Optional[int]:
+    if self.total_size - self.alloc_payload < self.min_alloc_size: return None
+    
     size = random.randint(self.min_alloc_size, min(self.max_alloc_size, self.total_size - self.alloc_payload))
 
     try:


### PR DESCRIPTION

This missing guard in the TLSF harness can cause a `ValueError` :
```
    if (random.random() < self.alloc_probability or not self.allocations): self.random_alloc()
                                                                           ~~~~~~~~~~~~~~~~~^^
  File "/home/tinygrad/test/external/external_fuzz_tlsf.py", line 33, in random_alloc
    size = random.randint(self.min_alloc_size, min(self.max_alloc_size, self.total_size - self.alloc_payload))
  File "/opt/homebrew/Cellar/python@3.13/3.13.4/Frameworks/Python.framework/Versions/3.13/lib/python3.13/random.py", line 340, in randint
    return self.randrange(a, b+1)
           ~~~~~~~~~~~~~~^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.4/Frameworks/Python.framework/Versions/3.13/lib/python3.13/random.py", line 323, in randrange
    raise ValueError(f"empty range in randrange({start}, {stop})")
ValueError: empty range in randrange(16, 11)
```

The seed is 1962489957
