### PR TITLE
rangeify: enable test_mnist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -535,7 +535,7 @@ jobs:
         CPU=1 RANGEIFY=1 python3 -m pytest test/test_multitensor.py::TestMultiAssign -k 'not (multi_assign_piece_noncontig or multi_assign_var_offset)'
     - name: Test CPU=1 RANGEIFY=2
       run: CPU=1 CPU_LLVM=0 RANGEIFY=2 python3 -m pytest -n auto test/test_tiny.py test/test_rangeify.py test/test_ops.py --durations 20
-    - name: Test LLVM RANGEIFY=1 (slow tests)
+    - name: Test LLVM RANGEIFY=1 #(slow tests)
       run: CPU=1 CPU_LLVM=1 RANGEIFY=1 python3 -m pytest -n auto test/models/test_mnist.py --durations 20
     - name: Run process replay tests
       uses: ./.github/actions/process-replay

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -535,9 +535,8 @@ jobs:
         CPU=1 RANGEIFY=1 python3 -m pytest test/test_multitensor.py::TestMultiAssign -k 'not (multi_assign_piece_noncontig or multi_assign_var_offset)'
     - name: Test CPU=1 RANGEIFY=2
       run: CPU=1 CPU_LLVM=0 RANGEIFY=2 python3 -m pytest -n auto test/test_tiny.py test/test_rangeify.py test/test_ops.py --durations 20
-    # slow (and still wrong on beautiful_mnist)
-    #- name: Test LLVM RANGEIFY=1 (slow tests)
-    #  run: CPU=1 CPU_LLVM=1 RANGEIFY=1 python3 -m pytest -n auto test/models/test_mnist.py --durations 20
+    - name: Test LLVM RANGEIFY=1 (slow tests)
+      run: CPU=1 CPU_LLVM=1 RANGEIFY=1 python3 -m pytest -n auto test/models/test_mnist.py --durations 20
     - name: Run process replay tests
       uses: ./.github/actions/process-replay
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -536,8 +536,9 @@ jobs:
         CPU=1 RANGEIFY=1 python3 -m pytest test/test_multitensor.py::TestMultiAssign -k 'not (multi_assign_piece_noncontig or multi_assign_var_offset)'
     - name: Test CPU=1 RANGEIFY=2
       run: CPU=1 CPU_LLVM=0 RANGEIFY=2 python3 -m pytest -n auto test/test_tiny.py test/test_rangeify.py test/test_ops.py --durations 20
-    - name: Test LLVM RANGEIFY=1 #(slow tests)
-      run: CPU=1 CPU_LLVM=1 RANGEIFY=1 python3 -m pytest -n auto test/models/test_mnist.py --durations 20
+    # passes on CL=1 rangeify, very slow convs on CPU
+    #- name: Test LLVM RANGEIFY=1 (slow tests)
+    #  run: CPU=1 CPU_LLVM=1 RANGEIFY=1 python3 -m pytest -n auto test/models/test_mnist.py --durations 20
     - name: Run process replay tests
       uses: ./.github/actions/process-replay
 

--- a/test/models/test_mnist.py
+++ b/test/models/test_mnist.py
@@ -2,7 +2,7 @@
 import unittest
 import numpy as np
 from tinygrad import Tensor, Device
-from tinygrad.helpers import CI
+from tinygrad.helpers import CI, getenv
 from tinygrad.nn.state import get_parameters
 from tinygrad.nn import optim, BatchNorm2d
 from extra.training import train, evaluate
@@ -49,7 +49,7 @@ class TinyConvNet:
     x = x.reshape(shape=[x.shape[0], -1])
     return x.dot(self.l1)
 
-@unittest.skipIf(CI and Device.DEFAULT == "CPU", "slow")
+@unittest.skipIf(CI and Device.DEFAULT == "CPU" and not getenv("CPU_LLVM"), "slow")
 class TestMNIST(unittest.TestCase):
   def test_sgd_onestep(self):
     np.random.seed(1337)

--- a/test/models/test_mnist.py
+++ b/test/models/test_mnist.py
@@ -2,7 +2,7 @@
 import unittest
 import numpy as np
 from tinygrad import Tensor, Device
-from tinygrad.helpers import CI, getenv
+from tinygrad.helpers import CI
 from tinygrad.nn.state import get_parameters
 from tinygrad.nn import optim, BatchNorm2d
 from extra.training import train, evaluate
@@ -49,7 +49,7 @@ class TinyConvNet:
     x = x.reshape(shape=[x.shape[0], -1])
     return x.dot(self.l1)
 
-@unittest.skipIf(CI and Device.DEFAULT == "CPU" and not getenv("CPU_LLVM"), "slow")
+@unittest.skipIf(CI and Device.DEFAULT == "CPU", "slow")
 class TestMNIST(unittest.TestCase):
   def test_sgd_onestep(self):
     np.random.seed(1337)


### PR DESCRIPTION
Last week this gave the wrong output.
```
~/code/tinygrad ((HEAD detached at ae0edc8a6)) > CPU=1 CPU_LLVM=1 RANGEIFY=1 python3 -m pytest -n auto test/models/test_mnist.py --durations 20
FAILED test/models/test_mnist.py::TestMNIST::test_sgd - assert np.float64(0.1254) > 0.94
FAILED test/models/test_mnist.py::TestMNIST::test_conv - assert np.float64(0.1584) > 0.93
FAILED test/models/test_mnist.py::TestMNIST::test_conv_with_bn - assert np.float64(0.1306) > 0.94
======= 3 failed, 6 passed, 59 warnings in 30.86s ===============================================================================================
```
 This week it's correct:
 
 ```
 ~/code/tinygrad ((HEAD detached at e8945c74d)) > CPU=1 CPU_LLVM=1 RANGEIFY=1 python3 -m pytest -n auto test/models/test_mnist.py --durations 20
 ======= 9 passed, 59 warnings in 32.99s ===============================================================================================================================================================================================================================================================================================================
 ```
 
 RANGEIFY=1 is slower, mostly conv:
 

| Test case             | RANGEIFY=1 (s) | RANGEIFY=0 |
|-----------------------|---------------|---------------:|
| test_conv             | 31.40 | 3.76 |
| test_conv_with_bn     | 30.06 | 9.55 |
| test_sgd              | 4.02  | 2.83 |
| test_conv_onestep     | 2.11  | 1.35 |
| test_adam_threestep   | 0.69  | 0.82 |
| test_sgd_threestep    | 0.56  | 0.66 |
| test_adam_onestep     | 0.49  | 0.66 |
| test_sgd_sixstep      | 0.44  | 0.60 |
| test_sgd_onestep      | 0.43  | 0.62 |

