### PR TITLE
fix word_wrap with newlines in input string [pr]

### DIFF
--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -408,6 +408,20 @@ class TestWordWrap(unittest.TestCase):
     st2 = word_wrap(st, wrap=wrap)
     self.assertEqual(len(st2.splitlines()), 2)
 
+  def test_wrap_explicit_newline(self):
+    wrap = 10
+    st = "\n".join(["x"*wrap, "x"*wrap, "x"*wrap])
+    st2 = word_wrap(st, wrap=wrap)
+    self.assertEqual(len(st2.splitlines()), len(st.splitlines()))
+
+    st = "\n".join(["x"*(wrap+1), "x"*wrap, "x"*wrap])
+    st2 = word_wrap(st, wrap=wrap)
+    self.assertEqual(len(st2.splitlines()), len(st.splitlines())+1)
+
+    st = "\n".join(["x"*(wrap+1), "x"*(wrap+1), "x"*(wrap+1)])
+    st2 = word_wrap(st, wrap=wrap)
+    self.assertEqual(len(st2.splitlines()), len(st.splitlines())+3)
+
 class TestIsNumpyNdarray(unittest.TestCase):
   def test_ndarray(self):
     self.assertTrue(is_numpy_ndarray(np.array([1, 2, 3])))

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -76,9 +76,11 @@ def get_child(obj, key):
   return obj
 def word_wrap(x, wrap=80):
   if len(ansistrip(x)) <= wrap: return x
+  if len(lines:=x.splitlines()) > 1: return "\n".join(word_wrap(line, wrap) for line in lines)
   i = 0
   while len(ansistrip(x[:i])) < wrap and i < len(x): i += 1
   return x[:i] + "\n" + word_wrap(x[i:], wrap)
+
 def pluralize(st:str, cnt:int): return f"{cnt} {st}"+('' if cnt == 1 else 's')
 
 class LazySeq(Generic[T]): # NOTE: Mapping requires __iter__ and __len__, Sequence requires supporting __len__ and slicing in __getitem__


### PR DESCRIPTION
This bug caused some labels in VIZ to be cut off early:

Branch:
<img width="3022" height="1734" alt="image" src="https://github.com/user-attachments/assets/7169f062-98ff-4257-a942-0abeea00c740" />
Master:
<img width="3024" height="1738" alt="image" src="https://github.com/user-attachments/assets/1cc526c5-b45e-41fc-8fec-94f6e2d374a1" />