### PR TITLE
viz: resolve all graph references in python

### DIFF
--- a/tinygrad/viz/js/worker.js
+++ b/tinygrad/viz/js/worker.js
@@ -10,15 +10,13 @@ onmessage = (e) => {
   g.setGraph({ rankdir: "LR" }).setDefaultEdgeLabel(function() { return {}; });
   if (additions.length !== 0) g.setNode("addition", {label:"", style:"fill: rgba(26, 27, 38, 0.5);", padding:0});
   for (let [k, {label, src, ref, ...rest }] of Object.entries(graph)) {
-    const idx = ref ? ctxs.findIndex(k => k.ref === ref) : -1;
-    if (idx != -1) label += `\ncodegen@${ctxs[idx].function_name}`;
     // adjust node dims by label size (excluding escape codes) + add padding
     let [width, height] = [0, 0];
     for (line of label.replace(/\u001B\[(?:K|.*?m)/g, "").split("\n")) {
       width = Math.max(width, ctx.measureText(line).width);
       height += LINE_HEIGHT;
     }
-    g.setNode(k, {width:width+NODE_PADDING*2, height:height+NODE_PADDING*2, padding:NODE_PADDING, label, ref:idx==-1 ? null : idx, ...rest});
+    g.setNode(k, {width:width+NODE_PADDING*2, height:height+NODE_PADDING*2, padding:NODE_PADDING, label, ref, ...rest});
     // add edges
     const edgeCounts = {}
     for (const s of src) edgeCounts[s] = (edgeCounts[s] || 0)+1;

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -26,11 +26,9 @@ def get_metadata(keys:list[Any], contexts:list[list[TrackedGraphRewrite]]) -> li
   ret = []
   for i,(k,v) in enumerate(zip(keys, contexts)):
     steps = [{"name":s.name, "loc":s.loc, "depth":s.depth, "match_count":len(s.matches), "code_line":printable(s.loc)} for s in v]
-    if isinstance(k, ProgramSpec):
-      ret.append(r:={"name":k.name, "kernel_code":k.src, "steps":steps})
-      ref_map.update(((k.function_name, i), (k.ast, i)))
-    else: ret.append(r:={"name":str(k), "steps":steps})
-    ref_map[r["name"]] = i
+    for key in (refs:=[k.name, k.function_name, k.ast] if isinstance(k, ProgramSpec) else [str(k)]): ref_map[key] = i
+    ret.append({"name":refs[0], "steps":steps})
+    if isinstance(k, ProgramSpec): ret[-1]["kernel_code"] = k.src
   return ret
 
 # ** Complete rewrite details for a graph_rewrite call

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -114,7 +114,9 @@ def timeline_layout(events:list[tuple[int, int, float, DevEvent]]) -> dict:
     depth = next((i for i,level_et in enumerate(levels) if st>=level_et), len(levels))
     if depth < len(levels): levels[depth] = et
     else: levels.append(et)
-    shapes.append({"name":ctxs[ref]["name"] if (ref:=ref_map.get(e.name)) is not None else e.name, "st":st, "dur":dur, "depth":depth, "ref":ref})
+    name = e.name
+    if (ref:=ref_map.get(name)) is not None: name = ctxs[ref]["name"]
+    shapes.append({"name":name, "ref":ref, "st":st, "dur":dur, "depth":depth})
   return {"shapes":shapes, "maxDepth":len(levels)}
 
 def mem_layout(events:list[tuple[int, int, float, DevEvent]]) -> dict:

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -28,7 +28,7 @@ def get_metadata(keys:list[Any], contexts:list[list[TrackedGraphRewrite]]) -> li
     steps = [{"name":s.name, "loc":s.loc, "depth":s.depth, "match_count":len(s.matches), "code_line":printable(s.loc)} for s in v]
     if isinstance(k, ProgramSpec):
       ret.append(r:={"name":k.name, "kernel_code":k.src, "steps":steps})
-      ref_map.update(((k.function_name, i), (id(k.ast), i)))
+      ref_map.update(((k.function_name, i), (k.ast, i)))
     else: ret.append(r:={"name":str(k), "steps":steps})
     ref_map[r["name"]] = i
   return ret
@@ -72,7 +72,7 @@ def uop_to_json(x:UOp) -> dict[int, dict]:
         label += f"\n{shape_to_str(u.shape)}"
     except Exception:
       label += "\n<ISSUE GETTING SHAPE>"
-    if (ref:=ref_map.get(id(u.arg.ast)) if u.op is Ops.KERNEL else None) is not None: label += f"\ncodegen@{ctxs[ref]['name']}"
+    if (ref:=ref_map.get(u.arg.ast) if u.op is Ops.KERNEL else None) is not None: label += f"\ncodegen@{ctxs[ref]['name']}"
     # NOTE: kernel already has metadata in arg
     if TRACEMETA >= 2 and u.metadata is not None and u.op is not Ops.KERNEL: label += "\n"+repr(u.metadata)
     graph[id(u)] = {"label":label, "src":[id(x) for x in u.src if x not in excluded], "color":uops_colors.get(u.op, "#ffffff"),

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -21,7 +21,7 @@ uops_colors = {Ops.LOAD: "#ffc0c0", Ops.STORE: "#87CEEB", Ops.CONST: "#e0e0e0", 
 
 # ** Metadata for a track_rewrites scope
 
-ref_map:dict[Any, dict] = {}
+ref_map:dict[Any, int] = {}
 def get_metadata(keys:list[Any], contexts:list[list[TrackedGraphRewrite]]) -> list[dict]:
   ret = []
   for i,(k,v) in enumerate(zip(keys, contexts)):

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -27,9 +27,10 @@ def get_metadata(keys:list[Any], contexts:list[list[TrackedGraphRewrite]]) -> li
   for i,(k,v) in enumerate(zip(keys, contexts)):
     steps = [{"name":s.name, "loc":s.loc, "depth":s.depth, "match_count":len(s.matches), "code_line":printable(s.loc)} for s in v]
     if isinstance(k, ProgramSpec):
-      ret.append({"name":k.name, "kernel_code":k.src, "steps":steps})
+      ret.append(r:={"name":k.name, "kernel_code":k.src, "steps":steps})
       ref_map.update(((k.function_name, i), (id(k.ast), i)))
-    else: ret.append({"name":str(k), "steps":steps})
+    else: ret.append(r:={"name":str(k), "steps":steps})
+    ref_map[r["name"]] = i
   return ret
 
 # ** Complete rewrite details for a graph_rewrite call


### PR DESCRIPTION
Some trace events (eg. codegen UOp rewrite) can relate to other trace events (eg. a Program run on the GPU) in VIZ.

This was scattered in python/javascript. This diff pushes the complexity to python.