### PR TITLE
viz: always left align timeline values

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -290,16 +290,14 @@ async function renderProfiler() {
     }
     // draw axes
     drawLine(ctx, xscale.range(), [0, 0]);
-    const ticks = xscale.ticks();
-    for (const [i, tick] of ticks.entries()) {
+    for (const tick of xscale.ticks()) {
       // tick line
       const x = xscale(tick);
       drawLine(ctx, [x, x], [0, tickSize])
       // tick label
       ctx.textBaseline = "top";
-      ctx.textAlign = i === ticks.length-1 ? "right" : "left";
-      const padding = i === ticks.length-1 ? -1 : 1;
-      ctx.fillText(formatTime(tick, et-st), x+(ctx.lineWidth+2)*padding, tickSize);
+      ctx.textAlign = "left";
+      ctx.fillText(formatTime(tick, et-st), x+ctx.lineWidth+2, tickSize);
     }
     if (yscale != null) {
       drawLine(ctx, [0, 0], yscale.range());


### PR DESCRIPTION
I think it looks more solid this way:
<img width="1440" height="174" alt="Screenshot 2025-08-13 at 11 34 54 PM" src="https://github.com/user-attachments/assets/7432b540-e656-43fe-82dd-cade67b2ea52" />
master right aligns the last tick, which makes values move too much when scrolling through time.
<img width="1440" height="174" alt="Screenshot 2025-08-13 at 11 34 59 PM" src="https://github.com/user-attachments/assets/7df9e95d-5ec9-47d1-90b1-a1069562d7ae" />