### PR TITLE
resolve bfloat16 numerical precision issues

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -3141,6 +3141,19 @@ class TestOpsUint8(unittest.TestCase):
       lambda x: x.type(torch.uint8).min(),
       lambda x: x.cast(dtypes.uint8).min(), forward_only=True, vals=[[0, 128, 255, 64, 32, 16]])
 
+  def test_log_bfloat16(self):
+    torch_result = torch.log(torch.tensor([12.0], dtype=torch.bfloat16))
+    tiny_result = Tensor([12.0], dtype="bfloat16").log()
+    np.testing.assert_allclose(tiny_result.float().numpy(), torch_result.float().numpy(), rtol=1e-3, atol=1e-3)
+  def test_cos_bfloat16(self):
+    torch_result = torch.cos(torch.tensor([12.0], dtype=torch.bfloat16))
+    tiny_result = Tensor([12.0], dtype="bfloat16").cos()
+    np.testing.assert_allclose(tiny_result.float().numpy(), torch_result.float().numpy(), rtol=1e-3, atol=1e-3)
+  def test_exp_bfloat16(self):
+    torch_result = torch.exp(torch.tensor([12.0], dtype=torch.bfloat16))
+    tiny_result = Tensor([12.0], dtype="bfloat16").exp()
+    np.testing.assert_allclose(tiny_result.float().numpy(), torch_result.float().numpy(), rtol=1e-3, atol=1e-3)
+
 if __name__ == '__main__':
   np.random.seed(1337)
   unittest.main(verbosity=2)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2972,6 +2972,8 @@ class Tensor(MathTrait):
     print(Tensor([1., 2., 4., 8.]).log().numpy())
     ```
     """
+    if self.dtype == dtypes.bfloat16:
+      return self.cast(dtypes.float32).log().cast(dtypes.bfloat16)
     return self.log2()*math.log(2)
 
   def log2(self) -> Tensor:
@@ -2996,6 +2998,8 @@ class Tensor(MathTrait):
     print(Tensor([0., 1., 2., 3.]).exp().numpy())
     ```
     """
+    if self.dtype == dtypes.bfloat16:
+      return self.cast(dtypes.float32).mul(1/math.log(2)).exp2().cast(dtypes.bfloat16)
     return self.mul(1/math.log(2)).exp2()
 
   def exp2(self) -> Tensor:
@@ -3096,6 +3100,8 @@ class Tensor(MathTrait):
     print(Tensor([0., math.pi/2, math.pi, 3*math.pi/2, 2*math.pi]).cos().numpy())
     ```
     """
+    if self.dtype == dtypes.bfloat16:
+      return self.cast(dtypes.float32).cos().cast(dtypes.bfloat16)
     return ((math.pi/2)-self).sin()
 
   def tan(self) -> Tensor:


### PR DESCRIPTION
This fixes precision issues for bfloat16 `exp`, `log` and `cos` ops by casting to float32 before computation

**Before:**

```
>>> import torch
... from tinygrad import Tensor
... 
... print(torch.tensor([12.0], dtype=torch.bfloat16).exp().tolist())
... print(torch.tensor([12.0], dtype=torch.float32).exp().tolist())
... print(Tensor([12.0], dtype="bfloat16").exp().tolist())
... print(Tensor([12.0], dtype="float32").exp().tolist())
... 
[162816.0]
[162754.796875]
[169984.0]
[162754.703125]
```
**After:**

```
>>> import torch
... from tinygrad import Tensor
... 
... print(torch.tensor([12.0], dtype=torch.bfloat16).exp().tolist())
... print(torch.tensor([12.0], dtype=torch.float32).exp().tolist())
... print(Tensor([12.0], dtype="bfloat16").exp().tolist())
... print(Tensor([12.0], dtype="float32").exp().tolist())
... 
[162816.0]
[162754.796875]
[162816.0]
[162754.796875]
This also contributes to inaccuracies in log/cos, see https://github.com/tinygrad/tinygrad/issues/11756
```

#11756
