### PR TITLE
reduce metal_compile_slow test to stay under 32k maxThreadgroupMemoryLength limit

### DIFF
--- a/test/external/external_metal_compile_slow.py
+++ b/test/external/external_metal_compile_slow.py
@@ -26,8 +26,8 @@ if __name__ == "__main__":
     ast = c15.sink()
 
     # this does have tons of locals
-    opts = [Opt(op=OptOps.LOCAL, axis=1, arg=16), Opt(op=OptOps.UPCAST, axis=3, arg=0),
-            Opt(op=OptOps.LOCAL, axis=0, arg=16), Opt(op=OptOps.UPCAST, axis=3, arg=2),
+    opts = [Opt(op=OptOps.LOCAL, axis=1, arg=8), Opt(op=OptOps.UPCAST, axis=3, arg=0),
+            Opt(op=OptOps.LOCAL, axis=0, arg=8), Opt(op=OptOps.UPCAST, axis=3, arg=2),
             Opt(op=OptOps.GROUPTOP, axis=0, arg=16)]
   else:
     c0 = UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(10616832), arg=0, src=())


### PR DESCRIPTION
We're hitting the [maxThreadgroupMemoryLength](https://developer.apple.com/documentation/metal/mtldevice/maxthreadgroupmemorylength) limit on the first iteration of the test, which causes a failure in the metal compiler:
```
python3.12: (Metal) compiling shader
ReportCrash: Unable to find store record for 'file:///System/Library/Frameworks/Metal.framework/Versions/A/XPCServices/MTLCompilerService.xpc/': Error Domain=NSOSStatusErrorDomain Code=-10811 "kLSNotAnApplicationErr: Item needs to be an application, but is not" UserInfo={_LSLine=180, _LSFunction=_LSFindBundleWithInfo_NoIOFiltered}
python3.12: (Metal) Compiler failed with XPC_ERROR_CONNECTION_INTERRUPTED
python3.12: (Metal) MTLCompiler: Compilation failed with XPC_ERROR_CONNECTION_INTERRUPTED on 1 try
python3.12: (Metal) compiling shader
launchd: [pid/12388/com.apple.MTLCompilerService.EC51F2DD-1577-4486-97F8-945BD0FBE56C [12452]:] exited with exit reason (namespace: 21 code: 0x0) - OS_REASON_METAL
```

You can check what your limit is by running:
```python3
from tinygrad.device import Device
from tinygrad.runtime.ops_metal import msg, ctypes
print("maxThreadgroupMemoryLength:", msg("maxThreadgroupMemoryLength", ctypes.c_ulong)(Device["METAL"].sysdevice), "bytes")
```
On my m3 ultra this is 32kb.