### PR TITLE
Add `tinygrad.frontend` to pip package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name='tinygrad',
       packages = ['tinygrad', 'tinygrad.runtime.autogen', 'tinygrad.runtime.autogen.am', 'tinygrad.codegen', 'tinygrad.nn',
                   'tinygrad.renderer', 'tinygrad.engine', 'tinygrad.viz', 'tinygrad.runtime', 'tinygrad.runtime.support', 'tinygrad.kernelize',
                   'tinygrad.runtime.support.am', 'tinygrad.runtime.graph', 'tinygrad.shape', 'tinygrad.uop', 'tinygrad.opt',
-                  'tinygrad.runtime.support.nv'],
+                  'tinygrad.runtime.support.nv', 'tinygrad.frontend'],
       package_data = {'tinygrad': ['py.typed'], 'tinygrad.viz': ['index.html', 'assets/**/*', 'js/*']},
       classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Moving openpilot to use it as a normal pip package and this this:
```
  File "/home/batman/fivepilot/selfdrive/modeld/compile3.py", line 15, in <module>
    from tinygrad.frontend.onnx import OnnxRunner, onnx_load
    from tinygrad.frontend.onnx import OnnxRunner, onnx_load
ModuleNotFoundError: No module named 'tinygrad.frontend'
ModuleNotFoundError: No module named 'tinygrad.frontend'
```

https://github.com/commaai/openpilot/pull/35638