### PR TITLE
process replay: optionally pass tinygrad import error

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -2,7 +2,6 @@
 # compare kernels created by HEAD against master
 import os, multiprocessing, logging, pickle, sqlite3, difflib, warnings, itertools, functools, base64, codecs
 from typing import Callable, Any
-from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connection, getenv, tqdm
 
 ASSERT_DIFF = int((flag:="[pr]") in os.getenv("COMMIT_MESSAGE", flag) or flag in os.getenv("PR_TITLE", flag))
 if not getenv("ASSERT_PROCESS_REPLAY", 1): ASSERT_DIFF = 0
@@ -11,17 +10,17 @@ REF = os.getenv("GITHUB_REF_NAME", "")
 if REF == "master": SKIP_PROCESS_REPLAY = True
 
 try:
-  from tinygrad.schedule.kernelize import get_kernelize_map
+  from tinygrad.kernelize.kernelize import get_kernelize_map
   from tinygrad.renderer import Renderer, ProgramSpec
   from tinygrad.engine.realize import get_program
   from tinygrad.uop.ops import UOp, Ops, KernelInfo
+  from tinygrad.helpers import VERSION, Context, ContextVar, colored, db_connection, getenv, tqdm
 except ImportError as e:
   print(repr(e))
   exit(int(ASSERT_DIFF))
 
 # *** process replay settings
 
-# internal
 PAGE_SIZE = getenv("PAGE_SIZE", 100)
 MAX_DIFF_PCT = getenv("PROCESS_REPLAY_MAX_DIFF_PCT", 20)
 TABLE_NAME = f"process_replay_{VERSION}"

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -4,7 +4,7 @@ import os, multiprocessing, logging, pickle, sqlite3, difflib, warnings, itertoo
 from typing import Callable, Any
 
 ASSERT_DIFF = int((flag:="[pr]") in os.getenv("COMMIT_MESSAGE", flag) or flag in os.getenv("PR_TITLE", flag))
-if not getenv("ASSERT_PROCESS_REPLAY", 1): ASSERT_DIFF = 0
+if not int(os.getenv("ASSERT_PROCESS_REPLAY", "1")): ASSERT_DIFF = 0
 SKIP_PROCESS_REPLAY = (k:="[skip_process_replay]") in os.getenv("COMMIT_MESSAGE", "") or k in os.getenv("PR_TITLE", "")
 REF = os.getenv("GITHUB_REF_NAME", "")
 if REF == "master": SKIP_PROCESS_REPLAY = True

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -5,9 +5,6 @@ from typing import Callable, Any
 
 ASSERT_DIFF = int((flag:="[pr]") in os.getenv("COMMIT_MESSAGE", flag) or flag in os.getenv("PR_TITLE", flag))
 if not int(os.getenv("ASSERT_PROCESS_REPLAY", "1")): ASSERT_DIFF = 0
-SKIP_PROCESS_REPLAY = (k:="[skip_process_replay]") in os.getenv("COMMIT_MESSAGE", "") or k in os.getenv("PR_TITLE", "")
-REF = os.getenv("GITHUB_REF_NAME", "")
-if REF == "master": SKIP_PROCESS_REPLAY = True
 
 try:
   from tinygrad.kernelize.kernelize import get_kernelize_map
@@ -21,7 +18,9 @@ except ImportError as e:
 
 # *** process replay settings
 
+# internal
 PAGE_SIZE = getenv("PAGE_SIZE", 100)
+REF = os.getenv("GITHUB_REF_NAME", "")
 MAX_DIFF_PCT = getenv("PROCESS_REPLAY_MAX_DIFF_PCT", 20)
 TABLE_NAME = f"process_replay_{VERSION}"
 os.environ["CAPTURE_PROCESS_REPLAY"] = "0"
@@ -33,6 +32,9 @@ def trunc_log(x):
     lines = lines[:MAX_LINES]+[f"WARN: truncated string with {len(lines)} lines"]
   logging.info("\n".join(lines))
 
+# user config
+SKIP_PROCESS_REPLAY = (k:="[skip_process_replay]") in os.getenv("COMMIT_MESSAGE", "") or k in os.getenv("PR_TITLE", "")
+if REF == "master": SKIP_PROCESS_REPLAY = True
 class ProcessReplayWarning(Warning): pass
 
 # *** replay the function and convert return values to string


### PR DESCRIPTION
Currently CI always import errors if filenames in core tinygrad change: https://github.com/tinygrad/tinygrad/actions/runs/16402863306/job/46344733955#step:11:54
When [pr] isn't explicitly enabled, ImportErrors can just exit early.