### PR TITLE
fix: correct sys.path in torch frontend to allow importing extra

### DIFF
--- a/tinygrad/nn/torch.py
+++ b/tinygrad/nn/torch.py
@@ -1,5 +1,5 @@
 # type: ignore
 import sys, pathlib
-sys.path.append(pathlib.Path(__file__).parent.parent.as_posix())
+sys.path.append(pathlib.Path(__file__).parent.parent.parent.as_posix())
 try: import extra.torch_backend.backend  # noqa: F401 # pylint: disable=unused-import
 except ImportError as e: raise ImportError("torch frontend not in release\nTo fix, install tinygrad from a git checkout with pip install -e .") from e


### PR DESCRIPTION
The torch frontend attempts to import `extra.torch_backend.backend`, but the `sys.path` modification was missing one `.parent` call.

Currently, it appends `.../tinygrad/tinygrad/` to the path, so `import extra` fails because it looks for `.../tinygrad/tinygrad/extra`.
This change updates it to append the repository root (`.../tinygrad/`), allowing `extra` to be imported correctly when running from a git checkout.