### PR TITLE
update viz to not use children [pr]

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -64,9 +64,7 @@ def uop_to_json(x:UOp) -> dict[int, dict]:
     # always exclude DEVICE/CONST/UNIQUE
     if u.op in {Ops.DEVICE, Ops.CONST, Ops.UNIQUE} and u is not x: excluded.add(u)
     # only exclude CONST VIEW source if it has no other children in the graph
-    # TODO: find a different way to do this, children isn't tracked
-    #if u.op is Ops.CONST and len(u.src) != 0 and all(cr.op is Ops.CONST for c in u.src[0].children if (cr:=c()) is not None and cr in toposort):
-    #  excluded.update(u.src)
+    if u.op is Ops.CONST and u.st is not None: excluded.update(u.src)
   for u in toposort:
     if u in excluded: continue
     argst = codecs.decode(str(u.arg), "unicode_escape")


### PR DESCRIPTION
It's because in the old scheduler we still do CONST(VIEW) and that VIEW shouldn't dangle when const gets removed from the graph:

master vs branch:
<img width="1240" height="362" alt="Screenshot 2025-10-08 at 9 19 46 AM" src="https://github.com/user-attachments/assets/ef06bb57-b910-4cc7-92f5-cc0c564318dd" />
<img width="1240" height="321" alt="Screenshot 2025-10-08 at 9 19 39 AM" src="https://github.com/user-attachments/assets/d65fe30a-1737-4b34-a4d0-c1c63849aaf3" />

In codegen it's already VIEW(CONST) so this isn't a problem
<img width="2480" height="724" alt="image" src="https://github.com/user-attachments/assets/149bff66-13b2-40da-b855-6b8c633f6197" />
