### PR TITLE
support capturing cpu_profile on error

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -1,7 +1,7 @@
-import unittest, struct, contextlib, statistics
+import unittest, struct, contextlib, statistics, time
 from tinygrad import Device, Tensor, dtypes, TinyJit
 from tinygrad.helpers import CI, getenv, Context
-from tinygrad.device import Buffer, BufferSpec, Compiled, ProfileRangeEvent, ProfileDeviceEvent, ProfileGraphEvent
+from tinygrad.device import Buffer, BufferSpec, Compiled, ProfileRangeEvent, ProfileDeviceEvent, ProfileGraphEvent, cpu_profile
 from tinygrad.runtime.support.hcq import HCQCompiled
 from tinygrad.engine.realize import get_runner
 
@@ -158,6 +158,24 @@ class TestProfiler(unittest.TestCase):
       jitter_matrix[i1][i2] = statistics.median(_sync_d2d(d1, d2) - _sync_d2d(d2, d1) for _ in range(20)) / 2 - cpu_diff
       assert abs(jitter_matrix[i1][i2]) < 0.5, "jitter should be less than 0.5ms"
     print("pairwise clock jitter matrix (us):\n" + '\n'.join([''.join([f'{float(item):8.3f}' for item in row]) for row in jitter_matrix]))
+
+  def test_cpu_profile(self):
+    def test_fxn(err=False):
+      time.sleep(0.1)
+      if err: raise Exception()
+      time.sleep(0.1)
+
+    with helper_collect_profile(dev:=TestProfiler.d0) as profile:
+      with cpu_profile("test_1", dev.device):
+        test_fxn(err=False)
+      with self.assertRaises(Exception):
+        with cpu_profile("test_2", dev.device):
+            test_fxn(err=True)
+
+    range_events = [p for p in profile if isinstance(p, ProfileRangeEvent)]
+    self.assertEqual(len(range_events), 2)
+    # record start/end time up to exit (error or success)
+    self.assertGreater(range_events[0].en-range_events[0].st, range_events[1].en-range_events[1].st)
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -170,7 +170,7 @@ class TestProfiler(unittest.TestCase):
         test_fxn(err=False)
       with self.assertRaises(Exception):
         with cpu_profile("test_2", dev.device):
-            test_fxn(err=True)
+          test_fxn(err=True)
 
     range_events = [p for p in profile if isinstance(p, ProfileRangeEvent)]
     self.assertEqual(len(range_events), 2)

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -76,7 +76,8 @@ class ProfileResult: st:Optional[int]=None; en:Optional[int]=None # noqa: E702
 
 @contextlib.contextmanager
 def cpu_profile(name, device="CPU", is_copy=False, display=True) -> Generator[ProfileResult, None, None]:
-  try: yield (res:=ProfileResult(st:=time.perf_counter_ns()))
+  res = ProfileResult(st:=time.perf_counter_ns())
+  try: yield res
   finally:
     res.en = en = time.perf_counter_ns()
     if PROFILE and display:

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -76,10 +76,11 @@ class ProfileResult: st:Optional[int]=None; en:Optional[int]=None # noqa: E702
 
 @contextlib.contextmanager
 def cpu_profile(name, device="CPU", is_copy=False, display=True) -> Generator[ProfileResult, None, None]:
-  yield (res:=ProfileResult(st:=time.perf_counter_ns()))
-  res.en = en = time.perf_counter_ns()
-  if PROFILE and display:
-    Compiled.profile_events += [ProfileRangeEvent(device, name, decimal.Decimal(st) / 1000, decimal.Decimal(en) / 1000, is_copy=is_copy)]
+  try: yield (res:=ProfileResult(st:=time.perf_counter_ns()))
+  finally:
+    res.en = en = time.perf_counter_ns()
+    if PROFILE and display:
+      Compiled.profile_events += [ProfileRangeEvent(device, name, decimal.Decimal(st) / 1000, decimal.Decimal(en) / 1000, is_copy=is_copy)]
 
 # **************** Buffer + Allocators ****************
 


### PR DESCRIPTION
This diff adds support for tracing cpu_profile events up to the point of error.
Currently in master if a function errors, we do not record any traces.

I think it'll be particularly useful for tracing graph_rewrite errors on the TINY device.