### PR TITLE
[bounty] Move UPCAST axis type before REDUCE to ensure yellow dims come before…

### DIFF
--- a/tinygrad/opt/kernel.py
+++ b/tinygrad/opt/kernel.py
@@ -461,11 +461,13 @@ class Kernel:
           for axis_type in axis_types:
             if axis_type != current_type:
               if current_group:
+                assert current_type is not None  # current_type cannot be None if current_group is not empty
                 groups.append((current_type, current_group))
               current_group = []
               current_type = axis_type
             current_group.append(axis_type)
           if current_group:
+            assert current_type is not None  # current_type cannot be None if current_group is not empty
             groups.append((current_type, current_group))
 
           reordered: list[AxisType] = []

--- a/tinygrad/opt/kernel.py
+++ b/tinygrad/opt/kernel.py
@@ -453,10 +453,10 @@ class Kernel:
         # NOTE: should group_for_reduces be added to the local_dims?
         kernel_name = ret.arg.name if ret.arg is not None else self.name if name_override is None else name_override
         # Reorder axis_types to put UPCAST before REDUCE while preserving all other ordering
-        def reorder_axis_types(axis_types):
-          groups = []
-          current_group = []
-          current_type = None
+        def reorder_axis_types(axis_types: list[AxisType]) -> list[AxisType]:
+          groups: list[tuple[AxisType, list[AxisType]]] = []
+          current_group: list[AxisType] = []
+          current_type: AxisType | None = None
 
           for axis_type in axis_types:
             if axis_type != current_type:
@@ -468,8 +468,8 @@ class Kernel:
           if current_group:
             groups.append((current_type, current_group))
 
-          reordered = []
-          upcast_groups = []
+          reordered: list[AxisType] = []
+          upcast_groups: list[list[AxisType]] = []
 
           for axis_type, group in groups:
             if axis_type == AxisType.UPCAST:

--- a/tinygrad/opt/kernel.py
+++ b/tinygrad/opt/kernel.py
@@ -482,7 +482,7 @@ class Kernel:
             else:
               reordered.extend(group)
 
-                    for upcast_group in upcast_groups:
+          for upcast_group in upcast_groups:
             reordered.extend(upcast_group)
 
           return reordered

--- a/tinygrad/opt/kernel.py
+++ b/tinygrad/opt/kernel.py
@@ -457,7 +457,7 @@ class Kernel:
           groups = []
           current_group = []
           current_type = None
-          
+
           for axis_type in axis_types:
             if axis_type != current_type:
               if current_group:
@@ -467,10 +467,10 @@ class Kernel:
             current_group.append(axis_type)
           if current_group:
             groups.append((current_type, current_group))
-          
+
           reordered = []
           upcast_groups = []
-          
+
           for axis_type, group in groups:
             if axis_type == AxisType.UPCAST:
               upcast_groups.append(group)
@@ -481,12 +481,12 @@ class Kernel:
               reordered.extend(group)
             else:
               reordered.extend(group)
-        
-          for upcast_group in upcast_groups:
+
+                    for upcast_group in upcast_groups:
             reordered.extend(upcast_group)
-          
+
           return reordered
-        
+
         reordered_axis_types = reorder_axis_types(self.axis_types)
         return ret.replace(arg=KernelInfo(kernel_name, tuple(reordered_axis_types), self.dont_use_locals, tuple(self.applied_opts)))
       if op.op is Ops.REDUCE_AXIS:


### PR DESCRIPTION
… red dims

## Summary
This PR addresses the bounty requirement to move yellow dims (UPCAST) before red dims (REDUCE) while preserving all functionality.

## Changes
- Modified `tinygrad/opt/kernel.py` to add `reorder_axis_types` function in `get_optimized_ast` method
- Reorders axis types to ensure UPCAST comes before REDUCE in the final kernel generation
- Operates at the kernel AST level to catch all kernels system-wide