### PR TITLE
add symbolic rule for x!=0*x=x

### DIFF
--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -473,6 +473,8 @@ sym = symbolic_flat+PatternMatcher([
   # ** self folding **
   # x!=0 -> (bool)x
   (UPat.var("x")!=0, lambda x: x.cast(dtypes.bool.vec(x.dtype.count))),
+  # cancel x!=0 * x = x
+  (UPat.var("x") * UPat.var("x").cast(dtype=dtypes.bool).where(UPat.cvar("t"), UPat.cvar("f")), lambda x,t,f: x if t.arg==1 and f.arg==0 else None),
   # ** where **
   # push cast to branches
   (UPat.var("s").where(UPat.var("a"), UPat.var("b")).cast().named("cast"), lambda s,a,b,cast: s.where(a.cast(cast.dtype), b.cast(cast.dtype))),


### PR DESCRIPTION
Currently simplifies NOOPT=1 DEBUG=4 CPU=1 python test.py
```python
from tinygrad import Tensor
a = Tensor([11])
b = a.sign() * a.sign() * a * a
print(b.tolist())
```
to
```C
void E_n2(int* restrict data0_1, int* restrict data1_1) {
  int val0 = (*(data1_1+0));
  *(data0_1+0) = (val0*val0);
}
```
but does not yet work for `x.abs()**2`, since other rules before do not apply when multiplying in different order.