### PR TITLE
fix resorce leak in disktensor 

### DIFF
--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -18,7 +18,7 @@ class DiskDevice(Compiled):
     super().__init__(device, DiskAllocator(self), None, None, None)
   def _might_open(self, size:int):
     assert self.size is None or size <= self.size, f"can't reopen Disk tensor with larger size, opened with {self.size}, tried to open with {size}"
-    if self.size is not None and hasattr(self.device, "mem"):
+    if self.size is not None:
       self.count += 1
       return
     filename = self.device[len("disk:"):]


### PR DESCRIPTION
`self.device` should always be a str object, so `mem` shouldn't ever be an attribute?

this change fixes this error I got while running huggingface onnx models.
```                                                                                                                                    
** Validating 193 models **                                                                                                                     
validating model sentence-transformers/all-MiniLM-L6-v2/onnx/model.onnx                                                                         
passed, took 2.70s                                                                                                                              
...                      
validating model cross-encoder/ms-marco-MiniLM-L6-v2/onnx/model_O3.onnx                                                                         
passed, took 1.09s                                                                                                                              
validating model BAAI/bge-m3/onnx/model.onnx                                                                                                    
Traceback (most recent call last):                                                                                                              
  File "/Users/zibo/fun/tiny/tinygrad/extra/huggingface_onnx/run_models.py", line 108, in <module>                                              
  File "/Users/zibo/fun/tiny/tinygrad/extra/huggingface_onnx/run_models.py", line 35, in validate_repos                                         
  File "/Users/zibo/fun/tiny/tinygrad/extra/huggingface_onnx/run_models.py", line 18, in run_huggingface_validate                               
  File "/Users/zibo/fun/tiny/tinygrad/extra/onnx_helpers.py", line 65, in validate                                                              
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/tensor.py", line 4423, in _wrapper                                                               
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/tensor.py", line 361, in numpy                                                                   
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/tensor.py", line 4398, in _wrapper                                                               
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/tensor.py", line 302, in _buffer                                                                 
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/tensor.py", line 4398, in _wrapper                                                               
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/tensor.py", line 269, in realize                                                                 
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/engine/realize.py", line 208, in run_schedule                                                    
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/engine/realize.py", line 148, in run                                                             
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/device.py", line 127, in ensure_allocated                                                        
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/device.py", line 136, in allocate                                                                
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/device.py", line 127, in ensure_allocated                                                        
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/device.py", line 141, in allocate
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/device.py", line 229, in alloc
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/runtime/ops_disk.py", line 79, in _alloc
  File "/Users/zibo/fun/tiny/tinygrad/tinygrad/runtime/ops_disk.py", line 35, in _might_open
OSError: [Errno 24] Too many open files
```

TODO: 
add a test for this

edit:
oh it's path object...