### PR TITLE
hotfix: cast half to float in Tensor.tolist

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -345,7 +345,8 @@ class Tensor(MathTrait):
     print(t.tolist())
     ```
     """
-    if self.dtype in (dtypes.bfloat16, *dtypes.fp8s): return self.cast(dtypes.float32).tolist()
+    # TODO: remove half once minimum python supports it
+    if self.dtype in (dtypes.half, dtypes.bfloat16, *dtypes.fp8s): return self.cast(dtypes.float32).tolist()
     return self.data().tolist()
 
   def numpy(self) -> 'np.ndarray':  # type: ignore [name-defined] # noqa: F821


### PR DESCRIPTION
workaround for python < 3.12