### PR TITLE
clean svd tests, set full_matrices false in torch backend

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -353,7 +353,7 @@ def sort_values(input, dim=-1, descending=False, stable=True, values=None, indic
   return wrap(out_values), wrap(out_indices)
 
 @torch.library.impl("aten::_linalg_svd", "privateuseone")
-def _linalg_svd(self, full_matrices=True):
+def _linalg_svd(self, full_matrices=False):
   U, S, Vh = unwrap(self).svd(full_matrices)
   return wrap(U), wrap(S), wrap(Vh)
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -3063,13 +3063,12 @@ class TestOps(unittest.TestCase):
     A = torch.randn(5, 5)
     U, S, Vh = torch.linalg.svd(A, full_matrices=True)
     np.testing.assert_allclose(torch.dist(A, U @ torch.diag(S) @ Vh).cpu().numpy(), 0, atol=1e-5)
-    U, S, Vh = torch.linalg.svd(A, full_matrices=False)
-    np.testing.assert_allclose(torch.dist(A, U @ torch.diag(S) @ Vh).cpu().numpy(), 0, atol=1e-5)
 
-    # # TODO: this works with torch, but not TINY_BACKEND. U has a wrong shape
-    # A = torch.randn(5, 3)
-    # U, S, Vh = torch.linalg.svd(A, full_matrices=False)
-    # np.testing.assert_allclose(torch.dist(A, U @ torch.diag(S) @ Vh).cpu().numpy(), 0, atol=1e-5)
+    A = torch.randn(5, 3)
+    U, S, Vh = torch.linalg.svd(A, full_matrices=False)
+    np.testing.assert_equal(U.shape, (5,3))
+    np.testing.assert_equal(Vh.shape, (3,3))
+    np.testing.assert_allclose(torch.dist(A, U @ torch.diag(S) @ Vh).cpu().numpy(), 0, atol=1e-5)
 
 @unittest.skipUnless(is_dtype_supported(dtypes.uchar), f"no uint8 on {Device.DEFAULT}")
 class TestOpsUint8(unittest.TestCase):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -3061,7 +3061,9 @@ class TestOps(unittest.TestCase):
   def test_svd(self):
     # test for tiny backend. real svd tests are in test_linalg
     A = torch.randn(5, 5)
-    U, S, Vh = torch.linalg.svd(A, full_matrices=True)
+    U, S, Vh = torch.linalg.svd(A)
+    np.testing.assert_equal(U.shape, (5,5))
+    np.testing.assert_equal(Vh.shape, (5,5))
     np.testing.assert_allclose(torch.dist(A, U @ torch.diag(S) @ Vh).cpu().numpy(), 0, atol=1e-5)
 
     A = torch.randn(5, 3)


### PR DESCRIPTION
Torch's aten operators make no sense at all