### PR TITLE
add timeout to benchmark_search and mlperf action

### DIFF
--- a/.github/workflows/benchmark_search.yml
+++ b/.github/workflows/benchmark_search.yml
@@ -10,6 +10,7 @@ jobs:
   run_script_job:
     runs-on: [self-hosted, Linux, tinybox]
     if: github.repository_owner == 'tinygrad'
+    timeout-minutes: 100
 
     steps:
     - name: Checkout Code

--- a/.github/workflows/mlperf.yml
+++ b/.github/workflows/mlperf.yml
@@ -12,6 +12,7 @@ jobs:
   run_script_job:
     runs-on: [self-hosted, Linux, tinybox]
     if: github.repository_owner == 'tinygrad'
+    timeout-minutes: 240
 
     steps:
     - name: Checkout Code


### PR DESCRIPTION
default timeout is 6 hours which is too long and occupies a box