### PR TITLE
viz: new canvas on first render

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -227,10 +227,7 @@
       </button>
     </div>
     <div class="container ctx-list-parent"><div class="ctx-list"></div></div>
-    <div class="view profiler">
-      <div id="device-list"></div>
-      <canvas id="timeline"></canvas>
-    </div>
+    <div class="view profiler"></div>
     <div class="view graph">
       <div class="progress-message">Rendering new layout...</div>
       <svg id="graph-svg" preserveAspectRatio="xMidYMid meet">


### PR DESCRIPTION
Working with a static pixel scaled dataset was challenging in buffer viz #10960.
This diff refactors the profiler to to always re-scale to pixels on first render.

Buffer viz uses this to expand the per device memory graph:

Default view:
![image](https://github.com/user-attachments/assets/94abd8f8-5ccb-44a7-acd9-2e8015d73e77)
Expanded, filling available screen real estate:
![image](https://github.com/user-attachments/assets/e88514b8-9da3-4e2e-9d8c-f6471fc9bc25)
