### PR TITLE
add mask dtype

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -111,7 +111,7 @@ class TestDType(unittest.TestCase):
     fields = dtypes.fields()
     self.assertIn("float", fields)
     self.assertIn("float32", fields)
-    self.assertEqual(len(fields), 26)
+    self.assertEqual(len(fields), 30)
     self.assertTrue(all(isinstance(value, DType) for value in fields.values()))
     self.assertTrue(all(issubclass(_to_np_dtype(value), np.generic) for value in fields.values() if _to_np_dtype(value) is not None))
 

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -307,6 +307,9 @@ def is_dtype_supported(dtype:DType, device:str|None=None) -> bool:
   if dtype in dtypes.fp8s:
     # not supported yet - in progress
     return False
+  if dtype in dtypes.masks:
+    # mask dtypes are specific to x86/a64 backends and are handled in a pattern matcher
+    return False
   if device == "WEBGPU": return dtype in [dtypes.bool, dtypes.char, dtypes.uchar, dtypes.short,
                                           dtypes.ushort, dtypes.float, dtypes.int32, dtypes.uint32, dtypes.half]
   # for CI GPU and OSX, cl_khr_fp16 isn't supported

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -96,6 +96,8 @@ class dtypes:
   @staticmethod
   def is_bool(x: DType) -> bool: return x.scalar() == dtypes.bool
   @staticmethod
+  def is_mask(x: DType) -> bool: return x.scalar() in dtypes.masks
+  @staticmethod
   def from_py(x) -> DType:
     if x.__class__ is float: return dtypes.default_float
     if x.__class__ is int: return dtypes.default_int
@@ -144,6 +146,11 @@ class dtypes:
   bfloat16: Final[DType] = DType.new(12, 2, "__bf16", None)
   float32: Final[DType] = DType.new(13, 4, "float", 'f')
   float64: Final[DType] = DType.new(14, 8, "double", 'd')
+  # used in x86/a64 backends
+  mask8: Final[DType] = DType.new(15, 1, "mask8", None)
+  mask16: Final[DType] = DType.new(16, 2, "mask16", None)
+  mask32: Final[DType] = DType.new(17, 4, "mask32", None)
+  mask64: Final[DType] = DType.new(18, 8, "mask64", None)
 
   # dtype aliases
   half = float16; float = float32; double = float64 # noqa: E702
@@ -159,6 +166,7 @@ class dtypes:
   default_float: ClassVar[DType] = float32
   default_int: ClassVar[DType] = int32
 
+  masks = (mask8, mask16, mask32, mask64)
   fp8s = (fp8e4m3, fp8e5m2)
   floats = fp8s + (float16, bfloat16, float32, float64)
   uints = (uint8, uint16, uint32, uint64)

--- a/tinygrad/uop/mathtraits.py
+++ b/tinygrad/uop/mathtraits.py
@@ -17,7 +17,7 @@ class MathTrait:
   def _check_dtype(self):
     if (dtype:=getattr(self, 'dtype')) is not None:
       if isinstance(dtype, tuple): dtype = dtype[0]
-      if not (dtypes.is_bool(dtype) or dtypes.is_int(dtype)): raise RuntimeError(f"{dtype} is not supported")
+      if not (dtypes.is_bool(dtype) or dtypes.is_int(dtype) or dtypes.is_mask(dtype)): raise RuntimeError(f"{dtype} is not supported")
   def add(self, x, reverse=False):
     """
     Adds `self` and `x`.


### PR DESCRIPTION
In the x86/arm64 backends certain comparisons result in masks instead of booleans. These instructions are necessary for full SIMD support. Masks don't really exist outside this context and are handled by a pattern matcher.

relevant for #11611