### PR TITLE
tracing: show NULL programs

### DIFF
--- a/tinygrad/runtime/ops_null.py
+++ b/tinygrad/runtime/ops_null.py
@@ -2,6 +2,7 @@ from tinygrad.device import Compiled, Compiler, Allocator
 from tinygrad.engine.jit import MultiGraphRunner
 from tinygrad.renderer.cstyle import CStyleLanguage
 from tinygrad.uop.ops import Ops
+from tinygrad.helpers import cpu_profile
 
 class NullRenderer(CStyleLanguage):
   device = "NULL"
@@ -11,9 +12,9 @@ class NullRenderer(CStyleLanguage):
   code_for_op = {**CStyleLanguage.code_for_op, Ops.THREEFRY: lambda a,b,dtype: f"threefry({a},{b})", Ops.MAX: lambda a,b,dtype: f"max({a},{b})"}
 
 class NullProgram:
-  def __init__(self, name:str, lib:bytes): pass
+  def __init__(self, name:str, lib:bytes): self.name = name
   def __call__(self, *bufs, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(), wait=False):
-    return 1e-4
+    with cpu_profile(self.name, "NULL"): return 1e-4
 
 class NullAllocator(Allocator['NullDevice']):
   def _alloc(self, size, options): pass


### PR DESCRIPTION
mostly <1 microsecond, timestamps align with the memory graph:
<img width="1659" height="440" alt="image" src="https://github.com/user-attachments/assets/c2ae0797-7cf3-4826-b9e2-c91a0f2079aa" />