### PR TITLE
amd: fp8 casts on gfx120x

### DIFF
--- a/test/unit/test_amd_rdna4_fp8_codegen.py
+++ b/test/unit/test_amd_rdna4_fp8_codegen.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+import unittest
+
+from tinygrad.codegen import full_rewrite
+from tinygrad.dtype import dtypes
+from tinygrad.renderer.cstyle import AMDRenderer
+from tinygrad.uop.ops import UOp, Ops
+
+class TestAMDRDNA4FP8Codegen(unittest.TestCase):
+  def _render_fp8_cast_kernel(self, fp8_dtype):
+    a = UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(), (), 0)
+    b = UOp(Ops.DEFINE_GLOBAL, fp8_dtype.ptr(), (), 1)
+    c = UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(), (), 2)
+    idx = UOp.const(dtypes.int, 0)
+
+    f = a.index(idx, ptr=True).load(dtype=dtypes.float)
+    q = f.cast(fp8_dtype)
+    dq = q.cast(dtypes.float)
+
+    uops = full_rewrite(UOp.sink(b.index(idx, ptr=True).store(q), c.index(idx, ptr=True).store(dq)))
+    return AMDRenderer("gfx1201").render(uops)
+
+  def test_fp8e4m3_casts_use_builtins_gfx1201(self):
+    src = self._render_fp8_cast_kernel(dtypes.fp8e4m3)
+    self.assertIn("__builtin_amdgcn_cvt_pk_fp8_f32", src)
+    self.assertIn("__builtin_amdgcn_cvt_f32_fp8", src)
+
+  def test_fp8e5m2_casts_use_builtins_gfx1201(self):
+    src = self._render_fp8_cast_kernel(dtypes.fp8e5m2)
+    self.assertIn("__builtin_amdgcn_cvt_pk_bf8_f32", src)
+    self.assertIn("__builtin_amdgcn_cvt_f32_bf8", src)
+
+if __name__ == "__main__":
+  unittest.main()

--- a/test/unit/test_amd_rdna4_fp8_codegen.py
+++ b/test/unit/test_amd_rdna4_fp8_codegen.py
@@ -7,6 +7,9 @@ from tinygrad.renderer.cstyle import AMDRenderer
 from tinygrad.uop.ops import UOp, Ops
 
 class TestAMDRDNA4FP8Codegen(unittest.TestCase):
+  def test_gfx1201_is_not_cdna(self):
+    self.assertFalse(AMDRenderer.is_cdna("gfx1201"))
+
   def _render_fp8_cast_kernel(self, fp8_dtype):
     a = UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(), (), 0)
     b = UOp(Ops.DEFINE_GLOBAL, fp8_dtype.ptr(), (), 1)

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -352,7 +352,9 @@ def is_dtype_supported(dtype:DType, device:str|None=None) -> bool:
   if dtype in dtypes.fp8s:
     if device == "CUDA": return not CI and not CUDA_PTX
     if device == "NV": return not CI and not NV_PTX and not NV_NAK
-    if device == "AMD": return not CI and getattr(Device["AMD"], "target") in {(9,4,2), (9,5,0)}
+    if device == "AMD":
+      # target is (major, minor, stepping) derived from gfx_target_version in ops_amd
+      return not CI and getattr(Device["AMD"], "target") in {(9,4,2), (9,5,0), (12,0,0), (12,0,1)}
     return device in {"PYTHON", "NULL"}
   if device == "WEBGPU": return dtype in [dtypes.bool, dtypes.char, dtypes.uchar, dtypes.short,
                                           dtypes.ushort, dtypes.float, dtypes.int32, dtypes.uint32, dtypes.half]


### PR DESCRIPTION
* fix fp8 casts on gfx1200/gfx1201 (rdna4)
* enable fp8 dtypes for gfx12 targets
* add unit test that checks builtins in generated code
* ensure gfx1201 is not treated as cdna

tests:
* python -m pytest -q test/unit/test_amd_rdna4_fp8_codegen.py