### PR TITLE
extract conv layer test logic

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -108,115 +108,30 @@ class TestNN(unittest.TestCase):
     _test_linear(Tensor.randn(BS, in_dim), in_dim, out_dim)
     _test_linear(Tensor.randn(BS, T, in_dim), in_dim, out_dim) # test with more dims
 
-  def _test_conv(self, tiny_conv, torch_conv, dim):
-    BS, C1, DIMS = 4, 16, [224//4] * dim
-    C2, K, S, P = 64, 7, 2, 1
 
+  def _test_conv(self, tiny_conv, torch_conv, BS, C1, DIMS, C2, K, S, P, D=1, winograd=False):
     # create in tinygrad
-    layer = tiny_conv(C1, C2, kernel_size=K, stride=S, padding=P)
+    layer = tiny_conv(C1, C2, kernel_size=K, stride=S, padding=P, dilation=D)
 
     # create in torch
     with torch.no_grad():
-      torch_layer = torch_conv(C1, C2, kernel_size=K, stride=S, padding=P).eval()
+      torch_layer = torch_conv(C1, C2, kernel_size=K, stride=S, padding=P, dilation=D).eval()
       torch_layer.weight[:] = torch.tensor(layer.weight.numpy(), dtype=torch.float32)
       torch_layer.bias[:] = torch.tensor(layer.bias.numpy(), dtype=torch.float32)
 
     # test
     x = Tensor.uniform(BS, C1, *DIMS)
-    z = layer(x)
-    torch_x = torch.tensor(x.numpy())
-    torch_z = torch_layer(torch_x)
-    np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-4, rtol=1e-5)
-
-  def test_conv1d(self): self._test_conv(Conv1d, torch.nn.Conv1d, 1)
-
-  def test_conv2d(self): self._test_conv(Conv2d, torch.nn.Conv2d, 2)
-
-  def test_conv1d_same_padding(self):
-    BS, C1, W = 8, 3, 32
-    C2, K, S, P = 16, 3, 1, 'same'
-
-    # create in tinygrad
-    layer = Conv1d(C1, C2, kernel_size=K, stride=S, padding=P)
-
-    # create in torch
-    with torch.no_grad():
-      torch_layer = torch.nn.Conv1d(C1, C2, kernel_size=K, stride=S, padding=P).eval()
-      torch_layer.weight[:] = torch.tensor(layer.weight.numpy(), dtype=torch.float32)
-      torch_layer.bias[:] = torch.tensor(layer.bias.numpy(), dtype=torch.float32)
-
-    # test
-    x = Tensor.uniform(BS, C1, W)
-    z = layer(x)
-    torch_x = torch.tensor(x.numpy())
-    torch_z = torch_layer(torch_x)
-    np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-4, rtol=1e-5)
-
-  def _run_conv2d_same_padding_test(self, BS, C1, C2, H, W, K, S, padding='same', D=1):
-    # create in tinygrad
-    layer = Conv2d(C1, C2, kernel_size=K, stride=S, padding=padding, dilation=D)
-
-    # create in torch
-    with torch.no_grad():
-      torch_layer = torch.nn.Conv2d(C1, C2, kernel_size=K, stride=S, padding=padding, dilation=D).eval()
-      torch_layer.weight[:] = torch.tensor(layer.weight.numpy(), dtype=torch.float32)
-      torch_layer.bias[:] = torch.tensor(layer.bias.numpy(), dtype=torch.float32)
-
-    # test
-    x = Tensor.uniform(BS, C1, H, W)
-    z = layer(x)
-    torch_x = torch.tensor(x.numpy())
-    torch_z = torch_layer(torch_x)
-    np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-4, rtol=1e-5)
-
-  def test_conv2d_same_padding_odd_input(self):
-    BS, C1, H, W = 16, 16, 29, 31
-    C2, K, S, P = 32, 5, 1, 'same'
-    self._run_conv2d_same_padding_test(BS, C1, C2, H, W, K, S, P)
-
-  def test_conv2d_same_padding_large_kernel(self):
-    BS, C1, H, W = 16, 16, 28, 33
-    C2, K, S, P = 32, 9, 1, 'same'
-    self._run_conv2d_same_padding_test(BS, C1, C2, H, W, K, S, P)
-
-  def test_conv2d_same_padding_with_dilation(self):
-    BS, C1, H, W = 16, 3, 28, 28
-    C2, K, S, P, D = 32, 3, 1, 'same', 3
-    self._run_conv2d_same_padding_test(BS, C1, C2, H, W, K, S, P, D)
-
-  def test_conv2d_same_padding_invalid_stride(self):
-    C1, C2, K, S, P = 16, 32, 2, 2, 'same'
-    self.assertRaises(ValueError, Conv2d, C1, C2, kernel_size=K, stride=S, padding=P)
-
-  def test_conv2d_same_padding_invalid_padding_str(self):
-    C1, C2, K, S, P = 16, 32, 2, 1, 'not_same'
-    self.assertRaises(ValueError, Conv2d, C1, C2, kernel_size=K, stride=S, padding=P)
-
-  @unittest.skip("Takes too long to compile for Compiled backends")
-  def test_conv2d_winograd(self):
-    BS, C1, H, W = 2, 8, 16, 16
-    C2, K, S, P = 8, 3, 1, 1
-
-    # create in tinygrad
-    layer = Conv2d(C1, C2, kernel_size=K, stride=S, padding=P)
-    layer.weight.requires_grad = True
-    layer.bias.requires_grad = True
-
-    # create in torch
-    torch_layer = torch.nn.Conv2d(C1, C2, kernel_size=K, stride=S, padding=P).eval()
-    torch_layer.weight = torch.nn.Parameter(torch.tensor(layer.weight.numpy(), dtype=torch.float32))
-    torch_layer.bias = torch.nn.Parameter(torch.tensor(layer.bias.numpy(), dtype=torch.float32))
-
-    # test
-    x = Tensor.uniform(BS, C1, H, W, requires_grad=True)
-
-    with Context(WINO=1):
+    if winograd:
+      with Context(WINO=1):
+        z = layer(x)
+    else:
       z = layer(x)
