### PR TITLE
remove no-op contiguous from rand

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -535,7 +535,7 @@ class Tensor(MathTrait):
         device=device, dtype=dtypes.uint32, requires_grad=False)
       Tensor._device_rng_counters[device] = Tensor([num], device=device, dtype=dtypes.uint32, requires_grad=False)
     # increment rng counter for devices
-    else: Tensor._device_rng_counters[device].assign(Tensor._device_rng_counters[device] + num).contiguous()
+    else: Tensor._device_rng_counters[device].assign(Tensor._device_rng_counters[device] + num)
 
     # threefry random bits
     bits_count = Tensor._device_rng_counters[device] - num


### PR DESCRIPTION
This probably existed when there was a mutable .lazydata on the Tensor with a forced_realize attribute on it. It absolutely does nothing in the new Tensor with immutable UOp world.