### PR TITLE
rope cache optim for jit prune in llm.py

### DIFF
--- a/test/unit/test_attention.py
+++ b/test/unit/test_attention.py
@@ -1,5 +1,6 @@
 import unittest
-from tinygrad import Tensor, dtypes
+from tinygrad import Tensor, dtypes, TinyJit, UOp
+from tinygrad.apps.llm import apply_rope
 
 # TODO: test_scheduler, but just in uint
 class TestAttention(unittest.TestCase):
@@ -15,6 +16,30 @@ class TestAttention(unittest.TestCase):
     softmax_inputs = sched[1:4]
     for si in softmax_inputs:
       assert all(b.dtype == dtypes.half for b in si.bufs), f"non half {si.bufs=}"
+
+  def test_apply_rope(self):
+    x = Tensor.randn(1, 2, 4, 8, dtype=dtypes.float32)
+    result = apply_rope(x, 0)
+    self.assertEqual(result.shape, x.shape)
+    self.assertEqual(result.dtype, x.dtype)
+    self.assertGreater((result - apply_rope(x, 5)).abs().max().item(), 1e-6)
+    with self.assertRaises(AssertionError): apply_rope(Tensor.randn(1, 1, 4, 7, dtype=dtypes.float32), 0)
+
+  def test_apply_rope_jit_prune(self):
+    def rope_fn(x_in, pos): return apply_rope(x_in, pos)
+    rope_noprune = TinyJit(rope_fn)
+    rope_prune = TinyJit(rope_fn, prune=True)
+    
+    v_pos = UOp.variable("start_pos", 0, 100)
+    for _ in range(3):
+      rope_noprune(Tensor.randn(1, 2, 4, 8, dtype=dtypes.float32), v_pos.bind(1))
+      rope_prune(Tensor.randn(1, 2, 4, 8, dtype=dtypes.float32), v_pos.bind(1))
+    noprune_size = len(rope_noprune.captured.jit_cache)
+    prune_size = len(rope_prune.captured.jit_cache)
+    
+    self.assertGreater(noprune_size, prune_size)
+    self.assertGreaterEqual(noprune_size, 3)
+    self.assertEqual(prune_size, 1)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/unit/test_attention.py
+++ b/test/unit/test_attention.py
@@ -29,14 +29,14 @@ class TestAttention(unittest.TestCase):
     def rope_fn(x_in, pos): return apply_rope(x_in, pos)
     rope_noprune = TinyJit(rope_fn)
     rope_prune = TinyJit(rope_fn, prune=True)
-    
+
     v_pos = UOp.variable("start_pos", 0, 100)
     for _ in range(3):
       rope_noprune(Tensor.randn(1, 2, 4, 8, dtype=dtypes.float32), v_pos.bind(1))
       rope_prune(Tensor.randn(1, 2, 4, 8, dtype=dtypes.float32), v_pos.bind(1))
     noprune_size = len(rope_noprune.captured.jit_cache)
     prune_size = len(rope_prune.captured.jit_cache)
-    
+
     self.assertGreater(noprune_size, prune_size)
     self.assertGreaterEqual(noprune_size, 3)
     self.assertEqual(prune_size, 1)

--- a/test/unit/test_llm_tokenizer.py
+++ b/test/unit/test_llm_tokenizer.py
@@ -1,7 +1,6 @@
 import unittest, base64, functools, sys
-from tinygrad.apps.llm import SimpleTokenizer, get_llama_re, apply_rope
+from tinygrad.apps.llm import SimpleTokenizer, get_llama_re
 from tinygrad.helpers import fetch
-from tinygrad import Tensor, dtypes
 
 @unittest.skipIf(sys.platform == 'win32', "fetch race condition on Windows")
 class TestLLMTokenizer(unittest.TestCase):
@@ -54,14 +53,6 @@ class TestLLMTokenizer(unittest.TestCase):
   def test_llama_special2(self): self._test_coding(self.llama_tok, "<|start_header_id|>user<|end_header_id|>\n\n", [ 128006, 882, 128007, 271 ])
   def test_llama_repeat(self): self._test_coding(self.llama_tok, "00000000000000000", [ 931, 931, 931, 931, 931, 410 ])
   def test_llama_pat(self): self._test_coding(self.llama_tok, "today\n  \n", [ 31213, 14211 ])
-
-  def test_apply_rope(self):
-    x = Tensor.randn(2, 4, 8, 32, dtype=dtypes.float32)
-    result = apply_rope(x, 0)
-    self.assertEqual(result.shape, x.shape)
-    self.assertEqual(result.dtype, x.dtype)
-    self.assertGreater((result - apply_rope(x, 5)).abs().max().item(), 1e-6)
-    with self.assertRaises(AssertionError): apply_rope(Tensor.randn(1, 1, 4, 7, dtype=dtypes.float32), 0)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/unit/test_llm_tokenizer.py
+++ b/test/unit/test_llm_tokenizer.py
@@ -1,6 +1,7 @@
 import unittest, base64, functools, sys
-from tinygrad.apps.llm import SimpleTokenizer, get_llama_re
+from tinygrad.apps.llm import SimpleTokenizer, get_llama_re, apply_rope
 from tinygrad.helpers import fetch
+from tinygrad import Tensor, dtypes
 
 @unittest.skipIf(sys.platform == 'win32', "fetch race condition on Windows")
 class TestLLMTokenizer(unittest.TestCase):
@@ -53,6 +54,14 @@ class TestLLMTokenizer(unittest.TestCase):
   def test_llama_special2(self): self._test_coding(self.llama_tok, "<|start_header_id|>user<|end_header_id|>\n\n", [ 128006, 882, 128007, 271 ])
   def test_llama_repeat(self): self._test_coding(self.llama_tok, "00000000000000000", [ 931, 931, 931, 931, 931, 410 ])
   def test_llama_pat(self): self._test_coding(self.llama_tok, "today\n  \n", [ 31213, 14211 ])
+
+  def test_apply_rope(self):
+    x = Tensor.randn(2, 4, 8, 32, dtype=dtypes.float32)
+    result = apply_rope(x, 0)
+    self.assertEqual(result.shape, x.shape)
+    self.assertEqual(result.dtype, x.dtype)
+    self.assertGreater((result - apply_rope(x, 5)).abs().max().item(), 1e-6)
+    with self.assertRaises(AssertionError): apply_rope(Tensor.randn(1, 1, 4, 7, dtype=dtypes.float32), 0)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
i worked on fixing the #Note/TODO comments to optimize RoPE so that JIT prunes rope cache outside the kernel. Jit can now optim and prune redundant rope comp by seing consistent tensor shape T + start_pos. I think now there is much better computation pattern and precision. Tried to make the math and code compact and in a few lines as possible. 