### PR TITLE
am_smi: increase kill retries

### DIFF
--- a/extra/amdpci/am_smi.py
+++ b/extra/amdpci/am_smi.py
@@ -284,8 +284,8 @@ if __name__ == "__main__":
           while True:
             try: pid = subprocess.check_output(['sudo', 'lsof', '-t', dev]).decode('utf-8').split('\n')[0]
             except subprocess.CalledProcessError: break
-            if stopped_pids[pid] > 0: time.sleep(0.5)
-            if stopped_pids[pid] == 10:
+            if stopped_pids[pid] > 0: time.sleep(0.1)
+            if stopped_pids[pid] == 64:
               print(f"{dev[8:-5]}: can't stop process {pid}, exitting")
               exit(1)
 


### PR DESCRIPTION
10 retries are not sufficient to stop mp-processes. 64 should be enough to cover our systems and kill all child pids when they get stuck