### PR TITLE
metal: fix incorrect _free on interpreter exit

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -198,7 +198,8 @@ class MetalAllocator(LRUAllocator[MetalDevice]):
     ret = msg("newBufferWithLength:options:", objc_id)(self.dev.sysdevice, ctypes.c_ulong(size), MTLResourceOptions.MTLResourceStorageModeShared)
     if ret.value is None: raise MemoryError(f"Metal OOM while allocating {size=}")
     return MetalBuffer(ret, size)
-  def _free(self, opaque:MetalBuffer, options): msg("release")(opaque.buf)
+  def _free(self, opaque:MetalBuffer, options):
+    if msg is not None and libobjc is not None: msg("release")(opaque.buf)
   def _transfer(self, dest:MetalBuffer, src:MetalBuffer, sz:int, src_dev:MetalDevice, dest_dev:MetalDevice):
     dest_dev.synchronize()
     src_command_buffer = msg("commandBuffer", objc_instance)(src_dev.mtl_queue)


### PR DESCRIPTION
The same idea as in #8950, this gets rid of the annoying `TypeError: 'NoneType' object is not callable` errors when running anything metal. This happens in CI every time: https://github.com/tinygrad/tinygrad/actions/runs/16180307775/job/45675203905#step:6:63

The original PR asks why `sys.is_finalizing` doesn't work here. Looks like the reason is that the python interpreter shutdown lifecycle is a complete shitshow with cleanup steps happening in all kinds of wonky orders. For example, in our case here if we were to try to call `sys.is_finalizing` to determine whether to release we would discover that `sys` is already `None`! Another way to write this fix is `if sys is not None: msg("release")(opaque.buf)`, but that's even more gross than this is.