### PR TITLE
viz: put a limit of brightness scale

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -217,8 +217,9 @@ async function renderProfiler() {
           levels.push(et);
         } else levels[depth] = et;
         if (depth === 0) colorKey = e.name.split(" ")[0];
-        if (!colorMap.has(colorKey)) colorMap.set(colorKey, cycleColors(colorScheme[k.split(":")[0]] ?? colorScheme.DEFAULT, colorMap.size));
-        const fillColor = d3.color(colorMap.get(colorKey)).brighter(depth).toString();
+        if (!colorMap.has(colorKey)) colorMap.set(colorKey, d3.rgb(cycleColors(colorScheme[k.split(":")[0]] ?? colorScheme.DEFAULT, colorMap.size)));
+        const base = colorMap.get(colorKey), s = Math.min(Math.pow(1/0.7, depth), 240 / Math.max(base.r, base.g, base.b));
+        const fillColor = d3.rgb(base.r*s, base.g*s, base.b*s).toString();
         const label = parseColors(e.name).map(({ color, st }) => ({ color, st, width:ctx.measureText(st).width }));
         if (e.ref != null) ref = {ctx:e.ref, step:0};
         else if (ref != null) {


### PR DESCRIPTION
VIZ colors the flamegraph by call depth. The deeper the brighter.
Our normal traces usually don't go deeper than 4 layers, but if there are custom `cpu_profile` some deep calls lighten to white and label becomes unreadable:
<img width="2054" height="563" alt="image" src="https://github.com/user-attachments/assets/044da755-99e8-44a4-bd23-6e0d39ca721c" />
This diff caps it to a reasonably dark color
<img width="2062" height="572" alt="image" src="https://github.com/user-attachments/assets/ab4a201d-053c-42c4-b5c2-be64811cd4a8" />