### PR TITLE
[bounty] Refactor VIEW(CONST(DEVICE))

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -44,8 +44,7 @@ def ast_const(dtype:DType, val:ConstType, shape:tuple[sint, ...]=(), st:Optional
   if st_src is None:
     st_src = (st.to_uop() if st is not None else ShapeTracker.from_shape(()).reshape((1,)*len(shape)).expand(shape).to_uop(),)
   st = unwrap(st_src[0].st)
-  if all(v.mask is None for v in st.views): return UOp.const(dtype, val).replace(src=(st.to_uop(),))
-  return graph_rewrite(UOp.const(dtype, val).view(st).valid(), view_left)
+  return UOp.const(dtype, val).view(st)
 
 def timeit(fxn:Callable[..., T], *args, **kwargs) -> tuple[T, float]:
   st = time.perf_counter_ns()

--- a/test/test_tensor_variable.py
+++ b/test/test_tensor_variable.py
@@ -79,8 +79,6 @@ class TestTensorVariable(unittest.TestCase):
     ret = Tensor.arange(vv.bind(4), 7)
     self.assertListEqual(ret.reshape(3).tolist(), [4,5,6])
 
-  # TODO: add vmin/vmax pattern for symbolic denominator
-  @unittest.expectedFailure
   def test_symbolic_arange_sym_step(self):
     vv = Variable("step", 1, 3)
     ret = Tensor.arange(0, 10, vv.bind(2))

--- a/test/unit/test_tensor_uop_representation.py
+++ b/test/unit/test_tensor_uop_representation.py
@@ -6,7 +6,7 @@ from tinygrad.uop.ops import UPat, Ops, UOp
 realized_pattern = UPat(Ops.BUFFER)
 # after realization, base tensor uops become RESHAPE(BUFFER)
 buffer_view_pattern = UPat(Ops.RESHAPE, src=(UPat(Ops.BUFFER),))
-const_pattern = UPat(Ops.CONST, src=(UPat(Ops.VIEW, src=(UPat(Ops.DEVICE),),)))
+const_pattern = UPat(Ops.VIEW, src=(UPat(Ops.CONST, src=(UPat(Ops.DEVICE),)),))
 def is_pattern_uop(u:UOp, pat:UPat): assert pat.match(u, {}), f"{u}\nis not\n{pat}"
 def is_pattern(ten:Tensor, pat:UPat): is_pattern_uop(ten.uop, pat)
 
@@ -61,7 +61,7 @@ class TestTensorUopRepresentation(unittest.TestCase):
   def test_const_pattern(self):
     a = Tensor(1)
     print(a.uop)
-    is_pattern(a, const_pattern) # const in tensor has a DEVICE and VIEW src
+    is_pattern(a, const_pattern) # const in tensor has a DEVICE src
     is_pattern(a, UPat.cvar("x")) # even cvar works!
 
   def test_consts_do_not_realize(self):

--- a/test/unit/test_uop_spec.py
+++ b/test/unit/test_uop_spec.py
@@ -73,6 +73,7 @@ class TestUOpSpec(unittest.TestCase):
     st = UOp.store(bufs[0], ShapeTracker.from_shape((32, 1)).to_uop(), r+a)
     with self.assertRaises(InvalidASTException): helper_test_verify_ast(st)
 
+  @unittest.skip("old store")
   def test_buffer_uops_st(self):
     a = Tensor.randn(4, 4)+2
     helper_test_verify_ast(ast:=a.schedule()[-1].ast)
@@ -81,6 +82,7 @@ class TestUOpSpec(unittest.TestCase):
     const_st = [u.st for u in ast.toposort() if u.op is Ops.CONST][0]
     self.assertEqual(const_st, ShapeTracker.from_shape((1, 1)).expand((4, 4)))
 
+  @unittest.skip("old store")
   def test_assert_swizzle(self):
     buf = UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(), (), 0)
     a = UOp(Ops.LOAD, dtypes.float, (buf.view(ShapeTracker.from_shape((32, 1))),))

--- a/test/unit/test_uop_spec.py
+++ b/test/unit/test_uop_spec.py
@@ -90,7 +90,7 @@ class TestUOpSpec(unittest.TestCase):
 
   def test_const_view_always_valid(self):
     buf = UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(), (), 0)
