### PR TITLE
fix: realize ScatterND updates to avoid graph_rewrite loop

### DIFF
--- a/tinygrad/nn/onnx.py
+++ b/tinygrad/nn/onnx.py
@@ -1164,6 +1164,7 @@ def get_onnx_ops() -> dict[str, types.FunctionType|dict[OpSetId, types.FunctionT
       elif reduction == "mul": x[i] *= u
       elif reduction == "max": x[i] = x[i].maximum(u)
       elif reduction == "min": x[i] = x[i].minimum(u)
+      x.realize()
     return x
 
   def TensorScatter(data: Tensor, updates: Tensor, indices: Tensor, mode: str = 'default'):


### PR DESCRIPTION
I dug into this a bit and it looks like the issue comes from the loop in ScatterND doing repeated in place updates on a lazy tensor.

Each `x[i] = u` builds on the previous graph, so after enough iterations you end up with a really deep chain that eventually causes graph_rewrite to blow up.

I tried a minimal fix where I just call `x.realize()` after each update to break that chain. That keeps the current behavior (including ordering for duplicate indices) but prevents the graph from growing unbounded.

I ran:
test/backend/test_arange.py (with CHECK=0)
test/backend/test_setitem.py

and both pass with this change.