### PR TITLE
pass params directly into function instead of surgery after

### DIFF
--- a/extra/thunder/tiny/tk/tiles.py
+++ b/extra/thunder/tiny/tk/tiles.py
@@ -69,11 +69,12 @@ class TileMathMixin(ElementwiseMixin):
       elif isinstance(src[0], (int,float,bool)): uop = self.ker.warp.map(self._uop, lambda x: UOp.alu(x, op, inner_op(x.ufix(src[0]))))
       elif src[0]._shape is None: uop = UOp.alu(self._uop, op, inner_op(self._uop.ufix(src[0])))
       else:
+        src_uop = unwrap(src[0])
         if isinstance(self, RT) and isinstance(src[0], RV):
           match self.layout:
-            case TileLayout.ROW: uop = self.ker.warp.map(self._uop, lambda x, idx: UOp.alu(x, op, inner_op(src[0]._uop[idx[0], 0])))
-            case TileLayout.COL: uop = self.ker.warp.map(self._uop, lambda x, idx: UOp.alu(x, op, inner_op(src[0]._uop[idx[1], 0])))
-        else: uop = self.ker.warp.map(self._uop, lambda x, idx: UOp.alu(x, op, inner_op(src[0]._uop[*idx])))
+            case TileLayout.ROW: uop = self.ker.warp.map(self._uop, lambda x, idx: UOp.alu(x, op, inner_op(src_uop[idx[0], 0])))
+            case TileLayout.COL: uop = self.ker.warp.map(self._uop, lambda x, idx: UOp.alu(x, op, inner_op(src_uop[idx[1], 0])))
+        else: uop = self.ker.warp.map(self._uop, lambda x, idx: UOp.alu(x, op, inner_op(src_uop[*idx])))
     else: raise NotImplementedError
     return self.ruop(uop)
   def const_like(self, b): return b

--- a/extra/thunder/tiny/tk/tiles.py
+++ b/extra/thunder/tiny/tk/tiles.py
@@ -62,12 +62,12 @@ class TileMathMixin(ElementwiseMixin):
   def alu(self, op, *src, inner_op=lambda x:x):
     assert isinstance(self, (RT, RV))
     if len(src) == 0:
-      if self._uop._shape is None: uop = UOp.alu(self._uop, op)
+      if not self._uop._shape: uop = UOp.alu(self._uop, op)
       else: uop = self.ker.warp.map(self._uop, lambda x: UOp.alu(x, op))
     elif len(src) == 1:
-      if self._uop._shape is None: uop = UOp.alu(self._uop, op, inner_op(self._uop.ufix(src[0])))
+      if not self._uop._shape: uop = UOp.alu(self._uop, op, inner_op(self._uop.ufix(src[0])))
       elif isinstance(src[0], (int,float,bool)): uop = self.ker.warp.map(self._uop, lambda x: UOp.alu(x, op, inner_op(x.ufix(src[0]))))
-      elif src[0]._shape is None: uop = UOp.alu(self._uop, op, inner_op(self._uop.ufix(src[0])))
+      elif not src[0]._shape: uop = UOp.alu(self._uop, op, inner_op(self._uop.ufix(src[0])))
       else:
         src_uop = unwrap(src[0])
         if isinstance(self, RT) and isinstance(src[0], RV):

--- a/test/unit/test_function.py
+++ b/test/unit/test_function.py
@@ -190,7 +190,7 @@ class TestFunction(unittest.TestCase):
 
     a = Tensor([1,2,3]).realize()
     np.testing.assert_equal(f(a).numpy(), [2,3,4])
-    np.testing.assert_equal(a.numpy(), [3,4,5])  # TODO: should be [1,2,3]
+    np.testing.assert_equal(a.numpy(), [2,3,4])  # TODO: should be [1,2,3]
 
   def test_implicit_assign(self):
     a = Tensor([1,2,3])
