### PR TITLE
metal: workaround for transfers sync issue

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -109,7 +109,6 @@ class TestProfiler(unittest.TestCase):
       assert evs[0].is_copy, "kernel should be copy"
 
   def test_profile_multidev_transfer(self):
-    if not hasattr(TestProfiler.d0.allocator, '_transfer'): self.skipTest("device is not supported (no transfers)")
     d1 = Device[f"{Device.DEFAULT}:1"]
 
     buf1 = Tensor.randn(10, 10, device=f"{Device.DEFAULT}:0").realize()

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -109,6 +109,7 @@ class TestProfiler(unittest.TestCase):
       assert evs[0].is_copy, "kernel should be copy"
 
   def test_profile_multidev_transfer(self):
+    if not hasattr(TestProfiler.d0.allocator, '_transfer'): self.skipTest("device is not supported (no transfers)")
     d1 = Device[f"{Device.DEFAULT}:1"]
 
     buf1 = Tensor.randn(10, 10, device=f"{Device.DEFAULT}:0").realize()

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -205,7 +205,11 @@ class MetalAllocator(LRUAllocator[MetalDevice]):
   def _free(self, opaque:MetalBuffer, options):
     if msg is not None and libobjc is not None: msg("release")(opaque.buf)
   def _transfer(self, dest:MetalBuffer, src:MetalBuffer, sz:int, src_dev:MetalDevice, dest_dev:MetalDevice):
+    # Transfers currently synchronize both devices. Otherwise, copies can sometimes lead to incorrect values.
+    # There is no real metal multidevice support for now, so transfer is used only for tests.
     dest_dev.synchronize()
