### PR TITLE
abs(x) ** 2 is x**2

### DIFF
--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -352,6 +352,8 @@ symbolic_flat = symbolic+PatternMatcher([
   (-1 * (UPat.var("x") + UPat.var("y")), lambda x,y: (-x)+(-y)),  # -(x+y) -> -x + -y
   # (x+y)*c -> x*c+y*c. only for int, float has inf*0=nan issue
   ((UPat.var("x", dtypes.ints) + UPat.var("y")) * UPat.cvar("c"), lambda x,y,c: x*c+y*c),
+  # abs(x) ** 2 -> x ** 2, abs(x) -> x*x.sign(), sign matched by checking bounds and dtype, can try to decompose it with a bunch of wheres instead but this works??
+  ((UPat.var("x") * UPat.var("y")).pow(2), lambda x,y: x.pow(2) if dtypes.is_int(y.dtype) and y.vmin >= -1 and y.vmax <= 1 else None),
 ])
 
 # ******** we take a small aside to "simplify_valid" to rewrite valids ********


### PR DESCRIPTION
closes https://github.com/tinygrad/tinygrad/issues/11626

code (run w `NOOPT=1 DEBUG=4 CPU=1`):
```
from tinygrad import Tensor
(Tensor([11]).abs()**2).realize()
```

before:
```
void E_(int* restrict data0, int* restrict data1) {
  int val0 = (*(data1+0));
  int alu0 = ((val0<0)?-1:1);
  int alu1 = (((_Bool)(val0))?alu0:0);
  int alu2 = (val0*alu1);
  *(data0+0) = (alu2*alu2);
}
```

after:
```
void E_(int* restrict data0_1, int* restrict data1_1) {
  int val0 = (*(data1_1+0));
  *(data0_1+0) = (val0*val0);
}
```