@@ -213,7 +213,6 @@ class TestFunction(unittest.TestCase):
     np.testing.assert_equal(a.numpy(), [11,21,31])  # TODO: should be [1,2,3]
     np.testing.assert_equal(b.numpy(), [10,20,30])
 
-  @unittest.expectedFailure
   def test_assign_slice(self):
     @function
     def f(a:Tensor, b:Tensor) -> Tensor:

--- a/tinygrad/function.py
+++ b/tinygrad/function.py
@@ -1,6 +1,6 @@
 import functools
 from typing import Generic, TypeVar, Callable, cast, overload
-from tinygrad.helpers import Context, dedup, getenv
+from tinygrad.helpers import dedup
 from tinygrad.uop.ops import UOp, Ops, graph_rewrite, PatternMatcher, UPat
 from tinygrad.tensor import Tensor
 
@@ -35,16 +35,21 @@ class _function(Generic[ReturnType]):
     # deduplicate input_uops, keeping the first occurrence index for each unique uop
     call_uops: list[UOp] = dedup(input_uops)
 
-    # disable realize/schedule while this is running
-    # run it and do surgery later. TODO: why am i not calling it with the params?
-    with Context(ALLOW_DEVICE_USAGE=getenv("DEVICE_IN_FUNCTION_BUG", 0)):
-      ret = self.fxn(*args, **kwargs)
+    # create params for each unique input up front
+    params: dict[UOp, UOp] = {x: x.param_like(i) for i, x in enumerate(call_uops)}
+
+    # rebuild args/kwargs with param-based tensors/uops
+    def sub(t):
+      if isinstance(t, Tensor) and t.uop in params: return Tensor(params[t.uop], device=t.device)
+      if isinstance(t, UOp) and t in params: return params[t]
+      return t
+    new_args = tuple(sub(a) for a in args)
+    new_kwargs = {k: sub(v) for k, v in kwargs.items()}
+
+    ret = self.fxn(*new_args, **new_kwargs)
     assert isinstance(ret, Tensor), "only supports one tensor return for now"
 
-    # replace the known inputs with params (using deduplicated slots)
-    subs = {}
-    for i,x in enumerate(call_uops): subs[x] = x.param_like(i)
-    uret = ret.uop.substitute(subs)
+    uret = ret.uop
 
     # add contiguous to call_uops
     #call_uops = [x.contiguous() for x in call_uops]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -504,6 +504,14 @@ class Tensor(OpMixin):
   @staticmethod
   def from_uop(y:UOp, **kwargs) -> Tensor:
     if y.op is Ops.BIND: return Tensor(y, **kwargs, requires_grad=False)
+    if y.op is Ops.PARAM:
+      # add device to deviceless variable PARAMs
+      if y._device is None and len(y.src) >= 2:
+        device = kwargs.get('device') or canonicalize_device(None)
+        y = y.replace(src=(y.src[0], UOp(Ops.DEVICE, arg=device)) + y.src[2:])
+      # cast index to int for tensor dtype promotion
+      data = y.cast(dtypes.int) if y.dtype == dtypes.index else y
+      return Tensor(data, **kwargs, requires_grad=False)
     if y.op is Ops.CONST: return Tensor(y.arg, **kwargs, requires_grad=False)
     if y.op is Ops.MUL: return Tensor.from_uop(y.src[0]) * Tensor.from_uop(y.src[1])
     if y.op is Ops.ADD: return Tensor.from_uop(y.src[0]) + Tensor.from_uop(y.src[1])

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -207,7 +207,7 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
   def _shape(self) -> tuple[sint, ...]|None:
     match self.op:
       # late ops don't have shape
