### PR TITLE
viz: convert to function_name in server [pr]

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -252,7 +252,7 @@ async function renderProfiler() {
     }
   }
   const kernelMap = new Map();
-  for (const [i, c] of ctxs.entries()) kernelMap.set(c.name.replace(/\x1b\[\d+m(.*?)\x1b\[0m/g, "$1"), { name:c.name, i });
+  for (const [i, c] of ctxs.entries()) kernelMap.set(c.function_name, { name:c.name, i });
   // place devices on the y axis and set vertical positions
   const [tickSize, padding] = [10, 8];
   const deviceList = document.getElementById("device-list");

--- a/tinygrad/viz/js/worker.js
+++ b/tinygrad/viz/js/worker.js
@@ -12,7 +12,7 @@ onmessage = (e) => {
   for (let [k, {label, src, ref, ...rest }] of Object.entries(graph)) {
     const idx = ref ? ctxs.findIndex(k => k.ref === ref) : -1;
     // replace colors in label
-    if (idx != -1) label += `\ncodegen@${ctxs[idx].name.replace(/\x1b\[\d+m(.*?)\x1b\[0m/g, "$1")}`;
+    if (idx != -1) label += `\ncodegen@${ctxs[idx].function_name}`;
     // adjust node dims by label size + add padding
     let [width, height] = [0, 0];
     for (line of label.split("\n")) {

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -3,7 +3,7 @@ import multiprocessing, pickle, difflib, os, threading, json, time, sys, webbrow
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import parse_qs, urlparse
 from typing import Any, TypedDict, Generator
-from tinygrad.helpers import colored, getenv, tqdm, unwrap, word_wrap, TRACEMETA
+from tinygrad.helpers import colored, getenv, tqdm, unwrap, word_wrap, TRACEMETA, to_function_name
 from tinygrad.uop.ops import TrackedGraphRewrite, UOp, Ops, lines, GroupOp, srender, sint
 from tinygrad.renderer import ProgramSpec
 from tinygrad.device import ProfileEvent, ProfileDeviceEvent, ProfileRangeEvent, ProfileGraphEvent
@@ -25,7 +25,8 @@ def get_metadata(keys:list[Any], contexts:list[list[TrackedGraphRewrite]]) -> li
   ret = []
   for k,v in zip(keys, contexts):
     steps = [{"name":s.name, "loc":s.loc, "depth":s.depth, "match_count":len(s.matches), "code_line":lines(s.loc[0])[s.loc[1]-1].strip()} for s in v]
-    if isinstance(k, ProgramSpec): ret.append({"name":k.name, "kernel_code":k.src, "ref":id(k.ast), "steps":steps})
+    if isinstance(k, ProgramSpec):
+      ret.append({"name":k.name, "kernel_code":k.src, "ref":id(k.ast), "function_name":to_function_name(k.name), "steps":steps})
     else: ret.append({"name":str(k), "steps":steps})
   return ret
 

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -3,7 +3,7 @@ import multiprocessing, pickle, difflib, os, threading, json, time, sys, webbrow
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import parse_qs, urlparse
 from typing import Any, TypedDict, Generator
-from tinygrad.helpers import colored, getenv, tqdm, unwrap, word_wrap, TRACEMETA, to_function_name
+from tinygrad.helpers import colored, getenv, tqdm, unwrap, word_wrap, TRACEMETA
 from tinygrad.uop.ops import TrackedGraphRewrite, UOp, Ops, lines, GroupOp, srender, sint
 from tinygrad.renderer import ProgramSpec
 from tinygrad.device import ProfileEvent, ProfileDeviceEvent, ProfileRangeEvent, ProfileGraphEvent
@@ -25,8 +25,7 @@ def get_metadata(keys:list[Any], contexts:list[list[TrackedGraphRewrite]]) -> li
   ret = []
   for k,v in zip(keys, contexts):
     steps = [{"name":s.name, "loc":s.loc, "depth":s.depth, "match_count":len(s.matches), "code_line":lines(s.loc[0])[s.loc[1]-1].strip()} for s in v]
-    if isinstance(k, ProgramSpec):
-      ret.append({"name":k.name, "kernel_code":k.src, "ref":id(k.ast), "function_name":to_function_name(k.name), "steps":steps})
+    if isinstance(k, ProgramSpec): ret.append({"name":k.name, "kernel_code":k.src, "ref":id(k.ast), "function_name":k.function_name, "steps":steps})
     else: ret.append({"name":str(k), "steps":steps})
   return ret
 


### PR DESCRIPTION
Caught this in llama kv cache assignment time VIZ. We don't put `(`s in the rendered code. The correct key is the function_name: `r_32_28start_pos2B129n1`
![image](https://github.com/user-attachments/assets/6436c3b8-bd6e-40b3-98a2-a4ae53316dba)
