### PR TITLE
support sam2_hiear2_tiny onnx

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -47,6 +47,7 @@ PB_INFOS: dict[str, dict] = {
     5: ("attribute", PBType.SUB, True, ("AttributeProto", lambda: {"floats": [], "ints": [], "strings": []}))},
   "AttributeProto": {1: ("name", PBType.STRING), 20: ("type", PBType.INT), 3: ("i", PBType.INT), 8: ("ints", PBType.INT, True),
     2: ("f", PBType.FLOAT), 7: ("floats", PBType.FLOAT, True), 4: ("s", PBType.BYTES), 9: ("strings", PBType.BYTES, True),
+    6: ("g", PBType.SUB, False, ("GraphProto", lambda: {"node": [], "initializer": [], "input": [], "output": [], "value_info": []})),
     5:("t", PBType.SUB, False, ("TensorProto", lambda: {"dims": [], "float_data": None, "int32_data": None, "string_data": None, "int64_data": None,
                                                         "double_data": None, "uint64_data": None, "raw_data": None}))},
   "ValueInfoProto": {1: ("name", PBType.STRING), 2: ("type", PBType.SUB, False, "TypeProto"), 3: ("doc_string", PBType.STRING)},
@@ -221,6 +222,7 @@ attribute_types: dict[int, Callable] = {
   2: lambda a: int(a.i),
   3: lambda a: a.s.data().tobytes().decode("utf8") if isinstance(a.s, Tensor) else a.s.decode("utf8"),
   4: lambda a: buffer_parse(a.t),
+  5: lambda a: a.g,
   6: lambda a: tuple(float(x) for x in a.floats),
   7: lambda a: tuple(int(x) for x in a.ints),
   8: lambda a: tuple(x.data().tobytes().decode("utf8") for x in a.strings)
@@ -345,22 +347,24 @@ class OnnxRunner:
   """
   def __init__(self, model_path: Tensor | str | pathlib.Path):
     model = onnx_load(model_path)
-    self.is_training = any(n.domain in {Domain.AI_ONNX_TRAINING, Domain.AI_ONNX_PREVIEW_TRAINING} for n in model.graph.node)
+    self.opset_imports = {Domain.from_onnx(getattr(x, "domain", "")):x.version for x in model.opset_import}
+    self._load_from_graph(model.graph, self.opset_imports)
+
+  def _load_from_graph(self, graph: SimpleNamespace, opset_imports: dict[Domain, int]):
+    self.is_training = any(n.domain in {Domain.AI_ONNX_TRAINING, Domain.AI_ONNX_PREVIEW_TRAINING} for n in graph.node)
     self.old_training = Tensor.training
     Tensor.training = True if self.is_training else False
-    self.graph_values = {"": None, **{x.name:buffer_parse(x) for x in model.graph.initializer}}
-    self.graph_inputs = {x.name:type_parse(x.type) for x in model.graph.input if x.name not in self.graph_values}
-    self.graph_outputs = tuple(x.name for x in model.graph.output)
-    opset_imports = {Domain.from_onnx(getattr(x, "domain", "")):x.version for x in model.opset_import}
+    self.graph_values = {"": None, **{x.name:buffer_parse(x) for x in graph.initializer}}
+    self.graph_inputs = {x.name:type_parse(x.type) for x in graph.input if x.name not in self.graph_values}
+    self.graph_outputs = tuple(x.name for x in graph.output)
     self.graph_nodes = []
-    for num, n in enumerate(model.graph.node):
+    for num, n in enumerate(graph.node):
       domain = Domain.from_onnx(n.domain)
       opset_id = OpSetId(domain, opset_imports.get(domain, 1))
       self.graph_nodes.append(OnnxNode(num, n.op_type, opset_id, tuple(n.input), tuple(n.output), {x.name:attribute_parse(x) for x in n.attribute}))
     self.graph_nodes = tuple(self.graph_nodes)
-    self.variable_dims: dict[str, int] = {}
-
     self.onnx_ops = onnx_ops
+    self.variable_dims: dict[str, int] = {}
 
   def _parse_input(self, name: str, value: Any, spec: OnnxValue):
     if spec.is_optional and value is None: return None
@@ -409,7 +413,8 @@ class OnnxRunner:
 
       # provide additional opts
       if node.op == "Split" and 'num_outputs' not in opts: opts['num_outputs'] = len(node.outputs)
-      if node.op == "Gradient": opts['intermediate_tensors'] = self.graph_values
+      if node.op in {"Gradient", "If"}: opts['intermediate_tensors'] = self.graph_values
+      if node.op == "If": opts['opset_imports'] = self.opset_imports
 
       if debug >= 1: print(f"{node.num}: op '{node.op}' opt {opts}")
       if debug >= 2 and node.inputs: print("\tinputs:\n" + "\n".join(f"\t\t{x} - {i!r}" for x,i in zip(node.inputs, inps)))
@@ -425,8 +430,9 @@ class OnnxRunner:
     Tensor.training = self.old_training
     return {name:self.graph_values[name] for name in self.graph_outputs}
 
-####################
-##### ONNX OPS #####
+class SubGraphOnnxRunner(OnnxRunner):
+  def __init__(self, graph: dict, opset_imports: dict[Domain, int]): self._load_from_graph(graph, opset_imports)
+
 ####################
 def get_onnx_ops() -> dict[str, types.FunctionType|dict[OpSetId, types.FunctionType]]:
   # ***** helper functions *****
@@ -491,6 +497,19 @@ def get_onnx_ops() -> dict[str, types.FunctionType|dict[OpSetId, types.FunctionT
     return __decorator
 
   # ***** Property/Graph Ops *****
+  def If(condition:Tensor, else_branch, then_branch, intermediate_tensors:dict[str, Tensor], opset_imports:dict[Domain, int]):
+    else_graph, then_graph = SubGraphOnnxRunner(else_branch, opset_imports), SubGraphOnnxRunner(then_branch, opset_imports)
+    else_graph.graph_values = intermediate_tensors
+    then_graph.graph_values = intermediate_tensors
+    else_out = else_graph({k:intermediate_tensors[k] for k in else_graph.graph_inputs.keys()})
+    then_out = then_graph({k:intermediate_tensors[k] for k in then_graph.graph_inputs.keys()})
+    assert len(else_out) == len(then_out), f"else_out and then_out must have the same number of outputs: {len(else_out)} != {len(then_out)}"
+    # can use where op when output shape is the same
+    if all(t.shape == e.shape for t,e in zip(then_out.values(), else_out.values())):
+      return tuple(condition.where(t,e) for t,e in zip(then_out.values(), else_out.values()))
+    # otherwise, use condition to select the output in python
+    return tuple(t if condition.item() else e for t,e in zip(then_out.values(), else_out.values()))
+
   def Identity(x:Tensor): return x
   def Constant(sparse_value:Tensor|None=None, value:Tensor|None=None, value_float:float|None=None, value_floats:list[float]|None=None,
               value_int:int|None=None, value_ints:list[int]|None=None, value_string:str|None=None, value_strings:list[str]|None=None):
@@ -757,7 +776,49 @@ def get_onnx_ops() -> dict[str, types.FunctionType|dict[OpSetId, types.FunctionT
         reshape[i] = expand[i] = sizes[i]
         low, high, perc = [y.reshape(reshape).expand(expand) for y in (index.floor().int(), index.ceil().int(), index - index.floor())]
         X = X.gather(i, low).lerp(X.gather(i, high), perc)
-    if mode == "cubic": raise NotImplementedError("cubic interpolation is not implemented")
+    if mode == "cubic":
+      A = cubic_coeff_a
+      expand = list(X.shape)
+      for i in range(-len(sizes), 0):
+        input_dim = X.shape[i]
+        reshape, index = [1] * X.ndim, indexes[i]
+        reshape[i] = expand[i] = sizes[i]
+
+        p = index.floor().cast(dtypes.int32)
+        ratio = index - p.cast(index.dtype)
+
+        # Calculate indices
+        idx0 = p - 1
+        idx1 = p
+        idx2 = p + 1
+        idx3 = p + 2
+
+        # Calculate coefficients
+        ratio_plus_1 = ratio + 1
+        one_minus_ratio = 1.0 - ratio
+        one_minus_ratio_plus_1 = one_minus_ratio + 1.0
+
+        c0 = ((A * ratio_plus_1 - 5 * A) * ratio_plus_1 + 8 * A) * ratio_plus_1 - 4 * A
+        c1 = ((A + 2) * ratio - (A + 3)) * ratio * ratio + 1.0
+        c2 = ((A + 2) * one_minus_ratio - (A + 3)) * one_minus_ratio * one_minus_ratio + 1.0
+        c3 = ((A * one_minus_ratio_plus_1 - 5 * A) * one_minus_ratio_plus_1 + 8 * A) * one_minus_ratio_plus_1 - 4 * A
+
+        if exclude_outside:
+          c0 = (p - 1 >= 0).where(c0, 0)
+          c2 = (p + 1 < input_dim).where(c2, 0)
+          c3 = (p + 2 < input_dim).where(c3, 0)
+
+          # Normalize coeffs
+          total = c0 + c1 + c2 + c3
+          c0, c1, c2, c3 = c0 / (total + 1e-9), c1 / (total + 1e-9), c2 / (total + 1e-9), c3 / (total + 1e-9)
+
+        # Reshape and expand
+        expanded_indices = [y.clip(0, input_dim - 1).reshape(reshape).expand(expand) for y in [idx0, idx1, idx2, idx3]]
+        expanded_coeffs = [y.reshape(reshape).expand(expand) for y in [c0, c1, c2, c3]]
+
+        # Gather values and apply coefficients
+        gathered_values = [X.gather(i, idx) for idx in expanded_indices]
+        X = sum(v * c for v, c in zip(gathered_values, expanded_coeffs))
     return X.permute(*argsort(perm)) if perm else X
   def Upsample(X, scales, mode): return Resize(X=X, scales=scales, mode=mode)  # deprecated
 

--- a/test/external/external_model_benchmark.py
+++ b/test/external/external_model_benchmark.py
@@ -17,6 +17,7 @@ MODELS = {
   # TODO: precision issue
   # "commavq": "https://huggingface.co/commaai/commavq-gpt2m/resolve/main/gpt2m.onnx",
   "dm": "https://github.com/commaai/openpilot/raw/ba7f840a06dbc8ae3c45b3b4976c88a21895aed0/selfdrive/modeld/models/dmonitoring_model.onnx",
+  "sam2_hiear2_tiny": "https://github.com/haraschax/filedump/raw/refs/heads/master/sam2_hiear2_tiny.onnx",
 
   # broken in torch MPS
   # "zfnet": "https://github.com/onnx/models/raw/main/archive/vision/classification/zfnet-512/model/zfnet512-9.onnx",

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -129,7 +129,8 @@ backend_test.exclude('test_simple_rnn_*')
 
 # no control flow
 # control flow uses AttributeProto.GRAPH
-backend_test.exclude('test_if_*')
+backend_test.exclude('test_if_opt_cpu') # ValueError: 13 is not a valid AttributeType
+backend_test.exclude('test_if_seq_cpu') # NotImplementedError: op='SequenceConstruct' is not supported
 backend_test.exclude('test_loop*')
 backend_test.exclude('test_range_float_type_positive_delta_expanded_cpu') # requires loop
 backend_test.exclude('test_affine_grid_2d_align_corners_expanded_cpu')
@@ -165,11 +166,15 @@ backend_test.exclude('test_deform_conv_*')
 backend_test.exclude('test_lppool_*')
 backend_test.exclude('test_scan_*')
 backend_test.exclude('test_split_to_sequence_*')
-backend_test.exclude('test_resize_downsample_scales_cubic_*') # unsure how to implement cubic
-backend_test.exclude('test_resize_downsample_sizes_cubic_*') # unsure how to implement cubic
-backend_test.exclude('test_resize_upsample_scales_cubic_*') # unsure how to implement cubic
-backend_test.exclude('test_resize_upsample_sizes_cubic_*') # unsure how to implement cubic
 backend_test.exclude('test_ai_onnx_ml_tree_ensemble_*') # https://github.com/onnx/onnx/blob/main/onnx/reference/ops/aionnxml/op_tree_ensemble.py#L121
+
+# TODO: cubic not fully supported
+backend_test.exclude('test_resize_downsample_scales_cubic_antialias_cpu')
+backend_test.exclude('test_resize_downsample_sizes_cubic_antialias_cpu')
+backend_test.exclude('test_resize_upsample_scales_cubic_A_n0p5_exclude_outside_cpu')
+backend_test.exclude('test_resize_upsample_scales_cubic_asymmetric_cpu')
+backend_test.exclude('test_resize_upsample_scales_cubic_cpu')
+backend_test.exclude('test_resize_upsample_sizes_cubic_cpu')
 
 # rest of the failing tests
 backend_test.exclude('test_resize_tf_crop_and_resize_cpu') # tf_crop_and_resize not implemented

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -173,8 +173,6 @@ backend_test.exclude('test_resize_downsample_scales_cubic_antialias_cpu')
 backend_test.exclude('test_resize_downsample_sizes_cubic_antialias_cpu')
 backend_test.exclude('test_resize_upsample_scales_cubic_A_n0p5_exclude_outside_cpu')
 backend_test.exclude('test_resize_upsample_scales_cubic_asymmetric_cpu')
-backend_test.exclude('test_resize_upsample_scales_cubic_cpu')
-backend_test.exclude('test_resize_upsample_sizes_cubic_cpu')
 
 # rest of the failing tests
 backend_test.exclude('test_resize_tf_crop_and_resize_cpu') # tf_crop_and_resize not implemented

--- a/test/external/external_test_onnx_ops.py
+++ b/test/external/external_test_onnx_ops.py
@@ -75,6 +75,25 @@ class TestMainOnnxOps(TestOnnxOps):
     outputs = ["y"]
     self.helper_test_single_op("Gather", inputs, attributes, outputs)
 
+  def _test_if(self, then_value, else_value):
+    then_out = onnx.helper.make_tensor_value_info("res", onnx.TensorProto.FLOAT, then_value.shape)
+    else_out = onnx.helper.make_tensor_value_info("res", onnx.TensorProto.FLOAT, else_value.shape)
+
+    then_const_node = onnx.helper.make_node("Constant", inputs=[], outputs=["res"], value=onnx.numpy_helper.from_array(then_value))
+    else_const_node = onnx.helper.make_node("Constant", inputs=[], outputs=["res"], value=onnx.numpy_helper.from_array(else_value))
+
+    then_body = onnx.helper.make_graph([then_const_node], "then_body", [], [then_out])
+    else_body = onnx.helper.make_graph([else_const_node], "else_body", [], [else_out])
+
+    self.helper_test_single_op("If", {"cond": np.array(False).astype(bool)}, {"then_branch": then_body, "else_branch": else_body}, ["res"])
+    self.helper_test_single_op("If", {"cond": np.array(True).astype(bool)}, {"then_branch": then_body, "else_branch": else_body}, ["res"])
+
+  def test_if_different_shapes_broadcastable(self):
+    self._test_if(np.array([[1], [2]]).astype(np.float32), np.array([[6, 5, 4, 3, 2, 1]]).astype(np.float32))
+
+  def test_if_different_shapes_not_broadcastable(self):
+    self._test_if(np.array([[1, 2, 3], [4, 5, 6]]).astype(np.float32), np.array([[6, 5, 4, 3, 2, 1]]).astype(np.float32))
+
   def test_maxunpool_export_with_output_shape(self):
     # https://github.com/onnx/onnx/blob/main/docs/Operators.md#examples-91
     xT = np.array([[[[5, 6], [7, 8]]]], dtype=np.float32)


### PR DESCRIPTION
wrote hacks to pass cubic interp test.
There are a lot of problems with that resize op. 
I have some of the problems resolved in https://github.com/tinygrad/tinygrad/pull/9609/files, so I might go from there to once and for all write a correct resize op.

Regarding perf on m1 pro:
```
(tinygrad) zibo@cloud:~/fun/tiny/tinygrad$ MODEL=sam2_hiear2_tiny PYTHONPATH=. python test/external/external_model_benchmark.py 
sam2_hiear2_tiny tinygrad_metal_jitless    1860.92 ms
sam2_hiear2_tiny tinygrad_metal_jit          34.16 ms
sam2_hiear2_tiny tinygrad_cpu_jitless      2655.32 ms
sam2_hiear2_tiny tinygrad_cpu_jit           679.48 ms
sam2_hiear2_tinyonnx2torch       NotImplementedError
sam2_hiear2_tiny onnxruntime_cpu             66.50 ms
sam2_hiear2_tiny onnxruntime_coreml          68.97 ms
sam2_hiear2_tinyoutputs validated on device='METAL' with rtol=2.0e-03, atol=2.0e-03
sam2_hiear2_tinyoutputs validated on device='CPU' with rtol=2.0e-03, atol=2.0e-03
```

Here're the ops used:
```
Counter({'Constant': 923, 'Unsqueeze': 234, 'Cast': 151, 'Shape': 122, 'Gather': 122, 'Add': 121, 'Mul': 109, 'Concat': 98, 'Transpose': 89, 'Reshape': 84, 'MatMul': 75, 'Div': 67, 'Mod': 48, 'Squeeze': 36, 'Sub': 35, 'Slice': 27, 'LayerNormalization': 25, 'Split': 12, 'Softmax': 12, 'Tanh': 12, 'ConstantOfShape': 9, 'Pad': 9, 'Gemm': 7, 'MaxPool': 6, 'Relu': 5, 'If': 2, 'Conv': 1, 'Resize': 1, 'Size': 1, 'Greater': 1, 'Less': 1, 'Tile': 1, 'ReduceMean': 1, 'Flatten': 1, 'ReduceSum': 1, 'Sqrt': 1, 'Clip': 1})
```
