### PR TITLE
rangeify: fix empty tags in reshapes

### DIFF
--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -15,7 +15,8 @@ from tinygrad.uop.ops import track_rewrites, graph_rewrite, identity_element, si
 
 double_reshape = PatternMatcher([
   # RESHAPE on RESHAPE is the second reshape
-  (UPat(Ops.RESHAPE, src=(UPat(Ops.RESHAPE),), name="x"), lambda x: x.replace(src=(x.src[0].src[0],), tag=(x.src[0].tag or ())+(x.tag or ()))),
+  (UPat(Ops.RESHAPE, src=(UPat(Ops.RESHAPE),), name="x"),
+   lambda x: x.replace(src=(x.src[0].src[0],), tag=((x.src[0].tag or ())+(x.tag or ())) or None)),
 ])
 
 earliest_rewrites = double_reshape+PatternMatcher([


### PR DESCRIPTION
eg `VIZ=1 CPU=1 RANGEIFY=1 python test/test_assign.py TestAssign.test_post_permuted_assignment` was creating extra tags
<img width="2555" height="1006" alt="image" src="https://github.com/user-attachments/assets/879a6924-52b6-4af9-af56-66102dcf001a" />
