### PR TITLE
add fuse and tc opt bug repro

### DIFF
--- a/test/test_softmax_fusion.py
+++ b/test/test_softmax_fusion.py
@@ -117,14 +117,14 @@ class TestFuse(unittest.TestCase):
     c = (a.sum(axis=1) + b.sum(axis=1)).fuse()
     self.assertListEqual(c.tolist(), [30]*16)
 
-  @unittest.skipUnless(Device.DEFAULT == "METAL", "repro from METAL TC")
-  # @unittest.expectedFailure
-  def test_tc_with_fuse_failure(self):
-    # NOTE: This AssertionError can be triggered from FUSE_ARANGE too
-    A = Tensor.randn(8, 8, dtype=dtypes.float16).realize()
-    B = Tensor.randn(8, 8, dtype=dtypes.float16).realize()
-    C = Tensor(1).expand(6, 8, 8).pad(((1,1), None, None),).sum(-1)
-    (C + (A @ B)).fuse().realize() # assert all_same(tensor_core_opts)
+  @unittest.skipUnless(Device.DEFAULT == "METAL", "METAL TC")
+  @unittest.expectedFailure # TODO: fix
+  def test_fuse_and_tc_opt(self):
+    A = Tensor.randn(8, 8).realize()
+    B = Tensor.randn(8, 8).realize()
+    C = Tensor.ones(1, 8, 8).pad(((1,1), None, None),).sum(0)
+    out = (C + (A @ B)).fuse()
+    out.realize()
 
 class TestSoftmaxFusion(unittest.TestCase):
   @classmethod

--- a/test/test_softmax_fusion.py
+++ b/test/test_softmax_fusion.py
@@ -118,7 +118,7 @@ class TestFuse(unittest.TestCase):
     self.assertListEqual(c.tolist(), [30]*16)
 
   @unittest.skipUnless(Device.DEFAULT == "METAL", "METAL TC")
-  @unittest.expectedFailure # TODO: fix
+  # @unittest.expectedFailure # TODO: fix
   def test_fuse_and_tc_opt(self):
     A = Tensor.randn(8, 8).realize()
     B = Tensor.randn(8, 8).realize()

--- a/test/test_softmax_fusion.py
+++ b/test/test_softmax_fusion.py
@@ -118,7 +118,7 @@ class TestFuse(unittest.TestCase):
     self.assertListEqual(c.tolist(), [30]*16)
 
   @unittest.skipUnless(Device.DEFAULT == "METAL", "METAL TC")
-  # @unittest.expectedFailure # TODO: fix
+  @unittest.expectedFailure # TODO: fix
   def test_fuse_and_tc_opt(self):
     A = Tensor.randn(8, 8).realize()
     B = Tensor.randn(8, 8).realize()

--- a/test/test_softmax_fusion.py
+++ b/test/test_softmax_fusion.py
@@ -118,10 +118,9 @@ class TestFuse(unittest.TestCase):
     self.assertListEqual(c.tolist(), [30]*16)
 
   @unittest.skipUnless(Device.DEFAULT == "METAL", "repro from METAL TC")
-  @unittest.expectedFailure
+  # @unittest.expectedFailure
   def test_tc_with_fuse_failure(self):
-    # NOTE: both Ops.FUSE and FUSE_ARANGE can cause this failure
-    # this is a small repro triggered by Ops.FUSE
+    # NOTE: This AssertionError can be triggered from FUSE_ARANGE too
     A = Tensor.randn(8, 8, dtype=dtypes.float16).realize()
     B = Tensor.randn(8, 8, dtype=dtypes.float16).realize()
     C = Tensor(1).expand(6, 8, 8).pad(((1,1), None, None),).sum(-1)

--- a/tinygrad/codegen/opt/kernel.py
+++ b/tinygrad/codegen/opt/kernel.py
@@ -378,9 +378,9 @@ class Kernel:
       tensor_cores = self.opts.tensor_cores if tc_select == -1 else [self.opts.tensor_cores[tc_select]]
       for tc in tensor_cores:
         tensor_core_opts = [self._create_tc_opts(reduceop, tc, axis, opt_level) for reduceop in self.reduceops]
+        if tensor_core_opts[0] is None: continue
         # can only fuse reduces with the same tc options
         assert all_same(tensor_core_opts)
-        if tensor_core_opts[0] is None: continue
         self.tensor_core_opts = tc_opts = tensor_core_opts[0]
 
         # attempt to pad the tensor axes that require it

--- a/tinygrad/codegen/opt/kernel.py
+++ b/tinygrad/codegen/opt/kernel.py
@@ -378,9 +378,9 @@ class Kernel:
       tensor_cores = self.opts.tensor_cores if tc_select == -1 else [self.opts.tensor_cores[tc_select]]
       for tc in tensor_cores:
         tensor_core_opts = [self._create_tc_opts(reduceop, tc, axis, opt_level) for reduceop in self.reduceops]
-        if tensor_core_opts[0] is None: continue
         # can only fuse reduces with the same tc options
         assert all_same(tensor_core_opts)
+        if tensor_core_opts[0] is None: continue
         self.tensor_core_opts = tc_opts = tensor_core_opts[0]
 
         # attempt to pad the tensor axes that require it


### PR DESCRIPTION
hits `assert all_same(tensor_core_opts)`
first found in #11648 by running `sam2_heiar2_tiny` model with `FUSE_ARANGE`.
Spent way too much time trying to write a `FUSE_ARANGE` repro, so I found a way to hit it with `.fuse()` instead. 