### PR TITLE
[bounty] Remove realize from __setitem__ and get TestSetitemLoop.test_arange to be one kernel

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1274,7 +1274,7 @@ class Tensor(MathTrait):
 
   def __setitem__(self, indices, v:Tensor|ConstType) -> None:
     if isinstance(self.device, str) and self.device.startswith("DISK"):
-      self.realize()._getitem(indices).assign(v)
+      self._getitem(indices).assign(v)
       return
     # NOTE: check that setitem target is valid first
     if not unwrap(self.uop.st).contiguous: raise RuntimeError("setitem target needs to be contiguous")
@@ -1282,13 +1282,13 @@ class Tensor(MathTrait):
     if not isinstance(v, Tensor): raise TypeError(f"can't set a {type(v).__name__} to a Tensor")
     if self.requires_grad or v.requires_grad: raise NotImplementedError("setitem with requires_grad is not supported")
 
-    res = self.realize()._getitem(indices, v)
+    res = self._getitem(indices, v)
     # if shapes match and data is not shared it's a copy and we assign to self
     if res.shape == self.shape and res.uop is not self.uop:
-      self.assign(res).realize()
+      self.assign(res)
     else: # no copy, basic setitem
       v = v.cast(res.dtype)._broadcast_to(_broadcast_shape(res.shape, v.shape)).contiguous()
-      res.assign(v).realize()
+      res.assign(v)
 
   def gather(self:Tensor, dim:int, index:Tensor) -> Tensor:
     """


### PR DESCRIPTION
-removed the realize from test_setitem.py and fused the TestSetitemLoop.test_arrange in a single kernel which was taking two kernels before. 
-mainly done by using vectorized assign arange instead of scalar indexing in a loop. kernels are only computed at numpy() instead of realize().