### PR TITLE
viz: support axis colors in UOp nodes

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -51,7 +51,7 @@ async function renderDag(graph, additions, recenter=false) {
       const y = (d.height-d.padding*2)/2+STROKE_WIDTH;
       return `translate(-${x}, -${y})`;
     }).selectAll("text").data(d => {
-      ret = [[]];
+      const ret = [[]];
       for (const { st, color } of parseColors(d.label)) {
         for (const [i, l] of st.split("\n").entries()) {
           if (i > 0) ret.push([]);

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -227,10 +227,8 @@ function renderMemoryGraph(graph) {
 }
 
 const ANSI_COLORS = ["#b3b3b3", "#ff6666", "#66b366", "#ffff66", "#6666ff", "#ff66ff", "#66ffff", "#ffffff"];
-const parseColors = (name, defaultColor="#ffffff") => {
-  return [...name.matchAll(/(?:\u001b\[(\d+)m([\s\S]*?)\u001b\[0m)|([^\u001b]+)/g)].map(([_, code, colored_st, st]) =>
-    ({ st: colored_st ?? st, color: code != null ? ANSI_COLORS[(parseInt(code)-30+60)%60] : defaultColor }));
-}
+const parseColors = (name, defaultColor="#ffffff") => [...name.matchAll(/(?:\u001b\[(\d+)m([\s\S]*?)\u001b\[0m)|([^\u001b]+)/g)]
+  .map(([_, code, colored_st, st]) => ({ st: colored_st ?? st, color: code != null ? ANSI_COLORS[(parseInt(code)-30+60)%60] : defaultColor }));
 
 // ** profiler graph
 

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -52,11 +52,10 @@ async function renderDag(graph, additions, recenter=false) {
       return `translate(-${x}, -${y})`;
     }).selectAll("text").data(d => {
       const ret = [[]];
-      for (const { st, color } of parseColors(d.label)) {
+      for (const { st, color } of parseColors(d.label, defaultColor="initial")) {
         for (const [i, l] of st.split("\n").entries()) {
           if (i > 0) ret.push([]);
-          // default node label color is black
-          ret.at(-1).push({ st:l, color: color == "#ffffff" ? "initial": color });
+          ret.at(-1).push({ st:l, color });
         }
       }
       return [ret];
@@ -228,8 +227,10 @@ function renderMemoryGraph(graph) {
 }
 
 const ANSI_COLORS = ["#b3b3b3", "#ff6666", "#66b366", "#ffff66", "#6666ff", "#ff66ff", "#66ffff", "#ffffff"];
-const parseColors = (name) => [...name.matchAll(/(?:\u001b\[(\d+)m([\s\S]*?)\u001b\[0m)|([^\u001b]+)/g)].map(([_, code, colored_st, st]) =>
-  ({ st: colored_st ?? st, color: code != null ? ANSI_COLORS[(parseInt(code)-30+60)%60] : "#ffffff" }));
+const parseColors = (name, defaultColor="#ffffff") => {
+  return [...name.matchAll(/(?:\u001b\[(\d+)m([\s\S]*?)\u001b\[0m)|([^\u001b]+)/g)].map(([_, code, colored_st, st]) =>
+    ({ st: colored_st ?? st, color: code != null ? ANSI_COLORS[(parseInt(code)-30+60)%60] : defaultColor }));
+}
 
 // ** profiler graph
 

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -50,8 +50,18 @@ async function renderDag(graph, additions, recenter=false) {
       const x = (d.width-d.padding*2)/2;
       const y = (d.height-d.padding*2)/2+STROKE_WIDTH;
       return `translate(-${x}, -${y})`;
-    }).selectAll("text").data(d => [d.label.split("\n")]).join("text").selectAll("tspan").data(d => d).join("tspan").text(d => d).attr("x", "0")
-      .attr("dy", 14).attr("xml:space", "preserve");
+    }).selectAll("text").data(d => {
+      ret = [[]];
+      for (const { st, color } of parseColors(d.label)) {
+        for (const [i, l] of st.split("\n").entries()) {
+          if (i > 0) ret.push([]);
+          // default node label color is black
+          ret.at(-1).push({ st:l, color: color == "#ffffff" ? "initial": color });
+        }
+      }
+      return [ret];
+    }).join("text").selectAll("tspan").data(d => d).join("tspan").attr("x", "0").attr("dy", 14).selectAll("tspan").data(d => d).join("tspan")
+      .attr("fill", d => d.color).text(d => d.st).attr("xml:space", "preserve");
     const tags = nodes.selectAll("g.tag").data(d => d.tag != null ? [d] : []).join("g").attr("class", "tag")
       .attr("transform", d => `translate(${-d.width/2+8}, ${-d.height/2+8})`);
     tags.selectAll("circle").data(d => [d]).join("circle");

--- a/tinygrad/viz/js/worker.js
+++ b/tinygrad/viz/js/worker.js
@@ -11,11 +11,12 @@ onmessage = (e) => {
   if (additions.length !== 0) g.setNode("addition", {label:"", style:"fill: rgba(26, 27, 38, 0.5);", padding:0});
   for (let [k, {label, src, ref, ...rest }] of Object.entries(graph)) {
     const idx = ref ? ctxs.findIndex(k => k.ref === ref) : -1;
-    // replace colors in label
+    // replace JSON.parse string literal with real ESC
+    label = label.replace(/\\x1b\r?\n*\[/g, "\u001B[");
     if (idx != -1) label += `\ncodegen@${ctxs[idx].function_name}`;
-    // adjust node dims by label size + add padding
+    // adjust node dims by label size (excluding escape codes) + add padding
     let [width, height] = [0, 0];
-    for (line of label.split("\n")) {
+    for (line of label.replace(/\u001B\[(?:K|.*?m)/g, "").split("\n")) {
       width = Math.max(width, ctx.measureText(line).width);
       height += LINE_HEIGHT;
     }


### PR DESCRIPTION
This diff fixes the rendering of KernelInfo in viz nodes:

Branch:
![image](https://github.com/user-attachments/assets/8b584250-a2a9-45d9-825d-dd8ffb35e033)

Master:
![image](https://github.com/user-attachments/assets/ada1fd7d-2717-4a0c-86a7-b18e913382ec)

per the JSON spec: http://datatracker.ietf.org/doc/html/rfc8259#section-8 escape codes become string literals, so this needed an extra fixup to work properly.