### PR TITLE
torch backend - torch.compile beautiful_mnist_torch using TinyJit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
         sudo apt update || true
         sudo apt install -y --no-install-recommends ninja-build
     - name: Test beautiful_mnist in torch with TINY_BACKEND
-      run: STEPS=20 CPU=1 TARGET_EVAL_ACC_PCT=90.0 TINY_BACKEND=1 python3 examples/other_mnist/beautiful_mnist_torch.py
+      run: STEPS=10 CPU=1 TARGET_EVAL_ACC_PCT=90.0 TINY_BACKEND=1 python3 examples/other_mnist/beautiful_mnist_torch.py
     - name: Test some torch tests (expect failure)
       run: python3 -m pytest extra/torch_backend/torch_tests.py -v --tb=no || true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
         sudo apt update || true
         sudo apt install -y --no-install-recommends ninja-build
     - name: Test beautiful_mnist in torch with TINY_BACKEND
-      run: STEPS=10 CPU=1 TARGET_EVAL_ACC_PCT=90.0 TINY_BACKEND=1 python3 examples/other_mnist/beautiful_mnist_torch.py
+      run: STEPS=20 CPU=1 TARGET_EVAL_ACC_PCT=90.0 TINY_BACKEND=1 python3 examples/other_mnist/beautiful_mnist_torch.py
     - name: Test some torch tests (expect failure)
       run: python3 -m pytest extra/torch_backend/torch_tests.py -v --tb=no || true
 

--- a/examples/other_mnist/beautiful_mnist_torch.py
+++ b/examples/other_mnist/beautiful_mnist_torch.py
@@ -4,6 +4,8 @@ from tinygrad.nn.datasets import mnist
 import torch
 from torch import nn, optim
 
+from extra.torch_backend.test_compile import tiny  # noqa: F401
+
 class Model(nn.Module):
   def __init__(self):
     super().__init__()
@@ -27,11 +29,10 @@ class Model(nn.Module):
 
 if __name__ == "__main__":
   if getenv("TINY_BACKEND"):
-    import tinygrad.nn.torch  # noqa: F401
-    device = torch.device("tiny")
+    device = torch.device("cpu")  # torch.compile traces with fake tensors, use CPU
   else:
     device = torch.device({"METAL":"mps","NV":"cuda"}.get(Device.DEFAULT, "cpu"))
-  if DEBUG >= 1: print(f"using torch backend {device}")
+  if DEBUG >= 1: print(f"using torch device {device}")
   X_train, Y_train, X_test, Y_test = mnist()
   X_train = torch.tensor(X_train.float().numpy(), device=device)
   Y_train = torch.tensor(Y_train.cast(dtypes.int64).numpy(), device=device)
@@ -40,10 +41,10 @@ if __name__ == "__main__":
 
   if getenv("TORCHVIZ"): torch.cuda.memory._record_memory_history()
   model = Model().to(device)
+  if getenv("TINY_BACKEND"): model = torch.compile(model, backend="tiny", dynamic=False)
   optimizer = optim.Adam(model.parameters(), 1e-3)
 
   loss_fn = nn.CrossEntropyLoss()
-  #@torch.compile
   def step(samples):
     X,Y = X_train[samples], Y_train[samples]
     out = model(X)

--- a/examples/other_mnist/beautiful_mnist_torch.py
+++ b/examples/other_mnist/beautiful_mnist_torch.py
@@ -46,7 +46,8 @@ if __name__ == "__main__":
   optimizer = optim.Adam(model.parameters(), 1e-3)
   loss_fn = nn.CrossEntropyLoss()
   @torch.compile(backend=compile_backend)
-  def step(samples):
+  def step():
+    samples = torch.randint(0, X_train.shape[0], (512,), device=device)
     X,Y = X_train[samples], Y_train[samples]
     out = model(X)
     loss = loss_fn(out, Y)
@@ -57,8 +58,7 @@ if __name__ == "__main__":
 
   test_acc = float('nan')
   for i in (t:=trange(getenv("STEPS", 70))):
-    samples = torch.randint(0, X_train.shape[0], (512,), device=device)  # putting this in JIT didn't work well
-    loss = step(samples)
+    loss = step()
     if i%10 == 9: test_acc = ((model(X_test).argmax(axis=-1) == Y_test).sum() * 100 / X_test.shape[0]).item()
     t.set_description(f"loss: {loss.item():6.2f} test_accuracy: {test_acc:5.2f}%")
 

--- a/examples/other_mnist/beautiful_mnist_torch.py
+++ b/examples/other_mnist/beautiful_mnist_torch.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     device = torch.device("cpu")  # torch.compile traces with fake tensors, use CPU
   else:
     device = torch.device({"METAL":"mps","NV":"cuda"}.get(Device.DEFAULT, "cpu"))
