### PR TITLE
nv: add support for Tegra (Jetson Orin) via nvgpu/nvmap

### DIFF
--- a/.github/workflows/autogen.yml
+++ b/.github/workflows/autogen.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         find tinygrad/runtime/autogen -type f -name "*.py" -not -path "*/amd/*" -not -name "__init__.py" -not -name "comgr.py" -not -name "metal.py" -not -name "iokit.py" -not -name "corefoundation.py" -not -name "libclang.py" -delete
         python3 -c "from tinygrad.runtime.autogen import opencl"
-        python3 -c "from tinygrad.runtime.autogen import cuda, nvrtc, nvjitlink, nv_570, nv_580, nv"
+        python3 -c "from tinygrad.runtime.autogen import cuda, nvrtc, nvjitlink, nv_570, nv_580, nv, tegra_36"
         python3 -c "from tinygrad.runtime.autogen import comgr_3, hsa, hip, amd_gpu, sqtt, rocprof, amdgpu_kd, amdgpu_drm"
         python3 -c "from tinygrad.runtime.autogen.am import am, pm4_soc15, pm4_nv, sdma_4_0_0, sdma_5_0_0, sdma_6_0_0, smu_v13_0_0, smu_v13_0_6, smu_v13_0_12, smu_v14_0_2"
         python3 -c "from tinygrad.runtime.autogen import libc, kfd, io_uring, ib, pci, vfio"

--- a/extra/tegra_gpu_driver/nvgpu-as.h
+++ b/extra/tegra_gpu_driver/nvgpu-as.h
@@ -1,0 +1,592 @@
+/*
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * /dev/nvhost-as-gpu device
+ *
+ * Opening a '/dev/nvhost-as-gpu' device node creates a new address
+ * space. nvgpu channels (for the same module) can then be bound to such an
+ * address space to define the addresses it has access to.
+ *
+ * Once a nvgpu channel has been bound to an address space it cannot be
+ * unbound. There is no support for allowing an nvgpu channel to change from
+ * one address space to another (or from one to none).
+ *
+ * As long as there is an open device file to the address space, or any bound
+ * nvgpu channels it will be valid.  Once all references to the address space
+ * are removed the address space is deleted.
+ *
+ */
+
+#ifndef _UAPI__LINUX_NVGPU_AS_H__
+#define _UAPI__LINUX_NVGPU_AS_H__
+
+#include "nvgpu-uapi-common.h"
+
+#define NVGPU_AS_IOCTL_MAGIC 'A'
+
+/*
+ * Allocating an address space range:
+ *
+ * Address ranges created with this ioctl are reserved for later use with
+ * fixed-address buffer mappings.
+ *
+ * If _FLAGS_FIXED_OFFSET is specified then the new range starts at the 'offset'
+ * given.  Otherwise the address returned is chosen to be a multiple of 'align.'
+ *
+ */
+struct nvgpu32_as_alloc_space_args {
+	__u32 pages;     /* in, pages */
+	__u32 page_size; /* in, bytes */
+	__u32 flags;     /* in */
+#define NVGPU_AS_ALLOC_SPACE_FLAGS_FIXED_OFFSET 0x1
+#define NVGPU_AS_ALLOC_SPACE_FLAGS_SPARSE 0x2
+	union {
+		__u64 offset; /* inout, byte address valid iff _FIXED_OFFSET */
+		__u64 align;  /* in, alignment multiple (0:={1 or n/a}) */
+	} o_a;
+};
+
+struct nvgpu_as_alloc_space_args {
+	__u64 pages;     /* in, pages */
+	__u32 page_size; /* in, bytes */
+	__u32 flags;     /* in */
+	union {
+		__u64 offset; /* inout, byte address valid iff _FIXED_OFFSET */
+		__u64 align;  /* in, alignment multiple (0:={1 or n/a}) */
+	} o_a;
+	__u32 padding[2];     /* in */
+};
+
+/*
+ * Releasing an address space range:
+ *
+ * The previously allocated region starting at 'offset' is freed.  If there are
+ * any buffers currently mapped inside the region the ioctl will fail.
+ */
+struct nvgpu_as_free_space_args {
+	__u64 offset; /* in, byte address */
+	__u64 pages;     /* in, pages */
+	__u32 page_size; /* in, bytes */
+	__u32 padding[3];
+};
+
+/*
+ * Binding a nvgpu channel to an address space:
+ *
+ * A channel must be bound to an address space before allocating a gpfifo
+ * in nvgpu.  The 'channel_fd' given here is the fd used to allocate the
+ * channel.  Once a channel has been bound to an address space it cannot
+ * be unbound (except for when the channel is destroyed).
+ */
+struct nvgpu_as_bind_channel_args {
+	__u32 channel_fd; /* in */
+};
+
+/*
+ * Mapping nvmap buffers into an address space:
+ *
+ * The start address is the 'offset' given if _FIXED_OFFSET is specified.
+ * Otherwise the address returned is a multiple of 'align.'
+ *
+ * If 'page_size' is set to 0 the nvmap buffer's allocation alignment/sizing
+ * will be used to determine the page size (largest possible).  The page size
+ * chosen will be returned back to the caller in the 'page_size' parameter in
+ * that case.
+ */
+#define NVGPU_AS_MAP_BUFFER_FLAGS_FIXED_OFFSET		(1 << 0)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_CACHEABLE		(1 << 2)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_UNMAPPED_PTE		(1 << 5)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_MAPPABLE_COMPBITS	(1 << 6)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_L3_ALLOC		(1 << 7)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_SYSTEM_COHERENT	(1 << 9)
+#define NVGPU_AS_MAP_BUFFER_FLAGS_TEGRA_RAW		(1 << 12)
+
+#define NVGPU_AS_MAP_BUFFER_FLAGS_ACCESS_BITMASK_OFFSET    10U
+#define NVGPU_AS_MAP_BUFFER_FLAGS_ACCESS_BITMASK_SIZE      2U
+
+#define NVGPU_AS_MAP_BUFFER_ACCESS_DEFAULT                 0U
+#define NVGPU_AS_MAP_BUFFER_ACCESS_READ_ONLY               1U
+#define NVGPU_AS_MAP_BUFFER_ACCESS_READ_WRITE              2U
+
+/*
+ * VM map buffer IOCTL
+ *
+ * This ioctl maps a buffer - generally a dma_buf FD - into the VM's address
+ * space. Usage of this API is as follows.
+ *
+ * @flags  [IN]
+ *
+ *   These are the flags passed to the IOCTL to modify the IOCTL behavior. The
+ *   following flags are supported:
+ *
+ *   %NVGPU_AS_MAP_BUFFER_FLAGS_FIXED_OFFSET
+ *
+ *     Specify that the mapping already has an address. The mapping address
+ *     must reside in an area already reserved with the as_alloc_space IOCTL.
+ *     If this flag is set then the @offset field must be populated with the
+ *     address to map to.
+ *
+ *   %NVGPU_AS_MAP_BUFFER_FLAGS_CACHEABLE
+ *
+ *     Specify that a mapping shall be GPU cachable.
+ *
+ *   %NVGPU_AS_MAP_BUFFER_FLAGS_UNMAPPED_PTE
+ *
+ *     Specify that a mapping shall be marked as invalid but otherwise
+ *     populated. This flag doesn't actually make a lot of sense. The
+ *     only reason to specify it is for testing replayable faults but
+ *     an actual useful implementation of such a feature would likely
+ *     not use this.
+ *
+ *     DEPRECATED: do not use! This will be removed in a future update.
+ *
+ *   %NVGPU_AS_MAP_BUFFER_FLAGS_MAPPABLE_COMPBITS
+ *
+ *     Deprecated.
+ *
+ *   %NVGPU_AS_MAP_BUFFER_FLAGS_SYSTEM_COHERENT
+ *
+ *     Specify that a mapping should use the system coherent aperture.
+ *     The mapping shall fail if the buffer is allocated from vidmem.
+ *
+ * @kind  [IN]
+ *
+ *   Specify the kind to use for the mapping.
+ *
+ * @compr_kind  [IN]
+ * @incompr_kind  [IN]
+ *
+ *   Specify the compressible and incompressible kinds to be used for the
+ *   mapping. The kernel will attempt to use @comp_kind and if for
+ *   some reason that is not possible will then fall back to using the
+ *   @incompr_kind.
+ *
+ * @dmabuf_fd  [IN]
+ *
+ *   FD pointing to the dmabuf that will be mapped into the GMMU.
+ *
+ * @page_size  [IN]
+ *
+ *   Specify the page size for the mapping. Must be set to a valid, supported
+ *   page size. If left unset this IOCTL will return -EINVAL. In general, a
+ *   small page size mapping will always be supported, but in certain cases of
+ *   compression this will not be the case.
+ *
+ * @buffer_offset  [IN]
+ *
+ *   Specify an offset into the physical buffer to begin the mapping at. For
+ *   example imagine a DMA buffer 32KB long. However, you wish to only map
+ *   this buffer starting at 8KB. In such a case you would pass 8KB as the
+ *   @buffer_offset. This is only available with fixed address mappings. All
+ *   regular (non-fixed) mappings require this field to be set to 0. This field
+ *   is in bytes.
+ *
+ * @mapping_size  [IN]
+ *
+ *   The size of the mapping in bytes. This is from the @buffer_offset position.
+ *   So for example, assuming you have a 32KB physical buffer and you want to
+ *   map only 8KB of it, starting at some offset, then you would specify 8192 in
+ *   this field. Of course this size + the buffer_offset must be less than the
+ *   length of the physical buffer; otherwise -EINVAL is returned. This is only
+ *   supported for fixed mappings.
+ *
+ * @offset  [IN, OUT]
+ *
+ *   The offset of the buffer in the GPU virtual address space. In other words
+ *   the virtual address of the buffer. If the
+ *   %NVGPU_AS_MAP_BUFFER_FLAGS_FIXED_OFFSET flag is set then this field must be
+ *   populated by userspace. In all cases the ultimate mapped address is
+ *   returned in this field. The field is in bytes.
+ */
+struct nvgpu_as_map_buffer_ex_args {
+	__u32 flags;		/* in/out */
+
+	/*
+	 * - If both compr_kind and incompr_kind are set
+	 *   (i.e., value is other than NV_KIND_INVALID),
+	 *   kernel attempts to use compr_kind first.
+	 *
+	 * - If compr_kind is set, kernel attempts to allocate
+	 *   comptags for the buffer. If successful,
+	 *   compr_kind is used as the PTE kind.
+	 *
+	 * - If incompr_kind is set, kernel uses incompr_kind as the
+	 *   PTE kind, if compr_kind cannot be used. Comptags are not
+	 *   allocated.
+	 *
+	 * - If neither compr_kind or incompr_kind is set, the
+	 *   map call will fail.
+	 */
+#define NV_KIND_INVALID -1
+	__s16 compr_kind;
+	__s16 incompr_kind;
+
+	__u32 dmabuf_fd;	/* in */
+	__u32 page_size;	/* inout, 0:= best fit to buffer */
+
+	__u64 buffer_offset;	/* in, offset of mapped buffer region */
+	__u64 mapping_size;	/* in, size of mapped buffer region */
+
+	__u64 offset;		/* in/out, we use this address if flag
+				 * FIXED_OFFSET is set. This will fail
+				 * if space is not properly allocated. The
+				 * actual virtual address to which we mapped
+				 * the buffer is returned in this field. */
+};
+
+/*
+ * Get info about buffer compbits. Requires that buffer is mapped with
+ * NVGPU_AS_MAP_BUFFER_FLAGS_MAPPABLE_COMPBITS.
+ *
+ * The compbits for a mappable buffer are organized in a mappable
+ * window to the compbits store. In case the window contains comptags
+ * for more than one buffer, the buffer comptag line index may differ
+ * from the window comptag line index.
+ */
+struct nvgpu_as_get_buffer_compbits_info_args {
+
+	/* in: address of an existing buffer mapping */
+	__u64 mapping_gva;
+
+	/* out: size of compbits mapping window (bytes) */
+	__u64 compbits_win_size;
+
+	/* out: comptag line index of the window start */
+	__u32 compbits_win_ctagline;
+
+	/* out: comptag line index of the buffer mapping */
+	__u32 mapping_ctagline;
+
+/* Buffer uses compbits */
+#define NVGPU_AS_GET_BUFFER_COMPBITS_INFO_FLAGS_HAS_COMPBITS    (1 << 0)
+
+/* Buffer compbits are mappable */
+#define NVGPU_AS_GET_BUFFER_COMPBITS_INFO_FLAGS_MAPPABLE        (1 << 1)
+
+/* Buffer IOVA addresses are discontiguous */
+#define NVGPU_AS_GET_BUFFER_COMPBITS_INFO_FLAGS_DISCONTIG_IOVA  (1 << 2)
+
+	/* out */
+	__u32 flags;
+
+	__u32 reserved1;
+};
+
+/*
+ * Map compbits of a mapped buffer to the GPU address space. The
+ * compbits mapping is automatically unmapped when the buffer is
+ * unmapped.
+ *
+ * The compbits mapping always uses small pages, it is read-only, and
+ * is GPU cacheable. The mapping is a window to the compbits
+ * store. The window may not be exactly the size of the cache lines
+ * for the buffer mapping.
+ */
+struct nvgpu_as_map_buffer_compbits_args {
+
+	/* in: address of an existing buffer mapping */
+	__u64 mapping_gva;
+
+	/* in: gva to the mapped compbits store window when
+	 * FIXED_OFFSET is set. Otherwise, ignored and should be be 0.
+	 *
+	 * For FIXED_OFFSET mapping:
+	 * - If compbits are already mapped compbits_win_gva
+	 *   must match with the previously mapped gva.
+	 * - The user must have allocated enough GVA space for the
+	 *   mapping window (see compbits_win_size in
+	 *   nvgpu_as_get_buffer_compbits_info_args)
+	 *
+	 * out: gva to the mapped compbits store window */
+	__u64 compbits_win_gva;
+
+	/* in: reserved, must be 0
+	   out: physical or IOMMU address for mapping */
+	union {
+		/* contiguous iova addresses */
+		__u64 mapping_iova;
+
+		/* buffer to receive discontiguous iova addresses (reserved) */
+		__u64 mapping_iova_buf_addr;
+	};
+
+	/* in: Buffer size (in bytes) for discontiguous iova
+	 * addresses. Reserved, must be 0. */
+	__u64 mapping_iova_buf_size;
+
+#define NVGPU_AS_MAP_BUFFER_COMPBITS_FLAGS_FIXED_OFFSET        (1 << 0)
+	__u32 flags;
+	__u32 reserved1;
+};
+
+/*
+ * Unmapping a buffer:
+ *
+ * To unmap a previously mapped buffer set 'offset' to the offset returned in
+ * the mapping call.  This includes where a buffer has been mapped into a fixed
+ * offset of a previously allocated address space range.
+ */
+struct nvgpu_as_unmap_buffer_args {
+	__u64 offset; /* in, byte address */
+};
+
+
+struct nvgpu_as_va_region {
+	__u64 offset;
+	__u32 page_size;
+	__u32 reserved;
+	__u64 pages;
+};
+
+struct nvgpu_as_get_va_regions_args {
+	__u64 buf_addr; /* Pointer to array of nvgpu_as_va_region:s.
+			 * Ignored if buf_size is 0 */
+	__u32 buf_size; /* in:  userspace buf size (in bytes)
+			   out: kernel buf size    (in bytes) */
+	__u32 reserved;
+};
+
+struct nvgpu_as_map_buffer_batch_args {
+	__u64 unmaps; /* ptr to array of nvgpu_as_unmap_buffer_args */
+	__u64 maps;   /* ptr to array of nvgpu_as_map_buffer_ex_args */
+	__u32 num_unmaps; /* in: number of unmaps
+			   * out: on error, number of successful unmaps */
+	__u32 num_maps;   /* in: number of maps
+			   * out: on error, number of successful maps */
+	__u64 reserved;
+};
+
+struct nvgpu_as_get_sync_ro_map_args {
+	__u64 base_gpuva;
+	__u32 sync_size;
+	__u32 num_syncpoints;
+};
+
+/*
+ * VM mapping modify IOCTL
+ *
+ * This ioctl changes the kind of an existing mapped buffer region.
+ *
+ * Usage of this API is as follows.
+ *
+ * @compr_kind  [IN]
+ *
+ *   Specify the new compressed kind to be used for the mapping.  This
+ *   parameter is only valid if compression resources are allocated to the
+ *   underlying physical buffer. If NV_KIND_INVALID is specified then the
+ *   fallback incompr_kind parameter is used.
+ *
+ * @incompr_kind  [IN]
+ *
+ *   Specify the new kind to be used for the mapping if compression is not
+ *   to be used.  If NV_KIND_INVALID is specified then incompressible fallback
+ *   is not allowed.
+ *
+ * @buffer_offset  [IN]
+ *
+ *   Specifies the beginning offset of the region within the existing buffer
+ *   for which the kind should be modified.  This field is in bytes.
+ *
+ * @buffer_size  [IN]
+ *
+ *   Specifies the size of the region within the existing buffer for which the
+ *   kind should be updated.  This field is in bytes.  Note that the region
+ *   described by <buffer_offset, buffer_offset + buffer_size> must reside
+ *   entirely within the existing buffer.
+ *
+ * @map_address  [IN]
+ *
+ *   The address of the existing buffer in the GPU virtual address space
+ *   specified in bytes.
+ */
+struct nvgpu_as_mapping_modify_args {
+	__s16 compr_kind;       /* in */
+	__s16 incompr_kind;     /* in */
+
+	__u64 buffer_offset;	/* in, offset of mapped buffer region */
+	__u64 buffer_size;	/* in, size of mapped buffer region */
+
+	__u64 map_address;	/* in, base virtual address of mapped buffer */
+};
+
+/*
+ * VM remap operation.
+ *
+ * The VM remap operation structure represents a single map or unmap operation
+ * to be executed by the NVGPU_AS_IOCTL_REMAP ioctl.
+ *
+ * The format of the structure is as follows:
+ *
+ * @flags [IN]
+ *
+ *   The following remap operation flags are supported:
+ *
+ *     %NVGPU_AS_REMAP_OP_FLAGS_CACHEABLE
+ *
+ *       Specify that the associated mapping shall be GPU cachable.
+ *
+ *     %NVGPU_AS_REMAP_OP_FLAGS_ACCESS_NO_WRITE
+ *
+ *       Specify that the associated mapping shall be read-only.  This flag
+ *       must be set if the physical memory buffer represented by @mem_handle
+ *       is mapped read-only.
+ *
+ *     %NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_4K
+ *     %NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_64K
+ *     %NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_128K
+ *
+ *       One, and only one, of these flags must be set for both map/unmap
+ *       ops and indicates the assumed page size of the mem_offset_in_pages
+ *       and virt_offset_in_pages. This value is also verified against the
+ *       page size of the address space.
+ *
+ * @compr_kind  [IN/OUT]
+ * @incompr_kind  [IN/OUT]
+ *
+ *   On input these fields specify the compressible and incompressible kinds
+ *   to be used for the mapping.  If @compr_kind is not set to NV_KIND_INVALID
+ *   then nvgpu will attempt to allocate compression resources.  If
+ *   @compr_kind is set to NV_KIND_INVALID or there are no compression
+ *   resources then nvgpu will attempt to use @incompr_kind.  If both
+ *   @compr_kind and @incompr_kind are set to NV_KIND_INVALID then -EINVAL is
+ *   returned.  These fields must be set to NV_KIND_INVALID for unmap
+ *   operations.  On output these fields return the selected kind.  If
+ *   @compr_kind is set to a valid compressible kind but the required
+ *   compression resources are not available then @compr_kind will return
+ *   NV_INVALID_KIND and the @incompr_kind value will be used for the mapping.
+ *
+ * @mem_handle [IN]
+ *
+ *   Specify the memory handle (dmabuf_fd) associated with the physical
+ *   memory buffer to be mapped.  This field must be zero for unmap
+ *   operations.
+ *
+ * @mem_offset_in_pages [IN]
+ *
+ *   Specify an offset (in pages) into the physical buffer associated with
+ *   mem_handle at which to start the mapping.  This value must be zero for
+ *   unmap operations.
+ *
+ * @virt_offset_in_pages [IN]
+ *
+ *   Specify the virtual memory start offset (in pages) of the region to map
+ *   or unmap.
+ *
+ * @num_pages [IN]
+ *   Specify the number of pages to map or unmap.
+ */
+struct nvgpu_as_remap_op {
+#define NVGPU_AS_REMAP_OP_FLAGS_CACHEABLE               (1 << 2)
+#define NVGPU_AS_REMAP_OP_FLAGS_ACCESS_NO_WRITE         (1 << 10)
+#define NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_4K             (1 << 15)
+#define NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_64K            (1 << 16)
+#define NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_128K           (1 << 17)
+
+	/* in: For map and unmap (one and only one) of the _PAGESIZE_ flags is
+     * required to interpret the mem_offset_in_pages and virt_offset_in_pages
+     * correctly. The other flags are used only with map operations. */
+	__u32 flags;
+
+	/* in: For map operations, this field specifies the desired
+	 * compressible kind.  For unmap operations this field must be set
+	 * to NV_KIND_INVALID.
+	 * out: For map operations this field returns the actual kind used
+	 * for the mapping.  This can be useful for detecting if a compressed
+	 * mapping request was forced to use the fallback incompressible kind
+	 * value because sufficient compression resources are not available. */
+	__s16 compr_kind;
+
+	/* in: For map operations, this field specifies the desired
+	 * incompressible kind.  This value will be used as the fallback kind
+	 * if a valid compressible kind value was specified in the compr_kind
+	 * field but sufficient compression resources are not available.  For
+	 * unmap operations this field must be set to NV_KIND_INVALID. */
+	__s16 incompr_kind;
+
+	/* in: For map operations, this field specifies the handle (dmabuf_fd)
+	 * for the physical memory buffer to map into the specified virtual
+	 * address range.  For unmap operations, this field must be set to
+         * zero. */
+	__u32 mem_handle;
+
+	/* This field is reserved for padding purposes. */
+	__s32 reserved;
+
+	/* in: For map operations this field specifies the offset (in pages)
+	 * into the physical memory buffer associated with mem_handle from
+	 * from which physical page information should be collected for
+	 * the mapping.  For unmap operations this field must be zero. */
+	__u64 mem_offset_in_pages;
+
+	/* in: For both map and unmap operations this field specifies the
+	 * virtual address space start offset in pages for the operation. */
+	__u64 virt_offset_in_pages;
+
+	/* in: For both map and unmap operations this field specifies the
+	 * number of pages to map or unmap. */
+	__u64 num_pages;
+};
+
+/*
+ * VM remap IOCTL
+ *
+ * This ioctl can be used to issue multiple map and/or unmap operations in
+ * a single request.  VM remap operations are only valid on address spaces
+ * that have been allocated with NVGPU_AS_ALLOC_SPACE_FLAGS_SPARSE.
+ * Validation of remap operations is performed before any changes are made
+ * to the associated sparse address space so either all map and/or unmap
+ * operations are performed or none of them are.
+ */
+struct nvgpu_as_remap_args {
+	/* in: This field specifies a pointer into the caller's address space
+	 * containing an array of one or more nvgpu_as_remap_op structures. */
+	__u64 ops;
+
+	/* in/out: On input this field specifies the number of operations in
+	 * the ops array.  On output this field returns the successful
+	 * number of remap operations. */
+	__u32 num_ops;
+};
+
+#define NVGPU_AS_IOCTL_BIND_CHANNEL \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 1, struct nvgpu_as_bind_channel_args)
+#define NVGPU32_AS_IOCTL_ALLOC_SPACE \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 2, struct nvgpu32_as_alloc_space_args)
+#define NVGPU_AS_IOCTL_FREE_SPACE \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 3, struct nvgpu_as_free_space_args)
+#define NVGPU_AS_IOCTL_UNMAP_BUFFER \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 5, struct nvgpu_as_unmap_buffer_args)
+#define NVGPU_AS_IOCTL_ALLOC_SPACE \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 6, struct nvgpu_as_alloc_space_args)
+#define NVGPU_AS_IOCTL_MAP_BUFFER_EX \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 7, struct nvgpu_as_map_buffer_ex_args)
+#define NVGPU_AS_IOCTL_GET_VA_REGIONS \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 8, struct nvgpu_as_get_va_regions_args)
+#define NVGPU_AS_IOCTL_GET_BUFFER_COMPBITS_INFO \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 9, struct nvgpu_as_get_buffer_compbits_info_args)
+#define NVGPU_AS_IOCTL_MAP_BUFFER_COMPBITS \
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 10, struct nvgpu_as_map_buffer_compbits_args)
+#define NVGPU_AS_IOCTL_MAP_BUFFER_BATCH	\
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 11, struct nvgpu_as_map_buffer_batch_args)
+#define NVGPU_AS_IOCTL_GET_SYNC_RO_MAP	\
+	_IOR(NVGPU_AS_IOCTL_MAGIC,  12, struct nvgpu_as_get_sync_ro_map_args)
+#define NVGPU_AS_IOCTL_MAPPING_MODIFY	\
+	_IOWR(NVGPU_AS_IOCTL_MAGIC,  13, struct nvgpu_as_mapping_modify_args)
+#define NVGPU_AS_IOCTL_REMAP		\
+	_IOWR(NVGPU_AS_IOCTL_MAGIC, 14, struct nvgpu_as_remap_args)
+
+#define NVGPU_AS_IOCTL_LAST		\
+	_IOC_NR(NVGPU_AS_IOCTL_REMAP)
+#define NVGPU_AS_IOCTL_MAX_ARG_SIZE	\
+	sizeof(struct nvgpu_as_map_buffer_ex_args)
+
+#endif /* #define _UAPI__LINUX_NVGPU_AS_H__ */

--- a/extra/tegra_gpu_driver/nvgpu-ctrl.h
+++ b/extra/tegra_gpu_driver/nvgpu-ctrl.h
@@ -1,0 +1,1304 @@
+/*
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * Legacy node:   /dev/nvhost-ctrl-gpu device
+ * New hierarchy: /dev/nvgpu/igpu0/ctrl
+ *
+ * This device serves as the core control node for NvGPU. From this node
+ * one can query GPU device information, instantiate GPU device objects
+ * (TSGs, address spaces, etc), and do various other non-context specific
+ * things.
+ */
+
+#ifndef _UAPI__LINUX_NVGPU_CTRL_H__
+#define _UAPI__LINUX_NVGPU_CTRL_H__
+
+#include "nvgpu-uapi-common.h"
+
+#define NVGPU_GPU_IOCTL_MAGIC 'G'
+
+/* return zcull ctx size */
+struct nvgpu_gpu_zcull_get_ctx_size_args {
+	__u32 size;
+};
+
+/* return zcull info */
+struct nvgpu_gpu_zcull_get_info_args {
+	__u32 width_align_pixels;
+	__u32 height_align_pixels;
+	__u32 pixel_squares_by_aliquots;
+	__u32 aliquot_total;
+	__u32 region_byte_multiplier;
+	__u32 region_header_size;
+	__u32 subregion_header_size;
+	__u32 subregion_width_align_pixels;
+	__u32 subregion_height_align_pixels;
+	__u32 subregion_count;
+};
+
+#define NVGPU_ZBC_COLOR_VALUE_SIZE	4
+#define NVGPU_ZBC_TYPE_INVALID		0
+#define NVGPU_ZBC_TYPE_COLOR		1
+#define NVGPU_ZBC_TYPE_DEPTH		2
+#define NVGPU_ZBC_TYPE_STENCIL		3
+
+struct nvgpu_gpu_zbc_set_table_args {
+	__u32 color_ds[NVGPU_ZBC_COLOR_VALUE_SIZE];
+	__u32 color_l2[NVGPU_ZBC_COLOR_VALUE_SIZE];
+	__u32 depth;
+	__u32 stencil;
+	__u32 format;
+	__u32 type;	/* color, depth or stencil */
+};
+
+struct nvgpu_gpu_zbc_query_table_args {
+	__u32 color_ds[NVGPU_ZBC_COLOR_VALUE_SIZE];
+	__u32 color_l2[NVGPU_ZBC_COLOR_VALUE_SIZE];
+	__u32 depth;
+	__u32 stencil;
+	__u32 ref_cnt;
+	__u32 format;
+	__u32 type;		/* color, depth or stencil */
+	__u32 index_size;	/* [out] size, [in] index */
+};
+
+
+/* This contains the minimal set by which the userspace can
+   determine all the properties of the GPU */
+#define NVGPU_GPU_ARCH_GK100	0x000000E0
+#define NVGPU_GPU_ARCH_GM200	0x00000120
+#define NVGPU_GPU_ARCH_GP100	0x00000130
+#define NVGPU_GPU_ARCH_GV110	0x00000150
+#define NVGPU_GPU_ARCH_GV100	0x00000140
+
+#define NVGPU_GPU_IMPL_GK20A	0x0000000A
+#define NVGPU_GPU_IMPL_GM204	0x00000004
+#define NVGPU_GPU_IMPL_GM206	0x00000006
+#define NVGPU_GPU_IMPL_GM20B	0x0000000B
+#define NVGPU_GPU_IMPL_GM20B_B	0x0000000E
+#define NVGPU_GPU_IMPL_GP104	0x00000004
+#define NVGPU_GPU_IMPL_GP106	0x00000006
+#define NVGPU_GPU_IMPL_GP10B	0x0000000B
+#define NVGPU_GPU_IMPL_GV11B	0x0000000B
+#define NVGPU_GPU_IMPL_GV100	0x00000000
+
+#define NVGPU_GPU_BUS_TYPE_NONE         0
+#define NVGPU_GPU_BUS_TYPE_AXI         32
+
+#define NVGPU_GPU_FLAGS_HAS_SYNCPOINTS			(1ULL << 0)
+/* MAP_BUFFER_EX with sparse allocations */
+#define NVGPU_GPU_FLAGS_SUPPORT_SPARSE_ALLOCS		(1ULL << 2)
+/* sync fence FDs are available in, e.g., submit_gpfifo */
+#define NVGPU_GPU_FLAGS_SUPPORT_SYNC_FENCE_FDS		(1ULL << 3)
+/* NVGPU_DBG_GPU_IOCTL_CYCLE_STATS is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_CYCLE_STATS		(1ULL << 4)
+/* NVGPU_DBG_GPU_IOCTL_CYCLE_STATS_SNAPSHOT is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_CYCLE_STATS_SNAPSHOT	(1ULL << 6)
+/* Both gpu driver and device support TSG */
+#define NVGPU_GPU_FLAGS_SUPPORT_TSG			(1ULL << 8)
+/* Clock control support */
+#define NVGPU_GPU_FLAGS_SUPPORT_CLOCK_CONTROLS		(1ULL << 9)
+/* NVGPU_GPU_IOCTL_GET_VOLTAGE is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_GET_VOLTAGE		(1ULL << 10)
+/* NVGPU_GPU_IOCTL_GET_CURRENT is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_GET_CURRENT		(1ULL << 11)
+/* NVGPU_GPU_IOCTL_GET_POWER is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_GET_POWER		(1ULL << 12)
+/* NVGPU_GPU_IOCTL_GET_TEMPERATURE is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_GET_TEMPERATURE		(1ULL << 13)
+/* NVGPU_GPU_IOCTL_SET_THERM_ALERT_LIMIT is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_SET_THERM_ALERT_LIMIT	(1ULL << 14)
+/* NVGPU_GPU_IOCTL_GET_EVENT_FD is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_DEVICE_EVENTS		(1ULL << 15)
+/* FECS context switch tracing is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_FECS_CTXSW_TRACE	(1ULL << 16)
+/* NVGPU_AS_IOCTL_MAP_BUFFER_COMPBITS is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_MAP_COMPBITS		(1ULL << 17)
+/* Fast deterministic submits with no job tracking are supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_DETERMINISTIC_SUBMIT_NO_JOBTRACKING (1ULL << 18)
+/* Deterministic submits are supported even with job tracking */
+#define NVGPU_GPU_FLAGS_SUPPORT_DETERMINISTIC_SUBMIT_FULL (1ULL << 19)
+/* IO coherence support is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_IO_COHERENCE		(1ULL << 20)
+/* NVGPU_IOCTL_CHANNEL_RESCHEDULE_RUNLIST is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_RESCHEDULE_RUNLIST	(1ULL << 21)
+/*  subcontexts are available */
+#define NVGPU_GPU_FLAGS_SUPPORT_TSG_SUBCONTEXTS         (1ULL << 22)
+/* NVGPU_GPU_IOCTL_SET_DETERMINISTIC_OPTS is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_DETERMINISTIC_OPTS	(1ULL << 24)
+/* SCG support is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_SCG			(1ULL << 25)
+/* GPU_VA address of a syncpoint is supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_SYNCPOINT_ADDRESS	(1ULL << 26)
+/* VPR is supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_VPR			(1ULL << 27)
+/* Allocating per-channel syncpoint in user space is supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_USER_SYNCPOINT		(1ULL << 28)
+/* Railgating (powering the GPU off completely) is supported and enabled */
+#define NVGPU_GPU_FLAGS_CAN_RAILGATE			(1ULL << 29)
+/* Usermode submit is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_USERMODE_SUBMIT		(1ULL << 30)
+/* Reduced profile is enabled */
+#define NVGPU_GPU_FLAGS_DRIVER_REDUCED_PROFILE		(1ULL << 31)
+/* Set MMU debug mode is available */
+#define NVGPU_GPU_FLAGS_SUPPORT_SET_CTX_MMU_DEBUG_MODE	(1ULL << 32)
+/* Fault recovery is enabled */
+#define NVGPU_GPU_FLAGS_SUPPORT_FAULT_RECOVERY		(1ULL << 33)
+/* Mapping modify is enabled */
+#define NVGPU_GPU_FLAGS_SUPPORT_MAPPING_MODIFY		(1ULL << 34)
+/* Remap is enabled */
+#define NVGPU_GPU_FLAGS_SUPPORT_REMAP			(1ULL << 35)
+/* Compression is enabled */
+#define NVGPU_GPU_FLAGS_SUPPORT_COMPRESSION		(1ULL << 36)
+/* SM TTU is enabled */
+#define NVGPU_GPU_FLAGS_SUPPORT_SM_TTU			(1ULL << 37)
+/* Compression PLC is enabled */
+#define NVGPU_GPU_FLAGS_SUPPORT_POST_L2_COMPRESSION	(1ULL << 38)
+/** GMMU map access type available */
+#define NVGPU_GPU_FLAGS_SUPPORT_MAP_ACCESS_TYPE		(1ULL << 39)
+/* Flag to indicate whether 2d operations are supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_2D			(1ULL << 40)
+/* Flag to indicate whether 3d graphics operations are supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_3D			(1ULL << 41)
+/* Flag to indicate whether compute operations are supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_COMPUTE			(1ULL << 42)
+/* Flag to indicate whether inline methods are supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_I2M			(1ULL << 43)
+/* Flag to indicate whether zbc classes are supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_ZBC			(1ULL << 44)
+/* Profiler V2 device objects are supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_PROFILER_V2_DEVICE	(1ULL << 46)
+/* Profiler V2 context objects are supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_PROFILER_V2_CONTEXT	(1ULL << 47)
+/* Profiling SMPC in global mode is supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_SMPC_GLOBAL_MODE	(1ULL << 48)
+/* Retrieving contents of graphics context is supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_GET_GR_CONTEXT	    (1ULL << 49)
+/*
+ * Note: Additional buffer metadata association support. This feature is only
+ * for supporting legacy userspace APIs and for compatibility with desktop
+ * RM behavior. Usage of this feature should be avoided.
+ */
+#define NVGPU_GPU_FLAGS_SUPPORT_BUFFER_METADATA		(1ULL << 50)
+/* Flag to indicate whether configuring L2_MAXEVICTLAST_WAYS is supported */
+#define NVGPU_GPU_FLAGS_L2_MAX_WAYS_EVICT_LAST_ENABLED	(1ULL << 51)
+/* Vidmem access bits feature is supported */
+#define NVGPU_GPU_FLAGS_SUPPORT_VAB		(1ULL << 52)
+/* The NVS scheduler interface is usable */
+#define NVGPU_GPU_FLAGS_SUPPORT_NVS		(1ULL << 53)
+/* Flag to indicate whether implicit ERRBAR is supported */
+#define NVGPU_GPU_FLAGS_SCHED_EXIT_WAIT_FOR_ERRBAR_SUPPORTED    (1ULL << 55)
+/* Flag to indicate whether multi-process TSG sharing is supported */
+#define NVGPU_GPU_FLAGS_MULTI_PROCESS_TSG_SHARING    (1ULL << 56)
+/* SM LRF ECC is enabled */
+#define NVGPU_GPU_FLAGS_ECC_ENABLED_SM_LRF	(1ULL << 60)
+/* Flag to indicate GPU MMIO support */
+#define NVGPU_GPU_FLAGS_SUPPORT_GPU_MMIO	(1ULL << 57)
+/* SM SHM ECC is enabled */
+#define NVGPU_GPU_FLAGS_ECC_ENABLED_SM_SHM	(1ULL << 61)
+/* TEX ECC is enabled */
+#define NVGPU_GPU_FLAGS_ECC_ENABLED_TEX		(1ULL << 62)
+/* L2 ECC is enabled */
+#define NVGPU_GPU_FLAGS_ECC_ENABLED_LTC		(1ULL << 63)
+/* All types of ECC are enabled */
+#define NVGPU_GPU_FLAGS_ALL_ECC_ENABLED	\
+				(NVGPU_GPU_FLAGS_ECC_ENABLED_SM_LRF |	\
+				NVGPU_GPU_FLAGS_ECC_ENABLED_SM_SHM |	\
+				NVGPU_GPU_FLAGS_ECC_ENABLED_TEX    |	\
+				NVGPU_GPU_FLAGS_ECC_ENABLED_LTC)
+
+struct nvgpu_gpu_characteristics {
+	__u32 arch;
+	__u32 impl;
+	__u32 rev;
+	__u32 num_gpc;
+
+	/*
+	 * Specifies the NUMA domain for the GPU device
+	 * A value of "-1" specifies no NUMA domain info.
+	 */
+#define NVGPU_GPU_CHARACTERISTICS_NO_NUMA_INFO (-1)
+	__s32 numa_domain_id;
+
+	__u64 L2_cache_size;               /* bytes */
+	__u64 on_board_video_memory_size;  /* bytes */
+
+	__u32 num_tpc_per_gpc; /* the architectural maximum */
+	__u32 bus_type;
+
+	__u32 big_page_size; /* the default big page size */
+	__u32 compression_page_size;
+
+	__u32 pde_coverage_bit_count;
+
+	/* bit N set ==> big page size 2^N is available in
+	   NVGPU_GPU_IOCTL_ALLOC_AS. The default big page size is
+	   always available regardless of this field. */
+	__u32 available_big_page_sizes;
+
+	__u64 flags;
+
+	__u32 twod_class;
+	__u32 threed_class;
+	__u32 compute_class;
+	__u32 gpfifo_class;
+	__u32 inline_to_memory_class;
+	__u32 dma_copy_class;
+
+	__u32 gpc_mask; /* enabled GPCs */
+
+	__u32 sm_arch_sm_version; /* sm version */
+	__u32 sm_arch_spa_version; /* sm instruction set */
+	__u32 sm_arch_warp_count;
+
+	/* IOCTL interface levels by service. -1 if not supported */
+	__s16 gpu_ioctl_nr_last;
+	__s16 tsg_ioctl_nr_last;
+	__s16 dbg_gpu_ioctl_nr_last;
+	__s16 ioctl_channel_nr_last;
+	__s16 as_ioctl_nr_last;
+
+	__u8 gpu_va_bit_count;
+	__u8 reserved;
+
+	__u32 max_fbps_count;
+	__u32 fbp_en_mask;
+	__u32 emc_en_mask;
+	__u32 max_ltc_per_fbp;
+	__u32 max_lts_per_ltc;
+	__u32 max_tex_per_tpc;
+	__u32 max_gpc_count;
+	/* mask of Rop_L2 for each FBP */
+	__u32 rop_l2_en_mask_DEPRECATED[2];
+
+
+	__u8 chipname[8];
+
+	__u64 gr_compbit_store_base_hw;
+	__u32 gr_gobs_per_comptagline_per_slice;
+	__u32 num_ltc;
+	__u32 lts_per_ltc;
+	__u32 cbc_cache_line_size;
+	__u32 cbc_comptags_per_line;
+
+	/* MAP_BUFFER_BATCH: the upper limit for num_unmaps and
+	 * num_maps */
+	__u32 map_buffer_batch_limit;
+
+	__u64 max_freq;
+
+	/* supported preemption modes */
+	__u32 graphics_preemption_mode_flags; /* NVGPU_GRAPHICS_PREEMPTION_MODE_* */
+	__u32 compute_preemption_mode_flags; /* NVGPU_COMPUTE_PREEMPTION_MODE_* */
+	/* default preemption modes */
+	__u32 default_graphics_preempt_mode; /* NVGPU_GRAPHICS_PREEMPTION_MODE_* */
+	__u32 default_compute_preempt_mode; /* NVGPU_COMPUTE_PREEMPTION_MODE_* */
+
+	__u64 local_video_memory_size; /* in bytes, non-zero only for dGPUs */
+
+	/* These are meaningful only for PCI devices */
+	__u16 pci_vendor_id, pci_device_id;
+	__u16 pci_subsystem_vendor_id, pci_subsystem_device_id;
+	__u16 pci_class;
+	__u8  pci_revision;
+	__u8  vbios_oem_version;
+	__u32 vbios_version;
+
+	/* NVGPU_DBG_GPU_IOCTL_REG_OPS: the upper limit for the number
+	 * of regops */
+	__u32 reg_ops_limit;
+	__u32 reserved1;
+
+	__s16 event_ioctl_nr_last;
+	__u16 pad;
+
+	__u32 max_css_buffer_size;
+
+	__s16 ctxsw_ioctl_nr_last;
+	__s16 prof_ioctl_nr_last;
+	__s16 nvs_ioctl_nr_last;
+	__u8 reserved2[2];
+
+	__u32 max_ctxsw_ring_buffer_size;
+	__u32 reserved3;
+
+	__u64 per_device_identifier;
+
+	__u32 num_ppc_per_gpc;
+	__u32 max_veid_count_per_tsg;
+
+	__u32 num_sub_partition_per_fbpa;
+	__u32 gpu_instance_id;
+
+	__u32 gr_instance_id;
+
+	/** Max gpfifo entries allowed by nvgpu-rm. */
+	__u32 max_gpfifo_entries;
+
+	__u32 max_dbg_tsg_timeslice;
+	__u32 reserved5;
+
+	/*
+	 * Instance id of the opened ctrl node. Unique number over the
+	 * nvgpu driver's lifetime (probe to unload).
+	 */
+	__u64 device_instance_id;
+
+	/* Notes:
+	   - This struct can be safely appended with new fields. However, always
+	     keep the structure size multiple of 8 and make sure that the binary
+	     layout does not change between 32-bit and 64-bit architectures.
+	   - If the last field is reserved/padding, it is not
+	     generally safe to repurpose the field in future revisions.
+	*/
+};
+
+struct nvgpu_gpu_get_characteristics {
+	/* [in]  size reserved by the user space. Can be 0.
+	   [out] full buffer size by kernel */
+	__u64 gpu_characteristics_buf_size;
+
+	/* [in]  address of nvgpu_gpu_characteristics buffer. Filled with field
+	   values by exactly MIN(buf_size_in, buf_size_out) bytes. Ignored, if
+	   buf_size_in is zero.  */
+	__u64 gpu_characteristics_buf_addr;
+};
+
+#define NVGPU_GPU_COMPBITS_NONE		0
+#define NVGPU_GPU_COMPBITS_GPU		(1 << 0)
+#define NVGPU_GPU_COMPBITS_CDEH		(1 << 1)
+#define NVGPU_GPU_COMPBITS_CDEV		(1 << 2)
+
+struct nvgpu_gpu_prepare_compressible_read_args {
+	__u32 handle;			/* in, dmabuf fd */
+	union {
+		__u32 request_compbits;	/* in */
+		__u32 valid_compbits;	/* out */
+	};
+	__u64 offset;			/* in, within handle */
+	__u64 compbits_hoffset;		/* in, within handle */
+	__u64 compbits_voffset;		/* in, within handle */
+	__u32 width;			/* in, in pixels */
+	__u32 height;			/* in, in pixels */
+	__u32 block_height_log2;	/* in */
+	__u32 submit_flags;		/* in (NVGPU_SUBMIT_GPFIFO_FLAGS_) */
+	union {
+		struct {
+			__u32 syncpt_id;
+			__u32 syncpt_value;
+		};
+		__s32 fd;
+	} fence;			/* in/out */
+	__u32 zbc_color;		/* out */
+	__u32 reserved;		/* must be zero */
+	__u64 scatterbuffer_offset;	/* in, within handle */
+	__u32 reserved2[2];		/* must be zero */
+};
+
+struct nvgpu_gpu_mark_compressible_write_args {
+	__u32 handle;			/* in, dmabuf fd */
+	__u32 valid_compbits;		/* in */
+	__u64 offset;			/* in, within handle */
+	__u32 zbc_color;		/* in */
+	__u32 reserved[3];		/* must be zero */
+};
+
+struct nvgpu_alloc_as_args {
+	__u32 big_page_size;	/* zero for no big pages for this VA */
+	__s32 as_fd;
+
+/*
+ * The GPU address space will be managed by the userspace. This has
+ * the following changes in functionality:
+ *   1. All non-fixed-offset user mappings are rejected (i.e.,
+ *      fixed-offset only)
+ *   2. Address space does not need to be allocated for fixed-offset
+ *      mappings, except to mark sparse address space areas.
+ *   3. Maps and unmaps are immediate. In particular, mapping ref
+ *      increments at kickoffs and decrements at job completion are
+ *      bypassed.
+ */
+#define NVGPU_GPU_IOCTL_ALLOC_AS_FLAGS_UNIFIED_VA	 	(1 << 1)
+	__u32 flags;
+	__u32 reserved;		/* must be zero */
+	__u64 va_range_start;	/* in: starting VA (aligned by PDE) */
+	__u64 va_range_end;	/* in: ending VA (aligned by PDE) */
+	__u64 va_range_split;	/* in: small/big page split (aligned by PDE,
+				 * must be zero if UNIFIED_VA is set) */
+	__u32 padding[6];
+};
+
+/*
+ * NVGPU_GPU_IOCTL_OPEN_TSG - create/share TSG ioctl.
+ *
+ * This IOCTL allocates one of the available TSG for user when called
+ * without share token specified. When called with share token specified,
+ * fd is created for already allocated TSG for sharing the TSG under
+ * different device/CTRL object hierarchies in different processes.
+ *
+ * Source device is specified in the arguments and target device is
+ * implied from the caller. Share token is unique for a TSG.
+ *
+ * When the TSG is successfully created first time or is opened with share
+ * token, the device instance id associated with the CTRL fd will be added
+ * to the TSG private data structure as authorized device instance ids.
+ * This is used for a security check when creating a TSG share token with
+ * nvgpu_tsg_get_share_token.
+ *
+ * return 0 on success, -1 on error.
+ * retval EINVAL if invalid parameters are specified (if TSG_FLAGS_SHARE
+ *               is set but source_device_instance_id and/or share token
+ *               are zero or TSG_FLAGS_SHARE is not set but other
+ *               arguments are non-zero).
+ * retval EINVAL if share token doesn't exist or is expired.
+ */
+
+/*
+ * Specify that the newly created TSG fd will map to existing hardware
+ * TSG resources.
+ */
+#define NVGPU_GPU_IOCTL_OPEN_TSG_FLAGS_SHARE	((__u32)1U << 0U)
+
+/* Arguments for NVGPU_GPU_IOCTL_OPEN_TSG */
+struct nvgpu_gpu_open_tsg_args {
+	__u32 tsg_fd;		/* out: tsg fd */
+	__u32 flags;		/* in: NVGPU_GPU_IOCTL_OPEN_TSG_FLAGS_* */
+
+	__u64 source_device_instance_id; /*
+					  * in: source device instance id
+					  * that created the token. Ignored when
+					  * NVGPU_GPU_IOCTL_OPEN_TSG_FLAGS_SHARE
+					  * is unset.
+					  */
+
+	__u64 share_token;	/*
+				 * in: share token obtained from
+				 * NVGPU_TSG_IOCTL_GET_SHARE_TOKEN. Ignored when
+				 * NVGPU_GPU_IOCTL_OPEN_TSG_FLAGS_SHARE
+				 * is unset.
+				 */
+};
+
+struct nvgpu_gpu_get_tpc_masks_args {
+	/* [in]  TPC mask buffer size reserved by userspace. Should be
+		 at least sizeof(__u32) * fls(gpc_mask) to receive TPC
+		 mask for each GPC.
+	   [out] full kernel buffer size
+	*/
+	__u32 mask_buf_size;
+	__u32 reserved;
+
+	/* [in]  pointer to TPC mask buffer. It will receive one
+		 32-bit TPC mask per GPC or 0 if GPC is not enabled or
+		 not present. This parameter is ignored if
+		 mask_buf_size is 0. */
+	__u64 mask_buf_addr;
+};
+
+struct nvgpu_gpu_get_gpc_physical_map_args {
+	/* [in] GPC logical-map-buffer size. It must be
+	 * sizeof(__u32) * popcnt(gpc_mask)
+	 */
+	__u32 map_buf_size;
+	__u32 reserved;
+
+	/* [out] pointer to array of u32 entries.
+	 * For each entry, index=local gpc index and value=physical gpc index.
+	 */
+	__u64 physical_gpc_buf_addr;
+};
+
+struct nvgpu_gpu_get_gpc_logical_map_args {
+	/* [in] GPC logical-map-buffer size. It must be
+	 * sizeof(__u32) * popcnt(gpc_mask)
+	 */
+	__u32 map_buf_size;
+	__u32 reserved;
+
+	/* [out] pointer to array of u32 entries.
+	 * For each entry, index=local gpc index and value=logical gpc index.
+	 */
+	__u64 logical_gpc_buf_addr;
+};
+
+struct nvgpu_gpu_open_channel_args {
+	union {
+		__s32 channel_fd; /* deprecated: use out.channel_fd instead */
+		struct {
+			 /* runlist_id is the runlist for the
+			  * channel. Basically, the runlist specifies the target
+			  * engine(s) for which the channel is
+			  * opened. Runlist_id -1 is synonym for the primary
+			  * graphics runlist. */
+			__s32 runlist_id;
+		} in;
+		struct {
+			__s32 channel_fd;
+		} out;
+	};
+};
+
+/* L2 cache writeback, optionally invalidate clean lines and flush fb */
+struct nvgpu_gpu_l2_fb_args {
+	__u32 l2_flush:1;
+	__u32 l2_invalidate:1;
+	__u32 fb_flush:1;
+	__u32 reserved;
+} __packed;
+
+struct nvgpu_gpu_mmu_debug_mode_args {
+	__u32 state;
+	__u32 reserved;
+};
+
+struct nvgpu_gpu_sm_debug_mode_args {
+	int channel_fd;
+	__u32 enable;
+	__u64 sms;
+};
+
+struct warpstate {
+	__u64 valid_warps[2];
+	__u64 trapped_warps[2];
+	__u64 paused_warps[2];
+};
+
+struct nvgpu_gpu_wait_pause_args {
+	__u64 pwarpstate;
+};
+
+struct nvgpu_gpu_tpc_exception_en_status_args {
+	__u64 tpc_exception_en_sm_mask;
+};
+
+struct nvgpu_gpu_num_vsms {
+	__u32 num_vsms;
+	__u32 reserved;
+};
+
+struct nvgpu_gpu_vsms_mapping_entry {
+	/* Logical GPC index */
+	__u8 gpc_logical_index;
+
+	/* Virtual GPC index */
+	__u8 gpc_virtual_index;
+
+	/* Local Logical index in TPC */
+	__u8 tpc_local_logical_index;
+
+	/* Global Logical index in GPU */
+	__u8 tpc_global_logical_index;
+
+	/* Local SM index in TPC */
+	__u8 sm_local_id;
+
+	/* Migratable TPC index */
+	__u8 tpc_migratable_index;
+};
+
+struct nvgpu_gpu_vsms_mapping {
+	__u64 vsms_map_buf_addr;
+};
+
+/*
+ * get buffer information ioctl.
+ *
+ * Note: Additional metadata is available with the buffer only for supporting
+ * legacy userspace APIs and for compatibility with desktop RM. Usage of this
+ * API should be avoided.
+ *
+ * This ioctl returns information about buffer to libnvrm_gpu. This information
+ * includes buffer registration status, comptags allocation status, size of the
+ * buffer, copy of the metadata blob associated with the buffer during
+ * registration based on input size and size of the metadata blob
+ * registered.
+ *
+ * return 0 on success, < 0 in case of failure. Note that If the buffer
+ *         has no privdata allocated or if it is not registered, this
+ *         devctl returns 0 with only size.
+ * retval -EINVAL if the enabled flag NVGPU_SUPPORT_BUFFER_METADATA isn't
+ *                set or invalid params.
+ * retval -EFAULT if the metadata blob copy fails.
+ */
+
+/*
+ * If the buffer registration is done, this flag is set in the output flags in
+ * the buffer info query ioctl.
+ */
+#define NVGPU_GPU_BUFFER_INFO_FLAGS_METADATA_REGISTERED		(1ULL << 0)
+
+/*
+ * If the comptags are allocated and enabled for the buffer, this flag is set
+ * in the output flags in the buffer info query ioctl.
+ */
+#define NVGPU_GPU_BUFFER_INFO_FLAGS_COMPTAGS_ALLOCATED		(1ULL << 1)
+
+/*
+ * If the metadata state (blob and comptags) of the buffer can be redefined,
+ * this flag is set in the output flags in the buffer info query ioctl.
+ */
+#define NVGPU_GPU_BUFFER_INFO_FLAGS_MUTABLE_METADATA		(1ULL << 2)
+
+/*
+ * get buffer info ioctl arguments struct.
+ *
+ * Note: Additional metadata is available with the buffer only for supporting
+ * legacy userspace APIs and for compatibility with desktop RM. Usage of this
+ * API should be avoided.
+ */
+struct nvgpu_gpu_get_buffer_info_args {
+	union {
+		struct {
+			/* [in] dma-buf fd */
+			__s32 dmabuf_fd;
+			/* [in] size reserved by the user space. */
+			__u32 metadata_size;
+			/* [in]  Pointer to receive the buffer metadata. */
+			__u64 metadata_addr;
+		} in;
+		struct {
+			/* [out] buffer information flags. */
+			__u64 flags;
+
+			/*
+			 * [out] buffer metadata size registered.
+			 *       this is always 0 for unregistered buffers.
+			 */
+			__u32 metadata_size;
+			__u32 reserved;
+
+			/* [out] allocated size of the buffer */
+			__u64 size;
+		} out;
+	};
+};
+
+#define NVGPU_GPU_GET_CPU_TIME_CORRELATION_INFO_MAX_COUNT		16
+#define NVGPU_GPU_GET_CPU_TIME_CORRELATION_INFO_SRC_ID_TSC		1
+#define NVGPU_GPU_GET_CPU_TIME_CORRELATION_INFO_SRC_ID_OSTIME	2
+
+struct nvgpu_gpu_get_cpu_time_correlation_sample {
+	/* gpu timestamp value */
+	__u64 cpu_timestamp;
+	/* raw GPU counter (PTIMER) value */
+	__u64 gpu_timestamp;
+};
+
+struct nvgpu_gpu_get_cpu_time_correlation_info_args {
+	/* timestamp pairs */
+	struct nvgpu_gpu_get_cpu_time_correlation_sample samples[
+		NVGPU_GPU_GET_CPU_TIME_CORRELATION_INFO_MAX_COUNT];
+	/* number of pairs to read */
+	__u32 count;
+	/* cpu clock source id */
+	__u32 source_id;
+};
+
+struct nvgpu_gpu_get_gpu_time_args {
+	/* raw GPU counter (PTIMER) value */
+	__u64 gpu_timestamp;
+
+	/* reserved for future extensions */
+	__u64 reserved;
+};
+
+struct nvgpu_gpu_get_engine_info_item {
+
+#define NVGPU_GPU_ENGINE_ID_GR 0
+#define NVGPU_GPU_ENGINE_ID_GR_COPY 1
+#define NVGPU_GPU_ENGINE_ID_ASYNC_COPY 2
+#define NVGPU_GPU_ENGINE_ID_NVENC 5
+#define NVGPU_GPU_ENGINE_ID_OFA 6
+#define NVGPU_GPU_ENGINE_ID_NVDEC 7
+#define NVGPU_GPU_ENGINE_ID_NVJPG 8
+	__u32 engine_id;
+
+	__u32 engine_instance;
+
+	/* runlist id for opening channels to the engine, or -1 if
+	 * channels are not supported */
+	__s32 runlist_id;
+
+	__u32 reserved;
+};
+
+struct nvgpu_gpu_get_engine_info_args {
+	/* [in]  Buffer size reserved by userspace.
+	 *
+	 * [out] Full kernel buffer size. Multiple of sizeof(struct
+	 *       nvgpu_gpu_get_engine_info_item)
+	*/
+	__u32 engine_info_buf_size;
+	__u32 reserved;
+	__u64 engine_info_buf_addr;
+};
+
+#define NVGPU_GPU_ALLOC_VIDMEM_FLAG_CONTIGUOUS		(1U << 0)
+
+/* CPU access and coherency flags (3 bits). Use CPU access with care,
+ * BAR resources are scarce. */
+#define NVGPU_GPU_ALLOC_VIDMEM_FLAG_CPU_NOT_MAPPABLE	(0U << 1)
+#define NVGPU_GPU_ALLOC_VIDMEM_FLAG_CPU_WRITE_COMBINE	(1U << 1)
+#define NVGPU_GPU_ALLOC_VIDMEM_FLAG_CPU_CACHED		(2U << 1)
+#define NVGPU_GPU_ALLOC_VIDMEM_FLAG_CPU_MASK		(7U << 1)
+
+#define NVGPU_GPU_ALLOC_VIDMEM_FLAG_VPR			(1U << 4)
+
+/* Allocation of device-specific local video memory. Returns dmabuf fd
+ * on success. */
+struct nvgpu_gpu_alloc_vidmem_args {
+	union {
+		struct {
+			/* Size for allocation. Must be a multiple of
+			 * small page size. */
+			__u64 size;
+
+			/* NVGPU_GPU_ALLOC_VIDMEM_FLAG_* */
+			__u32 flags;
+
+			/* Informational mem tag for resource usage
+			 * tracking. */
+			__u16 memtag;
+
+			__u16 reserved0;
+
+			/* GPU-visible physical memory alignment in
+			 * bytes.
+			 *
+			 * Alignment must be a power of two. Minimum
+			 * alignment is the small page size, which 0
+			 * also denotes.
+			 *
+			 * For contiguous and non-contiguous
+			 * allocations, the start address of the
+			 * physical memory allocation will be aligned
+			 * by this value.
+			 *
+			 * For non-contiguous allocations, memory is
+			 * internally allocated in round_up(size /
+			 * alignment) contiguous blocks. The start
+			 * address of each block is aligned by the
+			 * alignment value. If the size is not a
+			 * multiple of alignment (which is ok), the
+			 * last allocation block size is (size %
+			 * alignment).
+			 *
+			 * By specifying the big page size here and
+			 * allocation size that is a multiple of big
+			 * pages, it will be guaranteed that the
+			 * allocated buffer is big page size mappable.
+			 */
+			__u32 alignment;
+
+			__u32 reserved1[3];
+		} in;
+
+		struct {
+			__s32 dmabuf_fd;
+		} out;
+	};
+};
+
+/* Memory clock */
+#define NVGPU_GPU_CLK_DOMAIN_MCLK                                (0)
+/* Main graphics core clock */
+#define NVGPU_GPU_CLK_DOMAIN_GPCCLK	                         (1)
+
+struct nvgpu_gpu_clk_range {
+
+	/* Flags (not currently used) */
+	__u32 flags;
+
+	/* NVGPU_GPU_CLK_DOMAIN_* */
+	__u32 clk_domain;
+	__u64 min_hz;
+	__u64 max_hz;
+};
+
+/* Request on specific clock domains */
+#define NVGPU_GPU_CLK_FLAG_SPECIFIC_DOMAINS		(1UL << 0)
+
+struct nvgpu_gpu_clk_range_args {
+
+	/* Flags. If NVGPU_GPU_CLK_FLAG_SPECIFIC_DOMAINS the request will
+	   apply only to domains specified in clock entries. In this case
+	   caller must set clock domain in each entry. Otherwise, the
+	   ioctl will return all clock domains.
+	*/
+	__u32 flags;
+
+	__u16 pad0;
+
+	/* in/out: Number of entries in clk_range_entries buffer. If zero,
+	   NVGPU_GPU_IOCTL_CLK_GET_RANGE will return 0 and
+	   num_entries will be set to number of clock domains.
+	 */
+	__u16 num_entries;
+
+	/* in: Pointer to clock range entries in the caller's address space.
+	   size must be >= max_entries * sizeof(struct nvgpu_gpu_clk_range)
+	 */
+	__u64 clk_range_entries;
+};
+
+struct nvgpu_gpu_clk_vf_point {
+	__u64 freq_hz;
+};
+
+struct nvgpu_gpu_clk_vf_points_args {
+
+	/* in: Flags (not currently used) */
+	__u32 flags;
+
+	/* in: NVGPU_GPU_CLK_DOMAIN_* */
+	__u32 clk_domain;
+
+	/* in/out: max number of nvgpu_gpu_clk_vf_point entries in
+	   clk_vf_point_entries.  If max_entries is zero,
+	   NVGPU_GPU_IOCTL_CLK_GET_VF_POINTS will return 0 and max_entries will
+	   be set to the max number of VF entries for this clock domain. If
+	   there are more entries than max_entries, then ioctl will return
+	   -EINVAL.
+	*/
+	__u16 max_entries;
+
+	/* out: Number of nvgpu_gpu_clk_vf_point entries returned in
+	   clk_vf_point_entries. Number of entries might vary depending on
+	   thermal conditions.
+	*/
+	__u16 num_entries;
+
+	__u32 reserved;
+
+	/* in: Pointer to clock VF point entries in the caller's address space.
+	   size must be >= max_entries * sizeof(struct nvgpu_gpu_clk_vf_point).
+	 */
+	__u64 clk_vf_point_entries;
+};
+
+/* Target clock requested by application*/
+#define NVGPU_GPU_CLK_TYPE_TARGET	1
+/* Actual clock frequency for the domain.
+   May deviate from desired target frequency due to PLL constraints. */
+#define NVGPU_GPU_CLK_TYPE_ACTUAL	2
+/* Effective clock, measured from hardware */
+#define NVGPU_GPU_CLK_TYPE_EFFECTIVE	3
+
+struct nvgpu_gpu_clk_info {
+
+	/* Flags (not currently used) */
+	__u16 flags;
+
+	/* in: When NVGPU_GPU_CLK_FLAG_SPECIFIC_DOMAINS set, indicates
+	   the type of clock info to be returned for this entry. It is
+	   allowed to have several entries with different clock types in
+	   the same request (for instance query both target and actual
+	   clocks for a given clock domain). This field is ignored for a
+	   SET operation. */
+	__u16 clk_type;
+
+	/* NVGPU_GPU_CLK_DOMAIN_xxx */
+	__u32 clk_domain;
+
+	__u64 freq_hz;
+};
+
+struct nvgpu_gpu_clk_get_info_args {
+
+	/* Flags. If NVGPU_GPU_CLK_FLAG_SPECIFIC_DOMAINS the request will
+	   apply only to domains specified in clock entries. In this case
+	   caller must set clock domain in each entry. Otherwise, the
+	   ioctl will return all clock domains.
+	*/
+	__u32 flags;
+
+	/* in: indicates which type of clock info to be returned (see
+	   NVGPU_GPU_CLK_TYPE_xxx). If NVGPU_GPU_CLK_FLAG_SPECIFIC_DOMAINS
+	   is defined, clk_type is specified in each clock info entry instead.
+	 */
+	__u16 clk_type;
+
+	/* in/out: Number of clock info entries contained in clk_info_entries.
+	   If zero, NVGPU_GPU_IOCTL_CLK_GET_INFO will return 0 and
+	   num_entries will be set to number of clock domains. Also,
+	   last_req_nr will be updated, which allows checking if a given
+	   request has completed. If there are more entries than max_entries,
+	   then ioctl will return -EINVAL.
+	 */
+	__u16 num_entries;
+
+	/* in: Pointer to nvgpu_gpu_clk_info entries in the caller's address
+	   space. Buffer size must be at least:
+		num_entries * sizeof(struct nvgpu_gpu_clk_info)
+	   If NVGPU_GPU_CLK_FLAG_SPECIFIC_DOMAINS is set, caller should set
+	   clk_domain to be queried in  each entry. With this flag,
+	   clk_info_entries passed to an NVGPU_GPU_IOCTL_CLK_SET_INFO,
+	   can be re-used on completion for a NVGPU_GPU_IOCTL_CLK_GET_INFO.
+	   This allows checking actual_mhz.
+	 */
+	__u64 clk_info_entries;
+
+};
+
+struct nvgpu_gpu_clk_set_info_args {
+
+	/* in: Flags (not currently used). */
+	__u32 flags;
+
+	__u16 pad0;
+
+	/* Number of clock info entries contained in clk_info_entries.
+	   Must be > 0.
+	 */
+	__u16 num_entries;
+
+	/* Pointer to clock info entries in the caller's address space. Buffer
+	   size must be at least
+		num_entries * sizeof(struct nvgpu_gpu_clk_info)
+	 */
+	__u64 clk_info_entries;
+
+	/* out: File descriptor for request completion. Application can poll
+	   this file descriptor to determine when the request has completed.
+	   The fd must be closed afterwards.
+	 */
+	__s32 completion_fd;
+};
+
+struct nvgpu_gpu_get_event_fd_args {
+
+	/* in: Flags (not currently used). */
+	__u32 flags;
+
+	/* out: File descriptor for events, e.g. clock update.
+	 * On successful polling of this event_fd, application is
+	 * expected to read status (nvgpu_gpu_event_info),
+	 * which provides detailed event information
+	 * For a poll operation, alarms will be reported with POLLPRI,
+	 * and GPU shutdown will be reported with POLLHUP.
+	 */
+	__s32 event_fd;
+};
+
+struct nvgpu_gpu_get_memory_state_args {
+	/*
+	 * Current free space for this device; may change even when any
+	 * kernel-managed metadata (e.g., page tables or channels) is allocated
+	 * or freed. For an idle gpu, an allocation of this size would succeed.
+	 */
+	__u64 total_free_bytes;
+
+	/* For future use; must be set to 0. */
+	__u64 reserved[4];
+};
+
+struct nvgpu_gpu_get_fbp_l2_masks_args {
+	/* [in]  L2 mask buffer size reserved by userspace. Should be
+		 at least sizeof(__u32) * fls(fbp_en_mask) to receive LTC
+		 mask for each FBP.
+	   [out] full kernel buffer size
+	*/
+	__u32 mask_buf_size;
+	__u32 reserved;
+
+	/* [in]  pointer to L2 mask buffer. It will receive one
+		 32-bit L2 mask per FBP or 0 if FBP is not enabled or
+		 not present. This parameter is ignored if
+		 mask_buf_size is 0. */
+	__u64 mask_buf_addr;
+};
+
+#define NVGPU_GPU_VOLTAGE_CORE		1
+#define NVGPU_GPU_VOLTAGE_SRAM		2
+#define NVGPU_GPU_VOLTAGE_BUS		3	/* input to regulator */
+
+struct nvgpu_gpu_get_voltage_args {
+	__u64 reserved;
+	__u32 which;		/* in: NVGPU_GPU_VOLTAGE_* */
+	__u32 voltage;		/* uV */
+};
+
+struct nvgpu_gpu_get_current_args {
+	__u32 reserved[3];
+	__u32 currnt;		/* mA */
+};
+
+struct nvgpu_gpu_get_power_args {
+	__u32 reserved[3];
+	__u32 power;		/* mW */
+};
+
+struct nvgpu_gpu_get_temperature_args {
+	__u32 reserved[3];
+	/* Temperature in signed fixed point format SFXP24.8
+	 *    Celsius = temp_f24_8 / 256.
+	 */
+	__s32 temp_f24_8;
+};
+
+struct nvgpu_gpu_set_therm_alert_limit_args {
+	__u32 reserved[3];
+	/* Temperature in signed fixed point format SFXP24.8
+	 *    Celsius = temp_f24_8 / 256.
+	 */
+	__s32 temp_f24_8;
+};
+
+/*
+ * Adjust options of deterministic channels in channel batches.
+ *
+ * This supports only one option currently: relax railgate blocking by
+ * "disabling" the channel.
+ *
+ * Open deterministic channels do not allow the GPU to railgate by default. It
+ * may be preferable to hold preopened channel contexts open and idle and still
+ * railgate the GPU, taking the channels back into use dynamically in userspace
+ * as an optimization. This ioctl allows to drop or reacquire the requirement
+ * to hold GPU power on for individual channels. If allow_railgate is set on a
+ * channel, no work can be submitted to it.
+ *
+ * num_channels is updated to signify how many channels were updated
+ * successfully. It can be used to test which was the first update to fail.
+ */
+struct nvgpu_gpu_set_deterministic_opts_args {
+	__u32 num_channels; /* in/out */
+/*
+ * Set or unset the railgating reference held by deterministic channels. If
+ * the channel status is already the same as the flag, this is a no-op. Both
+ * of these flags cannot be set at the same time. If none are set, the state
+ * is left as is.
+ */
+#define NVGPU_GPU_SET_DETERMINISTIC_OPTS_FLAGS_ALLOW_RAILGATING    (1 << 0)
+#define NVGPU_GPU_SET_DETERMINISTIC_OPTS_FLAGS_DISALLOW_RAILGATING (1 << 1)
+	__u32 flags;        /* in */
+	/*
+	 * This is a pointer to an array of size num_channels.
+	 *
+	 * The channels have to be valid fds and be previously set as
+	 * deterministic.
+	 */
+	__u64 channels; /* in */
+};
+
+/*
+ * register buffer information ioctl.
+ *
+ * Note: Additional metadata is associated with the buffer only for supporting
+ * legacy userspace APIs and for compatibility with desktop RM. Usage of this
+ * API should be avoided.
+ *
+ * This ioctl allocates comptags for the buffer if requested/required
+ * by libnvrm_gpu and associates metadata blob sent by libnvrm_gpu
+ * with the buffer in the buffer privdata.
+ *
+ * return 0 on success, < 0 in case of failure.
+ * retval -EINVAL if the enabled flag NVGPU_SUPPORT_BUFFER_METADATA
+ *               isn't set or invalid params.
+ * retval -EINVAL if the enabled flag NVGPU_SUPPORT_COMPRESSION
+ *               isn't set and comptags are required.
+ * retval -ENOMEM in case of sufficient memory is not available for
+ *                privdata or comptags.
+ * retval -EFAULT if the metadata blob copy fails.
+ */
+
+/*
+ * NVGPU_GPU_COMPTAGS_ALLOC_NONE: Specified to not allocate comptags
+ * for the buffer.
+ */
+#define NVGPU_GPU_COMPTAGS_ALLOC_NONE			0U
+
+/*
+ * NVGPU_GPU_COMPTAGS_ALLOC_REQUESTED: Specified to attempt comptags
+ * allocation for the buffer. If comptags are not available, the
+ * register buffer call will not fail and userspace can fallback
+ * to no compression.
+ */
+#define NVGPU_GPU_COMPTAGS_ALLOC_REQUESTED		1U
+
+/*
+ * NVGPU_GPU_COMPTAGS_ALLOC_REQUIRED: Specified to allocate comptags
+ * for the buffer when userspace can't fallback to no compression.
+ * If comptags are not available, the register buffer call will fail.
+ */
+#define NVGPU_GPU_COMPTAGS_ALLOC_REQUIRED		2U
+
+/*
+ * If the comptags are allocated for the buffer, this flag is set in the output
+ * flags in the register buffer ioctl.
+ */
+#define NVGPU_GPU_REGISTER_BUFFER_FLAGS_COMPTAGS_ALLOCATED	(1U << 0)
+
+ /*
+  * Specify buffer registration as mutable. This allows modifying the buffer
+  * attributes by calling this IOCTL again with NVGPU_GPU_REGISTER_BUFFER_FLAGS_MODIFY.
+  *
+  * Mutable registration is intended for private buffers where the physical
+  * memory allocation may be recycled. Buffers intended for interoperability
+  * should be specified without this flag.
+  */
+#define NVGPU_GPU_REGISTER_BUFFER_FLAGS_MUTABLE			(1U << 1)
+
+ /*
+  * Re-register the buffer. When this flag is set, the buffer comptags state,
+  * metadata binary blob, and other attributes are re-defined.
+  *
+  * This flag may be set only when the buffer was previously registered as
+  * mutable. This flag is ignored when the buffer is registered for the
+  * first time.
+  *
+  * If the buffer previously had comptags and the re-registration also specifies
+  * comptags, the associated comptags are not cleared.
+  *
+  */
+#define NVGPU_GPU_REGISTER_BUFFER_FLAGS_MODIFY			(1U << 2)
+
+/* Maximum size of the user supplied buffer metadata */
+#define NVGPU_GPU_REGISTER_BUFFER_METADATA_MAX_SIZE	256U
+
+/*
+ * register buffer ioctl arguments struct.
+ *
+ * Note: Additional metadata is associated with the buffer only for supporting
+ * legacy userspace APIs and for compatibility with desktop RM. Usage of this
+ * API should be avoided.
+ */
+struct nvgpu_gpu_register_buffer_args {
+	/* [in] dmabuf fd */
+	__s32 dmabuf_fd;
+
+	/*
+	 * [in] Compression tags allocation control.
+	 *
+	 * Set to one of the NVGPU_GPU_COMPTAGS_ALLOC_* values. See the
+	 * description of the values for semantics of this field.
+	 */
+	__u8 comptags_alloc_control;
+	__u8 reserved0;
+	__u16 reserved1;
+
+	/*
+	 * [in] Pointer to buffer metadata.
+	 *
+	 * This is a binary blob populated by nvrm_gpu that will be associated
+	 * with the dmabuf.
+	 */
+	__u64 metadata_addr;
+
+	/* [in] buffer metadata size */
+	__u32 metadata_size;
+
+	/*
+	 * [in/out] flags.
+	 *
+	 * See description of NVGPU_GPU_REGISTER_BUFFER_FLAGS_* for semantics
+	 * of this field.
+	 */
+	__u32 flags;
+};
+
+#define NVGPU_GPU_IOCTL_ZCULL_GET_CTX_SIZE \
+	_IOR(NVGPU_GPU_IOCTL_MAGIC, 1, struct nvgpu_gpu_zcull_get_ctx_size_args)
+#define NVGPU_GPU_IOCTL_ZCULL_GET_INFO \
+	_IOR(NVGPU_GPU_IOCTL_MAGIC, 2, struct nvgpu_gpu_zcull_get_info_args)
+#define NVGPU_GPU_IOCTL_ZBC_SET_TABLE	\
+	_IOW(NVGPU_GPU_IOCTL_MAGIC, 3, struct nvgpu_gpu_zbc_set_table_args)
+#define NVGPU_GPU_IOCTL_ZBC_QUERY_TABLE	\
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 4, struct nvgpu_gpu_zbc_query_table_args)
+#define NVGPU_GPU_IOCTL_GET_CHARACTERISTICS   \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 5, struct nvgpu_gpu_get_characteristics)
+#define NVGPU_GPU_IOCTL_PREPARE_COMPRESSIBLE_READ \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 6, struct nvgpu_gpu_prepare_compressible_read_args)
+#define NVGPU_GPU_IOCTL_MARK_COMPRESSIBLE_WRITE \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 7, struct nvgpu_gpu_mark_compressible_write_args)
+#define NVGPU_GPU_IOCTL_ALLOC_AS \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 8, struct nvgpu_alloc_as_args)
+#define NVGPU_GPU_IOCTL_OPEN_TSG \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 9, struct nvgpu_gpu_open_tsg_args)
+#define NVGPU_GPU_IOCTL_GET_TPC_MASKS \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 10, struct nvgpu_gpu_get_tpc_masks_args)
+#define NVGPU_GPU_IOCTL_OPEN_CHANNEL \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 11, struct nvgpu_gpu_open_channel_args)
+#define NVGPU_GPU_IOCTL_FLUSH_L2 \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 12, struct nvgpu_gpu_l2_fb_args)
+#define NVGPU_GPU_IOCTL_SET_MMUDEBUG_MODE \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 14, struct nvgpu_gpu_mmu_debug_mode_args)
+#define NVGPU_GPU_IOCTL_SET_SM_DEBUG_MODE \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 15, struct nvgpu_gpu_sm_debug_mode_args)
+#define NVGPU_GPU_IOCTL_WAIT_FOR_PAUSE \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 16, struct nvgpu_gpu_wait_pause_args)
+#define NVGPU_GPU_IOCTL_GET_TPC_EXCEPTION_EN_STATUS \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 17, struct nvgpu_gpu_tpc_exception_en_status_args)
+#define NVGPU_GPU_IOCTL_NUM_VSMS \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 18, struct nvgpu_gpu_num_vsms)
+#define NVGPU_GPU_IOCTL_VSMS_MAPPING \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 19, struct nvgpu_gpu_vsms_mapping)
+#define NVGPU_GPU_IOCTL_RESUME_FROM_PAUSE \
+	_IO(NVGPU_GPU_IOCTL_MAGIC, 21)
+#define NVGPU_GPU_IOCTL_TRIGGER_SUSPEND \
+	_IO(NVGPU_GPU_IOCTL_MAGIC, 22)
+#define NVGPU_GPU_IOCTL_CLEAR_SM_ERRORS \
+	_IO(NVGPU_GPU_IOCTL_MAGIC, 23)
+#define NVGPU_GPU_IOCTL_GET_CPU_TIME_CORRELATION_INFO \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 24, \
+			struct nvgpu_gpu_get_cpu_time_correlation_info_args)
+#define NVGPU_GPU_IOCTL_GET_GPU_TIME \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 25, \
+			struct nvgpu_gpu_get_gpu_time_args)
+#define NVGPU_GPU_IOCTL_GET_ENGINE_INFO \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 26, \
+			struct nvgpu_gpu_get_engine_info_args)
+#define NVGPU_GPU_IOCTL_ALLOC_VIDMEM \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 27, \
+			struct nvgpu_gpu_alloc_vidmem_args)
+#define NVGPU_GPU_IOCTL_CLK_GET_RANGE \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 28, struct nvgpu_gpu_clk_range_args)
+#define NVGPU_GPU_IOCTL_CLK_GET_VF_POINTS \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 29, struct nvgpu_gpu_clk_vf_points_args)
+#define NVGPU_GPU_IOCTL_CLK_GET_INFO \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 30, struct nvgpu_gpu_clk_get_info_args)
+#define NVGPU_GPU_IOCTL_CLK_SET_INFO \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 31, struct nvgpu_gpu_clk_set_info_args)
+#define NVGPU_GPU_IOCTL_GET_EVENT_FD \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 32, struct nvgpu_gpu_get_event_fd_args)
+#define NVGPU_GPU_IOCTL_GET_MEMORY_STATE \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 33, \
+			struct nvgpu_gpu_get_memory_state_args)
+#define NVGPU_GPU_IOCTL_GET_VOLTAGE \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 34, struct nvgpu_gpu_get_voltage_args)
+#define NVGPU_GPU_IOCTL_GET_CURRENT \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 35, struct nvgpu_gpu_get_current_args)
+#define NVGPU_GPU_IOCTL_GET_POWER \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 36, struct nvgpu_gpu_get_power_args)
+#define NVGPU_GPU_IOCTL_GET_TEMPERATURE \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 37, struct nvgpu_gpu_get_temperature_args)
+#define NVGPU_GPU_IOCTL_GET_FBP_L2_MASKS \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 38, struct nvgpu_gpu_get_fbp_l2_masks_args)
+#define NVGPU_GPU_IOCTL_SET_THERM_ALERT_LIMIT \
+		_IOWR(NVGPU_GPU_IOCTL_MAGIC, 39, \
+			struct nvgpu_gpu_set_therm_alert_limit_args)
+#define NVGPU_GPU_IOCTL_SET_DETERMINISTIC_OPTS \
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 40, \
+			struct nvgpu_gpu_set_deterministic_opts_args)
+#define NVGPU_GPU_IOCTL_REGISTER_BUFFER	\
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 41, struct nvgpu_gpu_register_buffer_args)
+#define NVGPU_GPU_IOCTL_GET_BUFFER_INFO	\
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 42, struct nvgpu_gpu_get_buffer_info_args)
+#define NVGPU_GPU_IOCTL_GET_GPC_LOCAL_TO_PHYSICAL_MAP\
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 43, struct nvgpu_gpu_get_gpc_physical_map_args)
+#define NVGPU_GPU_IOCTL_GET_GPC_LOCAL_TO_LOGICAL_MAP\
+	_IOWR(NVGPU_GPU_IOCTL_MAGIC, 44, struct nvgpu_gpu_get_gpc_logical_map_args)
+#define NVGPU_GPU_IOCTL_LAST		\
+	_IOC_NR(NVGPU_GPU_IOCTL_GET_GPC_LOCAL_TO_LOGICAL_MAP)
+#define NVGPU_GPU_IOCTL_MAX_ARG_SIZE	\
+	sizeof(struct nvgpu_gpu_get_cpu_time_correlation_info_args)
+
+#endif /* _UAPI__LINUX_NVGPU_CTRL_H__ */

--- a/extra/tegra_gpu_driver/nvgpu-event.h
+++ b/extra/tegra_gpu_driver/nvgpu-event.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ * Event session
+ *
+ * NVGPU_GPU_IOCTL_GET_EVENT_FD opens an event session.
+ * Below ioctls can be used on these sessions fds.
+ */
+
+#ifndef _UAPI__LINUX_NVGPU_EVENT_H__
+#define _UAPI__LINUX_NVGPU_EVENT_H__
+
+#include "nvgpu-uapi-common.h"
+
+#define NVGPU_EVENT_IOCTL_MAGIC	'E'
+
+/* Normal events (POLLIN) */
+/* Event associated to a VF update */
+#define NVGPU_GPU_EVENT_VF_UPDATE				0
+
+/* Recoverable alarms (POLLPRI) */
+/* Alarm when target frequency on any session is not possible */
+#define NVGPU_GPU_EVENT_ALARM_TARGET_VF_NOT_POSSIBLE		1
+/* Alarm when target frequency on current session is not possible */
+#define NVGPU_GPU_EVENT_ALARM_LOCAL_TARGET_VF_NOT_POSSIBLE	2
+/* Alarm when Clock Arbiter failed */
+#define NVGPU_GPU_EVENT_ALARM_CLOCK_ARBITER_FAILED		3
+/* Alarm when VF table update failed */
+#define NVGPU_GPU_EVENT_ALARM_VF_TABLE_UPDATE_FAILED		4
+/* Alarm on thermal condition */
+#define NVGPU_GPU_EVENT_ALARM_THERMAL_ABOVE_THRESHOLD		5
+/* Alarm on power condition */
+#define NVGPU_GPU_EVENT_ALARM_POWER_ABOVE_THRESHOLD		6
+
+/* Non recoverable alarm (POLLHUP) */
+/* Alarm on GPU shutdown/fall from bus */
+#define NVGPU_GPU_EVENT_ALARM_GPU_LOST				7
+
+#define NVGPU_GPU_EVENT_LAST	NVGPU_GPU_EVENT_ALARM_GPU_LOST
+
+struct nvgpu_gpu_event_info {
+	__u32 event_id;		/* NVGPU_GPU_EVENT_* */
+	__u32 reserved;
+	__u64 timestamp;	/* CPU timestamp (in nanoseconds) */
+};
+
+struct nvgpu_gpu_set_event_filter_args {
+
+	/* in: Flags (not currently used). */
+	__u32 flags;
+
+	/* in: Size of event filter in 32-bit words */
+	__u32 size;
+
+	/* in: Address of buffer containing bit mask of events.
+	 * Bit #n is set if event #n should be monitored.
+	 */
+	__u64 buffer;
+};
+
+#define NVGPU_EVENT_IOCTL_SET_FILTER \
+	_IOW(NVGPU_EVENT_IOCTL_MAGIC, 1, struct nvgpu_gpu_set_event_filter_args)
+#define NVGPU_EVENT_IOCTL_LAST		\
+	_IOC_NR(NVGPU_EVENT_IOCTL_SET_FILTER)
+#define NVGPU_EVENT_IOCTL_MAX_ARG_SIZE	\
+	sizeof(struct nvgpu_gpu_set_event_filter_args)
+
+#endif

--- a/extra/tegra_gpu_driver/nvgpu-nvs.h
+++ b/extra/tegra_gpu_driver/nvgpu-nvs.h
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#ifndef _UAPI__LINUX_NVGPU_NVS_H
+#define _UAPI__LINUX_NVGPU_NVS_H
+
+#include "nvgpu-uapi-common.h"
+
+#define NVGPU_NVS_IOCTL_MAGIC 'N'
+#define NVGPU_NVS_CTRL_FIFO_IOCTL_MAGIC 'F'
+
+/**
+ * Domain parameters to pass to the kernel.
+ */
+struct nvgpu_nvs_ioctl_domain {
+	/*
+	 * Human readable null-terminated name for this domain.
+	 */
+	char name[32];
+
+	/*
+	 * Scheduling parameters: specify how long this domain should be scheduled
+	 * for and what the grace period the scheduler should give this domain when
+	 * preempting. A value of zero is treated as an infinite timeslice or an
+	 * infinite grace period, respectively.
+	 */
+	__u64 timeslice_ns;
+	__u64 preempt_grace_ns;
+
+	/*
+	 * Pick which subscheduler to use. These will be implemented by the kernel
+	 * as needed. There'll always be at least one, which is the host HW built in
+	 * round-robin scheduler.
+	 */
+	__u32 subscheduler;
+
+/*
+ * GPU host hardware round-robin.
+ */
+#define NVGPU_SCHED_IOCTL_SUBSCHEDULER_HOST_HW_RR 0x0
+
+	/*
+	 * Populated by the IOCTL when created: unique identifier. User space
+	 * must set this to 0.
+	 */
+	__u64 dom_id;
+
+	/* Must be 0. */
+	__u64 reserved1;
+	/* Must be 0. */
+	__u64 reserved2;
+};
+
+/**
+ * NVGPU_NVS_IOCTL_CREATE_DOMAIN
+ *
+ * Create a domain - essentially a group of GPU contexts. Applications
+ * can be bound into this domain on request for each TSG.
+ *
+ * The domain ID is returned in dom_id; this id is _not_ secure. The
+ * nvsched device needs to have restricted permissions such that only a
+ * single user, or group of users, has permissions to modify the
+ * scheduler.
+ *
+ * It's fine to allow read-only access to the device node for other
+ * users; this lets other users query scheduling information that may be
+ * of interest to them.
+ */
+struct nvgpu_nvs_ioctl_create_domain {
+	/*
+	 * In/out: domain parameters that userspace configures.
+	 *
+	 * The domain ID is returned here.
+	 */
+	struct nvgpu_nvs_ioctl_domain domain_params;
+
+	/* Must be 0. */
+	__u64 reserved1;
+};
+
+/**
+ * NVGPU_NVS_IOCTL_REMOVE_DOMAIN
+ *
+ * Remove a domain that has been previously created.
+ *
+ * The domain must be empty; it must have no TSGs bound to it. The domain's
+ * device node must not be open by anyone.
+ */
+struct nvgpu_nvs_ioctl_remove_domain {
+	/*
+	 * In: a domain_id to remove.
+	 */
+	__u64 dom_id;
+
+	/* Must be 0. */
+	__u64 reserved1;
+};
+
+/**
+ * NVGPU_NVS_IOCTL_QUERY_DOMAINS
+ *
+ * Query the current list of domains in the scheduler. This is a two
+ * part IOCTL.
+ *
+ * If domains is 0, then this IOCTL will populate nr with the number
+ * of present domains.
+ *
+ * If domains is nonzero, then this IOCTL will treat domains as a pointer to an
+ * array of nvgpu_nvs_ioctl_domain and will write up to nr domains into that
+ * array. The nr field will be updated with the number of present domains,
+ * which may be more than the number of entries written.
+ */
+struct nvgpu_nvs_ioctl_query_domains {
+	/*
+	 * In/Out: If 0, leave untouched. If nonzero, then write up to nr
+	 * elements of nvgpu_nvs_ioctl_domain into where domains points to.
+	 */
+	__u64 domains;
+
+	/*
+	 * - In: the capacity of the domains array if domais is not 0.
+	 * - Out: populate with the number of domains present.
+	 */
+	__u32 nr;
+
+	/* Must be 0. */
+	__u32 reserved0;
+
+	/* Must be 0. */
+	__u64 reserved1;
+};
+
+#define NVGPU_NVS_IOCTL_CREATE_DOMAIN			\
+	_IOWR(NVGPU_NVS_IOCTL_MAGIC, 1,			\
+	      struct nvgpu_nvs_ioctl_create_domain)
+#define NVGPU_NVS_IOCTL_REMOVE_DOMAIN			\
+	_IOW(NVGPU_NVS_IOCTL_MAGIC, 2,			\
+	      struct nvgpu_nvs_ioctl_remove_domain)
+#define NVGPU_NVS_IOCTL_QUERY_DOMAINS			\
+	_IOWR(NVGPU_NVS_IOCTL_MAGIC, 3,			\
+	      struct nvgpu_nvs_ioctl_query_domains)
+
+#define NVGPU_NVS_IOCTL_LAST				\
+	_IOC_NR(NVGPU_NVS_IOCTL_QUERY_DOMAINS)
+#define NVGPU_NVS_IOCTL_MAX_ARG_SIZE			\
+	sizeof(struct nvgpu_nvs_ioctl_create_domain)
+
+/* Request for a Control Queue. */
+#define NVGPU_NVS_CTRL_FIFO_QUEUE_NUM_CONTROL 1U
+/* Request for an Event queue.  */
+#define NVGPU_NVS_CTRL_FIFO_QUEUE_NUM_EVENT 2U
+
+/* Direction of the requested queue is from CLIENT(producer)
+ * to SCHEDULER(consumer).
+ */
+#define NVGPU_NVS_CTRL_FIFO_QUEUE_DIRECTION_CLIENT_TO_SCHEDULER 0
+
+/* Direction of the requested queue is from SCHEDULER(producer)
+ * to CLIENT(consumer).
+ */
+#define NVGPU_NVS_CTRL_FIFO_QUEUE_DIRECTION_SCHEDULER_TO_CLIENT 1
+
+#define NVGPU_NVS_CTRL_FIFO_QUEUE_ACCESS_TYPE_EXCLUSIVE 1
+#define NVGPU_NVS_CTRL_FIFO_QUEUE_ACCESS_TYPE_NON_EXCLUSIVE 0
+
+/**
+ * NVGPU_NVS_CTRL_FIFO_IOCTL_CREATE_QUEUE
+ *
+ * Create shared queues for domain scheduler's control fifo.
+ *
+ * 'queue_num' is set by UMD to NVS_CTRL_FIFO_QUEUE_NUM_CONTROL
+ * for Send/Receive queues and NVGPU_NVS_CTRL_FIFO_QUEUE_NUM_EVENT
+ * for Event Queue.
+ *
+ * 'direction' is set by UMD to NVGPU_NVS_CTRL_FIFO_QUEUE_DIRECTION_CLIENT_TO_SCHEDULER
+ * for Send Queue and NVGPU_NVS_CTRL_FIFO_QUEUE_DIRECTION_SCHEDULER_TO_CLIENT
+ * for Receive/Event Queue.
+ *
+ * The parameter 'queue_size' is set by KMD.
+ *
+ * Initially, all clients are setup as non-exclusive. The first client to successfully
+ * request an exclusive access is internally marked as an exclusive client. It remains
+ * so until the client closes the control-fifo device node.
+ *
+ * Clients that require exclusive access shall set 'access_type'
+ * to NVGPU_NVS_CTRL_FIFO_QUEUE_ACCESS_TYPE_EXCLUSIVE, otherwise set it to
+ * NVGPU_NVS_CTRL_FIFO_QUEUE_ACCESS_TYPE_NON_EXCLUSIVE.
+ *
+ * Note, queues of NVGPU_NVS_CTRL_FIFO_QUEUE_NUM_EVENT has shared read-only
+ * access irrespective of the type of client.
+ *
+ * 'dmabuf_fd' is populated by the KMD for the success case, else its set to -1.
+ */
+struct nvgpu_nvs_ctrl_fifo_ioctl_create_queue_args {
+	/* - In: Denote the queue num. */
+	__u32 queue_num;
+
+	/* - In: Denote the direction of producer => consumer */
+	__u8 direction;
+
+	/* - In: Denote the type of request */
+	__u8 access_type;
+
+	/* Must be 0. */
+	__u16 reserve0;
+
+	/* - Out: Size of the queue in bytes. Multiple of 4 bytes */
+	__u32 queue_size;
+
+	/* - Out: dmabuf file descriptor(FD) of the shared queue exposed via the KMD.
+	 * - This field is expected to be populated by the KMD.
+	 * - UMD is expected to close the FD.
+	 *
+	 * - mmap() is used to access the queue.
+	 * - MAP_SHARED must be specified.
+	 * - Exclusive access clients may map with read-write access (PROT_READ | PROT_WRITE).
+	 *   Shared access clients may map only with read-only access (PROT_READ)
+	 *
+	 * - Cpu Caching Mode
+	 * - cached-coherent memory type is used when the system supports this between the client and scheduler.
+	 * - non-cached memory type otherwise.
+	 *
+	 * - On Tegra:
+	 *   Normal cacheable (inner shareable) on T194/T234 with the KMD scheduler.
+	 *   Normal cacheable (outer shareable, I/O coherency enabled) for T234 with the GSP scheduler.
+	 *
+	 * - On generic ARM:
+	 *   Normal cacheable (inner shareable) with the KMD scheduler.
+	 *   Normal non-cacheable write-combining with the GSP scheduler.
+	 */
+	__s32 dmabuf_fd;
+};
+
+/**
+ * NVGPU_NVS_CTRL_FIFO_IOCTL_RELEASE_QUEUE
+ *
+ * Release a domain scheduler's queue.
+ *
+ * 'queue_num' is set by UMD to NVS_CTRL_FIFO_QUEUE_NUM_CONTROL
+ * for Send/Receive queues and NVGPU_NVS_CTRL_FIFO_QUEUE_NUM_EVENT
+ * for Event Queue.
+ *
+ * 'direction' is set by UMD to NVGPU_NVS_CTRL_FIFO_QUEUE_DIRECTION_CLIENT_TO_SCHEDULER
+ * for Send Queue and NVGPU_NVS_CTRL_FIFO_QUEUE_DIRECTION_SCHEDULER_TO_CLIENT
+ * for Receive/Event Queue.
+ *
+ * Returns an error if queues of type NVS_CTRL_FIFO_QUEUE_NUM_CONTROL
+ * have an active mapping.
+ *
+ * Mapped buffers are removed immediately for queues of type
+ * NVS_CTRL_FIFO_QUEUE_NUM_CONTROL while those of type NVGPU_NVS_CTRL_FIFO_QUEUE_NUM_EVENT
+ * are removed when the last user releases the control device node.
+ *
+ * User must ensure to invoke this IOCTL after invoking munmap on
+ * the mmapped address. Otherwise, accessing the buffer could lead to segfaults.
+ *
+ */
+struct nvgpu_nvs_ctrl_fifo_ioctl_release_queue_args {
+	/* - In: Denote the queue num. */
+	__u32 queue_num;
+
+	/* - In: Denote the direction of producer => consumer */
+	__u8 direction;
+
+	/* Must be 0. */
+	__u8 reserve0;
+
+	/* Must be 0. */
+	__u16 reserve1;
+
+
+	/* Must be 0. */
+	__u64 reserve2;
+};
+
+struct nvgpu_nvs_ctrl_fifo_ioctl_event {
+/* Enable Fault Detection Event */
+#define NVGPU_NVS_CTRL_FIFO_EVENT_FAULTDETECTED 1LLU
+/* Enable Fault Recovery Detection Event */
+#define NVGPU_NVS_CTRL_FIFO_EVENT_FAULTRECOVERY 2LLU
+	__u64 event_mask;
+
+	/* Must be 0. */
+	__u64 reserve0;
+};
+
+/**
+ * NVGPU_NVS_CTRL_FIFO_IOCTL_QUERY_SCHEDULER_CHARACTERISTICS
+ *
+ * Query the characteristics of the domain scheduler.
+ * For R/W user, available_queues is set to
+ * NVGPU_NVS_CTRL_FIFO_QUEUE_NUM_CONTROL | NVGPU_NVS_CTRL_FIFO_QUEUE_NUM_EVENT
+ *
+ * For Non-Exclusive users(can be multiple), available_queues is set to
+ * NVGPU_NVS_CTRL_FIFO_QUEUE_NUM_EVENT.
+ *
+ * Note that, even for multiple R/W users, only one user at a time
+ * can exist as an exclusive user. Only exclusive users can create/destroy
+ * queues of type 'NVGPU_NVS_CTRL_FIFO_QUEUE_NUM_CONTROL'
+ */
+struct nvgpu_nvs_ctrl_fifo_ioctl_query_scheduler_characteristics_args {
+	/*
+	 * Invalid domain scheduler.
+	 * The value of 'domain_scheduler_implementation'
+	 * when 'has_domain_scheduler_control_fifo' is 0.
+	 */
+#define NVGPU_NVS_DOMAIN_SCHED_INVALID 0U
+	/*
+	 * CPU based scheduler implementation. Intended use is mainly
+	 * for debug and testing purposes. Doesn't meet latency requirements.
+	 * Implementation will be supported in the initial versions and eventually
+	 * discarded.
+	 */
+#define NVGPU_NVS_DOMAIN_SCHED_KMD 1U
+	/*
+	 * GSP based scheduler implementation that meets latency requirements.
+	 * This implementation will eventually replace NVGPU_NVS_DOMAIN_SCHED_KMD.
+	 */
+#define NVGPU_NVS_DOMAIN_SCHED_GSP 2U
+	/*
+	 * - Out: Value is expected to be among the above available flags.
+	 */
+	__u8 domain_scheduler_implementation;
+
+	/* Must be 0 */
+	__u8 reserved0;
+
+	/* Must be 0 */
+	__u16 reserved1;
+
+	/* - Out: Mask of supported queue nums. */
+	__u32 available_queues;
+
+	/* Must be 0. */
+	__u64 reserved2[8];
+};
+
+#define NVGPU_NVS_CTRL_FIFO_IOCTL_CREATE_QUEUE		\
+	_IOWR(NVGPU_NVS_CTRL_FIFO_IOCTL_MAGIC, 1,	\
+	       struct nvgpu_nvs_ctrl_fifo_ioctl_create_queue_args)
+#define NVGPU_NVS_CTRL_FIFO_IOCTL_RELEASE_QUEUE		\
+	_IOWR(NVGPU_NVS_CTRL_FIFO_IOCTL_MAGIC, 2,	\
+	       struct nvgpu_nvs_ctrl_fifo_ioctl_release_queue_args)
+#define NVGPU_NVS_CTRL_FIFO_IOCTL_ENABLE_EVENT		\
+	_IOW(NVGPU_NVS_CTRL_FIFO_IOCTL_MAGIC, 3,	\
+	       struct nvgpu_nvs_ctrl_fifo_ioctl_event)
+#define NVGPU_NVS_CTRL_FIFO_IOCTL_QUERY_SCHEDULER_CHARACTERISTICS	\
+	_IOR(NVGPU_NVS_CTRL_FIFO_IOCTL_MAGIC, 4,	\
+	       struct nvgpu_nvs_ctrl_fifo_ioctl_query_scheduler_characteristics_args)
+#define NVGPU_NVS_CTRL_FIFO_IOCTL_LAST				\
+	_IOC_NR(NVGPU_NVS_CTRL_FIFO_IOCTL_QUERY_SCHEDULER_CHARACTERISTICS)
+#define NVGPU_NVS_CTRL_FIFO_IOCTL_MAX_ARG_SIZE			\
+	sizeof(struct nvgpu_nvs_ctrl_fifo_ioctl_query_scheduler_characteristics_args)
+
+#endif

--- a/extra/tegra_gpu_driver/nvgpu-uapi-common.h
+++ b/extra/tegra_gpu_driver/nvgpu-uapi-common.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#ifndef _UAPI__LINUX_NVGPU_UAPI_COMMON_H
+
+#include <linux/ioctl.h>
+#include <linux/types.h>
+
+#if !defined(__KERNEL__)
+#define __user
+#define nvgpu_user
+
+/* Some userspace builds have __packed defined already */
+#if !defined(__packed)
+#define __packed __attribute__((packed))
+#endif /* __packed */
+
+#endif /* __KERNEL__ */
+
+#endif

--- a/extra/tegra_gpu_driver/nvgpu.h
+++ b/extra/tegra_gpu_driver/nvgpu.h
@@ -1,0 +1,1584 @@
+/*
+ * NVGPU Public Interface Header
+ *
+ * Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#ifndef _UAPI__LINUX_NVGPU_IOCTL_H
+#define _UAPI__LINUX_NVGPU_IOCTL_H
+
+#include "nvgpu-ctrl.h"
+#include "nvgpu-event.h"
+#include "nvgpu-as.h"
+
+#include "nvgpu-nvs.h"
+
+/*
+ * /dev/nvhost-tsg-gpu device
+ *
+ * Opening a '/dev/nvhost-tsg-gpu' device node creates a way to
+ * bind/unbind a channel to/from TSG group
+ */
+
+#define NVGPU_TSG_IOCTL_MAGIC 'T'
+
+struct nvgpu_tsg_bind_channel_ex_args {
+	/* in: channel fd */
+	__s32 channel_fd;
+
+	/* in: VEID in Volta */
+	__u32 subcontext_id;
+	__u8 reserved[16];
+};
+
+struct nvgpu_tsg_bind_scheduling_domain_args {
+	/* in: id of the domain this tsg will be bound to */
+	__s32 domain_fd;
+	/* Must be set to 0 */
+	__s32 reserved0;
+	/* Must be set to 0 */
+	__u64 reserved[3];
+};
+
+/*
+ * This struct helps to report the SM error state of a single SM.
+ * This acts upon the currently resident TSG context.
+ * Global Error status register
+ * Warp Error status register
+ * Warp Error status register PC
+ * Global Error status register Report Mask
+ * Warp Error status register Report Mask
+ */
+struct nvgpu_tsg_sm_error_state_record {
+	__u32 global_esr;
+	__u32 warp_esr;
+	__u64 warp_esr_pc;
+	__u32 global_esr_report_mask;
+	__u32 warp_esr_report_mask;
+};
+
+/*
+ * This struct helps to read the SM error state.
+ */
+struct nvgpu_tsg_read_single_sm_error_state_args {
+	/* Valid SM ID */
+	__u32 sm_id;
+	__u32 reserved;
+	/*
+	 * This is pointer to the struct nvgpu_tsg_sm_error_state_record
+	 */
+	__u64 record_mem;
+	/* size of the record size to read */
+	__u64 record_size;
+};
+
+/*
+ * This struct helps to read SM error states for all the SMs
+ */
+struct nvgpu_tsg_read_all_sm_error_state_args {
+	/*
+	 * in: Number of SM error states to be returned. Must be equal to the number of SMs.
+	 */
+	__u32 num_sm;
+	/*
+	 * Padding to make KMD UAPI compatible with both 32-bit and 64-bit callers.
+	 */
+	__u32 reserved;
+	/*
+	 * out: This points to an array of nvgpu_tsg_read_single_sm_error_state_args.
+	 */
+	__u64 buffer_mem;
+	/* in: size of the buffer to store error states */
+	__u64 buffer_size;
+};
+
+/*
+ * This struct is used to read and configure l2 max evict_last
+ * setting.
+ */
+struct nvgpu_tsg_l2_max_ways_evict_last_args {
+	/*
+	 * Maximum number of ways in a l2 cache set that can be allocated
+	 * with eviction_policy=EVICT_LAST
+	 */
+	__u32 max_ways;
+	__u32 reserved;
+};
+
+/*
+ * This struct contains the parameter for configuring L2 sector promotion.
+ * It supports 3 valid options:-
+ *  - PROMOTE_NONE(1): cache-miss doens't get promoted.
+ *  - PROMOTE_64B(2): cache-miss gets promoted to 64 bytes if less than 64 bytes.
+ *  - PROMOTE_128B(4): cache-miss gets promoted to 128 bytes if less than 128 bytes.
+ */
+#define NVGPU_GPU_IOCTL_TSG_L2_SECTOR_PROMOTE_FLAG_NONE		(1U << 0U)
+#define NVGPU_GPU_IOCTL_TSG_L2_SECTOR_PROMOTE_FLAG_64B		(1U << 1U)
+#define NVGPU_GPU_IOCTL_TSG_L2_SECTOR_PROMOTE_FLAG_128B		(1U << 2U)
+struct nvgpu_tsg_set_l2_sector_promotion_args {
+	/* Valid promotion flag */
+	__u32 promotion_flag;
+	__u32 reserved;
+};
+
+/*
+ * NVGPU_TSG_IOCTL_CREATE_SUBCONTEXT - create a subcontext within a TSG.
+ *
+ * This IOCTL creates a subcontext of specified type within TSG if available
+ * and returns VEID for it. Subcontext is associated with the user supplied
+ * address space.
+ *
+ * return 0 on success, -1 on error.
+ * retval EINVAL if invalid parameters are specified.
+ * retval ENOSPC if subcontext of specified type can't be allocated.
+ */
+
+/* Subcontext types */
+
+/*
+ * Synchronous subcontext. Subcontext of this type may hold the
+ * graphics channel, and multiple copy engine and compute channels.
+ */
+#define NVGPU_TSG_SUBCONTEXT_TYPE_SYNC               (0x0U)
+
+/*
+ * Asynchronous subcontext. Asynchronous subcontext is for compute
+ * and copy engine channels only.
+ */
+#define NVGPU_TSG_SUBCONTEXT_TYPE_ASYNC              (0x1U)
+
+/* Arguments for NVGPU_TSG_IOCTL_CREATE_SUBCONTEXT */
+struct nvgpu_tsg_create_subcontext_args {
+	/* in: subcontext type */
+	__u32 type;
+
+	/* in: address space fd */
+	__s32 as_fd;
+
+	/*
+	 * out: VEID for the subcontext
+	 *      This is HW specific constant. For Volta+ chips (up to T234
+	 *      Legacy mode), the HW-specific range is [0..63]. Of these,
+	 *      0th subcontext is SYNC subcontext and remaining are
+	 *      ASYNC subcontexts.
+	 *      For SMC case, less number of VEIDs are supported per GPU
+	 *      instance. This value is SMC engine relative VEID.
+	 */
+	__u32 veid;
+	__u32 reserved;
+};
+
+/*
+ * NVGPU_TSG_IOCTL_DELETE_SUBCONTEXT - delete a subcontext within a TSG.
+ *
+ * This IOCTL deletes a subcontext with specified subcontext id.
+ *
+ * return 0 on success, -1 on error.
+ * retval EINVAL if invalid parameters are specified.
+ */
+
+/* Arguments for NVGPU_TSG_IOCTL_DELETE_SUBCONTEXT */
+struct nvgpu_tsg_delete_subcontext_args {
+	/* in: VEID for the subcontext */
+	__u32 veid;
+	__u32 reserved;
+};
+
+/*
+ * NVGPU_TSG_IOCTL_GET_SHARE_TOKEN - get TSG share token ioctl.
+ *
+ * This IOCTL creates a TSG share token. The TSG share token may be
+ * specified when opening new TSG fds with NVGPU_GPU_IOCTL_OPEN_TSG.
+ * In this case, the underlying HW TSG will be shared.
+ *
+ * The source_device_instance_id is checked to be authorized while
+ * creating share token.
+ *
+ * TBD: TSG share tokens have an expiration time. This is controlled
+ * by /sys/kernel/debug/<gpu>/tsg_share_token_timeout_ms. The default
+ * timeout is 30000 ms on silicon platforms and 0 (= no timeout) on
+ * pre-silicon platforms.
+ *
+ * When the TSG is closed, all share tokens on the TSG will be
+ * invalidated. Share token can also be invalidated by calling
+ * the ioctl NVGPU_TSG_IOCTL_REVOKE_SHARE_TOKEN.
+ *
+ * When creating a TSG fd with share token, it is ensured that
+ * target_device_instance_id specified here matches with the
+ * device instance id that is used to call the ioctl
+ * NVGPU_GPU_IOCTL_OPEN_TSG. This will secure the sharing of
+ * the TSG within trusted parties.
+ *
+ * Note: share token is unique in the context of the source and
+ * target device instance ids for a TSG.
+ *
+ * return 0 on success, -1 on error.
+ * retval EINVAL if invalid parameters are specified.
+ *               (if any of the device id argument is zero or
+ *                unauthorized device).
+ */
+
+/* Arguments for NVGPU_TSG_IOCTL_GET_SHARE_TOKEN */
+struct nvgpu_tsg_get_share_token_args {
+	/* in: Source (exporter) device id */
+	__u64 source_device_instance_id;
+
+	/* in: Target (importer) device id */
+	__u64 target_device_instance_id;
+
+	/* out: Share token */
+	__u64 share_token;
+};
+
+/*
+ * NVGPU_TSG_IOCTL_REVOKE_SHARE_TOKEN - revoke TSG share token ioctl.
+ *
+ * This IOCTL revokes a TSG share token. It is intended to be called
+ * whe the share token data exchange with the other end point is
+ * unsuccessful.
+ *
+ * return 0 on success, -1 on error.
+ * retval EINVAL if invalid parameters are specified.
+ *               (if any of the argument is zero or unauthorized device).
+ * retval EINVAL if share token doesn't exist or is expired.
+ */
+
+/* Arguments for NVGPU_TSG_IOCTL_REVOKE_SHARE_TOKEN */
+struct nvgpu_tsg_revoke_share_token_args {
+	/* in: Source (exporter) device id */
+	__u64 source_device_instance_id;
+
+	/* in: Target (importer) device id */
+	__u64 target_device_instance_id;
+
+	/* in: Share token */
+	__u64 share_token;
+};
+
+#define NVGPU_TSG_IOCTL_BIND_CHANNEL \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 1, int)
+#define NVGPU_TSG_IOCTL_UNBIND_CHANNEL \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 2, int)
+#define NVGPU_IOCTL_TSG_ENABLE \
+	_IO(NVGPU_TSG_IOCTL_MAGIC, 3)
+#define NVGPU_IOCTL_TSG_DISABLE \
+	_IO(NVGPU_TSG_IOCTL_MAGIC, 4)
+#define NVGPU_IOCTL_TSG_PREEMPT \
+	_IO(NVGPU_TSG_IOCTL_MAGIC, 5)
+#define NVGPU_IOCTL_TSG_EVENT_ID_CTRL \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 7, struct nvgpu_event_id_ctrl_args)
+#define NVGPU_IOCTL_TSG_SET_RUNLIST_INTERLEAVE \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 8, struct nvgpu_runlist_interleave_args)
+#define NVGPU_IOCTL_TSG_SET_TIMESLICE \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 9, struct nvgpu_timeslice_args)
+#define NVGPU_IOCTL_TSG_GET_TIMESLICE \
+	_IOR(NVGPU_TSG_IOCTL_MAGIC, 10, struct nvgpu_timeslice_args)
+#define NVGPU_TSG_IOCTL_BIND_CHANNEL_EX \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 11, struct nvgpu_tsg_bind_channel_ex_args)
+#define NVGPU_TSG_IOCTL_READ_SINGLE_SM_ERROR_STATE \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 12, \
+			struct nvgpu_tsg_read_single_sm_error_state_args)
+#define NVGPU_TSG_IOCTL_SET_L2_MAX_WAYS_EVICT_LAST \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 13, \
+			struct nvgpu_tsg_l2_max_ways_evict_last_args)
+#define NVGPU_TSG_IOCTL_GET_L2_MAX_WAYS_EVICT_LAST \
+	_IOR(NVGPU_TSG_IOCTL_MAGIC, 14, \
+			struct nvgpu_tsg_l2_max_ways_evict_last_args)
+#define NVGPU_TSG_IOCTL_SET_L2_SECTOR_PROMOTION \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 15, \
+			struct nvgpu_tsg_set_l2_sector_promotion_args)
+#define NVGPU_TSG_IOCTL_BIND_SCHEDULING_DOMAIN \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 16, \
+			struct nvgpu_tsg_bind_scheduling_domain_args)
+#define NVGPU_TSG_IOCTL_READ_ALL_SM_ERROR_STATES \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 17, \
+			struct nvgpu_tsg_read_all_sm_error_state_args)
+#define NVGPU_TSG_IOCTL_CREATE_SUBCONTEXT \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 18, \
+			struct nvgpu_tsg_create_subcontext_args)
+#define NVGPU_TSG_IOCTL_DELETE_SUBCONTEXT \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 19, \
+			struct nvgpu_tsg_delete_subcontext_args)
+#define NVGPU_TSG_IOCTL_GET_SHARE_TOKEN \
+	_IOWR(NVGPU_TSG_IOCTL_MAGIC, 20, \
+			struct nvgpu_tsg_get_share_token_args)
+#define NVGPU_TSG_IOCTL_REVOKE_SHARE_TOKEN \
+	_IOW(NVGPU_TSG_IOCTL_MAGIC, 21, \
+			struct nvgpu_tsg_revoke_share_token_args)
+#define NVGPU_TSG_IOCTL_MAX_ARG_SIZE	\
+		sizeof(struct nvgpu_tsg_bind_scheduling_domain_args)
+
+#define NVGPU_TSG_IOCTL_LAST		\
+	_IOC_NR(NVGPU_TSG_IOCTL_REVOKE_SHARE_TOKEN)
+
+/*
+ * /dev/nvhost-dbg-gpu device
+ *
+ * Opening a '/dev/nvhost-dbg-gpu' device node creates a new debugger
+ * session.  nvgpu channels (for the same module) can then be bound to such a
+ * session.
+ *
+ * One nvgpu channel can also be bound to multiple debug sessions
+ *
+ * As long as there is an open device file to the session, or any bound
+ * nvgpu channels it will be valid.  Once all references to the session
+ * are removed the session is deleted.
+ *
+ */
+
+#define NVGPU_DBG_GPU_IOCTL_MAGIC 'D'
+
+/*
+ * Binding/attaching a debugger session to an nvgpu channel
+ *
+ * The 'channel_fd' given here is the fd used to allocate the
+ * gpu channel context.
+ *
+ */
+struct nvgpu_dbg_gpu_bind_channel_args {
+	__u32 channel_fd; /* in */
+	__u32 _pad0[1];
+};
+
+#define NVGPU_DBG_GPU_IOCTL_BIND_CHANNEL				\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 1, struct nvgpu_dbg_gpu_bind_channel_args)
+
+/*
+ * Register operations
+ * All operations are targeted towards first channel
+ * attached to debug session
+ */
+/* valid op values */
+#define NVGPU_DBG_GPU_REG_OP_READ_32                             (0x00000000)
+#define NVGPU_DBG_GPU_REG_OP_WRITE_32                            (0x00000001)
+#define NVGPU_DBG_GPU_REG_OP_READ_64                             (0x00000002)
+#define NVGPU_DBG_GPU_REG_OP_WRITE_64                            (0x00000003)
+/* note: 8b ops are unsupported */
+#define NVGPU_DBG_GPU_REG_OP_READ_08                             (0x00000004)
+#define NVGPU_DBG_GPU_REG_OP_WRITE_08                            (0x00000005)
+
+/* valid type values */
+#define NVGPU_DBG_GPU_REG_OP_TYPE_GLOBAL                         (0x00000000)
+#define NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX                         (0x00000001)
+#define NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX_TPC                     (0x00000002)
+#define NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX_SM                      (0x00000004)
+#define NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX_CROP                    (0x00000008)
+#define NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX_ZROP                    (0x00000010)
+/*#define NVGPU_DBG_GPU_REG_OP_TYPE_FB                           (0x00000020)*/
+#define NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX_QUAD                    (0x00000040)
+
+/* valid status values */
+#define NVGPU_DBG_GPU_REG_OP_STATUS_SUCCESS                      (0x00000000)
+#define NVGPU_DBG_GPU_REG_OP_STATUS_INVALID_OP                   (0x00000001)
+#define NVGPU_DBG_GPU_REG_OP_STATUS_INVALID_TYPE                 (0x00000002)
+#define NVGPU_DBG_GPU_REG_OP_STATUS_INVALID_OFFSET               (0x00000004)
+#define NVGPU_DBG_GPU_REG_OP_STATUS_UNSUPPORTED_OP               (0x00000008)
+#define NVGPU_DBG_GPU_REG_OP_STATUS_INVALID_MASK                 (0x00000010)
+
+struct nvgpu_dbg_gpu_reg_op {
+	__u8    op;
+	__u8    type;
+	__u8    status;
+	__u8    quad;
+	__u32   group_mask;
+	__u32   sub_group_mask;
+	__u32   offset;
+	__u32   value_lo;
+	__u32   value_hi;
+	__u32   and_n_mask_lo;
+	__u32   and_n_mask_hi;
+};
+
+struct nvgpu_dbg_gpu_exec_reg_ops_args {
+	__u64 ops; /* pointer to nvgpu_reg_op operations */
+	__u32 num_ops;
+	__u32 gr_ctx_resident;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_REG_OPS					\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 2, struct nvgpu_dbg_gpu_exec_reg_ops_args)
+
+/* Enable/disable/clear event notifications */
+struct nvgpu_dbg_gpu_events_ctrl_args {
+	__u32 cmd; /* in */
+	__u32 _pad0[1];
+};
+
+/* valid event ctrl values */
+#define NVGPU_DBG_GPU_EVENTS_CTRL_CMD_DISABLE                    (0x00000000)
+#define NVGPU_DBG_GPU_EVENTS_CTRL_CMD_ENABLE                     (0x00000001)
+#define NVGPU_DBG_GPU_EVENTS_CTRL_CMD_CLEAR                      (0x00000002)
+
+#define NVGPU_DBG_GPU_IOCTL_EVENTS_CTRL				\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 3, struct nvgpu_dbg_gpu_events_ctrl_args)
+
+
+/* Powergate/Unpowergate control */
+
+#define NVGPU_DBG_GPU_POWERGATE_MODE_ENABLE                                 1
+#define NVGPU_DBG_GPU_POWERGATE_MODE_DISABLE                                2
+
+struct nvgpu_dbg_gpu_powergate_args {
+	__u32 mode;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_POWERGATE					\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 4, struct nvgpu_dbg_gpu_powergate_args)
+
+
+/* SMPC Context Switch Mode */
+#define NVGPU_DBG_GPU_SMPC_CTXSW_MODE_NO_CTXSW               (0x00000000)
+#define NVGPU_DBG_GPU_SMPC_CTXSW_MODE_CTXSW                  (0x00000001)
+
+struct nvgpu_dbg_gpu_smpc_ctxsw_mode_args {
+	__u32 mode;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_SMPC_CTXSW_MODE \
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 5, struct nvgpu_dbg_gpu_smpc_ctxsw_mode_args)
+
+/* Suspend /Resume SM control */
+#define NVGPU_DBG_GPU_SUSPEND_ALL_SMS 1
+#define NVGPU_DBG_GPU_RESUME_ALL_SMS  2
+
+struct nvgpu_dbg_gpu_suspend_resume_all_sms_args {
+	__u32 mode;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_SUSPEND_RESUME_ALL_SMS			\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 6, struct nvgpu_dbg_gpu_suspend_resume_all_sms_args)
+
+struct nvgpu_dbg_gpu_perfbuf_map_args {
+	__u32 dmabuf_fd;	/* in */
+	__u32 reserved;
+	__u64 mapping_size;	/* in, size of mapped buffer region */
+	__u64 offset;		/* out, virtual address of the mapping */
+};
+
+struct nvgpu_dbg_gpu_perfbuf_unmap_args {
+	__u64 offset;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_PERFBUF_MAP \
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 7, struct nvgpu_dbg_gpu_perfbuf_map_args)
+#define NVGPU_DBG_GPU_IOCTL_PERFBUF_UNMAP \
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 8, struct nvgpu_dbg_gpu_perfbuf_unmap_args)
+
+/* Enable/disable PC Sampling */
+struct nvgpu_dbg_gpu_pc_sampling_args {
+	__u32 enable;
+	__u32 _pad0[1];
+};
+
+#define NVGPU_DBG_GPU_IOCTL_PC_SAMPLING_DISABLE	0
+#define NVGPU_DBG_GPU_IOCTL_PC_SAMPLING_ENABLE	1
+
+#define NVGPU_DBG_GPU_IOCTL_PC_SAMPLING \
+	_IOW(NVGPU_DBG_GPU_IOCTL_MAGIC,  9, struct nvgpu_dbg_gpu_pc_sampling_args)
+
+/* Enable/Disable timeouts */
+#define NVGPU_DBG_GPU_IOCTL_TIMEOUT_ENABLE                                   1
+#define NVGPU_DBG_GPU_IOCTL_TIMEOUT_DISABLE                                  0
+
+struct nvgpu_dbg_gpu_timeout_args {
+	__u32 enable;
+	__u32 padding;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_TIMEOUT \
+	_IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 10, struct nvgpu_dbg_gpu_timeout_args)
+
+#define NVGPU_DBG_GPU_IOCTL_GET_TIMEOUT \
+	_IOR(NVGPU_DBG_GPU_IOCTL_MAGIC, 11, struct nvgpu_dbg_gpu_timeout_args)
+
+
+struct nvgpu_dbg_gpu_set_next_stop_trigger_type_args {
+	__u32 broadcast;
+	__u32 reserved;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_SET_NEXT_STOP_TRIGGER_TYPE			\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 12, struct nvgpu_dbg_gpu_set_next_stop_trigger_type_args)
+
+
+/* PM Context Switch Mode */
+/*This mode says that the pms are not to be context switched. */
+#define NVGPU_DBG_GPU_HWPM_CTXSW_MODE_NO_CTXSW               (0x00000000)
+/* This mode says that the pms in Mode-B are to be context switched */
+#define NVGPU_DBG_GPU_HWPM_CTXSW_MODE_CTXSW                  (0x00000001)
+/* This mode says that the pms in Mode-E (stream out) are to be context switched. */
+#define NVGPU_DBG_GPU_HWPM_CTXSW_MODE_STREAM_OUT_CTXSW       (0x00000002)
+
+struct nvgpu_dbg_gpu_hwpm_ctxsw_mode_args {
+	__u32 mode;
+	__u32 reserved;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_HWPM_CTXSW_MODE \
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 13, struct nvgpu_dbg_gpu_hwpm_ctxsw_mode_args)
+
+
+struct nvgpu_dbg_gpu_sm_error_state_record {
+	__u32 hww_global_esr;
+	__u32 hww_warp_esr;
+	__u64 hww_warp_esr_pc;
+	__u32 hww_global_esr_report_mask;
+	__u32 hww_warp_esr_report_mask;
+
+	/*
+	 * Notes
+	 * - This struct can be safely appended with new fields. However, always
+	 *   keep the structure size multiple of 8 and make sure that the binary
+	 *   layout does not change between 32-bit and 64-bit architectures.
+	 */
+};
+
+struct nvgpu_dbg_gpu_read_single_sm_error_state_args {
+	__u32 sm_id;
+	__u32 padding;
+	__u64 sm_error_state_record_mem;
+	__u64 sm_error_state_record_size;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_READ_SINGLE_SM_ERROR_STATE			\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 14, struct nvgpu_dbg_gpu_read_single_sm_error_state_args)
+
+
+struct nvgpu_dbg_gpu_clear_single_sm_error_state_args {
+	__u32 sm_id;
+	__u32 padding;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_CLEAR_SINGLE_SM_ERROR_STATE			\
+	_IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 15, struct nvgpu_dbg_gpu_clear_single_sm_error_state_args)
+
+/*
+ * Unbinding/detaching a debugger session from a nvgpu channel
+ *
+ * The 'channel_fd' given here is the fd used to allocate the
+ * gpu channel context.
+ */
+struct nvgpu_dbg_gpu_unbind_channel_args {
+	__u32 channel_fd; /* in */
+	__u32 _pad0[1];
+};
+
+#define NVGPU_DBG_GPU_IOCTL_UNBIND_CHANNEL				\
+	_IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 17, struct nvgpu_dbg_gpu_unbind_channel_args)
+
+
+#define NVGPU_DBG_GPU_SUSPEND_ALL_CONTEXTS	1
+#define NVGPU_DBG_GPU_RESUME_ALL_CONTEXTS	2
+
+struct nvgpu_dbg_gpu_suspend_resume_contexts_args {
+	__u32 action;
+	__u32 is_resident_context;
+	__s32 resident_context_fd;
+	__u32 padding;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_SUSPEND_RESUME_CONTEXTS			\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 18, struct nvgpu_dbg_gpu_suspend_resume_contexts_args)
+
+
+#define NVGPU_DBG_GPU_IOCTL_ACCESS_FB_MEMORY_CMD_READ	1
+#define NVGPU_DBG_GPU_IOCTL_ACCESS_FB_MEMORY_CMD_WRITE	2
+
+struct nvgpu_dbg_gpu_access_fb_memory_args {
+	__u32 cmd;       /* in: either read or write */
+
+	__s32 dmabuf_fd; /* in: dmabuf fd of the buffer in FB */
+	__u64 offset;    /* in: offset within buffer in FB, should be 4B aligned */
+
+	__u64 buffer;    /* in/out: temp buffer to read/write from */
+	__u64 size;      /* in: size of the buffer i.e. size of read/write in bytes, should be 4B aligned */
+};
+
+#define NVGPU_DBG_GPU_IOCTL_ACCESS_FB_MEMORY	\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 19, struct nvgpu_dbg_gpu_access_fb_memory_args)
+
+struct nvgpu_dbg_gpu_profiler_obj_mgt_args {
+	__u32 profiler_handle;
+	__u32 reserved;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_PROFILER_ALLOCATE	\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 20, struct nvgpu_dbg_gpu_profiler_obj_mgt_args)
+
+#define NVGPU_DBG_GPU_IOCTL_PROFILER_FREE	\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 21, struct nvgpu_dbg_gpu_profiler_obj_mgt_args)
+
+struct nvgpu_dbg_gpu_profiler_reserve_args {
+	__u32 profiler_handle;
+	__u32 acquire;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_PROFILER_RESERVE			\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 22, struct nvgpu_dbg_gpu_profiler_reserve_args)
+
+/*
+ * This struct helps to set the exception mask. If mask is not set
+ * or set to NVGPU_DBG_GPU_IOCTL_SET_SM_EXCEPTION_TYPE_MASK_NONE
+ * then kernel code will follow recovery path on sm exception.
+ * If mask is set to NVGPU_DBG_GPU_IOCTL_SET_SM_EXCEPTION_TYPE_MASK_FATAL, then
+ * kernel code will skip recovery path on sm exception.
+ */
+struct nvgpu_dbg_gpu_set_sm_exception_type_mask_args {
+#define NVGPU_DBG_GPU_IOCTL_SET_SM_EXCEPTION_TYPE_MASK_NONE	(0x0U)
+#define NVGPU_DBG_GPU_IOCTL_SET_SM_EXCEPTION_TYPE_MASK_FATAL	(0x1U << 0U)
+	/* exception type mask value */
+	__u32 exception_type_mask;
+	__u32 reserved;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_SET_SM_EXCEPTION_TYPE_MASK \
+	_IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 23, \
+			struct nvgpu_dbg_gpu_set_sm_exception_type_mask_args)
+
+struct nvgpu_dbg_gpu_cycle_stats_args {
+	__u32 dmabuf_fd;
+	__u32 reserved;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_CYCLE_STATS	\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 24, struct nvgpu_dbg_gpu_cycle_stats_args)
+
+/* cycle stats snapshot buffer support for mode E */
+struct nvgpu_dbg_gpu_cycle_stats_snapshot_args {
+	__u32 cmd;		/* in: command to handle     */
+	__u32 dmabuf_fd;	/* in: dma buffer handler    */
+	__u32 extra;		/* in/out: extra payload e.g.*/
+				/*    counter/start perfmon  */
+	__u32 reserved;
+};
+
+/* valid commands to control cycle stats shared buffer */
+#define NVGPU_DBG_GPU_IOCTL_CYCLE_STATS_SNAPSHOT_CMD_FLUSH   0
+#define NVGPU_DBG_GPU_IOCTL_CYCLE_STATS_SNAPSHOT_CMD_ATTACH  1
+#define NVGPU_DBG_GPU_IOCTL_CYCLE_STATS_SNAPSHOT_CMD_DETACH  2
+
+#define NVGPU_DBG_GPU_IOCTL_CYCLE_STATS_SNAPSHOT	\
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 25, struct nvgpu_dbg_gpu_cycle_stats_snapshot_args)
+
+/* MMU Debug Mode */
+#define NVGPU_DBG_GPU_CTX_MMU_DEBUG_MODE_DISABLED	0
+#define NVGPU_DBG_GPU_CTX_MMU_DEBUG_MODE_ENABLED	1
+
+struct nvgpu_dbg_gpu_set_ctx_mmu_debug_mode_args {
+	__u32 mode;
+	__u32 reserved;
+};
+#define NVGPU_DBG_GPU_IOCTL_SET_CTX_MMU_DEBUG_MODE	\
+	_IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 26, \
+	struct nvgpu_dbg_gpu_set_ctx_mmu_debug_mode_args)
+
+/* Get gr context size */
+struct nvgpu_dbg_gpu_get_gr_context_size_args {
+	__u32 size;
+	__u32 reserved;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_GET_GR_CONTEXT_SIZE \
+	_IOR(NVGPU_DBG_GPU_IOCTL_MAGIC, 27, \
+	struct nvgpu_dbg_gpu_get_gr_context_size_args)
+
+/* Get gr context */
+struct nvgpu_dbg_gpu_get_gr_context_args {
+	__u64 buffer;    /* in/out: the output buffer containing contents of the gr context.
+						buffer address is given by the user */
+	__u32 size;      /* in: size of the context buffer */
+	__u32 reserved;
+};
+
+#define NVGPU_DBG_GPU_IOCTL_GET_GR_CONTEXT \
+	_IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 28, \
+	struct nvgpu_dbg_gpu_get_gr_context_args)
+
+#define NVGPU_DBG_GPU_IOCTL_TSG_SET_TIMESLICE \
+	_IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 29, \
+	struct nvgpu_timeslice_args)
+
+#define NVGPU_DBG_GPU_IOCTL_TSG_GET_TIMESLICE \
+	_IOR(NVGPU_DBG_GPU_IOCTL_MAGIC, 30, \
+	struct nvgpu_timeslice_args)
+
+struct nvgpu_dbg_gpu_get_mappings_entry {
+	/* out: start of GPU VA for this mapping */
+	__u64 gpu_va;
+	/* out: size in bytes of this mapping */
+	__u64 size;
+};
+
+struct nvgpu_dbg_gpu_get_mappings_args {
+	/* in: lower VA range, inclusive */
+	__u64 va_lo;
+	/* in: upper VA range, exclusive */
+	__u64 va_hi;
+	/* in: Pointer to the struct nvgpu_dbg_gpu_get_mappings_entry. */
+	__u64 ops_buffer;
+	/*
+	 * in: maximum number of the entries that ops_buffer may hold.
+	 * out: number of entries written to ops_buffer.
+	 * When ops_buffer is zero:
+	 * out: number of mapping entries in range [va_lo, va_hi).
+	 */
+	__u32 count;
+	/* out: Has more valid mappings in this range than count */
+	__u8 has_more;
+	__u8 reserved[3];
+};
+
+/* Maximum read/write ops supported in a single call */
+#define NVGPU_DBG_GPU_IOCTL_ACCESS_GPUVA_CMD_READ 1U
+#define NVGPU_DBG_GPU_IOCTL_ACCESS_GPUVA_CMD_WRITE 2U
+struct nvgpu_dbg_gpu_va_access_entry {
+	/* in: gpu_va address */
+	__u64 gpu_va;
+	/* in/out: Pointer to buffer through which data needs to be read/written */
+	__u64 data;
+	/* in: Access size in bytes */
+	__u32 size;
+	/* out: Whether the GpuVA is accessible */
+	__u8 valid;
+	__u8 reserved[3];
+};
+
+struct nvgpu_dbg_gpu_va_access_args {
+	/* in/out: Pointer to the struct nvgpu_dbg_gpu_va_access_entry */
+	__u64 ops_buf;
+	/* in: Number of buffer ops */
+	__u32 count;
+	/* in: Access cmd Read/Write */
+	__u8 cmd;
+	__u8 reserved[3];
+};
+
+#define NVGPU_DBG_GPU_IOCTL_GET_MAPPINGS \
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 31, struct nvgpu_dbg_gpu_get_mappings_args)
+#define NVGPU_DBG_GPU_IOCTL_ACCESS_GPU_VA \
+	_IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 32, struct nvgpu_dbg_gpu_va_access_args)
+
+/* Implicit ERRBAR Mode */
+#define NVGPU_DBG_GPU_SCHED_EXIT_WAIT_FOR_ERRBAR_DISABLED	0
+#define NVGPU_DBG_GPU_SCHED_EXIT_WAIT_FOR_ERRBAR_ENABLED	1
+
+struct nvgpu_sched_exit_wait_for_errbar_args {
+	__u32 enable; /* enable 1, disable 0*/
+};
+
+#define NVGPU_DBG_GPU_IOCTL_SET_SCHED_EXIT_WAIT_FOR_ERRBAR \
+	_IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 33, \
+	struct nvgpu_sched_exit_wait_for_errbar_args)
+
+#define NVGPU_DBG_GPU_IOCTL_LAST		\
+	_IOC_NR(NVGPU_DBG_GPU_IOCTL_SET_SCHED_EXIT_WAIT_FOR_ERRBAR)
+
+#define NVGPU_DBG_GPU_IOCTL_MAX_ARG_SIZE		\
+	sizeof(struct nvgpu_dbg_gpu_access_fb_memory_args)
+
+
+/*
+ * /dev/nvhost-prof-dev-gpu and /dev/nvhost-prof-ctx-gpu devices
+ *
+ * Opening a '/dev/nvhost-prof-*' device node creates a way to
+ * open and manage a profiler object.
+ */
+
+#define NVGPU_PROFILER_IOCTL_MAGIC 'P'
+
+struct nvgpu_profiler_bind_context_args {
+	__s32 tsg_fd;		/* in: TSG file descriptor */
+	__u32 reserved;
+};
+
+#define NVGPU_PROFILER_PM_RESOURCE_ARG_HWPM_LEGACY	0U
+#define NVGPU_PROFILER_PM_RESOURCE_ARG_SMPC		1U
+#define NVGPU_PROFILER_PM_RESOURCE_ARG_PC_SAMPLER	2U
+#define NVGPU_PROFILER_PM_RESOURCE_ARG_HES_CWD		3U
+
+struct nvgpu_profiler_reserve_pm_resource_args {
+	__u32 resource; 	/* in: NVGPU_PROFILER_PM_RESOURCE_ARG_* resource to be reserved */
+
+/* in: if ctxsw should be enabled for resource */
+#define NVGPU_PROFILER_RESERVE_PM_RESOURCE_ARG_FLAG_CTXSW	(1 << 0)
+	__u32 flags;
+
+	__u32 reserved[2];
+};
+
+struct nvgpu_profiler_release_pm_resource_args {
+	__u32 resource; 	/* in: NVGPU_PROFILER_PM_RESOURCE_ARG_* resource to be released */
+	__u32 reserved;
+};
+
+struct nvgpu_profiler_alloc_pma_stream_args {
+	__u64 pma_buffer_map_size;			/* in: PMA stream buffer size */
+	__u64 pma_buffer_offset;			/* in: offset of PMA stream buffer */
+	__u64 pma_buffer_va;				/* out: PMA stream buffer virtual address */
+	__s32 pma_buffer_fd;				/* in: PMA stream buffer fd */
+
+	__s32 pma_bytes_available_buffer_fd;		/* in: PMA available bytes buffer fd */
+
+/* in: if ctxsw should be enabled for PMA channel */
+#define NVGPU_PROFILER_ALLOC_PMA_STREAM_ARG_FLAG_CTXSW		(1 << 0)
+	__u32 flags;
+
+	__u32 pma_channel_id;				/* out: PMA hardware stream id */
+
+	__u32 reserved[2];
+};
+
+struct nvgpu_profiler_free_pma_stream_args {
+	__u32 pma_channel_id;				/* in: PMA hardware stream id */
+	__u32 reserved[2];
+};
+
+struct nvgpu_profiler_pma_stream_update_get_put_args {
+	__u64 bytes_consumed;		/* in: total bytes consumed by user since last update */
+	__u64 bytes_available;		/* out: available bytes in PMA buffer for user to consume */
+
+	__u64 put_ptr;			/* out: current PUT pointer to be returned */
+
+/* in: if available bytes buffer should be updated */
+#define NVGPU_PROFILER_PMA_STREAM_UPDATE_GET_PUT_ARG_FLAG_UPDATE_AVAILABLE_BYTES	(1 << 0)
+/* in: if need to wait for available bytes buffer to get updated */
+#define NVGPU_PROFILER_PMA_STREAM_UPDATE_GET_PUT_ARG_FLAG_WAIT_FOR_UPDATE		(1 << 1)
+/* in: if current PUT pointer should be returned */
+#define NVGPU_PROFILER_PMA_STREAM_UPDATE_GET_PUT_ARG_FLAG_RETURN_PUT_PTR		(1 << 2)
+/* out: if PMA stream buffer overflow was triggered */
+#define NVGPU_PROFILER_PMA_STREAM_UPDATE_GET_PUT_ARG_FLAG_OVERFLOW_TRIGGERED		(1 << 3)
+	__u32 flags;
+
+	__u32 pma_channel_id;			/* in: PMA channel index */
+
+	__u32 reserved[2];
+};
+
+/*
+ * MODE_ALL_OR_NONE
+ * Reg_ops execution will bail out if any of the reg_op is not valid
+ * or if there is any other error such as failure to access context image.
+ * Subsequent reg_ops will not be executed and nvgpu_profiler_reg_op.status
+ * will not be populated for them.
+ * IOCTL will always return error for all of the errors.
+ */
+#define NVGPU_PROFILER_EXEC_REG_OPS_ARG_MODE_ALL_OR_NONE	0U
+/*
+ * MODE_CONTINUE_ON_ERROR
+ * This mode allows continuing reg_ops execution even if some of the
+ * reg_ops are not valid. Invalid reg_ops will be skipped and valid
+ * ones will be executed.
+ * IOCTL will return error only if there is some other severe failure
+ * such as failure to access context image.
+ * If any of the reg_op is invalid, or if didn't pass, it will be
+ * reported via NVGPU_PROFILER_EXEC_REG_OPS_ARG_FLAG_ALL_PASSED flag.
+ * IOCTL will return success in such cases.
+ */
+#define NVGPU_PROFILER_EXEC_REG_OPS_ARG_MODE_CONTINUE_ON_ERROR	1U
+
+struct nvgpu_profiler_reg_op {
+	__u8    op;		/* Operation in the form NVGPU_DBG_GPU_REG_OP_READ/WRITE_* */
+	__u8    status;		/* Status in the form NVGPU_DBG_GPU_REG_OP_STATUS_* */
+	__u32   offset;
+	__u64   value;
+	__u64   and_n_mask;
+};
+
+struct nvgpu_profiler_exec_reg_ops_args {
+	__u32 mode;		/* in: operation mode NVGPU_PROFILER_EXEC_REG_OPS_ARG_MODE_* */
+
+	__u32 count;		/* in: number of reg_ops operations,
+				 *     upper limit nvgpu_gpu_characteristics.reg_ops_limit
+				 */
+
+	__u64 ops;		/* in/out: pointer to actual operations nvgpu_profiler_reg_op */
+
+/* out: if all reg_ops passed, valid only for MODE_CONTINUE_ON_ERROR */
+#define NVGPU_PROFILER_EXEC_REG_OPS_ARG_FLAG_ALL_PASSED		(1 << 0)
+/* out: if the operations were performed directly on HW or in context image */
+#define NVGPU_PROFILER_EXEC_REG_OPS_ARG_FLAG_DIRECT_OPS		(1 << 1)
+	__u32 flags;
+
+	__u32 reserved[3];
+};
+
+struct nvgpu_profiler_vab_range_checker {
+
+	/*
+	 * in: starting physical address. Must be aligned by
+	 *     1 << (granularity_shift + bitmask_size_shift) where
+	 *     bitmask_size_shift is a HW specific constant.
+	 */
+	__u64 start_phys_addr;
+
+	/* in: log2 of coverage granularity per bit */
+	__u8  granularity_shift;
+
+	__u8  reserved[7];
+};
+
+/* Range checkers track all accesses (read and write) */
+#define NVGPU_PROFILER_VAB_RANGE_CHECKER_MODE_ACCESS  1U
+/* Range checkers track writes (writes and read-modify-writes) */
+#define NVGPU_PROFILER_VAB_RANGE_CHECKER_MODE_DIRTY   2U
+
+struct nvgpu_profiler_vab_reserve_args {
+
+	/* in: range checker mode */
+	__u8 vab_mode;
+
+	__u8 reserved[3];
+
+	/* in: number of range checkers, must match with the HW */
+	__u32 num_range_checkers;
+
+	/*
+	 * in: range checker parameters. Pointer to array of
+	 *     nvgpu_profiler_vab_range_checker elements
+	 */
+	__u64 range_checkers_ptr;
+};
+
+struct nvgpu_profiler_vab_flush_state_args {
+	__u64 buffer_ptr;	/* in: usermode pointer to receive the
+				 * VAB state buffer */
+	__u64 buffer_size;	/* in: VAB buffer size. Must match
+				 * with the hardware VAB state size */
+};
+
+#define NVGPU_PROFILER_IOCTL_BIND_CONTEXT \
+	_IOW(NVGPU_PROFILER_IOCTL_MAGIC, 1, struct nvgpu_profiler_bind_context_args)
+#define NVGPU_PROFILER_IOCTL_RESERVE_PM_RESOURCE \
+	_IOW(NVGPU_PROFILER_IOCTL_MAGIC, 2, struct nvgpu_profiler_reserve_pm_resource_args)
+#define NVGPU_PROFILER_IOCTL_RELEASE_PM_RESOURCE \
+	_IOW(NVGPU_PROFILER_IOCTL_MAGIC, 3, struct nvgpu_profiler_release_pm_resource_args)
+#define NVGPU_PROFILER_IOCTL_ALLOC_PMA_STREAM \
+	_IOWR(NVGPU_PROFILER_IOCTL_MAGIC, 4, struct nvgpu_profiler_alloc_pma_stream_args)
+#define NVGPU_PROFILER_IOCTL_FREE_PMA_STREAM \
+	_IOW(NVGPU_PROFILER_IOCTL_MAGIC, 5, struct nvgpu_profiler_free_pma_stream_args)
+#define NVGPU_PROFILER_IOCTL_BIND_PM_RESOURCES \
+	_IO(NVGPU_PROFILER_IOCTL_MAGIC, 6)
+#define NVGPU_PROFILER_IOCTL_UNBIND_PM_RESOURCES \
+	_IO(NVGPU_PROFILER_IOCTL_MAGIC, 7)
+#define NVGPU_PROFILER_IOCTL_PMA_STREAM_UPDATE_GET_PUT \
+	_IOWR(NVGPU_PROFILER_IOCTL_MAGIC, 8, struct nvgpu_profiler_pma_stream_update_get_put_args)
+#define NVGPU_PROFILER_IOCTL_EXEC_REG_OPS \
+	_IOWR(NVGPU_PROFILER_IOCTL_MAGIC, 9, struct nvgpu_profiler_exec_reg_ops_args)
+#define NVGPU_PROFILER_IOCTL_UNBIND_CONTEXT \
+	_IO(NVGPU_PROFILER_IOCTL_MAGIC, 10)
+#define NVGPU_PROFILER_IOCTL_VAB_RESERVE \
+	_IOW(NVGPU_PROFILER_IOCTL_MAGIC, 11, struct nvgpu_profiler_vab_reserve_args)
+#define NVGPU_PROFILER_IOCTL_VAB_RELEASE \
+	_IO(NVGPU_PROFILER_IOCTL_MAGIC, 12)
+#define NVGPU_PROFILER_IOCTL_VAB_FLUSH_STATE \
+	_IOW(NVGPU_PROFILER_IOCTL_MAGIC, 13, struct nvgpu_profiler_vab_flush_state_args)
+#define NVGPU_PROFILER_IOCTL_MAX_ARG_SIZE	\
+		sizeof(struct nvgpu_profiler_alloc_pma_stream_args)
+#define NVGPU_PROFILER_IOCTL_LAST		\
+	_IOC_NR(NVGPU_PROFILER_IOCTL_VAB_FLUSH_STATE)
+
+
+/*
+ * /dev/nvhost-gpu device
+ */
+
+#define NVGPU_IOCTL_MAGIC 'H'
+#define NVGPU_NO_TIMEOUT ((__u32)~0U)
+#define NVGPU_TIMEOUT_FLAG_DISABLE_DUMP		0
+
+/* this is also the hardware memory format */
+struct nvgpu_gpfifo {
+	__u32 entry0; /* first word of gpfifo entry */
+	__u32 entry1; /* second word of gpfifo entry */
+};
+
+struct nvgpu_get_param_args {
+	__u32 value;
+};
+
+struct nvgpu_channel_open_args {
+	union {
+		__s32 channel_fd; /* deprecated: use out.channel_fd instead */
+		struct {
+			 /* runlist_id is the runlist for the
+			  * channel. Basically, the runlist specifies the target
+			  * engine(s) for which the channel is
+			  * opened. Runlist_id -1 is synonym for the primary
+			  * graphics runlist. */
+			__s32 runlist_id;
+		} in;
+		struct {
+			__s32 channel_fd;
+		} out;
+	};
+};
+
+struct nvgpu_set_nvmap_fd_args {
+	__u32 fd;
+};
+
+#define NVGPU_ALLOC_OBJ_FLAGS_LOCKBOOST_ZERO	(1 << 0)
+/* Flags in nvgpu_alloc_obj_ctx_args.flags */
+#define NVGPU_ALLOC_OBJ_FLAGS_GFXP		(1 << 1)
+#define NVGPU_ALLOC_OBJ_FLAGS_CILP		(1 << 2)
+
+struct nvgpu_alloc_obj_ctx_args {
+	__u32 class_num; /* kepler3d, 2d, compute, etc       */
+	__u32 flags;     /* input, output */
+	__u64 obj_id;    /* output, used to free later       */
+};
+
+/* Deprecated. Use the SETUP_BIND IOCTL instead. */
+struct nvgpu_alloc_gpfifo_ex_args {
+	__u32 num_entries;
+	__u32 num_inflight_jobs;
+#define NVGPU_ALLOC_GPFIFO_EX_FLAGS_VPR_ENABLED		(1 << 0)
+#define NVGPU_ALLOC_GPFIFO_EX_FLAGS_DETERMINISTIC	(1 << 1)
+	__u32 flags;
+	__u32 reserved[5];
+};
+
+/*
+ * Setup the channel and bind it (enable).
+ */
+struct nvgpu_channel_setup_bind_args {
+/*
+ * Must be power of 2. Max value U32_MAX/8 (size of gpfifo entry) rounded of to
+ * nearest lower power of 2 i.e. 2^28. The lower limit is due to the fact that
+ * the last entry of gpfifo is kept empty and used to determine buffer empty or
+ * full condition. Additionally, kmd submit uses pre/post sync which needs
+ * another extra entry.
+ * Range: 2, 4, 8, ..., 2^28 when
+ *        NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT is set.
+ * Range: 4, 8, 16, ..., 2^28 otherwise.
+ */
+	__u32 num_gpfifo_entries;
+	__u32 num_inflight_jobs;
+/* Set owner channel of this gpfifo as a vpr channel. */
+#define NVGPU_CHANNEL_SETUP_BIND_FLAGS_VPR_ENABLED		(1 << 0)
+/*
+ * Channel shall exhibit deterministic behavior in the submit path.
+ *
+ * NOTE: as an exception, VPR resize may still cause the GPU to reset at any
+ * time, which is not deterministic behavior. If this is not acceptable, the
+ * user has to make sure that VPR resize does not occur.
+ *
+ * With this flag, any submits with in-kernel job tracking also require that
+ * num_inflight_jobs is nonzero, and additionally that
+ * NVGPU_GPU_FLAGS_SUPPORT_DETERMINISTIC_SUBMIT_FULL is found in gpu
+ * characteristics.flags.
+ *
+ * Note that fast submits (with no in-kernel job tracking) are also
+ * deterministic and are supported if the characteristics flags contain
+ * NVGPU_GPU_FLAGS_SUPPORT_DETERMINISTIC_SUBMIT_NO_JOBTRACKING; this flag or
+ * num_inflight_jobs are not necessary in that case.
+ */
+#define NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC	(1 << 1)
+/* enable replayable gmmu faults for this channel */
+#define NVGPU_CHANNEL_SETUP_BIND_FLAGS_REPLAYABLE_FAULTS_ENABLE   (1 << 2)
+/*
+ * Enable usermode submits on this channel.
+ *
+ * Submits in usermode are supported in some environments. If supported and
+ * this flag is set + USERD and GPFIFO buffers are provided here, a submit
+ * token is passed back to be written in the doorbell register in the usermode
+ * region to notify the GPU for new work on this channel. Usermode and
+ * kernelmode submit modes are mutually exclusive; by passing this flag, the
+ * SUBMIT_GPFIFO IOCTL cannot be used.
+ */
+#define NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT	(1 << 3)
+/*
+ * Map usermode resources to GPU and return GPU VAs to userspace.
+ */
+#define NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_GPU_MAP_RESOURCES_SUPPORT	(1 << 4)
+	__u32 flags;
+	__s32 userd_dmabuf_fd;	/* in */
+	__s32 gpfifo_dmabuf_fd;	/* in */
+	__u32 work_submit_token; /* out */
+	__u64 userd_dmabuf_offset; /* in */
+	__u64 gpfifo_dmabuf_offset; /* in */
+	__u64 gpfifo_gpu_va; /* out */
+	__u64 userd_gpu_va; /* out */
+	__u64 usermode_mmio_gpu_va; /* out */
+	__u32 reserved[9];
+};
+
+struct nvgpu_fence {
+	__u32 id;        /* syncpoint id or sync fence fd */
+	__u32 value;     /* syncpoint value (discarded when using sync fence) */
+};
+
+/* insert a wait on the fence before submitting gpfifo */
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_FENCE_WAIT	(1 << 0)
+/* insert a fence update after submitting gpfifo and
+   return the new fence for others to wait on */
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_FENCE_GET	(1 << 1)
+/* choose between different gpfifo entry formats */
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_HW_FORMAT	(1 << 2)
+/* interpret fence as a sync fence fd instead of raw syncpoint fence */
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_SYNC_FENCE	(1 << 3)
+/* suppress WFI before fence trigger */
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_SUPPRESS_WFI	(1 << 4)
+/* skip buffer refcounting during submit */
+#define NVGPU_SUBMIT_GPFIFO_FLAGS_SKIP_BUFFER_REFCOUNTING	(1 << 5)
+
+struct nvgpu_submit_gpfifo_args {
+	__u64 gpfifo;
+	__u32 num_entries;
+	__u32 flags;
+	struct nvgpu_fence fence;
+};
+
+struct nvgpu_wait_args {
+#define NVGPU_WAIT_TYPE_NOTIFIER	0x0
+#define NVGPU_WAIT_TYPE_SEMAPHORE	0x1
+	__u32 type;
+	__u32 timeout;
+	union {
+		struct {
+			/* handle and offset for notifier memory */
+			__u32 dmabuf_fd;
+			__u32 offset;
+			__u32 padding1;
+			__u32 padding2;
+		} notifier;
+		struct {
+			/* handle and offset for semaphore memory */
+			__u32 dmabuf_fd;
+			__u32 offset;
+			/* semaphore payload to wait for */
+			__u32 payload;
+			__u32 padding;
+		} semaphore;
+	} condition; /* determined by type field */
+};
+
+struct nvgpu_set_timeout_args {
+	__u32 timeout;
+};
+
+struct nvgpu_set_timeout_ex_args {
+	__u32 timeout;
+	__u32 flags;
+};
+
+#define NVGPU_ZCULL_MODE_GLOBAL		0
+#define NVGPU_ZCULL_MODE_NO_CTXSW		1
+#define NVGPU_ZCULL_MODE_SEPARATE_BUFFER	2
+#define NVGPU_ZCULL_MODE_PART_OF_REGULAR_BUF	3
+
+struct nvgpu_zcull_bind_args {
+	__u64 gpu_va;
+	__u32 mode;
+	__u32 padding;
+};
+
+struct nvgpu_set_error_notifier {
+	__u64 offset;
+	__u64 size;
+	__u32 mem;
+	__u32 padding;
+};
+
+struct nvgpu_notification {
+	struct {			/* 0000- */
+		__u32 nanoseconds[2];	/* nanoseconds since Jan. 1, 1970 */
+	} time_stamp;			/* -0007 */
+	__u32 info32;	/* info returned depends on method 0008-000b */
+#define	NVGPU_CHANNEL_FIFO_ERROR_IDLE_TIMEOUT		8
+#define	NVGPU_CHANNEL_GR_ERROR_SW_METHOD		12
+#define	NVGPU_CHANNEL_GR_ERROR_SW_NOTIFY		13
+#define	NVGPU_CHANNEL_GR_EXCEPTION			13
+#define	NVGPU_CHANNEL_GR_SEMAPHORE_TIMEOUT		24
+#define	NVGPU_CHANNEL_GR_ILLEGAL_NOTIFY			25
+#define	NVGPU_CHANNEL_FIFO_ERROR_MMU_ERR_FLT		31
+#define	NVGPU_CHANNEL_PBDMA_ERROR			32
+#define NVGPU_CHANNEL_FECS_ERR_UNIMP_FIRMWARE_METHOD	37
+#define	NVGPU_CHANNEL_RESETCHANNEL_VERIF_ERROR		43
+#define	NVGPU_CHANNEL_PBDMA_PUSHBUFFER_CRC_MISMATCH	80
+	__u16 info16;	/* info returned depends on method 000c-000d */
+	__u16 status;	/* user sets bit 15, NV sets status 000e-000f */
+#define	NVGPU_CHANNEL_SUBMIT_TIMEOUT		1
+};
+
+/* configure watchdog per-channel */
+struct nvgpu_channel_wdt_args {
+	__u32 wdt_status;
+	__u32 timeout_ms;
+};
+#define NVGPU_IOCTL_CHANNEL_DISABLE_WDT		  (1 << 0)
+#define NVGPU_IOCTL_CHANNEL_ENABLE_WDT		  (1 << 1)
+#define NVGPU_IOCTL_CHANNEL_WDT_FLAG_SET_TIMEOUT  (1 << 2)
+#define NVGPU_IOCTL_CHANNEL_WDT_FLAG_DISABLE_DUMP (1 << 3)
+
+/*
+ * Interleaving channels in a runlist is an approach to improve
+ * GPU scheduling by allowing certain channels to appear multiple
+ * times on the runlist. The number of times a channel appears is
+ * governed by the following levels:
+ *
+ * low (L)   : appears once
+ * medium (M): if L, appears L times
+ *             else, appears once
+ * high (H)  : if L, appears (M + 1) x L times
+ *             else if M, appears M times
+ *             else, appears once
+ */
+struct nvgpu_runlist_interleave_args {
+	__u32 level;
+	__u32 reserved;
+};
+#define NVGPU_RUNLIST_INTERLEAVE_LEVEL_LOW	0
+#define NVGPU_RUNLIST_INTERLEAVE_LEVEL_MEDIUM	1
+#define NVGPU_RUNLIST_INTERLEAVE_LEVEL_HIGH	2
+#define NVGPU_RUNLIST_INTERLEAVE_NUM_LEVELS	3
+
+/* controls how long a channel occupies an engine uninterrupted */
+struct nvgpu_timeslice_args {
+	__u32 timeslice_us;
+	__u32 reserved;
+};
+
+struct nvgpu_event_id_ctrl_args {
+	__u32 cmd; /* in */
+	__u32 event_id; /* in */
+	__s32 event_fd; /* out */
+	__u32 padding;
+};
+#define NVGPU_IOCTL_CHANNEL_EVENT_ID_BPT_INT		0
+#define NVGPU_IOCTL_CHANNEL_EVENT_ID_BPT_PAUSE		1
+#define NVGPU_IOCTL_CHANNEL_EVENT_ID_BLOCKING_SYNC	2
+#define NVGPU_IOCTL_CHANNEL_EVENT_ID_CILP_PREEMPTION_STARTED	3
+#define NVGPU_IOCTL_CHANNEL_EVENT_ID_CILP_PREEMPTION_COMPLETE	4
+#define NVGPU_IOCTL_CHANNEL_EVENT_ID_GR_SEMAPHORE_WRITE_AWAKEN	5
+#define NVGPU_IOCTL_CHANNEL_EVENT_ID_MAX		6
+
+#define NVGPU_IOCTL_CHANNEL_EVENT_ID_CMD_ENABLE		1
+
+struct nvgpu_preemption_mode_args {
+/* only one should be enabled at a time */
+#define NVGPU_GRAPHICS_PREEMPTION_MODE_WFI              (1 << 0)
+#define NVGPU_GRAPHICS_PREEMPTION_MODE_GFXP		(1 << 1)
+	__u32 graphics_preempt_mode; /* in */
+
+/* only one should be enabled at a time */
+#define NVGPU_COMPUTE_PREEMPTION_MODE_WFI               (1 << 0)
+#define NVGPU_COMPUTE_PREEMPTION_MODE_CTA               (1 << 1)
+#define NVGPU_COMPUTE_PREEMPTION_MODE_CILP		(1 << 2)
+
+	__u32 compute_preempt_mode; /* in */
+};
+
+struct nvgpu_boosted_ctx_args {
+#define NVGPU_BOOSTED_CTX_MODE_NORMAL			(0U)
+#define NVGPU_BOOSTED_CTX_MODE_BOOSTED_EXECUTION	(1U)
+	__u32 boost;
+	__u32 padding;
+};
+
+struct nvgpu_get_user_syncpoint_args {
+	__u64 gpu_va;		/* out */
+	__u32 syncpoint_id;	/* out */
+	__u32 syncpoint_max;	/* out */
+};
+
+struct nvgpu_reschedule_runlist_args {
+#define NVGPU_RESCHEDULE_RUNLIST_PREEMPT_NEXT           (1 << 0)
+	__u32 flags;
+};
+
+#define NVGPU_IOCTL_CHANNEL_SET_NVMAP_FD	\
+	_IOW(NVGPU_IOCTL_MAGIC, 5, struct nvgpu_set_nvmap_fd_args)
+#define NVGPU_IOCTL_CHANNEL_SET_TIMEOUT	\
+	_IOW(NVGPU_IOCTL_MAGIC, 11, struct nvgpu_set_timeout_args)
+#define NVGPU_IOCTL_CHANNEL_GET_TIMEDOUT	\
+	_IOR(NVGPU_IOCTL_MAGIC, 12, struct nvgpu_get_param_args)
+#define NVGPU_IOCTL_CHANNEL_SET_TIMEOUT_EX	\
+	_IOWR(NVGPU_IOCTL_MAGIC, 18, struct nvgpu_set_timeout_ex_args)
+#define NVGPU_IOCTL_CHANNEL_WAIT		\
+	_IOWR(NVGPU_IOCTL_MAGIC, 102, struct nvgpu_wait_args)
+#define NVGPU_IOCTL_CHANNEL_SUBMIT_GPFIFO	\
+	_IOWR(NVGPU_IOCTL_MAGIC, 107, struct nvgpu_submit_gpfifo_args)
+#define NVGPU_IOCTL_CHANNEL_ALLOC_OBJ_CTX	\
+	_IOWR(NVGPU_IOCTL_MAGIC, 108, struct nvgpu_alloc_obj_ctx_args)
+#define NVGPU_IOCTL_CHANNEL_ZCULL_BIND		\
+	_IOWR(NVGPU_IOCTL_MAGIC, 110, struct nvgpu_zcull_bind_args)
+#define NVGPU_IOCTL_CHANNEL_SET_ERROR_NOTIFIER  \
+	_IOWR(NVGPU_IOCTL_MAGIC, 111, struct nvgpu_set_error_notifier)
+#define NVGPU_IOCTL_CHANNEL_OPEN	\
+	_IOR(NVGPU_IOCTL_MAGIC,  112, struct nvgpu_channel_open_args)
+#define NVGPU_IOCTL_CHANNEL_ENABLE	\
+	_IO(NVGPU_IOCTL_MAGIC,  113)
+#define NVGPU_IOCTL_CHANNEL_DISABLE	\
+	_IO(NVGPU_IOCTL_MAGIC,  114)
+#define NVGPU_IOCTL_CHANNEL_PREEMPT	\
+	_IO(NVGPU_IOCTL_MAGIC,  115)
+#define NVGPU_IOCTL_CHANNEL_FORCE_RESET	\
+	_IO(NVGPU_IOCTL_MAGIC,  116)
+#define NVGPU_IOCTL_CHANNEL_EVENT_ID_CTRL \
+	_IOWR(NVGPU_IOCTL_MAGIC, 117, struct nvgpu_event_id_ctrl_args)
+#define NVGPU_IOCTL_CHANNEL_WDT \
+	_IOW(NVGPU_IOCTL_MAGIC, 119, struct nvgpu_channel_wdt_args)
+#define NVGPU_IOCTL_CHANNEL_SET_RUNLIST_INTERLEAVE \
+	_IOW(NVGPU_IOCTL_MAGIC, 120, struct nvgpu_runlist_interleave_args)
+#define NVGPU_IOCTL_CHANNEL_SET_PREEMPTION_MODE \
+	_IOW(NVGPU_IOCTL_MAGIC, 122, struct nvgpu_preemption_mode_args)
+#define NVGPU_IOCTL_CHANNEL_ALLOC_GPFIFO_EX	\
+	_IOW(NVGPU_IOCTL_MAGIC, 123, struct nvgpu_alloc_gpfifo_ex_args)
+#define NVGPU_IOCTL_CHANNEL_SET_BOOSTED_CTX	\
+	_IOW(NVGPU_IOCTL_MAGIC, 124, struct nvgpu_boosted_ctx_args)
+#define NVGPU_IOCTL_CHANNEL_GET_USER_SYNCPOINT \
+	_IOR(NVGPU_IOCTL_MAGIC, 126, struct nvgpu_get_user_syncpoint_args)
+#define NVGPU_IOCTL_CHANNEL_RESCHEDULE_RUNLIST	\
+	_IOW(NVGPU_IOCTL_MAGIC, 127, struct nvgpu_reschedule_runlist_args)
+#define NVGPU_IOCTL_CHANNEL_SETUP_BIND	\
+	_IOWR(NVGPU_IOCTL_MAGIC, 128, struct nvgpu_channel_setup_bind_args)
+
+#define NVGPU_IOCTL_CHANNEL_LAST	\
+	_IOC_NR(NVGPU_IOCTL_CHANNEL_SETUP_BIND)
+#define NVGPU_IOCTL_CHANNEL_MAX_ARG_SIZE \
+	sizeof(struct nvgpu_channel_setup_bind_args)
+
+/*
+ * /dev/nvhost-ctxsw-gpu device
+ *
+ * Opening a '/dev/nvhost-ctxsw-gpu' device node creates a way to trace
+ * context switches on GR engine
+ */
+
+#define NVGPU_CTXSW_IOCTL_MAGIC 'C'
+
+#define NVGPU_CTXSW_TAG_SOF			0x00
+#define NVGPU_CTXSW_TAG_CTXSW_REQ_BY_HOST	0x01
+#define NVGPU_CTXSW_TAG_FE_ACK			0x02
+#define NVGPU_CTXSW_TAG_FE_ACK_WFI		0x0a
+#define NVGPU_CTXSW_TAG_FE_ACK_GFXP		0x0b
+#define NVGPU_CTXSW_TAG_FE_ACK_CTAP		0x0c
+#define NVGPU_CTXSW_TAG_FE_ACK_CILP		0x0d
+#define NVGPU_CTXSW_TAG_SAVE_END		0x03
+#define NVGPU_CTXSW_TAG_RESTORE_START		0x04
+#define NVGPU_CTXSW_TAG_CONTEXT_START		0x05
+#define NVGPU_CTXSW_TAG_ENGINE_RESET		0xfe
+#define NVGPU_CTXSW_TAG_INVALID_TIMESTAMP	0xff
+#define NVGPU_CTXSW_TAG_LAST			\
+	NVGPU_CTXSW_TAG_INVALID_TIMESTAMP
+
+struct nvgpu_ctxsw_trace_entry {
+	__u8 tag;
+	__u8 vmid;
+	__u16 seqno;		/* sequence number to detect drops */
+	__u32 context_id;	/* context_id as allocated by FECS */
+	__u64 pid;		/* 64-bit is max bits of different OS pid */
+	__u64 timestamp;	/* 64-bit time */
+};
+
+#define NVGPU_CTXSW_RING_HEADER_MAGIC 0x7000fade
+#define NVGPU_CTXSW_RING_HEADER_VERSION 0
+
+struct nvgpu_ctxsw_ring_header {
+	__u32 magic;
+	__u32 version;
+	__u32 num_ents;
+	__u32 ent_size;
+	volatile __u32 drop_count;	/* excluding filtered out events */
+	volatile __u32 write_seqno;
+	volatile __u32 write_idx;
+	volatile __u32 read_idx;
+};
+
+struct nvgpu_ctxsw_ring_setup_args {
+	__u32 size;	/* [in/out] size of ring buffer in bytes (including
+			   header). will be rounded page size. this parameter
+			   is updated with actual allocated size. */
+};
+
+#define NVGPU_CTXSW_FILTER_SIZE	(NVGPU_CTXSW_TAG_LAST + 1)
+#define NVGPU_CTXSW_FILTER_SET(n, p) \
+	((p)->tag_bits[(n) / 64] |=  (1 << ((n) & 63)))
+#define NVGPU_CTXSW_FILTER_CLR(n, p) \
+	((p)->tag_bits[(n) / 64] &= ~(1 << ((n) & 63)))
+#define NVGPU_CTXSW_FILTER_ISSET(n, p) \
+	((p)->tag_bits[(n) / 64] &   (1 << ((n) & 63)))
+#define NVGPU_CTXSW_FILTER_CLR_ALL(p) \
+	((void) memset((void *)(p), 0, sizeof(*(p))))
+#define NVGPU_CTXSW_FILTER_SET_ALL(p) \
+	((void) memset((void *)(p), ~0, sizeof(*(p))))
+
+struct nvgpu_ctxsw_trace_filter {
+	__u64 tag_bits[(NVGPU_CTXSW_FILTER_SIZE + 63) / 64];
+};
+
+struct nvgpu_ctxsw_trace_filter_args {
+	struct nvgpu_ctxsw_trace_filter filter;
+};
+
+#define NVGPU_CTXSW_IOCTL_TRACE_ENABLE \
+	_IO(NVGPU_CTXSW_IOCTL_MAGIC, 1)
+#define NVGPU_CTXSW_IOCTL_TRACE_DISABLE \
+	_IO(NVGPU_CTXSW_IOCTL_MAGIC, 2)
+#define NVGPU_CTXSW_IOCTL_RING_SETUP \
+	_IOWR(NVGPU_CTXSW_IOCTL_MAGIC, 3, struct nvgpu_ctxsw_ring_setup_args)
+#define NVGPU_CTXSW_IOCTL_SET_FILTER \
+	_IOW(NVGPU_CTXSW_IOCTL_MAGIC, 4, struct nvgpu_ctxsw_trace_filter_args)
+#define NVGPU_CTXSW_IOCTL_GET_FILTER \
+	_IOR(NVGPU_CTXSW_IOCTL_MAGIC, 5, struct nvgpu_ctxsw_trace_filter_args)
+#define NVGPU_CTXSW_IOCTL_POLL \
+	_IO(NVGPU_CTXSW_IOCTL_MAGIC, 6)
+
+#define NVGPU_CTXSW_IOCTL_LAST            \
+	_IOC_NR(NVGPU_CTXSW_IOCTL_POLL)
+
+#define NVGPU_CTXSW_IOCTL_MAX_ARG_SIZE	\
+	sizeof(struct nvgpu_ctxsw_trace_filter_args)
+
+/*
+ * /dev/nvhost-sched-gpu device
+ *
+ * Opening a '/dev/nvhost-sched-gpu' device node creates a way to control
+ * GPU scheduling parameters.
+ */
+
+#define NVGPU_SCHED_IOCTL_MAGIC 'S'
+
+/*
+ * When the app manager receives a NVGPU_SCHED_STATUS_TSG_OPEN notification,
+ * it is expected to query the list of recently opened TSGs using
+ * NVGPU_SCHED_IOCTL_GET_RECENT_TSGS. The kernel driver maintains a bitmap
+ * of recently opened TSGs. When the app manager queries the list, it
+ * atomically clears the bitmap. This way, at each invocation of
+ * NVGPU_SCHED_IOCTL_GET_RECENT_TSGS, app manager only receives the list of
+ * TSGs that have been opened since last invocation.
+ *
+ * If the app manager needs to re-synchronize with the driver, it can use
+ * NVGPU_SCHED_IOCTL_GET_TSGS to retrieve the complete list of TSGs. The
+ * recent TSG bitmap will be cleared in that case too.
+ */
+struct nvgpu_sched_get_tsgs_args {
+	/* in: size of buffer in bytes */
+	/* out: actual size of size of TSG bitmap. if user-provided size is too
+	 * small, ioctl will return -ENOSPC, and update this field, allowing
+	 * application to discover required number of bytes and allocate
+	 * a buffer accordingly.
+	 */
+	__u32 size;
+
+	/* in: address of 64-bit aligned buffer */
+	/* out: buffer contains a TSG bitmap.
+	 * Bit #n will be set in the bitmap if TSG #n is present.
+	 * When using NVGPU_SCHED_IOCTL_GET_RECENT_TSGS, the first time you use
+	 * this command, it will return the opened TSGs and subsequent calls
+	 * will only return the delta (ie. each invocation clears bitmap)
+	 */
+	__u64 buffer;
+};
+
+struct nvgpu_sched_get_tsgs_by_pid_args {
+	/* in: process id for which we want to retrieve TSGs */
+	__u64 pid;
+
+	/* in: size of buffer in bytes */
+	/* out: actual size of size of TSG bitmap. if user-provided size is too
+	 * small, ioctl will return -ENOSPC, and update this field, allowing
+	 * application to discover required number of bytes and allocate
+	 * a buffer accordingly.
+	 */
+	__u32 size;
+
+	/* in: address of 64-bit aligned buffer */
+	/* out: buffer contains a TSG bitmap. */
+	__u64 buffer;
+};
+
+struct nvgpu_sched_tsg_get_params_args {
+	__u32 tsgid;		/* in: TSG identifier */
+	__u32 timeslice;	/* out: timeslice in usecs */
+	__u32 runlist_interleave;
+	__u32 graphics_preempt_mode;
+	__u32 compute_preempt_mode;
+	__u64 pid;		/* out: process identifier of TSG owner */
+};
+
+struct nvgpu_sched_tsg_timeslice_args {
+	__u32 tsgid;                    /* in: TSG identifier */
+	__u32 timeslice;                /* in: timeslice in usecs */
+};
+
+struct nvgpu_sched_tsg_runlist_interleave_args {
+	__u32 tsgid;			/* in: TSG identifier */
+
+		/* in: see NVGPU_RUNLIST_INTERLEAVE_LEVEL_ */
+	__u32 runlist_interleave;
+};
+
+struct nvgpu_sched_api_version_args {
+	__u32 version;
+};
+
+struct nvgpu_sched_tsg_refcount_args {
+	__u32 tsgid;                    /* in: TSG identifier */
+};
+
+#define NVGPU_SCHED_IOCTL_GET_TSGS					\
+	_IOWR(NVGPU_SCHED_IOCTL_MAGIC, 1,				\
+		struct nvgpu_sched_get_tsgs_args)
+#define NVGPU_SCHED_IOCTL_GET_RECENT_TSGS				\
+	_IOWR(NVGPU_SCHED_IOCTL_MAGIC, 2,				\
+		struct nvgpu_sched_get_tsgs_args)
+#define NVGPU_SCHED_IOCTL_GET_TSGS_BY_PID				\
+	_IOWR(NVGPU_SCHED_IOCTL_MAGIC, 3,				\
+		struct nvgpu_sched_get_tsgs_by_pid_args)
+#define NVGPU_SCHED_IOCTL_TSG_GET_PARAMS				\
+	_IOWR(NVGPU_SCHED_IOCTL_MAGIC, 4,				\
+		struct nvgpu_sched_tsg_get_params_args)
+#define NVGPU_SCHED_IOCTL_TSG_SET_TIMESLICE				\
+	_IOW(NVGPU_SCHED_IOCTL_MAGIC, 5,				\
+		struct nvgpu_sched_tsg_timeslice_args)
+#define NVGPU_SCHED_IOCTL_TSG_SET_RUNLIST_INTERLEAVE			\
+	_IOW(NVGPU_SCHED_IOCTL_MAGIC, 6,				\
+		struct nvgpu_sched_tsg_runlist_interleave_args)
+#define NVGPU_SCHED_IOCTL_LOCK_CONTROL					\
+	_IO(NVGPU_SCHED_IOCTL_MAGIC, 7)
+#define NVGPU_SCHED_IOCTL_UNLOCK_CONTROL				\
+	_IO(NVGPU_SCHED_IOCTL_MAGIC, 8)
+#define NVGPU_SCHED_IOCTL_GET_API_VERSION				\
+	_IOR(NVGPU_SCHED_IOCTL_MAGIC, 9,				\
+	    struct nvgpu_sched_api_version_args)
+#define NVGPU_SCHED_IOCTL_GET_TSG					\
+	_IOW(NVGPU_SCHED_IOCTL_MAGIC, 10,				\
+		struct nvgpu_sched_tsg_refcount_args)
+#define NVGPU_SCHED_IOCTL_PUT_TSG					\
+	_IOW(NVGPU_SCHED_IOCTL_MAGIC, 11,				\
+		struct nvgpu_sched_tsg_refcount_args)
+#define NVGPU_SCHED_IOCTL_LAST						\
+	_IOC_NR(NVGPU_SCHED_IOCTL_PUT_TSG)
+
+#define NVGPU_SCHED_IOCTL_MAX_ARG_SIZE					\
+	sizeof(struct nvgpu_sched_tsg_get_params_args)
+
+
+#define NVGPU_SCHED_SET(n, bitmap)	\
+	(((__u64 *)(bitmap))[(n) / 64] |=  (1ULL << (((__u64)n) & 63)))
+#define NVGPU_SCHED_CLR(n, bitmap)	\
+	(((__u64 *)(bitmap))[(n) / 64] &= ~(1ULL << (((__u64)n) & 63)))
+#define NVGPU_SCHED_ISSET(n, bitmap)	\
+	(((__u64 *)(bitmap))[(n) / 64] & (1ULL << (((__u64)n) & 63)))
+
+#define NVGPU_SCHED_STATUS_TSG_OPEN	(1ULL << 0)
+
+struct nvgpu_sched_event_arg {
+	__u64 reserved;
+	__u64 status;
+};
+
+#define NVGPU_SCHED_API_VERSION		1
+
+#endif

--- a/extra/tegra_gpu_driver/nvmap.h
+++ b/extra/tegra_gpu_driver/nvmap.h
@@ -1,0 +1,374 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2009-2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * structure declarations for nvmem and nvmap user-space ioctls
+ */
+
+#include <linux/ioctl.h>
+#include <linux/types.h>
+
+#ifndef __UAPI_LINUX_NVMAP_H
+#define __UAPI_LINUX_NVMAP_H
+
+/*
+ * DOC: NvMap Userspace API
+ *
+ * create a client by opening /dev/nvmap
+ * most operations handled via following ioctls
+ *
+ */
+enum {
+	NVMAP_HANDLE_PARAM_SIZE = 1,
+	NVMAP_HANDLE_PARAM_ALIGNMENT,
+	NVMAP_HANDLE_PARAM_BASE,
+	NVMAP_HANDLE_PARAM_HEAP,
+	NVMAP_HANDLE_PARAM_KIND,
+	NVMAP_HANDLE_PARAM_COMPR, /* ignored, to be removed */
+};
+
+enum {
+	NVMAP_CACHE_OP_WB = 0,
+	NVMAP_CACHE_OP_INV,
+	NVMAP_CACHE_OP_WB_INV,
+};
+
+enum {
+	NVMAP_PAGES_UNRESERVE = 0,
+	NVMAP_PAGES_RESERVE,
+	NVMAP_INSERT_PAGES_ON_UNRESERVE,
+	NVMAP_PAGES_PROT_AND_CLEAN,
+};
+
+#define NVMAP_ELEM_SIZE_U64 (1 << 31)
+
+struct nvmap_create_handle {
+	union {
+		struct {
+			union {
+				/* size will be overwritten */
+				__u32 size;	/* CreateHandle */
+				__s32 fd;	/* DmaBufFd or FromFd */
+			};
+			__u32 handle;		/* returns nvmap handle */
+		};
+		struct {
+			/* one is input parameter, and other is output parameter
+			 * since its a union please note that input parameter
+			 * will be overwritten once ioctl returns
+			 */
+			union {
+				__u64 ivm_id;	 /* CreateHandle from ivm*/
+				__u32 ivm_handle;/* Get ivm_id from handle */
+			};
+		};
+		struct {
+			union {
+				/* size64 will be overwritten */
+				__u64 size64; /* CreateHandle */
+				__u32 handle64; /* returns nvmap handle */
+			};
+		};
+	};
+};
+
+struct nvmap_create_handle_from_va {
+	__u64 va;		/* FromVA*/
+	__u32 size;		/* non-zero for partial memory VMA. zero for end of VMA */
+	__u32 flags;		/* wb/wc/uc/iwb, tag etc. */
+	union {
+		__u32 handle;		/* returns nvmap handle */
+		__u64 size64;		/* used when size is 0 */
+	};
+};
+
+struct nvmap_gup_test {
+	__u64 va;		/* FromVA*/
+	__u32 handle;		/* returns nvmap handle */
+	__u32 result;		/* result=1 for pass, result=-err for failure */
+};
+
+struct nvmap_alloc_handle {
+	__u32 handle;		/* nvmap handle */
+	__u32 heap_mask;	/* heaps to allocate from */
+	__u32 flags;		/* wb/wc/uc/iwb etc. */
+	__u32 align;		/* min alignment necessary */
+	__s32 numa_nid;		/* NUMA node id */
+};
+
+struct nvmap_alloc_ivm_handle {
+	__u32 handle;		/* nvmap handle */
+	__u32 heap_mask;	/* heaps to allocate from */
+	__u32 flags;		/* wb/wc/uc/iwb etc. */
+	__u32 align;		/* min alignment necessary */
+	__u32 peer;		/* peer with whom handle must be shared. Used
+				 *  only for NVMAP_HEAP_CARVEOUT_IVM
+				 */
+};
+
+struct nvmap_rw_handle {
+	__u64 addr;		/* user pointer*/
+	__u32 handle;		/* nvmap handle */
+	__u64 offset;		/* offset into hmem */
+	__u64 elem_size;	/* individual atom size */
+	__u64 hmem_stride;	/* delta in bytes between atoms in hmem */
+	__u64 user_stride;	/* delta in bytes between atoms in user */
+	__u64 count;		/* number of atoms to copy */
+};
+
+#ifdef __KERNEL__
+#ifdef CONFIG_COMPAT
+struct nvmap_rw_handle_32 {
+	__u32 addr;		/* user pointer */
+	__u32 handle;		/* nvmap handle */
+	__u32 offset;		/* offset into hmem */
+	__u32 elem_size;	/* individual atom size */
+	__u32 hmem_stride;	/* delta in bytes between atoms in hmem */
+	__u32 user_stride;	/* delta in bytes between atoms in user */
+	__u32 count;		/* number of atoms to copy */
+};
+#endif /* CONFIG_COMPAT */
+#endif /* __KERNEL__ */
+
+struct nvmap_handle_param {
+	__u32 handle;		/* nvmap handle */
+	__u32 param;		/* size/align/base/heap etc. */
+	unsigned long result;	/* returns requested info*/
+};
+
+#ifdef __KERNEL__
+#ifdef CONFIG_COMPAT
+struct nvmap_handle_param_32 {
+	__u32 handle;		/* nvmap handle */
+	__u32 param;		/* size/align/base/heap etc. */
+	__u32 result;		/* returns requested info*/
+};
+#endif /* CONFIG_COMPAT */
+#endif /* __KERNEL__ */
+
+struct nvmap_cache_op {
+	unsigned long addr;	/* user pointer*/
+	__u32 handle;		/* nvmap handle */
+	__u32 len;		/* bytes to flush */
+	__s32 op;		/* wb/wb_inv/inv */
+};
+
+struct nvmap_cache_op_64 {
+	unsigned long addr;	/* user pointer*/
+	__u32 handle;		/* nvmap handle */
+	__u64 len;		/* bytes to flush */
+	__s32 op;		/* wb/wb_inv/inv */
+};
+
+#ifdef __KERNEL__
+#ifdef CONFIG_COMPAT
+struct nvmap_cache_op_32 {
+	__u32 addr;		/* user pointer*/
+	__u32 handle;		/* nvmap handle */
+	__u32 len;		/* bytes to flush */
+	__s32 op;		/* wb/wb_inv/inv */
+};
+#endif /* CONFIG_COMPAT */
+#endif /* __KERNEL__ */
+
+struct nvmap_cache_op_list {
+	__u64 handles;		/* Ptr to u32 type array, holding handles */
+	__u64 offsets;		/* Ptr to u32 type array, holding offsets
+				 * into handle mem */
+	__u64 sizes;		/* Ptr to u32 type array, holindg sizes of memory
+				 * regions within each handle */
+	__u32 nr;		/* Number of handles */
+	__s32 op;		/* wb/wb_inv/inv */
+};
+
+struct nvmap_debugfs_handles_header {
+	__u8 version;
+};
+
+struct nvmap_debugfs_handles_entry {
+	__u64 base;
+	__u64 size;
+	__u32 flags;
+	__u32 share_count;
+	__u64 mapped_size;
+};
+
+struct nvmap_set_tag_label {
+	__u32 tag;
+	__u32 len;		/* in: label length
+				   out: number of characters copied */
+	__u64 addr;		/* in: pointer to label or NULL to remove */
+};
+
+struct nvmap_available_heaps {
+	__u64 heaps;		/* heaps bitmask */
+};
+
+struct nvmap_heap_size {
+	__u32 heap;
+	__u64 size;
+};
+
+struct nvmap_sciipc_map {
+	__u64 auth_token;    /* AuthToken */
+	__u32 flags;       /* Exporter permission flags */
+	__u64 sci_ipc_id;  /* FromImportId */
+	__u32 handle;      /* Nvmap handle */
+};
+
+struct nvmap_handle_parameters {
+    __u8 contig;
+    __u32 import_id;
+    __u32 handle;
+    __u32 heap_number;
+    __u32 access_flags;
+    __u64 heap;
+    __u64 align;
+    __u64 coherency;
+    __u64 size;
+    __u64 offset;
+    __u64 serial_id;
+};
+
+/**
+ * Struct used while querying heap parameters
+ */
+struct nvmap_query_heap_params {
+	__u32 heap_mask;
+	__u32 flags;
+	__u8 contig;
+	__u64 total;
+	__u64 free;
+	__u64 largest_free_block;
+	__u32 granule_size;
+};
+
+/**
+ * Struct used while duplicating memory handle
+ */
+struct nvmap_duplicate_handle {
+	__u32 handle;
+	__u32 access_flags;
+	__u32 dup_handle;
+};
+
+/**
+ * Struct used while duplicating memory handle
+ */
+struct nvmap_fd_for_range_from_list {
+	__u32 *handles;  /* Head of handles list */
+	__u32 num_handles; /* Number of handles in the list */
+	__u64 offset; /* Offset aligned by page size in the buffers */
+	__u64 size; /* Size of the sub buffer for which fd to be returned */
+	__s32 fd; /* Sub range Dma Buf fd to be returned*/
+};
+
+#define NVMAP_IOC_MAGIC 'N'
+
+/* Creates a new memory handle. On input, the argument is the size of the new
+ * handle; on return, the argument is the name of the new handle
+ */
+#define NVMAP_IOC_CREATE  _IOWR(NVMAP_IOC_MAGIC, 0, struct nvmap_create_handle)
+#define NVMAP_IOC_CREATE_64 \
+	_IOWR(NVMAP_IOC_MAGIC, 1, struct nvmap_create_handle)
+#define NVMAP_IOC_FROM_ID _IOWR(NVMAP_IOC_MAGIC, 2, struct nvmap_create_handle)
+
+/* Actually allocates memory for the specified handle */
+#define NVMAP_IOC_ALLOC    _IOW(NVMAP_IOC_MAGIC, 3, struct nvmap_alloc_handle)
+
+/* Frees a memory handle, unpinning any pinned pages and unmapping any mappings
+ */
+#define NVMAP_IOC_FREE       _IO(NVMAP_IOC_MAGIC, 4)
+
+/* Reads/writes data (possibly strided) from a user-provided buffer into the
+ * hmem at the specified offset */
+#define NVMAP_IOC_WRITE      _IOW(NVMAP_IOC_MAGIC, 6, struct nvmap_rw_handle)
+#define NVMAP_IOC_READ       _IOW(NVMAP_IOC_MAGIC, 7, struct nvmap_rw_handle)
+#ifdef __KERNEL__
+#ifdef CONFIG_COMPAT
+#define NVMAP_IOC_WRITE_32   _IOW(NVMAP_IOC_MAGIC, 6, struct nvmap_rw_handle_32)
+#define NVMAP_IOC_READ_32    _IOW(NVMAP_IOC_MAGIC, 7, struct nvmap_rw_handle_32)
+#endif /* CONFIG_COMPAT */
+#endif /* __KERNEL__ */
+
+#define NVMAP_IOC_PARAM _IOWR(NVMAP_IOC_MAGIC, 8, struct nvmap_handle_param)
+#ifdef __KERNEL__
+#ifdef CONFIG_COMPAT
+#define NVMAP_IOC_PARAM_32 _IOWR(NVMAP_IOC_MAGIC, 8, struct nvmap_handle_param_32)
+#endif /* CONFIG_COMPAT */
+#endif /* __KERNEL__ */
+
+#define NVMAP_IOC_CACHE      _IOW(NVMAP_IOC_MAGIC, 12, struct nvmap_cache_op)
+#define NVMAP_IOC_CACHE_64   _IOW(NVMAP_IOC_MAGIC, 12, struct nvmap_cache_op_64)
+#ifdef __KERNEL__
+#ifdef CONFIG_COMPAT
+#define NVMAP_IOC_CACHE_32  _IOW(NVMAP_IOC_MAGIC, 12, struct nvmap_cache_op_32)
+#endif /* CONFIG_COMPAT */
+#endif /* __KERNEL__ */
+
+/* Returns a global ID usable to allow a remote process to create a handle
+ * reference to the same handle */
+#define NVMAP_IOC_GET_ID  _IOWR(NVMAP_IOC_MAGIC, 13, struct nvmap_create_handle)
+
+/* Returns a file id that allows a remote process to create a handle
+ * reference to the same handle */
+#define NVMAP_IOC_GET_FD  _IOWR(NVMAP_IOC_MAGIC, 15, struct nvmap_create_handle)
+
+/* Create a new memory handle from file id passed */
+#define NVMAP_IOC_FROM_FD _IOWR(NVMAP_IOC_MAGIC, 16, struct nvmap_create_handle)
+
+/* Perform cache maintenance on a list of handles. */
+#define NVMAP_IOC_CACHE_LIST _IOW(NVMAP_IOC_MAGIC, 17,	\
+				  struct nvmap_cache_op_list)
+
+#define NVMAP_IOC_FROM_IVC_ID _IOWR(NVMAP_IOC_MAGIC, 19, struct nvmap_create_handle)
+#define NVMAP_IOC_GET_IVC_ID _IOWR(NVMAP_IOC_MAGIC, 20, struct nvmap_create_handle)
+#define NVMAP_IOC_GET_IVM_HEAPS _IOR(NVMAP_IOC_MAGIC, 21, unsigned int)
+
+/* Create a new memory handle from VA passed */
+#define NVMAP_IOC_FROM_VA _IOWR(NVMAP_IOC_MAGIC, 22, struct nvmap_create_handle_from_va)
+
+#define NVMAP_IOC_GUP_TEST _IOWR(NVMAP_IOC_MAGIC, 23, struct nvmap_gup_test)
+
+/* Define a label for allocation tag */
+#define NVMAP_IOC_SET_TAG_LABEL	_IOW(NVMAP_IOC_MAGIC, 24, struct nvmap_set_tag_label)
+
+#define NVMAP_IOC_GET_AVAILABLE_HEAPS \
+	_IOR(NVMAP_IOC_MAGIC, 25, struct nvmap_available_heaps)
+
+#define NVMAP_IOC_GET_HEAP_SIZE \
+	_IOR(NVMAP_IOC_MAGIC, 26, struct nvmap_heap_size)
+
+#define NVMAP_IOC_PARAMETERS \
+	_IOR(NVMAP_IOC_MAGIC, 27, struct nvmap_handle_parameters)
+
+/* START of T124 IOCTLS */
+/* Actually allocates memory from IVM heaps */
+#define NVMAP_IOC_ALLOC_IVM _IOW(NVMAP_IOC_MAGIC, 101, struct nvmap_alloc_ivm_handle)
+
+/* Allocate seperate memory for VPR */
+#define NVMAP_IOC_VPR_FLOOR_SIZE _IOW(NVMAP_IOC_MAGIC, 102, __u32)
+
+/* Get SCI_IPC_ID tied up with nvmap_handle */
+#define NVMAP_IOC_GET_SCIIPCID _IOR(NVMAP_IOC_MAGIC, 103, \
+		struct nvmap_sciipc_map)
+
+/* Get Nvmap handle from SCI_IPC_ID */
+#define NVMAP_IOC_HANDLE_FROM_SCIIPCID _IOR(NVMAP_IOC_MAGIC, 104, \
+		struct nvmap_sciipc_map)
+
+/* Get heap parameters such as total and frre size */
+#define NVMAP_IOC_QUERY_HEAP_PARAMS _IOR(NVMAP_IOC_MAGIC, 105, \
+		struct nvmap_query_heap_params)
+
+/* Duplicate NvRmMemHandle with same/reduced permission */
+#define NVMAP_IOC_DUP_HANDLE _IOWR(NVMAP_IOC_MAGIC, 106, \
+		struct nvmap_duplicate_handle)
+
+/*  Get for range from list of NvRmMemHandles */
+#define NVMAP_IOC_GET_FD_FOR_RANGE_FROM_LIST _IOR(NVMAP_IOC_MAGIC, 107, \
+		struct nvmap_fd_for_range_from_list)
+
+#define NVMAP_IOC_MAXNR (_IOC_NR(NVMAP_IOC_GET_FD_FOR_RANGE_FROM_LIST))
+
+#endif /* __UAPI_LINUX_NVMAP_H */

--- a/extra/tegra_gpu_driver/nvmap_extras.h
+++ b/extra/tegra_gpu_driver/nvmap_extras.h
@@ -1,0 +1,8 @@
+/* Constants from nvidia-oot/include/linux/nvmap.h (kernel-internal header).
+   The uapi header (uapi/linux/nvmap.h) doesn't export these, but they're needed
+   for nvmap_alloc_handle.heap_mask and .flags fields. */
+#define NVMAP_HEAP_IOVMM            (1 << 30)
+#define NVMAP_HANDLE_UNCACHEABLE    (0 << 0)
+#define NVMAP_HANDLE_WRITE_COMBINE  (1 << 0)
+#define NVMAP_HANDLE_INNER_CACHEABLE (2 << 0)
+#define NVMAP_HANDLE_CACHEABLE      (3 << 0)

--- a/tinygrad/runtime/autogen/__init__.py
+++ b/tinygrad/runtime/autogen/__init__.py
@@ -119,18 +119,10 @@ def __getattr__(nm):
                                 args=["-I/opt/rocm/include", "-x", "c++"])
     case "amdgpu_drm": return load("amdgpu_drm", None, [ "/usr/include/drm/drm.h", *[root/f"extra/hip_gpu_driver/{s}.h" for s in ["amdgpu_drm"]]])
     case "tegra_36":
-      def _tegra_preprocess(path):
-        subprocess.run("tar xjf kernel_oot_modules_src.tbz2 --strip-components=1 -C . nvidia-oot/include/uapi/linux/nvmap.h "
-          "nvidia-oot/include/linux/nvmap.h", cwd=path+"Linux_for_Tegra/source/", shell=True, check=False, stderr=subprocess.DEVNULL)
-        if not (pathlib.Path(path) / "Linux_for_Tegra/source/nvidia-oot/include/uapi/linux/nvmap.h").exists():
-          raise FileNotFoundError("nvmap.h not found after extraction")
-      l4t_src = "https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.4/sources/public_sources.tbz2"
-      return load("tegra_36", None, [
-        "{}/nvgpu/include/uapi/linux/nvgpu.h", "{}/nvgpu/include/uapi/linux/nvgpu-ctrl.h",
-        "{}/nvgpu/include/uapi/linux/nvgpu-as.h", "{}/nvidia-oot/include/uapi/linux/nvmap.h",
-      ], args=["-D__user=", "-D__u8=unsigned char", "-D__u16=unsigned short", "-D__u32=unsigned int", "-D__u64=unsigned long long",
-              "-D__s8=signed char", "-D__s16=short", "-D__s32=int", "-D__s64=long long", "-D_IOC_TYPECHECK(t)=sizeof(t)"],
-      srcs=l4t_src, preprocess=_tegra_preprocess)
+      return load("tegra_36", None, [root/f"extra/tegra_gpu_driver/{s}.h" for s in ["nvgpu", "nvgpu-ctrl", "nvgpu-as", "nvmap", "nvmap_extras"]],
+        args=["-D__user=", "-D__u8=unsigned char", "-D__u16=unsigned short", "-D__u32=unsigned int", "-D__u64=unsigned long long",
+              "-D__s8=signed char", "-D__s16=short", "-D__s32=int", "-D__s64=long long", "-D_IOC_TYPECHECK(t)=sizeof(t)",
+              f"-I{root/'extra/tegra_gpu_driver'}"])
     case "kgsl": return load("kgsl", None, [root/"extra/qcom_gpu_driver/msm_kgsl.h"], args=["-D__user="])
     case "qcom_dsp":
       return load("qcom_dsp", None, [root/f"extra/dsp/include/{s}.h" for s in ["ion", "msm_ion", "adsprpc_shared", "remote_default", "apps_std"]])

--- a/tinygrad/runtime/autogen/__init__.py
+++ b/tinygrad/runtime/autogen/__init__.py
@@ -119,15 +119,18 @@ def __getattr__(nm):
                                 args=["-I/opt/rocm/include", "-x", "c++"])
     case "amdgpu_drm": return load("amdgpu_drm", None, [ "/usr/include/drm/drm.h", *[root/f"extra/hip_gpu_driver/{s}.h" for s in ["amdgpu_drm"]]])
     case "tegra_36":
+      def _tegra_preprocess(path):
+        subprocess.run("tar xjf kernel_oot_modules_src.tbz2 --strip-components=1 -C . nvidia-oot/include/uapi/linux/nvmap.h "
+          "nvidia-oot/include/linux/nvmap.h", cwd=path+"Linux_for_Tegra/source/", shell=True, check=False, stderr=subprocess.DEVNULL)
+        if not (pathlib.Path(path) / "Linux_for_Tegra/source/nvidia-oot/include/uapi/linux/nvmap.h").exists():
+          raise FileNotFoundError("nvmap.h not found after extraction")
       l4t_src = "https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.4/sources/public_sources.tbz2"
       return load("tegra_36", None, [
         "{}/nvgpu/include/uapi/linux/nvgpu.h", "{}/nvgpu/include/uapi/linux/nvgpu-ctrl.h",
         "{}/nvgpu/include/uapi/linux/nvgpu-as.h", "{}/nvidia-oot/include/uapi/linux/nvmap.h",
       ], args=["-D__user=", "-D__u8=unsigned char", "-D__u16=unsigned short", "-D__u32=unsigned int", "-D__u64=unsigned long long",
               "-D__s8=signed char", "-D__s16=short", "-D__s32=int", "-D__s64=long long", "-D_IOC_TYPECHECK(t)=sizeof(t)"],
-      srcs=l4t_src, preprocess=lambda path: subprocess.run(
-        "tar xjf kernel_oot_modules_src.tbz2 --strip-components=1 -C . nvidia-oot/include/uapi/linux/nvmap.h "
-        "nvidia-oot/include/linux/nvmap.h 2>/dev/null; true", cwd=path+"Linux_for_Tegra/source/", shell=True, check=False))
+      srcs=l4t_src, preprocess=_tegra_preprocess)
     case "kgsl": return load("kgsl", None, [root/"extra/qcom_gpu_driver/msm_kgsl.h"], args=["-D__user="])
     case "qcom_dsp":
       return load("qcom_dsp", None, [root/f"extra/dsp/include/{s}.h" for s in ["ion", "msm_ion", "adsprpc_shared", "remote_default", "apps_std"]])

--- a/tinygrad/runtime/autogen/__init__.py
+++ b/tinygrad/runtime/autogen/__init__.py
@@ -118,6 +118,16 @@ def __getattr__(nm):
                                                                                                "sienna_cichlid_ip_offset"]],
                                 args=["-I/opt/rocm/include", "-x", "c++"])
     case "amdgpu_drm": return load("amdgpu_drm", None, [ "/usr/include/drm/drm.h", *[root/f"extra/hip_gpu_driver/{s}.h" for s in ["amdgpu_drm"]]])
+    case "tegra_36":
+      l4t_src = "https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.4/sources/public_sources.tbz2"
+      return load("tegra_36", None, [
+        "{}/nvgpu/include/uapi/linux/nvgpu.h", "{}/nvgpu/include/uapi/linux/nvgpu-ctrl.h",
+        "{}/nvgpu/include/uapi/linux/nvgpu-as.h", "{}/nvidia-oot/include/uapi/linux/nvmap.h",
+      ], args=["-D__user=", "-D__u8=unsigned char", "-D__u16=unsigned short", "-D__u32=unsigned int", "-D__u64=unsigned long long",
+              "-D__s8=signed char", "-D__s16=short", "-D__s32=int", "-D__s64=long long", "-D_IOC_TYPECHECK(t)=sizeof(t)"],
+      srcs=l4t_src, preprocess=lambda path: subprocess.run(
+        "tar xjf kernel_oot_modules_src.tbz2 --strip-components=1 -C . nvidia-oot/include/uapi/linux/nvmap.h "
+        "nvidia-oot/include/linux/nvmap.h 2>/dev/null; true", cwd=path+"Linux_for_Tegra/source/", shell=True, check=False))
     case "kgsl": return load("kgsl", None, [root/"extra/qcom_gpu_driver/msm_kgsl.h"], args=["-D__user="])
     case "qcom_dsp":
       return load("qcom_dsp", None, [root/f"extra/dsp/include/{s}.h" for s in ["ion", "msm_ion", "adsprpc_shared", "remote_default", "apps_std"]])

--- a/tinygrad/runtime/autogen/tegra_36.py
+++ b/tinygrad/runtime/autogen/tegra_36.py
@@ -1,0 +1,259 @@
+# mypy: disable-error-code="empty-body"
+# generated from L4T r36.4.4 public_sources.tbz2
+#   nvgpu uapi:  nvgpu/include/uapi/linux/{nvgpu.h, nvgpu-ctrl.h, nvgpu-as.h}
+#   nvmap uapi:  nvidia-oot/include/uapi/linux/nvmap.h
+from __future__ import annotations
+import ctypes
+from typing import Annotated, Literal
+from tinygrad.runtime.support.c import _IO, _IOW, _IOWR
+from tinygrad.runtime.support import c
+
+# nvgpu-ctrl.h: struct nvgpu_gpu_characteristics
+@c.record
+class nvgpu_gpu_characteristics(c.Struct):
+  SIZE = 328
+  arch: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  impl: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  rev: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  num_gpc: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  numa_domain_id: Annotated[Annotated[int, ctypes.c_int32], 16]
+  L2_cache_size: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  on_board_video_memory_size: Annotated[Annotated[int, ctypes.c_uint64], 32]
+  num_tpc_per_gpc: Annotated[Annotated[int, ctypes.c_uint32], 40]
+  bus_type: Annotated[Annotated[int, ctypes.c_uint32], 44]
+  big_page_size: Annotated[Annotated[int, ctypes.c_uint32], 48]
+  compression_page_size: Annotated[Annotated[int, ctypes.c_uint32], 52]
+  pde_coverage_bit_count: Annotated[Annotated[int, ctypes.c_uint32], 56]
+  available_big_page_sizes: Annotated[Annotated[int, ctypes.c_uint32], 60]
+  flags: Annotated[Annotated[int, ctypes.c_uint64], 64]
+  twod_class: Annotated[Annotated[int, ctypes.c_uint32], 72]
+  threed_class: Annotated[Annotated[int, ctypes.c_uint32], 76]
+  compute_class: Annotated[Annotated[int, ctypes.c_uint32], 80]
+  gpfifo_class: Annotated[Annotated[int, ctypes.c_uint32], 84]
+  inline_to_memory_class: Annotated[Annotated[int, ctypes.c_uint32], 88]
+  dma_copy_class: Annotated[Annotated[int, ctypes.c_uint32], 92]
+  gpc_mask: Annotated[Annotated[int, ctypes.c_uint32], 96]
+  sm_arch_sm_version: Annotated[Annotated[int, ctypes.c_uint32], 100]
+  sm_arch_spa_version: Annotated[Annotated[int, ctypes.c_uint32], 104]
+  sm_arch_warp_count: Annotated[Annotated[int, ctypes.c_uint32], 108]
+  gpu_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 112]
+  tsg_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 114]
+  dbg_gpu_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 116]
+  ioctl_channel_nr_last: Annotated[Annotated[int, ctypes.c_int16], 118]
+  as_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 120]
+  gpu_va_bit_count: Annotated[Annotated[int, ctypes.c_uint8], 122]
+  reserved: Annotated[Annotated[int, ctypes.c_uint8], 123]
+  max_fbps_count: Annotated[Annotated[int, ctypes.c_uint32], 124]
+  fbp_en_mask: Annotated[Annotated[int, ctypes.c_uint32], 128]
+  emc_en_mask: Annotated[Annotated[int, ctypes.c_uint32], 132]
+  max_ltc_per_fbp: Annotated[Annotated[int, ctypes.c_uint32], 136]
+  max_lts_per_ltc: Annotated[Annotated[int, ctypes.c_uint32], 140]
+  max_tex_per_tpc: Annotated[Annotated[int, ctypes.c_uint32], 144]
+  max_gpc_count: Annotated[Annotated[int, ctypes.c_uint32], 148]
+  rop_l2_en_mask_DEPRECATED: Annotated[c.Array[ctypes.c_uint32, Literal[2]], 152]
+  chipname: Annotated[c.Array[ctypes.c_uint8, Literal[8]], 160]
+  gr_compbit_store_base_hw: Annotated[Annotated[int, ctypes.c_uint64], 168]
+  gr_gobs_per_comptagline_per_slice: Annotated[Annotated[int, ctypes.c_uint32], 176]
+  num_ltc: Annotated[Annotated[int, ctypes.c_uint32], 180]
+  lts_per_ltc: Annotated[Annotated[int, ctypes.c_uint32], 184]
+  cbc_cache_line_size: Annotated[Annotated[int, ctypes.c_uint32], 188]
+  cbc_comptags_per_line: Annotated[Annotated[int, ctypes.c_uint32], 192]
+  map_buffer_batch_limit: Annotated[Annotated[int, ctypes.c_uint32], 196]
+  max_freq: Annotated[Annotated[int, ctypes.c_uint64], 200]
+  graphics_preemption_mode_flags: Annotated[Annotated[int, ctypes.c_uint32], 208]
+  compute_preemption_mode_flags: Annotated[Annotated[int, ctypes.c_uint32], 212]
+  default_graphics_preempt_mode: Annotated[Annotated[int, ctypes.c_uint32], 216]
+  default_compute_preempt_mode: Annotated[Annotated[int, ctypes.c_uint32], 220]
+  local_video_memory_size: Annotated[Annotated[int, ctypes.c_uint64], 224]
+  pci_vendor_id: Annotated[Annotated[int, ctypes.c_uint16], 232]
+  pci_device_id: Annotated[Annotated[int, ctypes.c_uint16], 234]
+  pci_subsystem_vendor_id: Annotated[Annotated[int, ctypes.c_uint16], 236]
+  pci_subsystem_device_id: Annotated[Annotated[int, ctypes.c_uint16], 238]
+  pci_class: Annotated[Annotated[int, ctypes.c_uint16], 240]
+  pci_revision: Annotated[Annotated[int, ctypes.c_uint8], 242]
+  vbios_oem_version: Annotated[Annotated[int, ctypes.c_uint8], 243]
+  vbios_version: Annotated[Annotated[int, ctypes.c_uint32], 244]
+  reg_ops_limit: Annotated[Annotated[int, ctypes.c_uint32], 248]
+  reserved1: Annotated[Annotated[int, ctypes.c_uint32], 252]
+  event_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 256]
+  pad: Annotated[Annotated[int, ctypes.c_uint16], 258]
+  max_css_buffer_size: Annotated[Annotated[int, ctypes.c_uint32], 260]
+  ctxsw_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 264]
+  prof_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 266]
+  nvs_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 268]
+  reserved2: Annotated[c.Array[ctypes.c_uint8, Literal[2]], 270]
+  max_ctxsw_ring_buffer_size: Annotated[Annotated[int, ctypes.c_uint32], 272]
+  reserved3: Annotated[Annotated[int, ctypes.c_uint32], 276]
+  per_device_identifier: Annotated[Annotated[int, ctypes.c_uint64], 280]
+  num_ppc_per_gpc: Annotated[Annotated[int, ctypes.c_uint32], 288]
+  max_veid_count_per_tsg: Annotated[Annotated[int, ctypes.c_uint32], 292]
+  num_sub_partition_per_fbpa: Annotated[Annotated[int, ctypes.c_uint32], 296]
+  gpu_instance_id: Annotated[Annotated[int, ctypes.c_uint32], 300]
+  gr_instance_id: Annotated[Annotated[int, ctypes.c_uint32], 304]
+  max_gpfifo_entries: Annotated[Annotated[int, ctypes.c_uint32], 308]
+  max_dbg_tsg_timeslice: Annotated[Annotated[int, ctypes.c_uint32], 312]
+  reserved5: Annotated[Annotated[int, ctypes.c_uint32], 316]
+  device_instance_id: Annotated[Annotated[int, ctypes.c_uint64], 320]
+@c.record
+class nvgpu_gpu_get_characteristics(c.Struct):
+  SIZE = 16
+  buf_size: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  buf_addr: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class nvgpu_alloc_as_args(c.Struct):
+  SIZE = 64
+  big_page_size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  as_fd: Annotated[Annotated[int, ctypes.c_int32], 4]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  va_range_start: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  va_range_end: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  va_range_split: Annotated[Annotated[int, ctypes.c_uint64], 32]
+  padding: Annotated[c.Array[ctypes.c_uint32, Literal[6]], 40]
+@c.record
+class nvgpu_gpu_open_tsg_args(c.Struct):
+  SIZE = 24
+  tsg_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  token: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  subctx_id: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  _pad: Annotated[Annotated[int, ctypes.c_uint32], 20]
+@c.record
+class nvgpu_gpu_open_channel_args(c.Struct):
+  SIZE = 4
+  channel_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+
+# nvgpu-as.h
+@c.record
+class nvgpu_as_bind_channel_args(c.Struct):
+  SIZE = 4
+  channel_fd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class nvgpu_as_alloc_space_args(c.Struct):
+  SIZE = 32
+  pages: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  page_size: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  padding: Annotated[c.Array[ctypes.c_uint32, Literal[2]], 24]
+@c.record
+class nvgpu_as_map_buffer_ex_args(c.Struct):
+  SIZE = 40
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  compr_kind: Annotated[Annotated[int, ctypes.c_int16], 4]
+  incompr_kind: Annotated[Annotated[int, ctypes.c_int16], 6]
+  dmabuf_fd: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  page_size: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  buffer_offset: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  mapping_size: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 32]
+@c.record
+class nvgpu_as_unmap_buffer_args(c.Struct):
+  SIZE = 8
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 0]
+
+# nvgpu.h: TSG ioctls
+@c.record
+class nvgpu_tsg_bind_channel_ex_args(c.Struct):
+  SIZE = 24
+  channel_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+  subcontext_id: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  reserved: Annotated[c.Array[ctypes.c_uint8, Literal[16]], 8]
+@c.record
+class nvgpu_tsg_create_subcontext_args(c.Struct):
+  SIZE = 16
+  type: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  as_fd: Annotated[Annotated[int, ctypes.c_int32], 4]
+  veid: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
+
+# nvgpu.h: channel ioctls
+@c.record
+class nvgpu_alloc_obj_ctx_args(c.Struct):
+  SIZE = 16
+  class_num: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  obj_id: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class nvgpu_channel_setup_bind_args(c.Struct):
+  SIZE = 104
+  num_gpfifo_entries: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  num_inflight_jobs: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  userd_dmabuf_fd: Annotated[Annotated[int, ctypes.c_int32], 12]
+  gpfifo_dmabuf_fd: Annotated[Annotated[int, ctypes.c_int32], 16]
+  work_submit_token: Annotated[Annotated[int, ctypes.c_uint32], 20]
+  userd_dmabuf_offset: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  gpfifo_dmabuf_offset: Annotated[Annotated[int, ctypes.c_uint64], 32]
+  gpfifo_gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 40]
+  userd_gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 48]
+  usermode_mmio_gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 56]
+  reserved: Annotated[c.Array[ctypes.c_uint32, Literal[9]], 64]
+@c.record
+class nvgpu_channel_wdt_args(c.Struct):
+  SIZE = 8
+  wdt_status: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  timeout_ms: Annotated[Annotated[int, ctypes.c_uint32], 4]
+
+# nvmap.h
+@c.record
+class nvmap_create_handle(c.Struct):
+  SIZE = 8
+  size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class nvmap_alloc_handle(c.Struct):
+  SIZE = 20
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  heap_mask: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  align: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  numa_nid: Annotated[Annotated[int, ctypes.c_int32], 16]
+
+# ioctl magic bytes
+NVGPU_GPU_IOCTL_MAGIC = ord('G')
+NVGPU_AS_IOCTL_MAGIC = ord('A')
+NVGPU_TSG_IOCTL_MAGIC = ord('T')
+NVGPU_IOCTL_MAGIC = ord('H')
+NVMAP_IOC_MAGIC = ord('N')
+
+# nvgpu-ctrl.h ioctls
+NVGPU_GPU_IOCTL_GET_CHARACTERISTICS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 5, nvgpu_gpu_get_characteristics)
+NVGPU_GPU_IOCTL_ALLOC_AS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 8, nvgpu_alloc_as_args)
+NVGPU_GPU_IOCTL_OPEN_TSG = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 9, nvgpu_gpu_open_tsg_args)
+NVGPU_GPU_IOCTL_OPEN_CHANNEL = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 11, nvgpu_gpu_open_channel_args)
+
+# nvgpu-as.h ioctls
+NVGPU_AS_IOCTL_BIND_CHANNEL = _IOWR(NVGPU_AS_IOCTL_MAGIC, 1, nvgpu_as_bind_channel_args)
+NVGPU_AS_IOCTL_UNMAP_BUFFER = _IOWR(NVGPU_AS_IOCTL_MAGIC, 5, nvgpu_as_unmap_buffer_args)
+NVGPU_AS_IOCTL_ALLOC_SPACE = _IOWR(NVGPU_AS_IOCTL_MAGIC, 6, nvgpu_as_alloc_space_args)
+NVGPU_AS_IOCTL_MAP_BUFFER_EX = _IOWR(NVGPU_AS_IOCTL_MAGIC, 7, nvgpu_as_map_buffer_ex_args)
+
+# nvgpu.h TSG ioctls
+NVGPU_TSG_IOCTL_BIND_CHANNEL_EX = _IOWR(NVGPU_TSG_IOCTL_MAGIC, 11, nvgpu_tsg_bind_channel_ex_args)
+NVGPU_TSG_IOCTL_CREATE_SUBCONTEXT = _IOWR(NVGPU_TSG_IOCTL_MAGIC, 18, nvgpu_tsg_create_subcontext_args)
+
+# nvgpu.h channel ioctls
+NVGPU_IOCTL_CHANNEL_ALLOC_OBJ_CTX = _IOWR(NVGPU_IOCTL_MAGIC, 108, nvgpu_alloc_obj_ctx_args)
+NVGPU_IOCTL_CHANNEL_WDT = _IOW(NVGPU_IOCTL_MAGIC, 119, nvgpu_channel_wdt_args)
+NVGPU_IOCTL_CHANNEL_SETUP_BIND = _IOWR(NVGPU_IOCTL_MAGIC, 128, nvgpu_channel_setup_bind_args)
+
+# nvmap.h ioctls
+NVMAP_IOC_CREATE = _IOWR(NVMAP_IOC_MAGIC, 0, nvmap_create_handle)
+NVMAP_IOC_ALLOC = _IOW(NVMAP_IOC_MAGIC, 3, nvmap_alloc_handle)
+NVMAP_IOC_FREE = _IO(NVMAP_IOC_MAGIC, 4)
+NVMAP_IOC_GET_FD = _IOWR(NVMAP_IOC_MAGIC, 15, nvmap_create_handle)
+
+# nvmap.h constants
+NVMAP_HEAP_IOVMM = 1 << 30
+NVMAP_HANDLE_UNCACHEABLE = 0
+NVMAP_HANDLE_WRITE_COMBINE = 1
+NVMAP_HANDLE_INNER_CACHEABLE = 2
+NVMAP_HANDLE_CACHEABLE = 3
+
+# nvgpu.h channel setup_bind flags
+NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC = 1 << 1
+NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT = 1 << 3
+
+c.init_records()

--- a/tinygrad/runtime/autogen/tegra_36.py
+++ b/tinygrad/runtime/autogen/tegra_36.py
@@ -1,16 +1,622 @@
 # mypy: disable-error-code="empty-body"
-# generated from L4T r36.4.4 public_sources.tbz2
-#   nvgpu uapi:  nvgpu/include/uapi/linux/{nvgpu.h, nvgpu-ctrl.h, nvgpu-as.h}
-#   nvmap uapi:  nvidia-oot/include/uapi/linux/nvmap.h
 from __future__ import annotations
 import ctypes
-from typing import Annotated, Literal
-from tinygrad.runtime.support.c import _IO, _IOW, _IOWR
+from typing import Annotated, Literal, TypeAlias
+from tinygrad.runtime.support.c import _IO, _IOW, _IOR, _IOWR
 from tinygrad.runtime.support import c
-
-# nvgpu-ctrl.h: struct nvgpu_gpu_characteristics
 @c.record
-class nvgpu_gpu_characteristics(c.Struct):
+class struct_nvgpu_tsg_bind_channel_ex_args(c.Struct):
+  SIZE = 24
+  channel_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+  subcontext_id: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_ubyte], Literal[16]], 8]
+@c.record
+class struct_nvgpu_tsg_bind_scheduling_domain_args(c.Struct):
+  SIZE = 32
+  domain_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+  reserved0: Annotated[Annotated[int, ctypes.c_int32], 4]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint64], Literal[3]], 8]
+@c.record
+class struct_nvgpu_tsg_sm_error_state_record(c.Struct):
+  SIZE = 24
+  global_esr: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  warp_esr: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  warp_esr_pc: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  global_esr_report_mask: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  warp_esr_report_mask: Annotated[Annotated[int, ctypes.c_uint32], 20]
+@c.record
+class struct_nvgpu_tsg_read_single_sm_error_state_args(c.Struct):
+  SIZE = 24
+  sm_id: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  record_mem: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  record_size: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_tsg_read_all_sm_error_state_args(c.Struct):
+  SIZE = 24
+  num_sm: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  buffer_mem: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  buffer_size: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_tsg_l2_max_ways_evict_last_args(c.Struct):
+  SIZE = 8
+  max_ways: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_tsg_set_l2_sector_promotion_args(c.Struct):
+  SIZE = 8
+  promotion_flag: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_tsg_create_subcontext_args(c.Struct):
+  SIZE = 16
+  type: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  as_fd: Annotated[Annotated[int, ctypes.c_int32], 4]
+  veid: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_tsg_delete_subcontext_args(c.Struct):
+  SIZE = 8
+  veid: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_tsg_get_share_token_args(c.Struct):
+  SIZE = 24
+  source_device_instance_id: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  target_device_instance_id: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  share_token: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_tsg_revoke_share_token_args(c.Struct):
+  SIZE = 24
+  source_device_instance_id: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  target_device_instance_id: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  share_token: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_dbg_gpu_bind_channel_args(c.Struct):
+  SIZE = 8
+  channel_fd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  _pad0: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[1]], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_reg_op(c.Struct):
+  SIZE = 32
+  op: Annotated[Annotated[int, ctypes.c_ubyte], 0]
+  type: Annotated[Annotated[int, ctypes.c_ubyte], 1]
+  status: Annotated[Annotated[int, ctypes.c_ubyte], 2]
+  quad: Annotated[Annotated[int, ctypes.c_ubyte], 3]
+  group_mask: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  sub_group_mask: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  offset: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  value_lo: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  value_hi: Annotated[Annotated[int, ctypes.c_uint32], 20]
+  and_n_mask_lo: Annotated[Annotated[int, ctypes.c_uint32], 24]
+  and_n_mask_hi: Annotated[Annotated[int, ctypes.c_uint32], 28]
+@c.record
+class struct_nvgpu_dbg_gpu_exec_reg_ops_args(c.Struct):
+  SIZE = 16
+  ops: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  num_ops: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  gr_ctx_resident: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_dbg_gpu_events_ctrl_args(c.Struct):
+  SIZE = 8
+  cmd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  _pad0: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[1]], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_powergate_args(c.Struct):
+  SIZE = 4
+  mode: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_dbg_gpu_smpc_ctxsw_mode_args(c.Struct):
+  SIZE = 4
+  mode: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_dbg_gpu_suspend_resume_all_sms_args(c.Struct):
+  SIZE = 4
+  mode: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_dbg_gpu_perfbuf_map_args(c.Struct):
+  SIZE = 24
+  dmabuf_fd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  mapping_size: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_dbg_gpu_perfbuf_unmap_args(c.Struct):
+  SIZE = 8
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 0]
+@c.record
+class struct_nvgpu_dbg_gpu_pc_sampling_args(c.Struct):
+  SIZE = 8
+  enable: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  _pad0: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[1]], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_timeout_args(c.Struct):
+  SIZE = 8
+  enable: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  padding: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_set_next_stop_trigger_type_args(c.Struct):
+  SIZE = 8
+  broadcast: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_hwpm_ctxsw_mode_args(c.Struct):
+  SIZE = 8
+  mode: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_sm_error_state_record(c.Struct):
+  SIZE = 24
+  hww_global_esr: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  hww_warp_esr: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  hww_warp_esr_pc: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  hww_global_esr_report_mask: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  hww_warp_esr_report_mask: Annotated[Annotated[int, ctypes.c_uint32], 20]
+@c.record
+class struct_nvgpu_dbg_gpu_read_single_sm_error_state_args(c.Struct):
+  SIZE = 24
+  sm_id: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  padding: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  sm_error_state_record_mem: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  sm_error_state_record_size: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_dbg_gpu_clear_single_sm_error_state_args(c.Struct):
+  SIZE = 8
+  sm_id: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  padding: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_unbind_channel_args(c.Struct):
+  SIZE = 8
+  channel_fd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  _pad0: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[1]], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_suspend_resume_contexts_args(c.Struct):
+  SIZE = 16
+  action: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  is_resident_context: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  resident_context_fd: Annotated[Annotated[int, ctypes.c_int32], 8]
+  padding: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_dbg_gpu_access_fb_memory_args(c.Struct):
+  SIZE = 32
+  cmd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  dmabuf_fd: Annotated[Annotated[int, ctypes.c_int32], 4]
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  buffer: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  size: Annotated[Annotated[int, ctypes.c_uint64], 24]
+@c.record
+class struct_nvgpu_dbg_gpu_profiler_obj_mgt_args(c.Struct):
+  SIZE = 8
+  profiler_handle: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_profiler_reserve_args(c.Struct):
+  SIZE = 8
+  profiler_handle: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  acquire: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_set_sm_exception_type_mask_args(c.Struct):
+  SIZE = 8
+  exception_type_mask: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_cycle_stats_args(c.Struct):
+  SIZE = 8
+  dmabuf_fd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_cycle_stats_snapshot_args(c.Struct):
+  SIZE = 16
+  cmd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  dmabuf_fd: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  extra: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_dbg_gpu_set_ctx_mmu_debug_mode_args(c.Struct):
+  SIZE = 8
+  mode: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_get_gr_context_size_args(c.Struct):
+  SIZE = 8
+  size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_dbg_gpu_get_gr_context_args(c.Struct):
+  SIZE = 16
+  buffer: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  size: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_dbg_gpu_get_mappings_entry(c.Struct):
+  SIZE = 16
+  gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  size: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_dbg_gpu_get_mappings_args(c.Struct):
+  SIZE = 32
+  va_lo: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  va_hi: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  ops_buffer: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  count: Annotated[Annotated[int, ctypes.c_uint32], 24]
+  has_more: Annotated[Annotated[int, ctypes.c_ubyte], 28]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_ubyte], Literal[3]], 29]
+@c.record
+class struct_nvgpu_dbg_gpu_va_access_entry(c.Struct):
+  SIZE = 24
+  gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  data: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  size: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  valid: Annotated[Annotated[int, ctypes.c_ubyte], 20]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_ubyte], Literal[3]], 21]
+@c.record
+class struct_nvgpu_dbg_gpu_va_access_args(c.Struct):
+  SIZE = 16
+  ops_buf: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  count: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  cmd: Annotated[Annotated[int, ctypes.c_ubyte], 12]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_ubyte], Literal[3]], 13]
+@c.record
+class struct_nvgpu_sched_exit_wait_for_errbar_args(c.Struct):
+  SIZE = 4
+  enable: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_profiler_bind_context_args(c.Struct):
+  SIZE = 8
+  tsg_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_profiler_reserve_pm_resource_args(c.Struct):
+  SIZE = 16
+  resource: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[2]], 8]
+@c.record
+class struct_nvgpu_profiler_release_pm_resource_args(c.Struct):
+  SIZE = 8
+  resource: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_profiler_alloc_pma_stream_args(c.Struct):
+  SIZE = 48
+  pma_buffer_map_size: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  pma_buffer_offset: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  pma_buffer_va: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  pma_buffer_fd: Annotated[Annotated[int, ctypes.c_int32], 24]
+  pma_bytes_available_buffer_fd: Annotated[Annotated[int, ctypes.c_int32], 28]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 32]
+  pma_channel_id: Annotated[Annotated[int, ctypes.c_uint32], 36]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[2]], 40]
+@c.record
+class struct_nvgpu_profiler_free_pma_stream_args(c.Struct):
+  SIZE = 12
+  pma_channel_id: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[2]], 4]
+@c.record
+class struct_nvgpu_profiler_pma_stream_update_get_put_args(c.Struct):
+  SIZE = 40
+  bytes_consumed: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  bytes_available: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  put_ptr: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 24]
+  pma_channel_id: Annotated[Annotated[int, ctypes.c_uint32], 28]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[2]], 32]
+@c.record
+class struct_nvgpu_profiler_reg_op(c.Struct):
+  SIZE = 24
+  op: Annotated[Annotated[int, ctypes.c_ubyte], 0]
+  status: Annotated[Annotated[int, ctypes.c_ubyte], 1]
+  offset: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  value: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  and_n_mask: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_profiler_exec_reg_ops_args(c.Struct):
+  SIZE = 32
+  mode: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  count: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  ops: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[3]], 20]
+@c.record
+class struct_nvgpu_profiler_vab_range_checker(c.Struct):
+  SIZE = 16
+  start_phys_addr: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  granularity_shift: Annotated[Annotated[int, ctypes.c_ubyte], 8]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_ubyte], Literal[7]], 9]
+@c.record
+class struct_nvgpu_profiler_vab_reserve_args(c.Struct):
+  SIZE = 16
+  vab_mode: Annotated[Annotated[int, ctypes.c_ubyte], 0]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_ubyte], Literal[3]], 1]
+  num_range_checkers: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  range_checkers_ptr: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_profiler_vab_flush_state_args(c.Struct):
+  SIZE = 16
+  buffer_ptr: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  buffer_size: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpfifo(c.Struct):
+  SIZE = 8
+  entry0: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  entry1: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_get_param_args(c.Struct):
+  SIZE = 4
+  value: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_channel_open_args(c.Struct):
+  SIZE = 4
+  channel_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+  _in: Annotated[struct_nvgpu_channel_open_args_in, 0]
+  out: Annotated[struct_nvgpu_channel_open_args_out, 0]
+@c.record
+class struct_nvgpu_channel_open_args_in(c.Struct):
+  SIZE = 4
+  runlist_id: Annotated[Annotated[int, ctypes.c_int32], 0]
+@c.record
+class struct_nvgpu_channel_open_args_out(c.Struct):
+  SIZE = 4
+  channel_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+@c.record
+class struct_nvgpu_set_nvmap_fd_args(c.Struct):
+  SIZE = 4
+  fd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_alloc_obj_ctx_args(c.Struct):
+  SIZE = 16
+  class_num: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  obj_id: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_alloc_gpfifo_ex_args(c.Struct):
+  SIZE = 32
+  num_entries: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  num_inflight_jobs: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[5]], 12]
+@c.record
+class struct_nvgpu_channel_setup_bind_args(c.Struct):
+  SIZE = 104
+  num_gpfifo_entries: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  num_inflight_jobs: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  userd_dmabuf_fd: Annotated[Annotated[int, ctypes.c_int32], 12]
+  gpfifo_dmabuf_fd: Annotated[Annotated[int, ctypes.c_int32], 16]
+  work_submit_token: Annotated[Annotated[int, ctypes.c_uint32], 20]
+  userd_dmabuf_offset: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  gpfifo_dmabuf_offset: Annotated[Annotated[int, ctypes.c_uint64], 32]
+  gpfifo_gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 40]
+  userd_gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 48]
+  usermode_mmio_gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 56]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[9]], 64]
+@c.record
+class struct_nvgpu_fence(c.Struct):
+  SIZE = 8
+  id: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  value: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_submit_gpfifo_args(c.Struct):
+  SIZE = 24
+  gpfifo: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  num_entries: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  fence: Annotated[struct_nvgpu_fence, 16]
+@c.record
+class struct_nvgpu_wait_args(c.Struct):
+  SIZE = 24
+  type: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  timeout: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  condition: Annotated[struct_nvgpu_wait_args_condition, 8]
+@c.record
+class struct_nvgpu_wait_args_condition(c.Struct):
+  SIZE = 16
+  notifier: Annotated[struct_nvgpu_wait_args_condition_notifier, 0]
+  semaphore: Annotated[struct_nvgpu_wait_args_condition_semaphore, 0]
+@c.record
+class struct_nvgpu_wait_args_condition_notifier(c.Struct):
+  SIZE = 16
+  dmabuf_fd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  offset: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  padding1: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  padding2: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_wait_args_condition_semaphore(c.Struct):
+  SIZE = 16
+  dmabuf_fd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  offset: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  payload: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  padding: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_set_timeout_args(c.Struct):
+  SIZE = 4
+  timeout: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_set_timeout_ex_args(c.Struct):
+  SIZE = 8
+  timeout: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_zcull_bind_args(c.Struct):
+  SIZE = 16
+  gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  mode: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  padding: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_set_error_notifier(c.Struct):
+  SIZE = 24
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  size: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  mem: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  padding: Annotated[Annotated[int, ctypes.c_uint32], 20]
+@c.record
+class struct_nvgpu_notification(c.Struct):
+  SIZE = 16
+  time_stamp: Annotated[struct_nvgpu_notification_time_stamp, 0]
+  info32: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  info16: Annotated[Annotated[int, ctypes.c_uint16], 12]
+  status: Annotated[Annotated[int, ctypes.c_uint16], 14]
+@c.record
+class struct_nvgpu_notification_time_stamp(c.Struct):
+  SIZE = 8
+  nanoseconds: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[2]], 0]
+@c.record
+class struct_nvgpu_channel_wdt_args(c.Struct):
+  SIZE = 8
+  wdt_status: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  timeout_ms: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_runlist_interleave_args(c.Struct):
+  SIZE = 8
+  level: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_timeslice_args(c.Struct):
+  SIZE = 8
+  timeslice_us: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_event_id_ctrl_args(c.Struct):
+  SIZE = 16
+  cmd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  event_id: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  event_fd: Annotated[Annotated[int, ctypes.c_int32], 8]
+  padding: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_preemption_mode_args(c.Struct):
+  SIZE = 8
+  graphics_preempt_mode: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  compute_preempt_mode: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_boosted_ctx_args(c.Struct):
+  SIZE = 8
+  boost: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  padding: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_get_user_syncpoint_args(c.Struct):
+  SIZE = 16
+  gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  syncpoint_id: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  syncpoint_max: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_reschedule_runlist_args(c.Struct):
+  SIZE = 4
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_ctxsw_trace_entry(c.Struct):
+  SIZE = 24
+  tag: Annotated[Annotated[int, ctypes.c_ubyte], 0]
+  vmid: Annotated[Annotated[int, ctypes.c_ubyte], 1]
+  seqno: Annotated[Annotated[int, ctypes.c_uint16], 2]
+  context_id: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  pid: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  timestamp: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_ctxsw_ring_header(c.Struct):
+  SIZE = 32
+  magic: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  version: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  num_ents: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  ent_size: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  drop_count: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  write_seqno: Annotated[Annotated[int, ctypes.c_uint32], 20]
+  write_idx: Annotated[Annotated[int, ctypes.c_uint32], 24]
+  read_idx: Annotated[Annotated[int, ctypes.c_uint32], 28]
+@c.record
+class struct_nvgpu_ctxsw_ring_setup_args(c.Struct):
+  SIZE = 4
+  size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_ctxsw_trace_filter(c.Struct):
+  SIZE = 32
+  tag_bits: Annotated[c.Array[Annotated[int, ctypes.c_uint64], Literal[4]], 0]
+@c.record
+class struct_nvgpu_ctxsw_trace_filter_args(c.Struct):
+  SIZE = 32
+  filter: Annotated[struct_nvgpu_ctxsw_trace_filter, 0]
+@c.record
+class struct_nvgpu_sched_get_tsgs_args(c.Struct):
+  SIZE = 16
+  size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  buffer: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_sched_get_tsgs_by_pid_args(c.Struct):
+  SIZE = 24
+  pid: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  size: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  buffer: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_sched_tsg_get_params_args(c.Struct):
+  SIZE = 32
+  tsgid: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  timeslice: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  runlist_interleave: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  graphics_preempt_mode: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  compute_preempt_mode: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  pid: Annotated[Annotated[int, ctypes.c_uint64], 24]
+@c.record
+class struct_nvgpu_sched_tsg_timeslice_args(c.Struct):
+  SIZE = 8
+  tsgid: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  timeslice: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_sched_tsg_runlist_interleave_args(c.Struct):
+  SIZE = 8
+  tsgid: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  runlist_interleave: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_sched_api_version_args(c.Struct):
+  SIZE = 4
+  version: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_sched_tsg_refcount_args(c.Struct):
+  SIZE = 4
+  tsgid: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_sched_event_arg(c.Struct):
+  SIZE = 16
+  reserved: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  status: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_zcull_get_ctx_size_args(c.Struct):
+  SIZE = 4
+  size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_gpu_zcull_get_info_args(c.Struct):
+  SIZE = 40
+  width_align_pixels: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  height_align_pixels: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  pixel_squares_by_aliquots: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  aliquot_total: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  region_byte_multiplier: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  region_header_size: Annotated[Annotated[int, ctypes.c_uint32], 20]
+  subregion_header_size: Annotated[Annotated[int, ctypes.c_uint32], 24]
+  subregion_width_align_pixels: Annotated[Annotated[int, ctypes.c_uint32], 28]
+  subregion_height_align_pixels: Annotated[Annotated[int, ctypes.c_uint32], 32]
+  subregion_count: Annotated[Annotated[int, ctypes.c_uint32], 36]
+@c.record
+class struct_nvgpu_gpu_zbc_set_table_args(c.Struct):
+  SIZE = 48
+  color_ds: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[4]], 0]
+  color_l2: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[4]], 16]
+  depth: Annotated[Annotated[int, ctypes.c_uint32], 32]
+  stencil: Annotated[Annotated[int, ctypes.c_uint32], 36]
+  format: Annotated[Annotated[int, ctypes.c_uint32], 40]
+  type: Annotated[Annotated[int, ctypes.c_uint32], 44]
+@c.record
+class struct_nvgpu_gpu_zbc_query_table_args(c.Struct):
+  SIZE = 56
+  color_ds: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[4]], 0]
+  color_l2: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[4]], 16]
+  depth: Annotated[Annotated[int, ctypes.c_uint32], 32]
+  stencil: Annotated[Annotated[int, ctypes.c_uint32], 36]
+  ref_cnt: Annotated[Annotated[int, ctypes.c_uint32], 40]
+  format: Annotated[Annotated[int, ctypes.c_uint32], 44]
+  type: Annotated[Annotated[int, ctypes.c_uint32], 48]
+  index_size: Annotated[Annotated[int, ctypes.c_uint32], 52]
+@c.record
+class struct_nvgpu_gpu_characteristics(c.Struct):
   SIZE = 328
   arch: Annotated[Annotated[int, ctypes.c_uint32], 0]
   impl: Annotated[Annotated[int, ctypes.c_uint32], 4]
@@ -41,8 +647,8 @@ class nvgpu_gpu_characteristics(c.Struct):
   dbg_gpu_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 116]
   ioctl_channel_nr_last: Annotated[Annotated[int, ctypes.c_int16], 118]
   as_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 120]
-  gpu_va_bit_count: Annotated[Annotated[int, ctypes.c_uint8], 122]
-  reserved: Annotated[Annotated[int, ctypes.c_uint8], 123]
+  gpu_va_bit_count: Annotated[Annotated[int, ctypes.c_ubyte], 122]
+  reserved: Annotated[Annotated[int, ctypes.c_ubyte], 123]
   max_fbps_count: Annotated[Annotated[int, ctypes.c_uint32], 124]
   fbp_en_mask: Annotated[Annotated[int, ctypes.c_uint32], 128]
   emc_en_mask: Annotated[Annotated[int, ctypes.c_uint32], 132]
@@ -50,8 +656,8 @@ class nvgpu_gpu_characteristics(c.Struct):
   max_lts_per_ltc: Annotated[Annotated[int, ctypes.c_uint32], 140]
   max_tex_per_tpc: Annotated[Annotated[int, ctypes.c_uint32], 144]
   max_gpc_count: Annotated[Annotated[int, ctypes.c_uint32], 148]
-  rop_l2_en_mask_DEPRECATED: Annotated[c.Array[ctypes.c_uint32, Literal[2]], 152]
-  chipname: Annotated[c.Array[ctypes.c_uint8, Literal[8]], 160]
+  rop_l2_en_mask_DEPRECATED: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[2]], 152]
+  chipname: Annotated[c.Array[Annotated[int, ctypes.c_ubyte], Literal[8]], 160]
   gr_compbit_store_base_hw: Annotated[Annotated[int, ctypes.c_uint64], 168]
   gr_gobs_per_comptagline_per_slice: Annotated[Annotated[int, ctypes.c_uint32], 176]
   num_ltc: Annotated[Annotated[int, ctypes.c_uint32], 180]
@@ -70,8 +676,8 @@ class nvgpu_gpu_characteristics(c.Struct):
   pci_subsystem_vendor_id: Annotated[Annotated[int, ctypes.c_uint16], 236]
   pci_subsystem_device_id: Annotated[Annotated[int, ctypes.c_uint16], 238]
   pci_class: Annotated[Annotated[int, ctypes.c_uint16], 240]
-  pci_revision: Annotated[Annotated[int, ctypes.c_uint8], 242]
-  vbios_oem_version: Annotated[Annotated[int, ctypes.c_uint8], 243]
+  pci_revision: Annotated[Annotated[int, ctypes.c_ubyte], 242]
+  vbios_oem_version: Annotated[Annotated[int, ctypes.c_ubyte], 243]
   vbios_version: Annotated[Annotated[int, ctypes.c_uint32], 244]
   reg_ops_limit: Annotated[Annotated[int, ctypes.c_uint32], 248]
   reserved1: Annotated[Annotated[int, ctypes.c_uint32], 252]
@@ -81,7 +687,7 @@ class nvgpu_gpu_characteristics(c.Struct):
   ctxsw_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 264]
   prof_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 266]
   nvs_ioctl_nr_last: Annotated[Annotated[int, ctypes.c_int16], 268]
-  reserved2: Annotated[c.Array[ctypes.c_uint8, Literal[2]], 270]
+  reserved2: Annotated[c.Array[Annotated[int, ctypes.c_ubyte], Literal[2]], 270]
   max_ctxsw_ring_buffer_size: Annotated[Annotated[int, ctypes.c_uint32], 272]
   reserved3: Annotated[Annotated[int, ctypes.c_uint32], 276]
   per_device_identifier: Annotated[Annotated[int, ctypes.c_uint64], 280]
@@ -95,12 +701,44 @@ class nvgpu_gpu_characteristics(c.Struct):
   reserved5: Annotated[Annotated[int, ctypes.c_uint32], 316]
   device_instance_id: Annotated[Annotated[int, ctypes.c_uint64], 320]
 @c.record
-class nvgpu_gpu_get_characteristics(c.Struct):
+class struct_nvgpu_gpu_get_characteristics(c.Struct):
   SIZE = 16
-  buf_size: Annotated[Annotated[int, ctypes.c_uint64], 0]
-  buf_addr: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  gpu_characteristics_buf_size: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  gpu_characteristics_buf_addr: Annotated[Annotated[int, ctypes.c_uint64], 8]
 @c.record
-class nvgpu_alloc_as_args(c.Struct):
+class struct_nvgpu_gpu_prepare_compressible_read_args(c.Struct):
+  SIZE = 80
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  request_compbits: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  valid_compbits: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  compbits_hoffset: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  compbits_voffset: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  width: Annotated[Annotated[int, ctypes.c_uint32], 32]
+  height: Annotated[Annotated[int, ctypes.c_uint32], 36]
+  block_height_log2: Annotated[Annotated[int, ctypes.c_uint32], 40]
+  submit_flags: Annotated[Annotated[int, ctypes.c_uint32], 44]
+  fence: Annotated[struct_nvgpu_gpu_prepare_compressible_read_args_fence, 48]
+  zbc_color: Annotated[Annotated[int, ctypes.c_uint32], 56]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 60]
+  scatterbuffer_offset: Annotated[Annotated[int, ctypes.c_uint64], 64]
+  reserved2: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[2]], 72]
+@c.record
+class struct_nvgpu_gpu_prepare_compressible_read_args_fence(c.Struct):
+  SIZE = 8
+  syncpt_id: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  syncpt_value: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+@c.record
+class struct_nvgpu_gpu_mark_compressible_write_args(c.Struct):
+  SIZE = 32
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  valid_compbits: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  zbc_color: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[3]], 20]
+@c.record
+class struct_nvgpu_alloc_as_args(c.Struct):
   SIZE = 64
   big_page_size: Annotated[Annotated[int, ctypes.c_uint32], 0]
   as_fd: Annotated[Annotated[int, ctypes.c_int32], 4]
@@ -109,36 +747,306 @@ class nvgpu_alloc_as_args(c.Struct):
   va_range_start: Annotated[Annotated[int, ctypes.c_uint64], 16]
   va_range_end: Annotated[Annotated[int, ctypes.c_uint64], 24]
   va_range_split: Annotated[Annotated[int, ctypes.c_uint64], 32]
-  padding: Annotated[c.Array[ctypes.c_uint32, Literal[6]], 40]
+  padding: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[6]], 40]
 @c.record
-class nvgpu_gpu_open_tsg_args(c.Struct):
+class struct_nvgpu_gpu_open_tsg_args(c.Struct):
   SIZE = 24
-  tsg_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+  tsg_fd: Annotated[Annotated[int, ctypes.c_uint32], 0]
   flags: Annotated[Annotated[int, ctypes.c_uint32], 4]
-  token: Annotated[Annotated[int, ctypes.c_uint32], 8]
-  reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
-  subctx_id: Annotated[Annotated[int, ctypes.c_uint32], 16]
-  _pad: Annotated[Annotated[int, ctypes.c_uint32], 20]
+  source_device_instance_id: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  share_token: Annotated[Annotated[int, ctypes.c_uint64], 16]
 @c.record
-class nvgpu_gpu_open_channel_args(c.Struct):
+class struct_nvgpu_gpu_get_tpc_masks_args(c.Struct):
+  SIZE = 16
+  mask_buf_size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  mask_buf_addr: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_get_gpc_physical_map_args(c.Struct):
+  SIZE = 16
+  map_buf_size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  physical_gpc_buf_addr: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_get_gpc_logical_map_args(c.Struct):
+  SIZE = 16
+  map_buf_size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  logical_gpc_buf_addr: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_open_channel_args(c.Struct):
   SIZE = 4
   channel_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
-
-# nvgpu-as.h
+  _in: Annotated[struct_nvgpu_gpu_open_channel_args_in, 0]
+  out: Annotated[struct_nvgpu_gpu_open_channel_args_out, 0]
 @c.record
-class nvgpu_as_bind_channel_args(c.Struct):
+class struct_nvgpu_gpu_open_channel_args_in(c.Struct):
   SIZE = 4
-  channel_fd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  runlist_id: Annotated[Annotated[int, ctypes.c_int32], 0]
 @c.record
-class nvgpu_as_alloc_space_args(c.Struct):
+class struct_nvgpu_gpu_open_channel_args_out(c.Struct):
+  SIZE = 4
+  channel_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+@c.record
+class struct_nvgpu_gpu_l2_fb_args(c.Struct):
+  SIZE = 5
+  l2_flush: Annotated[Annotated[int, ctypes.c_uint32], 0, 1, 0]
+  l2_invalidate: Annotated[Annotated[int, ctypes.c_uint32], 0, 1, 1]
+  fb_flush: Annotated[Annotated[int, ctypes.c_uint32], 0, 1, 2]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 1]
+@c.record
+class struct_nvgpu_gpu_mmu_debug_mode_args(c.Struct):
+  SIZE = 8
+  state: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_gpu_sm_debug_mode_args(c.Struct):
+  SIZE = 16
+  channel_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+  enable: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  sms: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_warpstate(c.Struct):
+  SIZE = 48
+  valid_warps: Annotated[c.Array[Annotated[int, ctypes.c_uint64], Literal[2]], 0]
+  trapped_warps: Annotated[c.Array[Annotated[int, ctypes.c_uint64], Literal[2]], 16]
+  paused_warps: Annotated[c.Array[Annotated[int, ctypes.c_uint64], Literal[2]], 32]
+@c.record
+class struct_nvgpu_gpu_wait_pause_args(c.Struct):
+  SIZE = 8
+  pwarpstate: Annotated[Annotated[int, ctypes.c_uint64], 0]
+@c.record
+class struct_nvgpu_gpu_tpc_exception_en_status_args(c.Struct):
+  SIZE = 8
+  tpc_exception_en_sm_mask: Annotated[Annotated[int, ctypes.c_uint64], 0]
+@c.record
+class struct_nvgpu_gpu_num_vsms(c.Struct):
+  SIZE = 8
+  num_vsms: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+@c.record
+class struct_nvgpu_gpu_vsms_mapping_entry(c.Struct):
+  SIZE = 6
+  gpc_logical_index: Annotated[Annotated[int, ctypes.c_ubyte], 0]
+  gpc_virtual_index: Annotated[Annotated[int, ctypes.c_ubyte], 1]
+  tpc_local_logical_index: Annotated[Annotated[int, ctypes.c_ubyte], 2]
+  tpc_global_logical_index: Annotated[Annotated[int, ctypes.c_ubyte], 3]
+  sm_local_id: Annotated[Annotated[int, ctypes.c_ubyte], 4]
+  tpc_migratable_index: Annotated[Annotated[int, ctypes.c_ubyte], 5]
+@c.record
+class struct_nvgpu_gpu_vsms_mapping(c.Struct):
+  SIZE = 8
+  vsms_map_buf_addr: Annotated[Annotated[int, ctypes.c_uint64], 0]
+@c.record
+class struct_nvgpu_gpu_get_buffer_info_args(c.Struct):
+  SIZE = 24
+  _in: Annotated[struct_nvgpu_gpu_get_buffer_info_args_in, 0]
+  out: Annotated[struct_nvgpu_gpu_get_buffer_info_args_out, 0]
+@c.record
+class struct_nvgpu_gpu_get_buffer_info_args_in(c.Struct):
+  SIZE = 16
+  dmabuf_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+  metadata_size: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  metadata_addr: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_get_buffer_info_args_out(c.Struct):
+  SIZE = 24
+  flags: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  metadata_size: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  size: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_gpu_get_cpu_time_correlation_sample(c.Struct):
+  SIZE = 16
+  cpu_timestamp: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  gpu_timestamp: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_get_cpu_time_correlation_info_args(c.Struct):
+  SIZE = 264
+  samples: Annotated[c.Array[struct_nvgpu_gpu_get_cpu_time_correlation_sample, Literal[16]], 0]
+  count: Annotated[Annotated[int, ctypes.c_uint32], 256]
+  source_id: Annotated[Annotated[int, ctypes.c_uint32], 260]
+@c.record
+class struct_nvgpu_gpu_get_gpu_time_args(c.Struct):
+  SIZE = 16
+  gpu_timestamp: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_get_engine_info_item(c.Struct):
+  SIZE = 16
+  engine_id: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  engine_instance: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  runlist_id: Annotated[Annotated[int, ctypes.c_int32], 8]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_gpu_get_engine_info_args(c.Struct):
+  SIZE = 16
+  engine_info_buf_size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  engine_info_buf_addr: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_alloc_vidmem_args(c.Struct):
+  SIZE = 32
+  _in: Annotated[struct_nvgpu_gpu_alloc_vidmem_args_in, 0]
+  out: Annotated[struct_nvgpu_gpu_alloc_vidmem_args_out, 0]
+@c.record
+class struct_nvgpu_gpu_alloc_vidmem_args_in(c.Struct):
+  SIZE = 32
+  size: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  memtag: Annotated[Annotated[int, ctypes.c_uint16], 12]
+  reserved0: Annotated[Annotated[int, ctypes.c_uint16], 14]
+  alignment: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  reserved1: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[3]], 20]
+@c.record
+class struct_nvgpu_gpu_alloc_vidmem_args_out(c.Struct):
+  SIZE = 4
+  dmabuf_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+@c.record
+class struct_nvgpu_gpu_clk_range(c.Struct):
+  SIZE = 24
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  clk_domain: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  min_hz: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  max_hz: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_gpu_clk_range_args(c.Struct):
+  SIZE = 16
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  pad0: Annotated[Annotated[int, ctypes.c_uint16], 4]
+  num_entries: Annotated[Annotated[int, ctypes.c_uint16], 6]
+  clk_range_entries: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_clk_vf_point(c.Struct):
+  SIZE = 8
+  freq_hz: Annotated[Annotated[int, ctypes.c_uint64], 0]
+@c.record
+class struct_nvgpu_gpu_clk_vf_points_args(c.Struct):
+  SIZE = 24
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  clk_domain: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  max_entries: Annotated[Annotated[int, ctypes.c_uint16], 8]
+  num_entries: Annotated[Annotated[int, ctypes.c_uint16], 10]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  clk_vf_point_entries: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvgpu_gpu_clk_info(c.Struct):
+  SIZE = 16
+  flags: Annotated[Annotated[int, ctypes.c_uint16], 0]
+  clk_type: Annotated[Annotated[int, ctypes.c_uint16], 2]
+  clk_domain: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  freq_hz: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_clk_get_info_args(c.Struct):
+  SIZE = 16
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  clk_type: Annotated[Annotated[int, ctypes.c_uint16], 4]
+  num_entries: Annotated[Annotated[int, ctypes.c_uint16], 6]
+  clk_info_entries: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_clk_set_info_args(c.Struct):
+  SIZE = 24
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  pad0: Annotated[Annotated[int, ctypes.c_uint16], 4]
+  num_entries: Annotated[Annotated[int, ctypes.c_uint16], 6]
+  clk_info_entries: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  completion_fd: Annotated[Annotated[int, ctypes.c_int32], 16]
+@c.record
+class struct_nvgpu_gpu_get_event_fd_args(c.Struct):
+  SIZE = 8
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  event_fd: Annotated[Annotated[int, ctypes.c_int32], 4]
+@c.record
+class struct_nvgpu_gpu_get_memory_state_args(c.Struct):
+  SIZE = 40
+  total_free_bytes: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint64], Literal[4]], 8]
+@c.record
+class struct_nvgpu_gpu_get_fbp_l2_masks_args(c.Struct):
+  SIZE = 16
+  mask_buf_size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  mask_buf_addr: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_get_voltage_args(c.Struct):
+  SIZE = 16
+  reserved: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  which: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  voltage: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_gpu_get_current_args(c.Struct):
+  SIZE = 16
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[3]], 0]
+  currnt: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_gpu_get_power_args(c.Struct):
+  SIZE = 16
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[3]], 0]
+  power: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_gpu_get_temperature_args(c.Struct):
+  SIZE = 16
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[3]], 0]
+  temp_f24_8: Annotated[Annotated[int, ctypes.c_int32], 12]
+@c.record
+class struct_nvgpu_gpu_set_therm_alert_limit_args(c.Struct):
+  SIZE = 16
+  reserved: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[3]], 0]
+  temp_f24_8: Annotated[Annotated[int, ctypes.c_int32], 12]
+@c.record
+class struct_nvgpu_gpu_set_deterministic_opts_args(c.Struct):
+  SIZE = 16
+  num_channels: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  channels: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvgpu_gpu_register_buffer_args(c.Struct):
+  SIZE = 24
+  dmabuf_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
+  comptags_alloc_control: Annotated[Annotated[int, ctypes.c_ubyte], 4]
+  reserved0: Annotated[Annotated[int, ctypes.c_ubyte], 5]
+  reserved1: Annotated[Annotated[int, ctypes.c_uint16], 6]
+  metadata_addr: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  metadata_size: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 20]
+@c.record
+class struct_nvgpu32_as_alloc_space_args(c.Struct):
+  SIZE = 24
+  pages: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  page_size: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  o_a: Annotated[struct_nvgpu32_as_alloc_space_args_o_a, 16]
+@c.record
+class struct_nvgpu32_as_alloc_space_args_o_a(c.Struct):
+  SIZE = 8
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  align: Annotated[Annotated[int, ctypes.c_uint64], 0]
+@c.record
+class struct_nvgpu_as_alloc_space_args(c.Struct):
   SIZE = 32
   pages: Annotated[Annotated[int, ctypes.c_uint64], 0]
   page_size: Annotated[Annotated[int, ctypes.c_uint32], 8]
   flags: Annotated[Annotated[int, ctypes.c_uint32], 12]
-  offset: Annotated[Annotated[int, ctypes.c_uint64], 16]
-  padding: Annotated[c.Array[ctypes.c_uint32, Literal[2]], 24]
+  o_a: Annotated[struct_nvgpu_as_alloc_space_args_o_a, 16]
+  padding: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[2]], 24]
 @c.record
-class nvgpu_as_map_buffer_ex_args(c.Struct):
+class struct_nvgpu_as_alloc_space_args_o_a(c.Struct):
+  SIZE = 8
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  align: Annotated[Annotated[int, ctypes.c_uint64], 0]
+@c.record
+class struct_nvgpu_as_free_space_args(c.Struct):
+  SIZE = 32
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  pages: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  page_size: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  padding: Annotated[c.Array[Annotated[int, ctypes.c_uint32], Literal[3]], 20]
+@c.record
+class struct_nvgpu_as_bind_channel_args(c.Struct):
+  SIZE = 4
+  channel_fd: Annotated[Annotated[int, ctypes.c_uint32], 0]
+@c.record
+class struct_nvgpu_as_map_buffer_ex_args(c.Struct):
   SIZE = 40
   flags: Annotated[Annotated[int, ctypes.c_uint32], 0]
   compr_kind: Annotated[Annotated[int, ctypes.c_int16], 4]
@@ -149,111 +1057,743 @@ class nvgpu_as_map_buffer_ex_args(c.Struct):
   mapping_size: Annotated[Annotated[int, ctypes.c_uint64], 24]
   offset: Annotated[Annotated[int, ctypes.c_uint64], 32]
 @c.record
-class nvgpu_as_unmap_buffer_args(c.Struct):
+class struct_nvgpu_as_get_buffer_compbits_info_args(c.Struct):
+  SIZE = 32
+  mapping_gva: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  compbits_win_size: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  compbits_win_ctagline: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  mapping_ctagline: Annotated[Annotated[int, ctypes.c_uint32], 20]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 24]
+  reserved1: Annotated[Annotated[int, ctypes.c_uint32], 28]
+@c.record
+class struct_nvgpu_as_map_buffer_compbits_args(c.Struct):
+  SIZE = 40
+  mapping_gva: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  compbits_win_gva: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  mapping_iova: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  mapping_iova_buf_addr: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  mapping_iova_buf_size: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 32]
+  reserved1: Annotated[Annotated[int, ctypes.c_uint32], 36]
+@c.record
+class struct_nvgpu_as_unmap_buffer_args(c.Struct):
   SIZE = 8
   offset: Annotated[Annotated[int, ctypes.c_uint64], 0]
-
-# nvgpu.h: TSG ioctls
 @c.record
-class nvgpu_tsg_bind_channel_ex_args(c.Struct):
+class struct_nvgpu_as_va_region(c.Struct):
   SIZE = 24
-  channel_fd: Annotated[Annotated[int, ctypes.c_int32], 0]
-  subcontext_id: Annotated[Annotated[int, ctypes.c_uint32], 4]
-  reserved: Annotated[c.Array[ctypes.c_uint8, Literal[16]], 8]
-@c.record
-class nvgpu_tsg_create_subcontext_args(c.Struct):
-  SIZE = 16
-  type: Annotated[Annotated[int, ctypes.c_uint32], 0]
-  as_fd: Annotated[Annotated[int, ctypes.c_int32], 4]
-  veid: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  page_size: Annotated[Annotated[int, ctypes.c_uint32], 8]
   reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
-
-# nvgpu.h: channel ioctls
+  pages: Annotated[Annotated[int, ctypes.c_uint64], 16]
 @c.record
-class nvgpu_alloc_obj_ctx_args(c.Struct):
+class struct_nvgpu_as_get_va_regions_args(c.Struct):
   SIZE = 16
-  class_num: Annotated[Annotated[int, ctypes.c_uint32], 0]
-  flags: Annotated[Annotated[int, ctypes.c_uint32], 4]
-  obj_id: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  buf_addr: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  buf_size: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  reserved: Annotated[Annotated[int, ctypes.c_uint32], 12]
 @c.record
-class nvgpu_channel_setup_bind_args(c.Struct):
-  SIZE = 104
-  num_gpfifo_entries: Annotated[Annotated[int, ctypes.c_uint32], 0]
-  num_inflight_jobs: Annotated[Annotated[int, ctypes.c_uint32], 4]
-  flags: Annotated[Annotated[int, ctypes.c_uint32], 8]
-  userd_dmabuf_fd: Annotated[Annotated[int, ctypes.c_int32], 12]
-  gpfifo_dmabuf_fd: Annotated[Annotated[int, ctypes.c_int32], 16]
-  work_submit_token: Annotated[Annotated[int, ctypes.c_uint32], 20]
-  userd_dmabuf_offset: Annotated[Annotated[int, ctypes.c_uint64], 24]
-  gpfifo_dmabuf_offset: Annotated[Annotated[int, ctypes.c_uint64], 32]
-  gpfifo_gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 40]
-  userd_gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 48]
-  usermode_mmio_gpu_va: Annotated[Annotated[int, ctypes.c_uint64], 56]
-  reserved: Annotated[c.Array[ctypes.c_uint32, Literal[9]], 64]
+class struct_nvgpu_as_map_buffer_batch_args(c.Struct):
+  SIZE = 32
+  unmaps: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  maps: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  num_unmaps: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  num_maps: Annotated[Annotated[int, ctypes.c_uint32], 20]
+  reserved: Annotated[Annotated[int, ctypes.c_uint64], 24]
 @c.record
-class nvgpu_channel_wdt_args(c.Struct):
-  SIZE = 8
-  wdt_status: Annotated[Annotated[int, ctypes.c_uint32], 0]
-  timeout_ms: Annotated[Annotated[int, ctypes.c_uint32], 4]
+class struct_nvgpu_as_get_sync_ro_map_args(c.Struct):
+  SIZE = 16
+  base_gpuva: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  sync_size: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  num_syncpoints: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvgpu_as_mapping_modify_args(c.Struct):
+  SIZE = 32
+  compr_kind: Annotated[Annotated[int, ctypes.c_int16], 0]
+  incompr_kind: Annotated[Annotated[int, ctypes.c_int16], 2]
+  buffer_offset: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  buffer_size: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  map_address: Annotated[Annotated[int, ctypes.c_uint64], 24]
+@c.record
+class struct_nvgpu_as_remap_op(c.Struct):
+  SIZE = 40
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  compr_kind: Annotated[Annotated[int, ctypes.c_int16], 4]
+  incompr_kind: Annotated[Annotated[int, ctypes.c_int16], 6]
+  mem_handle: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  reserved: Annotated[Annotated[int, ctypes.c_int32], 12]
+  mem_offset_in_pages: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  virt_offset_in_pages: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  num_pages: Annotated[Annotated[int, ctypes.c_uint64], 32]
+@c.record
+class struct_nvgpu_as_remap_args(c.Struct):
+  SIZE = 16
+  ops: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  num_ops: Annotated[Annotated[int, ctypes.c_uint32], 8]
+class _anonenum0(Annotated[int, ctypes.c_uint32], c.Enum): pass
+NVMAP_HANDLE_PARAM_SIZE = _anonenum0.define('NVMAP_HANDLE_PARAM_SIZE', 1)
+NVMAP_HANDLE_PARAM_ALIGNMENT = _anonenum0.define('NVMAP_HANDLE_PARAM_ALIGNMENT', 2)
+NVMAP_HANDLE_PARAM_BASE = _anonenum0.define('NVMAP_HANDLE_PARAM_BASE', 3)
+NVMAP_HANDLE_PARAM_HEAP = _anonenum0.define('NVMAP_HANDLE_PARAM_HEAP', 4)
+NVMAP_HANDLE_PARAM_KIND = _anonenum0.define('NVMAP_HANDLE_PARAM_KIND', 5)
+NVMAP_HANDLE_PARAM_COMPR = _anonenum0.define('NVMAP_HANDLE_PARAM_COMPR', 6)
 
-# nvmap.h
+class _anonenum1(Annotated[int, ctypes.c_uint32], c.Enum): pass
+NVMAP_CACHE_OP_WB = _anonenum1.define('NVMAP_CACHE_OP_WB', 0)
+NVMAP_CACHE_OP_INV = _anonenum1.define('NVMAP_CACHE_OP_INV', 1)
+NVMAP_CACHE_OP_WB_INV = _anonenum1.define('NVMAP_CACHE_OP_WB_INV', 2)
+
+class _anonenum2(Annotated[int, ctypes.c_uint32], c.Enum): pass
+NVMAP_PAGES_UNRESERVE = _anonenum2.define('NVMAP_PAGES_UNRESERVE', 0)
+NVMAP_PAGES_RESERVE = _anonenum2.define('NVMAP_PAGES_RESERVE', 1)
+NVMAP_INSERT_PAGES_ON_UNRESERVE = _anonenum2.define('NVMAP_INSERT_PAGES_ON_UNRESERVE', 2)
+NVMAP_PAGES_PROT_AND_CLEAN = _anonenum2.define('NVMAP_PAGES_PROT_AND_CLEAN', 3)
+
 @c.record
-class nvmap_create_handle(c.Struct):
+class struct_nvmap_create_handle(c.Struct):
   SIZE = 8
   size: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  fd: Annotated[Annotated[int, ctypes.c_int32], 0]
   handle: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  ivm_id: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  ivm_handle: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  size64: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  handle64: Annotated[Annotated[int, ctypes.c_uint32], 0]
 @c.record
-class nvmap_alloc_handle(c.Struct):
+class struct_nvmap_create_handle_from_va(c.Struct):
+  SIZE = 24
+  va: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  size: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  size64: Annotated[Annotated[int, ctypes.c_uint64], 16]
+@c.record
+class struct_nvmap_gup_test(c.Struct):
+  SIZE = 16
+  va: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  result: Annotated[Annotated[int, ctypes.c_uint32], 12]
+@c.record
+class struct_nvmap_alloc_handle(c.Struct):
   SIZE = 20
   handle: Annotated[Annotated[int, ctypes.c_uint32], 0]
   heap_mask: Annotated[Annotated[int, ctypes.c_uint32], 4]
   flags: Annotated[Annotated[int, ctypes.c_uint32], 8]
   align: Annotated[Annotated[int, ctypes.c_uint32], 12]
   numa_nid: Annotated[Annotated[int, ctypes.c_int32], 16]
-
-# ioctl magic bytes
-NVGPU_GPU_IOCTL_MAGIC = ord('G')
-NVGPU_AS_IOCTL_MAGIC = ord('A')
-NVGPU_TSG_IOCTL_MAGIC = ord('T')
-NVGPU_IOCTL_MAGIC = ord('H')
-NVMAP_IOC_MAGIC = ord('N')
-
-# nvgpu-ctrl.h ioctls
-NVGPU_GPU_IOCTL_GET_CHARACTERISTICS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 5, nvgpu_gpu_get_characteristics)
-NVGPU_GPU_IOCTL_ALLOC_AS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 8, nvgpu_alloc_as_args)
-NVGPU_GPU_IOCTL_OPEN_TSG = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 9, nvgpu_gpu_open_tsg_args)
-NVGPU_GPU_IOCTL_OPEN_CHANNEL = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 11, nvgpu_gpu_open_channel_args)
-
-# nvgpu-as.h ioctls
-NVGPU_AS_IOCTL_BIND_CHANNEL = _IOWR(NVGPU_AS_IOCTL_MAGIC, 1, nvgpu_as_bind_channel_args)
-NVGPU_AS_IOCTL_UNMAP_BUFFER = _IOWR(NVGPU_AS_IOCTL_MAGIC, 5, nvgpu_as_unmap_buffer_args)
-NVGPU_AS_IOCTL_ALLOC_SPACE = _IOWR(NVGPU_AS_IOCTL_MAGIC, 6, nvgpu_as_alloc_space_args)
-NVGPU_AS_IOCTL_MAP_BUFFER_EX = _IOWR(NVGPU_AS_IOCTL_MAGIC, 7, nvgpu_as_map_buffer_ex_args)
-
-# nvgpu.h TSG ioctls
-NVGPU_TSG_IOCTL_BIND_CHANNEL_EX = _IOWR(NVGPU_TSG_IOCTL_MAGIC, 11, nvgpu_tsg_bind_channel_ex_args)
-NVGPU_TSG_IOCTL_CREATE_SUBCONTEXT = _IOWR(NVGPU_TSG_IOCTL_MAGIC, 18, nvgpu_tsg_create_subcontext_args)
-
-# nvgpu.h channel ioctls
-NVGPU_IOCTL_CHANNEL_ALLOC_OBJ_CTX = _IOWR(NVGPU_IOCTL_MAGIC, 108, nvgpu_alloc_obj_ctx_args)
-NVGPU_IOCTL_CHANNEL_WDT = _IOW(NVGPU_IOCTL_MAGIC, 119, nvgpu_channel_wdt_args)
-NVGPU_IOCTL_CHANNEL_SETUP_BIND = _IOWR(NVGPU_IOCTL_MAGIC, 128, nvgpu_channel_setup_bind_args)
-
-# nvmap.h ioctls
-NVMAP_IOC_CREATE = _IOWR(NVMAP_IOC_MAGIC, 0, nvmap_create_handle)
-NVMAP_IOC_ALLOC = _IOW(NVMAP_IOC_MAGIC, 3, nvmap_alloc_handle)
-NVMAP_IOC_FREE = _IO(NVMAP_IOC_MAGIC, 4)
-NVMAP_IOC_GET_FD = _IOWR(NVMAP_IOC_MAGIC, 15, nvmap_create_handle)
-
-# nvmap.h constants
-NVMAP_HEAP_IOVMM = 1 << 30
-NVMAP_HANDLE_UNCACHEABLE = 0
-NVMAP_HANDLE_WRITE_COMBINE = 1
-NVMAP_HANDLE_INNER_CACHEABLE = 2
-NVMAP_HANDLE_CACHEABLE = 3
-
-# nvgpu.h channel setup_bind flags
-NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC = 1 << 1
-NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT = 1 << 3
-
+@c.record
+class struct_nvmap_alloc_ivm_handle(c.Struct):
+  SIZE = 20
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  heap_mask: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  align: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  peer: Annotated[Annotated[int, ctypes.c_uint32], 16]
+@c.record
+class struct_nvmap_rw_handle(c.Struct):
+  SIZE = 56
+  addr: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  elem_size: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  hmem_stride: Annotated[Annotated[int, ctypes.c_uint64], 32]
+  user_stride: Annotated[Annotated[int, ctypes.c_uint64], 40]
+  count: Annotated[Annotated[int, ctypes.c_uint64], 48]
+@c.record
+class struct_nvmap_handle_param(c.Struct):
+  SIZE = 16
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  param: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  result: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvmap_cache_op(c.Struct):
+  SIZE = 24
+  addr: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  len: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  op: Annotated[Annotated[int, ctypes.c_int32], 16]
+@c.record
+class struct_nvmap_cache_op_64(c.Struct):
+  SIZE = 32
+  addr: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  len: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  op: Annotated[Annotated[int, ctypes.c_int32], 24]
+@c.record
+class struct_nvmap_cache_op_list(c.Struct):
+  SIZE = 32
+  handles: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  offsets: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  sizes: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  nr: Annotated[Annotated[int, ctypes.c_uint32], 24]
+  op: Annotated[Annotated[int, ctypes.c_int32], 28]
+@c.record
+class struct_nvmap_debugfs_handles_header(c.Struct):
+  SIZE = 1
+  version: Annotated[Annotated[int, ctypes.c_ubyte], 0]
+@c.record
+class struct_nvmap_debugfs_handles_entry(c.Struct):
+  SIZE = 32
+  base: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  size: Annotated[Annotated[int, ctypes.c_uint64], 8]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  share_count: Annotated[Annotated[int, ctypes.c_uint32], 20]
+  mapped_size: Annotated[Annotated[int, ctypes.c_uint64], 24]
+@c.record
+class struct_nvmap_set_tag_label(c.Struct):
+  SIZE = 16
+  tag: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  len: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  addr: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvmap_available_heaps(c.Struct):
+  SIZE = 8
+  heaps: Annotated[Annotated[int, ctypes.c_uint64], 0]
+@c.record
+class struct_nvmap_heap_size(c.Struct):
+  SIZE = 16
+  heap: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  size: Annotated[Annotated[int, ctypes.c_uint64], 8]
+@c.record
+class struct_nvmap_sciipc_map(c.Struct):
+  SIZE = 32
+  auth_token: Annotated[Annotated[int, ctypes.c_uint64], 0]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  sci_ipc_id: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 24]
+@c.record
+class struct_nvmap_handle_parameters(c.Struct):
+  SIZE = 72
+  contig: Annotated[Annotated[int, ctypes.c_ubyte], 0]
+  import_id: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  heap_number: Annotated[Annotated[int, ctypes.c_uint32], 12]
+  access_flags: Annotated[Annotated[int, ctypes.c_uint32], 16]
+  heap: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  align: Annotated[Annotated[int, ctypes.c_uint64], 32]
+  coherency: Annotated[Annotated[int, ctypes.c_uint64], 40]
+  size: Annotated[Annotated[int, ctypes.c_uint64], 48]
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 56]
+  serial_id: Annotated[Annotated[int, ctypes.c_uint64], 64]
+@c.record
+class struct_nvmap_query_heap_params(c.Struct):
+  SIZE = 48
+  heap_mask: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  flags: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  contig: Annotated[Annotated[int, ctypes.c_ubyte], 8]
+  total: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  free: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  largest_free_block: Annotated[Annotated[int, ctypes.c_uint64], 32]
+  granule_size: Annotated[Annotated[int, ctypes.c_uint32], 40]
+@c.record
+class struct_nvmap_duplicate_handle(c.Struct):
+  SIZE = 12
+  handle: Annotated[Annotated[int, ctypes.c_uint32], 0]
+  access_flags: Annotated[Annotated[int, ctypes.c_uint32], 4]
+  dup_handle: Annotated[Annotated[int, ctypes.c_uint32], 8]
+@c.record
+class struct_nvmap_fd_for_range_from_list(c.Struct):
+  SIZE = 40
+  handles: Annotated[c.POINTER[Annotated[int, ctypes.c_uint32]], 0]
+  num_handles: Annotated[Annotated[int, ctypes.c_uint32], 8]
+  offset: Annotated[Annotated[int, ctypes.c_uint64], 16]
+  size: Annotated[Annotated[int, ctypes.c_uint64], 24]
+  fd: Annotated[Annotated[int, ctypes.c_int32], 32]
 c.init_records()
+NVGPU_TSG_IOCTL_MAGIC = 'T' # type: ignore
+NVGPU_GPU_IOCTL_TSG_L2_SECTOR_PROMOTE_FLAG_NONE = (1 << 0) # type: ignore
+NVGPU_GPU_IOCTL_TSG_L2_SECTOR_PROMOTE_FLAG_64B = (1 << 1) # type: ignore
+NVGPU_GPU_IOCTL_TSG_L2_SECTOR_PROMOTE_FLAG_128B = (1 << 2) # type: ignore
+NVGPU_TSG_SUBCONTEXT_TYPE_SYNC = (0x0) # type: ignore
+NVGPU_TSG_SUBCONTEXT_TYPE_ASYNC = (0x1) # type: ignore
+NVGPU_TSG_IOCTL_BIND_CHANNEL = _IOW(NVGPU_TSG_IOCTL_MAGIC, 1, int) # type: ignore
+NVGPU_TSG_IOCTL_UNBIND_CHANNEL = _IOW(NVGPU_TSG_IOCTL_MAGIC, 2, int) # type: ignore
+NVGPU_IOCTL_TSG_ENABLE = _IO(NVGPU_TSG_IOCTL_MAGIC, 3) # type: ignore
+NVGPU_IOCTL_TSG_DISABLE = _IO(NVGPU_TSG_IOCTL_MAGIC, 4) # type: ignore
+NVGPU_IOCTL_TSG_PREEMPT = _IO(NVGPU_TSG_IOCTL_MAGIC, 5) # type: ignore
+NVGPU_IOCTL_TSG_EVENT_ID_CTRL = _IOWR(NVGPU_TSG_IOCTL_MAGIC, 7, struct_nvgpu_event_id_ctrl_args) # type: ignore
+NVGPU_IOCTL_TSG_SET_RUNLIST_INTERLEAVE = _IOW(NVGPU_TSG_IOCTL_MAGIC, 8, struct_nvgpu_runlist_interleave_args) # type: ignore
+NVGPU_IOCTL_TSG_SET_TIMESLICE = _IOW(NVGPU_TSG_IOCTL_MAGIC, 9, struct_nvgpu_timeslice_args) # type: ignore
+NVGPU_IOCTL_TSG_GET_TIMESLICE = _IOR(NVGPU_TSG_IOCTL_MAGIC, 10, struct_nvgpu_timeslice_args) # type: ignore
+NVGPU_TSG_IOCTL_BIND_CHANNEL_EX = _IOWR(NVGPU_TSG_IOCTL_MAGIC, 11, struct_nvgpu_tsg_bind_channel_ex_args) # type: ignore
+NVGPU_TSG_IOCTL_READ_SINGLE_SM_ERROR_STATE = _IOWR(NVGPU_TSG_IOCTL_MAGIC, 12, struct_nvgpu_tsg_read_single_sm_error_state_args) # type: ignore
+NVGPU_TSG_IOCTL_SET_L2_MAX_WAYS_EVICT_LAST = _IOW(NVGPU_TSG_IOCTL_MAGIC, 13, struct_nvgpu_tsg_l2_max_ways_evict_last_args) # type: ignore
+NVGPU_TSG_IOCTL_GET_L2_MAX_WAYS_EVICT_LAST = _IOR(NVGPU_TSG_IOCTL_MAGIC, 14, struct_nvgpu_tsg_l2_max_ways_evict_last_args) # type: ignore
+NVGPU_TSG_IOCTL_SET_L2_SECTOR_PROMOTION = _IOW(NVGPU_TSG_IOCTL_MAGIC, 15, struct_nvgpu_tsg_set_l2_sector_promotion_args) # type: ignore
+NVGPU_TSG_IOCTL_BIND_SCHEDULING_DOMAIN = _IOW(NVGPU_TSG_IOCTL_MAGIC, 16, struct_nvgpu_tsg_bind_scheduling_domain_args) # type: ignore
+NVGPU_TSG_IOCTL_READ_ALL_SM_ERROR_STATES = _IOWR(NVGPU_TSG_IOCTL_MAGIC, 17, struct_nvgpu_tsg_read_all_sm_error_state_args) # type: ignore
+NVGPU_TSG_IOCTL_CREATE_SUBCONTEXT = _IOWR(NVGPU_TSG_IOCTL_MAGIC, 18, struct_nvgpu_tsg_create_subcontext_args) # type: ignore
+NVGPU_TSG_IOCTL_DELETE_SUBCONTEXT = _IOW(NVGPU_TSG_IOCTL_MAGIC, 19, struct_nvgpu_tsg_delete_subcontext_args) # type: ignore
+NVGPU_TSG_IOCTL_GET_SHARE_TOKEN = _IOWR(NVGPU_TSG_IOCTL_MAGIC, 20, struct_nvgpu_tsg_get_share_token_args) # type: ignore
+NVGPU_TSG_IOCTL_REVOKE_SHARE_TOKEN = _IOW(NVGPU_TSG_IOCTL_MAGIC, 21, struct_nvgpu_tsg_revoke_share_token_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_MAGIC = 'D' # type: ignore
+NVGPU_DBG_GPU_IOCTL_BIND_CHANNEL = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 1, struct_nvgpu_dbg_gpu_bind_channel_args) # type: ignore
+NVGPU_DBG_GPU_REG_OP_READ_32 = (0x00000000) # type: ignore
+NVGPU_DBG_GPU_REG_OP_WRITE_32 = (0x00000001) # type: ignore
+NVGPU_DBG_GPU_REG_OP_READ_64 = (0x00000002) # type: ignore
+NVGPU_DBG_GPU_REG_OP_WRITE_64 = (0x00000003) # type: ignore
+NVGPU_DBG_GPU_REG_OP_READ_08 = (0x00000004) # type: ignore
+NVGPU_DBG_GPU_REG_OP_WRITE_08 = (0x00000005) # type: ignore
+NVGPU_DBG_GPU_REG_OP_TYPE_GLOBAL = (0x00000000) # type: ignore
+NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX = (0x00000001) # type: ignore
+NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX_TPC = (0x00000002) # type: ignore
+NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX_SM = (0x00000004) # type: ignore
+NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX_CROP = (0x00000008) # type: ignore
+NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX_ZROP = (0x00000010) # type: ignore
+NVGPU_DBG_GPU_REG_OP_TYPE_GR_CTX_QUAD = (0x00000040) # type: ignore
+NVGPU_DBG_GPU_REG_OP_STATUS_SUCCESS = (0x00000000) # type: ignore
+NVGPU_DBG_GPU_REG_OP_STATUS_INVALID_OP = (0x00000001) # type: ignore
+NVGPU_DBG_GPU_REG_OP_STATUS_INVALID_TYPE = (0x00000002) # type: ignore
+NVGPU_DBG_GPU_REG_OP_STATUS_INVALID_OFFSET = (0x00000004) # type: ignore
+NVGPU_DBG_GPU_REG_OP_STATUS_UNSUPPORTED_OP = (0x00000008) # type: ignore
+NVGPU_DBG_GPU_REG_OP_STATUS_INVALID_MASK = (0x00000010) # type: ignore
+NVGPU_DBG_GPU_IOCTL_REG_OPS = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 2, struct_nvgpu_dbg_gpu_exec_reg_ops_args) # type: ignore
+NVGPU_DBG_GPU_EVENTS_CTRL_CMD_DISABLE = (0x00000000) # type: ignore
+NVGPU_DBG_GPU_EVENTS_CTRL_CMD_ENABLE = (0x00000001) # type: ignore
+NVGPU_DBG_GPU_EVENTS_CTRL_CMD_CLEAR = (0x00000002) # type: ignore
+NVGPU_DBG_GPU_IOCTL_EVENTS_CTRL = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 3, struct_nvgpu_dbg_gpu_events_ctrl_args) # type: ignore
+NVGPU_DBG_GPU_POWERGATE_MODE_ENABLE = 1 # type: ignore
+NVGPU_DBG_GPU_POWERGATE_MODE_DISABLE = 2 # type: ignore
+NVGPU_DBG_GPU_IOCTL_POWERGATE = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 4, struct_nvgpu_dbg_gpu_powergate_args) # type: ignore
+NVGPU_DBG_GPU_SMPC_CTXSW_MODE_NO_CTXSW = (0x00000000) # type: ignore
+NVGPU_DBG_GPU_SMPC_CTXSW_MODE_CTXSW = (0x00000001) # type: ignore
+NVGPU_DBG_GPU_IOCTL_SMPC_CTXSW_MODE = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 5, struct_nvgpu_dbg_gpu_smpc_ctxsw_mode_args) # type: ignore
+NVGPU_DBG_GPU_SUSPEND_ALL_SMS = 1 # type: ignore
+NVGPU_DBG_GPU_RESUME_ALL_SMS = 2 # type: ignore
+NVGPU_DBG_GPU_IOCTL_SUSPEND_RESUME_ALL_SMS = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 6, struct_nvgpu_dbg_gpu_suspend_resume_all_sms_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_PERFBUF_MAP = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 7, struct_nvgpu_dbg_gpu_perfbuf_map_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_PERFBUF_UNMAP = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 8, struct_nvgpu_dbg_gpu_perfbuf_unmap_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_PC_SAMPLING_DISABLE = 0 # type: ignore
+NVGPU_DBG_GPU_IOCTL_PC_SAMPLING_ENABLE = 1 # type: ignore
+NVGPU_DBG_GPU_IOCTL_PC_SAMPLING = _IOW(NVGPU_DBG_GPU_IOCTL_MAGIC,  9, struct_nvgpu_dbg_gpu_pc_sampling_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_TIMEOUT_ENABLE = 1 # type: ignore
+NVGPU_DBG_GPU_IOCTL_TIMEOUT_DISABLE = 0 # type: ignore
+NVGPU_DBG_GPU_IOCTL_TIMEOUT = _IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 10, struct_nvgpu_dbg_gpu_timeout_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_GET_TIMEOUT = _IOR(NVGPU_DBG_GPU_IOCTL_MAGIC, 11, struct_nvgpu_dbg_gpu_timeout_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_SET_NEXT_STOP_TRIGGER_TYPE = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 12, struct_nvgpu_dbg_gpu_set_next_stop_trigger_type_args) # type: ignore
+NVGPU_DBG_GPU_HWPM_CTXSW_MODE_NO_CTXSW = (0x00000000) # type: ignore
+NVGPU_DBG_GPU_HWPM_CTXSW_MODE_CTXSW = (0x00000001) # type: ignore
+NVGPU_DBG_GPU_HWPM_CTXSW_MODE_STREAM_OUT_CTXSW = (0x00000002) # type: ignore
+NVGPU_DBG_GPU_IOCTL_HWPM_CTXSW_MODE = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 13, struct_nvgpu_dbg_gpu_hwpm_ctxsw_mode_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_READ_SINGLE_SM_ERROR_STATE = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 14, struct_nvgpu_dbg_gpu_read_single_sm_error_state_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_CLEAR_SINGLE_SM_ERROR_STATE = _IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 15, struct_nvgpu_dbg_gpu_clear_single_sm_error_state_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_UNBIND_CHANNEL = _IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 17, struct_nvgpu_dbg_gpu_unbind_channel_args) # type: ignore
+NVGPU_DBG_GPU_SUSPEND_ALL_CONTEXTS = 1 # type: ignore
+NVGPU_DBG_GPU_RESUME_ALL_CONTEXTS = 2 # type: ignore
+NVGPU_DBG_GPU_IOCTL_SUSPEND_RESUME_CONTEXTS = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 18, struct_nvgpu_dbg_gpu_suspend_resume_contexts_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_ACCESS_FB_MEMORY_CMD_READ = 1 # type: ignore
+NVGPU_DBG_GPU_IOCTL_ACCESS_FB_MEMORY_CMD_WRITE = 2 # type: ignore
+NVGPU_DBG_GPU_IOCTL_ACCESS_FB_MEMORY = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 19, struct_nvgpu_dbg_gpu_access_fb_memory_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_PROFILER_ALLOCATE = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 20, struct_nvgpu_dbg_gpu_profiler_obj_mgt_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_PROFILER_FREE = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 21, struct_nvgpu_dbg_gpu_profiler_obj_mgt_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_PROFILER_RESERVE = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 22, struct_nvgpu_dbg_gpu_profiler_reserve_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_SET_SM_EXCEPTION_TYPE_MASK_NONE = (0x0) # type: ignore
+NVGPU_DBG_GPU_IOCTL_SET_SM_EXCEPTION_TYPE_MASK_FATAL = (0x1 << 0) # type: ignore
+NVGPU_DBG_GPU_IOCTL_SET_SM_EXCEPTION_TYPE_MASK = _IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 23, struct_nvgpu_dbg_gpu_set_sm_exception_type_mask_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_CYCLE_STATS = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 24, struct_nvgpu_dbg_gpu_cycle_stats_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_CYCLE_STATS_SNAPSHOT_CMD_FLUSH = 0 # type: ignore
+NVGPU_DBG_GPU_IOCTL_CYCLE_STATS_SNAPSHOT_CMD_ATTACH = 1 # type: ignore
+NVGPU_DBG_GPU_IOCTL_CYCLE_STATS_SNAPSHOT_CMD_DETACH = 2 # type: ignore
+NVGPU_DBG_GPU_IOCTL_CYCLE_STATS_SNAPSHOT = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 25, struct_nvgpu_dbg_gpu_cycle_stats_snapshot_args) # type: ignore
+NVGPU_DBG_GPU_CTX_MMU_DEBUG_MODE_DISABLED = 0 # type: ignore
+NVGPU_DBG_GPU_CTX_MMU_DEBUG_MODE_ENABLED = 1 # type: ignore
+NVGPU_DBG_GPU_IOCTL_SET_CTX_MMU_DEBUG_MODE = _IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 26, struct_nvgpu_dbg_gpu_set_ctx_mmu_debug_mode_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_GET_GR_CONTEXT_SIZE = _IOR(NVGPU_DBG_GPU_IOCTL_MAGIC, 27, struct_nvgpu_dbg_gpu_get_gr_context_size_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_GET_GR_CONTEXT = _IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 28, struct_nvgpu_dbg_gpu_get_gr_context_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_TSG_SET_TIMESLICE = _IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 29, struct_nvgpu_timeslice_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_TSG_GET_TIMESLICE = _IOR(NVGPU_DBG_GPU_IOCTL_MAGIC, 30, struct_nvgpu_timeslice_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_ACCESS_GPUVA_CMD_READ = 1 # type: ignore
+NVGPU_DBG_GPU_IOCTL_ACCESS_GPUVA_CMD_WRITE = 2 # type: ignore
+NVGPU_DBG_GPU_IOCTL_GET_MAPPINGS = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 31, struct_nvgpu_dbg_gpu_get_mappings_args) # type: ignore
+NVGPU_DBG_GPU_IOCTL_ACCESS_GPU_VA = _IOWR(NVGPU_DBG_GPU_IOCTL_MAGIC, 32, struct_nvgpu_dbg_gpu_va_access_args) # type: ignore
+NVGPU_DBG_GPU_SCHED_EXIT_WAIT_FOR_ERRBAR_DISABLED = 0 # type: ignore
+NVGPU_DBG_GPU_SCHED_EXIT_WAIT_FOR_ERRBAR_ENABLED = 1 # type: ignore
+NVGPU_DBG_GPU_IOCTL_SET_SCHED_EXIT_WAIT_FOR_ERRBAR = _IOW(NVGPU_DBG_GPU_IOCTL_MAGIC, 33, struct_nvgpu_sched_exit_wait_for_errbar_args) # type: ignore
+NVGPU_PROFILER_IOCTL_MAGIC = 'P' # type: ignore
+NVGPU_PROFILER_PM_RESOURCE_ARG_HWPM_LEGACY = 0 # type: ignore
+NVGPU_PROFILER_PM_RESOURCE_ARG_SMPC = 1 # type: ignore
+NVGPU_PROFILER_PM_RESOURCE_ARG_PC_SAMPLER = 2 # type: ignore
+NVGPU_PROFILER_PM_RESOURCE_ARG_HES_CWD = 3 # type: ignore
+NVGPU_PROFILER_RESERVE_PM_RESOURCE_ARG_FLAG_CTXSW = (1 << 0) # type: ignore
+NVGPU_PROFILER_ALLOC_PMA_STREAM_ARG_FLAG_CTXSW = (1 << 0) # type: ignore
+NVGPU_PROFILER_PMA_STREAM_UPDATE_GET_PUT_ARG_FLAG_UPDATE_AVAILABLE_BYTES = (1 << 0) # type: ignore
+NVGPU_PROFILER_PMA_STREAM_UPDATE_GET_PUT_ARG_FLAG_WAIT_FOR_UPDATE = (1 << 1) # type: ignore
+NVGPU_PROFILER_PMA_STREAM_UPDATE_GET_PUT_ARG_FLAG_RETURN_PUT_PTR = (1 << 2) # type: ignore
+NVGPU_PROFILER_PMA_STREAM_UPDATE_GET_PUT_ARG_FLAG_OVERFLOW_TRIGGERED = (1 << 3) # type: ignore
+NVGPU_PROFILER_EXEC_REG_OPS_ARG_MODE_ALL_OR_NONE = 0 # type: ignore
+NVGPU_PROFILER_EXEC_REG_OPS_ARG_MODE_CONTINUE_ON_ERROR = 1 # type: ignore
+NVGPU_PROFILER_EXEC_REG_OPS_ARG_FLAG_ALL_PASSED = (1 << 0) # type: ignore
+NVGPU_PROFILER_EXEC_REG_OPS_ARG_FLAG_DIRECT_OPS = (1 << 1) # type: ignore
+NVGPU_PROFILER_VAB_RANGE_CHECKER_MODE_ACCESS = 1 # type: ignore
+NVGPU_PROFILER_VAB_RANGE_CHECKER_MODE_DIRTY = 2 # type: ignore
+NVGPU_PROFILER_IOCTL_BIND_CONTEXT = _IOW(NVGPU_PROFILER_IOCTL_MAGIC, 1, struct_nvgpu_profiler_bind_context_args) # type: ignore
+NVGPU_PROFILER_IOCTL_RESERVE_PM_RESOURCE = _IOW(NVGPU_PROFILER_IOCTL_MAGIC, 2, struct_nvgpu_profiler_reserve_pm_resource_args) # type: ignore
+NVGPU_PROFILER_IOCTL_RELEASE_PM_RESOURCE = _IOW(NVGPU_PROFILER_IOCTL_MAGIC, 3, struct_nvgpu_profiler_release_pm_resource_args) # type: ignore
+NVGPU_PROFILER_IOCTL_ALLOC_PMA_STREAM = _IOWR(NVGPU_PROFILER_IOCTL_MAGIC, 4, struct_nvgpu_profiler_alloc_pma_stream_args) # type: ignore
+NVGPU_PROFILER_IOCTL_FREE_PMA_STREAM = _IOW(NVGPU_PROFILER_IOCTL_MAGIC, 5, struct_nvgpu_profiler_free_pma_stream_args) # type: ignore
+NVGPU_PROFILER_IOCTL_BIND_PM_RESOURCES = _IO(NVGPU_PROFILER_IOCTL_MAGIC, 6) # type: ignore
+NVGPU_PROFILER_IOCTL_UNBIND_PM_RESOURCES = _IO(NVGPU_PROFILER_IOCTL_MAGIC, 7) # type: ignore
+NVGPU_PROFILER_IOCTL_PMA_STREAM_UPDATE_GET_PUT = _IOWR(NVGPU_PROFILER_IOCTL_MAGIC, 8, struct_nvgpu_profiler_pma_stream_update_get_put_args) # type: ignore
+NVGPU_PROFILER_IOCTL_EXEC_REG_OPS = _IOWR(NVGPU_PROFILER_IOCTL_MAGIC, 9, struct_nvgpu_profiler_exec_reg_ops_args) # type: ignore
+NVGPU_PROFILER_IOCTL_UNBIND_CONTEXT = _IO(NVGPU_PROFILER_IOCTL_MAGIC, 10) # type: ignore
+NVGPU_PROFILER_IOCTL_VAB_RESERVE = _IOW(NVGPU_PROFILER_IOCTL_MAGIC, 11, struct_nvgpu_profiler_vab_reserve_args) # type: ignore
+NVGPU_PROFILER_IOCTL_VAB_RELEASE = _IO(NVGPU_PROFILER_IOCTL_MAGIC, 12) # type: ignore
+NVGPU_PROFILER_IOCTL_VAB_FLUSH_STATE = _IOW(NVGPU_PROFILER_IOCTL_MAGIC, 13, struct_nvgpu_profiler_vab_flush_state_args) # type: ignore
+NVGPU_IOCTL_MAGIC = 'H' # type: ignore
+NVGPU_TIMEOUT_FLAG_DISABLE_DUMP = 0 # type: ignore
+NVGPU_ALLOC_OBJ_FLAGS_LOCKBOOST_ZERO = (1 << 0) # type: ignore
+NVGPU_ALLOC_OBJ_FLAGS_GFXP = (1 << 1) # type: ignore
+NVGPU_ALLOC_OBJ_FLAGS_CILP = (1 << 2) # type: ignore
+NVGPU_ALLOC_GPFIFO_EX_FLAGS_VPR_ENABLED = (1 << 0) # type: ignore
+NVGPU_ALLOC_GPFIFO_EX_FLAGS_DETERMINISTIC = (1 << 1) # type: ignore
+NVGPU_CHANNEL_SETUP_BIND_FLAGS_VPR_ENABLED = (1 << 0) # type: ignore
+NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC = (1 << 1) # type: ignore
+NVGPU_CHANNEL_SETUP_BIND_FLAGS_REPLAYABLE_FAULTS_ENABLE = (1 << 2) # type: ignore
+NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT = (1 << 3) # type: ignore
+NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_GPU_MAP_RESOURCES_SUPPORT = (1 << 4) # type: ignore
+NVGPU_SUBMIT_GPFIFO_FLAGS_FENCE_WAIT = (1 << 0) # type: ignore
+NVGPU_SUBMIT_GPFIFO_FLAGS_FENCE_GET = (1 << 1) # type: ignore
+NVGPU_SUBMIT_GPFIFO_FLAGS_HW_FORMAT = (1 << 2) # type: ignore
+NVGPU_SUBMIT_GPFIFO_FLAGS_SYNC_FENCE = (1 << 3) # type: ignore
+NVGPU_SUBMIT_GPFIFO_FLAGS_SUPPRESS_WFI = (1 << 4) # type: ignore
+NVGPU_SUBMIT_GPFIFO_FLAGS_SKIP_BUFFER_REFCOUNTING = (1 << 5) # type: ignore
+NVGPU_WAIT_TYPE_NOTIFIER = 0x0 # type: ignore
+NVGPU_WAIT_TYPE_SEMAPHORE = 0x1 # type: ignore
+NVGPU_ZCULL_MODE_GLOBAL = 0 # type: ignore
+NVGPU_ZCULL_MODE_NO_CTXSW = 1 # type: ignore
+NVGPU_ZCULL_MODE_SEPARATE_BUFFER = 2 # type: ignore
+NVGPU_ZCULL_MODE_PART_OF_REGULAR_BUF = 3 # type: ignore
+NVGPU_CHANNEL_FIFO_ERROR_IDLE_TIMEOUT = 8 # type: ignore
+NVGPU_CHANNEL_GR_ERROR_SW_METHOD = 12 # type: ignore
+NVGPU_CHANNEL_GR_ERROR_SW_NOTIFY = 13 # type: ignore
+NVGPU_CHANNEL_GR_EXCEPTION = 13 # type: ignore
+NVGPU_CHANNEL_GR_SEMAPHORE_TIMEOUT = 24 # type: ignore
+NVGPU_CHANNEL_GR_ILLEGAL_NOTIFY = 25 # type: ignore
+NVGPU_CHANNEL_FIFO_ERROR_MMU_ERR_FLT = 31 # type: ignore
+NVGPU_CHANNEL_PBDMA_ERROR = 32 # type: ignore
+NVGPU_CHANNEL_FECS_ERR_UNIMP_FIRMWARE_METHOD = 37 # type: ignore
+NVGPU_CHANNEL_RESETCHANNEL_VERIF_ERROR = 43 # type: ignore
+NVGPU_CHANNEL_PBDMA_PUSHBUFFER_CRC_MISMATCH = 80 # type: ignore
+NVGPU_CHANNEL_SUBMIT_TIMEOUT = 1 # type: ignore
+NVGPU_IOCTL_CHANNEL_DISABLE_WDT = (1 << 0) # type: ignore
+NVGPU_IOCTL_CHANNEL_ENABLE_WDT = (1 << 1) # type: ignore
+NVGPU_IOCTL_CHANNEL_WDT_FLAG_SET_TIMEOUT = (1 << 2) # type: ignore
+NVGPU_IOCTL_CHANNEL_WDT_FLAG_DISABLE_DUMP = (1 << 3) # type: ignore
+NVGPU_RUNLIST_INTERLEAVE_LEVEL_LOW = 0 # type: ignore
+NVGPU_RUNLIST_INTERLEAVE_LEVEL_MEDIUM = 1 # type: ignore
+NVGPU_RUNLIST_INTERLEAVE_LEVEL_HIGH = 2 # type: ignore
+NVGPU_RUNLIST_INTERLEAVE_NUM_LEVELS = 3 # type: ignore
+NVGPU_IOCTL_CHANNEL_EVENT_ID_BPT_INT = 0 # type: ignore
+NVGPU_IOCTL_CHANNEL_EVENT_ID_BPT_PAUSE = 1 # type: ignore
+NVGPU_IOCTL_CHANNEL_EVENT_ID_BLOCKING_SYNC = 2 # type: ignore
+NVGPU_IOCTL_CHANNEL_EVENT_ID_CILP_PREEMPTION_STARTED = 3 # type: ignore
+NVGPU_IOCTL_CHANNEL_EVENT_ID_CILP_PREEMPTION_COMPLETE = 4 # type: ignore
+NVGPU_IOCTL_CHANNEL_EVENT_ID_GR_SEMAPHORE_WRITE_AWAKEN = 5 # type: ignore
+NVGPU_IOCTL_CHANNEL_EVENT_ID_MAX = 6 # type: ignore
+NVGPU_IOCTL_CHANNEL_EVENT_ID_CMD_ENABLE = 1 # type: ignore
+NVGPU_GRAPHICS_PREEMPTION_MODE_WFI = (1 << 0) # type: ignore
+NVGPU_GRAPHICS_PREEMPTION_MODE_GFXP = (1 << 1) # type: ignore
+NVGPU_COMPUTE_PREEMPTION_MODE_WFI = (1 << 0) # type: ignore
+NVGPU_COMPUTE_PREEMPTION_MODE_CTA = (1 << 1) # type: ignore
+NVGPU_COMPUTE_PREEMPTION_MODE_CILP = (1 << 2) # type: ignore
+NVGPU_BOOSTED_CTX_MODE_NORMAL = (0) # type: ignore
+NVGPU_BOOSTED_CTX_MODE_BOOSTED_EXECUTION = (1) # type: ignore
+NVGPU_RESCHEDULE_RUNLIST_PREEMPT_NEXT = (1 << 0) # type: ignore
+NVGPU_IOCTL_CHANNEL_SET_NVMAP_FD = _IOW(NVGPU_IOCTL_MAGIC, 5, struct_nvgpu_set_nvmap_fd_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_SET_TIMEOUT = _IOW(NVGPU_IOCTL_MAGIC, 11, struct_nvgpu_set_timeout_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_GET_TIMEDOUT = _IOR(NVGPU_IOCTL_MAGIC, 12, struct_nvgpu_get_param_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_SET_TIMEOUT_EX = _IOWR(NVGPU_IOCTL_MAGIC, 18, struct_nvgpu_set_timeout_ex_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_WAIT = _IOWR(NVGPU_IOCTL_MAGIC, 102, struct_nvgpu_wait_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_SUBMIT_GPFIFO = _IOWR(NVGPU_IOCTL_MAGIC, 107, struct_nvgpu_submit_gpfifo_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_ALLOC_OBJ_CTX = _IOWR(NVGPU_IOCTL_MAGIC, 108, struct_nvgpu_alloc_obj_ctx_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_ZCULL_BIND = _IOWR(NVGPU_IOCTL_MAGIC, 110, struct_nvgpu_zcull_bind_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_SET_ERROR_NOTIFIER = _IOWR(NVGPU_IOCTL_MAGIC, 111, struct_nvgpu_set_error_notifier) # type: ignore
+NVGPU_IOCTL_CHANNEL_OPEN = _IOR(NVGPU_IOCTL_MAGIC,  112, struct_nvgpu_channel_open_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_ENABLE = _IO(NVGPU_IOCTL_MAGIC,  113) # type: ignore
+NVGPU_IOCTL_CHANNEL_DISABLE = _IO(NVGPU_IOCTL_MAGIC,  114) # type: ignore
+NVGPU_IOCTL_CHANNEL_PREEMPT = _IO(NVGPU_IOCTL_MAGIC,  115) # type: ignore
+NVGPU_IOCTL_CHANNEL_FORCE_RESET = _IO(NVGPU_IOCTL_MAGIC,  116) # type: ignore
+NVGPU_IOCTL_CHANNEL_EVENT_ID_CTRL = _IOWR(NVGPU_IOCTL_MAGIC, 117, struct_nvgpu_event_id_ctrl_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_WDT = _IOW(NVGPU_IOCTL_MAGIC, 119, struct_nvgpu_channel_wdt_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_SET_RUNLIST_INTERLEAVE = _IOW(NVGPU_IOCTL_MAGIC, 120, struct_nvgpu_runlist_interleave_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_SET_PREEMPTION_MODE = _IOW(NVGPU_IOCTL_MAGIC, 122, struct_nvgpu_preemption_mode_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_ALLOC_GPFIFO_EX = _IOW(NVGPU_IOCTL_MAGIC, 123, struct_nvgpu_alloc_gpfifo_ex_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_SET_BOOSTED_CTX = _IOW(NVGPU_IOCTL_MAGIC, 124, struct_nvgpu_boosted_ctx_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_GET_USER_SYNCPOINT = _IOR(NVGPU_IOCTL_MAGIC, 126, struct_nvgpu_get_user_syncpoint_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_RESCHEDULE_RUNLIST = _IOW(NVGPU_IOCTL_MAGIC, 127, struct_nvgpu_reschedule_runlist_args) # type: ignore
+NVGPU_IOCTL_CHANNEL_SETUP_BIND = _IOWR(NVGPU_IOCTL_MAGIC, 128, struct_nvgpu_channel_setup_bind_args) # type: ignore
+NVGPU_CTXSW_IOCTL_MAGIC = 'C' # type: ignore
+NVGPU_CTXSW_TAG_SOF = 0x00 # type: ignore
+NVGPU_CTXSW_TAG_CTXSW_REQ_BY_HOST = 0x01 # type: ignore
+NVGPU_CTXSW_TAG_FE_ACK = 0x02 # type: ignore
+NVGPU_CTXSW_TAG_FE_ACK_WFI = 0x0a # type: ignore
+NVGPU_CTXSW_TAG_FE_ACK_GFXP = 0x0b # type: ignore
+NVGPU_CTXSW_TAG_FE_ACK_CTAP = 0x0c # type: ignore
+NVGPU_CTXSW_TAG_FE_ACK_CILP = 0x0d # type: ignore
+NVGPU_CTXSW_TAG_SAVE_END = 0x03 # type: ignore
+NVGPU_CTXSW_TAG_RESTORE_START = 0x04 # type: ignore
+NVGPU_CTXSW_TAG_CONTEXT_START = 0x05 # type: ignore
+NVGPU_CTXSW_TAG_ENGINE_RESET = 0xfe # type: ignore
+NVGPU_CTXSW_TAG_INVALID_TIMESTAMP = 0xff # type: ignore
+NVGPU_CTXSW_TAG_LAST = NVGPU_CTXSW_TAG_INVALID_TIMESTAMP # type: ignore
+NVGPU_CTXSW_RING_HEADER_MAGIC = 0x7000fade # type: ignore
+NVGPU_CTXSW_RING_HEADER_VERSION = 0 # type: ignore
+NVGPU_CTXSW_FILTER_SIZE = (NVGPU_CTXSW_TAG_LAST + 1) # type: ignore
+NVGPU_CTXSW_IOCTL_TRACE_ENABLE = _IO(NVGPU_CTXSW_IOCTL_MAGIC, 1) # type: ignore
+NVGPU_CTXSW_IOCTL_TRACE_DISABLE = _IO(NVGPU_CTXSW_IOCTL_MAGIC, 2) # type: ignore
+NVGPU_CTXSW_IOCTL_RING_SETUP = _IOWR(NVGPU_CTXSW_IOCTL_MAGIC, 3, struct_nvgpu_ctxsw_ring_setup_args) # type: ignore
+NVGPU_CTXSW_IOCTL_SET_FILTER = _IOW(NVGPU_CTXSW_IOCTL_MAGIC, 4, struct_nvgpu_ctxsw_trace_filter_args) # type: ignore
+NVGPU_CTXSW_IOCTL_GET_FILTER = _IOR(NVGPU_CTXSW_IOCTL_MAGIC, 5, struct_nvgpu_ctxsw_trace_filter_args) # type: ignore
+NVGPU_CTXSW_IOCTL_POLL = _IO(NVGPU_CTXSW_IOCTL_MAGIC, 6) # type: ignore
+NVGPU_SCHED_IOCTL_MAGIC = 'S' # type: ignore
+NVGPU_SCHED_IOCTL_GET_TSGS = _IOWR(NVGPU_SCHED_IOCTL_MAGIC, 1, struct_nvgpu_sched_get_tsgs_args) # type: ignore
+NVGPU_SCHED_IOCTL_GET_RECENT_TSGS = _IOWR(NVGPU_SCHED_IOCTL_MAGIC, 2, struct_nvgpu_sched_get_tsgs_args) # type: ignore
+NVGPU_SCHED_IOCTL_GET_TSGS_BY_PID = _IOWR(NVGPU_SCHED_IOCTL_MAGIC, 3, struct_nvgpu_sched_get_tsgs_by_pid_args) # type: ignore
+NVGPU_SCHED_IOCTL_TSG_GET_PARAMS = _IOWR(NVGPU_SCHED_IOCTL_MAGIC, 4, struct_nvgpu_sched_tsg_get_params_args) # type: ignore
+NVGPU_SCHED_IOCTL_TSG_SET_TIMESLICE = _IOW(NVGPU_SCHED_IOCTL_MAGIC, 5, struct_nvgpu_sched_tsg_timeslice_args) # type: ignore
+NVGPU_SCHED_IOCTL_TSG_SET_RUNLIST_INTERLEAVE = _IOW(NVGPU_SCHED_IOCTL_MAGIC, 6, struct_nvgpu_sched_tsg_runlist_interleave_args) # type: ignore
+NVGPU_SCHED_IOCTL_LOCK_CONTROL = _IO(NVGPU_SCHED_IOCTL_MAGIC, 7) # type: ignore
+NVGPU_SCHED_IOCTL_UNLOCK_CONTROL = _IO(NVGPU_SCHED_IOCTL_MAGIC, 8) # type: ignore
+NVGPU_SCHED_IOCTL_GET_API_VERSION = _IOR(NVGPU_SCHED_IOCTL_MAGIC, 9, struct_nvgpu_sched_api_version_args) # type: ignore
+NVGPU_SCHED_IOCTL_GET_TSG = _IOW(NVGPU_SCHED_IOCTL_MAGIC, 10, struct_nvgpu_sched_tsg_refcount_args) # type: ignore
+NVGPU_SCHED_IOCTL_PUT_TSG = _IOW(NVGPU_SCHED_IOCTL_MAGIC, 11, struct_nvgpu_sched_tsg_refcount_args) # type: ignore
+NVGPU_SCHED_STATUS_TSG_OPEN = (1 << 0) # type: ignore
+NVGPU_SCHED_API_VERSION = 1 # type: ignore
+NVGPU_GPU_IOCTL_MAGIC = 'G' # type: ignore
+NVGPU_ZBC_COLOR_VALUE_SIZE = 4 # type: ignore
+NVGPU_ZBC_TYPE_INVALID = 0 # type: ignore
+NVGPU_ZBC_TYPE_COLOR = 1 # type: ignore
+NVGPU_ZBC_TYPE_DEPTH = 2 # type: ignore
+NVGPU_ZBC_TYPE_STENCIL = 3 # type: ignore
+NVGPU_GPU_ARCH_GK100 = 0x000000E0 # type: ignore
+NVGPU_GPU_ARCH_GM200 = 0x00000120 # type: ignore
+NVGPU_GPU_ARCH_GP100 = 0x00000130 # type: ignore
+NVGPU_GPU_ARCH_GV110 = 0x00000150 # type: ignore
+NVGPU_GPU_ARCH_GV100 = 0x00000140 # type: ignore
+NVGPU_GPU_IMPL_GK20A = 0x0000000A # type: ignore
+NVGPU_GPU_IMPL_GM204 = 0x00000004 # type: ignore
+NVGPU_GPU_IMPL_GM206 = 0x00000006 # type: ignore
+NVGPU_GPU_IMPL_GM20B = 0x0000000B # type: ignore
+NVGPU_GPU_IMPL_GM20B_B = 0x0000000E # type: ignore
+NVGPU_GPU_IMPL_GP104 = 0x00000004 # type: ignore
+NVGPU_GPU_IMPL_GP106 = 0x00000006 # type: ignore
+NVGPU_GPU_IMPL_GP10B = 0x0000000B # type: ignore
+NVGPU_GPU_IMPL_GV11B = 0x0000000B # type: ignore
+NVGPU_GPU_IMPL_GV100 = 0x00000000 # type: ignore
+NVGPU_GPU_BUS_TYPE_NONE = 0 # type: ignore
+NVGPU_GPU_BUS_TYPE_AXI = 32 # type: ignore
+NVGPU_GPU_FLAGS_HAS_SYNCPOINTS = (1 << 0) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_SPARSE_ALLOCS = (1 << 2) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_SYNC_FENCE_FDS = (1 << 3) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_CYCLE_STATS = (1 << 4) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_CYCLE_STATS_SNAPSHOT = (1 << 6) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_TSG = (1 << 8) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_CLOCK_CONTROLS = (1 << 9) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_GET_VOLTAGE = (1 << 10) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_GET_CURRENT = (1 << 11) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_GET_POWER = (1 << 12) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_GET_TEMPERATURE = (1 << 13) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_SET_THERM_ALERT_LIMIT = (1 << 14) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_DEVICE_EVENTS = (1 << 15) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_FECS_CTXSW_TRACE = (1 << 16) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_MAP_COMPBITS = (1 << 17) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_DETERMINISTIC_SUBMIT_NO_JOBTRACKING = (1 << 18) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_DETERMINISTIC_SUBMIT_FULL = (1 << 19) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_IO_COHERENCE = (1 << 20) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_RESCHEDULE_RUNLIST = (1 << 21) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_TSG_SUBCONTEXTS = (1 << 22) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_DETERMINISTIC_OPTS = (1 << 24) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_SCG = (1 << 25) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_SYNCPOINT_ADDRESS = (1 << 26) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_VPR = (1 << 27) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_USER_SYNCPOINT = (1 << 28) # type: ignore
+NVGPU_GPU_FLAGS_CAN_RAILGATE = (1 << 29) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_USERMODE_SUBMIT = (1 << 30) # type: ignore
+NVGPU_GPU_FLAGS_DRIVER_REDUCED_PROFILE = (1 << 31) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_SET_CTX_MMU_DEBUG_MODE = (1 << 32) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_FAULT_RECOVERY = (1 << 33) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_MAPPING_MODIFY = (1 << 34) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_REMAP = (1 << 35) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_COMPRESSION = (1 << 36) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_SM_TTU = (1 << 37) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_POST_L2_COMPRESSION = (1 << 38) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_MAP_ACCESS_TYPE = (1 << 39) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_2D = (1 << 40) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_3D = (1 << 41) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_COMPUTE = (1 << 42) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_I2M = (1 << 43) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_ZBC = (1 << 44) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_PROFILER_V2_DEVICE = (1 << 46) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_PROFILER_V2_CONTEXT = (1 << 47) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_SMPC_GLOBAL_MODE = (1 << 48) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_GET_GR_CONTEXT = (1 << 49) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_BUFFER_METADATA = (1 << 50) # type: ignore
+NVGPU_GPU_FLAGS_L2_MAX_WAYS_EVICT_LAST_ENABLED = (1 << 51) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_VAB = (1 << 52) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_NVS = (1 << 53) # type: ignore
+NVGPU_GPU_FLAGS_SCHED_EXIT_WAIT_FOR_ERRBAR_SUPPORTED = (1 << 55) # type: ignore
+NVGPU_GPU_FLAGS_MULTI_PROCESS_TSG_SHARING = (1 << 56) # type: ignore
+NVGPU_GPU_FLAGS_ECC_ENABLED_SM_LRF = (1 << 60) # type: ignore
+NVGPU_GPU_FLAGS_SUPPORT_GPU_MMIO = (1 << 57) # type: ignore
+NVGPU_GPU_FLAGS_ECC_ENABLED_SM_SHM = (1 << 61) # type: ignore
+NVGPU_GPU_FLAGS_ECC_ENABLED_TEX = (1 << 62) # type: ignore
+NVGPU_GPU_FLAGS_ECC_ENABLED_LTC = (1 << 63) # type: ignore
+NVGPU_GPU_FLAGS_ALL_ECC_ENABLED = (NVGPU_GPU_FLAGS_ECC_ENABLED_SM_LRF | NVGPU_GPU_FLAGS_ECC_ENABLED_SM_SHM | NVGPU_GPU_FLAGS_ECC_ENABLED_TEX    | NVGPU_GPU_FLAGS_ECC_ENABLED_LTC) # type: ignore
+NVGPU_GPU_CHARACTERISTICS_NO_NUMA_INFO = (-1) # type: ignore
+NVGPU_GPU_COMPBITS_NONE = 0 # type: ignore
+NVGPU_GPU_COMPBITS_GPU = (1 << 0) # type: ignore
+NVGPU_GPU_COMPBITS_CDEH = (1 << 1) # type: ignore
+NVGPU_GPU_COMPBITS_CDEV = (1 << 2) # type: ignore
+NVGPU_GPU_IOCTL_ALLOC_AS_FLAGS_UNIFIED_VA = (1 << 1) # type: ignore
+NVGPU_GPU_BUFFER_INFO_FLAGS_METADATA_REGISTERED = (1 << 0) # type: ignore
+NVGPU_GPU_BUFFER_INFO_FLAGS_COMPTAGS_ALLOCATED = (1 << 1) # type: ignore
+NVGPU_GPU_BUFFER_INFO_FLAGS_MUTABLE_METADATA = (1 << 2) # type: ignore
+NVGPU_GPU_GET_CPU_TIME_CORRELATION_INFO_MAX_COUNT = 16 # type: ignore
+NVGPU_GPU_GET_CPU_TIME_CORRELATION_INFO_SRC_ID_TSC = 1 # type: ignore
+NVGPU_GPU_GET_CPU_TIME_CORRELATION_INFO_SRC_ID_OSTIME = 2 # type: ignore
+NVGPU_GPU_ENGINE_ID_GR = 0 # type: ignore
+NVGPU_GPU_ENGINE_ID_GR_COPY = 1 # type: ignore
+NVGPU_GPU_ENGINE_ID_ASYNC_COPY = 2 # type: ignore
+NVGPU_GPU_ENGINE_ID_NVENC = 5 # type: ignore
+NVGPU_GPU_ENGINE_ID_OFA = 6 # type: ignore
+NVGPU_GPU_ENGINE_ID_NVDEC = 7 # type: ignore
+NVGPU_GPU_ENGINE_ID_NVJPG = 8 # type: ignore
+NVGPU_GPU_ALLOC_VIDMEM_FLAG_CONTIGUOUS = (1 << 0) # type: ignore
+NVGPU_GPU_ALLOC_VIDMEM_FLAG_CPU_NOT_MAPPABLE = (0 << 1) # type: ignore
+NVGPU_GPU_ALLOC_VIDMEM_FLAG_CPU_WRITE_COMBINE = (1 << 1) # type: ignore
+NVGPU_GPU_ALLOC_VIDMEM_FLAG_CPU_CACHED = (2 << 1) # type: ignore
+NVGPU_GPU_ALLOC_VIDMEM_FLAG_CPU_MASK = (7 << 1) # type: ignore
+NVGPU_GPU_ALLOC_VIDMEM_FLAG_VPR = (1 << 4) # type: ignore
+NVGPU_GPU_CLK_DOMAIN_MCLK = (0) # type: ignore
+NVGPU_GPU_CLK_DOMAIN_GPCCLK = (1) # type: ignore
+NVGPU_GPU_CLK_FLAG_SPECIFIC_DOMAINS = (1 << 0) # type: ignore
+NVGPU_GPU_CLK_TYPE_TARGET = 1 # type: ignore
+NVGPU_GPU_CLK_TYPE_ACTUAL = 2 # type: ignore
+NVGPU_GPU_CLK_TYPE_EFFECTIVE = 3 # type: ignore
+NVGPU_GPU_VOLTAGE_CORE = 1 # type: ignore
+NVGPU_GPU_VOLTAGE_SRAM = 2 # type: ignore
+NVGPU_GPU_VOLTAGE_BUS = 3 # type: ignore
+NVGPU_GPU_SET_DETERMINISTIC_OPTS_FLAGS_ALLOW_RAILGATING = (1 << 0) # type: ignore
+NVGPU_GPU_SET_DETERMINISTIC_OPTS_FLAGS_DISALLOW_RAILGATING = (1 << 1) # type: ignore
+NVGPU_GPU_COMPTAGS_ALLOC_NONE = 0 # type: ignore
+NVGPU_GPU_COMPTAGS_ALLOC_REQUESTED = 1 # type: ignore
+NVGPU_GPU_COMPTAGS_ALLOC_REQUIRED = 2 # type: ignore
+NVGPU_GPU_REGISTER_BUFFER_FLAGS_COMPTAGS_ALLOCATED = (1 << 0) # type: ignore
+NVGPU_GPU_REGISTER_BUFFER_FLAGS_MUTABLE = (1 << 1) # type: ignore
+NVGPU_GPU_REGISTER_BUFFER_FLAGS_MODIFY = (1 << 2) # type: ignore
+NVGPU_GPU_REGISTER_BUFFER_METADATA_MAX_SIZE = 256 # type: ignore
+NVGPU_GPU_IOCTL_ZCULL_GET_CTX_SIZE = _IOR(NVGPU_GPU_IOCTL_MAGIC, 1, struct_nvgpu_gpu_zcull_get_ctx_size_args) # type: ignore
+NVGPU_GPU_IOCTL_ZCULL_GET_INFO = _IOR(NVGPU_GPU_IOCTL_MAGIC, 2, struct_nvgpu_gpu_zcull_get_info_args) # type: ignore
+NVGPU_GPU_IOCTL_ZBC_SET_TABLE = _IOW(NVGPU_GPU_IOCTL_MAGIC, 3, struct_nvgpu_gpu_zbc_set_table_args) # type: ignore
+NVGPU_GPU_IOCTL_ZBC_QUERY_TABLE = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 4, struct_nvgpu_gpu_zbc_query_table_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_CHARACTERISTICS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 5, struct_nvgpu_gpu_get_characteristics) # type: ignore
+NVGPU_GPU_IOCTL_PREPARE_COMPRESSIBLE_READ = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 6, struct_nvgpu_gpu_prepare_compressible_read_args) # type: ignore
+NVGPU_GPU_IOCTL_MARK_COMPRESSIBLE_WRITE = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 7, struct_nvgpu_gpu_mark_compressible_write_args) # type: ignore
+NVGPU_GPU_IOCTL_ALLOC_AS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 8, struct_nvgpu_alloc_as_args) # type: ignore
+NVGPU_GPU_IOCTL_OPEN_TSG = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 9, struct_nvgpu_gpu_open_tsg_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_TPC_MASKS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 10, struct_nvgpu_gpu_get_tpc_masks_args) # type: ignore
+NVGPU_GPU_IOCTL_OPEN_CHANNEL = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 11, struct_nvgpu_gpu_open_channel_args) # type: ignore
+NVGPU_GPU_IOCTL_FLUSH_L2 = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 12, struct_nvgpu_gpu_l2_fb_args) # type: ignore
+NVGPU_GPU_IOCTL_SET_MMUDEBUG_MODE = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 14, struct_nvgpu_gpu_mmu_debug_mode_args) # type: ignore
+NVGPU_GPU_IOCTL_SET_SM_DEBUG_MODE = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 15, struct_nvgpu_gpu_sm_debug_mode_args) # type: ignore
+NVGPU_GPU_IOCTL_WAIT_FOR_PAUSE = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 16, struct_nvgpu_gpu_wait_pause_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_TPC_EXCEPTION_EN_STATUS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 17, struct_nvgpu_gpu_tpc_exception_en_status_args) # type: ignore
+NVGPU_GPU_IOCTL_NUM_VSMS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 18, struct_nvgpu_gpu_num_vsms) # type: ignore
+NVGPU_GPU_IOCTL_VSMS_MAPPING = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 19, struct_nvgpu_gpu_vsms_mapping) # type: ignore
+NVGPU_GPU_IOCTL_RESUME_FROM_PAUSE = _IO(NVGPU_GPU_IOCTL_MAGIC, 21) # type: ignore
+NVGPU_GPU_IOCTL_TRIGGER_SUSPEND = _IO(NVGPU_GPU_IOCTL_MAGIC, 22) # type: ignore
+NVGPU_GPU_IOCTL_CLEAR_SM_ERRORS = _IO(NVGPU_GPU_IOCTL_MAGIC, 23) # type: ignore
+NVGPU_GPU_IOCTL_GET_CPU_TIME_CORRELATION_INFO = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 24, struct_nvgpu_gpu_get_cpu_time_correlation_info_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_GPU_TIME = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 25, struct_nvgpu_gpu_get_gpu_time_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_ENGINE_INFO = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 26, struct_nvgpu_gpu_get_engine_info_args) # type: ignore
+NVGPU_GPU_IOCTL_ALLOC_VIDMEM = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 27, struct_nvgpu_gpu_alloc_vidmem_args) # type: ignore
+NVGPU_GPU_IOCTL_CLK_GET_RANGE = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 28, struct_nvgpu_gpu_clk_range_args) # type: ignore
+NVGPU_GPU_IOCTL_CLK_GET_VF_POINTS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 29, struct_nvgpu_gpu_clk_vf_points_args) # type: ignore
+NVGPU_GPU_IOCTL_CLK_GET_INFO = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 30, struct_nvgpu_gpu_clk_get_info_args) # type: ignore
+NVGPU_GPU_IOCTL_CLK_SET_INFO = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 31, struct_nvgpu_gpu_clk_set_info_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_EVENT_FD = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 32, struct_nvgpu_gpu_get_event_fd_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_MEMORY_STATE = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 33, struct_nvgpu_gpu_get_memory_state_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_VOLTAGE = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 34, struct_nvgpu_gpu_get_voltage_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_CURRENT = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 35, struct_nvgpu_gpu_get_current_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_POWER = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 36, struct_nvgpu_gpu_get_power_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_TEMPERATURE = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 37, struct_nvgpu_gpu_get_temperature_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_FBP_L2_MASKS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 38, struct_nvgpu_gpu_get_fbp_l2_masks_args) # type: ignore
+NVGPU_GPU_IOCTL_SET_THERM_ALERT_LIMIT = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 39, struct_nvgpu_gpu_set_therm_alert_limit_args) # type: ignore
+NVGPU_GPU_IOCTL_SET_DETERMINISTIC_OPTS = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 40, struct_nvgpu_gpu_set_deterministic_opts_args) # type: ignore
+NVGPU_GPU_IOCTL_REGISTER_BUFFER = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 41, struct_nvgpu_gpu_register_buffer_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_BUFFER_INFO = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 42, struct_nvgpu_gpu_get_buffer_info_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_GPC_LOCAL_TO_PHYSICAL_MAP = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 43, struct_nvgpu_gpu_get_gpc_physical_map_args) # type: ignore
+NVGPU_GPU_IOCTL_GET_GPC_LOCAL_TO_LOGICAL_MAP = _IOWR(NVGPU_GPU_IOCTL_MAGIC, 44, struct_nvgpu_gpu_get_gpc_logical_map_args) # type: ignore
+NVGPU_AS_IOCTL_MAGIC = 'A' # type: ignore
+NVGPU_AS_ALLOC_SPACE_FLAGS_FIXED_OFFSET = 0x1 # type: ignore
+NVGPU_AS_ALLOC_SPACE_FLAGS_SPARSE = 0x2 # type: ignore
+NVGPU_AS_MAP_BUFFER_FLAGS_FIXED_OFFSET = (1 << 0) # type: ignore
+NVGPU_AS_MAP_BUFFER_FLAGS_CACHEABLE = (1 << 2) # type: ignore
+NVGPU_AS_MAP_BUFFER_FLAGS_UNMAPPED_PTE = (1 << 5) # type: ignore
+NVGPU_AS_MAP_BUFFER_FLAGS_MAPPABLE_COMPBITS = (1 << 6) # type: ignore
+NVGPU_AS_MAP_BUFFER_FLAGS_L3_ALLOC = (1 << 7) # type: ignore
+NVGPU_AS_MAP_BUFFER_FLAGS_SYSTEM_COHERENT = (1 << 9) # type: ignore
+NVGPU_AS_MAP_BUFFER_FLAGS_TEGRA_RAW = (1 << 12) # type: ignore
+NVGPU_AS_MAP_BUFFER_FLAGS_ACCESS_BITMASK_OFFSET = 10 # type: ignore
+NVGPU_AS_MAP_BUFFER_FLAGS_ACCESS_BITMASK_SIZE = 2 # type: ignore
+NVGPU_AS_MAP_BUFFER_ACCESS_DEFAULT = 0 # type: ignore
+NVGPU_AS_MAP_BUFFER_ACCESS_READ_ONLY = 1 # type: ignore
+NVGPU_AS_MAP_BUFFER_ACCESS_READ_WRITE = 2 # type: ignore
+NV_KIND_INVALID = -1 # type: ignore
+NVGPU_AS_GET_BUFFER_COMPBITS_INFO_FLAGS_HAS_COMPBITS = (1 << 0) # type: ignore
+NVGPU_AS_GET_BUFFER_COMPBITS_INFO_FLAGS_MAPPABLE = (1 << 1) # type: ignore
+NVGPU_AS_GET_BUFFER_COMPBITS_INFO_FLAGS_DISCONTIG_IOVA = (1 << 2) # type: ignore
+NVGPU_AS_MAP_BUFFER_COMPBITS_FLAGS_FIXED_OFFSET = (1 << 0) # type: ignore
+NVGPU_AS_REMAP_OP_FLAGS_CACHEABLE = (1 << 2) # type: ignore
+NVGPU_AS_REMAP_OP_FLAGS_ACCESS_NO_WRITE = (1 << 10) # type: ignore
+NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_4K = (1 << 15) # type: ignore
+NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_64K = (1 << 16) # type: ignore
+NVGPU_AS_REMAP_OP_FLAGS_PAGESIZE_128K = (1 << 17) # type: ignore
+NVGPU_AS_IOCTL_BIND_CHANNEL = _IOWR(NVGPU_AS_IOCTL_MAGIC, 1, struct_nvgpu_as_bind_channel_args) # type: ignore
+NVGPU32_AS_IOCTL_ALLOC_SPACE = _IOWR(NVGPU_AS_IOCTL_MAGIC, 2, struct_nvgpu32_as_alloc_space_args) # type: ignore
+NVGPU_AS_IOCTL_FREE_SPACE = _IOWR(NVGPU_AS_IOCTL_MAGIC, 3, struct_nvgpu_as_free_space_args) # type: ignore
+NVGPU_AS_IOCTL_UNMAP_BUFFER = _IOWR(NVGPU_AS_IOCTL_MAGIC, 5, struct_nvgpu_as_unmap_buffer_args) # type: ignore
+NVGPU_AS_IOCTL_ALLOC_SPACE = _IOWR(NVGPU_AS_IOCTL_MAGIC, 6, struct_nvgpu_as_alloc_space_args) # type: ignore
+NVGPU_AS_IOCTL_MAP_BUFFER_EX = _IOWR(NVGPU_AS_IOCTL_MAGIC, 7, struct_nvgpu_as_map_buffer_ex_args) # type: ignore
+NVGPU_AS_IOCTL_GET_VA_REGIONS = _IOWR(NVGPU_AS_IOCTL_MAGIC, 8, struct_nvgpu_as_get_va_regions_args) # type: ignore
+NVGPU_AS_IOCTL_GET_BUFFER_COMPBITS_INFO = _IOWR(NVGPU_AS_IOCTL_MAGIC, 9, struct_nvgpu_as_get_buffer_compbits_info_args) # type: ignore
+NVGPU_AS_IOCTL_MAP_BUFFER_COMPBITS = _IOWR(NVGPU_AS_IOCTL_MAGIC, 10, struct_nvgpu_as_map_buffer_compbits_args) # type: ignore
+NVGPU_AS_IOCTL_MAP_BUFFER_BATCH = _IOWR(NVGPU_AS_IOCTL_MAGIC, 11, struct_nvgpu_as_map_buffer_batch_args) # type: ignore
+NVGPU_AS_IOCTL_GET_SYNC_RO_MAP = _IOR(NVGPU_AS_IOCTL_MAGIC,  12, struct_nvgpu_as_get_sync_ro_map_args) # type: ignore
+NVGPU_AS_IOCTL_MAPPING_MODIFY = _IOWR(NVGPU_AS_IOCTL_MAGIC,  13, struct_nvgpu_as_mapping_modify_args) # type: ignore
+NVGPU_AS_IOCTL_REMAP = _IOWR(NVGPU_AS_IOCTL_MAGIC, 14, struct_nvgpu_as_remap_args) # type: ignore
+NVMAP_ELEM_SIZE_U64 = (1 << 31) # type: ignore
+NVMAP_IOC_MAGIC = 'N' # type: ignore
+NVMAP_IOC_CREATE = _IOWR(NVMAP_IOC_MAGIC, 0, struct_nvmap_create_handle) # type: ignore
+NVMAP_IOC_CREATE_64 = _IOWR(NVMAP_IOC_MAGIC, 1, struct_nvmap_create_handle) # type: ignore
+NVMAP_IOC_FROM_ID = _IOWR(NVMAP_IOC_MAGIC, 2, struct_nvmap_create_handle) # type: ignore
+NVMAP_IOC_ALLOC = _IOW(NVMAP_IOC_MAGIC, 3, struct_nvmap_alloc_handle) # type: ignore
+NVMAP_IOC_FREE = _IO(NVMAP_IOC_MAGIC, 4) # type: ignore
+NVMAP_IOC_WRITE = _IOW(NVMAP_IOC_MAGIC, 6, struct_nvmap_rw_handle) # type: ignore
+NVMAP_IOC_READ = _IOW(NVMAP_IOC_MAGIC, 7, struct_nvmap_rw_handle) # type: ignore
+NVMAP_IOC_PARAM = _IOWR(NVMAP_IOC_MAGIC, 8, struct_nvmap_handle_param) # type: ignore
+NVMAP_IOC_CACHE = _IOW(NVMAP_IOC_MAGIC, 12, struct_nvmap_cache_op) # type: ignore
+NVMAP_IOC_CACHE_64 = _IOW(NVMAP_IOC_MAGIC, 12, struct_nvmap_cache_op_64) # type: ignore
+NVMAP_IOC_GET_ID = _IOWR(NVMAP_IOC_MAGIC, 13, struct_nvmap_create_handle) # type: ignore
+NVMAP_IOC_GET_FD = _IOWR(NVMAP_IOC_MAGIC, 15, struct_nvmap_create_handle) # type: ignore
+NVMAP_IOC_FROM_FD = _IOWR(NVMAP_IOC_MAGIC, 16, struct_nvmap_create_handle) # type: ignore
+NVMAP_IOC_CACHE_LIST = _IOW(NVMAP_IOC_MAGIC, 17, struct_nvmap_cache_op_list) # type: ignore
+NVMAP_IOC_FROM_IVC_ID = _IOWR(NVMAP_IOC_MAGIC, 19, struct_nvmap_create_handle) # type: ignore
+NVMAP_IOC_GET_IVC_ID = _IOWR(NVMAP_IOC_MAGIC, 20, struct_nvmap_create_handle) # type: ignore
+NVMAP_IOC_FROM_VA = _IOWR(NVMAP_IOC_MAGIC, 22, struct_nvmap_create_handle_from_va) # type: ignore
+NVMAP_IOC_GUP_TEST = _IOWR(NVMAP_IOC_MAGIC, 23, struct_nvmap_gup_test) # type: ignore
+NVMAP_IOC_SET_TAG_LABEL = _IOW(NVMAP_IOC_MAGIC, 24, struct_nvmap_set_tag_label) # type: ignore
+NVMAP_IOC_GET_AVAILABLE_HEAPS = _IOR(NVMAP_IOC_MAGIC, 25, struct_nvmap_available_heaps) # type: ignore
+NVMAP_IOC_GET_HEAP_SIZE = _IOR(NVMAP_IOC_MAGIC, 26, struct_nvmap_heap_size) # type: ignore
+NVMAP_IOC_PARAMETERS = _IOR(NVMAP_IOC_MAGIC, 27, struct_nvmap_handle_parameters) # type: ignore
+NVMAP_IOC_ALLOC_IVM = _IOW(NVMAP_IOC_MAGIC, 101, struct_nvmap_alloc_ivm_handle) # type: ignore
+NVMAP_IOC_GET_SCIIPCID = _IOR(NVMAP_IOC_MAGIC, 103, struct_nvmap_sciipc_map) # type: ignore
+NVMAP_IOC_HANDLE_FROM_SCIIPCID = _IOR(NVMAP_IOC_MAGIC, 104, struct_nvmap_sciipc_map) # type: ignore
+NVMAP_IOC_QUERY_HEAP_PARAMS = _IOR(NVMAP_IOC_MAGIC, 105, struct_nvmap_query_heap_params) # type: ignore
+NVMAP_IOC_DUP_HANDLE = _IOWR(NVMAP_IOC_MAGIC, 106, struct_nvmap_duplicate_handle) # type: ignore
+NVMAP_IOC_GET_FD_FOR_RANGE_FROM_LIST = _IOR(NVMAP_IOC_MAGIC, 107, struct_nvmap_fd_for_range_from_list) # type: ignore
+NVMAP_HEAP_IOVMM = (1 << 30) # type: ignore
+NVMAP_HANDLE_UNCACHEABLE = (0 << 0) # type: ignore
+NVMAP_HANDLE_WRITE_COMBINE = (1 << 0) # type: ignore
+NVMAP_HANDLE_INNER_CACHEABLE = (2 << 0) # type: ignore
+NVMAP_HANDLE_CACHEABLE = (3 << 0) # type: ignore

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -14,6 +14,7 @@ from tinygrad.renderer.cstyle import CUDARenderer
 from tinygrad.runtime.autogen import nv_570, nv_580, mesa
 from tinygrad.runtime.support.elf import elf_loader
 from tinygrad.runtime.support.nv.nvdev import NVDev, NVMemoryManager
+from tinygrad.runtime.support.nv.tegradev import TegraIface
 from tinygrad.runtime.support.system import System, PCIIfaceBase, MAP_FIXED
 from tinygrad.renderer.nir import NAKRenderer
 if getenv("IOCTL"): import extra.nv_gpu_driver.nv_ioctl # noqa: F401 # pylint: disable=unused-import
@@ -127,6 +128,8 @@ class NVCommandQueue(HWQueue[HCQSignal, 'NVDevice', 'NVProgram', 'NVArgsState'])
     gpfifo.put_value += 1
 
 class NVComputeQueue(NVCommandQueue):
+  _tegra_signal: ClassVar[bool] = False
+
   def memory_barrier(self):
     self.nvm(1, nv_gpu.NVC6C0_INVALIDATE_SHADER_CACHES_NO_WFI,
              nv_flags("NVC6C0_INVALIDATE_SHADER_CACHES_NO_WFI", instruction="true", global_data="true", constant="true"))
@@ -158,7 +161,7 @@ class NVComputeQueue(NVCommandQueue):
     return self
 
   def signal(self, signal:HCQSignal, value:sint=0):
-    if self.active_qmd is not None:
+    if self.active_qmd is not None and not NVComputeQueue._tegra_signal:
       for i in range(2):
         if self.active_qmd.read(f'release{i}_enable') == 0:
           self.active_qmd.write(**{f'release{i}_enable': 1})
@@ -329,7 +332,7 @@ class NVAllocator(HCQAllocator['NVDevice']):
   def __init__(self, dev:'NVDevice'): super().__init__(dev, supports_copy_from_disk=not dev.is_nvd() or dev.iface.is_local())
 
   def _alloc(self, size:int, options:BufferSpec) -> HCQBuffer:
-    return self.dev.iface.alloc(size, cpu_access=options.cpu_access, host=options.host)
+    return self.dev.iface.alloc(size, cpu_access=options.cpu_access, host=options.host, uncached=options.uncached)
 
   def _do_free(self, opaque:HCQBuffer, options:BufferSpec): self.dev.iface.free(opaque)
 
@@ -572,10 +575,11 @@ class PCIIface(PCIIfaceBase):
 
 class NVDevice(HCQCompiled[NVSignal]):
   def is_nvd(self) -> bool: return isinstance(self.iface, PCIIface)
+  def is_tegra(self) -> bool: return isinstance(self.iface, TegraIface)
 
   def __init__(self, device:str=""):
     self.device_id = int(device.split(":")[1]) if ":" in device else 0
-    self.iface = self._select_iface(NVKIface, PCIIface)
+    self.iface = self._select_iface(TegraIface, NVKIface, PCIIface)
 
     device_params = nv_gpu.NV0080_ALLOC_PARAMETERS(deviceId=self.iface.gpu_instance, hClientShare=self.iface.root,
                                                    vaMode=nv_gpu.NV_DEVICE_ALLOCATION_VAMODE_OPTIONAL_MULTIPLE_VASPACES)
@@ -597,14 +601,18 @@ class NVDevice(HCQCompiled[NVSignal]):
     channel_params = nv_gpu.NV_CHANNEL_GROUP_ALLOCATION_PARAMETERS(engineType=nv_gpu.NV2080_ENGINE_TYPE_GRAPHICS)
     self.channel_group = self.iface.rm_alloc(self.nvdevice, nv_gpu.KEPLER_CHANNEL_GROUP_A, channel_params)
 
-    self.gpfifo_area = self.iface.alloc(0x300000, contiguous=True, cpu_access=True, force_devmem=True,
+    self.gpfifo_area = self.iface.alloc(0x10000 if self.is_tegra() else 0x300000, contiguous=True, cpu_access=True, force_devmem=True,
       map_flags=(nv_gpu.NVOS33_FLAGS_CACHING_TYPE_WRITECOMBINED<<23))
 
     ctxshare_params = nv_gpu.NV_CTXSHARE_ALLOCATION_PARAMETERS(hVASpace=vaspace, flags=nv_gpu.NV_CTXSHARE_ALLOCATION_FLAGS_SUBCONTEXT_ASYNC)
     ctxshare = self.iface.rm_alloc(self.channel_group, nv_gpu.FERMI_CONTEXT_SHARE_A, ctxshare_params)
 
-    self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=0x10000, compute=True)
-    self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0x100000, entries=0x10000, compute=False)
+    if self.is_tegra():
+      self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=1024, compute=True)
+      self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=1024*8+0x1000, entries=1024, compute=False)
+    else:
+      self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=0x10000, compute=True)
+      self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0x100000, entries=0x10000, compute=False)
     self.iface.rm_control(self.channel_group, nv_gpu.NVA06C_CTRL_CMD_GPFIFO_SCHEDULE, nv_gpu.NVA06C_CTRL_GPFIFO_SCHEDULE_PARAMS(bEnable=1))
 
     self.cmdq_page:HCQBuffer = self.iface.alloc(0x200000, cpu_access=True)
@@ -624,9 +632,10 @@ class NVDevice(HCQCompiled[NVSignal]):
        (functools.partial(CUDARenderer, self.arch, use_nvcc=True), NV_NVCC)])
     super().__init__(device, NVAllocator(self), compilers, functools.partial(NVProgram, self), NVSignal, NVComputeQueue, NVCopyQueue)
 
-    self.pma_enabled = PMA.value > 0 and PROFILE >= 1
+    self.pma_enabled = PMA.value > 0 and PROFILE >= 1 and not self.is_tegra()
     if self.pma_enabled: self._prof_init()
 
+    if self.is_tegra(): NVComputeQueue._tegra_signal = True
     self._setup_gpfifos()
 
   def _new_gpu_fifo(self, gpfifo_area, ctxshare, channel_group, offset=0, entries=0x400, compute=False, video=False) -> GPFifo:
@@ -671,7 +680,8 @@ class NVDevice(HCQCompiled[NVSignal]):
     self.slm_per_thread, self.shader_local_mem = 0, None
 
     # Set windows addresses to not collide with other allocated buffers.
-    self.shared_mem_window, self.local_mem_window = 0x729400000000, 0x729300000000
+    self.shared_mem_window = 0xFE00000000 if self.is_tegra() else 0x729400000000
+    self.local_mem_window = 0xFD00000000 if self.is_tegra() else 0x729300000000
 
     NVComputeQueue().setup(compute_class=self.iface.compute_class, local_mem_window=self.local_mem_window, shared_mem_window=self.shared_mem_window) \
                     .signal(self.timeline_signal, self.next_timeline()).submit(self)
@@ -687,6 +697,7 @@ class NVDevice(HCQCompiled[NVSignal]):
 
     self.slm_per_thread, old_slm_per_thread = round_up(required, 32), self.slm_per_thread
     bytes_per_tpc = round_up(round_up(self.slm_per_thread * 32, 0x200) * self.max_warps_per_sm * self.num_sm_per_tpc, 0x8000)
+    self.synchronize()
     self.shader_local_mem, ok = self._realloc(self.shader_local_mem, round_up(bytes_per_tpc*self.num_tpc_per_gpc*self.num_gpcs, 0x20000))
 
     # Realloc failed, restore the old value.
@@ -726,6 +737,7 @@ class NVDevice(HCQCompiled[NVSignal]):
               (nv_gpu.NV2080_CTRL_FB_FLUSH_GPU_CACHE_FLAGS_FLUSH_MODE_FULL_CACHE << 4))))
 
   def on_device_hang(self):
+    if self.is_tegra(): raise RuntimeError("Tegra device hang detected (no RM debugger)")
     # Prepare fault report.
     # TODO: Restore the GPU using NV83DE_CTRL_CMD_CLEAR_ALL_SM_ERROR_STATES if needed.
 

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -128,7 +128,7 @@ class NVCommandQueue(HWQueue[HCQSignal, 'NVDevice', 'NVProgram', 'NVArgsState'])
     gpfifo.put_value += 1
 
 class NVComputeQueue(NVCommandQueue):
-  _tegra_signal: ClassVar[bool] = False
+  _tegra_signal = False
 
   def memory_barrier(self):
     self.nvm(1, nv_gpu.NVC6C0_INVALIDATE_SHADER_CACHES_NO_WFI,
@@ -607,9 +607,12 @@ class NVDevice(HCQCompiled[NVSignal]):
     ctxshare_params = nv_gpu.NV_CTXSHARE_ALLOCATION_PARAMETERS(hVASpace=vaspace, flags=nv_gpu.NV_CTXSHARE_ALLOCATION_FLAGS_SUBCONTEXT_ASYNC)
     ctxshare = self.iface.rm_alloc(self.channel_group, nv_gpu.FERMI_CONTEXT_SHARE_A, ctxshare_params)
 
-    _e, _o = (1024, 1024*8+0x1000) if self.is_tegra() else (0x10000, 0x100000)
-    self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=_e, compute=True)
-    self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=_o, entries=_e, compute=False)
+    if self.is_tegra():
+      self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=1024, compute=True)
+      self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=1024*8+0x1000, entries=1024, compute=False)
+    else:
+      self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=0x10000, compute=True)
+      self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0x100000, entries=0x10000, compute=False)
     self.iface.rm_control(self.channel_group, nv_gpu.NVA06C_CTRL_CMD_GPFIFO_SCHEDULE, nv_gpu.NVA06C_CTRL_GPFIFO_SCHEDULE_PARAMS(bEnable=1))
 
     self.cmdq_page:HCQBuffer = self.iface.alloc(0x200000, cpu_access=True)

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -695,7 +695,6 @@ class NVDevice(HCQCompiled[NVSignal]):
 
     self.slm_per_thread, old_slm_per_thread = round_up(required, 32), self.slm_per_thread
     bytes_per_tpc = round_up(round_up(self.slm_per_thread * 32, 0x200) * self.max_warps_per_sm * self.num_sm_per_tpc, 0x8000)
-    self.synchronize()
     self.shader_local_mem, ok = self._realloc(self.shader_local_mem, round_up(bytes_per_tpc*self.num_tpc_per_gpc*self.num_gpcs, 0x20000))
 
     # Realloc failed, restore the old value.

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -128,7 +128,7 @@ class NVCommandQueue(HWQueue[HCQSignal, 'NVDevice', 'NVProgram', 'NVArgsState'])
     gpfifo.put_value += 1
 
 class NVComputeQueue(NVCommandQueue):
-  # Tegra SoC race condition:MMIO doorbell races CWD release payload patching (desktop hidden by PCIe latency)
+  # NOTE: Tegra SoC race: MMIO doorbell races CWD release payload patching (hidden by PCIe latency on desktop).
   _tegra_signal = False
 
   def memory_barrier(self):

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -128,6 +128,7 @@ class NVCommandQueue(HWQueue[HCQSignal, 'NVDevice', 'NVProgram', 'NVArgsState'])
     gpfifo.put_value += 1
 
 class NVComputeQueue(NVCommandQueue):
+  # Tegra SoC race condition:MMIO doorbell races CWD release payload patching (desktop hidden by PCIe latency)
   _tegra_signal = False
 
   def memory_barrier(self):
@@ -608,6 +609,7 @@ class NVDevice(HCQCompiled[NVSignal]):
     ctxshare = self.iface.rm_alloc(self.channel_group, nv_gpu.FERMI_CONTEXT_SHARE_A, ctxshare_params)
 
     _gfe, _doff = (0x400, 0x3000) if self.is_tegra() else (0x10000, 0x100000)
+    assert _doff >= _gfe * 8 + 0x1000, f"gpfifo layout overflow: _doff={_doff:#x} needs >= {_gfe*8+0x1000:#x} (ring+USERD page)"
     self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=_gfe, compute=True)
     self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=_doff, entries=_gfe, compute=False)
     self.iface.rm_control(self.channel_group, nv_gpu.NVA06C_CTRL_CMD_GPFIFO_SCHEDULE, nv_gpu.NVA06C_CTRL_GPFIFO_SCHEDULE_PARAMS(bEnable=1))
@@ -632,7 +634,7 @@ class NVDevice(HCQCompiled[NVSignal]):
     self.pma_enabled = PMA.value > 0 and PROFILE >= 1 and not self.is_tegra()
     if self.pma_enabled: self._prof_init()
 
-    if self.is_tegra(): NVComputeQueue._tegra_signal = True
+    if self.is_tegra(): NVComputeQueue._tegra_signal = True  # force GPFIFO signal path
     self._setup_gpfifos()
 
   def _new_gpu_fifo(self, gpfifo_area, ctxshare, channel_group, offset=0, entries=0x400, compute=False, video=False) -> GPFifo:
@@ -733,7 +735,7 @@ class NVDevice(HCQCompiled[NVSignal]):
               (nv_gpu.NV2080_CTRL_FB_FLUSH_GPU_CACHE_FLAGS_FLUSH_MODE_FULL_CACHE << 4))))
 
   def on_device_hang(self):
-    if self.is_tegra(): raise RuntimeError("Tegra device hang detected (no RM debugger)")
+    if self.is_tegra(): raise RuntimeError("Tegra device hang, nvgpu driver resets GPU channel on fd close")
     # Prepare fault report.
     # TODO: Restore the GPU using NV83DE_CTRL_CMD_CLEAR_ALL_SM_ERROR_STATES if needed.
 

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -607,12 +607,9 @@ class NVDevice(HCQCompiled[NVSignal]):
     ctxshare_params = nv_gpu.NV_CTXSHARE_ALLOCATION_PARAMETERS(hVASpace=vaspace, flags=nv_gpu.NV_CTXSHARE_ALLOCATION_FLAGS_SUBCONTEXT_ASYNC)
     ctxshare = self.iface.rm_alloc(self.channel_group, nv_gpu.FERMI_CONTEXT_SHARE_A, ctxshare_params)
 
-    if self.is_tegra():
-      self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=1024, compute=True)
-      self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=1024*8+0x1000, entries=1024, compute=False)
-    else:
-      self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=0x10000, compute=True)
-      self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0x100000, entries=0x10000, compute=False)
+    _e, _o = (1024, 1024*8+0x1000) if self.is_tegra() else (0x10000, 0x100000)
+    self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=_e, compute=True)
+    self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=_o, entries=_e, compute=False)
     self.iface.rm_control(self.channel_group, nv_gpu.NVA06C_CTRL_CMD_GPFIFO_SCHEDULE, nv_gpu.NVA06C_CTRL_GPFIFO_SCHEDULE_PARAMS(bEnable=1))
 
     self.cmdq_page:HCQBuffer = self.iface.alloc(0x200000, cpu_access=True)

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -607,12 +607,9 @@ class NVDevice(HCQCompiled[NVSignal]):
     ctxshare_params = nv_gpu.NV_CTXSHARE_ALLOCATION_PARAMETERS(hVASpace=vaspace, flags=nv_gpu.NV_CTXSHARE_ALLOCATION_FLAGS_SUBCONTEXT_ASYNC)
     ctxshare = self.iface.rm_alloc(self.channel_group, nv_gpu.FERMI_CONTEXT_SHARE_A, ctxshare_params)
 
-    if self.is_tegra():
-      self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=1024, compute=True)
-      self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=1024*8+0x1000, entries=1024, compute=False)
-    else:
-      self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=0x10000, compute=True)
-      self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0x100000, entries=0x10000, compute=False)
+    _gfe, _doff = (0x400, 0x3000) if self.is_tegra() else (0x10000, 0x100000)
+    self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=_gfe, compute=True)
+    self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=_doff, entries=_gfe, compute=False)
     self.iface.rm_control(self.channel_group, nv_gpu.NVA06C_CTRL_CMD_GPFIFO_SCHEDULE, nv_gpu.NVA06C_CTRL_GPFIFO_SCHEDULE_PARAMS(bEnable=1))
 
     self.cmdq_page:HCQBuffer = self.iface.alloc(0x200000, cpu_access=True)
@@ -680,8 +677,7 @@ class NVDevice(HCQCompiled[NVSignal]):
     self.slm_per_thread, self.shader_local_mem = 0, None
 
     # Set windows addresses to not collide with other allocated buffers.
-    self.shared_mem_window = 0xFE00000000 if self.is_tegra() else 0x729400000000
-    self.local_mem_window = 0xFD00000000 if self.is_tegra() else 0x729300000000
+    self.shared_mem_window, self.local_mem_window = (0xFE00000000, 0xFD00000000) if self.is_tegra() else (0x729400000000, 0x729300000000)
 
     NVComputeQueue().setup(compute_class=self.iface.compute_class, local_mem_window=self.local_mem_window, shared_mem_window=self.shared_mem_window) \
                     .signal(self.timeline_signal, self.next_timeline()).submit(self)

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -3,10 +3,10 @@ import os, ctypes, contextlib, fcntl, mmap
 from dataclasses import dataclass
 from tinygrad.runtime.autogen import nv_570 as nv_gpu, tegra_36 as tegra
 from tinygrad.runtime.support.hcq import HCQBuffer, MMIOInterface, FileIOInterface
-from tinygrad.runtime.support.system import MAP_FIXED # Force mmap to fixed address
+from tinygrad.runtime.support.system import MAP_FIXED
 from tinygrad.helpers import round_up, to_mv
 
-_NVMAP_FREE = (ord('N') << 8) | 4  # _IO('N', 4): handle passed as integer, not struct
+_NVMAP_FREE = (ord('N') << 8) | 4  # _IO('N', 4), raw int handle
 _NVMAP_TAG = 0x0900
 
 def _nvmap_buf(nvmap_fd, size, cache_flags, align=4096):
@@ -16,12 +16,12 @@ def _nvmap_buf(nvmap_fd, size, cache_flags, align=4096):
 
 @dataclass(eq=False)
 class TegraMem:
-  handle: int = 0        # nvmap handle (kernel tracking)
-  dmabuf_fd: int = -1    # dmabuf file descriptor (for mmap + GPU map)
-  gpu_va: int = 0        # GPU virtual address (from MAP_BUFFER_EX)
+  handle: int = 0
+  dmabuf_fd: int = -1
+  gpu_va: int = 0
   size: int = 0
-  cpu_addr: int = 0      # CPU virtual address (from mmap)
-  hMemory: int = 0       # synthetic RM handle (for gpfifo_area lookup)
+  cpu_addr: int = 0
+  hMemory: int = 0  # synthetic RM handle for gpfifo_area lookup
 
 class TegraIface:
   _nvmap_fd, _ctrl_fd, _gpu_info = -1, -1, None
@@ -40,73 +40,66 @@ class TegraIface:
     self.dev, self.device_id = dev, device_id
     tegra_gpu_info = TegraIface._gpu_info
     self.compute_class, self.gpfifo_class, self.dma_class = tegra_gpu_info.compute_class, tegra_gpu_info.gpfifo_class, tegra_gpu_info.dma_copy_class
-    self.viddec_class = None # no video decoder on Tegra
-    self._handle_cnt = 0x10000 # (NVKIface starts at 0x1000) TinyGrad internal bookkeeping (RM's rm_alloc)
+    self.viddec_class = None  # no video decoder on Tegra iGPU
+    self._handle_cnt = 0x10000
     self._as_fd, self._tsg_fd, self._subctx_veid = -1, -1, 0
-    self._ch_fds: dict[int, int] = {} # handle -> channel fd
-    self._ws_tokens: dict[int, int] = {} # handle -> work_submit_token
-    self._ch_bufs: dict[int, tuple[int, int, int, int]] = {} # handle -> (ring_nvmap_h, ring_fd, userd_nvmap_h, userd_fd)
+    self._ch_fds: dict[int, int] = {}
+    self._ws_tokens: dict[int, int] = {}
+    self._ch_bufs: dict[int, tuple[int, int, int, int]] = {}
     self.root, self.gpu_instance = self._next_handle(), 0
     self._allocs: list[TegraMem] = []
 
-  # RM would get integer handle from kernel, we mimic this with int handles (start at 0x10000 to avoid collisions with NVKIface that starts at 0x1000)
-  # Used to lookup gpfifo_area
   def _next_handle(self) -> int:
     self._handle_cnt += 1
     return self._handle_cnt
 
-  # map RM's alloc to TegraIface alloc
   def rm_alloc(self, parent, clss, params=None, root=None) -> int:
     handle = self._next_handle()
 
-    # stub/no-op (They exist for RM but no nvgpu driver equivalent)
+    # no-op for nvgpu
     if clss in (nv_gpu.NV01_DEVICE_0, nv_gpu.NV20_SUBDEVICE_0, nv_gpu.FERMI_VASPACE_A, nv_gpu.NV01_ROOT_CLIENT, nv_gpu.NV01_ROOT,
                 nv_gpu.NV1_MEMORY_SYSTEM, nv_gpu.NV1_MEMORY_USER, nv_gpu.NV01_MEMORY_SYSTEM_OS_DESCRIPTOR):
       return handle
 
-    # open GPU address space and pre-reserve two 1GB VA windows tinygrad uses for fixed-address buffers
+    # open address space, reserve VA windows for fixed-address buffers
     if clss == nv_gpu.NV01_MEMORY_VIRTUAL:
       self._as_fd = tegra.NVGPU_GPU_IOCTL_ALLOC_AS(self._ctrl_fd, flags=2, va_range_start=(1 << 21), va_range_end=(1 << 40) - (1 << 21)).as_fd
       for reserved_va in [0xFD00000000, 0xFE00000000]:
         tegra.NVGPU_AS_IOCTL_ALLOC_SPACE(self._as_fd, pages=0x40000000 // mmap.PAGESIZE, page_size=mmap.PAGESIZE, flags=1, offset=reserved_va)
       return handle
 
-    # open TSG (time-sliced GPU group); channels bind to it for scheduling
     if clss == nv_gpu.KEPLER_CHANNEL_GROUP_A:
       self._tsg_fd = tegra.NVGPU_GPU_IOCTL_OPEN_TSG(self._ctrl_fd).tsg_fd
       return handle
 
-    # create subcontext; VEID lets the GR engine distinguish address spaces within the TSG
     if clss == nv_gpu.FERMI_CONTEXT_SHARE_A:
       self._subctx_veid = tegra.NVGPU_TSG_IOCTL_CREATE_SUBCONTEXT(self._tsg_fd, type=1, as_fd=self._as_fd).veid
       return handle
 
-    # open channel fd, bind to AS + TSG, overlay ring and USERD dmabufs into gpfifo_area via MAP_FIXED
     if clss in (self.gpfifo_class, nv_gpu.AMPERE_CHANNEL_GPFIFO_A):
       ch_fd = tegra.NVGPU_GPU_IOCTL_OPEN_CHANNEL(self._ctrl_fd, channel_fd=-1).channel_fd
-      tegra.NVGPU_AS_IOCTL_BIND_CHANNEL(self._as_fd, channel_fd=ch_fd) # attach to address space
-      tegra.NVGPU_TSG_IOCTL_BIND_CHANNEL_EX(self._tsg_fd, channel_fd=ch_fd, subcontext_id=self._subctx_veid) # attach to scheduler
-      tegra.NVGPU_IOCTL_CHANNEL_WDT(ch_fd, wdt_status=1) # disable watchdog
+      tegra.NVGPU_AS_IOCTL_BIND_CHANNEL(self._as_fd, channel_fd=ch_fd)
+      tegra.NVGPU_TSG_IOCTL_BIND_CHANNEL_EX(self._tsg_fd, channel_fd=ch_fd, subcontext_id=self._subctx_veid)
+      tegra.NVGPU_IOCTL_CHANNEL_WDT(ch_fd, wdt_status=1)  # disable watchdog
 
       gpfifo_entries, gpfifo_buf_handle, gpfifo_va, userd_off = 0x10000, 0, 0, 0
       if params is not None:
         gpfifo_va, gpfifo_entries, gpfifo_buf_handle = params.gpFifoOffset, params.gpFifoEntries, params.hObjectBuffer
         userd_off = params.userdOffset[0]
 
-      # find the gpfifo_area TegraMem by the synthetic RM handle tinygrad assigned it
       gpfifo_area_mem = next((m for m in self._allocs if m.hMemory == gpfifo_buf_handle), None)
       if gpfifo_area_mem is None: raise RuntimeError(f"TegraIface: gpfifo_area alloc not found for handle {gpfifo_buf_handle}")
       ring_sz = gpfifo_entries * 8
 
-      # nvgpu requires separate owned dmabufs for ring and USERD - can't use offsets into gpfifo_area
+      # nvgpu requires separate dmabufs for ring and USERD
       ring_nvmap_h, ring_fd = _nvmap_buf(self._nvmap_fd, ring_sz, tegra.NVMAP_HANDLE_WRITE_COMBINE)
       userd_nvmap_h, userd_fd = _nvmap_buf(self._nvmap_fd, 4096, tegra.NVMAP_HANDLE_WRITE_COMBINE)
 
-      # pin ring+USERD into hw channel; work_submit_token is the doorbell value written to wake the GPU
-      setup = tegra.NVGPU_IOCTL_CHANNEL_SETUP_BIND(ch_fd, num_gpfifo_entries=gpfifo_entries, gpfifo_dmabuf_fd=ring_fd, userd_dmabuf_fd=userd_fd,
-                                                    flags=tegra.NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT|tegra.NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC)
+      bind_flags = tegra.NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT | tegra.NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC
+      setup = tegra.NVGPU_IOCTL_CHANNEL_SETUP_BIND(ch_fd, num_gpfifo_entries=gpfifo_entries,
+                                                    gpfifo_dmabuf_fd=ring_fd, userd_dmabuf_fd=userd_fd, flags=bind_flags)
 
-      # punch dmabuf pages into gpfifo_area CPU mapping so tinygrad writes hit the same physical pages the GPU reads
+      # overlay dmabufs onto gpfifo_area via MAP_FIXED
       cpu_base = gpfifo_area_mem.cpu_addr
       FileIOInterface._mmap(cpu_base + (gpfifo_va - gpfifo_area_mem.gpu_va), ring_sz,
                             mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED | MAP_FIXED, ring_fd, 0)
@@ -117,7 +110,7 @@ class TegraIface:
       self._ch_bufs[handle] = (ring_nvmap_h, ring_fd, userd_nvmap_h, userd_fd)
       return handle
 
-    # bind GR (compute) or CE (copy) engine to the channel
+    # bind engine (GR or CE) to channel
     if clss in (self.compute_class, nv_gpu.AMPERE_COMPUTE_B, self.dma_class, nv_gpu.AMPERE_DMA_COPY_B):
       ch_fd = self._ch_fds.get(parent, -1)
       if ch_fd == -1: raise RuntimeError(f"TegraIface: no channel fd for handle {parent}")
@@ -176,33 +169,29 @@ class TegraIface:
     addr = FileIOInterface._mmap(0, 0x10000, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, self._ctrl_fd, 0)
     return 0, MMIOInterface(addr, 0x10000, fmt='I')
 
-  def setup_vm(self, vaspace): pass # nvgpu owns the AS, no separate UVM step needed
-  def setup_gpfifo_vm(self, gpfifo): pass # handled internally by nvgpu on channel bind
+  def setup_vm(self, vaspace): pass
+  def setup_gpfifo_vm(self, gpfifo): pass
 
   def alloc(self, size:int, host=False, uncached=False, cpu_access=False, **kwargs) -> HCQBuffer:
-    # 2MB huge pages for large (>=8MB) buffers to reduce TLB pressure; 4KB otherwise
     alloc_align = mmap.PAGESIZE if (uncached or host) else ((2 << 20) if size >= (8 << 20) else mmap.PAGESIZE)
     size = round_up(size, alloc_align)
-    # WRITE_COMBINE for CPU-polled bufs (notifiers/signals) - no cache, GPU writes visible immediately
-    # INNER_CACHEABLE for compute data - Orin's interconnect provides hardware IO coherence, no manual flushes
+    # Uncached: write-combine for CPU-polled bufs. Cached: HW IO coherent on Orin, no manual flushes.
     cache = tegra.NVMAP_HANDLE_WRITE_COMBINE if (uncached or host) else tegra.NVMAP_HANDLE_INNER_CACHEABLE
 
     handle, dmabuf_fd = _nvmap_buf(self._nvmap_fd, size, cache, alloc_align)
 
-    # GPU mapping: map dmabuf into GPU's address space
     gpu_va = 0
     if self._as_fd >= 0:
       gpu_va = tegra.NVGPU_AS_IOCTL_MAP_BUFFER_EX(self._as_fd, compr_kind=-1, dmabuf_fd=dmabuf_fd, page_size=mmap.PAGESIZE).offset
 
-    # CPU mapping: try MAP_FIXED at the GPU VA for CPU VA = GPU VA, fallback is kernel chosen address (PCIface pattern)
+    # MAP_FIXED for CPU VA = GPU VA, fallback to kernel-chosen addr
     addr = FileIOInterface._mmap(gpu_va or 0, size, mmap.PROT_READ | mmap.PROT_WRITE,
                                  mmap.MAP_SHARED | (MAP_FIXED if gpu_va else 0), dmabuf_fd, 0)
     if gpu_va and addr != gpu_va:
       addr = FileIOInterface._mmap(0, size, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, dmabuf_fd, 0)
 
-    # track alloc metadata
     meta = TegraMem(handle=handle, dmabuf_fd=dmabuf_fd, gpu_va=gpu_va, size=size, cpu_addr=addr, hMemory=self._next_handle())
-    self._allocs.append(meta) # track allocs for free() and gpfifo_area lookup
+    self._allocs.append(meta)
     return HCQBuffer(va_addr=gpu_va, size=size, meta=meta, view=MMIOInterface(addr, size, fmt='B'), owner=self.dev)
 
   def free(self, mem:HCQBuffer):
@@ -217,8 +206,8 @@ class TegraIface:
       with contextlib.suppress(OSError): fcntl.ioctl(self._nvmap_fd, _NVMAP_FREE, ctypes.c_int32(meta.handle).value)
     if meta in self._allocs: self._allocs.remove(meta)
 
-  def map(self, mem:HCQBuffer): pass # already mapped to GPU as in alloc()
-  def sleep(self, tm:int): pass # no GSP firmware on Tegra iGPU so no status queue to service during long waits
+  def map(self, mem:HCQBuffer): pass
+  def sleep(self, tm:int): pass
 
   def device_fini(self):
     for ch_fd in self._ch_fds.values():

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -8,14 +8,42 @@ from tinygrad.helpers import round_up, to_mv
 def _ct(fields):
   return type("_s", (ctypes.Structure,), {"_fields_": fields})
 
-# struct nvgpu_gpu_characteristics (include/uapi/linux/nvgpu-ctrl.h), truncated to fields used by tinygrad
+# struct nvgpu_gpu_characteristics from include/uapi/linux/nvgpu-ctrl.h
 _nvgpu_gpu_characteristics = _ct([
-  ("_pad0", ctypes.c_uint8 * 12), ("num_gpc", ctypes.c_uint32),
-  ("_pad1", ctypes.c_uint8 * 24), ("num_tpc_per_gpc", ctypes.c_uint32),
-  ("_pad2", ctypes.c_uint8 * 36),
-  ("compute_class", ctypes.c_uint32), ("gpfifo_class", ctypes.c_uint32), ("_pad3", ctypes.c_uint32),
-  ("dma_copy_class", ctypes.c_uint32), ("_pad4", ctypes.c_uint32),
-  ("sm_arch_sm_version", ctypes.c_uint32), ("_pad5", ctypes.c_uint32), ("sm_arch_warp_count", ctypes.c_uint32)])
+  ("arch", ctypes.c_uint32), ("impl", ctypes.c_uint32), ("rev", ctypes.c_uint32), ("num_gpc", ctypes.c_uint32),
+  ("numa_domain_id", ctypes.c_int32),
+  ("L2_cache_size", ctypes.c_uint64), ("on_board_video_memory_size", ctypes.c_uint64),
+  ("num_tpc_per_gpc", ctypes.c_uint32), ("bus_type", ctypes.c_uint32), ("big_page_size", ctypes.c_uint32),
+  ("compression_page_size", ctypes.c_uint32), ("pde_coverage_bit_count", ctypes.c_uint32), ("available_big_page_sizes", ctypes.c_uint32),
+  ("flags", ctypes.c_uint64),
+  ("twod_class", ctypes.c_uint32), ("threed_class", ctypes.c_uint32), ("compute_class", ctypes.c_uint32),
+  ("gpfifo_class", ctypes.c_uint32), ("inline_to_memory_class", ctypes.c_uint32), ("dma_copy_class", ctypes.c_uint32),
+  ("gpc_mask", ctypes.c_uint32), ("sm_arch_sm_version", ctypes.c_uint32), ("sm_arch_spa_version", ctypes.c_uint32),
+  ("sm_arch_warp_count", ctypes.c_uint32),
+  ("gpu_ioctl_nr_last", ctypes.c_int16), ("tsg_ioctl_nr_last", ctypes.c_int16), ("dbg_gpu_ioctl_nr_last", ctypes.c_int16),
+  ("ioctl_channel_nr_last", ctypes.c_int16), ("as_ioctl_nr_last", ctypes.c_int16), ("gpu_va_bit_count", ctypes.c_uint8), ("reserved", ctypes.c_uint8),
+  ("max_fbps_count", ctypes.c_uint32), ("fbp_en_mask", ctypes.c_uint32), ("emc_en_mask", ctypes.c_uint32),
+  ("max_ltc_per_fbp", ctypes.c_uint32), ("max_lts_per_ltc", ctypes.c_uint32), ("max_tex_per_tpc", ctypes.c_uint32),
+  ("max_gpc_count", ctypes.c_uint32), ("rop_l2_en_mask_DEPRECATED", ctypes.c_uint32 * 2), ("chipname", ctypes.c_uint8 * 8),
+  ("gr_compbit_store_base_hw", ctypes.c_uint64),
+  ("gr_gobs_per_comptagline_per_slice", ctypes.c_uint32), ("num_ltc", ctypes.c_uint32), ("lts_per_ltc", ctypes.c_uint32),
+  ("cbc_cache_line_size", ctypes.c_uint32), ("cbc_comptags_per_line", ctypes.c_uint32), ("map_buffer_batch_limit", ctypes.c_uint32),
+  ("max_freq", ctypes.c_uint64),
+  ("graphics_preemption_mode_flags", ctypes.c_uint32), ("compute_preemption_mode_flags", ctypes.c_uint32),
+  ("default_graphics_preempt_mode", ctypes.c_uint32), ("default_compute_preempt_mode", ctypes.c_uint32),
+  ("local_video_memory_size", ctypes.c_uint64),
+  ("pci_vendor_id", ctypes.c_uint16), ("pci_device_id", ctypes.c_uint16), ("pci_subsystem_vendor_id", ctypes.c_uint16),
+  ("pci_subsystem_device_id", ctypes.c_uint16), ("pci_class", ctypes.c_uint16), ("pci_revision", ctypes.c_uint8),
+  ("vbios_oem_version", ctypes.c_uint8),
+  ("vbios_version", ctypes.c_uint32), ("reg_ops_limit", ctypes.c_uint32), ("reserved1", ctypes.c_uint32),
+  ("event_ioctl_nr_last", ctypes.c_int16), ("pad", ctypes.c_uint16), ("max_css_buffer_size", ctypes.c_uint32),
+  ("ctxsw_ioctl_nr_last", ctypes.c_int16), ("prof_ioctl_nr_last", ctypes.c_int16), ("nvs_ioctl_nr_last", ctypes.c_int16),
+  ("reserved2", ctypes.c_uint8 * 2),
+  ("max_ctxsw_ring_buffer_size", ctypes.c_uint32), ("reserved3", ctypes.c_uint32), ("per_device_identifier", ctypes.c_uint64),
+  ("num_ppc_per_gpc", ctypes.c_uint32), ("max_veid_count_per_tsg", ctypes.c_uint32),
+  ("num_sub_partition_per_fbpa", ctypes.c_uint32), ("gpu_instance_id", ctypes.c_uint32),
+  ("gr_instance_id", ctypes.c_uint32), ("max_gpfifo_entries", ctypes.c_uint32),
+  ("max_dbg_tsg_timeslice", ctypes.c_uint32), ("reserved5", ctypes.c_uint32), ("device_instance_id", ctypes.c_uint64)])
 _nvgpu_gpu_get_characteristics = _ct([("buf_size", ctypes.c_uint64), ("buf_addr", ctypes.c_uint64)])
 _nvmap_handle = _ct([("size", ctypes.c_uint32), ("handle", ctypes.c_uint32)])
 _nvmap_alloc = _ct([("handle", ctypes.c_uint32), ("heap_mask", ctypes.c_uint32), ("flags", ctypes.c_uint32),

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -12,7 +12,7 @@ _NVMAP_TAG = 0x0900
 def _nvmap_buf(nvmap_fd, size, cache_flags, align=4096):
   c = tegra.NVMAP_IOC_CREATE(nvmap_fd, size=size)
   tegra.NVMAP_IOC_ALLOC(nvmap_fd, handle=c.handle, heap_mask=tegra.NVMAP_HEAP_IOVMM, flags=(_NVMAP_TAG << 16) | cache_flags, align=align)
-  return c.handle, tegra.NVMAP_IOC_GET_FD(nvmap_fd, handle=c.handle).size
+  return c.handle, tegra.NVMAP_IOC_GET_FD(nvmap_fd, handle=c.handle).size  # .size field holds the returned dmabuf fd (kernel ioctl struct layout)
 
 @dataclass(eq=False)
 class TegraMem:
@@ -30,8 +30,8 @@ class TegraIface:
     if device_id != 0: raise RuntimeError("TegraIface only supports device 0 (single iGPU)")
     if TegraIface._gpu_info is None:
       if not os.path.exists("/dev/nvgpu/igpu0/ctrl"): raise FileNotFoundError("/dev/nvgpu/igpu0/ctrl")
-      TegraIface._nvmap_fd = os.open("/dev/nvmap", os.O_RDWR | os.O_SYNC)
-      TegraIface._ctrl_fd = os.open("/dev/nvgpu/igpu0/ctrl", os.O_RDWR)
+      TegraIface._nvmap_fd = os.open("/dev/nvmap", os.O_RDWR | os.O_SYNC | os.O_CLOEXEC)
+      TegraIface._ctrl_fd = os.open("/dev/nvgpu/igpu0/ctrl", os.O_RDWR | os.O_CLOEXEC)
       tegra_gpu_info = tegra.nvgpu_gpu_characteristics()
       tegra.NVGPU_GPU_IOCTL_GET_CHARACTERISTICS(TegraIface._ctrl_fd,
         buf_size=ctypes.sizeof(tegra_gpu_info), buf_addr=ctypes.addressof(tegra_gpu_info))
@@ -210,6 +210,17 @@ class TegraIface:
   def sleep(self, tm:int): pass
 
   def device_fini(self):
+    # free outstanding allocations before closing shared fds
+    while self._allocs:
+      meta = self._allocs.pop()
+      if meta.gpu_va and self._as_fd >= 0:
+        with contextlib.suppress(OSError): tegra.NVGPU_AS_IOCTL_UNMAP_BUFFER(self._as_fd, offset=meta.gpu_va)
+      if meta.cpu_addr:
+        with contextlib.suppress(Exception): FileIOInterface.munmap(meta.cpu_addr, meta.size)
+      if meta.dmabuf_fd >= 0:
+        with contextlib.suppress(OSError): os.close(meta.dmabuf_fd)
+      if meta.handle and self._nvmap_fd >= 0:
+        with contextlib.suppress(OSError): fcntl.ioctl(self._nvmap_fd, _NVMAP_FREE, ctypes.c_int32(meta.handle).value)
     for ch_fd in self._ch_fds.values():
       with contextlib.suppress(OSError): os.close(ch_fd)
     for ring_nvmap_h, ring_fd, userd_nvmap_h, userd_fd in self._ch_bufs.values():

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import os, ctypes, contextlib, fcntl, mmap
+from dataclasses import dataclass
 from tinygrad.runtime.autogen import nv_570 as nv_gpu
 from tinygrad.runtime.support.c import _IOW, _IOWR
 from tinygrad.runtime.support.hcq import HCQBuffer, MMIOInterface, FileIOInterface
@@ -99,12 +100,16 @@ _NVMAP_HEAP_IOVMM, _NVMAP_WC, _NVMAP_CACHED, _NVMAP_TAG = (1 << 30), 1, 2, 0x090
 def _nvmap_buf(nvmap_fd, size, cache_flags, align=4096):
   c = NVMAP_CREATE(nvmap_fd, size=size)
   NVMAP_ALLOC(nvmap_fd, handle=c.handle, heap_mask=_NVMAP_HEAP_IOVMM, flags=(_NVMAP_TAG << 16) | cache_flags, align=align)
-  g = NVMAP_GET_FD(nvmap_fd, handle=c.handle)
-  return c.handle, g.size  # g.size is the dmabuf fd
+  return c.handle, NVMAP_GET_FD(nvmap_fd, handle=c.handle).size  # .size is dmabuf fd (kernel struct union)
 
+@dataclass(eq=False)
 class TegraMem:
-  def __init__(self, handle, dmabuf_fd, gpu_va, size, cpu_addr=0, hMemory=0):
-    self.handle, self.dmabuf_fd, self.gpu_va, self.size, self.cpu_addr, self.hMemory = handle, dmabuf_fd, gpu_va, size, cpu_addr, hMemory
+  handle: int = 0
+  dmabuf_fd: int = -1
+  gpu_va: int = 0
+  size: int = 0
+  cpu_addr: int = 0
+  hMemory: int = 0
 
 class TegraIface:
   _nvmap_fd, _ctrl_fd, _chars = -1, -1, None
@@ -279,3 +284,8 @@ class TegraIface:
 
   def map(self, mem: HCQBuffer): pass
   def sleep(self, tm: int): pass
+
+  def device_fini(self):
+    if TegraIface._ctrl_fd >= 0: os.close(TegraIface._ctrl_fd)
+    if TegraIface._nvmap_fd >= 0: os.close(TegraIface._nvmap_fd)
+    TegraIface._ctrl_fd, TegraIface._nvmap_fd, TegraIface._chars = -1, -1, None

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 import os, ctypes, contextlib, fcntl, mmap
-from typing import ClassVar
-from dataclasses import dataclass
 from tinygrad.runtime.autogen import nv_570 as nv_gpu
 from tinygrad.runtime.support.hcq import HCQBuffer, MMIOInterface, FileIOInterface
 from tinygrad.runtime.support.system import MAP_FIXED
 from tinygrad.helpers import round_up, to_mv
-
-# --- nvgpu / nvmap ctypes structs ---
 
 def _ct(fields):
   return type("_s", (ctypes.Structure,), {"_fields_": fields})
@@ -78,11 +74,8 @@ _nvgpu_setup_bind = _ct([("num_gpfifo_entries", ctypes.c_uint32), ("num_inflight
                           ("reserved", ctypes.c_uint32 * 9)])
 _nvgpu_channel_wdt = _ct([("wdt_status", ctypes.c_uint32), ("timeout_ms", ctypes.c_uint32)])
 
-# --- ioctl number helpers ---
-
 def _ioc(d, t, nr, size): return (d << 30) | (size << 16) | (ord(t) << 8) | nr
 def _io(t, nr): return _ioc(0, t, nr, 0)
-def _ior(t, nr, sz): return _ioc(2, t, nr, sz)
 def _iow(t, nr, sz): return _ioc(1, t, nr, sz)
 def _iowr(t, nr, sz): return _ioc(3, t, nr, sz)
 
@@ -104,8 +97,7 @@ _NVGPU_CH_ALLOC_OBJ = _iowr('H', 108, ctypes.sizeof(_nvgpu_alloc_obj_ctx))
 _NVGPU_CH_SETUP_BIND = _iowr('H', 128, ctypes.sizeof(_nvgpu_setup_bind))
 _NVGPU_CH_WDT = _iow('H', 119, ctypes.sizeof(_nvgpu_channel_wdt))
 
-_NVMAP_HEAP_IOVMM, _NVMAP_WC, _NVMAP_CACHED = (1 << 30), 1, 2
-_NVMAP_TAG = 0x0900
+_NVMAP_HEAP_IOVMM, _NVMAP_WC, _NVMAP_CACHED, _NVMAP_TAG = (1 << 30), 1, 2, 0x0900
 
 def _tioctl(fd, nr, buf):
   if fcntl.ioctl(fd, nr, buf) < 0: raise OSError(f"tegra ioctl 0x{nr:08x} failed")
@@ -119,41 +111,32 @@ def _nvmap_buf(nvmap_fd, size, cache_flags, align=4096):
   _tioctl(nvmap_fd, _NVMAP_GET_FD, g)
   return c.handle, g.size  # g.size is the dmabuf fd
 
-# --- Memory tracking ---
-
-@dataclass
 class TegraMem:
-  handle: int; dmabuf_fd: int; gpu_va: int; size: int; cpu_addr: int = 0; hMemory: int = 0 # noqa: E702
-
-# --- TegraIface ---
+  def __init__(self, handle, dmabuf_fd, gpu_va, size, cpu_addr=0, hMemory=0):
+    self.handle, self.dmabuf_fd, self.gpu_va, self.size, self.cpu_addr, self.hMemory = handle, dmabuf_fd, gpu_va, size, cpu_addr, hMemory
 
 class TegraIface:
-  _inited: ClassVar[bool] = False
-  _nvmap_fd: ClassVar[int] = -1
-  _ctrl_fd: ClassVar[int] = -1
-  _chars: ClassVar[_nvgpu_gpu_characteristics|None] = None
+  _nvmap_fd, _ctrl_fd, _chars = -1, -1, None
 
   def __init__(self, dev, device_id):
     if device_id != 0: raise RuntimeError("TegraIface only supports device 0 (single iGPU)")
-    if not TegraIface._inited:
+    if TegraIface._chars is None:
       if not os.path.exists("/dev/nvgpu/igpu0/ctrl"): raise FileNotFoundError("/dev/nvgpu/igpu0/ctrl")
       TegraIface._nvmap_fd = os.open("/dev/nvmap", os.O_RDWR | os.O_SYNC)
       TegraIface._ctrl_fd = os.open("/dev/nvgpu/igpu0/ctrl", os.O_RDWR)
       chars = _nvgpu_gpu_characteristics()
       req = _nvgpu_gpu_get_characteristics(buf_size=ctypes.sizeof(chars), buf_addr=ctypes.addressof(chars))
       _tioctl(TegraIface._ctrl_fd, _NVGPU_GET_CHARS, req)
-      TegraIface._chars, TegraIface._inited = chars, True
+      TegraIface._chars = chars
 
     self.dev, self.device_id = dev, device_id
     chars = TegraIface._chars
-    assert chars is not None
     self.compute_class, self.gpfifo_class, self.dma_class = chars.compute_class, chars.gpfifo_class, chars.dma_copy_class
     self.viddec_class = None
-    self._gpu_chars, self._sm_version = chars, chars.sm_arch_sm_version
-    self._hcnt, self._handles = 0x10000, {}
+    self._hcnt = 0x10000
     self._as_fd, self._tsg_fd, self._subctx_veid = -1, -1, 0
     self._ch_fds: dict[int, int] = {}
-    self._work_submit_tokens: dict[int, int] = {}
+    self._ws_tokens: dict[int, int] = {}
     self.root, self.gpu_instance = self._nh(), 0
     self._allocs: list[TegraMem] = []
 
@@ -220,7 +203,7 @@ class TegraIface:
       FileIOInterface._mmap(cpu_base + userd_off, 4096,
                             mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED | MAP_FIXED, userd_fd, 0)
 
-      self._ch_fds[handle], self._work_submit_tokens[handle] = ch_fd, setup.work_submit_token
+      self._ch_fds[handle], self._ws_tokens[handle] = ch_fd, setup.work_submit_token
       return handle
 
     if clss in (self.compute_class, nv_gpu.AMPERE_COMPUTE_B, self.dma_class, nv_gpu.AMPERE_DMA_COPY_B):
@@ -230,7 +213,7 @@ class TegraIface:
       _tioctl(ch_fd, _NVGPU_CH_ALLOC_OBJ, obj)
       return handle
 
-    return handle  # GT200_DEBUGGER and others are NOP on Tegra
+    return handle
 
   def rm_control(self, obj, cmd, params=None, **kwargs):
     if cmd == nv_gpu.NV2080_CTRL_CMD_PERF_BOOST:
@@ -241,11 +224,11 @@ class TegraIface:
       return params
 
     if cmd == nv_gpu.NVC36F_CTRL_CMD_GPFIFO_GET_WORK_SUBMIT_TOKEN:
-      if params is not None: params.workSubmitToken = self._work_submit_tokens.get(obj, 0)
+      if params is not None: params.workSubmitToken = self._ws_tokens.get(obj, 0)
       return params
 
     if cmd == nv_gpu.NV2080_CTRL_CMD_GR_GET_INFO:
-      chars = self._gpu_chars
+      chars = TegraIface._chars
       info_map = {getattr(nv_gpu, k, None): v for k, v in {
         'NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_GPCS': chars.num_gpc,
         'NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_TPC_PER_GPC': chars.num_tpc_per_gpc,
@@ -273,7 +256,7 @@ class TegraIface:
         for i in range(16): params.data[i] = (0x4A + i) & 0xFF
       return params
 
-    return params  # all other commands are NOP on Tegra
+    return params
 
   def setup_usermode(self):
     addr = FileIOInterface._mmap(0, 0x10000, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, self._ctrl_fd, 0)
@@ -306,7 +289,6 @@ class TegraIface:
 
   def free(self, mem: HCQBuffer):
     meta = mem.meta
-    if not isinstance(meta, TegraMem): return
     if meta.gpu_va and self._as_fd >= 0:
       with contextlib.suppress(OSError): _tioctl(self._as_fd, _NVGPU_AS_UNMAP_BUF, _nvgpu_as_unmap_buffer(offset=meta.gpu_va))
     if meta.cpu_addr:

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -32,7 +32,7 @@ class TegraIface:
       if not os.path.exists("/dev/nvgpu/igpu0/ctrl"): raise FileNotFoundError("/dev/nvgpu/igpu0/ctrl")
       TegraIface._nvmap_fd = os.open("/dev/nvmap", os.O_RDWR | os.O_SYNC | os.O_CLOEXEC)
       TegraIface._ctrl_fd = os.open("/dev/nvgpu/igpu0/ctrl", os.O_RDWR | os.O_CLOEXEC)
-      tegra_gpu_info = tegra.nvgpu_gpu_characteristics()
+      tegra_gpu_info = tegra.struct_nvgpu_gpu_characteristics()
       tegra.NVGPU_GPU_IOCTL_GET_CHARACTERISTICS(TegraIface._ctrl_fd,
         buf_size=ctypes.sizeof(tegra_gpu_info), buf_addr=ctypes.addressof(tegra_gpu_info))
       TegraIface._gpu_info = tegra_gpu_info

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -34,7 +34,7 @@ class TegraIface:
       TegraIface._ctrl_fd = os.open("/dev/nvgpu/igpu0/ctrl", os.O_RDWR | os.O_CLOEXEC)
       tegra_gpu_info = tegra.struct_nvgpu_gpu_characteristics()
       tegra.NVGPU_GPU_IOCTL_GET_CHARACTERISTICS(TegraIface._ctrl_fd,
-        buf_size=ctypes.sizeof(tegra_gpu_info), buf_addr=ctypes.addressof(tegra_gpu_info))
+        gpu_characteristics_buf_size=ctypes.sizeof(tegra_gpu_info), gpu_characteristics_buf_addr=ctypes.addressof(tegra_gpu_info))
       TegraIface._gpu_info = tegra_gpu_info
 
     self.dev, self.device_id = dev, device_id
@@ -65,7 +65,9 @@ class TegraIface:
     if clss == nv_gpu.NV01_MEMORY_VIRTUAL:
       self._as_fd = tegra.NVGPU_GPU_IOCTL_ALLOC_AS(self._ctrl_fd, flags=2, va_range_start=(1 << 21), va_range_end=(1 << 40) - (1 << 21)).as_fd
       for reserved_va in [0xFD00000000, 0xFE00000000]:
-        tegra.NVGPU_AS_IOCTL_ALLOC_SPACE(self._as_fd, pages=0x40000000 // mmap.PAGESIZE, page_size=mmap.PAGESIZE, flags=1, offset=reserved_va)
+        rsv = tegra.struct_nvgpu_as_alloc_space_args(pages=0x40000000 // mmap.PAGESIZE, page_size=mmap.PAGESIZE, flags=1)
+        rsv.o_a.offset = reserved_va
+        tegra.NVGPU_AS_IOCTL_ALLOC_SPACE(self._as_fd, __payload=rsv)
       return handle
 
     if clss == nv_gpu.KEPLER_CHANNEL_GROUP_A:

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -212,6 +212,7 @@ class TegraIface:
 
     if cmd == nv_gpu.NV2080_CTRL_CMD_GR_GET_INFO:
       chars = TegraIface._chars
+      assert chars is not None
       info_map = {
         nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_GPCS: chars.num_gpc,
         nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_TPC_PER_GPC: chars.num_tpc_per_gpc,
@@ -249,7 +250,7 @@ class TegraIface:
   def setup_vm(self, vaspace): pass
   def setup_gpfifo_vm(self, gpfifo): pass
 
-  def alloc(self, size: int, host=False, uncached=False, cpu_access=False, **kwargs) -> HCQBuffer:
+  def alloc(self, size:int, host=False, uncached=False, cpu_access=False, **kwargs) -> HCQBuffer:
     alloc_align = mmap.PAGESIZE if (uncached or host) else ((2 << 20) if size >= (8 << 20) else mmap.PAGESIZE)
     size = round_up(size, alloc_align)
     cache = _NVMAP_WC if (uncached or host) else _NVMAP_CACHED
@@ -269,7 +270,7 @@ class TegraIface:
     self._allocs.append(meta)
     return HCQBuffer(va_addr=gpu_va, size=size, meta=meta, view=MMIOInterface(addr, size, fmt='B'), owner=self.dev)
 
-  def free(self, mem: HCQBuffer):
+  def free(self, mem:HCQBuffer):
     meta = mem.meta
     if meta.gpu_va and self._as_fd >= 0:
       with contextlib.suppress(OSError): NVGPU_AS_UNMAP_BUF(self._as_fd, offset=meta.gpu_va)
@@ -277,13 +278,13 @@ class TegraIface:
       with contextlib.suppress(Exception): FileIOInterface.munmap(meta.cpu_addr, meta.size)
     if meta.dmabuf_fd >= 0:
       with contextlib.suppress(OSError): os.close(meta.dmabuf_fd)
-    if meta.handle:
+    if meta.handle and self._nvmap_fd >= 0:
       h = meta.handle if meta.handle < 0x80000000 else meta.handle - 0x100000000
       with contextlib.suppress(OSError): fcntl.ioctl(self._nvmap_fd, _NVMAP_FREE, h)
     if meta in self._allocs: self._allocs.remove(meta)
 
-  def map(self, mem: HCQBuffer): pass
-  def sleep(self, tm: int): pass
+  def map(self, mem:HCQBuffer): pass
+  def sleep(self, tm:int): pass
 
   def device_fini(self):
     if TegraIface._ctrl_fd >= 0: os.close(TegraIface._ctrl_fd)

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -6,7 +6,7 @@ from tinygrad.runtime.support.hcq import HCQBuffer, MMIOInterface, FileIOInterfa
 from tinygrad.runtime.support.system import MAP_FIXED
 from tinygrad.helpers import round_up, to_mv
 
-_NVMAP_FREE = (ord('N') << 8) | 4  # _IO('N', 4), raw int handle
+_NVMAP_FREE = (ord('N') << 8) | 4
 _NVMAP_TAG = 0x0900
 
 def _nvmap_buf(nvmap_fd, size, cache_flags, align=4096):
@@ -21,7 +21,7 @@ class TegraMem:
   gpu_va: int = 0
   size: int = 0
   cpu_addr: int = 0
-  hMemory: int = 0  # synthetic RM handle for gpfifo_area lookup
+  hMemory: int = 0
 
 class TegraIface:
   _nvmap_fd, _ctrl_fd, _gpu_info = -1, -1, None
@@ -40,7 +40,7 @@ class TegraIface:
     self.dev, self.device_id = dev, device_id
     tegra_gpu_info = TegraIface._gpu_info
     self.compute_class, self.gpfifo_class, self.dma_class = tegra_gpu_info.compute_class, tegra_gpu_info.gpfifo_class, tegra_gpu_info.dma_copy_class
-    self.viddec_class = None  # no video decoder on Tegra iGPU
+    self.viddec_class = None
     self._handle_cnt = 0x10000
     self._as_fd, self._tsg_fd, self._subctx_veid = -1, -1, 0
     self._ch_fds: dict[int, int] = {}
@@ -80,7 +80,7 @@ class TegraIface:
       ch_fd = tegra.NVGPU_GPU_IOCTL_OPEN_CHANNEL(self._ctrl_fd, channel_fd=-1).channel_fd
       tegra.NVGPU_AS_IOCTL_BIND_CHANNEL(self._as_fd, channel_fd=ch_fd)
       tegra.NVGPU_TSG_IOCTL_BIND_CHANNEL_EX(self._tsg_fd, channel_fd=ch_fd, subcontext_id=self._subctx_veid)
-      tegra.NVGPU_IOCTL_CHANNEL_WDT(ch_fd, wdt_status=1)  # disable watchdog
+      tegra.NVGPU_IOCTL_CHANNEL_WDT(ch_fd, wdt_status=1)
 
       gpfifo_entries, gpfifo_buf_handle, gpfifo_va, userd_off = 0x10000, 0, 0, 0
       if params is not None:

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os, ctypes, contextlib, fcntl, mmap
 from tinygrad.runtime.autogen import nv_570 as nv_gpu
+from tinygrad.runtime.support.c import _IOW, _IOWR
 from tinygrad.runtime.support.hcq import HCQBuffer, MMIOInterface, FileIOInterface
 from tinygrad.runtime.support.system import MAP_FIXED
 from tinygrad.helpers import round_up, to_mv
@@ -74,40 +75,31 @@ _nvgpu_setup_bind = _ct([("num_gpfifo_entries", ctypes.c_uint32), ("num_inflight
                           ("reserved", ctypes.c_uint32 * 9)])
 _nvgpu_channel_wdt = _ct([("wdt_status", ctypes.c_uint32), ("timeout_ms", ctypes.c_uint32)])
 
-def _ioc(d, t, nr, size): return (d << 30) | (size << 16) | (ord(t) << 8) | nr
-def _io(t, nr): return _ioc(0, t, nr, 0)
-def _iow(t, nr, sz): return _ioc(1, t, nr, sz)
-def _iowr(t, nr, sz): return _ioc(3, t, nr, sz)
-
-_NVGPU_GET_CHARS = _iowr('G', 5, ctypes.sizeof(_nvgpu_gpu_get_characteristics))
-_NVGPU_ALLOC_AS = _iowr('G', 8, ctypes.sizeof(_nvgpu_alloc_as))
-_NVGPU_OPEN_TSG = _iowr('G', 9, ctypes.sizeof(_nvgpu_open_tsg))
-_NVGPU_OPEN_CH = _iowr('G', 11, ctypes.sizeof(_nvgpu_open_channel))
-_NVMAP_CREATE = _iowr('N', 0, ctypes.sizeof(_nvmap_handle))
-_NVMAP_ALLOC = _iow('N', 3, ctypes.sizeof(_nvmap_alloc))
-_NVMAP_GET_FD = _iowr('N', 15, ctypes.sizeof(_nvmap_handle))
-_NVMAP_FREE = _io('N', 4)
-_NVGPU_AS_BIND_CH = _iowr('A', 1, ctypes.sizeof(_nvgpu_as_bind_channel))
-_NVGPU_AS_ALLOC_SPACE = _iowr('A', 6, ctypes.sizeof(_nvgpu_as_alloc_space))
-_NVGPU_AS_MAP_BUF = _iowr('A', 7, ctypes.sizeof(_nvgpu_as_map_buffer_ex))
-_NVGPU_AS_UNMAP_BUF = _iowr('A', 5, ctypes.sizeof(_nvgpu_as_unmap_buffer))
-_NVGPU_TSG_BIND_CH = _iowr('T', 11, ctypes.sizeof(_nvgpu_tsg_bind_channel_ex))
-_NVGPU_TSG_SUBCTX = _iowr('T', 18, ctypes.sizeof(_nvgpu_tsg_create_subctx))
-_NVGPU_CH_ALLOC_OBJ = _iowr('H', 108, ctypes.sizeof(_nvgpu_alloc_obj_ctx))
-_NVGPU_CH_SETUP_BIND = _iowr('H', 128, ctypes.sizeof(_nvgpu_setup_bind))
-_NVGPU_CH_WDT = _iow('H', 119, ctypes.sizeof(_nvgpu_channel_wdt))
+# ioctl callables: NAME(fd, **kwargs) -> struct  (see tinygrad/runtime/support/c.py _do_ioctl)
+NVGPU_GET_CHARS    = _IOWR('G', 5,   _nvgpu_gpu_get_characteristics)
+NVGPU_ALLOC_AS     = _IOWR('G', 8,   _nvgpu_alloc_as)
+NVGPU_OPEN_TSG     = _IOWR('G', 9,   _nvgpu_open_tsg)
+NVGPU_OPEN_CH      = _IOWR('G', 11,  _nvgpu_open_channel)
+NVMAP_CREATE       = _IOWR('N', 0,   _nvmap_handle)
+NVMAP_ALLOC        = _IOW ('N', 3,   _nvmap_alloc)
+NVMAP_GET_FD       = _IOWR('N', 15,  _nvmap_handle)
+NVGPU_AS_BIND_CH   = _IOWR('A', 1,   _nvgpu_as_bind_channel)
+NVGPU_AS_ALLOC_SP  = _IOWR('A', 6,   _nvgpu_as_alloc_space)
+NVGPU_AS_MAP_BUF   = _IOWR('A', 7,   _nvgpu_as_map_buffer_ex)
+NVGPU_AS_UNMAP_BUF = _IOWR('A', 5,   _nvgpu_as_unmap_buffer)
+NVGPU_TSG_BIND_CH  = _IOWR('T', 11,  _nvgpu_tsg_bind_channel_ex)
+NVGPU_TSG_SUBCTX   = _IOWR('T', 18,  _nvgpu_tsg_create_subctx)
+NVGPU_CH_ALLOC_OBJ = _IOWR('H', 108, _nvgpu_alloc_obj_ctx)
+NVGPU_CH_SETUP_BIND= _IOWR('H', 128, _nvgpu_setup_bind)
+NVGPU_CH_WDT       = _IOW ('H', 119, _nvgpu_channel_wdt)
+_NVMAP_FREE        = (ord('N') << 8) | 4  # _IO('N', 4): handle passed as integer value
 
 _NVMAP_HEAP_IOVMM, _NVMAP_WC, _NVMAP_CACHED, _NVMAP_TAG = (1 << 30), 1, 2, 0x0900
 
-def _tioctl(fd, nr, buf): fcntl.ioctl(fd, nr, buf)
-
 def _nvmap_buf(nvmap_fd, size, cache_flags, align=4096):
-  c = _nvmap_handle(size=size)
-  _tioctl(nvmap_fd, _NVMAP_CREATE, c)
-  a = _nvmap_alloc(handle=c.handle, heap_mask=_NVMAP_HEAP_IOVMM, flags=(_NVMAP_TAG << 16) | cache_flags, align=align)
-  _tioctl(nvmap_fd, _NVMAP_ALLOC, a)
-  g = _nvmap_handle(handle=c.handle)
-  _tioctl(nvmap_fd, _NVMAP_GET_FD, g)
+  c = NVMAP_CREATE(nvmap_fd, size=size)
+  NVMAP_ALLOC(nvmap_fd, handle=c.handle, heap_mask=_NVMAP_HEAP_IOVMM, flags=(_NVMAP_TAG << 16) | cache_flags, align=align)
+  g = NVMAP_GET_FD(nvmap_fd, handle=c.handle)
   return c.handle, g.size  # g.size is the dmabuf fd
 
 class TegraMem:
@@ -124,8 +116,7 @@ class TegraIface:
       TegraIface._nvmap_fd = os.open("/dev/nvmap", os.O_RDWR | os.O_SYNC)
       TegraIface._ctrl_fd = os.open("/dev/nvgpu/igpu0/ctrl", os.O_RDWR)
       chars = _nvgpu_gpu_characteristics()
-      req = _nvgpu_gpu_get_characteristics(buf_size=ctypes.sizeof(chars), buf_addr=ctypes.addressof(chars))
-      _tioctl(TegraIface._ctrl_fd, _NVGPU_GET_CHARS, req)
+      NVGPU_GET_CHARS(TegraIface._ctrl_fd, buf_size=ctypes.sizeof(chars), buf_addr=ctypes.addressof(chars))
       TegraIface._chars = chars
 
     self.dev, self.device_id = dev, device_id
@@ -151,33 +142,24 @@ class TegraIface:
       return handle
 
     if clss == nv_gpu.NV01_MEMORY_VIRTUAL:
-      args = _nvgpu_alloc_as(flags=2, va_range_start=(1 << 21), va_range_end=(1 << 40) - (1 << 21))
-      _tioctl(self._ctrl_fd, _NVGPU_ALLOC_AS, args)
-      self._as_fd = args.as_fd
+      self._as_fd = NVGPU_ALLOC_AS(self._ctrl_fd, flags=2, va_range_start=(1 << 21), va_range_end=(1 << 40) - (1 << 21)).as_fd
       for wva in [0xFD00000000, 0xFE00000000]:
-        rsv = _nvgpu_as_alloc_space(pages=0x40000000 // mmap.PAGESIZE, page_size=mmap.PAGESIZE, flags=1, offset=wva)
-        _tioctl(self._as_fd, _NVGPU_AS_ALLOC_SPACE, rsv)
+        NVGPU_AS_ALLOC_SP(self._as_fd, pages=0x40000000 // mmap.PAGESIZE, page_size=mmap.PAGESIZE, flags=1, offset=wva)
       return handle
 
     if clss == nv_gpu.KEPLER_CHANNEL_GROUP_A:
-      tsg = _nvgpu_open_tsg()
-      _tioctl(self._ctrl_fd, _NVGPU_OPEN_TSG, tsg)
-      self._tsg_fd = tsg.tsg_fd
+      self._tsg_fd = NVGPU_OPEN_TSG(self._ctrl_fd).tsg_fd
       return handle
 
     if clss == nv_gpu.FERMI_CONTEXT_SHARE_A:
-      subctx = _nvgpu_tsg_create_subctx(type=1, as_fd=self._as_fd)
-      _tioctl(self._tsg_fd, _NVGPU_TSG_SUBCTX, subctx)
-      self._subctx_veid = subctx.veid
+      self._subctx_veid = NVGPU_TSG_SUBCTX(self._tsg_fd, type=1, as_fd=self._as_fd).veid
       return handle
 
     if clss in (self.gpfifo_class, nv_gpu.AMPERE_CHANNEL_GPFIFO_A):
-      ch = _nvgpu_open_channel(channel_fd=-1)
-      _tioctl(self._ctrl_fd, _NVGPU_OPEN_CH, ch)
-      ch_fd = ch.channel_fd
-      _tioctl(self._as_fd, _NVGPU_AS_BIND_CH, _nvgpu_as_bind_channel(channel_fd=ch_fd))
-      _tioctl(self._tsg_fd, _NVGPU_TSG_BIND_CH, _nvgpu_tsg_bind_channel_ex(channel_fd=ch_fd, subcontext_id=self._subctx_veid))
-      _tioctl(ch_fd, _NVGPU_CH_WDT, _nvgpu_channel_wdt(wdt_status=1))
+      ch_fd = NVGPU_OPEN_CH(self._ctrl_fd, channel_fd=-1).channel_fd
+      NVGPU_AS_BIND_CH(self._as_fd, channel_fd=ch_fd)
+      NVGPU_TSG_BIND_CH(self._tsg_fd, channel_fd=ch_fd, subcontext_id=self._subctx_veid)
+      NVGPU_CH_WDT(ch_fd, wdt_status=1)
 
       gpfifo_entries, gpfifo_buf_handle, gpfifo_va, userd_off = 0x10000, 0, 0, 0
       if params is not None:
@@ -191,9 +173,8 @@ class TegraIface:
       _, ring_fd = _nvmap_buf(self._nvmap_fd, ring_sz, _NVMAP_WC)
       _, userd_fd = _nvmap_buf(self._nvmap_fd, 4096, _NVMAP_WC)
 
-      setup = _nvgpu_setup_bind(num_gpfifo_entries=gpfifo_entries, gpfifo_dmabuf_fd=ring_fd, userd_dmabuf_fd=userd_fd,
-                                flags=(1 << 3) | (1 << 1))
-      _tioctl(ch_fd, _NVGPU_CH_SETUP_BIND, setup)
+      setup = NVGPU_CH_SETUP_BIND(ch_fd, num_gpfifo_entries=gpfifo_entries, gpfifo_dmabuf_fd=ring_fd, userd_dmabuf_fd=userd_fd,
+                                  flags=(1 << 3) | (1 << 1))
 
       cpu_base = gpfifo_area_mem.cpu_addr
       FileIOInterface._mmap(cpu_base + (gpfifo_va - gpfifo_area_mem.gpu_va), ring_sz,
@@ -207,8 +188,7 @@ class TegraIface:
     if clss in (self.compute_class, nv_gpu.AMPERE_COMPUTE_B, self.dma_class, nv_gpu.AMPERE_DMA_COPY_B):
       ch_fd = self._ch_fds.get(parent, -1)
       if ch_fd == -1: raise RuntimeError(f"TegraIface: no channel fd for handle {parent}")
-      obj = _nvgpu_alloc_obj_ctx(class_num=self.compute_class if clss in (self.compute_class, nv_gpu.AMPERE_COMPUTE_B) else self.dma_class)
-      _tioctl(ch_fd, _NVGPU_CH_ALLOC_OBJ, obj)
+      NVGPU_CH_ALLOC_OBJ(ch_fd, class_num=self.compute_class if clss in (self.compute_class, nv_gpu.AMPERE_COMPUTE_B) else self.dma_class)
       return handle
 
     return handle
@@ -273,9 +253,7 @@ class TegraIface:
 
     gpu_va = 0
     if self._as_fd >= 0:
-      m = _nvgpu_as_map_buffer_ex(compr_kind=-1, dmabuf_fd=dmabuf_fd, page_size=mmap.PAGESIZE)
-      _tioctl(self._as_fd, _NVGPU_AS_MAP_BUF, m)
-      gpu_va = m.offset
+      gpu_va = NVGPU_AS_MAP_BUF(self._as_fd, compr_kind=-1, dmabuf_fd=dmabuf_fd, page_size=mmap.PAGESIZE).offset
 
     addr = FileIOInterface._mmap(gpu_va or 0, size, mmap.PROT_READ | mmap.PROT_WRITE,
                                  mmap.MAP_SHARED | (MAP_FIXED if gpu_va else 0), dmabuf_fd, 0)
@@ -289,7 +267,7 @@ class TegraIface:
   def free(self, mem: HCQBuffer):
     meta = mem.meta
     if meta.gpu_va and self._as_fd >= 0:
-      with contextlib.suppress(OSError): _tioctl(self._as_fd, _NVGPU_AS_UNMAP_BUF, _nvgpu_as_unmap_buffer(offset=meta.gpu_va))
+      with contextlib.suppress(OSError): NVGPU_AS_UNMAP_BUF(self._as_fd, offset=meta.gpu_va)
     if meta.cpu_addr:
       with contextlib.suppress(Exception): FileIOInterface.munmap(meta.cpu_addr, meta.size)
     if meta.dmabuf_fd >= 0:

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+import os, ctypes, contextlib, fcntl, mmap
+from typing import ClassVar
+from dataclasses import dataclass
+from tinygrad.runtime.autogen import nv_570 as nv_gpu
+from tinygrad.runtime.support.hcq import HCQBuffer, MMIOInterface, FileIOInterface
+from tinygrad.runtime.support.system import MAP_FIXED
+from tinygrad.helpers import round_up, to_mv
+
+# --- nvgpu / nvmap ctypes structs ---
+
+def _ct(fields):
+  return type("_s", (ctypes.Structure,), {"_fields_": fields})
+
+_nvgpu_gpu_characteristics = _ct([
+  ("arch", ctypes.c_uint32), ("impl", ctypes.c_uint32), ("rev", ctypes.c_uint32), ("num_gpc", ctypes.c_uint32),
+  ("numa_domain_id", ctypes.c_int32), ("_pad0", ctypes.c_uint32),
+  ("L2_cache_size", ctypes.c_uint64), ("on_board_video_memory_size", ctypes.c_uint64),
+  ("num_tpc_per_gpc", ctypes.c_uint32), ("bus_type", ctypes.c_uint32), ("big_page_size", ctypes.c_uint32),
+  ("compression_page_size", ctypes.c_uint32), ("pde_coverage_bit_count", ctypes.c_uint32), ("available_big_page_sizes", ctypes.c_uint32),
+  ("flags", ctypes.c_uint64),
+  ("twod_class", ctypes.c_uint32), ("threed_class", ctypes.c_uint32), ("compute_class", ctypes.c_uint32),
+  ("gpfifo_class", ctypes.c_uint32), ("inline_to_memory_class", ctypes.c_uint32), ("dma_copy_class", ctypes.c_uint32),
+  ("gpc_mask", ctypes.c_uint32), ("sm_arch_sm_version", ctypes.c_uint32), ("sm_arch_spa_version", ctypes.c_uint32),
+  ("sm_arch_warp_count", ctypes.c_uint32),
+  ("gpu_ioctl_nr_last", ctypes.c_int16), ("tsg_ioctl_nr_last", ctypes.c_int16), ("dbg_gpu_ioctl_nr_last", ctypes.c_int16),
+  ("ioctl_channel_nr_last", ctypes.c_int16), ("as_ioctl_nr_last", ctypes.c_int16),
+  ("gpu_va_bit_count", ctypes.c_uint8), ("reserved", ctypes.c_uint8),
+  ("max_fbps_count", ctypes.c_uint32), ("fbp_en_mask", ctypes.c_uint32), ("emc_en_mask", ctypes.c_uint32),
+  ("max_ltc_per_fbp", ctypes.c_uint32), ("max_lts_per_ltc", ctypes.c_uint32), ("max_tex_per_tpc", ctypes.c_uint32),
+  ("max_gpc_count", ctypes.c_uint32), ("rop_l2_en_mask_DEPRECATED", ctypes.c_uint32 * 2), ("chipname", ctypes.c_uint8 * 8),
+  ("gr_compbit_store_base_hw", ctypes.c_uint64),
+  ("gr_gobs_per_comptagline_per_slice", ctypes.c_uint32), ("num_ltc", ctypes.c_uint32),
+  ("lts_per_ltc", ctypes.c_uint32), ("cbc_cache_line_size", ctypes.c_uint32),
+  ("cbc_comptags_per_line", ctypes.c_uint32), ("map_buffer_batch_limit", ctypes.c_uint32), ("max_freq", ctypes.c_uint64),
+  ("graphics_preemption_mode_flags", ctypes.c_uint32), ("compute_preemption_mode_flags", ctypes.c_uint32),
+  ("default_graphics_preempt_mode", ctypes.c_uint32), ("default_compute_preempt_mode", ctypes.c_uint32),
+  ("local_video_memory_size", ctypes.c_uint64),
+  ("pci_vendor_id", ctypes.c_uint16), ("pci_device_id", ctypes.c_uint16), ("pci_subsystem_vendor_id", ctypes.c_uint16),
+  ("pci_subsystem_device_id", ctypes.c_uint16), ("pci_class", ctypes.c_uint16), ("pci_revision", ctypes.c_uint8),
+  ("vbios_oem_version", ctypes.c_uint8), ("vbios_version", ctypes.c_uint32),
+  ("reg_ops_limit", ctypes.c_uint32), ("reserved1", ctypes.c_uint32),
+  ("event_ioctl_nr_last", ctypes.c_int16), ("pad", ctypes.c_uint16), ("max_css_buffer_size", ctypes.c_uint32),
+  ("ctxsw_ioctl_nr_last", ctypes.c_int16), ("prof_ioctl_nr_last", ctypes.c_int16),
+  ("nvs_ioctl_nr_last", ctypes.c_int16), ("reserved2", ctypes.c_uint8 * 2),
+  ("max_ctxsw_ring_buffer_size", ctypes.c_uint32), ("reserved3", ctypes.c_uint32), ("per_device_identifier", ctypes.c_uint64),
+  ("num_ppc_per_gpc", ctypes.c_uint32), ("max_veid_count_per_tsg", ctypes.c_uint32),
+  ("num_sub_partition_per_fbpa", ctypes.c_uint32), ("gpu_instance_id", ctypes.c_uint32),
+  ("gr_instance_id", ctypes.c_uint32), ("max_gpfifo_entries", ctypes.c_uint32),
+  ("max_dbg_tsg_timeslice", ctypes.c_uint32), ("reserved5", ctypes.c_uint32), ("device_instance_id", ctypes.c_uint64)])
+_nvgpu_gpu_get_characteristics = _ct([("buf_size", ctypes.c_uint64), ("buf_addr", ctypes.c_uint64)])
+_nvmap_handle = _ct([("size", ctypes.c_uint32), ("handle", ctypes.c_uint32)])
+_nvmap_alloc = _ct([("handle", ctypes.c_uint32), ("heap_mask", ctypes.c_uint32), ("flags", ctypes.c_uint32),
+                     ("align", ctypes.c_uint32), ("numa_nid", ctypes.c_int32)])
+_nvgpu_alloc_as = _ct([("big_page_size", ctypes.c_uint32), ("as_fd", ctypes.c_int32), ("flags", ctypes.c_uint32),
+                        ("reserved", ctypes.c_uint32), ("va_range_start", ctypes.c_uint64), ("va_range_end", ctypes.c_uint64),
+                        ("va_range_split", ctypes.c_uint64), ("padding", ctypes.c_uint32 * 6)])
+_nvgpu_as_bind_channel = _ct([("channel_fd", ctypes.c_uint32)])
+_nvgpu_as_alloc_space = _ct([("pages", ctypes.c_uint64), ("page_size", ctypes.c_uint32), ("flags", ctypes.c_uint32),
+                              ("offset", ctypes.c_uint64), ("padding", ctypes.c_uint32 * 2)])
+_nvgpu_as_map_buffer_ex = _ct([("flags", ctypes.c_uint32), ("compr_kind", ctypes.c_int16), ("incompr_kind", ctypes.c_int16),
+                                ("dmabuf_fd", ctypes.c_uint32), ("page_size", ctypes.c_uint32), ("buffer_offset", ctypes.c_uint64),
+                                ("mapping_size", ctypes.c_uint64), ("offset", ctypes.c_uint64)])
+_nvgpu_as_unmap_buffer = _ct([("offset", ctypes.c_uint64)])
+_nvgpu_open_tsg = _ct([("tsg_fd", ctypes.c_int32), ("flags", ctypes.c_uint32), ("token", ctypes.c_uint32),
+                        ("reserved", ctypes.c_uint32), ("subctx_id", ctypes.c_uint32), ("_pad", ctypes.c_uint32)])
+_nvgpu_tsg_bind_channel_ex = _ct([("channel_fd", ctypes.c_int32), ("subcontext_id", ctypes.c_uint32),
+                                   ("reserved", ctypes.c_uint8 * 16)])
+_nvgpu_tsg_create_subctx = _ct([("type", ctypes.c_uint32), ("as_fd", ctypes.c_int32),
+                                 ("veid", ctypes.c_uint32), ("reserved", ctypes.c_uint32)])
+_nvgpu_open_channel = _ct([("channel_fd", ctypes.c_int32)])
+_nvgpu_alloc_obj_ctx = _ct([("class_num", ctypes.c_uint32), ("flags", ctypes.c_uint32), ("obj_id", ctypes.c_uint64)])
+_nvgpu_setup_bind = _ct([("num_gpfifo_entries", ctypes.c_uint32), ("num_inflight_jobs", ctypes.c_uint32),
+                          ("flags", ctypes.c_uint32), ("userd_dmabuf_fd", ctypes.c_int32), ("gpfifo_dmabuf_fd", ctypes.c_int32),
+                          ("work_submit_token", ctypes.c_uint32), ("userd_dmabuf_offset", ctypes.c_uint64),
+                          ("gpfifo_dmabuf_offset", ctypes.c_uint64), ("gpfifo_gpu_va", ctypes.c_uint64),
+                          ("userd_gpu_va", ctypes.c_uint64), ("usermode_mmio_gpu_va", ctypes.c_uint64),
+                          ("reserved", ctypes.c_uint32 * 9)])
+_nvgpu_channel_wdt = _ct([("wdt_status", ctypes.c_uint32), ("timeout_ms", ctypes.c_uint32)])
+
+# --- ioctl number helpers ---
+
+def _ioc(d, t, nr, size): return (d << 30) | (size << 16) | (ord(t) << 8) | nr
+def _io(t, nr): return _ioc(0, t, nr, 0)
+def _ior(t, nr, sz): return _ioc(2, t, nr, sz)
+def _iow(t, nr, sz): return _ioc(1, t, nr, sz)
+def _iowr(t, nr, sz): return _ioc(3, t, nr, sz)
+
+_NVGPU_GET_CHARS = _iowr('G', 5, ctypes.sizeof(_nvgpu_gpu_get_characteristics))
+_NVGPU_ALLOC_AS = _iowr('G', 8, ctypes.sizeof(_nvgpu_alloc_as))
+_NVGPU_OPEN_TSG = _iowr('G', 9, ctypes.sizeof(_nvgpu_open_tsg))
+_NVGPU_OPEN_CH = _iowr('G', 11, ctypes.sizeof(_nvgpu_open_channel))
+_NVMAP_CREATE = _iowr('N', 0, ctypes.sizeof(_nvmap_handle))
+_NVMAP_ALLOC = _iow('N', 3, ctypes.sizeof(_nvmap_alloc))
+_NVMAP_GET_FD = _iowr('N', 15, ctypes.sizeof(_nvmap_handle))
+_NVMAP_FREE = _io('N', 4)
+_NVGPU_AS_BIND_CH = _iowr('A', 1, ctypes.sizeof(_nvgpu_as_bind_channel))
+_NVGPU_AS_ALLOC_SPACE = _iowr('A', 6, ctypes.sizeof(_nvgpu_as_alloc_space))
+_NVGPU_AS_MAP_BUF = _iowr('A', 7, ctypes.sizeof(_nvgpu_as_map_buffer_ex))
+_NVGPU_AS_UNMAP_BUF = _iowr('A', 5, ctypes.sizeof(_nvgpu_as_unmap_buffer))
+_NVGPU_TSG_BIND_CH = _iowr('T', 11, ctypes.sizeof(_nvgpu_tsg_bind_channel_ex))
+_NVGPU_TSG_SUBCTX = _iowr('T', 18, ctypes.sizeof(_nvgpu_tsg_create_subctx))
+_NVGPU_CH_ALLOC_OBJ = _iowr('H', 108, ctypes.sizeof(_nvgpu_alloc_obj_ctx))
+_NVGPU_CH_SETUP_BIND = _iowr('H', 128, ctypes.sizeof(_nvgpu_setup_bind))
+_NVGPU_CH_WDT = _iow('H', 119, ctypes.sizeof(_nvgpu_channel_wdt))
+
+_NVMAP_HEAP_IOVMM, _NVMAP_WC, _NVMAP_CACHED = (1 << 30), 1, 2
+_NVMAP_TAG = 0x0900
+
+def _tioctl(fd, nr, buf):
+  if fcntl.ioctl(fd, nr, buf) < 0: raise OSError(f"tegra ioctl 0x{nr:08x} failed")
+
+def _nvmap_buf(nvmap_fd, size, cache_flags, align=4096):
+  c = _nvmap_handle(size=size)
+  _tioctl(nvmap_fd, _NVMAP_CREATE, c)
+  a = _nvmap_alloc(handle=c.handle, heap_mask=_NVMAP_HEAP_IOVMM, flags=(_NVMAP_TAG << 16) | cache_flags, align=align)
+  _tioctl(nvmap_fd, _NVMAP_ALLOC, a)
+  g = _nvmap_handle(handle=c.handle)
+  _tioctl(nvmap_fd, _NVMAP_GET_FD, g)
+  return c.handle, g.size  # g.size is the dmabuf fd
+
+# --- Memory tracking ---
+
+@dataclass
+class TegraMem:
+  handle: int; dmabuf_fd: int; gpu_va: int; size: int; cpu_addr: int = 0; hMemory: int = 0 # noqa: E702
+
+# --- TegraIface ---
+
+class TegraIface:
+  _inited: ClassVar[bool] = False
+  _nvmap_fd: ClassVar[int] = -1
+  _ctrl_fd: ClassVar[int] = -1
+  _chars: ClassVar[_nvgpu_gpu_characteristics|None] = None
+
+  def __init__(self, dev, device_id):
+    if device_id != 0: raise RuntimeError("TegraIface only supports device 0 (single iGPU)")
+    if not TegraIface._inited:
+      if not os.path.exists("/dev/nvgpu/igpu0/ctrl"): raise FileNotFoundError("/dev/nvgpu/igpu0/ctrl")
+      TegraIface._nvmap_fd = os.open("/dev/nvmap", os.O_RDWR | os.O_SYNC)
+      TegraIface._ctrl_fd = os.open("/dev/nvgpu/igpu0/ctrl", os.O_RDWR)
+      chars = _nvgpu_gpu_characteristics()
+      req = _nvgpu_gpu_get_characteristics(buf_size=ctypes.sizeof(chars), buf_addr=ctypes.addressof(chars))
+      _tioctl(TegraIface._ctrl_fd, _NVGPU_GET_CHARS, req)
+      TegraIface._chars, TegraIface._inited = chars, True
+
+    self.dev, self.device_id = dev, device_id
+    chars = TegraIface._chars
+    assert chars is not None
+    self.compute_class, self.gpfifo_class, self.dma_class = chars.compute_class, chars.gpfifo_class, chars.dma_copy_class
+    self.viddec_class = None
+    self._gpu_chars, self._sm_version = chars, chars.sm_arch_sm_version
+    self._hcnt, self._handles = 0x10000, {}
+    self._as_fd, self._tsg_fd, self._subctx_veid = -1, -1, 0
+    self._ch_fds: dict[int, int] = {}
+    self._work_submit_tokens: dict[int, int] = {}
+    self.root, self.gpu_instance = self._nh(), 0
+    self._allocs: list[TegraMem] = []
+
+  def _nh(self) -> int:
+    self._hcnt += 1
+    return self._hcnt
+
+  def rm_alloc(self, parent, clss, params=None, root=None) -> int:
+    handle = self._nh()
+
+    if clss in (nv_gpu.NV01_DEVICE_0, nv_gpu.NV20_SUBDEVICE_0, nv_gpu.FERMI_VASPACE_A, nv_gpu.NV01_ROOT_CLIENT, nv_gpu.NV01_ROOT,
+                getattr(nv_gpu, 'NV1_MEMORY_SYSTEM', 0), getattr(nv_gpu, 'NV1_MEMORY_USER', 0),
+                getattr(nv_gpu, 'NV01_MEMORY_SYSTEM_OS_DESCRIPTOR', 0)):
+      return handle
+
+    if clss == nv_gpu.NV01_MEMORY_VIRTUAL:
+      args = _nvgpu_alloc_as(flags=2, va_range_start=(1 << 21), va_range_end=(1 << 40) - (1 << 21))
+      _tioctl(self._ctrl_fd, _NVGPU_ALLOC_AS, args)
+      self._as_fd = args.as_fd
+      for wva in [0xFD00000000, 0xFE00000000]:
+        rsv = _nvgpu_as_alloc_space(pages=0x40000000 // mmap.PAGESIZE, page_size=mmap.PAGESIZE, flags=1, offset=wva)
+        _tioctl(self._as_fd, _NVGPU_AS_ALLOC_SPACE, rsv)
+      return handle
+
+    if clss == nv_gpu.KEPLER_CHANNEL_GROUP_A:
+      tsg = _nvgpu_open_tsg()
+      _tioctl(self._ctrl_fd, _NVGPU_OPEN_TSG, tsg)
+      self._tsg_fd = tsg.tsg_fd
+      return handle
+
+    if clss == nv_gpu.FERMI_CONTEXT_SHARE_A:
+      subctx = _nvgpu_tsg_create_subctx(type=1, as_fd=self._as_fd)
+      _tioctl(self._tsg_fd, _NVGPU_TSG_SUBCTX, subctx)
+      self._subctx_veid = subctx.veid
+      return handle
+
+    if clss in (self.gpfifo_class, nv_gpu.AMPERE_CHANNEL_GPFIFO_A):
+      ch = _nvgpu_open_channel(channel_fd=-1)
+      _tioctl(self._ctrl_fd, _NVGPU_OPEN_CH, ch)
+      ch_fd = ch.channel_fd
+      _tioctl(self._as_fd, _NVGPU_AS_BIND_CH, _nvgpu_as_bind_channel(channel_fd=ch_fd))
+      _tioctl(self._tsg_fd, _NVGPU_TSG_BIND_CH, _nvgpu_tsg_bind_channel_ex(channel_fd=ch_fd, subcontext_id=self._subctx_veid))
+      _tioctl(ch_fd, _NVGPU_CH_WDT, _nvgpu_channel_wdt(wdt_status=1))
+
+      gpfifo_entries, gpfifo_buf_handle, gpfifo_va, userd_off = 0x10000, 0, 0, 0
+      if params is not None:
+        gpfifo_va, gpfifo_entries, gpfifo_buf_handle = params.gpFifoOffset, params.gpFifoEntries, params.hObjectBuffer
+        userd_off = params.userdOffset[0]
+
+      gpfifo_area_mem = next((m for m in self._allocs if m.hMemory == gpfifo_buf_handle), None)
+      if gpfifo_area_mem is None: raise RuntimeError(f"TegraIface: gpfifo_area alloc not found for handle {gpfifo_buf_handle}")
+      ring_sz = gpfifo_entries * 8
+
+      _, ring_fd = _nvmap_buf(self._nvmap_fd, ring_sz, _NVMAP_WC)
+      _, userd_fd = _nvmap_buf(self._nvmap_fd, 4096, _NVMAP_WC)
+
+      setup = _nvgpu_setup_bind(num_gpfifo_entries=gpfifo_entries, gpfifo_dmabuf_fd=ring_fd, userd_dmabuf_fd=userd_fd,
+                                flags=(1 << 3) | (1 << 1))
+      _tioctl(ch_fd, _NVGPU_CH_SETUP_BIND, setup)
+
+      cpu_base = gpfifo_area_mem.cpu_addr
+      FileIOInterface._mmap(cpu_base + (gpfifo_va - gpfifo_area_mem.gpu_va), ring_sz,
+                            mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED | MAP_FIXED, ring_fd, 0)
+      FileIOInterface._mmap(cpu_base + userd_off, 4096,
+                            mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED | MAP_FIXED, userd_fd, 0)
+
+      self._ch_fds[handle], self._work_submit_tokens[handle] = ch_fd, setup.work_submit_token
+      return handle
+
+    if clss in (self.compute_class, nv_gpu.AMPERE_COMPUTE_B, self.dma_class, nv_gpu.AMPERE_DMA_COPY_B):
+      ch_fd = self._ch_fds.get(parent, -1)
+      if ch_fd == -1: raise RuntimeError(f"TegraIface: no channel fd for handle {parent}")
+      obj = _nvgpu_alloc_obj_ctx(class_num=self.compute_class if clss in (self.compute_class, nv_gpu.AMPERE_COMPUTE_B) else self.dma_class)
+      _tioctl(ch_fd, _NVGPU_CH_ALLOC_OBJ, obj)
+      return handle
+
+    return handle  # GT200_DEBUGGER and others are NOP on Tegra
+
+  def rm_control(self, obj, cmd, params=None, **kwargs):
+    if cmd == nv_gpu.NV2080_CTRL_CMD_PERF_BOOST:
+      try:
+        with open("/sys/class/devfreq/17000000.gpu/max_freq") as f: mx = f.read().strip()
+        with open("/sys/class/devfreq/17000000.gpu/min_freq", "w") as f: f.write(mx)
+      except OSError: pass
+      return params
+
+    if cmd == nv_gpu.NVC36F_CTRL_CMD_GPFIFO_GET_WORK_SUBMIT_TOKEN:
+      if params is not None: params.workSubmitToken = self._work_submit_tokens.get(obj, 0)
+      return params
+
+    if cmd == nv_gpu.NV2080_CTRL_CMD_GR_GET_INFO:
+      chars = self._gpu_chars
+      info_map = {getattr(nv_gpu, k, None): v for k, v in {
+        'NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_GPCS': chars.num_gpc,
+        'NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_TPC_PER_GPC': chars.num_tpc_per_gpc,
+        'NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_SM_PER_TPC': 2,
+        'NV2080_CTRL_GR_INFO_INDEX_MAX_WARPS_PER_SM': chars.sm_arch_warp_count,
+        'NV2080_CTRL_GR_INFO_INDEX_SM_VERSION': chars.sm_arch_sm_version}.items() if getattr(nv_gpu, k, None) is not None}
+      if params is not None:
+        for i in range(params.grInfoListSize):
+          info = nv_gpu.NV2080_CTRL_GR_INFO.from_address(params.grInfoList + i * ctypes.sizeof(nv_gpu.NV2080_CTRL_GR_INFO))
+          info.data = info_map.get(info.index, 0)
+      return params
+
+    if cmd == nv_gpu.NV0080_CTRL_CMD_GPU_GET_CLASSLIST:
+      if params is not None:
+        known = [self.compute_class, self.gpfifo_class, self.dma_class, nv_gpu.TURING_USERMODE_A]
+        if params.numClasses == 0: params.numClasses = len(known)
+        else:
+          cl = to_mv(params.classList, params.numClasses * 4).cast('I')
+          for i, c in enumerate(known[:params.numClasses]): cl[i] = c
+      return params
+
+    if cmd == nv_gpu.NV2080_CTRL_CMD_GPU_GET_GID_INFO:
+      if params is not None:
+        params.length = 16
+        for i in range(16): params.data[i] = (0x4A + i) & 0xFF
+      return params
+
+    return params  # all other commands are NOP on Tegra
+
+  def setup_usermode(self):
+    addr = FileIOInterface._mmap(0, 0x10000, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, self._ctrl_fd, 0)
+    return 0, MMIOInterface(addr, 0x10000, fmt='I')
+
+  def setup_vm(self, vaspace): pass
+  def setup_gpfifo_vm(self, gpfifo): pass
+
+  def alloc(self, size: int, host=False, uncached=False, cpu_access=False, **kwargs) -> HCQBuffer:
+    alloc_align = mmap.PAGESIZE if (uncached or host) else ((2 << 20) if size >= (8 << 20) else mmap.PAGESIZE)
+    size = round_up(size, alloc_align)
+    cache = _NVMAP_WC if (uncached or host) else _NVMAP_CACHED
+
+    handle, dmabuf_fd = _nvmap_buf(self._nvmap_fd, size, cache, alloc_align)
+
+    gpu_va = 0
+    if self._as_fd >= 0:
+      m = _nvgpu_as_map_buffer_ex(compr_kind=-1, dmabuf_fd=dmabuf_fd, page_size=mmap.PAGESIZE)
+      _tioctl(self._as_fd, _NVGPU_AS_MAP_BUF, m)
+      gpu_va = m.offset
+
+    addr = FileIOInterface._mmap(gpu_va or 0, size, mmap.PROT_READ | mmap.PROT_WRITE,
+                                 mmap.MAP_SHARED | (MAP_FIXED if gpu_va else 0), dmabuf_fd, 0)
+    if gpu_va and addr != gpu_va:
+      addr = FileIOInterface._mmap(0, size, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, dmabuf_fd, 0)
+
+    meta = TegraMem(handle=handle, dmabuf_fd=dmabuf_fd, gpu_va=gpu_va, size=size, cpu_addr=addr, hMemory=self._nh())
+    self._allocs.append(meta)
+    return HCQBuffer(va_addr=gpu_va, size=size, meta=meta, view=MMIOInterface(addr, size, fmt='B'), owner=self.dev)
+
+  def free(self, mem: HCQBuffer):
+    meta = mem.meta
+    if not isinstance(meta, TegraMem): return
+    if meta.gpu_va and self._as_fd >= 0:
+      with contextlib.suppress(OSError): _tioctl(self._as_fd, _NVGPU_AS_UNMAP_BUF, _nvgpu_as_unmap_buffer(offset=meta.gpu_va))
+    if meta.cpu_addr:
+      with contextlib.suppress(Exception): FileIOInterface.munmap(meta.cpu_addr, meta.size)
+    if meta.dmabuf_fd >= 0:
+      with contextlib.suppress(OSError): os.close(meta.dmabuf_fd)
+    if meta.handle:
+      h = meta.handle if meta.handle < 0x80000000 else meta.handle - 0x100000000
+      with contextlib.suppress(OSError): fcntl.ioctl(self._nvmap_fd, _NVMAP_FREE, h)
+    if meta in self._allocs: self._allocs.remove(meta)
+
+  def map(self, mem: HCQBuffer): pass
+  def sleep(self, tm: int): pass

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -1,106 +1,18 @@
 from __future__ import annotations
 import os, ctypes, contextlib, fcntl, mmap
 from dataclasses import dataclass
-from tinygrad.runtime.autogen import nv_570 as nv_gpu
-from tinygrad.runtime.support.c import _IOW, _IOWR
+from tinygrad.runtime.autogen import nv_570 as nv_gpu, tegra_36 as tegra
 from tinygrad.runtime.support.hcq import HCQBuffer, MMIOInterface, FileIOInterface
 from tinygrad.runtime.support.system import MAP_FIXED
 from tinygrad.helpers import round_up, to_mv
 
-def _ct(fields):
-  return type("_s", (ctypes.Structure,), {"_fields_": fields})
-
-# struct nvgpu_gpu_characteristics from include/uapi/linux/nvgpu-ctrl.h
-_nvgpu_gpu_characteristics = _ct([
-  ("arch", ctypes.c_uint32), ("impl", ctypes.c_uint32), ("rev", ctypes.c_uint32), ("num_gpc", ctypes.c_uint32),
-  ("numa_domain_id", ctypes.c_int32),
-  ("L2_cache_size", ctypes.c_uint64), ("on_board_video_memory_size", ctypes.c_uint64),
-  ("num_tpc_per_gpc", ctypes.c_uint32), ("bus_type", ctypes.c_uint32), ("big_page_size", ctypes.c_uint32),
-  ("compression_page_size", ctypes.c_uint32), ("pde_coverage_bit_count", ctypes.c_uint32), ("available_big_page_sizes", ctypes.c_uint32),
-  ("flags", ctypes.c_uint64),
-  ("twod_class", ctypes.c_uint32), ("threed_class", ctypes.c_uint32), ("compute_class", ctypes.c_uint32),
-  ("gpfifo_class", ctypes.c_uint32), ("inline_to_memory_class", ctypes.c_uint32), ("dma_copy_class", ctypes.c_uint32),
-  ("gpc_mask", ctypes.c_uint32), ("sm_arch_sm_version", ctypes.c_uint32), ("sm_arch_spa_version", ctypes.c_uint32),
-  ("sm_arch_warp_count", ctypes.c_uint32),
-  ("gpu_ioctl_nr_last", ctypes.c_int16), ("tsg_ioctl_nr_last", ctypes.c_int16), ("dbg_gpu_ioctl_nr_last", ctypes.c_int16),
-  ("ioctl_channel_nr_last", ctypes.c_int16), ("as_ioctl_nr_last", ctypes.c_int16), ("gpu_va_bit_count", ctypes.c_uint8), ("reserved", ctypes.c_uint8),
-  ("max_fbps_count", ctypes.c_uint32), ("fbp_en_mask", ctypes.c_uint32), ("emc_en_mask", ctypes.c_uint32),
-  ("max_ltc_per_fbp", ctypes.c_uint32), ("max_lts_per_ltc", ctypes.c_uint32), ("max_tex_per_tpc", ctypes.c_uint32),
-  ("max_gpc_count", ctypes.c_uint32), ("rop_l2_en_mask_DEPRECATED", ctypes.c_uint32 * 2), ("chipname", ctypes.c_uint8 * 8),
-  ("gr_compbit_store_base_hw", ctypes.c_uint64),
-  ("gr_gobs_per_comptagline_per_slice", ctypes.c_uint32), ("num_ltc", ctypes.c_uint32), ("lts_per_ltc", ctypes.c_uint32),
-  ("cbc_cache_line_size", ctypes.c_uint32), ("cbc_comptags_per_line", ctypes.c_uint32), ("map_buffer_batch_limit", ctypes.c_uint32),
-  ("max_freq", ctypes.c_uint64),
-  ("graphics_preemption_mode_flags", ctypes.c_uint32), ("compute_preemption_mode_flags", ctypes.c_uint32),
-  ("default_graphics_preempt_mode", ctypes.c_uint32), ("default_compute_preempt_mode", ctypes.c_uint32),
-  ("local_video_memory_size", ctypes.c_uint64),
-  ("pci_vendor_id", ctypes.c_uint16), ("pci_device_id", ctypes.c_uint16), ("pci_subsystem_vendor_id", ctypes.c_uint16),
-  ("pci_subsystem_device_id", ctypes.c_uint16), ("pci_class", ctypes.c_uint16), ("pci_revision", ctypes.c_uint8),
-  ("vbios_oem_version", ctypes.c_uint8),
-  ("vbios_version", ctypes.c_uint32), ("reg_ops_limit", ctypes.c_uint32), ("reserved1", ctypes.c_uint32),
-  ("event_ioctl_nr_last", ctypes.c_int16), ("pad", ctypes.c_uint16), ("max_css_buffer_size", ctypes.c_uint32),
-  ("ctxsw_ioctl_nr_last", ctypes.c_int16), ("prof_ioctl_nr_last", ctypes.c_int16), ("nvs_ioctl_nr_last", ctypes.c_int16),
-  ("reserved2", ctypes.c_uint8 * 2),
-  ("max_ctxsw_ring_buffer_size", ctypes.c_uint32), ("reserved3", ctypes.c_uint32), ("per_device_identifier", ctypes.c_uint64),
-  ("num_ppc_per_gpc", ctypes.c_uint32), ("max_veid_count_per_tsg", ctypes.c_uint32),
-  ("num_sub_partition_per_fbpa", ctypes.c_uint32), ("gpu_instance_id", ctypes.c_uint32),
-  ("gr_instance_id", ctypes.c_uint32), ("max_gpfifo_entries", ctypes.c_uint32),
-  ("max_dbg_tsg_timeslice", ctypes.c_uint32), ("reserved5", ctypes.c_uint32), ("device_instance_id", ctypes.c_uint64)])
-_nvgpu_gpu_get_characteristics = _ct([("buf_size", ctypes.c_uint64), ("buf_addr", ctypes.c_uint64)])
-_nvmap_handle = _ct([("size", ctypes.c_uint32), ("handle", ctypes.c_uint32)])
-_nvmap_alloc = _ct([("handle", ctypes.c_uint32), ("heap_mask", ctypes.c_uint32), ("flags", ctypes.c_uint32),
-                     ("align", ctypes.c_uint32), ("numa_nid", ctypes.c_int32)])
-_nvgpu_alloc_as = _ct([("big_page_size", ctypes.c_uint32), ("as_fd", ctypes.c_int32), ("flags", ctypes.c_uint32),
-                        ("reserved", ctypes.c_uint32), ("va_range_start", ctypes.c_uint64), ("va_range_end", ctypes.c_uint64),
-                        ("va_range_split", ctypes.c_uint64), ("padding", ctypes.c_uint32 * 6)])
-_nvgpu_as_bind_channel = _ct([("channel_fd", ctypes.c_uint32)])
-_nvgpu_as_alloc_space = _ct([("pages", ctypes.c_uint64), ("page_size", ctypes.c_uint32), ("flags", ctypes.c_uint32),
-                              ("offset", ctypes.c_uint64), ("padding", ctypes.c_uint32 * 2)])
-_nvgpu_as_map_buffer_ex = _ct([("flags", ctypes.c_uint32), ("compr_kind", ctypes.c_int16), ("incompr_kind", ctypes.c_int16),
-                                ("dmabuf_fd", ctypes.c_uint32), ("page_size", ctypes.c_uint32), ("buffer_offset", ctypes.c_uint64),
-                                ("mapping_size", ctypes.c_uint64), ("offset", ctypes.c_uint64)])
-_nvgpu_as_unmap_buffer = _ct([("offset", ctypes.c_uint64)])
-_nvgpu_open_tsg = _ct([("tsg_fd", ctypes.c_int32), ("flags", ctypes.c_uint32), ("token", ctypes.c_uint32),
-                        ("reserved", ctypes.c_uint32), ("subctx_id", ctypes.c_uint32), ("_pad", ctypes.c_uint32)])
-_nvgpu_tsg_bind_channel_ex = _ct([("channel_fd", ctypes.c_int32), ("subcontext_id", ctypes.c_uint32),
-                                   ("reserved", ctypes.c_uint8 * 16)])
-_nvgpu_tsg_create_subctx = _ct([("type", ctypes.c_uint32), ("as_fd", ctypes.c_int32),
-                                 ("veid", ctypes.c_uint32), ("reserved", ctypes.c_uint32)])
-_nvgpu_open_channel = _ct([("channel_fd", ctypes.c_int32)])
-_nvgpu_alloc_obj_ctx = _ct([("class_num", ctypes.c_uint32), ("flags", ctypes.c_uint32), ("obj_id", ctypes.c_uint64)])
-_nvgpu_setup_bind = _ct([("num_gpfifo_entries", ctypes.c_uint32), ("num_inflight_jobs", ctypes.c_uint32),
-                          ("flags", ctypes.c_uint32), ("userd_dmabuf_fd", ctypes.c_int32), ("gpfifo_dmabuf_fd", ctypes.c_int32),
-                          ("work_submit_token", ctypes.c_uint32), ("userd_dmabuf_offset", ctypes.c_uint64),
-                          ("gpfifo_dmabuf_offset", ctypes.c_uint64), ("gpfifo_gpu_va", ctypes.c_uint64),
-                          ("userd_gpu_va", ctypes.c_uint64), ("usermode_mmio_gpu_va", ctypes.c_uint64),
-                          ("reserved", ctypes.c_uint32 * 9)])
-_nvgpu_channel_wdt = _ct([("wdt_status", ctypes.c_uint32), ("timeout_ms", ctypes.c_uint32)])
-
-# ioctl callables: NAME(fd, **kwargs) -> struct  (see tinygrad/runtime/support/c.py _do_ioctl)
-NVGPU_GET_CHARS    = _IOWR('G', 5,   _nvgpu_gpu_get_characteristics)
-NVGPU_ALLOC_AS     = _IOWR('G', 8,   _nvgpu_alloc_as)
-NVGPU_OPEN_TSG     = _IOWR('G', 9,   _nvgpu_open_tsg)
-NVGPU_OPEN_CH      = _IOWR('G', 11,  _nvgpu_open_channel)
-NVMAP_CREATE       = _IOWR('N', 0,   _nvmap_handle)
-NVMAP_ALLOC        = _IOW ('N', 3,   _nvmap_alloc)
-NVMAP_GET_FD       = _IOWR('N', 15,  _nvmap_handle)
-NVGPU_AS_BIND_CH   = _IOWR('A', 1,   _nvgpu_as_bind_channel)
-NVGPU_AS_ALLOC_SP  = _IOWR('A', 6,   _nvgpu_as_alloc_space)
-NVGPU_AS_MAP_BUF   = _IOWR('A', 7,   _nvgpu_as_map_buffer_ex)
-NVGPU_AS_UNMAP_BUF = _IOWR('A', 5,   _nvgpu_as_unmap_buffer)
-NVGPU_TSG_BIND_CH  = _IOWR('T', 11,  _nvgpu_tsg_bind_channel_ex)
-NVGPU_TSG_SUBCTX   = _IOWR('T', 18,  _nvgpu_tsg_create_subctx)
-NVGPU_CH_ALLOC_OBJ = _IOWR('H', 108, _nvgpu_alloc_obj_ctx)
-NVGPU_CH_SETUP_BIND= _IOWR('H', 128, _nvgpu_setup_bind)
-NVGPU_CH_WDT       = _IOW ('H', 119, _nvgpu_channel_wdt)
-_NVMAP_FREE        = (ord('N') << 8) | 4  # _IO('N', 4): handle passed as integer value
-
-_NVMAP_HEAP_IOVMM, _NVMAP_WC, _NVMAP_CACHED, _NVMAP_TAG = (1 << 30), 1, 2, 0x0900
+_NVMAP_FREE = (ord('N') << 8) | 4  # _IO('N', 4): handle passed as integer, not struct
+_NVMAP_TAG = 0x0900
 
 def _nvmap_buf(nvmap_fd, size, cache_flags, align=4096):
-  c = NVMAP_CREATE(nvmap_fd, size=size)
-  NVMAP_ALLOC(nvmap_fd, handle=c.handle, heap_mask=_NVMAP_HEAP_IOVMM, flags=(_NVMAP_TAG << 16) | cache_flags, align=align)
-  return c.handle, NVMAP_GET_FD(nvmap_fd, handle=c.handle).size  # .size is dmabuf fd (kernel struct union)
+  c = tegra.NVMAP_IOC_CREATE(nvmap_fd, size=size)
+  tegra.NVMAP_IOC_ALLOC(nvmap_fd, handle=c.handle, heap_mask=tegra.NVMAP_HEAP_IOVMM, flags=(_NVMAP_TAG << 16) | cache_flags, align=align)
+  return c.handle, tegra.NVMAP_IOC_GET_FD(nvmap_fd, handle=c.handle).size
 
 @dataclass(eq=False)
 class TegraMem:
@@ -120,8 +32,8 @@ class TegraIface:
       if not os.path.exists("/dev/nvgpu/igpu0/ctrl"): raise FileNotFoundError("/dev/nvgpu/igpu0/ctrl")
       TegraIface._nvmap_fd = os.open("/dev/nvmap", os.O_RDWR | os.O_SYNC)
       TegraIface._ctrl_fd = os.open("/dev/nvgpu/igpu0/ctrl", os.O_RDWR)
-      chars = _nvgpu_gpu_characteristics()
-      NVGPU_GET_CHARS(TegraIface._ctrl_fd, buf_size=ctypes.sizeof(chars), buf_addr=ctypes.addressof(chars))
+      chars = tegra.nvgpu_gpu_characteristics()
+      tegra.NVGPU_GPU_IOCTL_GET_CHARACTERISTICS(TegraIface._ctrl_fd, buf_size=ctypes.sizeof(chars), buf_addr=ctypes.addressof(chars))
       TegraIface._chars = chars
 
     self.dev, self.device_id = dev, device_id
@@ -147,24 +59,24 @@ class TegraIface:
       return handle
 
     if clss == nv_gpu.NV01_MEMORY_VIRTUAL:
-      self._as_fd = NVGPU_ALLOC_AS(self._ctrl_fd, flags=2, va_range_start=(1 << 21), va_range_end=(1 << 40) - (1 << 21)).as_fd
+      self._as_fd = tegra.NVGPU_GPU_IOCTL_ALLOC_AS(self._ctrl_fd, flags=2, va_range_start=(1 << 21), va_range_end=(1 << 40) - (1 << 21)).as_fd
       for wva in [0xFD00000000, 0xFE00000000]:
-        NVGPU_AS_ALLOC_SP(self._as_fd, pages=0x40000000 // mmap.PAGESIZE, page_size=mmap.PAGESIZE, flags=1, offset=wva)
+        tegra.NVGPU_AS_IOCTL_ALLOC_SPACE(self._as_fd, pages=0x40000000 // mmap.PAGESIZE, page_size=mmap.PAGESIZE, flags=1, offset=wva)
       return handle
 
     if clss == nv_gpu.KEPLER_CHANNEL_GROUP_A:
-      self._tsg_fd = NVGPU_OPEN_TSG(self._ctrl_fd).tsg_fd
+      self._tsg_fd = tegra.NVGPU_GPU_IOCTL_OPEN_TSG(self._ctrl_fd).tsg_fd
       return handle
 
     if clss == nv_gpu.FERMI_CONTEXT_SHARE_A:
-      self._subctx_veid = NVGPU_TSG_SUBCTX(self._tsg_fd, type=1, as_fd=self._as_fd).veid
+      self._subctx_veid = tegra.NVGPU_TSG_IOCTL_CREATE_SUBCONTEXT(self._tsg_fd, type=1, as_fd=self._as_fd).veid
       return handle
 
     if clss in (self.gpfifo_class, nv_gpu.AMPERE_CHANNEL_GPFIFO_A):
-      ch_fd = NVGPU_OPEN_CH(self._ctrl_fd, channel_fd=-1).channel_fd
-      NVGPU_AS_BIND_CH(self._as_fd, channel_fd=ch_fd)
-      NVGPU_TSG_BIND_CH(self._tsg_fd, channel_fd=ch_fd, subcontext_id=self._subctx_veid)
-      NVGPU_CH_WDT(ch_fd, wdt_status=1)
+      ch_fd = tegra.NVGPU_GPU_IOCTL_OPEN_CHANNEL(self._ctrl_fd, channel_fd=-1).channel_fd
+      tegra.NVGPU_AS_IOCTL_BIND_CHANNEL(self._as_fd, channel_fd=ch_fd)
+      tegra.NVGPU_TSG_IOCTL_BIND_CHANNEL_EX(self._tsg_fd, channel_fd=ch_fd, subcontext_id=self._subctx_veid)
+      tegra.NVGPU_IOCTL_CHANNEL_WDT(ch_fd, wdt_status=1)
 
       gpfifo_entries, gpfifo_buf_handle, gpfifo_va, userd_off = 0x10000, 0, 0, 0
       if params is not None:
@@ -175,11 +87,11 @@ class TegraIface:
       if gpfifo_area_mem is None: raise RuntimeError(f"TegraIface: gpfifo_area alloc not found for handle {gpfifo_buf_handle}")
       ring_sz = gpfifo_entries * 8
 
-      _, ring_fd = _nvmap_buf(self._nvmap_fd, ring_sz, _NVMAP_WC)
-      _, userd_fd = _nvmap_buf(self._nvmap_fd, 4096, _NVMAP_WC)
+      _, ring_fd = _nvmap_buf(self._nvmap_fd, ring_sz, tegra.NVMAP_HANDLE_WRITE_COMBINE)
+      _, userd_fd = _nvmap_buf(self._nvmap_fd, 4096, tegra.NVMAP_HANDLE_WRITE_COMBINE)
 
-      setup = NVGPU_CH_SETUP_BIND(ch_fd, num_gpfifo_entries=gpfifo_entries, gpfifo_dmabuf_fd=ring_fd, userd_dmabuf_fd=userd_fd,
-                                  flags=(1 << 3) | (1 << 1))
+      setup = tegra.NVGPU_IOCTL_CHANNEL_SETUP_BIND(ch_fd, num_gpfifo_entries=gpfifo_entries, gpfifo_dmabuf_fd=ring_fd, userd_dmabuf_fd=userd_fd,
+                                                    flags=tegra.NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT|tegra.NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC)
 
       cpu_base = gpfifo_area_mem.cpu_addr
       FileIOInterface._mmap(cpu_base + (gpfifo_va - gpfifo_area_mem.gpu_va), ring_sz,
@@ -193,7 +105,8 @@ class TegraIface:
     if clss in (self.compute_class, nv_gpu.AMPERE_COMPUTE_B, self.dma_class, nv_gpu.AMPERE_DMA_COPY_B):
       ch_fd = self._ch_fds.get(parent, -1)
       if ch_fd == -1: raise RuntimeError(f"TegraIface: no channel fd for handle {parent}")
-      NVGPU_CH_ALLOC_OBJ(ch_fd, class_num=self.compute_class if clss in (self.compute_class, nv_gpu.AMPERE_COMPUTE_B) else self.dma_class)
+      obj_cls = self.compute_class if clss in (self.compute_class, nv_gpu.AMPERE_COMPUTE_B) else self.dma_class
+      tegra.NVGPU_IOCTL_CHANNEL_ALLOC_OBJ_CTX(ch_fd, class_num=obj_cls)
       return handle
 
     return handle
@@ -253,13 +166,13 @@ class TegraIface:
   def alloc(self, size:int, host=False, uncached=False, cpu_access=False, **kwargs) -> HCQBuffer:
     alloc_align = mmap.PAGESIZE if (uncached or host) else ((2 << 20) if size >= (8 << 20) else mmap.PAGESIZE)
     size = round_up(size, alloc_align)
-    cache = _NVMAP_WC if (uncached or host) else _NVMAP_CACHED
+    cache = tegra.NVMAP_HANDLE_WRITE_COMBINE if (uncached or host) else tegra.NVMAP_HANDLE_INNER_CACHEABLE
 
     handle, dmabuf_fd = _nvmap_buf(self._nvmap_fd, size, cache, alloc_align)
 
     gpu_va = 0
     if self._as_fd >= 0:
-      gpu_va = NVGPU_AS_MAP_BUF(self._as_fd, compr_kind=-1, dmabuf_fd=dmabuf_fd, page_size=mmap.PAGESIZE).offset
+      gpu_va = tegra.NVGPU_AS_IOCTL_MAP_BUFFER_EX(self._as_fd, compr_kind=-1, dmabuf_fd=dmabuf_fd, page_size=mmap.PAGESIZE).offset
 
     addr = FileIOInterface._mmap(gpu_va or 0, size, mmap.PROT_READ | mmap.PROT_WRITE,
                                  mmap.MAP_SHARED | (MAP_FIXED if gpu_va else 0), dmabuf_fd, 0)
@@ -273,7 +186,7 @@ class TegraIface:
   def free(self, mem:HCQBuffer):
     meta = mem.meta
     if meta.gpu_va and self._as_fd >= 0:
-      with contextlib.suppress(OSError): NVGPU_AS_UNMAP_BUF(self._as_fd, offset=meta.gpu_va)
+      with contextlib.suppress(OSError): tegra.NVGPU_AS_IOCTL_UNMAP_BUFFER(self._as_fd, offset=meta.gpu_va)
     if meta.cpu_addr:
       with contextlib.suppress(Exception): FileIOInterface.munmap(meta.cpu_addr, meta.size)
     if meta.dmabuf_fd >= 0:

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -99,8 +99,7 @@ _NVGPU_CH_WDT = _iow('H', 119, ctypes.sizeof(_nvgpu_channel_wdt))
 
 _NVMAP_HEAP_IOVMM, _NVMAP_WC, _NVMAP_CACHED, _NVMAP_TAG = (1 << 30), 1, 2, 0x0900
 
-def _tioctl(fd, nr, buf):
-  if fcntl.ioctl(fd, nr, buf) < 0: raise OSError(f"tegra ioctl 0x{nr:08x} failed")
+def _tioctl(fd, nr, buf): fcntl.ioctl(fd, nr, buf)
 
 def _nvmap_buf(nvmap_fd, size, cache_flags, align=4096):
   c = _nvmap_handle(size=size)
@@ -148,8 +147,7 @@ class TegraIface:
     handle = self._nh()
 
     if clss in (nv_gpu.NV01_DEVICE_0, nv_gpu.NV20_SUBDEVICE_0, nv_gpu.FERMI_VASPACE_A, nv_gpu.NV01_ROOT_CLIENT, nv_gpu.NV01_ROOT,
-                getattr(nv_gpu, 'NV1_MEMORY_SYSTEM', 0), getattr(nv_gpu, 'NV1_MEMORY_USER', 0),
-                getattr(nv_gpu, 'NV01_MEMORY_SYSTEM_OS_DESCRIPTOR', 0)):
+                nv_gpu.NV1_MEMORY_SYSTEM, nv_gpu.NV1_MEMORY_USER, nv_gpu.NV01_MEMORY_SYSTEM_OS_DESCRIPTOR):
       return handle
 
     if clss == nv_gpu.NV01_MEMORY_VIRTUAL:
@@ -229,12 +227,13 @@ class TegraIface:
 
     if cmd == nv_gpu.NV2080_CTRL_CMD_GR_GET_INFO:
       chars = TegraIface._chars
-      info_map = {getattr(nv_gpu, k, None): v for k, v in {
-        'NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_GPCS': chars.num_gpc,
-        'NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_TPC_PER_GPC': chars.num_tpc_per_gpc,
-        'NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_SM_PER_TPC': 2,
-        'NV2080_CTRL_GR_INFO_INDEX_MAX_WARPS_PER_SM': chars.sm_arch_warp_count,
-        'NV2080_CTRL_GR_INFO_INDEX_SM_VERSION': chars.sm_arch_sm_version}.items() if getattr(nv_gpu, k, None) is not None}
+      info_map = {
+        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_GPCS: chars.num_gpc,
+        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_TPC_PER_GPC: chars.num_tpc_per_gpc,
+        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_SM_PER_TPC: 2,
+        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_MAX_WARPS_PER_SM: chars.sm_arch_warp_count,
+        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_SM_VERSION: chars.sm_arch_sm_version,
+      }
       if params is not None:
         for i in range(params.grInfoListSize):
           info = nv_gpu.NV2080_CTRL_GR_INFO.from_address(params.grInfoList + i * ctypes.sizeof(nv_gpu.NV2080_CTRL_GR_INFO))

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -3,7 +3,7 @@ import os, ctypes, contextlib, fcntl, mmap
 from dataclasses import dataclass
 from tinygrad.runtime.autogen import nv_570 as nv_gpu, tegra_36 as tegra
 from tinygrad.runtime.support.hcq import HCQBuffer, MMIOInterface, FileIOInterface
-from tinygrad.runtime.support.system import MAP_FIXED
+from tinygrad.runtime.support.system import MAP_FIXED # Force mmap to fixed address
 from tinygrad.helpers import round_up, to_mv
 
 _NVMAP_FREE = (ord('N') << 8) | 4  # _IO('N', 4): handle passed as integer, not struct
@@ -16,83 +16,97 @@ def _nvmap_buf(nvmap_fd, size, cache_flags, align=4096):
 
 @dataclass(eq=False)
 class TegraMem:
-  handle: int = 0
-  dmabuf_fd: int = -1
-  gpu_va: int = 0
+  handle: int = 0        # nvmap handle (kernel tracking)
+  dmabuf_fd: int = -1    # dmabuf file descriptor (for mmap + GPU map)
+  gpu_va: int = 0        # GPU virtual address (from MAP_BUFFER_EX)
   size: int = 0
-  cpu_addr: int = 0
-  hMemory: int = 0
+  cpu_addr: int = 0      # CPU virtual address (from mmap)
+  hMemory: int = 0       # synthetic RM handle (for gpfifo_area lookup)
 
 class TegraIface:
-  _nvmap_fd, _ctrl_fd, _chars = -1, -1, None
+  _nvmap_fd, _ctrl_fd, _gpu_info = -1, -1, None
 
   def __init__(self, dev, device_id):
     if device_id != 0: raise RuntimeError("TegraIface only supports device 0 (single iGPU)")
-    if TegraIface._chars is None:
+    if TegraIface._gpu_info is None:
       if not os.path.exists("/dev/nvgpu/igpu0/ctrl"): raise FileNotFoundError("/dev/nvgpu/igpu0/ctrl")
       TegraIface._nvmap_fd = os.open("/dev/nvmap", os.O_RDWR | os.O_SYNC)
       TegraIface._ctrl_fd = os.open("/dev/nvgpu/igpu0/ctrl", os.O_RDWR)
-      chars = tegra.nvgpu_gpu_characteristics()
-      tegra.NVGPU_GPU_IOCTL_GET_CHARACTERISTICS(TegraIface._ctrl_fd, buf_size=ctypes.sizeof(chars), buf_addr=ctypes.addressof(chars))
-      TegraIface._chars = chars
+      tegra_gpu_info = tegra.nvgpu_gpu_characteristics()
+      tegra.NVGPU_GPU_IOCTL_GET_CHARACTERISTICS(TegraIface._ctrl_fd,
+        buf_size=ctypes.sizeof(tegra_gpu_info), buf_addr=ctypes.addressof(tegra_gpu_info))
+      TegraIface._gpu_info = tegra_gpu_info
 
     self.dev, self.device_id = dev, device_id
-    chars = TegraIface._chars
-    self.compute_class, self.gpfifo_class, self.dma_class = chars.compute_class, chars.gpfifo_class, chars.dma_copy_class
-    self.viddec_class = None
-    self._hcnt = 0x10000
+    tegra_gpu_info = TegraIface._gpu_info
+    self.compute_class, self.gpfifo_class, self.dma_class = tegra_gpu_info.compute_class, tegra_gpu_info.gpfifo_class, tegra_gpu_info.dma_copy_class
+    self.viddec_class = None # no video decoder on Tegra
+    self._handle_cnt = 0x10000 # (NVKIface starts at 0x1000) TinyGrad internal bookkeeping (RM's rm_alloc)
     self._as_fd, self._tsg_fd, self._subctx_veid = -1, -1, 0
-    self._ch_fds: dict[int, int] = {}
-    self._ws_tokens: dict[int, int] = {}
-    self.root, self.gpu_instance = self._nh(), 0
+    self._ch_fds: dict[int, int] = {} # handle -> channel fd
+    self._ws_tokens: dict[int, int] = {} # handle -> work_submit_token
+    self._ch_bufs: dict[int, tuple[int, int, int, int]] = {} # handle -> (ring_nvmap_h, ring_fd, userd_nvmap_h, userd_fd)
+    self.root, self.gpu_instance = self._next_handle(), 0
     self._allocs: list[TegraMem] = []
 
-  def _nh(self) -> int:
-    self._hcnt += 1
-    return self._hcnt
+  # RM would get integer handle from kernel, we mimic this with int handles (start at 0x10000 to avoid collisions with NVKIface that starts at 0x1000)
+  # Used to lookup gpfifo_area
+  def _next_handle(self) -> int:
+    self._handle_cnt += 1
+    return self._handle_cnt
 
+  # map RM's alloc to TegraIface alloc
   def rm_alloc(self, parent, clss, params=None, root=None) -> int:
-    handle = self._nh()
+    handle = self._next_handle()
 
+    # stub/no-op (They exist for RM but no nvgpu driver equivalent)
     if clss in (nv_gpu.NV01_DEVICE_0, nv_gpu.NV20_SUBDEVICE_0, nv_gpu.FERMI_VASPACE_A, nv_gpu.NV01_ROOT_CLIENT, nv_gpu.NV01_ROOT,
                 nv_gpu.NV1_MEMORY_SYSTEM, nv_gpu.NV1_MEMORY_USER, nv_gpu.NV01_MEMORY_SYSTEM_OS_DESCRIPTOR):
       return handle
 
+    # open GPU address space and pre-reserve two 1GB VA windows tinygrad uses for fixed-address buffers
     if clss == nv_gpu.NV01_MEMORY_VIRTUAL:
       self._as_fd = tegra.NVGPU_GPU_IOCTL_ALLOC_AS(self._ctrl_fd, flags=2, va_range_start=(1 << 21), va_range_end=(1 << 40) - (1 << 21)).as_fd
-      for wva in [0xFD00000000, 0xFE00000000]:
-        tegra.NVGPU_AS_IOCTL_ALLOC_SPACE(self._as_fd, pages=0x40000000 // mmap.PAGESIZE, page_size=mmap.PAGESIZE, flags=1, offset=wva)
+      for reserved_va in [0xFD00000000, 0xFE00000000]:
+        tegra.NVGPU_AS_IOCTL_ALLOC_SPACE(self._as_fd, pages=0x40000000 // mmap.PAGESIZE, page_size=mmap.PAGESIZE, flags=1, offset=reserved_va)
       return handle
 
+    # open TSG (time-sliced GPU group); channels bind to it for scheduling
     if clss == nv_gpu.KEPLER_CHANNEL_GROUP_A:
       self._tsg_fd = tegra.NVGPU_GPU_IOCTL_OPEN_TSG(self._ctrl_fd).tsg_fd
       return handle
 
+    # create subcontext; VEID lets the GR engine distinguish address spaces within the TSG
     if clss == nv_gpu.FERMI_CONTEXT_SHARE_A:
       self._subctx_veid = tegra.NVGPU_TSG_IOCTL_CREATE_SUBCONTEXT(self._tsg_fd, type=1, as_fd=self._as_fd).veid
       return handle
 
+    # open channel fd, bind to AS + TSG, overlay ring and USERD dmabufs into gpfifo_area via MAP_FIXED
     if clss in (self.gpfifo_class, nv_gpu.AMPERE_CHANNEL_GPFIFO_A):
       ch_fd = tegra.NVGPU_GPU_IOCTL_OPEN_CHANNEL(self._ctrl_fd, channel_fd=-1).channel_fd
-      tegra.NVGPU_AS_IOCTL_BIND_CHANNEL(self._as_fd, channel_fd=ch_fd)
-      tegra.NVGPU_TSG_IOCTL_BIND_CHANNEL_EX(self._tsg_fd, channel_fd=ch_fd, subcontext_id=self._subctx_veid)
-      tegra.NVGPU_IOCTL_CHANNEL_WDT(ch_fd, wdt_status=1)
+      tegra.NVGPU_AS_IOCTL_BIND_CHANNEL(self._as_fd, channel_fd=ch_fd) # attach to address space
+      tegra.NVGPU_TSG_IOCTL_BIND_CHANNEL_EX(self._tsg_fd, channel_fd=ch_fd, subcontext_id=self._subctx_veid) # attach to scheduler
+      tegra.NVGPU_IOCTL_CHANNEL_WDT(ch_fd, wdt_status=1) # disable watchdog
 
       gpfifo_entries, gpfifo_buf_handle, gpfifo_va, userd_off = 0x10000, 0, 0, 0
       if params is not None:
         gpfifo_va, gpfifo_entries, gpfifo_buf_handle = params.gpFifoOffset, params.gpFifoEntries, params.hObjectBuffer
         userd_off = params.userdOffset[0]
 
+      # find the gpfifo_area TegraMem by the synthetic RM handle tinygrad assigned it
       gpfifo_area_mem = next((m for m in self._allocs if m.hMemory == gpfifo_buf_handle), None)
       if gpfifo_area_mem is None: raise RuntimeError(f"TegraIface: gpfifo_area alloc not found for handle {gpfifo_buf_handle}")
       ring_sz = gpfifo_entries * 8
 
-      _, ring_fd = _nvmap_buf(self._nvmap_fd, ring_sz, tegra.NVMAP_HANDLE_WRITE_COMBINE)
-      _, userd_fd = _nvmap_buf(self._nvmap_fd, 4096, tegra.NVMAP_HANDLE_WRITE_COMBINE)
+      # nvgpu requires separate owned dmabufs for ring and USERD - can't use offsets into gpfifo_area
+      ring_nvmap_h, ring_fd = _nvmap_buf(self._nvmap_fd, ring_sz, tegra.NVMAP_HANDLE_WRITE_COMBINE)
+      userd_nvmap_h, userd_fd = _nvmap_buf(self._nvmap_fd, 4096, tegra.NVMAP_HANDLE_WRITE_COMBINE)
 
+      # pin ring+USERD into hw channel; work_submit_token is the doorbell value written to wake the GPU
       setup = tegra.NVGPU_IOCTL_CHANNEL_SETUP_BIND(ch_fd, num_gpfifo_entries=gpfifo_entries, gpfifo_dmabuf_fd=ring_fd, userd_dmabuf_fd=userd_fd,
                                                     flags=tegra.NVGPU_CHANNEL_SETUP_BIND_FLAGS_USERMODE_SUPPORT|tegra.NVGPU_CHANNEL_SETUP_BIND_FLAGS_DETERMINISTIC)
 
+      # punch dmabuf pages into gpfifo_area CPU mapping so tinygrad writes hit the same physical pages the GPU reads
       cpu_base = gpfifo_area_mem.cpu_addr
       FileIOInterface._mmap(cpu_base + (gpfifo_va - gpfifo_area_mem.gpu_va), ring_sz,
                             mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED | MAP_FIXED, ring_fd, 0)
@@ -100,8 +114,10 @@ class TegraIface:
                             mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED | MAP_FIXED, userd_fd, 0)
 
       self._ch_fds[handle], self._ws_tokens[handle] = ch_fd, setup.work_submit_token
+      self._ch_bufs[handle] = (ring_nvmap_h, ring_fd, userd_nvmap_h, userd_fd)
       return handle
 
+    # bind GR (compute) or CE (copy) engine to the channel
     if clss in (self.compute_class, nv_gpu.AMPERE_COMPUTE_B, self.dma_class, nv_gpu.AMPERE_DMA_COPY_B):
       ch_fd = self._ch_fds.get(parent, -1)
       if ch_fd == -1: raise RuntimeError(f"TegraIface: no channel fd for handle {parent}")
@@ -124,14 +140,14 @@ class TegraIface:
       return params
 
     if cmd == nv_gpu.NV2080_CTRL_CMD_GR_GET_INFO:
-      chars = TegraIface._chars
-      assert chars is not None
+      tegra_gpu_info = TegraIface._gpu_info
+      assert tegra_gpu_info is not None
       info_map = {
-        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_GPCS: chars.num_gpc,
-        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_TPC_PER_GPC: chars.num_tpc_per_gpc,
+        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_GPCS: tegra_gpu_info.num_gpc,
+        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_TPC_PER_GPC: tegra_gpu_info.num_tpc_per_gpc,
         nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_SM_PER_TPC: 2,
-        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_MAX_WARPS_PER_SM: chars.sm_arch_warp_count,
-        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_SM_VERSION: chars.sm_arch_sm_version,
+        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_MAX_WARPS_PER_SM: tegra_gpu_info.sm_arch_warp_count,
+        nv_gpu.NV2080_CTRL_GR_INFO_INDEX_SM_VERSION: tegra_gpu_info.sm_arch_sm_version,
       }
       if params is not None:
         for i in range(params.grInfoListSize):
@@ -160,27 +176,33 @@ class TegraIface:
     addr = FileIOInterface._mmap(0, 0x10000, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, self._ctrl_fd, 0)
     return 0, MMIOInterface(addr, 0x10000, fmt='I')
 
-  def setup_vm(self, vaspace): pass
-  def setup_gpfifo_vm(self, gpfifo): pass
+  def setup_vm(self, vaspace): pass # nvgpu owns the AS, no separate UVM step needed
+  def setup_gpfifo_vm(self, gpfifo): pass # handled internally by nvgpu on channel bind
 
   def alloc(self, size:int, host=False, uncached=False, cpu_access=False, **kwargs) -> HCQBuffer:
+    # 2MB huge pages for large (>=8MB) buffers to reduce TLB pressure; 4KB otherwise
     alloc_align = mmap.PAGESIZE if (uncached or host) else ((2 << 20) if size >= (8 << 20) else mmap.PAGESIZE)
     size = round_up(size, alloc_align)
+    # WRITE_COMBINE for CPU-polled bufs (notifiers/signals) - no cache, GPU writes visible immediately
+    # INNER_CACHEABLE for compute data - Orin's interconnect provides hardware IO coherence, no manual flushes
     cache = tegra.NVMAP_HANDLE_WRITE_COMBINE if (uncached or host) else tegra.NVMAP_HANDLE_INNER_CACHEABLE
 
     handle, dmabuf_fd = _nvmap_buf(self._nvmap_fd, size, cache, alloc_align)
 
+    # GPU mapping: map dmabuf into GPU's address space
     gpu_va = 0
     if self._as_fd >= 0:
       gpu_va = tegra.NVGPU_AS_IOCTL_MAP_BUFFER_EX(self._as_fd, compr_kind=-1, dmabuf_fd=dmabuf_fd, page_size=mmap.PAGESIZE).offset
 
+    # CPU mapping: try MAP_FIXED at the GPU VA for CPU VA = GPU VA, fallback is kernel chosen address (PCIface pattern)
     addr = FileIOInterface._mmap(gpu_va or 0, size, mmap.PROT_READ | mmap.PROT_WRITE,
                                  mmap.MAP_SHARED | (MAP_FIXED if gpu_va else 0), dmabuf_fd, 0)
     if gpu_va and addr != gpu_va:
       addr = FileIOInterface._mmap(0, size, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, dmabuf_fd, 0)
 
-    meta = TegraMem(handle=handle, dmabuf_fd=dmabuf_fd, gpu_va=gpu_va, size=size, cpu_addr=addr, hMemory=self._nh())
-    self._allocs.append(meta)
+    # track alloc metadata
+    meta = TegraMem(handle=handle, dmabuf_fd=dmabuf_fd, gpu_va=gpu_va, size=size, cpu_addr=addr, hMemory=self._next_handle())
+    self._allocs.append(meta) # track allocs for free() and gpfifo_area lookup
     return HCQBuffer(va_addr=gpu_va, size=size, meta=meta, view=MMIOInterface(addr, size, fmt='B'), owner=self.dev)
 
   def free(self, mem:HCQBuffer):
@@ -192,14 +214,23 @@ class TegraIface:
     if meta.dmabuf_fd >= 0:
       with contextlib.suppress(OSError): os.close(meta.dmabuf_fd)
     if meta.handle and self._nvmap_fd >= 0:
-      h = meta.handle if meta.handle < 0x80000000 else meta.handle - 0x100000000
-      with contextlib.suppress(OSError): fcntl.ioctl(self._nvmap_fd, _NVMAP_FREE, h)
+      with contextlib.suppress(OSError): fcntl.ioctl(self._nvmap_fd, _NVMAP_FREE, ctypes.c_int32(meta.handle).value)
     if meta in self._allocs: self._allocs.remove(meta)
 
-  def map(self, mem:HCQBuffer): pass
-  def sleep(self, tm:int): pass
+  def map(self, mem:HCQBuffer): pass # already mapped to GPU as in alloc()
+  def sleep(self, tm:int): pass # no GSP firmware on Tegra iGPU so no status queue to service during long waits
 
   def device_fini(self):
+    for ch_fd in self._ch_fds.values():
+      with contextlib.suppress(OSError): os.close(ch_fd)
+    for ring_nvmap_h, ring_fd, userd_nvmap_h, userd_fd in self._ch_bufs.values():
+      for fd in (ring_fd, userd_fd):
+        with contextlib.suppress(OSError): os.close(fd)
+      for h in (ring_nvmap_h, userd_nvmap_h):
+        with contextlib.suppress(OSError): fcntl.ioctl(TegraIface._nvmap_fd, _NVMAP_FREE, ctypes.c_int32(h).value)
+    if self._tsg_fd >= 0: os.close(self._tsg_fd)
+    if self._as_fd >= 0: os.close(self._as_fd)
+    self._tsg_fd, self._as_fd = -1, -1
     if TegraIface._ctrl_fd >= 0: os.close(TegraIface._ctrl_fd)
     if TegraIface._nvmap_fd >= 0: os.close(TegraIface._nvmap_fd)
-    TegraIface._ctrl_fd, TegraIface._nvmap_fd, TegraIface._chars = -1, -1, None
+    TegraIface._ctrl_fd, TegraIface._nvmap_fd, TegraIface._gpu_info = -1, -1, None

--- a/tinygrad/runtime/support/nv/tegradev.py
+++ b/tinygrad/runtime/support/nv/tegradev.py
@@ -8,42 +8,14 @@ from tinygrad.helpers import round_up, to_mv
 def _ct(fields):
   return type("_s", (ctypes.Structure,), {"_fields_": fields})
 
+# struct nvgpu_gpu_characteristics (include/uapi/linux/nvgpu-ctrl.h), truncated to fields used by tinygrad
 _nvgpu_gpu_characteristics = _ct([
-  ("arch", ctypes.c_uint32), ("impl", ctypes.c_uint32), ("rev", ctypes.c_uint32), ("num_gpc", ctypes.c_uint32),
-  ("numa_domain_id", ctypes.c_int32), ("_pad0", ctypes.c_uint32),
-  ("L2_cache_size", ctypes.c_uint64), ("on_board_video_memory_size", ctypes.c_uint64),
-  ("num_tpc_per_gpc", ctypes.c_uint32), ("bus_type", ctypes.c_uint32), ("big_page_size", ctypes.c_uint32),
-  ("compression_page_size", ctypes.c_uint32), ("pde_coverage_bit_count", ctypes.c_uint32), ("available_big_page_sizes", ctypes.c_uint32),
-  ("flags", ctypes.c_uint64),
-  ("twod_class", ctypes.c_uint32), ("threed_class", ctypes.c_uint32), ("compute_class", ctypes.c_uint32),
-  ("gpfifo_class", ctypes.c_uint32), ("inline_to_memory_class", ctypes.c_uint32), ("dma_copy_class", ctypes.c_uint32),
-  ("gpc_mask", ctypes.c_uint32), ("sm_arch_sm_version", ctypes.c_uint32), ("sm_arch_spa_version", ctypes.c_uint32),
-  ("sm_arch_warp_count", ctypes.c_uint32),
-  ("gpu_ioctl_nr_last", ctypes.c_int16), ("tsg_ioctl_nr_last", ctypes.c_int16), ("dbg_gpu_ioctl_nr_last", ctypes.c_int16),
-  ("ioctl_channel_nr_last", ctypes.c_int16), ("as_ioctl_nr_last", ctypes.c_int16),
-  ("gpu_va_bit_count", ctypes.c_uint8), ("reserved", ctypes.c_uint8),
-  ("max_fbps_count", ctypes.c_uint32), ("fbp_en_mask", ctypes.c_uint32), ("emc_en_mask", ctypes.c_uint32),
-  ("max_ltc_per_fbp", ctypes.c_uint32), ("max_lts_per_ltc", ctypes.c_uint32), ("max_tex_per_tpc", ctypes.c_uint32),
-  ("max_gpc_count", ctypes.c_uint32), ("rop_l2_en_mask_DEPRECATED", ctypes.c_uint32 * 2), ("chipname", ctypes.c_uint8 * 8),
-  ("gr_compbit_store_base_hw", ctypes.c_uint64),
-  ("gr_gobs_per_comptagline_per_slice", ctypes.c_uint32), ("num_ltc", ctypes.c_uint32),
-  ("lts_per_ltc", ctypes.c_uint32), ("cbc_cache_line_size", ctypes.c_uint32),
-  ("cbc_comptags_per_line", ctypes.c_uint32), ("map_buffer_batch_limit", ctypes.c_uint32), ("max_freq", ctypes.c_uint64),
-  ("graphics_preemption_mode_flags", ctypes.c_uint32), ("compute_preemption_mode_flags", ctypes.c_uint32),
-  ("default_graphics_preempt_mode", ctypes.c_uint32), ("default_compute_preempt_mode", ctypes.c_uint32),
-  ("local_video_memory_size", ctypes.c_uint64),
-  ("pci_vendor_id", ctypes.c_uint16), ("pci_device_id", ctypes.c_uint16), ("pci_subsystem_vendor_id", ctypes.c_uint16),
-  ("pci_subsystem_device_id", ctypes.c_uint16), ("pci_class", ctypes.c_uint16), ("pci_revision", ctypes.c_uint8),
-  ("vbios_oem_version", ctypes.c_uint8), ("vbios_version", ctypes.c_uint32),
-  ("reg_ops_limit", ctypes.c_uint32), ("reserved1", ctypes.c_uint32),
-  ("event_ioctl_nr_last", ctypes.c_int16), ("pad", ctypes.c_uint16), ("max_css_buffer_size", ctypes.c_uint32),
-  ("ctxsw_ioctl_nr_last", ctypes.c_int16), ("prof_ioctl_nr_last", ctypes.c_int16),
-  ("nvs_ioctl_nr_last", ctypes.c_int16), ("reserved2", ctypes.c_uint8 * 2),
-  ("max_ctxsw_ring_buffer_size", ctypes.c_uint32), ("reserved3", ctypes.c_uint32), ("per_device_identifier", ctypes.c_uint64),
-  ("num_ppc_per_gpc", ctypes.c_uint32), ("max_veid_count_per_tsg", ctypes.c_uint32),
-  ("num_sub_partition_per_fbpa", ctypes.c_uint32), ("gpu_instance_id", ctypes.c_uint32),
-  ("gr_instance_id", ctypes.c_uint32), ("max_gpfifo_entries", ctypes.c_uint32),
-  ("max_dbg_tsg_timeslice", ctypes.c_uint32), ("reserved5", ctypes.c_uint32), ("device_instance_id", ctypes.c_uint64)])
+  ("_pad0", ctypes.c_uint8 * 12), ("num_gpc", ctypes.c_uint32),
+  ("_pad1", ctypes.c_uint8 * 24), ("num_tpc_per_gpc", ctypes.c_uint32),
+  ("_pad2", ctypes.c_uint8 * 36),
+  ("compute_class", ctypes.c_uint32), ("gpfifo_class", ctypes.c_uint32), ("_pad3", ctypes.c_uint32),
+  ("dma_copy_class", ctypes.c_uint32), ("_pad4", ctypes.c_uint32),
+  ("sm_arch_sm_version", ctypes.c_uint32), ("_pad5", ctypes.c_uint32), ("sm_arch_warp_count", ctypes.c_uint32)])
 _nvgpu_gpu_get_characteristics = _ct([("buf_size", ctypes.c_uint64), ("buf_addr", ctypes.c_uint64)])
 _nvmap_handle = _ct([("size", ctypes.c_uint32), ("handle", ctypes.c_uint32)])
 _nvmap_alloc = _ct([("handle", ctypes.c_uint32), ("heap_mask", ctypes.c_uint32), ("flags", ctypes.c_uint32),


### PR DESCRIPTION
# TL;DR

- The AGX Orin SoC uses different drivers (nvgpu.ko and nvmap.ko) so I mapped the RM object model to these two SoC drivers to get NV=1 working
- I gave a talk at Planet Nix on using [jetpack-nixos](https://github.com/anduril/jetpack-nixos) and tinygrad NV=1 to run small models that are overhead bound on the Jetson AGX Orin Dev Kit (The neural network in this paper is an example: [Learned Inertial Odometry for Autonomous Drone Racing](https://arxiv.org/pdf/2210.15287))

> [Presentation slides](https://docs.google.com/presentation/d/19xHB1MYYi9ymqYTc1L_TDDKvYxkP46PQeEPb4mX5QQA/edit?usp=sharing)
> [Planet Nix Speaker list (Spencer Willett)](https://planetnix.com/speakers)

- I can bring the AGX Orin dev kit for testing/verification to San Diego if needed (I live in the area) or you can SSH into the device for testing
- This PR description is handwritten by myself (minus the tables below). Code is written mostly by Opus/Sonnet 4.6. This code was not one-shotted. I have manually read/audited/ and refactored the code line by line multiple times. I have used it for running CNN's, TCN's, LLM's, etc. 

AI notes generated below (with slight edits from me)

---

## Changes

| File | Lines | What |
|------|-------|------|
| `tinygrad/runtime/support/nv/tegradev.py` | +236 (new) | `TegraIface` — nvgpu/nvmap ioctl adapter |
| `tinygrad/runtime/autogen/tegra_36.py` | +1798 (new, autogen) | Autogenerated ioctl structs from L4T r36 UAPI headers via libclang |
| `extra/tegra_gpu_driver/` | +4333 (8 files, new) | L4T r36 UAPI headers (matches `extra/hip_gpu_driver/` pattern) |
| `tinygrad/runtime/ops_nv.py` | +17 / −8 | `is_tegra()`, `_tegra_signal`, 40-bit VA windows, 64KB gpfifo |
| `tinygrad/runtime/autogen/__init__.py` | +5 | Autogen recipe pointing to local `extra/tegra_gpu_driver/` headers |
| `.github/workflows/autogen.yml` | +1 / −1 | Add `tegra_36` to CI autogen regeneration |

Desktop and MOCKGPU untouched — `is_tegra()` is `False` on non-Tegra, `TegraIface` never instantiates.

## Test Results

**Jetson Orin AGX 64GB** — L4T r36.4.4, CUDA 12.6, Python 3.12, `NV=1`. Baseline: `upstream/master` at `713b322e7` with `CUDA=1`.

| Suite | NV=1 | CUDA=1 baseline | Match? |
|-------|------|-----------------|--------|
| test_ops | 410 pass, 7 skip | 410 pass, 7 skip | **Yes** |
| test_schedule | 147 pass, 12 skip | 147 pass, 12 skip | **Yes** |
| test_assign | 82 pass, 9 skip | 82 pass, 9 skip | **Yes** |
| test_tensor | 64 pass, 4 skip | 64 pass, 4 skip | **Yes** |
| test_jit | 41 pass, 9 skip | 45 pass, 9 skip | **Yes**\* |
| test_hcq | 19 pass, 7 skip | — | **N/A**\*\* |
| test_tiny, test_pattern_matcher, test_schedule_cache, test_helpers | all pass | all pass | **Yes** |

\* 4 cross-device CPU↔NV tests excluded — no UVM on Tegra (all 4 pass on CUDA=1).
\*\* HCQ is NV-only; 3 tests excluded (2 speed thresholds + 1 cross-device copy).

**7 known failures, none introduced by this PR.** 5 are cross-device CPU↔NV copies (Tegra has no UVM — needs upstream HCQ split-VA support). 2 are speed thresholds calibrated for discrete GPUs. [Full root-cause analysis here.](https://github.com/GiveThanksAlways/agx-orin-dev-kit/blob/tinyGrad-PR/docs/code-audit/03-PR-extra-notes.md)

## Code Quality

Ruff pass, Mypy pass (0 errors), Pylint pass, [sz.py](vscode-file://vscode-app/c:/Users/spencer.willett/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/bc8f9ef3d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) +200 token-lines (tegradev.py = 193; tegra_36.py excluded as autogen; headers excluded as vendored).

## Detailed Code Audit

- [Overview — how Tegra works in tinygrad](https://github.com/GiveThanksAlways/agx-orin-dev-kit/blob/tinyGrad-PR/docs/code-audit/01-overview.md)
- [Full line-by-line audit of every changed file](https://github.com/GiveThanksAlways/agx-orin-dev-kit/blob/tinyGrad-PR/docs/code-audit/02-full-audit-line-by-line.md)
- [Extended notes — test methodology, linting, known failures](https://github.com/GiveThanksAlways/agx-orin-dev-kit/blob/tinyGrad-PR/docs/code-audit/03-PR-extra-notes.md)
- [TL;DR summary](https://github.com/GiveThanksAlways/agx-orin-dev-kit/blob/tinyGrad-PR/docs/code-audit/04-tldr.md)