### PR TITLE
upcast float log and cos to float32 and use mul/sub instead of */-

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2972,7 +2972,9 @@ class Tensor(MathTrait):
     print(Tensor([1., 2., 4., 8.]).log().numpy())
     ```
     """
-    return self.log2()*math.log(2)
+    if self.is_floating_point(): return self.cast(least_upper_dtype(self.dtype, dtypes.float32)).log2().mul(math.log(2)).cast(self.dtype)
+
+    return self.log2().mul(math.log(2))
 
   def log2(self) -> Tensor:
     """
@@ -3099,7 +3101,9 @@ class Tensor(MathTrait):
     print(Tensor([0., math.pi/2, math.pi, 3*math.pi/2, 2*math.pi]).cos().numpy())
     ```
     """
-    return ((math.pi/2)-self).sin()
+    if self.is_floating_point(): return self.cast(least_upper_dtype(self.dtype, dtypes.float32)).sub(math.pi/2, reverse=True).sin().cast(self.dtype)
+
+    return self.sub(math.pi/2,reverse=True).sin()
 
   def tan(self) -> Tensor:
     """


### PR DESCRIPTION
copied @chenyuxyz solution for #11756  used for exp but applied to log and cos. replaced */- operators for Tensor.mul and Tensor.sub.

```python
from tinygrad import Tensor, dtypes
import torch

print(f'torch bfloat log: {torch.tensor([12.0], dtype=torch.bfloat16).log().tolist()}')
print(f'torch float32 log: {torch.tensor([12.0], dtype=torch.float32).log().tolist()}')
print(f'tinygrad bfloat log: {Tensor([12.0], dtype="bfloat16").log().tolist()}')
print(f'tinygrad float32 log: {Tensor([12.0], dtype="float32").log().tolist()}')


print(f'torch bfloat cos: {torch.tensor([12.0], dtype=torch.bfloat16).cos().tolist()}')
print(f'torch float32 cos: {torch.tensor([12.0], dtype=torch.float32).cos().tolist()}')
print(f'tinygrad bfloat cos: {Tensor([12.0], dtype="bfloat16").cos().tolist()}')
print(f'tinygrad float32 cos: {Tensor([12.0], dtype="float32").cos().tolist()}')
```

output:
```bash
torch bfloat log: [2.484375]
torch float32 log: [2.4849066734313965]
tinygrad bfloat log: [2.484375]
tinygrad float32 log: [2.4849066734313965]
torch bfloat cos: [0.84375]
torch float32 cos: [0.8438539505004883]
tinygrad bfloat cos: [0.84375]
tinygrad float32 cos: [0.8438541293144226]
```