### PR TITLE
early copy fixup

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2227,6 +2227,11 @@ class TestCopyFolding(unittest.TestCase):
     check_schedule(b, 0, filter_sink=False)
     assert b.item() == 1
 
+  def test_const_copy_multi(self):
+    x = Tensor.ones(1, device="CPU").to_(["CPU", "CPU:1"])
+    check_schedule(x, 0, filter_sink=False)
+    self.assertEqual(x.item(), 1)
+
   def test_late_const_copy_folding(self):
     a = Tensor.arange(3).realize()
     zeros = Tensor.zeros(3).realize()


### PR DESCRIPTION
`RANGEIFY=1 MAX_BUFFER_SIZE=0 NULL=1 python examples/beautiful_mnist_multigpu.py` failure was pretty simple, it's an issue with CONST/COPY. The old multi stuff expected a direct edge to CONST:
https://github.com/tinygrad/tinygrad/blob/c1e85f699c1b3cf7db9e10a367a6feef69ecc6ec/tinygrad/schedule/multi.py#L120-L125
It doesn't work like this in rangeify (no view pushing).
It's easier to reason about these in rangeify earliest_rewrites though, I thought of modifying multi.py but that's gonna go away.
<img height="200" alt="image" src="https://github.com/user-attachments/assets/e0967f18-dead-42ac-99b9-6f05175b5a7b" />
