### PR TITLE
rangeify: simplify reshaped buffers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -529,7 +529,7 @@ jobs:
     - name: Test multitensor
       run: CPU=1 RANGEIFY=1 PYTHONPATH="." python3 test/test_multitensor.py TestMultiTensor.test_matmul_shard_1_1 TestMultiTensor.test_simple_add_W
     - name: Test Fuse
-      run: CL=1 RANGEIFY=2 python3 -m pytest --durations 20 test/test_softmax_fusion.py -k "not test_auto_softmax"
+      run: CL=1 RANGEIFY=2 python3 -m pytest --durations 20 test/test_softmax_fusion.py
     - name: Test CL=1 RANGEIFY=1
       run: CL=1 RANGEIFY=1 pytest -n auto test/test_ops.py
     - name: Test CPU=1 RANGEIFY=2

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -542,10 +542,8 @@ split_kernels = PatternMatcher([
 ])
 
 def tag_uop(ctx:list[UOp], x:UOp):
-  if x.tag is not None:
-    ctx.append(x)
-    return None
   ctx.append(x)
+  if x.tag is not None: return None
   return x.replace(tag=(len(ctx)-1,))
 add_tags = PatternMatcher([
   # don't tag BUFFERs, they are global

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -52,6 +52,7 @@ earliest_rewrites = double_reshape+PatternMatcher([
 
   # contiguous/buffer/copy/assign is already contiguous
   #(UPat(Ops.CONTIGUOUS, name="root", src=(UPat((Ops.CONTIGUOUS, Ops.BUFFER, Ops.COPY, Ops.ASSIGN)),)), lambda root: root.src[0]),
+  (UPat(Ops.RESHAPE, src=(UPat(Ops.BUFFER),), name="a").f(Ops.CONTIGUOUS, name="b"), lambda a,b: a.replace(tag=a.tag+b.tag)),
 ])
 
 # *****************
@@ -574,7 +575,7 @@ def get_rangeify_map(sink:UOp) -> dict[UOp, UOp]:
 
   # rebuild the sink with all the BUFFERIZEs with tags, this is what's ending up in the tensor graph
   # if it's not tagged by here, it's out
-  tsink = UOp.sink(*[x for x in tsink.parents if x.op is Ops.BUFFERIZE and x.tag is not None])
+  tsink = UOp.sink(*[x for x in tsink.parents if (x.op is Ops.BUFFERIZE or x.base.op is Ops.BUFFER) and x.tag is not None])
 
   if getenv("VIZ"): graph_rewrite(tsink, PatternMatcher([]), name="View Tagged Rangeify")
 

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -542,7 +542,9 @@ split_kernels = PatternMatcher([
 ])
 
 def tag_uop(ctx:list[UOp], x:UOp):
-  if x.tag is not None: return None
+  if x.tag is not None:
+    ctx.append(x)
+    return None
   ctx.append(x)
   return x.replace(tag=(len(ctx)-1,))
 add_tags = PatternMatcher([


### PR DESCRIPTION
The tags get merged:
```
VIZ=1 RANGEIFY=1 python test/test_schedule.py TestSchedule.test_contiguous_while_contiguous
```
<img width="3024" height="1266" alt="image" src="https://github.com/user-attachments/assets/dd1ed79d-b6d0-4377-9f6a-2cea5835d17f" />

<img width="3024" height="1266" alt="image" src="https://github.com/user-attachments/assets/85faa17c-17f8-449e-a38a-8788dd920a8b" />
