### PR TITLE
viz: add font-weight to OffscreenCanvas config

### DIFF
--- a/tinygrad/viz/js/worker.js
+++ b/tinygrad/viz/js/worker.js
@@ -2,7 +2,7 @@ const NODE_PADDING = 10;
 const LINE_HEIGHT = 14;
 const canvas = new OffscreenCanvas(0, 0);
 const ctx = canvas.getContext("2d");
-ctx.font = `${LINE_HEIGHT}px sans-serif`;
+ctx.font = `350 ${LINE_HEIGHT}px sans-serif`;
 
 onmessage = (e) => {
   const { graph, additions } = e.data;


### PR DESCRIPTION
It was giving the wrong text widths:
master:
<img width="3830" height="898" alt="image" src="https://github.com/user-attachments/assets/1ad0312f-d1d1-4cde-8f9c-3c40cae9d8e3" />

branch:
<img height="898" alt="image" src="https://github.com/user-attachments/assets/195065a9-2a1c-461f-b0e1-12790c921a64" />
