### PR TITLE
viz: show total mem in tooltip

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -221,7 +221,13 @@ async function renderProfiler() {
         ctx.closePath();
         ctx.fill();
         // NOTE: y coordinates are in reverse order
-        for (let i = 0; i < x.length - 1; i++) rectLst.push({ x0:x[i], x1:x[i+1], y0:e.y1[i], y1:e.y0[i], arg:e.arg });
+        for (let i = 0; i < x.length - 1; i++) {
+          let tooltipText = e.arg.tooltipText;
+          if (yscale != null && ((yaxisVal=yscale.invert(e.y1[i]))>0)) {
+            tooltipText += `\nTotal: ${formatUnit(yaxisVal, data.axes.y.fmt)}`;
+          }
+          rectLst.push({ x0:x[i], x1:x[i+1], y0:e.y1[i], y1:e.y0[i], arg:{...e.arg, tooltipText} });
+        }
         continue;
       }
       // contiguous rect


### PR DESCRIPTION
This value is slightly different from GlobalCounters.total_mem,
A Buffer can have multiple total memory values in its lifetime, based on all alive buffers at the hovered position.

eg in beautiful_mnist, total starts at 2.11GB and goes to 1.5GB as nearby bufs free:
<img height="302" alt="Screenshot 2025-08-06 at 6 20 53 AM" src="https://github.com/user-attachments/assets/a215b4ef-269d-43a8-8883-cf3b9bfabf2f" />
<img height="302" alt="Screenshot 2025-08-06 at 6 21 16 AM" src="https://github.com/user-attachments/assets/9207e65a-1fd1-4dc6-b226-7d7c3c7502b1" />