-  if DEBUG >= 1: print(f"using torch device {device}")
+  if DEBUG >= 1: print(f"using torch backend {device}")
   X_train, Y_train, X_test, Y_test = mnist()
   X_train = torch.tensor(X_train.float().numpy(), device=device)
   Y_train = torch.tensor(Y_train.cast(dtypes.int64).numpy(), device=device)

--- a/examples/other_mnist/beautiful_mnist_torch.py
+++ b/examples/other_mnist/beautiful_mnist_torch.py
@@ -27,8 +27,8 @@ class Model(nn.Module):
 
 if __name__ == "__main__":
   if getenv("TINY_BACKEND"):
-    import extra.torch_backend.backend  # noqa: F401  # register tiny device
-    import extra.torch_backend.test_compile  # noqa: F401  # patch torch.compile for backend="tiny"
+    import tinygrad.nn.torch  # noqa: F401
+    import extra.torch_backend.test_compile  # noqa: F401
     device = torch.device("tiny")
     compile_backend = "tiny"
   else:

--- a/examples/other_mnist/beautiful_mnist_torch.py
+++ b/examples/other_mnist/beautiful_mnist_torch.py
@@ -4,8 +4,6 @@ from tinygrad.nn.datasets import mnist
 import torch
 from torch import nn, optim
 
-from extra.torch_backend.test_compile import tiny  # noqa: F401
-
 class Model(nn.Module):
   def __init__(self):
     super().__init__()
@@ -41,7 +39,9 @@ if __name__ == "__main__":
 
   if getenv("TORCHVIZ"): torch.cuda.memory._record_memory_history()
   model = Model().to(device)
-  if getenv("TINY_BACKEND"): model = torch.compile(model, backend="tiny", dynamic=False)
+  if getenv("TINY_BACKEND"):
+    from extra.torch_backend.test_compile import tiny  # noqa: F401
+    model = torch.compile(model, backend="tiny", dynamic=False)
   optimizer = optim.Adam(model.parameters(), 1e-3)
 
   loss_fn = nn.CrossEntropyLoss()

--- a/extra/torch_backend/test_compile.py
+++ b/extra/torch_backend/test_compile.py
@@ -5,6 +5,7 @@ from extra.torch_backend.backend import unwrap, wrap
 
 from torch._dynamo.backends.registry import register_backend
 from torch._functorch.aot_autograd import aot_module_simplified
+from functorch.compile import make_boxed_func
 
 from tinygrad import Tensor, TinyJit
 
@@ -14,12 +15,13 @@ def tiny(gm:torch.fx.GraphModule, sample_inputs):
     # TODO: the jit should capture the graph directly, not need three runs. this is a planned tinygrad refactor after becomes_map
     @TinyJit
     def tiny_function(*args:Tensor):
-      outs = gm(*[wrap(x) for x in args])
-      for x in outs: unwrap(x).realize()
+      outs = gm(*[wrap(x) if isinstance(x, Tensor) else x for x in args])
+      Tensor.realize(*[unwrap(x) for x in outs if isinstance(x, torch.Tensor)])
       return outs
-    # TODO: this should be able to pass in .tiny() Tensors, not need to convert them. it tries to access Storage if you pass in.
-    def torch_function(*args:torch.Tensor): return tiny_function(*[unwrap(x.tiny()) for x in args])
-    return torch_function
+    def torch_function(*args):
+      tiny_args = [unwrap(x.tiny()) if isinstance(x, torch.Tensor) else x for x in args]
+      return [x.cpu() if isinstance(x, torch.Tensor) else x for x in tiny_function(*tiny_args)]
+    return make_boxed_func(torch_function)
   return aot_module_simplified(gm, sample_inputs, decompositions={}, fw_compiler=my_compiler)
 
 if __name__ == "__main__":


### PR DESCRIPTION
New version: monkeypatch and `@torch.compile` on `def step`
Also allows pulling in the rand into the JIT.
Can't do the neat `register_backend` if we want a decorator to work on the `step`.

I believe the choice is between:
* this
* `register_backend` + CPU tensors and only the model fully jitted (see old version below)
* something more involved that actually fixes the missing storage on `OpaqueTensorImpl`

### Old version (before https://github.com/tinygrad/tinygrad/pull/13850/commits/92551b97e22979e901132e97446333894ed02a71)
Sidestep the tensor storage access issue completely by keeping all tensors on cpu, compile the model only.
Allows using `model = torch.compile(model, backend="tiny", dynamic=False)` which uses `TinyJit` under the hood.
Probably not what you had in mind here - but it works. Maybe a stepping stone to full support of tensors on `tiny` + compilation.


```
(.venv) ➜  tinygrad git:(torch_jit_2) ✗ PYTHONPATH=. STEPS=10 TINY_BACKEND=1 python examples/other_mnist/beautiful_mnist_torch.py 
loss:   0.45 test_accuracy: 90.68%: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:03<00:00,  2.53it/s]
```