### PR TITLE
late_rewrite_patterns gets its own rewrite step

### DIFF
--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -782,7 +782,7 @@ class TestLateRewritePatterns(unittest.TestCase):
     from tinygrad import Context
     mul = UOp(Ops.DEFINE_VAR, dtypes.int.vec(4)) * 2
     with Context(DEVECTORIZE=0):
-      sink = full_rewrite_to_sink(UOp.sink(*[mul]), ClangRenderer)
+      sink = full_rewrite_to_sink(mul.sink(), ClangRenderer)
     self.assertEqual(sink.src[0].op, Ops.SHL)
 
 if __name__ == '__main__':

--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -776,5 +776,14 @@ class TestUOpTags(unittest.TestCase):
     g = graph_rewrite(g, pm_plus_1)
     assert g.ssimplify() == 6
 
+class TestLateRewritePatterns(unittest.TestCase):
+  def test_vector_shl(self):
+    from tinygrad.renderer.cstyle import ClangRenderer
+    from tinygrad import Context
+    mul = UOp(Ops.DEFINE_VAR, dtypes.int.vec(4)) * 2
+    with Context(DEVECTORIZE=0):
+      sink = full_rewrite_to_sink(UOp.sink(*[mul]), ClangRenderer)
+    self.assertEqual(sink.src[0].op, Ops.SHL)
+
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -70,12 +70,10 @@ def _get_rewrites_for_renderer(opts:Renderer, linearizer:bool, _QUANTIZE, _DEVEC
   if opts.pre_matcher is not None: ret.append(RewriteStep(opts.pre_matcher, name="pre_matcher"))
 
   # late rewrite patterns (without sym)
-  pm_late_rewrite = symbolic_simple+get_late_rewrite_patterns(supported_ops, _TRANSCENDENTAL>=2)
-  ret.append(RewriteStep(pm_late_rewrite, lambda _: opts, name="late rewrite"))
+  ret.append(RewriteStep(symbolic_simple+get_late_rewrite_patterns(supported_ops, _TRANSCENDENTAL>=2), lambda _: opts, name="late rewrite"))
 
   # final rules for the renderer (without sym)
-  pm_renderer_rewrite = symbolic_simple+pm_render+extra_matcher
-  ret.append(RewriteStep(pm_renderer_rewrite, lambda _: opts, name="renderer rewrite"))
+  ret.append(RewriteStep(symbolic_simple+pm_render+extra_matcher, name="renderer rewrite"))
 
   # return the list (with optional linearizer)
   return ret + (rewrites_for_linearizer if linearizer else [])

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -69,9 +69,13 @@ def _get_rewrites_for_renderer(opts:Renderer, linearizer:bool, _QUANTIZE, _DEVEC
   # optional pre matcher
   if opts.pre_matcher is not None: ret.append(RewriteStep(opts.pre_matcher, name="pre_matcher"))
 
+  # late rewrite patterns (without sym)
+  pm_late_rewrite = symbolic_simple+get_late_rewrite_patterns(supported_ops, _TRANSCENDENTAL>=2)
+  ret.append(RewriteStep(pm_late_rewrite, lambda _: opts, name="late rewrite"))
+
   # final rules for the renderer (without sym)
-  pm_final_rewrite = symbolic_simple+get_late_rewrite_patterns(supported_ops, _TRANSCENDENTAL>=2)+pm_render+extra_matcher
-  ret.append(RewriteStep(pm_final_rewrite, lambda _: opts, name="final rewrite"))
+  pm_renderer_rewrite = symbolic_simple+pm_render+extra_matcher
+  ret.append(RewriteStep(pm_renderer_rewrite, lambda _: opts, name="renderer rewrite"))
 
   # return the list (with optional linearizer)
   return ret + (rewrites_for_linearizer if linearizer else [])


### PR DESCRIPTION
Most patterns in `late_rewrite_patterns` look for consts. But because the rewrite step includes `pm_render`, vector consts will be explicitly vectorized before the patterns hit. So patterns like shl/shr never apply for vectorized mul/idiv