### PR TITLE
Fix arange folding with uncancelled idx

### DIFF
--- a/tinygrad/uop/decompositions.py
+++ b/tinygrad/uop/decompositions.py
@@ -347,7 +347,9 @@ def get_late_rewrite_patterns(ops:tuple[Ops, ...], force_transcendental=False):
       pat += [(UPat.var("x", dtypes.ints)%UPat.var("d"), lambda x, d: x-d*(x//d))]
   if Ops.NEG in ops:
     pat += [(UPat.var('x')*-1, lambda x: x.alu(Ops.NEG))]
-    if Ops.SUB in ops: pat += [(UPat.var('x')+UPat.var('y').alu(Ops.NEG), lambda x,y: x.alu(Ops.SUB, y))]
+    if Ops.SUB in ops:
+      pat += [(UPat.var('x')+UPat.var('y').alu(Ops.NEG), lambda x,y: x.alu(Ops.SUB, y))]
+      pat += [(UPat(Ops.SUB, src=(UPat.var("x"), UPat.var("x"))), lambda x: x.const_like(0))]  # x-x -> 0
   if Ops.CMPLT in ops:
     # These are late rewrites because simplex expects equalities to be a certain format
     pat += [

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -73,7 +73,6 @@ symbolic_simple = propagate_invalid + PatternMatcher([
   (UPat.var("x", dtype=dtypes.ints+(dtypes.bool, dtypes.index)).trunc(), lambda x: x),
   # ** zero folding **
   (UPat.var("x") < UPat.var("x"), lambda x: x.const_like(False).cast(dtypes.bool.vec(x.dtype.count))), # x < x -> False
-  (UPat(Ops.SUB, src=(UPat.var("x"), UPat.var("x"))), lambda x: x.const_like(0)), # x-x -> 0
   (UPat.var("x") % UPat.var("x"), lambda x: x.const_like(0)), # x%x -> 0
   (UPat.var("x", dtype=dtypes.ints+(dtypes.bool, dtypes.index)) != UPat.var("x"),
    lambda x: x.const_like(False).cast(dtypes.bool.vec(x.dtype.count))), # x != x -> False (only ints)

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -73,6 +73,7 @@ symbolic_simple = propagate_invalid + PatternMatcher([
   (UPat.var("x", dtype=dtypes.ints+(dtypes.bool, dtypes.index)).trunc(), lambda x: x),
   # ** zero folding **
   (UPat.var("x") < UPat.var("x"), lambda x: x.const_like(False).cast(dtypes.bool.vec(x.dtype.count))), # x < x -> False
+  (UPat(Ops.SUB, src=(UPat.var("x"), UPat.var("x"))), lambda x: x.const_like(0)), # x-x -> 0
   (UPat.var("x") % UPat.var("x"), lambda x: x.const_like(0)), # x%x -> 0
   (UPat.var("x", dtype=dtypes.ints+(dtypes.bool, dtypes.index)) != UPat.var("x"),
    lambda x: x.const_like(False).cast(dtypes.bool.vec(x.dtype.count))), # x != x -> False (only ints)


### PR DESCRIPTION
Fixed issue #12238

Fix:
- Added zero folding for Ops.SUB when the src values are the same

Results:
```
CPU=1 RANGEIFY=1 DEBUG=4 python3 arange.py
void E_5(int* restrict data0_5, int core_id) {
  for (int ridx0 = 0; ridx0 < 5; ridx0++) {
    *(data0_5+ridx0) = 4;
  }
}

*** CPU        1 E_5                                          arg  1 mem  0.00 GB tm     10.88us/     0.01ms (     0.00 GFLOPS    0.0|0.0     GB/s) ['__add__', 'arange']
[4, 4, 4, 4, 4]
``` 
```
CL=1 RANGEIFY=1 DEBUG=4 python3 arange.py
__kernel void E_5(__global int* data0_5) {
  int gidx0 = get_group_id(0); /* 5 */
  *(data0_5+gidx0) = 4;
}
*** CL         1 E_5                                          arg  1 mem  0.00 GB tm      8.46us/     0.01ms (     0.00 GFLOPS    0.0|0.0     GB/s) ['__add__', 'arange']
[4, 4, 4, 4, 4]
``` 