### PR TITLE
viz: 404 if the requested rewrite doesn't exist

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -251,7 +251,9 @@ class Handler(BaseHTTPRequestHandler):
       except FileNotFoundError: status_code = 404
     elif (query:=parse_qs(url.query)):
       if url.path == "/disasm": ret, content_type = get_disassembly(**query), "application/json"
-      else: return self.stream_json(get_details(traces[i:=int(query["ctx"][0])][1][int(query["idx"][0])], i))
+      else:
+        try: return self.stream_json(get_details(traces[i:=int(query["ctx"][0])][1][int(query["idx"][0])], i))
+        except KeyError: status_code = 404
     elif url.path == "/ctxs": ret, content_type = json.dumps(ctxs).encode(), "application/json"
     elif url.path == "/get_profile" and profile_ret: ret, content_type = profile_ret, "application/octet-stream"
     else: status_code = 404


### PR DESCRIPTION
Fixes the spam logs when you navigate through VIZ on a different tab:

Server and client logs before/after:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/3459c4a8-5696-48d6-8587-ab68f7fb7c8f" />
<img height="200" alt="image" src="https://github.com/user-attachments/assets/ee62caf7-18cf-468f-b69d-8ba6670ae5e7" />
