### PR TITLE
BPE tokenizer

### DIFF
--- a/test/external/external_llm_eval.py
+++ b/test/external/external_llm_eval.py
@@ -21,12 +21,12 @@ if __name__ == "__main__":
                '\n'.join([f"{k}) {v}" for k,v in zip(choices['label'], choices['text'])]) +\
                "\n\nReply with the letter of the correct answer only."
     try:
-      ids = [bos_id] + tok.role(b"user") + tok.encode(phrasing.encode()) + [eos_id] + tok.role(b"assistant") + tok.encode(b"Answer: ")
-    except KeyError:
+      ids = [bos_id] + tok.role("user") + tok.encode(phrasing) + [eos_id] + tok.role("assistant") + tok.encode("Answer: ")
+    except RuntimeError:
       # TODO: fix the tokenizer
       pass
     next_id = next(model.generate(ids))
-    correct, given = answer.as_py().strip(), tok.decode([next_id]).decode().strip()
+    correct, given = answer.as_py().strip(), tok.decode([next_id]).strip()
     num_correct += correct == given
     num_answered += 1
     print(f"{num_answered:4d}/{total_questions:4d}  "+\

--- a/test/external/external_test_simple_tokenizer.py
+++ b/test/external/external_test_simple_tokenizer.py
@@ -1,14 +1,15 @@
 from transformers import AutoTokenizer
 from datasets import load_dataset
 from tinygrad.apps.llm import SimpleTokenizer
-from tinygrad.helpers import tqdm, getenv
+from tinygrad.helpers import tqdm, getenv, partition
 
 # use ALLOW_FAILED=-1 to go over the entire dataset without printing.
 if __name__ == "__main__":
   base_tokenizer = AutoTokenizer.from_pretrained("NousResearch/Meta-Llama-3-8B-Instruct")
-  vocab_words = [ word for word, _ in sorted(base_tokenizer.get_vocab().items(), key=lambda t: t[1]) ]
+  special_tokens, normal_tokens = partition(((t.encode(), tid) for t, tid in base_tokenizer.vocab.items()),
+    lambda e: e[1] in base_tokenizer.all_special_ids)
   inv_vocab = { tid: word for word, tid in base_tokenizer.get_vocab().items() }
-  simple_tokenizer = SimpleTokenizer(vocab_words)
+  simple_tokenizer = SimpleTokenizer(dict(normal_tokens), dict(special_tokens))
 
   color_codes = [ 91, 92, 94, 93, 95 ]
   def color_tokens(tids): return "".join(f"\033[{color_codes[i%len(color_codes)]}m{inv_vocab[t]}" for i, t in enumerate(tids)) + "\033[0m"
@@ -21,8 +22,8 @@ if __name__ == "__main__":
   for idx, el in enumerate(tqdm(ds["train"])):
     total += 1
 
-    try: simple_tokens = tuple(simple_tokenizer.encode(el["text"]))
-    except RuntimeError: simple_tokens = ()
+    try: simple_tokens = tuple(simple_tokenizer.encode(el["text"].encode()))
+    except KeyError: simple_tokens = ()
     base_tokens = tuple(base_tokenizer.encode(el["text"], add_special_tokens=False))
 
     if simple_tokens != base_tokens:

--- a/test/external/external_test_simple_tokenizer.py
+++ b/test/external/external_test_simple_tokenizer.py
@@ -22,8 +22,8 @@ if __name__ == "__main__":
   for idx, el in enumerate(tqdm(ds["train"])):
     total += 1
 
-    try: simple_tokens = tuple(simple_tokenizer.encode(el["text"].encode()))
-    except KeyError: simple_tokens = ()
+    try: simple_tokens = tuple(simple_tokenizer.encode(el["text"]))
+    except RuntimeError: simple_tokens = ()
     base_tokens = tuple(base_tokenizer.encode(el["text"], add_special_tokens=False))
 
     if simple_tokens != base_tokens:

--- a/test/unit/test_llm_tokenizer.py
+++ b/test/unit/test_llm_tokenizer.py
@@ -2,17 +2,20 @@ import unittest
 from tinygrad.apps.llm import SimpleTokenizer
 
 class TestLLMTokenizer(unittest.TestCase):
-  def _test_basic(self, text: bytes, expected_tokens: list[int]):
+  def _test_basic(self, text: str, expected_tokens: list[int]):
     tok = SimpleTokenizer({ b"a": 0, b"b": 1, b"c": 2, b"ab": 3, b"bc": 4 }, { b"<x>": 5, b"<y>": 6, b"<z>": 7 })
     self.assertEqual(tok.encode(text), expected_tokens)
     self.assertEqual(tok.decode(expected_tokens), text)
 
-  def test_abc(self): self._test_basic(b"abc", [ 3, 2 ])
-  def test_abbc(self): self._test_basic(b"abbc", [ 3, 4 ])
-  def test_aabbbcc(self): self._test_basic(b"aabbbcc", [ 0, 3, 1, 4, 2 ])
+  def test_abc(self): self._test_basic("abc", [ 3, 2 ])
+  def test_abbc(self): self._test_basic("abbc", [ 3, 4 ])
+  def test_aabbbcc(self): self._test_basic("aabbbcc", [ 0, 3, 1, 4, 2 ])
 
-  def test_specials1(self): self._test_basic(b"a<x>a<y>a<z>a", [ 0, 5, 0, 6, 0, 7, 0 ])
-  def test_specials2(self): self._test_basic(b"<x>a<y>a<z>", [ 5, 0, 6, 0, 7 ])
+  def test_specials1(self): self._test_basic("a<x>a<y>a<z>a", [ 0, 5, 0, 6, 0, 7, 0 ])
+  def test_specials2(self): self._test_basic("<x>a<y>a<z>", [ 5, 0, 6, 0, 7 ])
+
+  def test_invalid_token(self):
+    with self.assertRaises(RuntimeError): self._test_basic("L", [])
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/unit/test_llm_tokenizer.py
+++ b/test/unit/test_llm_tokenizer.py
@@ -1,0 +1,18 @@
+import unittest
+from tinygrad.apps.llm import SimpleTokenizer
+
+class TestLLMTokenizer(unittest.TestCase):
+  def _test_basic(self, text: bytes, expected_tokens: list[int]):
+    tok = SimpleTokenizer({ b"a": 0, b"b": 1, b"c": 2, b"ab": 3, b"bc": 4 }, { b"<x>": 5, b"<y>": 6, b"<z>": 7 })
+    self.assertEqual(tok.encode(text), expected_tokens)
+    self.assertEqual(tok.decode(expected_tokens), text)
+
+  def test_abc(self): self._test_basic(b"abc", [ 3, 2 ])
+  def test_abbc(self): self._test_basic(b"abbc", [ 3, 4 ])
+  def test_aabbbcc(self): self._test_basic(b"aabbbcc", [ 0, 3, 1, 4, 2 ])
+
+  def test_specials1(self): self._test_basic(b"a<x>a<y>a<z>a", [ 0, 5, 0, 6, 0, 7, 0 ])
+  def test_specials2(self): self._test_basic(b"<x>a<y>a<z>", [ 5, 0, 6, 0, 7 ])
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tinygrad/apps/llm.py
+++ b/tinygrad/apps/llm.py
@@ -178,7 +178,6 @@ if __name__ == "__main__":
 
   ids: list[int] = [bos_id]
   while 1:
-    print(ids)
     start_pos = len(ids) - 1
     try:
       ids += tok.role(b"user") + tok.encode(input('>>> ').encode()) + [eos_id] + tok.role(b"assistant")


### PR DESCRIPTION
replaces the old tokenizer with a byte pair tokenizer.

To make the tokenization fully match with the reference, the words must be split into smaller words with a regex pattern. That is still missing.

Consistency has improved. Testing with `test/external/external_test_simple_tokenizer.py` the error rate has gone from 10/11 to 10/22.

I added tests for some of the BPE edge cases.