### PR TITLE
tdma for am dmabuf export

### DIFF
--- a/.github/workflows/autogen.yml
+++ b/.github/workflows/autogen.yml
@@ -55,16 +55,19 @@ jobs:
       run: |
         cp tinygrad/runtime/autogen/hsa.py /tmp/hsa.py.bak
         cp tinygrad/runtime/autogen/kfd.py /tmp/kfd.py.bak
+        cp tinygrad/runtime/autogen/tdma.py /tmp/tdma.py.bak
         cp tinygrad/runtime/autogen/comgr.py /tmp/comgr.py.bak
         cp tinygrad/runtime/autogen/amd_gpu.py /tmp/amd_gpu.py.bak
         cp tinygrad/runtime/autogen/sqtt.py /tmp/sqtt.py.bak
         ./autogen_stubs.sh hsa
         ./autogen_stubs.sh kfd
+        ./autogen_stubs.sh tdma
         ./autogen_stubs.sh comgr
         ./autogen_stubs.sh amd
         ./autogen_stubs.sh sqtt
         diff /tmp/hsa.py.bak tinygrad/runtime/autogen/hsa.py
         diff /tmp/kfd.py.bak tinygrad/runtime/autogen/kfd.py
+        diff /tmp/tdma.py.bak tinygrad/runtime/autogen/tdma.py
         diff /tmp/comgr.py.bak tinygrad/runtime/autogen/comgr.py
         diff /tmp/amd_gpu.py.bak tinygrad/runtime/autogen/amd_gpu.py
         diff /tmp/sqtt.py.bak tinygrad/runtime/autogen/sqtt.py

--- a/autogen_stubs.sh
+++ b/autogen_stubs.sh
@@ -87,6 +87,17 @@ generate_kfd() {
   python3 -c "import tinygrad.runtime.autogen.kfd"
 }
 
