### PR TITLE
hcq: fix race in _at_profile_finalize

### DIFF
--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -406,6 +406,8 @@ class HCQCompiled(Compiled, Generic[SignalType]):
     return self.signal_t(base_buf=HCQCompiled.signal_pool[pg].pop(), owner=self, **kwargs)
 
   def _at_profile_finalize(self):
+    self.synchronize() # Expect device to be synchronizes
+
     def _sync(d:HCQCompiled, q_t:Callable[[], HWQueue]):
       q_t().timestamp(d.timeline_signal).signal(d.timeline_signal, d.next_timeline()).submit(d)
       st = time.perf_counter_ns()


### PR DESCRIPTION
`HCQ._at_profile_finalize` expects the device to be synchronized, since it calls `q_t().timestamp(d.timeline_signal).signal(d.timeline_signal, d.next_timeline()).submit(d)` without any wait (for precision).

The race condition occurred only with SQTT: `self.allocator._copyout(sqtt_buf := memoryview(bytearray(wptr)), buf0))`, which may have a profiling wrapper that signals.

Synchronization is added in `_at_profile_finalize`, as it is required for the function to proceed correctly.