### PR TITLE
fix: getenv("NOLOCALS")/NOLOCALS context var

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -114,7 +114,7 @@ DEBUG, IMAGE, BEAM, NOOPT = ContextVar("DEBUG", 0), ContextVar("IMAGE", 0), Cont
 JIT = ContextVar("JIT", 2 if platform.system() == 'Darwin' and ('Intel' in platform.processor() or 'i386' in platform.processor()) else 1)
 WINO, CAPTURING, TRACEMETA = ContextVar("WINO", 0), ContextVar("CAPTURING", 1), ContextVar("TRACEMETA", 1)
 USE_TC, TC_SELECT, TC_OPT, AMX = ContextVar("TC", 1), ContextVar("TC_SELECT", -1), ContextVar("TC_OPT", 0), ContextVar("AMX", 0)
-TRANSCENDENTAL, TC_SEARCH_OVER_SHAPE = ContextVar("TRANSCENDENTAL", 1), ContextVar("TC_SEARCH_OVER_SHAPE", 1)
+TRANSCENDENTAL, TC_SEARCH_OVER_SHAPE, NOLOCALS = ContextVar("TRANSCENDENTAL", 1), ContextVar("TC_SEARCH_OVER_SHAPE", 1), ContextVar("NOLOCALS", 0)
 FUSE_ARANGE, FUSE_CONV_BW = ContextVar("FUSE_ARANGE", 0), ContextVar("FUSE_CONV_BW", 0)
 SPLIT_REDUCEOP, NO_MEMORY_PLANNER, RING = ContextVar("SPLIT_REDUCEOP", 1), ContextVar("NO_MEMORY_PLANNER", 0), ContextVar("RING", 1)
 PICKLE_BUFFERS, PROFILE, LRU = ContextVar("PICKLE_BUFFERS", 1), ContextVar("PROFILE", getenv("VIZ")), ContextVar("LRU", 1)

--- a/tinygrad/opt/heuristic.py
+++ b/tinygrad/opt/heuristic.py
@@ -1,6 +1,6 @@
 import itertools
 from tinygrad.opt.kernel import Kernel, Opt, OptOps, KernelOptError
-from tinygrad.helpers import getenv, DEBUG, all_int, prod
+from tinygrad.helpers import getenv, DEBUG, all_int, prod, NOLOCALS
 from tinygrad.dtype import ImageDType
 from tinygrad.uop.ops import Ops, resolve
 
@@ -112,7 +112,7 @@ def hand_coded_optimizations(k:Kernel) -> list[Opt]:
   # **** local groups ****
 
   if k.opts.has_local:
-    if getenv("NOLOCALS") and k.local_dims == 0 and not k.group_for_reduces:
+    if NOLOCALS and k.local_dims == 0 and not k.group_for_reduces:
       k.apply_opt(Opt(OptOps.NOLOCALS))
     else:
       # prioritize making expand axes local


### PR DESCRIPTION
OptOps shouldn't rely on os.environ.