### PR TITLE
[BUG] hip_ioctl: fallback platform.machine() when platform.processor() is empty,

### DIFF
--- a/extra/hip_gpu_driver/hip_ioctl.py
+++ b/extra/hip_gpu_driver/hip_ioctl.py
@@ -5,7 +5,7 @@ start = time.perf_counter()
 # *** ioctl lib ***
 libc = ctypes.CDLL(ctypes.util.find_library("c"))
 # platform.processor calls `uname -p` which can return `unknown` on some systems
-processor = os.getenv("IOCTL_PROCESSOR") or platform.processor()
+processor = os.getenv("IOCTL_PROCESSOR") or platform.processor() or platform.machine()
 IOCTL_SYSCALL = {"aarch64": 0x1d, "x86_64":16}[processor]
 
 def get_struct(argp, stype):


### PR DESCRIPTION
This PR addresses a KeyError that can occur when running pytest (specifically tests involving extra.hip_gpu_driver.hip_ioctl) on systems where platform.processor() returns an empty string or an unrecognized architecture.

The original code relied on os.getenv("IOCTL_PROCESSOR") or platform.processor() to determine the system's processor architecture. However, platform.processor() can sometimes return an empty string or a value not directly mapped in the IOCTL_SYSCALL dictionary, leading to a KeyError.

This PR modifies the processor detection logic in extra/hip_gpu_driver/hip_ioctl.py to include platform.machine() as an additional fallback. platform.machine() generally provides a more consistent and widely recognized machine architecture string (e.g., 'x86_64', 'aarch64'), which helps prevent the KeyError.

Before this change (demonstrating the error):
(base) cypix-pc@fedora:~/tinygrad$ CAPTURE_PROCESS_REPLAY=1 pytest -q
INTERNALERROR> Traceback (most recent call last):
# ... (snip for brevity) ...
INTERNALERROR>   File "/home/cypix-pc/tinygrad/extra/hip_gpu_driver/hip_ioctl.py", line 9, in <module>
INTERNALERROR>     IOCTL_SYSCALL = {"aarch64": 0x1d, "x86_64":16}[processor]
INTERNALERROR>                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
INTERNALERROR> KeyError: ''
1 warning in 0.54s

After this change (successful run):
(base) cypix-pc@fedora:~/tinygrad$ CAPTURE_PROCESS_REPLAY=1 pytest -q
   6.61 ms +   0.01 ms : ioctl idir=0 size=0 itype=84 nr=81 fd=12 ret=0 /tmp/tmp30u_b1fd
# ... (successful pytest output indicating no KeyError) ...