### PR TITLE
skip test_multihost_aware_schedule, assign devices mismatch 

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -47,6 +47,12 @@ class TestMultiTensor(unittest.TestCase):
     grad = X.sum().gradient(X)[0]
     grad.realize()
 
+  def test_acc(self):
+    acc = Tensor.zeros(1)
+    ss = [Tensor.ones(32).shard(devices_2, 0) for _ in range(2)]
+    for s in ss: acc += s.sum()
+    self.assertEqual(acc.to("CPU").item(), 32*2)
+
   def test_shard(self):
     X = Tensor.ones(256).contiguous().realize()
     X.shard_(devices_2, 0)

--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -47,12 +47,6 @@ class TestMultiTensor(unittest.TestCase):
     grad = X.sum().gradient(X)[0]
     grad.realize()
 
-  def test_acc(self):
-    acc = Tensor.zeros(1)
-    ss = [Tensor.ones(32).shard(devices_2, 0) for _ in range(2)]
-    for s in ss: acc += s.sum()
-    self.assertEqual(acc.to("CPU").item(), 32*2)
-
   def test_shard(self):
     X = Tensor.ones(256).contiguous().realize()
     X.shard_(devices_2, 0)

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -36,7 +36,7 @@ class TestRemoteMultiHost(unittest.TestCase):
   def test_multihost_aware_schedule(self):
     @TinyJit
     def do(*ts:Tensor):
-      acc = Tensor.zeros(1, dtype=dtypes.float32)
+      acc = Tensor.zeros(1, dtype=dtypes.float32).contiguous().realize()
       for t in ts: acc += t.sum()
       return acc.realize()
 

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -33,6 +33,7 @@ class TestRemoteMultiHost(unittest.TestCase):
     assert len(do.captured._jit_cache) == 1 and isinstance(do.captured._jit_cache[0].prg, RemoteGraph), repr(do.captured)
 
   @Context(JIT_BATCH_SIZE=2**32)
+  @unittest.skip("assign target and input devices mismatch")
   def test_multihost_aware_schedule(self):
     @TinyJit
     def do(*ts:Tensor):


### PR DESCRIPTION
It got lucky because Tensor.zeros is a CONST and no buffers asserted. We don't support assigning from a multi device to a single device (eg. without an MSELECT in between)
<img width="1774" height="454" alt="image" src="https://github.com/user-attachments/assets/ccd7fac5-ca7b-496f-a8bd-9b80222b0088" />
