### PR TITLE
perf: parallel adds instead of sequential adds (test_sum vs torch)

### DIFF
--- a/test/external/external_test_onnx_ops.py
+++ b/test/external/external_test_onnx_ops.py
@@ -379,7 +379,7 @@ class TestContribOnnxOps(TestOnnxOps):
         inps = {**base_inps, **extra_inps}
         opts = {**base_opts, **extra_opts}
         outputs = ["output", "present"] if "past" in inps else ["output"]
-        self.helper_test_single_op("Attention", inps, opts, outputs, atol=1e-4)
+        self.helper_test_single_op("Attention", inps, opts, outputs, rtol=5e-3, atol=5e-3)
 
   def test_skip_layer_normalization(self):
     shape = (2, 8, 32)

--- a/test/test_linearizer.py
+++ b/test/test_linearizer.py
@@ -540,5 +540,17 @@ def _helper_linearizer_opt_ast(realized_ast:UOp, real_bufs:list[Buffer], opts=[]
   for x in opts: # Check custom transformations if any.
     check_opt(([Opt(OptOps.TC, 0, (TC_SELECT.value, TC_OPT.value, 1))] if apply_tc else [])+x)
 
+class TestVectorAccumulator(unittest.TestCase):
+  @unittest.skipUnless(Device[Device.DEFAULT].renderer.supports_float4, "test requires float4")
+  def test_reduce_vector_accumulator_no_dependency_chain(self):
+    x = Tensor.rand(256, 256).realize()
+    r = x.sum()
+    ast = r.schedule()[-1].ast
+    uops = get_program(ast, renderer=Device[Device.DEFAULT].renderer, opts=[Opt(OptOps.UNROLL, 0, 4)]).uops
+    accs = [u for u in uops if u.op is Ops.DEFINE_REG]
+    assert len(accs) == 1, f"expected 1 vector accumulator, got {len(accs)}"
+    acc_size = accs[0].dtype.size if hasattr(accs[0].dtype, 'size') else 1
+    assert acc_size == 4, f"accumulator should have size 4, got {acc_size}"
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -305,7 +305,7 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
     input_ranges = tuple([x for x in topo if x.op is Ops.RANGE and x not in reduce_range and x not in ended_ranges])
     identity  = red.const(red.dtype, identity_element(red.arg, red.dtype.scalar()))
     idx0 = UOp.const(dtypes.index, 0)
-    vec_count = len(lst) if red.dtype.count == 1 else 1
+    vec_count = len(lst) if red.dtype.count == 1 and red.dtype.scalar() in dtypes.floats else 1
     acc_dtype = red.dtype.vec(vec_count) if vec_count > 1 else red.dtype
     acc = UOp(Ops.DEFINE_REG, acc_dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)
     acc_init = (acc.after(*input_ranges) if input_ranges else acc).index(idx0).store(identity.broadcast(vec_count) if vec_count > 1 else identity)

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -304,7 +304,7 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
     ended_ranges = flatten([x.ended_ranges for x in topo if x.op is Ops.END])
     input_ranges = tuple([x for x in topo if x.op is Ops.RANGE and x not in reduce_range and x not in ended_ranges])
     identity = red.const(red.dtype, identity_element(red.arg, red.dtype.scalar()))
-    # vector accumulator: no dependency chain between unrolled adds
+    # vector accumulator, no dependency chain between unrolled adds
     if (vec_count:=len(lst)) > 1 and red.dtype.count == 1:
       vec_dtype, idx0 = red.dtype.vec(vec_count), UOp.const(dtypes.int, 0)
       acc = UOp(Ops.DEFINE_REG, vec_dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -304,7 +304,7 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
     ended_ranges = flatten([x.ended_ranges for x in topo if x.op is Ops.END])
     input_ranges = tuple([x for x in topo if x.op is Ops.RANGE and x not in reduce_range and x not in ended_ranges])
     identity = red.const(red.dtype, identity_element(red.arg, red.dtype.scalar()))
-    # vector accumulator, no dependency chain between unrolled adds
+    # vector accumulator: no dependency chain between unrolled adds
     if (vec_count:=len(lst)) > 1 and red.dtype.count == 1:
       vec_dtype, idx0 = red.dtype.vec(vec_count), UOp.const(dtypes.int, 0)
       acc = UOp(Ops.DEFINE_REG, vec_dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -313,9 +313,8 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
       acc_out = acc.after(acc.index(idx0).store(new_val).end(*reduce_range)).index(idx0)
       ctx.acc_num += 1
       lanes = [acc_out.gep((i,)) for i in range(vec_count)]
-      while len(lanes) > 1:
-        lanes = [lanes[i].alu(red.arg, lanes[i+1]) if i+1 < len(lanes) else lanes[i] for i in range(0, len(lanes), 2)]
-      return lanes[0]
+      pairs = [lanes[i].alu(red.arg, lanes[i+1]) if i+1 < len(lanes) else lanes[i] for i in range(0, len(lanes), 2)]
+      return functools.reduce(lambda x,y: x.alu(red.arg, y), pairs) # pairwise sums then linear across: numerically closer ORT
     acc = UOp(Ops.DEFINE_REG, red.dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)
     acc_init = acc.after(*input_ranges).index(UOp.const(dtypes.int, 0)).store(identity) if len(input_ranges) else \
                acc.index(UOp.const(dtypes.int, 0)).store(identity)

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -303,22 +303,21 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
     topo = inp.toposort()
     ended_ranges = flatten([x.ended_ranges for x in topo if x.op is Ops.END])
     input_ranges = tuple([x for x in topo if x.op is Ops.RANGE and x not in reduce_range and x not in ended_ranges])
-    identity  = red.const(red.dtype, identity_element(red.arg, red.dtype.scalar()))
-    idx0 = UOp.const(dtypes.index, 0)
     vec_count = len(lst) if red.dtype.count == 1 and red.dtype.scalar() in dtypes.floats else 1
-    acc_dtype = red.dtype.vec(vec_count) if vec_count > 1 else red.dtype
-    acc = UOp(Ops.DEFINE_REG, acc_dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)
-    acc_init = (acc.after(*input_ranges) if input_ranges else acc).index(idx0).store(identity.broadcast(vec_count) if vec_count > 1 else identity)
+    acc = UOp(Ops.DEFINE_REG, (red.dtype.vec(vec_count) if vec_count > 1 else red.dtype).ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)
     ctx.acc_num += 1
-    acc_val = acc.after(acc_init, *reduce_range).index(idx0)
-    def acc_end(val): return acc.after(acc.index(idx0).store(val).end(*reduce_range)).index(idx0)
+    def acc_at(*deps): return (acc.after(*deps) if deps else acc).index(UOp.const(dtypes.index, 0))
+    identity = red.const(red.dtype, identity_element(red.arg, red.dtype.scalar()))
+    acc_init = acc_at(*input_ranges).store(identity.broadcast(vec_count) if vec_count > 1 else identity)
+    acc_val = acc_at(acc_init, *reduce_range)
     if vec_count > 1: # vector accumulator: no dependency chain between unrolled adds
-      new_val = acc_val.alu(red.arg, UOp(Ops.VECTORIZE, acc_dtype, tuple(lst)))
-      return functools.reduce(lambda x,y: x.alu(red.arg, y), [acc_end(new_val).gep((i,)) for i in range(vec_count)])
+      new_val = acc_val.alu(red.arg, UOp(Ops.VECTORIZE, red.dtype.vec(vec_count), tuple(lst)))
+      ended = acc_at(acc_at().store(new_val).end(*reduce_range))
+      return functools.reduce(lambda x,y: x.alu(red.arg, y), [ended.gep((i,)) for i in range(vec_count)])
     lst = [acc_val] + lst  # put acc as the first element
   ret = functools.reduce(lambda x,y: x.alu(red.arg, y), lst)
   if len(reduce_range) == 0: return ret
-  return acc_end(ret)
+  return acc_at(acc_at().store(ret).end(*reduce_range))
 
 pm_reduce = PatternMatcher([
   # REDUCE -> DEFINE_ACC+ASSIGN

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -313,8 +313,9 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
       acc_out = acc.after(acc.index(idx0).store(new_val).end(*reduce_range)).index(idx0)
       ctx.acc_num += 1
       lanes = [acc_out.gep((i,)) for i in range(vec_count)]
-      pairs = [lanes[i].alu(red.arg, lanes[i+1]) if i+1 < len(lanes) else lanes[i] for i in range(0, len(lanes), 2)]
-      return functools.reduce(lambda x,y: x.alu(red.arg, y), pairs) # pairwise sums then linear across: numerically closer ORT
+      while len(lanes) > 1:
+        lanes = [lanes[i].alu(red.arg, lanes[i+1]) if i+1 < len(lanes) else lanes[i] for i in range(0, len(lanes), 2)]
+      return lanes[0]
     acc = UOp(Ops.DEFINE_REG, red.dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)
     acc_init = acc.after(*input_ranges).index(UOp.const(dtypes.int, 0)).store(identity) if len(input_ranges) else \
                acc.index(UOp.const(dtypes.int, 0)).store(identity)

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -312,7 +312,9 @@ def reduce_to_acc(ctx:ReduceContext, red:UOp):
       new_val = acc.after(acc_init, *reduce_range).index(idx0).alu(red.arg, UOp(Ops.VECTORIZE, vec_dtype, tuple(lst)))
       acc_out = acc.after(acc.index(idx0).store(new_val).end(*reduce_range)).index(idx0)
       ctx.acc_num += 1
-      return functools.reduce(lambda x,y: x.alu(red.arg, y), [acc_out.gep((i,)) for i in range(vec_count)])
+      lanes = [acc_out.gep((i,)) for i in range(vec_count)]
+      pairs = [lanes[i].alu(red.arg, lanes[i+1]) if i+1 < len(lanes) else lanes[i] for i in range(0, len(lanes), 2)]
+      return functools.reduce(lambda x,y: x.alu(red.arg, y), pairs) # pairwise sums then linear across: numerically closer ORT
     acc = UOp(Ops.DEFINE_REG, red.dtype.ptr(size=1, addrspace=AddrSpace.REG), arg=ctx.acc_num)
     acc_init = acc.after(*input_ranges).index(UOp.const(dtypes.int, 0)).store(identity) if len(input_ranges) else \
                acc.index(UOp.const(dtypes.int, 0)).store(identity)


### PR DESCRIPTION
Change from sequential adds to parallel adds. Needs a test tolerance adjustment on the external ONNX flash attention test (different float accumulation).

This would generate lots of PR changes - any key benchmarks you'd like me to check for regressions?

Helps a lot for `sum`, `max`, `partial_sum`, `mul_sum`.


<img width="1231" height="264" alt="image" src="https://github.com/user-attachments/assets/684710ee-b575-4a38-ae18-e820944f9726" />




Notably, also 2x faster for the smaller kernel with only `CPU=1`:
master
```
(.venv) (base) ➜  tinygrad git:(master) ✗ CPU=1 python3 test/speed/external_test_speed_v_torch.py TestSpeed.test_sum 
sum                             2048x 2048    0.27 ms (    15.56 GFLOPS   62.23 GB/s) in torch,    0.75 ms (     5.62 GFLOPS   22.47 GB/s) in tinygrad,    2.77x slower       4.19 MOPS    16.78 MB
sum                             4096x 4096    1.02 ms (    16.45 GFLOPS   65.81 GB/s) in torch,    1.07 ms (    15.70 GFLOPS   62.80 GB/s) in tinygrad,    1.05x slower      16.78 MOPS    67.14 MB
```

branch
```
sum                             2048x 2048    0.26 ms (    16.06 GFLOPS   64.22 GB/s) in torch,    0.36 ms (    11.64 GFLOPS   46.54 GB/s) in tinygrad,    1.38x slower       4.20 MOPS    16.78 MB
sum                             4096x 4096    1.01 ms (    16.59 GFLOPS   66.36 GB/s) in torch,    0.88 ms (    19.09 GFLOPS   76.40 GB/s) in tinygrad,    0.87x faster      16.78 MOPS    67.14 MB
```