### PR TITLE
skip test_bf16_disk_write_read on CL=1

### DIFF
--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -307,7 +307,7 @@ class TestDiskTensor(unittest.TestCase):
     ret = t.bitcast(dtypes.uint16).to("CPU") + 1
     assert ret.tolist() == [2827, 3341, 3855, 4369]
 
-  @unittest.skipIf(OSX, "new LLVM has an issue on OSX")
+  @unittest.skipIf(OSX or Device.DEFAULT == "CL", "new LLVM has an issue on OSX, CL=1 gives the wrong output")
   def test_bf16_disk_write_read(self):
     t = Tensor([10000, -1, -1000, -10000, 20], dtype=dtypes.float32)
     t.to(f"disk:{temp('dt_bf16_disk_write_read_f32')}").realize()


### PR DESCRIPTION
Tested on tinyg3, 
```
~/code/tinygrad ((HEAD detached at 5e794be8a)) > DEBUG=1 CL=1 python test/unit/test_disk_tensor.py TestDiskTensor.test_bf16_disk_write_read
PYTHON: using PythonCompiler
opened device PYTHON from pid:25061
CLDevice: got 1 platforms and 6 devices
4141
CLDevice: opening NVIDIA GeForce RTX 4090 with version 570.133.20
CL: using CLCompiler
opened device CL from pid:25061
DISK:/tmp/dt_bf16_disk_write_read_f32: using Compiler
opened device DISK:/tmp/dt_bf16_disk_write_read_f32 from pid:25061
scheduled 2 kernels in 534.03 ms
DISK:/tmp/dt_bf16_disk_write_read_bf16: using Compiler
opened device DISK:/tmp/dt_bf16_disk_write_read_bf16 from pid:25061
scheduled 2 kernels in 1.67 ms
[17948. 49024. 50298. 50716. 16800.]
F
======================================================================
FAIL: test_bf16_disk_write_read (__main__.TestDiskTensor.test_bf16_disk_write_read)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/qazal/code/tinygrad/test/unit/test_disk_tensor.py", line 323, in test_bf16_disk_write_read
    assert ct.numpy().tolist() == [9984., -1, -1000, -9984, 20]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError

----------------------------------------------------------------------
Ran 1 test in 0.567s
```