### PR TITLE
remove invalid int div test

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -589,10 +589,6 @@ class TestOps(unittest.TestCase):
       np.testing.assert_equal(x.numpy(), 2**64 - 1)
     # 1 // 0 is device dependent, but it should not raise
     Tensor([1]).idiv(1).realize()
-    if not CI:  # TODO: crashed in CI on some devices
-      # ... because if might be in a where branch that the output is well defined
-      t = Tensor([-1, 0, 1, 2])
-      np.testing.assert_equal((t > 0).where(1//t, t).numpy(), [-1, 0, 1, 0])
 
   def test_scalar_div(self):
     helper_test_op([(45,65)], lambda x: x/255)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -587,8 +587,6 @@ class TestOps(unittest.TestCase):
     if is_dtype_supported(dtypes.uint64):
       x = Tensor(2**64 - 1, dtype=dtypes.uint64).idiv(1)
       np.testing.assert_equal(x.numpy(), 2**64 - 1)
-    # 1 // 0 is device dependent, but it should not raise
-    Tensor([1]).idiv(1).realize()
 
   def test_scalar_div(self):
     helper_test_op([(45,65)], lambda x: x/255)


### PR DESCRIPTION
The test divides by 0, crashes in llvm, cpu. A conditional move doesn't branch so the division by 0 is always performed even if the condition is false.