### PR TITLE
Load weights from any path to inception model, for SD mlperf training eval

### DIFF
--- a/extra/models/inception.py
+++ b/extra/models/inception.py
@@ -270,8 +270,10 @@ class FidInceptionV3:
     self.Mixed_7b = inception.Mixed_7b
     self.Mixed_7c = inception.Mixed_7c
 
-  def load_from_pretrained(self):
-    state_dict = torch_load(str(fetch("https://github.com/mseitzer/pytorch-fid/releases/download/fid_weights/pt_inception-2015-12-05-6726825d.pth", "pt_inception-2015-12-05-6726825d.pth")))
+  def load_from_pretrained(self, path=None):
+    if path is None:
+      path = fetch("https://github.com/mseitzer/pytorch-fid/releases/download/fid_weights/pt_inception-2015-12-05-6726825d.pth", "pt_inception-2015-12-05-6726825d.pth")
+    state_dict = torch_load(str(path))
     for k,v in state_dict.items():
       if k.endswith(".num_batches_tracked"):
         state_dict[k] = v.reshape(1)


### PR DESCRIPTION
Part of #11304.

This diff enables the Inception model to load weights from an arbitrary path. This lets us load the official mlperf inception checkpoint, downloaded from mlcommons as part of #12170. This model is used in eval of Stable Diffusion v2 training.