### PR TITLE
RANGEIFY=1 looping in map_pad

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -372,7 +372,7 @@ class TestMultiTensor(unittest.TestCase):
 
   # NOTE: this is failing on LLVM CI, no idea why. Works locally.
   @unittest.skipIf(CI and REAL_DEV in ("CUDA", "NV", "CPU", "AMD"), "slow, and flaky on CPU")
-  @unittest.skipIf(RANGEIFY, "TODO: pm_rangeify hangs")
+  #@unittest.skipIf(RANGEIFY, "TODO: pm_rangeify hangs")
   def test_data_parallel_resnet(self):
     from extra.models.resnet import ResNet18
 


### PR DESCRIPTION
@S-Lykles to repro, you can run `VIZ=1 PYTHONPATH=. RANGEIFY=1 python test/test_multitensor.py TestMultiTensor.test_data_parallel_resnet` (wait for ~5 seconds and ctrl+c).

It seems like map_pad never resolves the UOp.invalid call. I could trace it back to `nest_div_by_smallest_factor`
<img width="2557" height="394" alt="image" src="https://github.com/user-attachments/assets/2d07a4e4-2b96-4575-8157-fce6c4e66a71" />
