### PR TITLE
add opts_to_apply option to AST KernelInfo

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -41,7 +41,7 @@ def replay_kernelize(ret:dict[UOp, UOp], big_sink:UOp) -> tuple[str, str, tuple[
   return to_str(new_sink), to_str(ret[big_sink]), (big_sink,)
 
 def replay_get_program(p:ProgramSpec, ast:UOp, renderer:Renderer) -> tuple[str, str, tuple[Any, ...]]:
-  p2 = get_program(ast.replace(arg=KernelInfo(opts_to_apply=p.applied_opts, name=p.name)), renderer)
+  p2 = get_program(ast.replace(arg=KernelInfo(opts_to_apply=p.applied_opts, name=p.name)) if ast.arg is None else ast, renderer)
   def to_str(ret:ProgramSpec) -> str: return ret.src
   return to_str(p2), to_str(p), (p.ast, renderer, p.applied_opts)
 

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -6,7 +6,7 @@ from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connectio
 from tinygrad.kernelize.kernelize import get_kernelize_map
 from tinygrad.renderer import Renderer, ProgramSpec
 from tinygrad.engine.realize import get_program
-from tinygrad.uop.ops import UOp, Ops
+from tinygrad.uop.ops import UOp, Ops, KernelInfo
 
 # *** process replay settings
 
@@ -41,7 +41,7 @@ def replay_kernelize(ret:dict[UOp, UOp], big_sink:UOp) -> tuple[str, str, tuple[
   return to_str(new_sink), to_str(ret[big_sink]), (big_sink,)
 
 def replay_get_program(p:ProgramSpec, ast:UOp, renderer:Renderer) -> tuple[str, str, tuple[Any, ...]]:
-  p2 = get_program(ast, renderer, opts_override=p.applied_opts, name_override=p.name)
+  p2 = get_program(ast.replace(arg=KernelInfo(opts_to_apply=p.applied_opts, name=p.name)), renderer)
   def to_str(ret:ProgramSpec) -> str: return ret.src
   return to_str(p2), to_str(p), (p.ast, renderer, p.applied_opts)
 

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -4,7 +4,6 @@ import os, multiprocessing, logging, pickle, sqlite3, difflib, warnings, itertoo
 from typing import Callable, Any
 from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connection, getenv, tqdm
 from tinygrad.kernelize.kernelize import get_kernelize_map
-from tinygrad.opt.kernel import Kernel
 from tinygrad.renderer import Renderer, ProgramSpec
 from tinygrad.engine.realize import get_program
 from tinygrad.uop.ops import UOp, Ops
@@ -42,13 +41,7 @@ def replay_kernelize(ret:dict[UOp, UOp], big_sink:UOp) -> tuple[str, str, tuple[
   return to_str(new_sink), to_str(ret[big_sink]), (big_sink,)
 
 def replay_get_program(p:ProgramSpec, ast:UOp, renderer:Renderer) -> tuple[str, str, tuple[Any, ...]]:
-  # only use Kernel class if captured ast isn't already optimized
-  if ast.arg is None:
-    k2 = Kernel(ast, opts=renderer)
-    k2.apply_opts(p.applied_opts)
-    optimized_ast = k2.get_optimized_ast(name_override=p.name)
-  else: optimized_ast = ast
-  p2 = get_program(optimized_ast, renderer)
+  p2 = get_program(ast, renderer, opts_override=p.applied_opts, name_override=p.name)
   def to_str(ret:ProgramSpec) -> str: return ret.src
   return to_str(p2), to_str(p), (p.ast, renderer, p.applied_opts)
 

--- a/test/unit/test_linearizer_rewrite.py
+++ b/test/unit/test_linearizer_rewrite.py
@@ -2,6 +2,7 @@ import unittest
 from tinygrad import Tensor, Context, Device
 from tinygrad.engine.realize import get_program
 from tinygrad.renderer import Opt, OptOps
+from tinygrad.uop.ops import KernelInfo
 
 class TestLinearizerRewrite(unittest.TestCase):
   def test_reduction(self):
@@ -9,20 +10,22 @@ class TestLinearizerRewrite(unittest.TestCase):
     out = (t*2).sum(axis=1)
     with Context(SPLIT_REDUCEOP=0, DEVECTORIZE=0):
       si = out.schedule()[-1]
-      opts_override = []
-      opts_override.append(Opt(OptOps.UPCAST, 0, 4))
-      opts_override.append(Opt(OptOps.UNROLL, 0, 4))
-      prg = get_program(si.ast, Device["CPU"].renderer, opts_override=opts_override)
+      opts_to_apply = []
+      opts_to_apply.append(Opt(OptOps.UPCAST, 0, 4))
+      opts_to_apply.append(Opt(OptOps.UNROLL, 0, 4))
+      ast = si.ast.replace(arg=KernelInfo(opts_to_apply=tuple(opts_to_apply)))
+      prg = get_program(ast, Device["CPU"].renderer)
       print(prg.src)
 
   def test_arange(self):
     out = Tensor.arange(32, device="NULL")
     with Context(SPLIT_REDUCEOP=0, DEVECTORIZE=0):
       si = out.schedule()[-1]
-      opts_override = []
-      opts_override.append(Opt(OptOps.UPCAST, 0, 4))
-      opts_override.append(Opt(OptOps.UNROLL, 0, 4))
-      prg = get_program(si.ast, Device["CPU"].renderer, opts_override=opts_override)
+      opts_to_apply = []
+      opts_to_apply.append(Opt(OptOps.UPCAST, 0, 4))
+      opts_to_apply.append(Opt(OptOps.UNROLL, 0, 4))
+      ast = si.ast.replace(arg=KernelInfo(opts_to_apply=tuple(opts_to_apply)))
+      prg = get_program(ast, Device["CPU"].renderer)
       print(prg.src)
 
 if __name__ == '__main__':

--- a/test/unit/test_linearizer_rewrite.py
+++ b/test/unit/test_linearizer_rewrite.py
@@ -1,6 +1,7 @@
 import unittest
 from tinygrad import Tensor, Context, Device
-from tinygrad.opt.kernel import Kernel, Opt, OptOps
+from tinygrad.engine.realize import get_program
+from tinygrad.renderer import Opt, OptOps
 
 class TestLinearizerRewrite(unittest.TestCase):
   def test_reduction(self):
@@ -8,20 +9,20 @@ class TestLinearizerRewrite(unittest.TestCase):
     out = (t*2).sum(axis=1)
     with Context(SPLIT_REDUCEOP=0, DEVECTORIZE=0):
       si = out.schedule()[-1]
-      k = Kernel(si.ast, Device["CPU"].renderer)
-      k.apply_opt(Opt(OptOps.UPCAST, 0, 4))
-      k.apply_opt(Opt(OptOps.UNROLL, 0, 4))
-      prg = k.to_program()
+      opts_override = []
+      opts_override.append(Opt(OptOps.UPCAST, 0, 4))
+      opts_override.append(Opt(OptOps.UNROLL, 0, 4))
+      prg = get_program(si.ast, Device["CPU"].renderer, opts_override=opts_override)
       print(prg.src)
 
   def test_arange(self):
     out = Tensor.arange(32, device="NULL")
     with Context(SPLIT_REDUCEOP=0, DEVECTORIZE=0):
       si = out.schedule()[-1]
-      k = Kernel(si.ast, Device["CPU"].renderer)
-      k.apply_opt(Opt(OptOps.UPCAST, 0, 4))
-      k.apply_opt(Opt(OptOps.UNROLL, 0, 4))
-      prg = k.to_program()
+      opts_override = []
+      opts_override.append(Opt(OptOps.UPCAST, 0, 4))
+      opts_override.append(Opt(OptOps.UNROLL, 0, 4))
+      prg = get_program(si.ast, Device["CPU"].renderer, opts_override=opts_override)
       print(prg.src)
 
 if __name__ == '__main__':

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -22,7 +22,7 @@ def get_program(ast:UOp, renderer:Renderer, opts_override:Sequence[Opt]|None=Non
     ast: The Ops.SINK rooted AST
     renderer: The renderer used to generate the code
     opts_override: Optionally override the opts used to transform the AST
-    name_override: Optionally override the name of the rendered code
+    name_override: Optionally override the name of the output program
 
   Returns:
     The ProgramSpec of the program.

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -1,11 +1,11 @@
-from typing import Optional, cast, Generator, Sequence
+from typing import Optional, cast, Generator
 import time, pprint
 from dataclasses import dataclass, replace, field
 from tinygrad.helpers import all_same, colored, DEBUG, GlobalCounters, ansilen, BEAM, NOOPT, all_int, CAPTURING, Metadata, TRACEMETA
 from tinygrad.helpers import DEVECTORIZE, time_to_str, VALIDATE_WITH_CPU, getenv
 from tinygrad.uop.ops import Ops, PatternMatcher, UOp, UPat, Variable, sym_infer, graph_rewrite, print_uops, track_rewrites
 from tinygrad.device import Device, Buffer
-from tinygrad.renderer import Renderer, ProgramSpec, Estimates, Opt
+from tinygrad.renderer import Renderer, ProgramSpec, Estimates
 from tinygrad.engine.schedule import ScheduleItem
 from tinygrad.opt import get_optimized_ast
 from tinygrad.codegen import full_rewrite
@@ -13,23 +13,21 @@ from tinygrad.uop.spec import type_verify
 
 # **************** Program Creation ****************
 
-@track_rewrites(name=lambda _ast,_renderer,ret,**_:ret)
-def get_program(ast:UOp, renderer:Renderer, opts_override:Sequence[Opt]|None=None, name_override:str|None=None) -> ProgramSpec:
+@track_rewrites(name=lambda _ast,_renderer,ret:ret)
+def get_program(ast:UOp, renderer:Renderer) -> ProgramSpec:
   """
   Transform an AST into a ProgramSpec. May trigger BEAM search.
 
   Args:
     ast: The Ops.SINK rooted AST
     renderer: The renderer used to generate the code
-    opts_override: Optionally override the opts used to transform the AST
-    name_override: Optionally override the name of the output program
 
   Returns:
     The ProgramSpec of the program.
   """
 
   if getenv("VIZ"): graph_rewrite(ast, PatternMatcher([]), name="View Base AST")
-  modified_ast = get_optimized_ast(ast, renderer, opts_override=opts_override, name_override=name_override) if ast.arg is None else ast
+  modified_ast = get_optimized_ast(ast, renderer) if ast.arg is None or ast.arg.opts_to_apply is not None else ast
   if __debug__: type_verify(list(modified_ast.toposort()))
 
   # linearize

--- a/tinygrad/opt/__init__.py
+++ b/tinygrad/opt/__init__.py
@@ -1,28 +1,25 @@
 # opt opinionatedly transforms an ast into an optimized ast using either heuristics or beam search
 
-from typing import Sequence
 from tinygrad.opt.kernel import Kernel
 from tinygrad.opt.heuristic import hand_coded_optimizations
 from tinygrad.uop.ops import UOp
 from tinygrad.helpers import NOOPT, BEAM, USE_TC, getenv
-from tinygrad.renderer import Renderer, Opt
+from tinygrad.renderer import Renderer
 
-def get_optimized_ast(ast:UOp, renderer:Renderer, opts_override:Sequence[Opt]|None=None, name_override:str|None=None) -> UOp:
+def get_optimized_ast(ast:UOp, renderer:Renderer) -> UOp:
   """
   Optimize an AST based on heuristics or BEAM search.
 
   Args:
     ast: The Ops.SINK rooted AST
     renderer: The renderer used to generate the code
-    opts_override: Optionally override the opts used to transform the AST
-    name_override: Optionally override the name of the output AST
 
   Returns:
     The Ops.SINK rooted AST transformed to apply the opts and with a KernelInfo in the arg.
   """
 
   k = Kernel(ast, opts=renderer)
-  if opts_override is not None: k.apply_opts(opts_override)
+  if ast.arg is not None and ast.arg.opts_to_apply is not None: k.apply_opts(ast.arg.opts_to_apply)
   elif not NOOPT:
     if not k.apply_tensor_cores(USE_TC.value): k.apply_opts(hand_coded_optimizations(k))
     if BEAM >= 1:
@@ -30,4 +27,4 @@ def get_optimized_ast(ast:UOp, renderer:Renderer, opts_override:Sequence[Opt]|No
       kb = Kernel(ast, opts=renderer)
       rawbufs = bufs_from_lin(kb, allocate=False)
       k = beam_search(kb, rawbufs, BEAM.value, bool(getenv("BEAM_ESTIMATE", 1)))
-  return k.get_optimized_ast(name_override=name_override)
+  return k.get_optimized_ast()

--- a/tinygrad/opt/__init__.py
+++ b/tinygrad/opt/__init__.py
@@ -1,29 +1,33 @@
 # opt opinionatedly transforms an ast into an optimized ast using either heuristics or beam search
 
+from typing import Sequence
 from tinygrad.opt.kernel import Kernel
 from tinygrad.opt.heuristic import hand_coded_optimizations
 from tinygrad.uop.ops import UOp
 from tinygrad.helpers import NOOPT, BEAM, USE_TC, getenv
-from tinygrad.renderer import Renderer
+from tinygrad.renderer import Renderer, Opt
 
-def get_optimized_ast(ast:UOp, renderer:Renderer) -> UOp:
+def get_optimized_ast(ast:UOp, renderer:Renderer, opts_override:Sequence[Opt]|None=None, name_override:str|None=None) -> UOp:
   """
   Optimize an AST based on heuristics or BEAM search.
 
   Args:
     ast: The Ops.SINK rooted AST
     renderer: The renderer used to generate the code
+    opts_override: Optionally override the opts used to transform the AST
+    name_override: Optionally override the name of the output AST
 
   Returns:
     The Ops.SINK rooted AST transformed to apply the opts and with a KernelInfo in the arg.
   """
 
   k = Kernel(ast, opts=renderer)
-  if not NOOPT:
+  if opts_override is not None: k.apply_opts(opts_override)
+  elif not NOOPT:
     if not k.apply_tensor_cores(USE_TC.value): k.apply_opts(hand_coded_optimizations(k))
     if BEAM >= 1:
       from tinygrad.opt.search import beam_search, bufs_from_lin
       kb = Kernel(ast, opts=renderer)
       rawbufs = bufs_from_lin(kb, allocate=False)
       k = beam_search(kb, rawbufs, BEAM.value, bool(getenv("BEAM_ESTIMATE", 1)))
-  return k.get_optimized_ast()
+  return k.get_optimized_ast(name_override=name_override)

--- a/tinygrad/opt/kernel.py
+++ b/tinygrad/opt/kernel.py
@@ -454,7 +454,7 @@ class Kernel:
         # otherwise we just replace the VIEW source
         return ret.replace(src=(ret.src[0].replace(arg=st),)+ret.src[1:])
       if op.op is Ops.SINK:
-        return ret.replace(arg = KernelInfo(self.name if name_override is None else name_override,
+        return ret.replace(arg = KernelInfo(ret.arg.name if ret.arg is not None else self.name if name_override is None else name_override,
                                             self.local_dims, self.upcasted, self.dont_use_locals, tuple(self.applied_opts)))
       if op.op is Ops.REDUCE_AXIS:
         reduce_idx = len(self.bufs) + self.reduceops.index(op) * 2

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -519,7 +519,7 @@ class KernelInfo:
   upcasted: int = 0             # count that are upcasted     (this is remapping RANGE to UNROLL)
   dont_use_locals: bool = False # don't use local indexing
   applied_opts: tuple = tuple()
-  opts_to_apply: tuple = tuple()
+  opts_to_apply: tuple|None = None
   @property
   def function_name(self): return to_function_name(self.name)
 

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -519,6 +519,7 @@ class KernelInfo:
   upcasted: int = 0             # count that are upcasted     (this is remapping RANGE to UNROLL)
   dont_use_locals: bool = False # don't use local indexing
   applied_opts: tuple = tuple()
+  opts_to_apply: tuple = tuple()
   @property
   def function_name(self): return to_function_name(self.name)
 


### PR DESCRIPTION
Process replay and some other tests override OptOps with a custom sequence.

Currently, this is done through interfacing with the Kernel class. This diff moves this to the SINK UOp's argument.

Updating some of the tests to demonstrate use-case, I think this change enables removing kernel.py from the rest of the tests as well.

The get_optimized_ast stage moves opts_to_apply to applied_opts.

opts_to_apply=None. No optimizations specified by the sink. Use the default path (BEAM, NOOPT, heuristic.py)
opts_to_apply=() -> Equivalent to NOOPT=1.