### PR TITLE
viz: small profiler resizing improvements

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -261,6 +261,9 @@
   #device-list > div:hover {
     background-color: rgba(20, 23, 35, 0.3);
   }
+  #device-list {
+    height: fit-content;
+  }
   .raw-text {
     padding: 0 8px;
     width: 100%;

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -252,7 +252,7 @@
   }
   #device-list > div {
     min-height: 32px;
-    max-width: 132px;
+    width: 132px;
     overflow-x: auto;
     overflow-y: hidden;
     white-space: nowrap;

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -380,8 +380,8 @@ async function renderProfiler() {
 
   function resize() {
     const profiler = document.querySelector(".profiler");
-    let { height, width:sideWidth } = rect("#device-list");
-    width = profiler.clientWidth-(sideWidth+padding), height = Math.round(height);
+    const sideRect = rect("#device-list");
+    const width = profiler.clientWidth-(sideRect.width+padding), height = Math.round(sideRect.height);
     if (canvas.width === width*dpr && canvas.height === height*dpr) return;
     canvas.width = width*dpr;
     canvas.height = height*dpr;

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -380,9 +380,8 @@ async function renderProfiler() {
 
   function resize() {
     const profiler = document.querySelector(".profiler");
-    // NOTE: use clientWidth to account for the scrollbar
-    let [width, height] = [profiler.clientWidth, profiler.scrollHeight];
-    width -= rect("#device-list").width+padding;
+    const { height, width:sideWidth } = rect("#device-list");
+    const width = profiler.clientWidth-(sideWidth+padding);
     if (canvas.width === width*dpr && canvas.height === height*dpr) return;
     canvas.width = width*dpr;
     canvas.height = height*dpr;

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -383,6 +383,7 @@ async function renderProfiler() {
     // NOTE: use clientWidth to account for the scrollbar
     let [width, height] = [profiler.clientWidth, profiler.scrollHeight];
     width -= rect("#device-list").width+padding;
+    if (canvas.width === width*dpr && canvas.height === height*dpr) return;
     canvas.width = width*dpr;
     canvas.height = height*dpr;
     canvas.style.height = `${height}px`;
@@ -395,7 +396,6 @@ async function renderProfiler() {
   d3.select(canvas).call(canvasZoom);
   document.addEventListener("contextmenu", e => e.ctrlKey && e.preventDefault());
 
-  resize();
   new ResizeObserver(([e]) => e.contentRect.width > 0 && resize()).observe(profiler.node());
 
   function findRectAtPosition(x, y) {

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -396,7 +396,7 @@ async function renderProfiler() {
   document.addEventListener("contextmenu", e => e.ctrlKey && e.preventDefault());
 
   resize();
-  window.addEventListener("resize", resize);
+  new ResizeObserver(([e]) => e.contentRect.width > 0 && resize()).observe(profiler.node());
 
   function findRectAtPosition(x, y) {
     const { top, left, width, height } = rect(canvas);

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -380,8 +380,8 @@ async function renderProfiler() {
 
   function resize() {
     const profiler = document.querySelector(".profiler");
-    const { height, width:sideWidth } = rect("#device-list");
-    const width = profiler.clientWidth-(sideWidth+padding);
+    let { height, width:sideWidth } = rect("#device-list");
+    width = profiler.clientWidth-(sideWidth+padding), height = Math.round(height);
     if (canvas.width === width*dpr && canvas.height === height*dpr) return;
     canvas.width = width*dpr;
     canvas.height = height*dpr;


### PR DESCRIPTION
- In master resizing happens even if the profiler page is hidden. The bug is easy to repro:
   1. Resize the window in UOp VIZ
   2. Navigate to Profiler, canvas collapses to 0px.

- min-width -> width to keep the layout in predictable, integer pixels. Longer names (like DISK paths) are scrollable:
<img width="2560" height="568" alt="image" src="https://github.com/user-attachments/assets/5bcab837-2d4b-4c42-8fef-4637080dd11c" />
