### PR TITLE
rangeify: enable assign to mstack target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -541,7 +541,7 @@ jobs:
       run: |
         CPU=1 RANGEIFY=1 python3 test/test_multitensor.py TestMultiTensor.test_matmul_shard_1_1 TestMultiTensor.test_simple_add_W TestMultiTensor.test_simple_reduce \
         TestMultiTensor.test_elementwise_dtype TestMultiTensor.test_shard_no_recompile TestHandleData.test_copied_to_device TestMultiRamUsage
-        CPU=1 RANGEIFY=1 python3 -m pytest test/test_multitensor.py::TestMultiAssign -k 'not (multi_assign_piece_noncontig or multi_assign_var_offset)'
+        CPU=1 RANGEIFY=1 python3 -m pytest test/test_multitensor.py::TestMultiAssign
         CPU=1 RANGEIFY=1 python3 -m pytest -n=auto test/test_multitensor.py::TestMultiTensor test/test_multitensor.py::TestBatchNorm test/unit/test_allreduce.py -k 'not const_folding'
     - name: Test CPU=1 RANGEIFY=2
       run: CPU=1 CPU_LLVM=0 RANGEIFY=2 python3 -m pytest -n auto test/test_tiny.py test/test_rangeify.py test/test_ops.py --durations 20

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -44,7 +44,8 @@ earliest_rewrites = double_reshape+PatternMatcher([
 
   # assign only to buffer, otherwise make it a CONTIGUOUS
   (UPat(Ops.ASSIGN, src=(UPat(GroupOp.All-{Ops.BUFFER}, name="target"), UPat(name="x")), name="assign"),
-   lambda x,target,assign: x.f(Ops.CONTIGUOUS, tag=assign.tag) if target.base.op is not Ops.BUFFER else None),
+   lambda x,target,assign: x.f(Ops.CONTIGUOUS, tag=assign.tag) if ((t:=target.base).op is not Ops.BUFFER and \
+       not (t.op is Ops.MSTACK and all(s.op is Ops.BUFFER for s in t.src))) else None),
 
   # realize before assign if input permutes the target buffer
   (UPat(Ops.ASSIGN, src=(UPat.var("a"), UPat.var("b")), name="assign"), lambda a,b,assign: assign.replace(src=(a, b.contiguous())) \

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -470,7 +470,7 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
     if self.op is Ops.MSTACK: return UOp(Ops.MSTACK, self.dtype, src=tuple(x.as_buf() for x in self.src))
     # TODO: this should be the only one of these. this is the one RANGEIFY uses
     s = self
-    while len(s.src) and s.op is not Ops.BUFFER: s = s.src[0]
+    while len(s.src) and s.op not in {Ops.BUFFER, Ops.MSTACK}: s = s.src[0]
     return s
 
   @property


### PR DESCRIPTION
The INDEX walks to the MSTACK:
<img width="3840" height="1304" alt="image" src="https://github.com/user-attachments/assets/e06b7f9e-88d2-4f94-8766-712099c2d8a1" />
And the realized assign matcher also checks MSTACK sources. This assign still gets removed:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/31b73a30-2da9-43bb-8837-ca797877df7c" />
with this, down to 2 failing multi tests:
`RANGEIFY=1 python3 -m pytest -n=auto ./test/test_multitensor.py`
```
FAILED test/test_multitensor.py::TestMultiTensor::test_multi_const_folding - AssertionError: 7 != 0
FAILED test/test_multitensor.py::TestMultiTransformer::test_transformer - AssertionError: UOp sources must have the same shape UOp(Ops.MUL, dtypes.float, arg=None, tag=(37,), src=(
======================================================================================= 2 failed, 90 passed, 19 skipped, 3 xfailed, 14 warnings in 6.24s =======================================================================================
```