### PR TITLE
nv: set lower interleave level to reduce GPU hogging (Fixes #10773) (ai slop)

### DIFF
--- a/test/mockgpu/nv/nvdriver.py
+++ b/test/mockgpu/nv/nvdriver.py
@@ -197,7 +197,8 @@ class NVDriver(VirtDriver):
       params = nv_gpu.NVC36F_CTRL_CMD_GPFIFO_GET_WORK_SUBMIT_TOKEN_PARAMS.from_address(params_ptr)
       gpu_fifo = self.object_by_handle[struct.hObject]
       params.workSubmitToken = gpu_fifo.token
-    elif struct.cmd in (nv_gpu.NVA06C_CTRL_CMD_GPFIFO_SCHEDULE, nv_gpu.NVA06F_CTRL_CMD_BIND, nv_gpu.NVA06F_CTRL_CMD_GPFIFO_SCHEDULE): pass
+    elif struct.cmd in (nv_gpu.NVA06C_CTRL_CMD_GPFIFO_SCHEDULE, nv_gpu.NVA06F_CTRL_CMD_BIND, nv_gpu.NVA06F_CTRL_CMD_GPFIFO_SCHEDULE,
+                        nv_gpu.NVA06C_CTRL_CMD_SET_INTERLEAVE_LEVEL): pass
     elif struct.cmd == nv_gpu.NV2080_CTRL_CMD_PERF_BOOST: pass
     elif struct.cmd == nv_gpu.NV2080_CTRL_CMD_FB_FLUSH_GPU_CACHE: pass
     elif struct.cmd == nv_gpu.NV83DE_CTRL_CMD_DEBUG_READ_ALL_SM_ERROR_STATES:

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -606,6 +606,8 @@ class NVDevice(HCQCompiled[NVSignal]):
     self.compute_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0, entries=0x10000, compute=True)
     self.dma_gpfifo = self._new_gpu_fifo(self.gpfifo_area, ctxshare, self.channel_group, offset=0x100000, entries=0x10000, compute=False)
     self.iface.rm_control(self.channel_group, nv_gpu.NVA06C_CTRL_CMD_GPFIFO_SCHEDULE, nv_gpu.NVA06C_CTRL_GPFIFO_SCHEDULE_PARAMS(bEnable=1))
+    self.iface.rm_control(self.channel_group, nv_gpu.NVA06C_CTRL_CMD_SET_INTERLEAVE_LEVEL,
+      nv_gpu.NVA06C_CTRL_SET_INTERLEAVE_LEVEL_PARAMS(tsgInterleaveLevel=getenv("NV_INTERLEAVE", 0)))
 
     self.cmdq_page:HCQBuffer = self.iface.alloc(0x200000, cpu_access=True)
     self.cmdq_allocator = BumpAllocator(size=self.cmdq_page.size, base=int(self.cmdq_page.va_addr), wrap=True)


### PR DESCRIPTION
Fixes #10773. The NV backend makes desktop systems unusable (cursor lag, video drops) because the channel group runs at the default HIGH interleave level, monopolizing the GPU and starving the display compositor.

Sets tsgInterleaveLevel to LOW (0) by default so the GPU scheduler can preempt compute work for display refresh. Dedicated compute machines can restore full priority with NV_INTERLEAVE=2.

Uses the same rm_control pattern as the adjacent GPFIFO_SCHEDULE call. Constants verified present in both nv_570.py and nv_580.py autogen.