### PR TITLE
more rangeify multi

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -56,9 +56,9 @@ class TestMultiTensor(unittest.TestCase):
 
   def test_shard_alt(self):
     t = Tensor.ones(4).contiguous().realize().shard(devices_2, 0)
-    r = t.reshape((2, 2))
-    self.assertEqual(r.tolist(), [[1.,1.],[1.,1.]])
+    r = t.reshape((2, 2)).realize()
     assert t.uop.is_realized, "shard didn't realize"
+    self.assertEqual(r.tolist(), [[1.,1.],[1.,1.]])
 
   def test_shard_not_multiple(self):
     X = Tensor.ones(256).contiguous().realize()

--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -54,6 +54,12 @@ class TestMultiTensor(unittest.TestCase):
       assert lb.shape == (128,)
     (X + X).realize()
 
+  def test_shard_alt(self):
+    t = Tensor.ones(4).contiguous().realize().shard(devices_2, 0)
+    r = t.reshape((2, 2))
+    self.assertEqual(r.tolist(), [[1.,1.],[1.,1.]])
+    assert t.uop.is_realized, "shard didn't realize"
+
   def test_shard_not_multiple(self):
     X = Tensor.ones(256).contiguous().realize()
     with self.assertRaises(RuntimeError):


### PR DESCRIPTION
`test_shard_alt` is a small repro of `TestBatchNorm.test_synced_vs_unsynced_bn`.
t.shard(devices_2, 0).reshape((2, 2)) maps to:
<img width="1940" height="234" alt="image" src="https://github.com/user-attachments/assets/b1561c99-071b-4761-9f46-6900a5f5a88e" />
<img width="1946" height="478" alt="image" src="https://github.com/user-attachments/assets/4ceb43af-dc87-4267-8da0-cb928fb7296b" />
tag1 _is_ a MULTI (4,) but that's reordered past the reshape?