### PR TITLE
remu: add new instructions introduced in RANGEIFY

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -709,8 +709,6 @@ jobs:
         run: |
           VIZ=1 SQTT=1 DEBUG=5 python3 test/test_ops.py TestOps.test_add
           extra/sqtt/rgptool.py create "/tmp/profile.pkl.$USER" -o /tmp/gpu0.rgp
-      - name: Run RANGEIFY=1 test_ops
-        run: RANGEIFY=1 python3 -m pytest -n=auto test/test_ops.py
       - name: Run process replay tests
         uses: ./.github/actions/process-replay
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -709,6 +709,8 @@ jobs:
         run: |
           VIZ=1 SQTT=1 DEBUG=5 python3 test/test_ops.py TestOps.test_add
           extra/sqtt/rgptool.py create "/tmp/profile.pkl.$USER" -o /tmp/gpu0.rgp
+      - name: Run RANGEIFY=1 test_ops
+        run: RANGEIFY=1 python3 -m pytest -n=auto test/test_ops.py
       - name: Run process replay tests
         uses: ./.github/actions/process-replay
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -3164,6 +3164,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(32,10)], lambda x: x.masked_fill((x>0.1).detach(), -math.inf))
     helper_test_op([(32,10)], lambda x: x.masked_fill((x<0.1).detach(), -math.inf))
 
+  @unittest.skipIf(getenv("MOCKGPU") and Device.DEFAULT == "AMD" and RANGEIFY, "very slow on MOCKGPU because reduce does not fold")
   def test_masked_select(self):
     helper_test_op([(32, 10)], lambda x: x.masked_select(x>0.5), lambda x: x.masked_select(x>0.5), forward_only=True)
     helper_test_op([(32, 10)], lambda x: x.masked_select(torch.tensor(True)), lambda x: x.masked_select(Tensor(True)), forward_only=True)


### PR DESCRIPTION
test_masked_select is still very slow for the emulator...
`CI=1 FORWARD_ONLY=1 AMD_LLVM=0 PYTHONPATH=. AMD=1 RANGEIFY=1 python3 test/test_ops.py TestOps.test_masked_select`
The slowness also happens for the PYTHON backend.