### PR TITLE
UPCAST is for globals [pr]

### DIFF
--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -1401,6 +1401,7 @@ class TestLinearizer(unittest.TestCase):
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.supports_float4, "test requires float4")
+  @unittest.skip("upcasting locals")
   def test_skip_unmatching_upcasts(self):
     Tensor.manual_seed(0)
     ast = UOp(Ops.SINK, dtypes.void, arg=None, src=(
@@ -1420,6 +1421,7 @@ class TestLinearizer(unittest.TestCase):
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.supports_float4, "test requires float4")
+  @unittest.skip("upcasting locals")
   def test_skip_unmatching_upcasts_with_gep(self):
     Tensor.manual_seed(0)
     ast = UOp(Ops.SINK, dtypes.void, arg=None, src=(

--- a/tinygrad/opt/kernel.py
+++ b/tinygrad/opt/kernel.py
@@ -394,7 +394,7 @@ class Kernel:
       self.shift_to(axis, amt, insert_before=None)
       self.upcast()
     elif opt.op is OptOps.UPCAST:                     # yellow
-      check(axis < self.first_reduce, "upcast is for non-reduce")
+      check(axis < self.global_dims, "upcast is for globals")
       check(not (self.tensor_core and self.global_dims <= axis < self.global_dims+len(self.tensor_core.get_local_axes())), "can't upcast TC locals")
       check((self.opts is not None and self.opts.device == "DSP") or amt <= 16, "don't upcast more than 16")
       self.shift_to(axis, amt, insert_before=None)


### PR DESCRIPTION
I'll post benchmark results.

My initial hypothesis is that it might make search a little slower but it will converge faster as the search space is reduced. The explanation to why it might be this way is primarily due to the current search algorithm. The current BEAM algo is pretty greedy, keeping best performing kernels based on local performance. Upcasting locals is currently a workaround to this locality, as upcasting a local is equivalent to upcasting the global **before** the local opt.

``` c
[Opt(op=OptOps.LOCAL, axis=1, arg=4), Opt(op=OptOps.UPCAST, axis=2, arg=2)]
[64, 256, 1] [2, 1, 1]
__kernel void r_256_64_2_256_2(__global float* data0, __global float* data1, __global float* data2) {
  int gidx0 = get_group_id(0); /* 64 */
  int gidx1 = get_group_id(1); /* 256 */
  int lidx0 = get_local_id(0); /* 2 */
  int alu0 = (lidx0<<1);
  int alu1 = (gidx0<<2);
  int alu2 = (gidx1<<8);
  float acc0 = 0.0f;
  float acc1 = 0.0f;
  for (int ridx3 = 0; ridx3 < 256; ridx3++) {
    float val0 = *(data1+(alu2+ridx3));
    float2 val1 = *((__global float2*)((data2+(alu1+alu0+(ridx3<<8)))));
    acc0 = (acc0+(val0*val1.x));
    acc1 = (acc1+(val0*val1.y));
  }
  *((__global float2*)((data0+(alu1+alu2+alu0)))) = (float2)(acc0,acc1);
}

### upcast before local###
# index is contiguous along upcast dim

[Opt(op=OptOps.UPCAST, axis=1, arg=2), Opt(op=OptOps.LOCAL, axis=1, arg=2)]
[64, 256, 1] [2, 1, 1]
__kernel void r_256_64_2_256_2(__global float* data0, __global float* data1, __global float* data2) {
  int gidx0 = get_group_id(0); /* 64 */
  int gidx1 = get_group_id(1); /* 256 */
  int lidx0 = get_local_id(0); /* 2 */
  int alu0 = (lidx0<<1);
  int alu1 = (gidx0<<2);
  int alu2 = (gidx1<<8);
  float acc0 = 0.0f;
  float acc1 = 0.0f;
  for (int ridx3 = 0; ridx3 < 256; ridx3++) {
    float val0 = *(data1+(alu2+ridx3));
    float2 val1 = *((__global float2*)((data2+(alu1+alu0+(ridx3<<8)))));
    acc0 = (acc0+(val0*val1.x));
    acc1 = (acc1+(val0*val1.y));
  }
  *((__global float2*)((data0+(alu1+alu2+alu0)))) = (float2)(acc0,acc1);
}

### upcast after local ###
# index is contiguous along local dim

[Opt(op=OptOps.LOCAL, axis=1, arg=2), Opt(op=OptOps.UPCAST, axis=1, arg=2)]
[64, 256, 1] [2, 1, 1]
__kernel void r_256_64_2_256_2(__global float* data0, __global float* data1, __global float* data2) {
  int gidx0 = get_group_id(0); /* 64 */
  int gidx1 = get_group_id(1); /* 256 */
  int lidx0 = get_local_id(0); /* 2 */
  int alu0 = (gidx0<<2);
  int alu1 = (gidx1<<8);
  float acc0 = 0.0f;
  float acc1 = 0.0f;
  for (int ridx3 = 0; ridx3 < 256; ridx3++) {
    float val0 = *(data1+(alu1+ridx3));
    int alu2 = (lidx0+alu0+(ridx3<<8));
    float val1 = *(data2+alu2);
    float val2 = *(data2+(alu2+2));
    acc0 = (acc0+(val0*val1));
    acc1 = (acc1+(val0*val2));
  }
  int alu6 = (lidx0+alu0+alu1);
  *(data0+alu6) = acc0;
  *(data0+(alu6+2)) = acc1;
}

```
