### PR TITLE
disable flaky assert in test_cpu_profile

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -182,7 +182,13 @@ class TestProfiler(unittest.TestCase):
     range_events = [p for p in profile if isinstance(p, ProfileRangeEvent)]
     self.assertEqual(len(range_events), 2)
     # record start/end time up to exit (error or success)
-    self.assertGreater(range_events[0].en-range_events[0].st, range_events[1].en-range_events[1].st)
+    for e in range_events:
+      self.assertGreater(e.en, e.st)
+    e1, e2 = range_events
+    self.assertEqual([e1.name, e2.name], ["test_1", "test_2"])
+    # TODO: this is flaky
+    #self.assertLess(e1.st, e2.st)
+    #self.assertGreater(e1.en-e1.st, e2.en-e2.st)
 
   @unittest.skipUnless(Device[Device.DEFAULT].graph is not None, "graph support required")
   def test_graph(self):


### PR DESCRIPTION
Failing https://github.com/tinygrad/tinygrad/actions/runs/16330790359/job/46132585222?pr=11268#step:6:147
with error:
```
AssertionError: Decimal('215782.959') not greater than Decimal('222239.667')
```

Replacing it with a local assert for the duration of each function call. The extra time in the second call might be because of CPU noise.