-    a = UOp.const(dtypes.int, 0).replace(src=(UOp(Ops.VIEW, dtypes.void, (), ShapeTracker.from_shape(())),))
+    a = ast_const(dtypes.int, 0).replace(src=(UOp(Ops.VIEW, dtypes.void, (), ShapeTracker.from_shape(())),))
     st = UOp.store(buf.view(ShapeTracker.from_shape(())), a.cast(dtypes.float))
     helper_test_verify_ast(st)
 

--- a/test/unit/test_uop_spec.py
+++ b/test/unit/test_uop_spec.py
@@ -90,15 +90,10 @@ class TestUOpSpec(unittest.TestCase):
 
   def test_const_view_always_valid(self):
     buf = UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(), (), 0)
-    a = ast_const(dtypes.int, 0).replace(src=(UOp(Ops.VIEW, dtypes.void, (), ShapeTracker.from_shape(())),))
+    a = UOp.const(dtypes.int, 0, None, ())
     st = UOp.store(buf.view(ShapeTracker.from_shape(())), a.cast(dtypes.float))
     helper_test_verify_ast(st)
 
-  def test_assert_masked_view_in_const(self):
-    t = Tensor(6).uop
-    a = t.replace(src=(t.src[0].replace(arg=t.st.reshape((1,)).pad(((0, 1),))),))
-    with self.assertRaisesRegex(RuntimeError, "UOp verification failed"):
-      type_verify([a], tensor_uop_spec)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -133,12 +133,6 @@ def lower_const(ctx:IndexContext, view:UOp, c:UOp):
   return valid.where(c, c.const_like(0))
 
 pm_lowerer = PatternMatcher([
-  # TODO: remove these hacks
-  # hack for old style CONST(VIEW) (now it's just VIEW(CONST))
-  # (UPat((Ops.DEFINE_VAR, Ops.CONST), src=(UPat(Ops.VIEW, name="v"),), name="c"), lambda c,v: c.replace(src=()).view(v.arg)),
-  # hack for old style VALID (now it's just VIEW(CONST))
-  # (UPat(Ops.VALID, src=(UPat(Ops.VIEW, name="v"),)).where(UPat.cvar("c"), UPat(Ops.CONST, arg=0)), lambda c,v: c.replace(src=()).view(v.arg)),
-
   # reduce/view_const
   (UPat(Ops.REDUCE_AXIS, name="x"), lower_reduce_axis),
   (UPat(Ops.VIEW, src=(UPat((Ops.CONST, Ops.DEFINE_VAR), name="c"),), name="view"), lower_const),

--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -135,9 +135,9 @@ def lower_const(ctx:IndexContext, view:UOp, c:UOp):
 pm_lowerer = PatternMatcher([
   # TODO: remove these hacks
   # hack for old style CONST(VIEW) (now it's just VIEW(CONST))
-  (UPat((Ops.DEFINE_VAR, Ops.CONST), src=(UPat(Ops.VIEW, name="v"),), name="c"), lambda c,v: c.replace(src=()).view(v.arg)),
+  # (UPat((Ops.DEFINE_VAR, Ops.CONST), src=(UPat(Ops.VIEW, name="v"),), name="c"), lambda c,v: c.replace(src=()).view(v.arg)),
   # hack for old style VALID (now it's just VIEW(CONST))
-  (UPat(Ops.VALID, src=(UPat(Ops.VIEW, name="v"),)).where(UPat.cvar("c"), UPat(Ops.CONST, arg=0)), lambda c,v: c.replace(src=()).view(v.arg)),
+  # (UPat(Ops.VALID, src=(UPat(Ops.VIEW, name="v"),)).where(UPat.cvar("c"), UPat(Ops.CONST, arg=0)), lambda c,v: c.replace(src=()).view(v.arg)),
 
   # reduce/view_const
   (UPat(Ops.REDUCE_AXIS, name="x"), lower_reduce_axis),

--- a/tinygrad/kernelize/grouper.py
+++ b/tinygrad/kernelize/grouper.py
@@ -3,7 +3,7 @@ from tinygrad.helpers import all_int, prod, unwrap, dedup, DONT_REALIZE_EXPAND, 
 from tinygrad.shape.shapetracker import ShapeTracker
 
 ALWAYS_CONTIGUOUS = {Ops.CONTIGUOUS, Ops.ASSIGN, Ops.COPY, Ops.BUFFER, Ops.BUFFER_VIEW,
-                     Ops.CONST, Ops.BIND, Ops.DEVICE, Ops.MSELECT, Ops.MSTACK, Ops.GBARRIER}
+                     Ops.CONST, Ops.BIND, Ops.DEVICE, Ops.MSELECT, Ops.MSTACK, Ops.GBARRIER, Ops.DEFINE_VAR}
 
 # **** Grouper decides which of the UOps realize
 

--- a/tinygrad/kernelize/kernelize.py
+++ b/tinygrad/kernelize/kernelize.py
@@ -161,8 +161,8 @@ merge_views = PatternMatcher([
   (UPat(GroupOp.All-{Ops.DEFINE_GLOBAL}).view(name="view"),
    lambda view: view.const_like(0) if (mask:=view.st.views[-1].mask) is not None and any((x[1]-x[0]) == 0 for x in mask) else None),
   # only unmaksed VIEW on CONST replaces the ShapeTracker
-  (UPat(Ops.VIEW, src=(UPat((Ops.CONST, Ops.DEFINE_VAR), name="x"),), name="view"),
-   lambda x,view: x.replace(src=(x.src[0].replace(arg=x.st+view.st),)) if all(v.mask is None for v in (x.st+view.st).views) else None),
+  # (UPat(Ops.VIEW, src=(UPat((Ops.CONST, Ops.DEFINE_VAR), name="x"),), name="view"),
+  #  lambda x,view: x.replace(src=(x.src[0].replace(arg=x.st+view.st),)) if all(v.mask is None for v in (x.st+view.st).views) else None),
 ])
 
 def reduce_push_add_ones(src:UOp, r:UOp, view:UOp):
@@ -259,7 +259,7 @@ add_buffer_ops = PatternMatcher([
   # passthrough ASSIGN
   (UPat(Ops.ASSIGN, name="x"), lambda x: x.src[1]),
   # VALID
-  (UPat(Ops.VIEW, src=(UPat.cvar(),), name="self"), UOp.valid),
+  # (UPat(Ops.VIEW, src=(UPat.cvar(),), name="self"), UOp.valid),
 ])
 
 def check_load_st(glbl:UOp, view:UOp):
@@ -275,7 +275,7 @@ def check_load_st(glbl:UOp, view:UOp):
 fix_kernel_ops = PatternMatcher([
   # remove CONTIGUOUS/DEVICE from kernel AST
   (UPat((Ops.CONTIGUOUS, Ops.MSELECT), src=(UPat.var("x"),)), lambda x: x),
-  (UPat(Ops.VIEW, src=(UPat(Ops.DEVICE),), name="view"), lambda view: view.replace(src=())),
+  (UPat((Ops.VIEW, Ops.CONST), src=(UPat(Ops.DEVICE),), name="u"), lambda u: u.replace(src=())),
   # no ImageDType after index
   (UPat(GroupOp.All-{Ops.DEFINE_GLOBAL, Ops.VIEW}, name="x"), lambda x: x.replace(dtype=x.dtype.base) if isinstance(x.dtype, ImageDType) else None),
   # if this kernel also assigns to the loaded buffer, ensure we can index it correctly

--- a/tinygrad/kernelize/kernelize.py
+++ b/tinygrad/kernelize/kernelize.py
@@ -189,7 +189,7 @@ def reduce_push_add_ones(src:UOp, r:UOp, view:UOp):
 
 view_left = merge_views+PatternMatcher([
   # view before elementwise and buffer ops
-  (UPat(Ops.VIEW, src=(UPat({*GroupOp.ALU, Ops.CAST, Ops.BITCAST, Ops.BIND, Ops.LOAD, Ops.STORE, Ops.VALID}, name="e"),), name="view"),
+  (UPat(Ops.VIEW, src=(UPat({*GroupOp.ALU, Ops.CAST, Ops.BITCAST, Ops.LOAD, Ops.STORE}, name="e"),), name="view"),
    lambda e,view: e.replace(src=tuple(s.view(view.st) for s in e.src))),
   # if there's ones added after reduce, put this before the reduce
   (UPat(Ops.VIEW, src=(UPat(Ops.REDUCE_AXIS, src=(UPat.var("src"),), name="r"),), name="view"), reduce_push_add_ones),
@@ -275,7 +275,7 @@ def check_load_st(glbl:UOp, view:UOp):
 fix_kernel_ops = PatternMatcher([
   # remove CONTIGUOUS/DEVICE from kernel AST
   (UPat((Ops.CONTIGUOUS, Ops.MSELECT), src=(UPat.var("x"),)), lambda x: x),
-  (UPat((Ops.VIEW, Ops.CONST), src=(UPat(Ops.DEVICE),), name="u"), lambda u: u.replace(src=())),
+  (UPat((Ops.CONST, Ops.DEFINE_VAR), src=(UPat(Ops.DEVICE),), name="u"), lambda u: u.replace(src=())),
   # no ImageDType after index
   (UPat(GroupOp.All-{Ops.DEFINE_GLOBAL, Ops.VIEW}, name="x"), lambda x: x.replace(dtype=x.dtype.base) if isinstance(x.dtype, ImageDType) else None),
   # if this kernel also assigns to the loaded buffer, ensure we can index it correctly

--- a/tinygrad/kernelize/kernelize.py
+++ b/tinygrad/kernelize/kernelize.py
@@ -160,9 +160,6 @@ merge_views = PatternMatcher([
   (UPat.var("x").view(name="view"), lambda x,view: x if x.st is not None and view.st.contiguous and view.shape == x.shape else None),
   (UPat(GroupOp.All-{Ops.DEFINE_GLOBAL}).view(name="view"),
    lambda view: view.const_like(0) if (mask:=view.st.views[-1].mask) is not None and any((x[1]-x[0]) == 0 for x in mask) else None),
-  # only unmaksed VIEW on CONST replaces the ShapeTracker
-  # (UPat(Ops.VIEW, src=(UPat((Ops.CONST, Ops.DEFINE_VAR), name="x"),), name="view"),
-  #  lambda x,view: x.replace(src=(x.src[0].replace(arg=x.st+view.st),)) if all(v.mask is None for v in (x.st+view.st).views) else None),
 ])
 
 def reduce_push_add_ones(src:UOp, r:UOp, view:UOp):
@@ -258,8 +255,6 @@ add_buffer_ops = PatternMatcher([
    UOp.sink(*[UOp.store(UOp(Ops.DEFINE_GLOBAL, (s:=x.base).dtype.ptr(ctx[i].size), (), i).view(s.st), s) for i,x in enumerate(sink.src)])),
   # passthrough ASSIGN
   (UPat(Ops.ASSIGN, name="x"), lambda x: x.src[1]),
-  # VALID
-  # (UPat(Ops.VIEW, src=(UPat.cvar(),), name="self"), UOp.valid),
 ])
 
 def check_load_st(glbl:UOp, view:UOp):

--- a/tinygrad/opt/search.py
+++ b/tinygrad/opt/search.py
@@ -11,6 +11,7 @@ from tinygrad.opt.kernel import Kernel, Opt, OptOps, KernelOptError
 from tinygrad.tensor import Tensor
 from tinygrad.engine.realize import CompiledRunner
 from tinygrad.renderer import ProgramSpec
+from tinygrad.shape.shapetracker import ShapeTracker
 
 actions = [Opt(op=OptOps.UPCAST, axis=axis, arg=amt) for amt in [0,2,3,4,5,7] for axis in range(6)]
 actions += [Opt(op=OptOps.UNROLL, axis=axis, arg=amt) for amt in [0,4,7] for axis in range(5)]
@@ -92,7 +93,7 @@ def _ensure_buffer_alloc(bufs:list[Buffer]) -> list[Buffer]: return [buf.ensure_
 
 # get (scrap) buffers for timing the linearizer
 def bufs_from_lin(lin:Kernel, allocate:bool=True) -> list[Buffer]:
-  bufsts: defaultdict[int, list[UOp]] = defaultdict(list)
+  bufsts: defaultdict[UOp, list[ShapeTracker]] = defaultdict(list)
   for b,st in zip(lin.bufs,lin.sts):
     if b.op is Ops.DEFINE_GLOBAL: bufsts[b].append(st)
   # TODO: Nones are staying in here if buffers are optimized out!

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -141,8 +141,8 @@ class Tensor(MathTrait):
       if data.op is Ops.BIND:
         var, val = data.unbind()
         # give the bound constant a device
-        const = UOp.const(var.dtype, val, device, ())
-        data = data.replace(src=(var.replace(src=const.src), const))
+        const = UOp.const(var.dtype, val, device, ())  # this is now a VIEW(CONST)
+        data = data.replace(src=(var.replace(src=const.src[0].src), const.src[0])).view(const.st_arg)  # move the view from const to bound op
     elif data is None: data = UOp.const(dtype or dtypes.default_float, 0, device, ())
     elif isinstance(data, get_args(ConstType)): data = UOp.const(dtype or dtypes.from_py(data), data, device, ())
     elif isinstance(data, bytes): data = _frompy(data, dtypes.uint8 if dtype is None else dtype)

--- a/tinygrad/uop/__init__.py
+++ b/tinygrad/uop/__init__.py
@@ -79,7 +79,7 @@ class GroupOp:
   Irreducible = {Ops.CONST, Ops.DEFINE_VAR, Ops.SPECIAL, Ops.RANGE}
   Movement = {Ops.RESHAPE, Ops.EXPAND, Ops.PERMUTE, Ops.PAD, Ops.SHRINK, Ops.FLIP}
 
-  Buffer = {Ops.LOAD, Ops.STORE, Ops.VALID, Ops.CONST, Ops.DEFINE_VAR}
+  Buffer = {Ops.LOAD, Ops.STORE, Ops.CONST, Ops.DEFINE_VAR}
   Block = {Ops.BLOCK, Ops.BLOCKEND, Ops.BLOCKSTART}
 
   # BinaryOps that can be flipped

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -219,7 +219,7 @@ ast_spec = PatternMatcher([
   # shapes must have either 1 or n in each dimension
   (UPat(Ops.SINK, src=UPat(Ops.STORE), name="sink"), verify_sink_dims),
   # VIEW can only exist in the edges
-  (UPat(Ops.VIEW, src=(UPat((Ops.DEFINE_GLOBAL, Ops.DEFINE_LOCAL),))), lambda: True),
+  (UPat(Ops.VIEW, src=(UPat((Ops.DEFINE_GLOBAL, Ops.DEFINE_LOCAL, Ops.CONST),))), lambda: True),
   (UPat(Ops.VIEW, name="view"), lambda view: len(view.src) == 0),
   # all parent UOps must have the same shape
   (UPat(GroupOp.All-{Ops.SINK}, name="root"), lambda root: all_same([x.shape for x in root.src if x.st is not None])),

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -217,7 +217,7 @@ ast_spec = PatternMatcher([
   # shapes must have either 1 or n in each dimension
   (UPat(Ops.SINK, src=UPat(Ops.STORE), name="sink"), verify_sink_dims),
   # VIEW can only exist in the edges
-  (UPat(Ops.VIEW, src=(UPat((Ops.DEFINE_GLOBAL, Ops.DEFINE_LOCAL, Ops.CONST, Ops.DEFINE_VAR),))), lambda: True),
+  (UPat(Ops.VIEW, src=(UPat((Ops.DEFINE_GLOBAL, Ops.DEFINE_LOCAL, Ops.CONST, Ops.DEFINE_VAR, Ops.BIND),))), lambda: True),
   # all parent UOps must have the same shape
   (UPat(GroupOp.All-{Ops.SINK}, name="root"), lambda root: all_same([x.shape for x in root.src if x.st is not None])),
 ])


### PR DESCRIPTION
So this does most of the changes I think you want in kernel/kernelize/grouper/spec

### Main changes
- added `kernel.views`, this fixup_optimized_ast is now way easier since you just find all the views and replace their shapetracker
- `kernel.bufs` is now a list of `CONST`/`DEFINE_VAR`/`DEFINE_GLOBAL`/`DEFINE_LOCAL` instead of `LOAD`/`STORE`, basically the source of the view. `bufs` are therefore the inputs to the graph
- If you create a tensor out of a bound variable, the view sits on top of the bind, this makes binding/unbinding simpler because you ideally don't want `BIND(VIEW(DEFINE_VAR), VIEW(CONST))`
- `DEFINE_VAR` is now also `VIEW(DEFINE_VAR(DEVICE))`

### Problems
- No more constant folding at the scheduling level. You will only get constant folding after lowering. Another problem of no constant folding is that `0/0` won't become `0*inf -> nan` but instead will still be rewritten by `x/x -> 1`. This is one of the tests in `test_ops.py` thats failing
- A lot of the tests are failing because they create CONST(VIEW(DEVICE)) by hand, there was discussion in the discord about removing them

### TODO
- Fix the tests
- I will try to get some degree of const folding back by just not having a view on the const if its not masked