### PR TITLE
viz: remove support for naming with self

### DIFF
--- a/test/unit/test_viz.py
+++ b/test/unit/test_viz.py
@@ -94,14 +94,6 @@ class TestViz(unittest.TestCase):
     lst = get_viz_list()
     self.assertEqual(lst[0]["name"], "name_default n1")
 
-  # name can also be the first arg
-  def test_self_name(self):
-    @track_rewrites()
-    def name_is_self(s:UOp): return graph_rewrite(s, PatternMatcher([]))
-    name_is_self(arg:=UOp.variable("a", 1, 10))
-    lst = get_viz_list()
-    self.assertEqual(lst[0]["name"], str(arg))
-
   # name can also come from a function
   def test_dyn_name_fxn(self):
     @track_rewrites(name=lambda a,ret: a.render())

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -778,11 +778,11 @@ if getenv("CAPTURE_PROCESS_REPLAY"):
   def save_to_diskcache():
     for k,v in replay_capture.items(): diskcache_put("process_replay", k, v, prepickled=True)
 
-def track_rewrites(name:Callable|bool|None=None):
+def track_rewrites(name:Callable|bool=True):
   def _decorator(func):
     def __wrapper(*args, **kwargs):
       if TRACK_MATCH_STATS >= 2:
-        tracked_keys.append(args[0] if args and name is None else (fn:=func.__name__)+f" n{next(_name_cnt.setdefault(fn, itertools.count(1)))}")
+        tracked_keys.append((fn:=func.__name__)+f" n{next(_name_cnt.setdefault(fn, itertools.count(1)))}")
         tracked_ctxs.append([])
       ret = func(*args, **kwargs)
       if TRACK_MATCH_STATS >= 2 and callable(name):


### PR DESCRIPTION
It existed to deal with kernel.py, now everything in core tinygrad uses a name function.