### PR TITLE
[Bounty] Switch the meaning of Reduce keepdim

### DIFF
--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -83,7 +83,7 @@ class ShapeTracker:
   @property
   def size(self) -> int: return self.views[-1].size()
 
-  def reduce(self, axis:tuple[int, ...]) -> tuple[sint, ...]: return tuple(1 if i in axis else s for i,s in enumerate(self.shape))
+  def reduce(self, axis:tuple[int, ...]) -> tuple[sint, ...]: return tuple(s for i,s in enumerate(self.shape) if i not in axis)
 
   def to_uop(self) -> UOp: return UOp(Ops.VIEW, dtypes.void, (), self)
   def to_indexed_uops(self, _idxs:Optional[list[UOp]|tuple[UOp, ...]]=None) -> tuple[UOp, UOp]:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1663,7 +1663,8 @@ class Tensor(MathTrait):
     axis = tuple(self._resolve_dim(x) for x in (range(self.ndim) if axis is None else make_tuple(axis, 1)))
     if self.ndim == 0: axis = ()
     ret = self._apply_uop(UOp.r, op=op, axis=axis)
-    return ret if keepdim else ret.reshape(tuple(s for i,s in enumerate(self.shape) if i not in axis))
+    # return ret if keepdim else ret.reshape(tuple(s for i,s in enumerate(self.shape) if i not in axis))
+    return ret.reshape(tuple(1 if i in axis else s for i,s in enumerate(self.shape))) if keepdim else ret
 
   def sum(self, axis:int|Sequence[int]|None=None, keepdim=False, dtype:DTypeLike|None=None) -> Tensor:
     """


### PR DESCRIPTION
Most reduce ops are called with `keepdim=False` (e.g. `Tensor.sum` implicitly has `keepdim=False`).

But internally, `REDUCE_AXIS` and `REDUCE` produce outputs with `keepdim=True`.

So whenever the user sets `keepdim=False` we constantly have to add reshape operations to remove the extra 1 dimensions .

This is annoying + expensive.

Let's redesign `REDUCE_AXIS` and `REDUCE` so that by default they produce outputs with `keepdim=True`, sparring us the need to do extra reshapes.