### PR TITLE
Stable Diffusion mlperf training

### DIFF
--- a/examples/mlperf/dataloader.py
+++ b/examples/mlperf/dataloader.py
@@ -1,4 +1,4 @@
-import os, random, pickle, queue
+import os, random, pickle, queue, functools
 from typing import List
 from pathlib import Path
 from multiprocessing import Queue, Process, shared_memory, connection, Lock, cpu_count
@@ -512,18 +512,18 @@ def batch_load_retinanet(dataset, val:bool, base_dir:Path, batch_size:int=32, sh
 
 # stable diffusion callbacks to match mlperf ref; declared here because they're pickled
 def filter_dataset(sample:dict): return {k:v for k,v in sample.items() if k in {'npy', 'txt'}}
-def collate(batch:list[dict]):
+def collate(batch:list[dict], device:str|None=None):
   # mlperf ref uses torch.utils.data.default_collate
   ret = {"npy": [], "txt": [], "__key__": []}
   for sample in batch:
     for k,v in sample.items():
       ret[k].append(v)
-  ret['npy'] = Tensor.cat(*[Tensor(x) for x in ret['npy']], dim=0)
+  ret['npy'] = Tensor.cat(*[Tensor(x, device=device) for x in ret['npy']], dim=0)
   return ret
 
 # Reference (code): https://github.com/mlcommons/training/blob/2f4a93fb4888180755a8ef55f4b977ef8f60a89e/stable_diffusion/ldm/data/webdatasets.py, Line 55
 # Reference (params): https://github.com/mlcommons/training/blob/ab4ae1ca718d7fe62c369710a316dff18768d04b/stable_diffusion/configs/train_01x08x08.yaml, Line 107
-def batch_load_train_stable_diffusion(BS:int):
+def batch_load_train_stable_diffusion(BS:int, device:str|None=None):
   # TODO: replace webdataset with pure python (tarfile, etc.); would need to replicate reservoir sampling across all shards
   # webdataset depends on torch.utils.data.DataLoader
   import webdataset
@@ -533,7 +533,7 @@ def batch_load_train_stable_diffusion(BS:int):
   dataset = dataset.shuffle(size=1000)
   dataset = dataset.decode()
   dataset = dataset.map(filter_dataset)
-  dataset = dataset.batched(BS, partial=False, collation_fn=collate)
+  dataset = dataset.batched(BS, partial=False, collation_fn=functools.partial(collate, device=device))
   dataset = webdataset.WebLoader(dataset, batch_size=None, shuffle=False, num_workers=1, persistent_workers=True)
 
   for x in dataset:

--- a/examples/mlperf/dataloader.py
+++ b/examples/mlperf/dataloader.py
@@ -522,12 +522,12 @@ def collate(batch:list[dict]):
   return ret
 
 # Reference (code): https://github.com/mlcommons/training/blob/2f4a93fb4888180755a8ef55f4b977ef8f60a89e/stable_diffusion/ldm/data/webdatasets.py, Line 55
-# Reference (params): https://github.com/mlcommons/training/blob/2f4a93fb4888180755a8ef55f4b977ef8f60a89e/stable_diffusion/configs/train_01x08x08.yaml, Line 110
+# Reference (params): https://github.com/mlcommons/training/blob/ab4ae1ca718d7fe62c369710a316dff18768d04b/stable_diffusion/configs/train_01x08x08.yaml, Line 107
 def batch_load_train_stable_diffusion(BS:int):
   # TODO: replace webdataset with pure python (tarfile, etc.); would need to replicate reservoir sampling across all shards
   # webdataset depends on torch.utils.data.DataLoader
   import webdataset
-  # TODO: code for downloading/caching dataset, in extra/datasets/laion
+  # TODO: add code for downloading/caching dataset, in extra/datasets/laion
   dataset = webdataset.WebDataset(urls=f'{os.getenv("BASEDIR")}/laion-400m/webdataset-moments-filtered/{{00000..00000}}.tar', resampled=True,
                                   cache_size=-1, cache_dir=None)
   dataset = dataset.shuffle(size=1000)

--- a/examples/mlperf/dataloader.py
+++ b/examples/mlperf/dataloader.py
@@ -528,7 +528,7 @@ def batch_load_train_stable_diffusion(BS:int, device:str|None=None):
   # webdataset depends on torch.utils.data.DataLoader
   import webdataset
   # TODO: add code for downloading/caching dataset, in extra/datasets/laion
-  dataset = webdataset.WebDataset(urls=f'{os.getenv("BASEDIR")}/laion-400m/webdataset-moments-filtered/{{00000..00000}}.tar', resampled=True,
+  dataset = webdataset.WebDataset(urls=f'{os.getenv("BASEDIR")}/datasets/laion-400m/webdataset-moments-filtered/{{00000..00000}}.tar', resampled=True,
                                   cache_size=-1, cache_dir=None)
   dataset = dataset.shuffle(size=1000)
   dataset = dataset.decode()

--- a/examples/mlperf/lr_schedulers.py
+++ b/examples/mlperf/lr_schedulers.py
@@ -1,8 +1,9 @@
 import math
-from tinygrad import dtypes
+from tinygrad import dtypes, Tensor
 from tinygrad.nn.optim import Optimizer
 
 from extra.lr_scheduler import LR_Scheduler
+from typing import Callable
 
 # https://github.com/mlcommons/training/blob/e237206991d10449d9675d95606459a3cb6c21ad/image_classification/tensorflow2/lars_util.py
 class PolynomialDecayWithWarmup(LR_Scheduler):
@@ -37,3 +38,81 @@ class CosineAnnealingLRWithWarmup(LR_Scheduler):
     warmup_lr = ((self.epoch_counter+1) / self.warmup_steps) * self.base_lr
     decay_lr = self.end_lr + 0.5 * (self.base_lr-self.end_lr) * (1 + (((self.epoch_counter+1-self.warmup_steps)/self.decay_steps) * math.pi).cos())
     return (self.epoch_counter < self.warmup_steps).where(warmup_lr, decay_lr).cast(self.optimizer.lr.dtype)
+
+try: import numpy as np
+except: pass
+# Reference: https://github.com/mlcommons/training/blob/64b14a9abc74e08779a175abca7d291f8c957632/stable_diffusion/ldm/lr_scheduler.py, Lines 36-97
+# TODO: refactor this code for better integration with tinygrad's LR_Scheduler
+# TODO: use Tensors for everything instead of numpy/python
+class LambdaWarmUpCosineScheduler2:
+  """
+  supports repeated iterations, configurable via lists
+  note: use with a base_lr of 1.0.
+  """
+  def __init__(self, warm_up_steps, f_min, f_max, f_start, cycle_lengths, verbosity_interval=0):
+    assert len(warm_up_steps) == len(f_min) == len(f_max) == len(f_start) == len(cycle_lengths)
+    self.lr_warm_up_steps = warm_up_steps
+    self.f_start = f_start
+    self.f_min = f_min
+    self.f_max = f_max
+    self.cycle_lengths = cycle_lengths
+    self.cum_cycles = np.cumsum([0] + list(self.cycle_lengths))
+    self.last_f = 0.
+    self.verbosity_interval = verbosity_interval
+
+  def find_in_interval(self, n):
+    interval = 0
+    for cl in self.cum_cycles[1:]:
+      if n <= cl:
+        return interval
+      interval += 1
+
+  def schedule(self, n, **kwargs):
+    cycle = self.find_in_interval(n)
+    n = n - self.cum_cycles[cycle]
+    if self.verbosity_interval > 0:
+      if n % self.verbosity_interval == 0: print(f"current step: {n}, recent lr-multiplier: {self.last_f}, "
+                                                    f"current cycle {cycle}")
+    if n < self.lr_warm_up_steps[cycle]:
+      f = (self.f_max[cycle] - self.f_start[cycle]) / self.lr_warm_up_steps[cycle] * n + self.f_start[cycle]
+      self.last_f = f
+      return f
+    else:
+      t = (n - self.lr_warm_up_steps[cycle]) / (self.cycle_lengths[cycle] - self.lr_warm_up_steps[cycle])
+      t = min(t, 1.0)
+      f = self.f_min[cycle] + 0.5 * (self.f_max[cycle] - self.f_min[cycle]) * (1 + np.cos(t * np.pi))
+      self.last_f = f
+      return f
+
+  def __call__(self, n, **kwargs):
+      return self.schedule(n, **kwargs)
+
+class LambdaLinearScheduler(LambdaWarmUpCosineScheduler2):
+
+  def schedule(self, n, **kwargs):
+    cycle = self.find_in_interval(n)
+    n = n - self.cum_cycles[cycle]
+    if self.verbosity_interval > 0:
+      if n % self.verbosity_interval == 0:
+        print(f"current step: {n}, recent lr-multiplier: {self.last_f}, current cycle {cycle}")
+
+    if n < self.lr_warm_up_steps[cycle]:
+      f = (self.f_max[cycle] - self.f_start[cycle]) / self.lr_warm_up_steps[cycle] * n + self.f_start[cycle]
+      self.last_f = f
+      return f
+    else:
+      f = self.f_min[cycle] + (self.f_max[cycle] - self.f_min[cycle]) * (self.cycle_lengths[cycle] - n) / (self.cycle_lengths[cycle])
+      self.last_f = f
+      return f
+
+# based on torch.optim.lr_scheduler.LambdaLR
+class LambdaLR(LR_Scheduler):
+  def __init__(self, optimizer:Optimizer, base_lr:float, lr_lambda:Callable):
+    self.optimizer, self.base_lr, self.lr_lambda = optimizer, base_lr, lr_lambda
+    self.epoch_counter = Tensor([0], requires_grad=False, device=self.optimizer.device)
+
+  def get_lr(self):
+    # LR_Scheduler.schedule_step increments self.epoch_counter by 1 before calling get_lr,
+    #  but we need to calc. our first lr with self.epoch_counter=0
+    lr = self.base_lr * self.lr_lambda(self.epoch_counter.item() - 1)
+    return Tensor([lr])

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -1513,15 +1513,18 @@ def train_stable_diffusion():
       #print("saved model")
       #safe_save(get_state_dict(losses), BASEDIR / "checkpoints" / f"tiny_losses_after_{i+1}_steps.safetensors")
       #print("saved losses")
-      grads = {}
+      #grads = {}
+      out = {}
       for k,v in get_state_dict(unet).items():
         if k == "out.2.bias":
-          if v.grad is not None:
+          #if v.grad is not None:
             #x = v.grad.to("NV").contiguous().to("CPU").realize()
             #grads[f"{k}.grad"] = x
-            grads[f"{k}.grad"] = v.grad.contiguous().realize()
-      safe_save(grads, BASEDIR / "checkpoints" / f"tiny_grads_after_{i+1}_steps.safetensors")
-      print("saved grads")
+            #grads[f"{k}.grad"] = v.grad.contiguous().realize()
+          out[k] = v
+      #safe_save(grads, BASEDIR / "checkpoints" / f"tiny_grads_after_{i+1}_steps.safetensors")
+      safe_save(out, BASEDIR / "checkpoints" / f"tiny_out.2.bias_after_{i+1}_steps.safetensors")
+      print("saved")
       import sys
       sys.exit()
 

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -1486,12 +1486,14 @@ def train_stable_diffusion():
 
     v_true = sqrt_alphas_cumprod[t] * noise - sqrt_one_minus_alphas_cumprod[t] * latent
     loss = jit_step(latent_with_noise, t, context, v_true, unet, optimizer, scheduler)
-    losses.append(loss)
+    losses.append(loss.clone().realize())
     ref_loss = data['loss'][i].item()
     print(f"epoch {i}: loss: {loss.item():.9f}, ref_loss: {ref_loss:.9f}, loss_diff: {(ref_loss - loss.item()):.9f}")
     if i == 10:
       safe_save(get_state_dict(unet), BASEDIR / "checkpoints" / "tiny_after_eleven_training_steps.safetensors")
       safe_save(get_state_dict(losses), BASEDIR / "checkpoints" / "tiny_losses.safetensors")
+      import sys
+      sys.exit()
 
 if __name__ == "__main__":
   multiprocessing.set_start_method('spawn')

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -1400,11 +1400,11 @@ def train_stable_diffusion():
 
   # NOTE: Here the goal is to compare output against the mlperf reference implementation, using the same inputs for both
   # NOTE: Therefore we load the same input samples (including randn samples) that were used in the mlperf reference run
-  with open(BASEDIR / "checkpoints" / "1_training_prompts.txt") as f:
+  with open(BASEDIR / "checkpoints" / "3_training_prompts.txt") as f:
     prompts = f.read().split("\n")
   print(prompts[0])
 
-  data = safe_load(BASEDIR / "checkpoints" / "1_training_steps.safetensors")
+  data = safe_load(BASEDIR / "checkpoints" / "3_training_steps.safetensors")
   for p in data.values(): p.to_("CPU").realize()
 
   for p in get_parameters(model.cond_stage_model): p.to_("NV")
@@ -1467,7 +1467,7 @@ def train_stable_diffusion():
     return loss
   
   jit_step = TinyJit(train_step, optimize=True)
-  jit_step.cnt = 1 # capture right away
+  #jit_step.cnt = 1 # capture right away
 
   dl = batch_load_train_stable_diffusion(BS, device=Device.DEFAULT)
   # training loop, one iteration = one epoch
@@ -1508,7 +1508,7 @@ def train_stable_diffusion():
     ref_loss = data['loss'][i].item()
     print(f"epoch {i}: loss: {loss.item():.9f}, ref_loss: {ref_loss:.9f}, loss_diff: {(ref_loss - loss.item()):.9f}")
     #if i == 10:
-    if i == 0:
+    if i == 2:
       #safe_save(get_state_dict(unet), BASEDIR / "checkpoints" / f"tiny_after_{i+1}_training_steps.safetensors")
       #print("saved model")
       #safe_save(get_state_dict(losses), BASEDIR / "checkpoints" / f"tiny_losses_after_{i+1}_steps.safetensors")

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -1355,6 +1355,8 @@ def train_llama3():
     print(loss.item(), lr.item(), f"{GlobalCounters.global_mem//10**9=}")
 
 def train_stable_diffusion():
+  from extra.models.unet import UNetModel
+  from examples.mlperf.dataloader import batch_load_train_stable_diffusion
   config = {}
   # ** hyperparameters **
   BS                 = config["BS"]                     = getenv("BS", 1)
@@ -1363,6 +1365,25 @@ def train_stable_diffusion():
 
   BASEDIR = getenv("BASEDIR", "")
   assert BASEDIR, "set BASEDIR to path of datasets"
+
+  x = batch_load_train_stable_diffusion(BS)
+  for batch in x:
+    break
+  
+  unet_params = {
+    "adm_in_ch": None,
+    "in_ch": 4,
+    "out_ch": 4,
+    "model_ch": 320,
+    "attention_resolutions": [4, 2, 1],
+    "num_res_blocks": 2,
+    "channel_mult": [1, 2, 4, 4],
+    "d_head": 64,
+    "transformer_depth": [1, 1, 1, 1],
+    "ctx_dim": 1024,
+    "use_linear": True,
+  }
+  model = UNetModel(**unet_params)
 
   """
   opt = torch.optim.AdamW(params, lr=lr)
@@ -1380,7 +1401,7 @@ Parameter Group 0
     weight_decay: 0.01
 )
   """
-  #optimizer = AdamW(get_parameters(model), lr=lr)
+  optimizer = AdamW(get_parameters(model), lr=lr)
 
   @TinyJit
   @Tensor.train()

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -1354,6 +1354,44 @@ def train_llama3():
     # BS=1 SEQLEN=4000 OPTIM_DTYPE=bfloat16 LLAMA3_SIZE=8B WARMUP_STEPS=2 DECAY_STEPS=300 PYTHONPATH=. AMD=1 MODEL=llama3 python3 examples/mlperf/model_train.py
     print(loss.item(), lr.item(), f"{GlobalCounters.global_mem//10**9=}")
 
+def train_stable_diffusion():
+  config = {}
+  # ** hyperparameters **
+  BS                 = config["BS"]                     = getenv("BS", 1)
+  EVAL_BS            = config["EVAL_BS"]                = getenv("EVAL_BS", 1)
+  lr                 = config["LEARNING_RATE"]          = getenv("LEARNING_RATE", 1.25e-7)
+
+  BASEDIR = getenv("BASEDIR", "")
+  assert BASEDIR, "set BASEDIR to path of datasets"
+
+  """
+  opt = torch.optim.AdamW(params, lr=lr)
+  AdamW (
+Parameter Group 0
+    amsgrad: False
+    betas: (0.9, 0.999)
+    capturable: False
+    differentiable: False
+    eps: 1e-08
+    foreach: None
+    fused: None
+    lr: 1.25e-07
+    maximize: False
+    weight_decay: 0.01
+)
+  """
+  #optimizer = AdamW(get_parameters(model), lr=lr)
+
+  @TinyJit
+  @Tensor.train()
+  def train_step(model, optimizer, scheduler): pass
+    #optimizer.zero_grad()
+
+    #optimizer.step()
+    #scheduler.step()
+    #Tensor.realize(loss, optimizer.optimizers[0].lr)
+    #return loss, optimizer.optimizers[0].lr
+
 if __name__ == "__main__":
   multiprocessing.set_start_method('spawn')
 
@@ -1362,7 +1400,7 @@ if __name__ == "__main__":
   else: bench_log_manager = contextlib.nullcontext()
 
   with Tensor.train():
-    for m in getenv("MODEL", "resnet,retinanet,unet3d,rnnt,bert,maskrcnn").split(","):
+    for m in getenv("MODEL", "resnet,retinanet,unet3d,rnnt,bert,maskrcnn,stable_diffusion").split(","):
       nm = f"train_{m}"
       if nm in globals():
         print(f"training {m}")

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -1358,6 +1358,7 @@ def train_stable_diffusion():
   from extra.models.unet import UNetModel
   from examples.mlperf.dataloader import batch_load_train_stable_diffusion
   from examples.mlperf.lr_schedulers import LambdaLR, LambdaLinearScheduler
+  from examples.stable_diffusion import get_alphas_cumprod
   config = {}
   # ** hyperparameters **
   BS                 = config["BS"]                     = getenv("BS", 1)
@@ -1405,6 +1406,12 @@ def train_stable_diffusion():
     mean, logvar = Tensor.chunk(batch['npy'].cast(dtypes.half), 2, dim=1)
     std = Tensor.exp(0.5 * logvar.clamp(-30.0, 20.0))
     latent = (mean + std * Tensor.randn(mean.shape)).cast(dtypes.half) * SCALE_FACTOR
+    alphas_cumprod = get_alphas_cumprod()
+    sqrt_alphas_cumprod = alphas_cumprod.sqrt()
+    sqrt_one_minus_alphas_cumprod = (1 - alphas_cumprod).sqrt()
+    t = Tensor.randint(0, alphas_cumprod.shape[0], (latent.shape[0],), dtype=dtypes.long)
+    noise = Tensor.randn_like(latent)
+    latent_with_noise = sqrt_alphas_cumprod[t] * latent + sqrt_one_minus_alphas_cumprod[t] * noise
     break
 
 if __name__ == "__main__":

--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -1362,6 +1362,7 @@ def train_stable_diffusion():
   from examples.stable_diffusion import get_alphas_cumprod
   from tinygrad.nn.state import load_state_dict, torch_load
   from collections import namedtuple
+
   config = {}
   # ** hyperparameters **
   BS                 = config["BS"]                     = getenv("BS", 1)
@@ -1408,7 +1409,7 @@ def train_stable_diffusion():
       p.to_("NV")
 
     out = model(x_noised, t, c)
-    loss = ((out - v_true) ** 2).mean() / v_true.shape[0]
+    loss = ((out - v_true) ** 2).mean()
 
     loss.backward().to_("CPU")
 

--- a/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
+++ b/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# NOTE: The current settings are sufficient to test whether this tinygrad implementation matches the mlperf reference implementation.
+#   The approach is to test I/O with each component, ensuring tinygrad/ref implementations match.
+#   The focus is on correctness, not speed - I use CPU because my local GPU isn't big enough for holding all the training params.
+# TODO: next steps: train to convergence on one big NVIDIA GPU (cloud rented), then on tinybox
+
+# dependencies
+# pip install tqdm
+
+#export PYTHONPATH="." NV=1
+export PYTHONPATH="." CPU=1
+
+#export MODEL="bert"
+export MODEL="stable_diffusion"
+
+#export DEFAULT_FLOAT="HALF" SUM_DTYPE="HALF" GPUS=6 BS=96 EVAL_BS=96
+export BS=1 EVAL_BS=1
+
+#export FUSE_ARANGE=1 FUSE_ARANGE_UINT=0
+
+#export BEAM=8 BEAM_UOPS_MAX=10000 BEAM_UPCAST_MAX=256 BEAM_LOCAL_MAX=1024 BEAM_MIN_PROGRESS=5
+#export IGNORE_JIT_FIRST_BEAM=1
+
+#export BASEDIR="/raid/datasets/wiki"
+# TODO: this will change when training on a tinybox
+export BASEDIR="/home/hooved/train-sd/training/stable_diffusion/datasets"
+
+#export WANDB=1 PARALLEL=0
+export PARALLEL=0
+
+RUNMLPERF=1 python3 examples/mlperf/model_train.py

--- a/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
+++ b/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
@@ -8,8 +8,7 @@
 # dependencies
 # pip install tqdm
 
-#export PYTHONPATH="." NV=1
-export PYTHONPATH="." CPU=1
+export PYTHONPATH="." NV=1
 
 #export MODEL="bert"
 export MODEL="stable_diffusion"

--- a/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
+++ b/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
@@ -28,4 +28,6 @@ export BASEDIR="/home/hooved/train-sd/training/stable_diffusion/datasets"
 #export WANDB=1 PARALLEL=0
 export PARALLEL=0
 
+export LIMIT_GPU_RAM=1
+
 RUNMLPERF=1 python3 examples/mlperf/model_train.py

--- a/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
+++ b/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
@@ -5,23 +5,26 @@
 #   The focus is on correctness, not speed - I use CPU because my local GPU isn't big enough for holding all the training params.
 # TODO: next steps: train to convergence on one big NVIDIA GPU (cloud rented), then on tinybox
 
-# dependencies
-# pip install tqdm
+# *** dependencies
+#pip install tqdm
+#pip install numpy
+
+## to match mlperf reference clip tokenizer behavior
+#pip install ftfy
+#pip install regex
+
+## to use mlperf reference dataloader
+#pip install webdataset
+#pip install torch # for torch.utils.data.DataLoader, which webdataset depends on
 
 export PYTHONPATH="." NV=1
 
-#export MODEL="bert"
 export MODEL="stable_diffusion"
 
-#export DEFAULT_FLOAT="HALF" SUM_DTYPE="HALF" GPUS=6 BS=96 EVAL_BS=96
-export BS=1 EVAL_BS=1
+# https://github.com/mlcommons/training_policies/blob/master/training_rules.adoc#benchmark_specific_rules
+# Checkpoint must be collected every 512,000 images. CEIL(512000 / global_batch_size) if 512000 is not divisible by GBS.
+export BS=1 EVAL_BS=512000
 
-#export FUSE_ARANGE=1 FUSE_ARANGE_UINT=0
-
-#export BEAM=8 BEAM_UOPS_MAX=10000 BEAM_UPCAST_MAX=256 BEAM_LOCAL_MAX=1024 BEAM_MIN_PROGRESS=5
-#export IGNORE_JIT_FIRST_BEAM=1
-
-#export BASEDIR="/raid/datasets/wiki"
 # TODO: this will change when training on a tinybox
 export BASEDIR="/home/hooved/train-sd/training/stable_diffusion"
 

--- a/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
+++ b/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
@@ -21,12 +21,11 @@ export PYTHONPATH="." NV=1
 
 export MODEL="stable_diffusion"
 
-# https://github.com/mlcommons/training_policies/blob/master/training_rules.adoc#benchmark_specific_rules
-# Checkpoint must be collected every 512,000 images. CEIL(512000 / global_batch_size) if 512000 is not divisible by GBS.
-export BS=1 EVAL_BS=512000
+export BS=1 EVAL_BS=1
 
 # TODO: this will change when training on a tinybox
 export BASEDIR="/home/hooved/train-sd/training/stable_diffusion"
+export UNET_CKPTDIR="${BASEDIR}/checkpoints/training_checkpoints"
 
 #export WANDB=1 PARALLEL=0
 export PARALLEL=0

--- a/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
+++ b/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
@@ -6,16 +6,16 @@
 # TODO: next steps: train to convergence on one big NVIDIA GPU (cloud rented), then on tinybox
 
 # *** dependencies
-#pip install tqdm
-#pip install numpy
+pip install tqdm
+pip install numpy
 
 ## to match mlperf reference clip tokenizer behavior
-#pip install ftfy
-#pip install regex
+pip install ftfy
+pip install regex
 
 ## to use mlperf reference dataloader
-#pip install webdataset
-#pip install torch # for torch.utils.data.DataLoader, which webdataset depends on
+pip install webdataset
+pip install torch # for torch.utils.data.DataLoader, which webdataset depends on
 
 export PYTHONPATH="." NV=1
 

--- a/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
+++ b/examples/mlperf/training_submission_v5.1/tinycorp/benchmarks/stable_diffusion/implementations/tinybox_green/dev_run.sh
@@ -23,11 +23,9 @@ export BS=1 EVAL_BS=1
 
 #export BASEDIR="/raid/datasets/wiki"
 # TODO: this will change when training on a tinybox
-export BASEDIR="/home/hooved/train-sd/training/stable_diffusion/datasets"
+export BASEDIR="/home/hooved/train-sd/training/stable_diffusion"
 
 #export WANDB=1 PARALLEL=0
 export PARALLEL=0
-
-export LIMIT_GPU_RAM=1
 
 RUNMLPERF=1 python3 examples/mlperf/model_train.py

--- a/extra/models/inception.py
+++ b/extra/models/inception.py
@@ -270,8 +270,10 @@ class FidInceptionV3:
     self.Mixed_7b = inception.Mixed_7b
     self.Mixed_7c = inception.Mixed_7c
 
-  def load_from_pretrained(self):
-    state_dict = torch_load(str(fetch("https://github.com/mseitzer/pytorch-fid/releases/download/fid_weights/pt_inception-2015-12-05-6726825d.pth", "pt_inception-2015-12-05-6726825d.pth")))
+  def load_from_pretrained(self, path=None):
+    if path is None:
+      path = fetch("https://github.com/mseitzer/pytorch-fid/releases/download/fid_weights/pt_inception-2015-12-05-6726825d.pth", "pt_inception-2015-12-05-6726825d.pth")
+    state_dict = torch_load(str(path))
     for k,v in state_dict.items():
       if k.endswith(".num_batches_tracked"):
         state_dict[k] = v.reshape(1)

--- a/extra/models/unet.py
+++ b/extra/models/unet.py
@@ -1,16 +1,8 @@
 from tinygrad import Tensor, dtypes
 from tinygrad.nn import Linear, Conv2d, GroupNorm, LayerNorm
+# TODO: refactor to enable control over dtype autocasting (and GroupNorm channel count for mlperf)
 #from tinygrad.device import is_dtype_supported
 def is_dtype_supported(x): return False
-def md(a, b):
-  diff = (a - b).abs().mean().item()
-  ratio = diff / a.abs().mean().item()
-  return diff, ratio
-from tinygrad.nn.state import safe_load, get_state_dict
-unet_io = safe_load("/home/hooved/train-sd/training/stable_diffusion/datasets/tensors/unet_training_io.safetensors")
-for k,v in unet_io.items():
-  unet_io[k] = v.to("NV").realize()
-
 from typing import Optional, Union, List, Any, Tuple
 import math
 

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -311,8 +311,7 @@ class TinyJit(Generic[ReturnType]):
       # Exclude buffers involved in transfer ops to preserve parallelism.
       noopt_buffers = {b for ji in jit_cache if isinstance(ji.prg, BufferXfer) for b in ji.bufs}
       assigned = _internal_memory_planner([cast(list[Buffer], item.bufs) for item in jit_cache], noopt_buffers, debug_prefix="JIT ")
-      #jit_cache = [ExecItem(item.prg, [assigned.get(b,b).ensure_allocated() for b in item.bufs if b is not None],
-      jit_cache = [ExecItem(item.prg, [assigned.get(b,b) for b in item.bufs if b is not None],
+      jit_cache = [ExecItem(item.prg, [assigned.get(b,b).ensure_allocated() for b in item.bufs if b is not None],
                             item.metadata, item.fixedvars) for item in jit_cache]
 
       input_replace = get_input_replace(jit_cache, input_buffers)

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -311,7 +311,8 @@ class TinyJit(Generic[ReturnType]):
       # Exclude buffers involved in transfer ops to preserve parallelism.
       noopt_buffers = {b for ji in jit_cache if isinstance(ji.prg, BufferXfer) for b in ji.bufs}
       assigned = _internal_memory_planner([cast(list[Buffer], item.bufs) for item in jit_cache], noopt_buffers, debug_prefix="JIT ")
-      jit_cache = [ExecItem(item.prg, [assigned.get(b,b).ensure_allocated() for b in item.bufs if b is not None],
+      #jit_cache = [ExecItem(item.prg, [assigned.get(b,b).ensure_allocated() for b in item.bufs if b is not None],
+      jit_cache = [ExecItem(item.prg, [assigned.get(b,b) for b in item.bufs if b is not None],
                             item.metadata, item.fixedvars) for item in jit_cache]
 
       input_replace = get_input_replace(jit_cache, input_buffers)


### PR DESCRIPTION
This PR implements training and eval of the Stable Diffusion v2 UNet, with every component tested for conformity to the mlperf reference implementation.

Although the code is close to being ready for training runs, I just noticed the mlperf training benchmarks have been updated for v5.1, with Stable Diffusion v2 being replaced by FLUX.1. Therefore it seems that this work (and the Stable Diffusion mlperf training bounty) are probably not relevant going forward, and I will close this PR assuming that's the case. Maybe this PR would still have some value to someone as a reference.

Below would have been the next steps from the current state of the PR:

- Modify training loop to use fp16 math (currently uses fp32 math) and loss scaling
- Implement and use gelu without tanh approximation to match mlperf reference
- Modify training/eval to use multigpu (currently uses 1 gpu)
- Attempt convergent training runs