### PR TITLE
viz: add runtime stats

### DIFF
--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -336,7 +336,7 @@ if PROFILE:
 
     if not getenv("SQTT", 0):
       from tinygrad.uop.ops import launch_viz
-      launch_viz("PROFILE", fn)
+      launch_viz(PROFILE, fn)
 
 if __name__ == "__main__":
   for device in ALL_DEVICES:

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -858,7 +858,7 @@ if TRACK_MATCH_STATS or PROFILE:
       with open(fn:=temp("rewrites.pkl", append_user=True), "wb") as f:
         print(f"rewrote {len(tracked_ctxs)} graphs and matched {sum(len(r.matches) for x in tracked_ctxs for r in x)} times, saved to {fn}")
         pickle.dump((tracked_keys, tracked_ctxs, uop_fields), f)
-    if VIZ: launch_viz("VIZ", temp("rewrites.pkl", append_user=True))
+    if VIZ: launch_viz(VIZ, temp("rewrites.pkl", append_user=True))
     if getenv("PRINT_MATCH_STATS", TRACK_MATCH_STATS.value):
       ret = [0,0,0.0,0.0]
       for k,v in sorted(list(match_stats.items()), key=lambda x: x[1][2]+x[1][3]):
@@ -868,9 +868,10 @@ if TRACK_MATCH_STATS or PROFILE:
       print(f"{ret[0]:6d} / {ret[1]:7d} -- {ret[3]*1000.:9.2f} / {(ret[2]+ret[3])*1000.:9.2f} ms -- TOTAL")
       print(f"{len(match_stats)} rules, {sum(v[0] > 0 for v in match_stats.values())} matched once")
 
-  def launch_viz(env_str:str, data:str):
-    os.environ[env_str] = "0"
+  def launch_viz(var:ContextVar, data:str):
+    os.environ[(env_str:=var.key)] = "0"
     os.environ[f"{env_str}_DATA"] = data
