### PR TITLE
move `sym` before `multi_pm`

### DIFF
--- a/tinygrad/kernelize/kernelize.py
+++ b/tinygrad/kernelize/kernelize.py
@@ -434,7 +434,7 @@ def get_kernelize_map(sink:UOp) -> dict[UOp, UOp]:
   """
 
   # multi + merge_views + simplify
-  tensor_map = graph_rewrite_map(sink, multi_pm+do_fuse+merge_views+sym+replace_contiguous, ctx={}, name="merge_views")
+  tensor_map = graph_rewrite_map(sink, do_fuse+merge_views+sym+multi_pm+replace_contiguous, ctx={}, name="merge_views")
 
   # display the cleaned up tensor graph
   if getenv("VIZ"): graph_rewrite(tensor_map[sink], PatternMatcher([]), name="View Tensor Graph")


### PR DESCRIPTION
I need something like this for #11011 the problem is in these rules

```python
(UPat(Ops.COPY, name="c", src=(UPat(GroupOp.All-{Ops.CONST}, name="x"), UPat(Ops.DEVICE))), lambda c,x:
    UOp(Ops.MSTACK, c.dtype, tuple(x.copy_to_device(d) for d in c.device)) if isinstance(c.device, tuple) and isinstance(x.device, str) else None),
  # COPY_TO_ONE: if copying from multidevice to one, MSELECT the first (TODO: a little from each?)
  (UPat(Ops.COPY, name="c", src=(UPat(GroupOp.All-{Ops.CONST}, name="x"), UPat(Ops.DEVICE))), lambda c,x:
    x.mselect(0).copy_to_device(c.device) if isinstance(c.device, str) and isinstance(x.device, tuple) else None),
```

Since `COPY` is now `VIEW(COPY)` the `-{Ops.CONST}` doesn't work. 

currently I added a check in this rule like 
```python
  (UPat(Ops.COPY, name="c", src=(UPat.var("x"), UPat(Ops.DEVICE))), lambda c,x: UOp(Ops.MSTACK,c.dtype, tuple(x.copy_to_device(d) for d in c.device))
    if isinstance(c.device, tuple) and isinstance(x.device, str) and (x.op is not Ops.VIEW or x.src[0].op is not Ops.CONST) else None),
  # COPY_TO_ONE: if copying from multidevice to one, MSELECT the first (TODO: a little from each?)
  (UPat(Ops.COPY, name="c", src=(UPat.var("x"), UPat(Ops.DEVICE))), lambda c,x: x.mselect(0).copy_to_device(c.device)
    if isinstance(c.device, str) and isinstance(x.device, tuple) and (x.op is not Ops.VIEW or x.src[0].op is not Ops.CONST) else None),
```

But this is simpler if it works