+generate_tdma() {
+  clang2py -k cdefstum ./extra/tdma/tdma.h -o $BASE/tdma.py
+
+  fixup $BASE/tdma.py
+  sed -i "s/import fcntl, functools/import functools/g" $BASE/tdma.py
+  sed -i "/import functools/a from tinygrad.runtime.support.hcq import FileIOInterface" $BASE/tdma.py
+  sed -i "s/def _do_ioctl(__idir, __base, __nr, __user_struct, __fd, \*\*kwargs):/def _do_ioctl(__idir, __base, __nr, __user_struct, __fd:FileIOInterface, \*\*kwargs):/g" $BASE/tdma.py
+  sed -i "s/fcntl.ioctl(__fd, (__idir<<30)/__fd.ioctl((__idir<<30)/g" $BASE/tdma.py
+  python3 -c "import tinygrad.runtime.autogen.tdma"
+}
+
 generate_cuda() {
   clang2py /usr/include/cuda.h --clang-args="-D__CUDA_API_VERSION_INTERNAL" -o $BASE/cuda.py -l /usr/lib/x86_64-linux-gnu/libcuda.so
   sed -i "s\import ctypes\import ctypes, ctypes.util\g" $BASE/cuda.py
@@ -449,6 +460,7 @@ elif [ "$1" == "cuda" ]; then generate_cuda
 elif [ "$1" == "nvrtc" ]; then generate_nvrtc
 elif [ "$1" == "hsa" ]; then generate_hsa
 elif [ "$1" == "kfd" ]; then generate_kfd
+elif [ "$1" == "tdma" ]; then generate_tdma
 elif [ "$1" == "nv" ]; then generate_nv
 elif [ "$1" == "amd" ]; then generate_amd
 elif [ "$1" == "am" ]; then generate_am

--- a/extra/tdma/.gitignore
+++ b/extra/tdma/.gitignore
@@ -1,0 +1,11 @@
+*.ko
+*.o
+*.cmd
+*.mod
+*.mod.c
+
+.cache
+
+compile_commands.json
+modules.order
+Module.symvers

--- a/extra/tdma/Makefile
+++ b/extra/tdma/Makefile
@@ -1,0 +1,9 @@
+obj-m += tdma.o
+
+KERN_DIR ?= /lib/modules/$(shell uname -r)/build/
+
+modules:
+	make -C $(KERN_DIR) M=$(PWD) modules
+
+clean:
+	make -C $(KERN_DIR) M=$(PWD) clean

--- a/extra/tdma/tdma.c
+++ b/extra/tdma/tdma.c
@@ -1,0 +1,269 @@
+#include <linux/module.h>
+#include <linux/miscdevice.h>
+#include <linux/pci.h>
+#include <linux/pci-p2pdma.h>
+#include <linux/dma-buf.h>
+#include "tdma.h"
+
+// To see pr_debug logs:
+// echo 'module tdma +p' | sudo tee /sys/kernel/debug/dynamic_debug/control
+
+struct tdma_priv {
+  struct pci_dev *pdev;
+  int bar;
+  resource_size_t bar_start;
+  resource_size_t bar_size;
+  int usgl_size;
+  struct tdma_ioctl_usge* usgl;
+};
+
+static int tdma_attach(struct dma_buf *dmabuf, struct dma_buf_attachment *attach) {
+  struct tdma_priv *priv = dmabuf->priv;
+  pr_debug("tdma: %s is attaching to %s", dev_name(attach->dev), dev_name(&priv->pdev->dev));
+
+  // Negative distance = can't reach
+  if (pci_p2pdma_distance(priv->pdev, attach->dev, true) < 0) {
+    pr_err("tdma: %s can't reach %s", dev_name(attach->dev), dev_name(&priv->pdev->dev));
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+static void tdma_detach(struct dma_buf *dmabuf, struct dma_buf_attachment *attach) {
+  struct tdma_priv *priv = dmabuf->priv;
+  pr_debug("tdma: %s is detached from %s", dev_name(attach->dev), dev_name(&priv->pdev->dev));
+}
+
+static struct sg_table *tdma_map(struct dma_buf_attachment *attach, enum dma_data_direction dir) {
+  struct dma_buf* dmabuf = attach->dmabuf;
+  struct tdma_priv *priv = dmabuf->priv;
+  pr_debug("tdma: %s is mapping %s", dev_name(attach->dev), dev_name(&priv->pdev->dev));
+
+  struct sg_table* sgt = kzalloc(sizeof(*sgt), GFP_KERNEL);
+  if (!sgt) {
+    pr_err("tdma: failed to allocate memory for sg_table");
+    return ERR_PTR(-ENOMEM);
+  }
+
+  if (sg_alloc_table(sgt, priv->usgl_size, GFP_KERNEL)) {
+    pr_err("tdma: failed to allocate sg_table");
+    kfree(sgt);
+    return ERR_PTR(-ENOMEM);
+  }
+
+  struct scatterlist* sg;
+  unsigned int i;
+  for_each_sgtable_sg(sgt, sg, i) {
+    struct tdma_ioctl_usge usge = priv->usgl[i];
+
+    dma_addr_t dma_addr = dma_map_resource(attach->dev, priv->bar_start + usge.offset, usge.size, dir, DMA_ATTR_SKIP_CPU_SYNC);
+
+    if (dma_mapping_error(attach->dev, dma_addr)) {
+      pr_err("tdma: dma mapping error");
+      struct scatterlist* unmap_sg;
+      unsigned int unmap_i;
+      for_each_sgtable_sg(sgt, unmap_sg, unmap_i) {
+        if (unmap_i >= i) continue;
+        pr_debug("tdma: destroying sg[%d] dma=0x%llx size=0x%x", unmap_i, unmap_sg->dma_address, unmap_sg->dma_length);
+        dma_unmap_resource(attach->dev, unmap_sg->dma_address, unmap_sg->dma_length, dir, DMA_ATTR_SKIP_CPU_SYNC);
+      }
+      sg_free_table(sgt);
+      kfree(sgt);
+      return ERR_PTR(-EIO);
+    }
+
+    sg_set_page(sg, NULL, usge.size, 0);
+    sg_dma_address(sg) = dma_addr;
+    sg_dma_len(sg) = usge.size;
+  }
+
+  return sgt;
+}
+
+static void tdma_unmap(struct dma_buf_attachment *attach, struct sg_table *sgt, enum dma_data_direction dir) {
+  struct dma_buf* dmabuf = attach->dmabuf;
+  struct tdma_priv *priv = dmabuf->priv;
+  pr_debug("tdma: %s is unmapping %s", dev_name(attach->dev), dev_name(&priv->pdev->dev));
+  struct scatterlist* sg;
+  unsigned int i;
+  for_each_sgtable_sg(sgt, sg, i) {
+    pr_debug("tdma: destroying sg[%d] dma=0x%llx size=0x%x", i, sg->dma_address, sg->dma_length);
+    dma_unmap_resource(attach->dev, sg->dma_address, sg->dma_length, dir, DMA_ATTR_SKIP_CPU_SYNC);
+  }
+  sg_free_table(sgt);
+  kfree(sgt);
+}
+
+static void tdma_release(struct dma_buf *dmabuf) {
+  struct tdma_priv *priv = dmabuf->priv;
+  pr_debug("tdma: released dmabuf for %s", dev_name(&priv->pdev->dev));
+  pci_dev_put(priv->pdev);
+  kfree(priv->usgl);
+  kfree(priv);
+}
+
+static const struct dma_buf_ops tdma_ops = {
+  .cache_sgt_mapping = true,
+  .attach = tdma_attach,
+  .detach = tdma_detach,
+  .map_dma_buf = tdma_map,
+  .unmap_dma_buf = tdma_unmap,
+  .release = tdma_release,
+};
+
+static long tdma_ioctl(struct file *filp, unsigned int cmd, unsigned long uarg) {
+  if (cmd != TDMA_GET_DMABUF)
+    return -ENOTTY;
+
+  // Copy arguments from userspace to kernel
+  struct tdma_ioctl arg;
+  if (copy_from_user(&arg, (void __user *)uarg, sizeof(arg))) {
+    pr_err("tdma: failed to copy ioctl arguments from userspace");
+    return -EFAULT;
+  }
+
+  struct tdma_ioctl_usge* arg_usgl = kzalloc(sizeof(struct tdma_ioctl_usge) * (u32)arg.usgl_size, GFP_KERNEL);
+  if (!arg_usgl) {
+    pr_err("tdma: failed to allocate memory for tdma_ioctl_sge");
+    return -ENOMEM;
+  }  
+
+  if (copy_from_user(arg_usgl, (void __user *)arg.usgl, sizeof(struct tdma_ioctl_usge) * (u32)arg.usgl_size)) {
+    pr_err("tdma: failed to copy tdma_ioctl_sge from userspace");
+    kfree(arg_usgl);
+    return -EFAULT;
+  }
+
+  // Locate PCI device
+  struct pci_dev* pdev = pci_get_domain_bus_and_slot(arg.domain, arg.bus, PCI_DEVFN(arg.device, arg.function));
+  if (!pdev) {
+    pr_err("tdma: pci device not found: %04x:%02x:%02x.%x", arg.domain, arg.bus, arg.device, arg.function);
+    kfree(arg_usgl);
+    return -ENODEV;
+  }
+
+  // Validate the BAR
+  if (arg.bar >= PCI_STD_NUM_BARS) {
+    pr_err("tdma: BAR out of bounds: %s %u", dev_name(&pdev->dev), arg.bar);
+    pci_dev_put(pdev);
+    kfree(arg_usgl);
+    return -EINVAL;
+  }
+
+  resource_size_t bar_start = pci_resource_start(pdev, arg.bar);
+  resource_size_t bar_size = pci_resource_len(pdev, arg.bar);
+  unsigned long bar_flags = pci_resource_flags(pdev, arg.bar);
+
+  if (!bar_size || !(bar_flags & IORESOURCE_MEM)) {
+    pr_err("tdma: invalid BAR %u: device=%s size=%llu flags=0x%lx", arg.bar, dev_name(&pdev->dev), bar_size, bar_flags);
+    pci_dev_put(pdev);
+    kfree(arg_usgl);
+    return -EINVAL;
+  }
+
+  // Validate user sgl and calculate total dmabuf size
+  resource_size_t dmabuf_size = 0;
+  for(int i = 0; i < arg.usgl_size; i++) {
+    struct tdma_ioctl_usge usge = arg_usgl[i];
+
+    if (usge.offset >= bar_size || usge.offset % PAGE_SIZE != 0 ||
+        usge.size == 0 || usge.size > SZ_2G || usge.size % PAGE_SIZE != 0 ||
+        (usge.offset + usge.size) > bar_size) {
+      pr_err("tdma: invalid user sge");
+      pci_dev_put(pdev);
+      kfree(arg_usgl);
+      return -EINVAL;
+    }
+
+    dmabuf_size += usge.size;
+  }
+
+  // Create DMABuf
+  struct tdma_priv* priv = kzalloc(sizeof(*priv), GFP_KERNEL);
+  if (!priv) {
+    pr_err("tdma: failed to allocate memory for tdma_priv");
+    pci_dev_put(pdev);
+    kfree(arg_usgl);
+    return -ENOMEM;
+  }  
+
+  priv->pdev = pdev;
+  priv->bar = arg.bar;
+  priv->bar_start = bar_start;
+  priv->bar_size = bar_size;
+  priv->usgl_size = arg.usgl_size;
+  priv->usgl = arg_usgl;
+
+  DEFINE_DMA_BUF_EXPORT_INFO(exp); // sets exp_name to module name and owner to THIS_MODULE (for refcounting, can't rmmod while dmabufs are alive)
+  exp.ops = &tdma_ops;
+  exp.priv = priv;
+  exp.size = dmabuf_size;
+
+  struct dma_buf* dmabuf = dma_buf_export(&exp);
+  if (IS_ERR(dmabuf)) {
+    pr_err("tdma: failed to export dmabuf: %ld", PTR_ERR(dmabuf));
+    kfree(priv);
+    pci_dev_put(pdev);
+    kfree(arg_usgl);
+    return PTR_ERR(dmabuf);
+  }
+  // DMABuf is created succesfully, the ownership of priv, usgl and pdev is now transfered to it and will be released when dmabuf is released
+
+  int dmabuf_fd = dma_buf_fd(dmabuf, O_CLOEXEC); // TODO: flags should be from userspace. for now cloexec as a sane default
+  if (dmabuf_fd < 0) {
+    pr_err("tdma: failed to create dmabuf fd: %d", dmabuf_fd);
+    dma_buf_put(dmabuf);
+    return dmabuf_fd; // if dmabuf_fd < 0 it's the error code instead of an fd
+  }
+  // DMABuf-fd is created succesfully. It looks like the ownership of dmabuf is now transfered to fd??? Somehow dma_buf_put here is not needed
+
+  pr_debug("tdma: %s exported as dmabuf (fd=%d)", dev_name(&pdev->dev), dmabuf_fd);
+
+  arg.out_fd = dmabuf_fd;
+
+  if (copy_to_user((void __user *)uarg, &arg, sizeof(arg))) {
+    pr_err("tdma: Failed to copy ioctl result to userspace");
+    // Attempting to deallocate the dmabuf or put the fd here is not done on purpose because it is **NOT** safe to do, as for example another thread
+    // might've duplicated the fd and in that case there would be a use after free.
+    return -EFAULT;
+  }
+
+  return 0;
+}
+
+static const struct file_operations tdma_fops = {
+  .owner = THIS_MODULE,
+  .unlocked_ioctl = tdma_ioctl,
+};
+
+static struct miscdevice tdma_misc = {
+  .minor = MISC_DYNAMIC_MINOR,
+  .name = "tdma",
+  .fops = &tdma_fops,
+};
+
+static int __init tdma_init(void) {
+  int ret = misc_register(&tdma_misc);
+
+  if (ret)
+    pr_err("tdma: load error: %i", ret);
+  else
+    pr_info("tdma: module ready");
+
+  return ret;
+}
+
+static void __exit tdma_exit(void) {
+  misc_deregister(&tdma_misc);
+  pr_info("tdma: unloaded");
+}
+
+module_init(tdma_init);
+module_exit(tdma_exit);
+
+MODULE_IMPORT_NS("DMA_BUF");
+
+MODULE_LICENSE("Dual MIT/GPL"); // kernel will refuse to load without gpl here...
+MODULE_AUTHOR("uuuvn");
+MODULE_DESCRIPTION("tdma");

--- a/extra/tdma/tdma.h
+++ b/extra/tdma/tdma.h
@@ -1,0 +1,25 @@
+#ifndef TDMA_H
+#define TDMA_H
+
+#include <linux/types.h>
+#include <linux/ioctl.h>
+
+struct tdma_ioctl_usge {
+  __u64 offset;
+  __u64 size;
+};
+
+struct tdma_ioctl {
+  __u16 domain;
+  __u8 bus;
+  __u8 device;
+  __u8 function;
+  __u8 bar;
+  __u16 usgl_size;
+  struct tdma_ioctl_usge* usgl;
+  __s32 out_fd;
+};
+
+#define TDMA_GET_DMABUF   _IOWR('T', 0x01, struct tdma_ioctl)
+
+#endif

--- a/tinygrad/runtime/autogen/tdma.py
+++ b/tinygrad/runtime/autogen/tdma.py
@@ -1,0 +1,165 @@
+# mypy: ignore-errors
+# -*- coding: utf-8 -*-
+#
+# TARGET arch is: []
+# WORD_SIZE is: 8
+# POINTER_SIZE is: 8
+# LONGDOUBLE_SIZE is: 16
+#
+import ctypes
+
+
+class AsDictMixin:
+    @classmethod
+    def as_dict(cls, self):
+        result = {}
+        if not isinstance(self, AsDictMixin):
+            # not a structure, assume it's already a python object
+            return self
+        if not hasattr(cls, "_fields_"):
+            return result
+        # sys.version_info >= (3, 5)
+        # for (field, *_) in cls._fields_:  # noqa
+        for field_tuple in cls._fields_:  # noqa
+            field = field_tuple[0]
+            if field.startswith('PADDING_'):
+                continue
+            value = getattr(self, field)
+            type_ = type(value)
+            if hasattr(value, "_length_") and hasattr(value, "_type_"):
+                # array
+                if not hasattr(type_, "as_dict"):
+                    value = [v for v in value]
+                else:
+                    type_ = type_._type_
+                    value = [type_.as_dict(v) for v in value]
+            elif hasattr(value, "contents") and hasattr(value, "_type_"):
+                # pointer
+                try:
+                    if not hasattr(type_, "as_dict"):
+                        value = value.contents
+                    else:
+                        type_ = type_._type_
+                        value = type_.as_dict(value.contents)
+                except ValueError:
+                    # nullptr
+                    value = None
+            elif isinstance(value, AsDictMixin):
+                # other structure
+                value = type_.as_dict(value)
+            result[field] = value
+        return result
+
+
+class Structure(ctypes.Structure, AsDictMixin):
+
+    def __init__(self, *args, **kwds):
+        # We don't want to use positional arguments fill PADDING_* fields
+
+        args = dict(zip(self.__class__._field_names_(), args))
+        args.update(kwds)
+        super(Structure, self).__init__(**args)
+
+    @classmethod
+    def _field_names_(cls):
+        if hasattr(cls, '_fields_'):
+            return (f[0] for f in cls._fields_ if not f[0].startswith('PADDING'))
+        else:
+            return ()
+
+    @classmethod
+    def get_type(cls, field):
+        for f in cls._fields_:
+            if f[0] == field:
+                return f[1]
+        return None
+
+    @classmethod
+    def bind(cls, bound_fields):
+        fields = {}
+        for name, type_ in cls._fields_:
+            if hasattr(type_, "restype"):
+                if name in bound_fields:
+                    if bound_fields[name] is None:
+                        fields[name] = type_()
+                    else:
+                        # use a closure to capture the callback from the loop scope
+                        fields[name] = (
+                            type_((lambda callback: lambda *args: callback(*args))(
+                                bound_fields[name]))
+                        )
+                    del bound_fields[name]
+                else:
+                    # default callback implementation (does nothing)
+                    try:
+                        default_ = type_(0).restype().value
+                    except TypeError:
+                        default_ = None
+                    fields[name] = type_((
+                        lambda default_: lambda *args: default_)(default_))
+            else:
+                # not a callback function, use default initialization
+                if name in bound_fields:
+                    fields[name] = bound_fields[name]
+                    del bound_fields[name]
+                else:
+                    fields[name] = type_()
+        if len(bound_fields) != 0:
+            raise ValueError(
+                "Cannot bind the following unknown callback(s) {}.{}".format(
+                    cls.__name__, bound_fields.keys()
+            ))
+        return cls(**fields)
+
+
+class Union(ctypes.Union, AsDictMixin):
+    pass
+
+
+
+
+import functools
+from tinygrad.runtime.support.hcq import FileIOInterface
+
+def _do_ioctl(__idir, __base, __nr, __user_struct, __fd:FileIOInterface, **kwargs):
+  ret = __fd.ioctl((__idir<<30) | (ctypes.sizeof(made := __user_struct(**kwargs))<<16) | (__base<<8) | __nr, made)
+  if ret != 0: raise RuntimeError(f"ioctl returned {ret}")
+  return made
+
+def _IO(base, nr): return functools.partial(_do_ioctl, 0, ord(base) if isinstance(base, str) else base, nr, None)
+def _IOW(base, nr, type): return functools.partial(_do_ioctl, 1, ord(base) if isinstance(base, str) else base, nr, type)
+def _IOR(base, nr, type): return functools.partial(_do_ioctl, 2, ord(base) if isinstance(base, str) else base, nr, type)
+def _IOWR(base, nr, type): return functools.partial(_do_ioctl, 3, ord(base) if isinstance(base, str) else base, nr, type)
+
+
+
+TDMA_H = True # macro
+class struct_tdma_ioctl_usge(Structure):
+    pass
+
+struct_tdma_ioctl_usge._pack_ = 1 # source:False
+struct_tdma_ioctl_usge._fields_ = [
+    ('offset', ctypes.c_uint64),
+    ('size', ctypes.c_uint64),
+]
+
+class struct_tdma_ioctl(Structure):
+    pass
+
+struct_tdma_ioctl._pack_ = 1 # source:False
+struct_tdma_ioctl._fields_ = [
+    ('domain', ctypes.c_uint16),
+    ('bus', ctypes.c_ubyte),
+    ('device', ctypes.c_ubyte),
+    ('function', ctypes.c_ubyte),
+    ('bar', ctypes.c_ubyte),
+    ('usgl_size', ctypes.c_uint16),
+    ('usgl', ctypes.POINTER(struct_tdma_ioctl_usge)),
+    ('out_fd', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+]
+
+TDMA_GET_DMABUF = _IOWR ( 'T' , 0x01 , struct_tdma_ioctl ) # macro (from list)
+__all__ = \
+    ['TDMA_H', '_IO', '_IOR', '_IOW', '_IOWR', 'struct_tdma_ioctl',
+    'struct_tdma_ioctl_usge']

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -677,6 +677,10 @@ class PCIIface(PCIIfaceBase):
       'max_slots_scratch_cu': self.dev_impl.gc_info.gc_max_scratch_slots_per_cu, 'max_waves_per_simd': self.dev_impl.gc_info.gc_max_waves_per_simd,
       'simd_arrays_per_engine': self.dev_impl.gc_info.gc_num_sa_per_se, 'lds_size_in_kb': self.dev_impl.gc_info.gc_lds_size}
 
+  def as_dmaref(self, mem:HCQBuffer) -> DMAFdRef:
+    base = mem._base if mem._base is not None else mem
+    return DMAFdRef(self.pci_dev.export_bar_parts(0, base.meta.mapping.paddrs), mem.va_addr-base.va_addr, mem.size)
+
   def create_queue(self, queue_type, ring, gart, rptr, wptr, eop_buffer=None, cwsr_buffer=None, ctl_stack_size=0, ctx_save_restore_size=0, xcc_id=0):
     assert cwsr_buffer is None, "no cwsr buffer for am"
 


### PR DESCRIPTION
slightly more complicated than the previous version to allow exporting buffers that aren't contiguous in bar memory

with this bert can run at BS=84 with ibv cross-host transfers.

`AMD=1 DEBUG=0 python tinygrad/runtime/ops_remote.py`

`REMOTE=1 HOST=192.168.200.6:6667 PYTHONPATH="." MODEL="bert" DEFAULT_FLOAT="HALF" SUM_DTYPE="HALF" GPUS=6 BS=84 EVAL_BS=84 FUSE_ARANGE=1 FUSE_ARANGE_UINT=0 BASEDIR="/raid/datasets/wiki" PARALLEL=0 RUNMLPERF=1 python3 examples/mlperf/model_train.py` -> ~1120ms

`REMOTE=1 HOST=192.168.200.6:6667*3,192.168.200.4:6667*3 PYTHONPATH="." MODEL="bert" DEFAULT_FLOAT="HALF" SUM_DTYPE="HALF" GPUS=6 BS=84 EVAL_BS=84 FUSE_ARANGE=1 FUSE_ARANGE_UINT=0 BASEDIR="/raid/datasets/wiki" PARALLEL=0 RUNMLPERF=1 python3 examples/mlperf/model_train.py` ->  ~1350 ms