### PR TITLE
add a test for untested Tensor.assign behavior

### DIFF
--- a/test/test_assign.py
+++ b/test/test_assign.py
@@ -119,6 +119,15 @@ class TestAssign(unittest.TestCase):
     new = a + old_a
     np.testing.assert_allclose(new.numpy(), 4)
 
+  def test_assign_changes_alt(self):
+    a = Tensor.full((2, 2), 1.).contiguous().realize()
+    b = a.contiguous() # b returns a new Tensor
+    b.assign(Tensor.full((2, 2), 2.))
+    b.realize()
+    # but assigning to b also changes a, this isn't true if you remove "contiguous buffer is contiguous" rules
+    self.assertListEqual(a.tolist(), [[2., 2.], [2., 2.]])
+    self.assertListEqual(b.tolist(), [[2., 2.], [2., 2.]])
+
   def test_assign_diamond_cycle(self):
     # NOTE: should *not* raise AssertionError from numpy
     with self.assertRaisesRegex(RuntimeError, "cycle"):

--- a/test/test_assign.py
+++ b/test/test_assign.py
@@ -119,14 +119,16 @@ class TestAssign(unittest.TestCase):
     new = a + old_a
     np.testing.assert_allclose(new.numpy(), 4)
 
-  def test_assign_changes_alt(self):
-    a = Tensor.full((2, 2), 1.).contiguous().realize()
-    b = a.contiguous() # b returns a new Tensor
-    b.assign(Tensor.full((2, 2), 2.))
+  def test_assign_changes_alt(self, realize=False):
+    a = Tensor(1).contiguous()
+    if realize: a.realize()
+    b = a.contiguous()    # b returns a new Tensor
+    b.assign(2)
     b.realize()
-    # but assigning to b also changes a, this isn't true if you remove "contiguous buffer is contiguous" rules
-    self.assertListEqual(a.tolist(), [[2., 2.], [2., 2.]])
-    self.assertListEqual(b.tolist(), [[2., 2.], [2., 2.]])
+    self.assertNotEqual(a.item(), b.item())
+  # on a realized Tensor contiguous child changes the source
+  @unittest.expectedFailure
+  def test_assign_changes_realized_alt(self): return self.test_assign_changes_alt(realize=True)
 
   def test_assign_diamond_cycle(self):
     # NOTE: should *not* raise AssertionError from numpy


### PR DESCRIPTION
I think only `a != b` is correct, sadly both behaviors exist.