-
-    torch_x = torch.tensor(x.numpy(), requires_grad=True)
+    torch_x = torch.tensor(x.numpy())
     torch_z = torch_layer(torch_x)
     np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-4, rtol=1e-5)
 
+    # extra tests for winograd
+    if not winograd: return
     m = z.mean()
     m.backward()
     gw = layer.weight.grad.realize()
@@ -228,9 +143,59 @@ class TestNN(unittest.TestCase):
     np.testing.assert_allclose(gb.numpy(), torch_layer.bias.grad.numpy(), atol=5e-4, rtol=1e-5)
     np.testing.assert_allclose(gx.numpy(), torch_x.grad.numpy(), atol=5e-4, rtol=1e-5)
 
-  def test_conv_transpose1d(self): self._test_conv(ConvTranspose1d, torch.nn.ConvTranspose1d, 1)
+  def test_conv1d(self): 
+    BS, C1, DIMS = 4, 16, [224//4]
+    C2, K, S, P = 64, 7, 2, 1
+    self._test_conv(Conv1d, torch.nn.Conv1d, BS, C1, DIMS, C2, K, S, P)
 
-  def test_conv_transpose2d(self): self._test_conv(ConvTranspose2d, torch.nn.ConvTranspose2d, 2)
+  def test_conv2d(self): 
+    BS, C1, DIMS = 4, 16, [224//4, 224//4]
+    C2, K, S, P = 64, 7, 2, 1
+    self._test_conv(Conv2d, torch.nn.Conv2d, BS, C1, DIMS, C2, K, S, P)
+
+  def test_conv1d_same_padding(self):
+    BS, C1, DIMS = 8, 3, [32]
+    C2, K, S, P = 16, 3, 1, 'same'
+    self._test_conv(Conv1d, torch.nn.Conv1d, BS, C1, DIMS, C2, K, S, P)
+
+  def test_conv2d_same_padding_odd_input(self):
+    BS, C1, DIMS = 16, 16, [29, 31]
+    C2, K, S, P = 32, 5, 1, 'same'
+    self._test_conv(Conv2d, torch.nn.Conv2d, BS, C1, DIMS, C2, K, S, P)
+
+  def test_conv2d_same_padding_large_kernel(self):
+    BS, C1, DIMS = 16, 16, [28, 33]
+    C2, K, S, P = 32, 9, 1, 'same'
+    self._test_conv(Conv2d, torch.nn.Conv2d, BS, C1, DIMS, C2, K, S, P)
+
+  def test_conv2d_same_padding_with_dilation(self):
+    BS, C1, DIMS = 16, 3, [28, 28]
+    C2, K, S, P, D = 32, 3, 1, 'same', 3
+    self._test_conv(Conv2d, torch.nn.Conv2d, BS, C1, DIMS, C2, K, S, P)
+
+  def test_conv2d_same_padding_invalid_stride(self):
+    C1, C2, K, S, P = 16, 32, 2, 2, 'same'
+    self.assertRaises(ValueError, Conv2d, C1, C2, kernel_size=K, stride=S, padding=P)
+
+  def test_conv2d_same_padding_invalid_padding_str(self):
+    C1, C2, K, S, P = 16, 32, 2, 1, 'not_same'
+    self.assertRaises(ValueError, Conv2d, C1, C2, kernel_size=K, stride=S, padding=P)
+
+  @unittest.skip("Takes too long to compile for Compiled backends")
+  def test_conv2d_winograd(self):
+    BS, C1, DIMS = 2, 8, [16, 16]
+    C2, K, S, P = 8, 3, 1, 1
+    self._test_conv(Conv2d, torch.nn.Conv2d, BS, C1, DIMS, C2, K, S, P, winograd=True)
+
+  def test_conv_transpose1d(self): 
+    BS, C1, DIMS = 4, 16, [224//4]
+    C2, K, S, P = 64, 7, 2, 1
+    self._test_conv(ConvTranspose1d, torch.nn.ConvTranspose1d, BS, C1, DIMS, C2, K, S, P)
+
+  def test_conv_transpose2d(self):
+    BS, C1, DIMS = 4, 16, [224//4, 224//4]
+    C2, K, S, P = 64, 7, 2, 1
+    self._test_conv(ConvTranspose2d, torch.nn.ConvTranspose2d, BS, C1, DIMS, C2, K, S, P)
 
   @unittest.skipIf(Device.DEFAULT == "WEBGPU" and not OSX, "WEBGPU Vulkan can only run kernels with up to 10 buffers")
   def test_groupnorm(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -108,7 +108,6 @@ class TestNN(unittest.TestCase):
     _test_linear(Tensor.randn(BS, in_dim), in_dim, out_dim)
     _test_linear(Tensor.randn(BS, T, in_dim), in_dim, out_dim) # test with more dims
 
-
   def _test_conv(self, tiny_conv, torch_conv, BS, C1, DIMS, C2, K, S, P, D=1, winograd=False):
     # create in tinygrad
     layer = tiny_conv(C1, C2, kernel_size=K, stride=S, padding=P, dilation=D)
@@ -143,12 +142,12 @@ class TestNN(unittest.TestCase):
     np.testing.assert_allclose(gb.numpy(), torch_layer.bias.grad.numpy(), atol=5e-4, rtol=1e-5)
     np.testing.assert_allclose(gx.numpy(), torch_x.grad.numpy(), atol=5e-4, rtol=1e-5)
 
-  def test_conv1d(self): 
+  def test_conv1d(self):
     BS, C1, DIMS = 4, 16, [224//4]
     C2, K, S, P = 64, 7, 2, 1
     self._test_conv(Conv1d, torch.nn.Conv1d, BS, C1, DIMS, C2, K, S, P)
 
-  def test_conv2d(self): 
+  def test_conv2d(self):
     BS, C1, DIMS = 4, 16, [224//4, 224//4]
     C2, K, S, P = 64, 7, 2, 1
     self._test_conv(Conv2d, torch.nn.Conv2d, BS, C1, DIMS, C2, K, S, P)
@@ -171,7 +170,7 @@ class TestNN(unittest.TestCase):
   def test_conv2d_same_padding_with_dilation(self):
     BS, C1, DIMS = 16, 3, [28, 28]
     C2, K, S, P, D = 32, 3, 1, 'same', 3
-    self._test_conv(Conv2d, torch.nn.Conv2d, BS, C1, DIMS, C2, K, S, P)
+    self._test_conv(Conv2d, torch.nn.Conv2d, BS, C1, DIMS, C2, K, S, P, D)
 
   def test_conv2d_same_padding_invalid_stride(self):
     C1, C2, K, S, P = 16, 32, 2, 2, 'same'
@@ -187,7 +186,7 @@ class TestNN(unittest.TestCase):
     C2, K, S, P = 8, 3, 1, 1
     self._test_conv(Conv2d, torch.nn.Conv2d, BS, C1, DIMS, C2, K, S, P, winograd=True)
 
-  def test_conv_transpose1d(self): 
+  def test_conv_transpose1d(self):
     BS, C1, DIMS = 4, 16, [224//4]
     C2, K, S, P = 64, 7, 2, 1
     self._test_conv(ConvTranspose1d, torch.nn.ConvTranspose1d, BS, C1, DIMS, C2, K, S, P)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -109,7 +109,7 @@ class TestNN(unittest.TestCase):
     _test_linear(Tensor.randn(BS, T, in_dim), in_dim, out_dim) # test with more dims
 
   def _test_conv(self, tiny_conv, torch_conv, dim):
-    BS, C1, DIMS = 4, 16, tuple([224//4] * dim)
+    BS, C1, DIMS = 4, 16, [224//4] * dim
     C2, K, S, P = 64, 7, 2, 1
 
     # create in tinygrad


### PR DESCRIPTION
makes adding Conv3d test only a few lines

dim parameter is awkward but I can't really think of a cleaner way to do it while keeping a structure that supports future Conv3d testing; tinygrad's Conv2d layer needs an indicator to determine 3d-ness