### PR TITLE
[WIP] Remove realize from __setitem__ and get test_arange to one kernel (bounty)

### DIFF
--- a/tinygrad/kernelize/kernelize.py
+++ b/tinygrad/kernelize/kernelize.py
@@ -8,7 +8,7 @@ from tinygrad.dtype import ImageDType
 from tinygrad.kernelize.multi import multi_pm
 from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.shape.view import View, strides_for_shape, get_contraction_with_reduce
-from tinygrad.kernelize.grouper import group_realizes, ALWAYS_CONTIGUOUS
+from tiny  grad.kernelize.grouper import group_realizes, ALWAYS_CONTIGUOUS
 
 # creation can recurse a lot
 import sys


### PR DESCRIPTION
**### Goal**
Remove `realize()` call from `__setitem__` to enable lazy fusion,
so that `TestSetitemLoop.test_arange` runs as **one fused kernel**.

**###  Progress**
- [ ] Investigating existing `__setitem__` behavior
- [ ] Removed forced realization
- [ ] Verified one-kernel execution using `DEBUG=4`
- [ ] All tests passing

More updates soon. Just locking the bounty before starting deeper work.