### PR TITLE
keep global dims

### DIFF
--- a/tinygrad/codegen/gpudims.py
+++ b/tinygrad/codegen/gpudims.py
@@ -53,7 +53,7 @@ def get_grouped_dims(prefix, dims:tuple[sint, ...], max_sizes:tuple[int, ...]|No
 def add_gpudims(ctx:Renderer, s:UOp):
   if s.arg is None: return None
   ki: KernelInfo = s.arg
-  if ki.global_dims == 0 and ki.local_dims == 0: return None
+  if not ctx.has_local or (ki.global_dims == 0 and ki.local_dims == 0): return None
   s_topo = list(s.toposort())
   if any(x.op is Ops.SPECIAL for x in s_topo): return None
   ranges = sorted([x for x in s_topo if x.op is Ops.RANGE and x.arg < (ki.global_dims+ki.local_dims)], key=lambda x: x.arg)

--- a/tinygrad/opt/kernel.py
+++ b/tinygrad/opt/kernel.py
@@ -456,7 +456,7 @@ class Kernel:
       if op.op is Ops.SINK:
         # NOTE: should group_for_reduces be added to the local_dims?
         return ret.replace(arg = KernelInfo(ret.arg.name if ret.arg is not None else self.name if name_override is None else name_override,
-                                            self.global_dims if self.opts.has_local else 0, self.local_dims+self.group_for_reduces,
+                                            self.global_dims, self.local_dims+self.group_for_reduces,
                                             self.upcasted, self.dont_use_locals, tuple(self.applied_opts)))
       if op.op is Ops.REDUCE_AXIS:
         reduce_idx = len(self.bufs) + self.reduceops.index(op) * 2


### PR DESCRIPTION
for some reason it breaks pr for cpu and llvm backends

for the offsets refactor, its useful to keep count of global dims even for backends that don't have support for it

if it is preferred to leave this in the current state, the whole approach for the refactor has to be thought through again as there is no way of calculating offsets reliably anymore

the responsibility for checking global support now lays on gpudims

its a draft as I'm not sure, asking for feedback here. I know it's more correct the other way, and you usually don't want to move away from correctness to fit an implementation, but I don't know how to continue the yellow before red refactor in the direction its going if this isn't changed. If this is rejected, it forces a new way of approaching the problem