-      case Ops.UNIQUE | Ops.LUNIQUE | Ops.DEVICE | Ops.LOAD | Ops.IF | Ops.BARRIER | Ops.CUSTOM | Ops.CUSTOMI | \
+      case Ops.UNIQUE | Ops.LUNIQUE | Ops.DEVICE | Ops.LOAD | Ops.STORE | Ops.IF | Ops.BARRIER | Ops.CUSTOM | Ops.CUSTOMI | \
            Ops.VECTORIZE | Ops.GEP | Ops.SPECIAL | Ops.UNROLL | Ops.CONTRACT | Ops.SINK | \
            Ops.LINEAR | Ops.PROGRAM | Ops.SOURCE | Ops.BINARY | Ops.INS:
         return None
@@ -218,10 +218,9 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
           return None
 
       case Ops.INDEX:
-        # non pointer index
+        # non pointer index (element access) — shape is just the broadcast of index shapes
         if not isinstance(self.dtype, PtrDType):
-          idxs = flatten([d.shape for d in self.src[1:]])
-          return tuple(idxs) + self.src[0].shape[len(self.src)-1:]
+          return tuple(flatten([d.shape for d in self.src[1:]]))
         # fully indexed doesn't have a shape. TODO: remove this
         if self.src[0]._shape is None or len(self.src[1:]) == len(self.src[0].shape): return None
         # pointer index
@@ -308,7 +307,7 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
     if self.op is Ops.ASSIGN: return self.src[1]._shape
 
     # elementwise ops keep the shape the same. all inputs with shape must match
-    if self.op in GroupOp.ALU.union({Ops.CAST, Ops.COPY, Ops.NOOP, Ops.GROUP, Ops.SINK, Ops.ALLREDUCE, Ops.STORE}):
+    if self.op in GroupOp.ALU.union({Ops.CAST, Ops.COPY, Ops.NOOP, Ops.GROUP, Ops.SINK, Ops.ALLREDUCE}):
       input_shapes = [x._shape for x in self.src if x._shape is not None]
       if len(input_shapes) == 0: return None
       if not all_same(input_shapes): raise RuntimeError(f"shape mismatch at {self.op}: {input_shapes}")

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -208,8 +208,13 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
     match self.op:
       # late ops don't have shape
       case Ops.UNIQUE | Ops.LUNIQUE | Ops.DEVICE | Ops.LOAD | Ops.STORE | Ops.IF | Ops.BARRIER | Ops.CUSTOM | Ops.CUSTOMI | \
-           Ops.VECTORIZE | Ops.GEP | Ops.SPECIAL | Ops.UNROLL | Ops.CONTRACT | Ops.SINK | \
+           Ops.GEP | Ops.SPECIAL | Ops.UNROLL | Ops.CONTRACT | Ops.SINK | \
            Ops.LINEAR | Ops.PROGRAM | Ops.SOURCE | Ops.BINARY | Ops.INS:
+        return None
+
+      case Ops.VECTORIZE:
+        input_shapes = [x._shape for x in self.src]
+        if len(input_shapes) > 0 and all_same(input_shapes) and input_shapes[0] is not None: return input_shapes[0]
         return None
 
       case Ops.CAST:

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -225,7 +225,9 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
       case Ops.INDEX:
         # non pointer index (element access) — shape is just the broadcast of index shapes
         if not isinstance(self.dtype, PtrDType):
-          return tuple(flatten([d.shape for d in self.src[1:]]))
+          idx_shapes = [d._shape for d in self.src[1:]]
+          if any(s is None for s in idx_shapes): return None
+          return tuple(flatten(idx_shapes))
         # fully indexed doesn't have a shape. TODO: remove this
         if self.src[0]._shape is None or len(self.src[1:]) == len(self.src[0].shape): return None
         # pointer index


### PR DESCRIPTION
instead of running the function with real tensors and substituting PARAMs after, create PARAMs up front and pass them in directly.

removes the ALLOW_DEVICE_USAGE hack and fixes double-mutation bugs:
- test_iadd: a goes [1,2,3]->[2,3,4] instead of [3,4,5]
- test_assign_slice: no longer expectedFailure