### PR TITLE
AMD_LLVM=1 behaves differently for x < nan

### DIFF
--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -114,6 +114,8 @@ class TestDTypeALU(unittest.TestCase):
   @given(ht.bfloat16, ht.bfloat16, strat.sampled_from(binary_operations))
   def test_bfloat16(self, a, b, op): universal_test(a, b, dtypes.bfloat16, op)
 
+  def test_bfloat16_nan_lt(self): universal_test(0.0, math.nan, dtypes.bfloat16, operator.lt)
+
   @given(ht.float32, strat.sampled_from(unary_operations))
   def test_float32_unary(self, a, op): universal_test_unary(a, dtypes.float32, op)
 


### PR DESCRIPTION
comgr is correct, AMDLLVM uses unordered compare.

@b1tg if you're interested at looking.
`DEBUG=7 MOCKGPU=1 PYTHONPATH=. AMD_LLVM=1 AMD=1 python test/test_dtype_alu.py TestDTypeALU.test_bfloat16_nan_lt`


comgr:
```
	v_cmp_lt_f32_e64 s0, s1, s0                                // 0000000016D4: D4110000 00000001
	v_cndmask_b32_e64 v1, 0, 1, s0                             // 0000000016DC: D5010001 00010280
	global_store_b8 v0, v1, s[4:5]                             // 0000000016E4: DC620000 00040100
```
LLVM:
```
	v_cmp_nge_f32_e64 s0, s1, s0                               // 000000000094: D4190000 00000001
	v_cndmask_b32_e64 v1, 0, 1, s0                             // 00000000009C: D5010001 00010280
	global_store_b8 v0, v1, s[4:5]                             // 0000000000A4: DC620000 00040100
```