### PR TITLE
add z3 timeout and warning

### DIFF
--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -110,10 +110,12 @@ def validate_index(idx:UOp, gate:UOp=UOp.const(dtypes.bool, True)):
   z3_sink = graph_rewrite(idx.src[1].sink(mask), z3_renderer, ctx=(solver, {}))
   z3_idx = z3_sink.src[0].arg
   solver.add(z3_sink.src[1].arg)
-  if solver.check((z3_idx<0)|(sz<=z3_idx)) == z3.sat:
+  solver.set("timeout", 5000)
+  if not ((res:=solver.check((z3_idx<0)|(sz<=z3_idx))) == z3.unsat):
+    if res == z3.unknown: print(f"# OOB SOLVER TIMEOUT\n{solver.model()} \nconstraints = {solver}")
+    else: print(f"# OUT OF BOUNDS ACCESS: at {solver.model()} INDEX not in 0 - {sz}\nconstraints = {solver}")
     print(f"idx={idx.src[1].render(simplify=False)}")
     print(f"mask & gate={mask.render(simplify=False)}")
-    print(f"# OUT OF BOUNDS ACCESS: at {solver.model()} INDEX not in 0 - {sz}\nconstraints = {solver}")
     return False
   return True
 


### PR DESCRIPTION
addded a timeout to the solver of 5 seconds. Should also work if you ctrl-c during the solving. In those cases the solver returns `z3.unknown`