### PR TITLE
rangeify: fix copy size mismatch errs

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2195,6 +2195,12 @@ class TestCopyFolding(unittest.TestCase):
     add.kernelize()
     assert all_same([x.device for x in add.uop.src]), f"ALU has different devices! {[x.device for x in add.src]}"
 
+  def test_alu_before_copy(self):
+    buf = Tensor.ones(1).contiguous().realize()
+    a = buf+1
+    b = a.to("CPU")
+    self.assertListEqual(b.tolist(), [2.])
+
   def test_copy_to_same_device(self):
     a = Tensor.empty(4).uop
     b = a.copy_to_device(a.device)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2180,13 +2180,13 @@ class TestCopyFolding(unittest.TestCase):
     check_schedule(b, 0, filter_sink=False)
     assert b.item() == 1
 
-  @expect_rangeify_fails
   def test_late_const_copy_folding(self):
     a = Tensor.arange(3).realize()
     zeros = Tensor.zeros(3).realize()
     b = (a*zeros).to("CPU")
     run_schedule(check_schedule(b, 0, filter_sink=False))
     self.assertListEqual(b.tolist(), [0, 0, 0])
+    self.assertEqual(b.device, "CPU")
 
   def test_alu_after_copy(self):
     a = Tensor.ones((4,)).to("CPU")

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -345,12 +345,6 @@ pm_rangeify = pm_mops+PatternMatcher([
 # *****************
 # 3.5 cleanups
 
-class RealizeTag:
-  def __init__(self, x): self.x = x
-  def __repr__(self): return f"R({self.x})"
-def tag_bufferize(x:UOp): return x if isinstance(x.tag, RealizeTag) else x.replace(tag=RealizeTag(x.tag))
-remove_realize_tag = PatternMatcher([(UPat(Ops.BUFFERIZE, name="x"), lambda x:x.replace(tag=x.tag.x) if isinstance(x.tag,RealizeTag) else None),])
-
 # you don't know in the first pass if axes are going to die, this happens if there's an EXPAND to the left
 def cleanup_dead_axes(b:UOp):
   new_rng = []
@@ -375,7 +369,6 @@ def remove_bufferize(src:UOp, buf:UOp, idx:UOp):
 
   # if it's user contiguous, we never remove it
   if src.op is Ops.CONTIGUOUS: return None
-  if isinstance(buf.tag, RealizeTag): return None
 
   # here is where we compute the cost
   # for now just no REDUCE, COPY, or ASSIGN
@@ -388,6 +381,10 @@ def remove_bufferize(src:UOp, buf:UOp, idx:UOp):
 
   # this is the ranges replaced
   return src.substitute(dict(zip(buf.src[1:], idx.src[1:])))
+
+def pre_bufferize(b:UOp, x:UOp, copy:UOp):
+  nb = b.replace(src=(b.src[0].contiguous(),)+b.src[1:])
+  return copy.replace(src=(x.replace(src=(nb,)+x.src[1:]), copy.src[1]))
 
 pm_cleanups = double_reshape+pm_mops+PatternMatcher([
   #(UPat(Ops.BUFFERIZE, name="b"), cleanup_dead_axes),
@@ -404,8 +401,8 @@ pm_cleanups = double_reshape+pm_mops+PatternMatcher([
   #(UPat(Ops.DEVICE).f(Ops.CONST, name="c"), lambda c: c.replace(src=())),
   # copy on CONST is CONST
   (UPat(Ops.COPY, src=(UPat.cvar("x"), UPat()), name="copy"), lambda copy,x: copy.const_like(x.arg)),
-  (UPat(Ops.COPY, src=(UPat(Ops.BUFFERIZE, name="b").f(Ops.INDEX, allow_any_len=True, name="idx"), UPat()), name="copy"),
-   lambda copy,idx,b: copy.replace(src=(idx.replace(src=(tag_bufferize(b),)+idx.src[1:]), copy.src[1]))),
+  (UPat(Ops.COPY, src=(UPat(GroupOp.All-{Ops.CONTIGUOUS, Ops.COPY}).f(Ops.BUFFERIZE, allow_any_len=True, name="b")
+                       .f(Ops.INDEX, allow_any_len=True, name="x"), UPat()), name="copy"), pre_bufferize),
 ])
 
 # *****************
@@ -592,7 +589,7 @@ def get_rangeify_map(sink:UOp) -> dict[UOp, UOp]:
   if getenv("VIZ"): graph_rewrite(tsink, PatternMatcher([]), name="View Tagged Rangeify")
 
   # bufferize -> store
-  tsink = graph_rewrite(tsink, remove_realize_tag+pm_add_buffers, bottom_up=True, name="bufferize to store")
+  tsink = graph_rewrite(tsink, pm_add_buffers, bottom_up=True, name="bufferize to store")
   tsink = graph_rewrite(tsink, split_kernels, ctx=uop_list, name="split kernels")
 
   # if a kernel depends on a buffer, and that buffer is later assigned to, make the assign depend on the kernel's assign

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -365,10 +365,12 @@ def cleanup_dead_axes(b:UOp):
 
 # if a buffer is being stored just for permutes or something, remove it
 # we want to reexpress the indexes of idx2 in terms of the implied b1
-def remove_bufferize(src:UOp, buf:UOp, idx:UOp):
+def remove_bufferize(ctx:set[UOp], src:UOp, buf:UOp, idx:UOp):
   # see if we can't do it, should this ever hit?
   assert len(buf.src) == len(idx.src), "index on wrong bufferize"
   assert all(x.op is Ops.RANGE for x in buf.src[1:])
+
+  if src in ctx: return None
 
   # if it's user contiguous, we never remove it
   if src.op is Ops.CONTIGUOUS: return None
@@ -392,6 +394,7 @@ pm_cleanups = double_reshape+pm_mops+PatternMatcher([
   (UPat(Ops.INDEX, name="idx").f(Ops.BUFFERIZE, allow_any_len=True, name="b2"),
    lambda idx,b2: idx.src[0].replace(tag=nt if len(nt:=(idx.src[0].tag or ()) + (b2.tag or ())) else None) if idx.src[1:] == b2.src[1:] else None),
   # remove reindexing with cost function
+  (UPat.var("op").f(Ops.BUFFERIZE, allow_any_len=True).f(Ops.INDEX, allow_any_len=True).f(Ops.COPY,allow_any_len=True), lambda ctx,op: ctx.add(op)),
   (UPat.var("src").f(Ops.BUFFERIZE, allow_any_len=True, name="buf").f(Ops.INDEX, allow_any_len=True, name="idx"), remove_bufferize),
   # no buffers for const
   (UPat(Ops.CONST, name='c').f(Ops.BUFFERIZE, allow_any_len=True, name="b"),
@@ -575,7 +578,7 @@ def get_rangeify_map(sink:UOp) -> dict[UOp, UOp]:
   tsink = graph_rewrite(tsink, pm_rangeify, ctx=RangeifyContext(), bottom_up=True, name="rangeify")
   # NOTE: sym (vs symbolic_simple) breaks things here because ranges with len 1 aren't handled right
   tsink = graph_rewrite(tsink, symbolic_simple, name="symbolic")  # this supports const folding
-  tsink = graph_rewrite(tsink, pm_cleanups, bottom_up=True, name="remove costly buffers")
+  tsink = graph_rewrite(tsink, pm_cleanups, ctx=set(), bottom_up=True, name="remove costly buffers")
 
   # rebuild the sink with all the BUFFERIZEs with tags, this is what's ending up in the tensor graph
   # if it's not tagged by here, it's out

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -395,9 +395,8 @@ pm_cleanups = double_reshape+pm_mops+PatternMatcher([
    lambda c,b: c.reshape((1,)*len(b.shape)).expand(b.shape).replace(tag=b.tag)),
   # if any CONST with DEVICE make it here (symbolic/copy issue), remove it
   #(UPat(Ops.DEVICE).f(Ops.CONST, name="c"), lambda c: c.replace(src=())),
-
   # copy on CONST is CONST
-  (UPat(Ops.COPY, src=(UPat.cvar("c"), UPat()), name="copy"), lambda copy,c: copy.const_like(c.arg)),
+  (UPat(Ops.COPY, src=(UPat.cvar("x"), UPat()), name="copy"), lambda copy,x: copy.const_like(x.arg)),
 ])
 
 # *****************


### PR DESCRIPTION
a lot of these are failing
<img width="2994" height="476" alt="image" src="https://github.com/user-attachments/assets/8ed4e45c-b84d-4715-b25f-37f35ca20256" />

Because pm_cleanups removes the bufferizes of COPY's parent.

In the current design, REALIZE can be removed. But realize before a COPY (even if it's a system op), needs to always happen.

We need a way to express this. maybe even insert **contiguous** between COPY and its parents.

update: it's fine if you push the compute to the other device. But currently rangeify is either silently wrong or runtime asserts.