+    src_dev.synchronize()
+
     src_command_buffer = msg("commandBuffer", objc_instance)(src_dev.mtl_queue)
     encoder = msg("blitCommandEncoder", objc_instance)(src_command_buffer)
     msg("copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:")(encoder, src.buf, ctypes.c_ulong(src.offset),

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -68,6 +68,8 @@ class MetalDevice(Compiled):
     self.mtl_queue = msg("newCommandQueueWithMaxCommandBufferCount:", objc_instance)(self.sysdevice, 1024)
     if self.mtl_queue is None: raise RuntimeError("Cannot allocate a new command queue")
     self.mtl_buffers_in_flight: list[Any] = []
+    self.timeline_signal = msg("newSharedEvent", objc_instance)(self.sysdevice)
+    self.timeline_value = 0
 
     Compiled.profile_events += [ProfileDeviceEvent(device)]
 
@@ -202,6 +204,26 @@ class MetalAllocator(LRUAllocator[MetalDevice]):
     return MetalBuffer(ret, size)
   def _free(self, opaque:MetalBuffer, options):
     if msg is not None and libobjc is not None: msg("release")(opaque.buf)
+  def _transfer(self, dest:MetalBuffer, src:MetalBuffer, sz:int, src_dev:MetalDevice, dest_dev:MetalDevice):
+    dest_dev.synchronize()
+    src_command_buffer = msg("commandBuffer", objc_instance)(src_dev.mtl_queue)
+    encoder = msg("blitCommandEncoder", objc_instance)(src_command_buffer)
+    msg("copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:")(encoder, src.buf, ctypes.c_ulong(src.offset),
+        dest.buf, ctypes.c_ulong(dest.offset), ctypes.c_ulong(sz))
+    msg("endEncoding")(encoder)
+    if src_dev != dest_dev:
+      msg("encodeSignalEvent:value:")(src_command_buffer, src_dev.timeline_signal, src_dev.timeline_value)
+      dest_command_buffer = msg("commandBuffer", objc_instance)(dest_dev.mtl_queue)
+      msg("encodeWaitForEvent:value:")(dest_command_buffer, src_dev.timeline_signal, src_dev.timeline_value)
+      msg("commit")(dest_command_buffer)
+      dest_dev.mtl_buffers_in_flight.append(dest_command_buffer)
+      src_dev.timeline_value += 1
+    msg("setLabel:")(src_command_buffer, to_ns_str(f"COPY {src_dev.device} -> {dest_dev.device}"))
+    msg("commit")(src_command_buffer)
+    src_dev.mtl_buffers_in_flight.append(src_command_buffer)
+    # Transfers currently synchronize the completion. Otherwise, copies can sometimes lead to incorrect values.
+    # There is no real metal multidevice support for now, so transfer is used only for tests.
+    src_dev.synchronize()
   def _cp_mv(self, dst, src, prof_desc):
     with cpu_profile(prof_desc, self.dev.device, is_copy=True): dst[:] = src
   def _as_buffer(self, src:MetalBuffer) -> memoryview:

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -68,8 +68,6 @@ class MetalDevice(Compiled):
     self.mtl_queue = msg("newCommandQueueWithMaxCommandBufferCount:", objc_instance)(self.sysdevice, 1024)
     if self.mtl_queue is None: raise RuntimeError("Cannot allocate a new command queue")
     self.mtl_buffers_in_flight: list[Any] = []
-    self.timeline_signal = msg("newSharedEvent", objc_instance)(self.sysdevice)
-    self.timeline_value = 0
 
     Compiled.profile_events += [ProfileDeviceEvent(device)]
 
@@ -204,27 +202,6 @@ class MetalAllocator(LRUAllocator[MetalDevice]):
     return MetalBuffer(ret, size)
   def _free(self, opaque:MetalBuffer, options):
     if msg is not None and libobjc is not None: msg("release")(opaque.buf)
-  def _transfer(self, dest:MetalBuffer, src:MetalBuffer, sz:int, src_dev:MetalDevice, dest_dev:MetalDevice):
-    # Transfers currently synchronize both devices. Otherwise, copies can sometimes lead to incorrect values.
-    # There is no real metal multidevice support for now, so transfer is used only for tests.
-    dest_dev.synchronize()
-    src_dev.synchronize()
-
-    src_command_buffer = msg("commandBuffer", objc_instance)(src_dev.mtl_queue)
-    encoder = msg("blitCommandEncoder", objc_instance)(src_command_buffer)
-    msg("copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:")(encoder, src.buf, ctypes.c_ulong(src.offset),
-        dest.buf, ctypes.c_ulong(dest.offset), ctypes.c_ulong(sz))
-    msg("endEncoding")(encoder)
-    if src_dev != dest_dev:
-      msg("encodeSignalEvent:value:")(src_command_buffer, src_dev.timeline_signal, src_dev.timeline_value)
-      dest_command_buffer = msg("commandBuffer", objc_instance)(dest_dev.mtl_queue)
-      msg("encodeWaitForEvent:value:")(dest_command_buffer, src_dev.timeline_signal, src_dev.timeline_value)
-      msg("commit")(dest_command_buffer)
-      dest_dev.mtl_buffers_in_flight.append(dest_command_buffer)
-      src_dev.timeline_value += 1
-    msg("setLabel:")(src_command_buffer, to_ns_str(f"COPY {src_dev.device} -> {dest_dev.device}"))
-    msg("commit")(src_command_buffer)
-    src_dev.mtl_buffers_in_flight.append(src_command_buffer)
   def _cp_mv(self, dst, src, prof_desc):
     with cpu_profile(prof_desc, self.dev.device, is_copy=True): dst[:] = src
   def _as_buffer(self, src:MetalBuffer) -> memoryview:


### PR DESCRIPTION
in `TestMultiTensor.test_shrink_on_shard_axis` there is a reproducible failure:
```
opened device METAL from pid:93942
*** METAL      1 r_16_16                                      arg  1 mem  0.00 GB tm      9.50us/     0.01ms (     0.54 GFLOPS    0.0|1.9     GB/s) ['arange']
opened device METAL:1 from pid:93942
opened device METAL:2 from pid:93942
*** METAL      2 E_2_4                                        arg  2 mem  0.00 GB tm      9.00us/     0.02ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** METAL:1    3 xfer       32, METAL:1 <- METAL              arg  2 mem  0.00 GB tm    245.83us/     0.26ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** METAL:2    4 xfer       32, METAL:2 <- METAL:1            arg  2 mem  0.00 GB tm    177.79us/     0.44ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** METAL:1    5 E_2_4n1                                      arg  2 mem  0.00 GB tm     10.00us/     0.45ms (     0.00 GFLOPS    0.0|0.0     GB/s) ['__getitem__']
*** METAL:2    6 E_2_4n1                                      arg  2 mem  0.00 GB tm      7.12us/     0.46ms (     0.00 GFLOPS    0.0|0.0     GB/s) ['__getitem__']
opened device CPU from pid:93942
*** CPU        7 copy       32,     CPU <- METAL:1            arg  2 mem  0.00 GB tm     74.08us/     0.53ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** METAL      8 E_2_4n2                                      arg  2 mem  0.00 GB tm      8.25us/     0.54ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** METAL:2    9 xfer       32, METAL:2 <- METAL              arg  2 mem  0.00 GB tm    308.17us/     0.85ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** METAL:1   10 xfer       32, METAL:1 <- METAL:2            arg  2 mem  0.00 GB tm     73.92us/     0.92ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
*** METAL:1   11 E_2_4n1                                      arg  2 mem  0.00 GB tm     11.88us/     0.94ms (     0.00 GFLOPS    0.0|0.0     GB/s) ['__getitem__']
*** METAL:2   12 E_2_4n1                                      arg  2 mem  0.00 GB tm      6.42us/     0.94ms (     0.00 GFLOPS    0.0|0.0     GB/s) ['__getitem__']
*** CPU       13 copy       32,     CPU <- METAL:1            arg  2 mem  0.00 GB tm     25.50us/     0.97ms (     0.00 GFLOPS    0.0|0.0     GB/s) 
.
----------------------------------------------------------------------
Ran 1 test in 0.037s

OK
```

in both the metal debugger and manual debugging, the 10th kernel `METAL:1 <- METAL:2` sees the old values of the src buffer. this seems to happen if the source was a destination in a previous transfer. however, the metal debugger shows the correct dependency graph and edges between these two nodes:
<img width="500" alt="Screenshot 2025-08-11 at 22 54 12" src="https://github.com/user-attachments/assets/eb02f1d1-a377-4ba3-a4f3-04c1d26267b2" />

so, workaround it with a manual src sync for now.