### PR TITLE
fix silent mypy failure in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -332,7 +332,8 @@ jobs:
       run: python -m pylint tinygrad/
     - name: Run mypy
       run: |
-        python -m mypy --strict-equality --lineprecision-report . && cat lineprecision.txt
+        python -m mypy --strict-equality --lineprecision-report .
+        cat lineprecision.txt
         python -m mypy --strict-equality extra/onnx_parser.py
 
   unittest:


### PR DESCRIPTION
Example: https://github.com/tinygrad/tinygrad/actions/runs/16215577171/job/45784110543?pr=11177#step:7:20

Caused by footguny exception in how `set -e` works:

```bash
python -m mypy --strict-equality --lineprecision-report . && cat lineprecision.txt
```

Will fail (and have non-zero exit code if run in interactive mode) but because there is `&&` it won't count as script-terminating failure in a script with `set -e` and instead as a test (similar to how fail of a command in if condition won't count as a script-terminating failure despite having non-zero exit code)