+    os.environ[f"{env_str}_VALUE"] = str(var.value)
     if not int(os.getenv("VIZ", "0")) and not int(os.getenv("PROFILE", "0")):
       args = ['--kernels', getenv("VIZ_DATA", "")] if getenv("VIZ_DATA", "") else []
       args += ['--profile', getenv("PROFILE_DATA", "")] if getenv("PROFILE_DATA", "") else []

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -510,7 +510,7 @@ async function main() {
     div.style.maxHeight = "100px";
     div.style.overflow = "auto";
     for (const [i, s] of ctx.runtime_stats.entries()) {
-r     const p = div.appendChild(document.createElement("p"));
+      const p = div.appendChild(document.createElement("p"));
       p.innerText = `Run ${i}`;
       for (const [k, v] of Object.entries(s)) {
         p.innerText += `\n${k} ${typeof v === "string" ? v : formatUnit(v.value, v.fmt)}`

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -107,7 +107,7 @@ function formatTime(ts, dur=ts) {
   if (dur<=1e6) return `${(ts*1e-3).toFixed(2)}ms`;
   return `${(ts*1e-6).toFixed(2)}s`;
 }
-const formatUnit = (d, unit="") => d3.format(".3~s")(d)+unit;
+const formatUnit = (d, unit="") => unit === "time" ? formatTime(d) : d3.format(".3~s")(d)+unit;
 
 const devColors = {"TINY":["rgb(27 87 69)", "rgb(53 79 82)", "rgb(53 79 82)", "rgb(70 172 194)", "rgb(29, 46, 98)"],
                    "DEFAULT":["rgb(29,31,42)","rgb(42,45,61)","rgb(55,59,79)","rgb(68,72,98)","rgb(18,19,26)","rgb(47,50,68)","rgb(59,63,84)","rgb(74,78,101)","rgb(24,26,35)","rgb(35,37,50)","rgb(49,53,72)","rgb(64,68,89)"],}
@@ -505,6 +505,18 @@ async function main() {
   const metadata = document.querySelector(".metadata");
   const [code, lang] = ctx.fmt != null ? [ctx.fmt, "cpp"] : [ret[currentRewrite].uop, "python"];
   metadata.replaceChildren(codeBlock(step.code_line, "python", { loc:step.loc, wrap:true }), codeBlock(code, lang, { wrap:false }));
+  if (ctx.runtime_stats != null) {
+    const div = metadata.appendChild(document.createElement("div"));
+    div.style.maxHeight = "100px";
+    div.style.overflow = "auto";
+    for (const [i, s] of ctx.runtime_stats.entries()) {
+r     const p = div.appendChild(document.createElement("p"));
+      p.innerText = `Run ${i}`;
+      for (const [k, v] of Object.entries(s)) {
+        p.innerText += `\n${k} ${typeof v === "string" ? v : formatUnit(v.value, v.fmt)}`
+      }
+    }
+  }
   // ** rewrite steps
   if (step.match_count >= 1) {
     const rewriteList = metadata.appendChild(document.createElement("div"));

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -107,7 +107,7 @@ function formatTime(ts, dur=ts) {
   if (dur<=1e6) return `${(ts*1e-3).toFixed(2)}ms`;
   return `${(ts*1e-6).toFixed(2)}s`;
 }
-const formatUnit = (d, unit="") => unit === "time" ? formatTime(d) : d3.format(".3~s")(d)+unit;
+const formatUnit = (d, unit="") => d3.format(".3~s")(d)+unit;
 
 const devColors = {"TINY":["rgb(27 87 69)", "rgb(53 79 82)", "rgb(53 79 82)", "rgb(70 172 194)", "rgb(29, 46, 98)"],
                    "DEFAULT":["rgb(29,31,42)","rgb(42,45,61)","rgb(55,59,79)","rgb(68,72,98)","rgb(18,19,26)","rgb(47,50,68)","rgb(59,63,84)","rgb(74,78,101)","rgb(24,26,35)","rgb(35,37,50)","rgb(49,53,72)","rgb(64,68,89)"],}
@@ -362,7 +362,7 @@ document.getElementById("zoom-to-fit-btn").addEventListener("click", () => {
 
 // **** main VIZ interfacae
 
-function codeBlock(st, language, { loc, wrap }) {
+function codeBlock(st, language, { loc, wrap }={}) {
   const code = document.createElement("code");
   code.innerHTML = hljs.highlight(st, { language }).value;
   code.className = "hljs";
@@ -507,14 +507,12 @@ async function main() {
   metadata.replaceChildren(codeBlock(step.code_line, "python", { loc:step.loc, wrap:true }), codeBlock(code, lang, { wrap:false }));
   if (ctx.runtime_stats != null) {
     const div = metadata.appendChild(document.createElement("div"));
-    div.style.maxHeight = "100px";
+    div.className = "rewrite-container";
+    div.style.maxHeight = "200px";
     div.style.overflow = "auto";
     for (const [i, s] of ctx.runtime_stats.entries()) {
-      const p = div.appendChild(document.createElement("p"));
-      p.innerText = `Run ${i}`;
-      for (const [k, v] of Object.entries(s)) {
-        p.innerText += `\n${k} ${typeof v === "string" ? v : formatUnit(v.value, v.fmt)}`
-      }
+      const fmt = `${s.device}  ${i+1} ${formatTime(s.duration)}`;
+      div.appendChild(codeBlock(fmt, "txt"));
     }
   }
   // ** rewrite steps

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -507,12 +507,11 @@ async function main() {
   metadata.replaceChildren(codeBlock(step.code_line, "python", { loc:step.loc, wrap:true }), codeBlock(code, lang, { wrap:false }));
   if (ctx.runtime_stats != null) {
     const div = metadata.appendChild(document.createElement("div"));
-    div.className = "rewrite-container";
     div.style.maxHeight = "200px";
     div.style.overflow = "auto";
     for (const [i, s] of ctx.runtime_stats.entries()) {
-      const fmt = `${s.device}  ${i+1} ${formatTime(s.duration)}`;
-      div.appendChild(codeBlock(fmt, "txt"));
+      const p = div.appendChild(document.createElement("p"));
+      p.innerText = `Run ${i+1} ${formatTime(s.duration)}`;
     }
   }
   // ** rewrite steps

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -26,7 +26,8 @@ def get_metadata(keys:list[TracingKey], contexts:list[list[TrackedGraphRewrite]]
   ret = []
   for i,(k,v) in enumerate(zip(keys, contexts)):
     steps = [{"name":s.name, "loc":s.loc, "depth":s.depth, "match_count":len(s.matches), "code_line":printable(s.loc)} for s in v]
-    ret.append({"name":k.display_name, "fmt":k.fmt, "steps":steps})
+    ret.append(r:={"name":k.display_name, "fmt":k.fmt, "steps":steps})
+    if getenv("PROFILE_VALUE") >= 2 and k.keys: r["runtime_stats"] = get_runtime_stats(k.keys[0])
     for key in k.keys: ref_map[key] = i
   return ret
 
@@ -171,6 +172,13 @@ def get_profile(profile:list[ProfileEvent]):
   for events in dev_events.values(): events.sort(key=lambda v:v[0])
   dev_layout = {k:{"timeline":timeline_layout(v), "mem":mem_layout(v)} for k,v in dev_events.items()}
   return json.dumps({"layout":dev_layout, "st":min_ts, "et":max_ts}).encode("utf-8")
+
+def get_runtime_stats(key) -> list[dict]:
+  ret:list[dict] = []
+  for e in profile:
+    if isinstance(e, ProfileRangeEvent) and e.name == key:
+      ret.append({"Device":e.device, "Duration": {"value":float(e.en-e.st), "fmt":"time"}})
+  return ret
 
 # ** HTTP server
 

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -176,8 +176,8 @@ def get_profile(profile:list[ProfileEvent]):
 def get_runtime_stats(key) -> list[dict]:
   ret:list[dict] = []
   for e in profile:
-    if isinstance(e, ProfileRangeEvent) and e.name == key:
-      ret.append({"Device":e.device, "Duration": {"value":float(e.en-e.st), "fmt":"time"}})
+    if isinstance(e, ProfileRangeEvent) and e.en is not None and e.name == key:
+      ret.append({"Device":e.device, "Duration":{"value":float(e.en-e.st), "fmt":"time"}})
   return ret
 
 # ** HTTP server

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -177,7 +177,7 @@ def get_runtime_stats(key) -> list[dict]:
   ret:list[dict] = []
   for e in profile:
     if isinstance(e, ProfileRangeEvent) and e.en is not None and e.name == key:
-      ret.append({"Device":e.device, "Duration":{"value":float(e.en-e.st), "fmt":"time"}})
+      ret.append({"device":e.device, "duration":float(e.en-e.st)})
   return ret
 
 # ** HTTP server


### PR DESCRIPTION
This creates a place for showing stats about execution(s) of a kernel in the UOp VIZ sidebar.

Starting with `duration` and `device`, will expand to utilization/occupancy as we make progress on sampling GPU counters.