### PR TITLE
fix fromarray deprecation in example/train_resnet.py

### DIFF
--- a/examples/train_resnet.py
+++ b/examples/train_resnet.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
   lr = 5e-3
   transform = ComposeTransforms([
-    lambda x: [Image.fromarray(xx, mode='L').resize((64, 64)) for xx in x],
+    lambda x: [Image.fromarray(xx).resize((64, 64)) for xx in x],
     lambda x: np.stack([np.asarray(xx) for xx in x], 0),
     lambda x: x / 255.0,
     lambda x: np.tile(np.expand_dims(x, 1), (1, 3, 1, 1)).astype(np.float32),


### PR DESCRIPTION
## Remove deprecated `mode` parameter from `Image.fromarray` calls

fix for #12513 

### Problem
The `mode='L'` parameter in `Image.fromarray()` calls is deprecated in Pillow and triggers deprecation warnings. According to [PIL documentation](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.fromarray), the `mode` parameter is deprecated and Pillow now reliably auto-detects the appropriate mode from array data.

### Solution
Remove the explicit `mode='L'` parameter since Pillow's auto-detection correctly identifies the mode as `'L'` (grayscale) for the input data.

### Testing
- Verified that after removal, Pillow correctly auto-detects `'L'` mode for all input images
- Confirmed the model trains successfully without any behavior changes
- Elimination of deprecation warnings


### Before
```python
lambda x: [Image.fromarray(xx, mode='L').resize((64, 64)) for xx in x]
```

### After 
```python
lambda x: [Image.fromarray(xx).resize((64, 64)) for xx in x]
```

