### PR TITLE
remove outdated index masking in lowerer [pr] 

### DIFF
--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -122,10 +122,6 @@ def lower_load_store(ctx: IndexContext, x: UOp, buf: UOp):
     reduce_input = x.src[1].src[0]
     store_back = reduce_input.op is Ops.LOAD and cast(PtrDType, reduce_input.src[0].dtype).local
   else: store_back = False
-  # NOTE: If we're storing the reduced value back into each thread, need to zero-out the reduced axes
-  if store_back:
-    assert all(False if u in x.src[1].src else True for u in ctx.idxs)
-    idx, _ = x.st_arg.to_indexed_uops([u.const_like(0) if u in x.src[1].src else u for u in ctx.idxs])
   if (not cast(PtrDType, buf.dtype).local) or store_back:
     for oidx, ridx in zip(ctx.idxs, ctx.ridxs):
       if oidx is not ridx: valid = valid * oidx.eq(0)

--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -123,7 +123,9 @@ def lower_load_store(ctx: IndexContext, x: UOp, buf: UOp):
     store_back = reduce_input.op is Ops.LOAD and cast(PtrDType, reduce_input.src[0].dtype).local
   else: store_back = False
   # NOTE: If we're storing the reduced value back into each thread, need to zero-out the reduced axes
-  if store_back: idx, _ = x.st_arg.to_indexed_uops([u.const_like(0) if u in x.src[1].src else u for u in ctx.idxs])
+  if store_back:
+    assert all(False if u in x.src[1].src else True for u in ctx.idxs)
+    idx, _ = x.st_arg.to_indexed_uops([u.const_like(0) if u in x.src[1].src else u for u in ctx.idxs])
   if (not cast(PtrDType, buf.dtype).local) or store_back:
     for oidx, ridx in zip(ctx.idxs, ctx.ridxs):
       if oidx is not ridx: valid = valid * oidx.eq(0)


### PR DESCRIPTION
In the first commit I added an assert that checked this was never actually masking, and is indeed outdated. The whole CI passed with process_replay and this assertion in place.

``` python
 if store_back:
    assert all(False if u in x.src[1].src else True for u in ctx.idxs)
    idx, _ = x.st_arg.to_indexed_uops([u.const_like(0) if u in x.src[1].src else u for u in ctx.idxs])
```