### PR TITLE
propagate NaN through float max rewrites

### DIFF
--- a/test/backend/test_edgecases.py
+++ b/test/backend/test_edgecases.py
@@ -35,12 +35,21 @@ MOCKGPU = DEV.interface.startswith("MOCK")
 class TestNaNEdgeCases(unittest.TestCase):
   # we don't need more of these. it's unclear if torch's behavior is desired here
 
-  @unittest.expectedFailure
   def test_max_nan(self):
     # Reductions with NaN should propagate NaN like PyTorch.
     arr = [1.0, float('nan'), 3.0]
     torch_out = torch.tensor(arr).max().item()
     out = Tensor(arr).max().numpy()
+    if np.isnan(torch_out):
+      self.assertTrue(np.isnan(out))
+    else:
+      np.testing.assert_equal(out, torch_out)
+
+  def test_min_nan(self):
+    # Reductions with NaN should propagate NaN like PyTorch.
+    arr = [1.0, float('nan'), 3.0]
+    torch_out = torch.tensor(arr).min().item()
+    out = Tensor(arr).min().numpy()
     if np.isnan(torch_out):
       self.assertTrue(np.isnan(out))
     else:

--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -489,6 +489,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(), ()], torch.maximum, Tensor.maximum)
     helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[1., 0., 3., -4.], 3.])
     helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[1., 0., 3., -4.], [-1., -2., 3., 0.]])
+    helper_test_op(None, torch.maximum, Tensor.maximum, vals=[[1., float("nan"), -4.], [float("nan"), 2., 0.]])
     helper_test_op(None, torch.maximum, Tensor.maximum,
                    vals=[[-1234, 0, 1234, dtypes.int.max, dtypes.int.min], dtypes.int.max], forward_only=True)
     helper_test_op(None, torch.maximum, Tensor.maximum,
@@ -506,6 +507,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(), ()], torch.minimum, Tensor.minimum)
     helper_test_op(None, torch.minimum, Tensor.minimum, vals=[[1., 0., 3., -4.], 3.])
     helper_test_op(None, torch.minimum, Tensor.minimum, vals=[[1., 0., 3., -4.], [-1., -2., 3., 0.]])
+    helper_test_op(None, torch.minimum, Tensor.minimum, vals=[[1., float("nan"), -4.], [float("nan"), 2., 0.]])
     helper_test_op(None, torch.minimum, Tensor.minimum,
                    vals=[[-1234, 0, 1234, dtypes.int.max, dtypes.int.min], dtypes.int.max], forward_only=True)
     helper_test_op(None, torch.minimum, Tensor.minimum,

--- a/test/unit/test_nan_reductions.py
+++ b/test/unit/test_nan_reductions.py
@@ -1,0 +1,26 @@
+import unittest
+
+import numpy as np
+
+from tinygrad import Tensor
+
+
+class TestNaNReductions(unittest.TestCase):
+  def test_max_propagates_nan(self):
+    out = Tensor([1.0, float("nan"), 3.0]).max().numpy()
+    self.assertTrue(np.isnan(out))
+
+  def test_min_propagates_nan(self):
+    out = Tensor([1.0, float("nan"), 3.0]).min().numpy()
+    self.assertTrue(np.isnan(out))
+
+  def test_max_axis_propagates_nan(self):
+    out = Tensor([[float("nan"), 2.0], [1.0, 3.0]]).max(axis=0).numpy()
+    np.testing.assert_equal(np.isnan(out), np.array([True, False]))
+    np.testing.assert_allclose(out[1:], np.array([3.0]))
+
+  def test_elementwise_maximum_propagates_nan(self):
+    out = Tensor([1.0, float("nan")]).maximum(Tensor([float("nan"), 2.0])).numpy()
+    self.assertTrue(np.isnan(out[0]))
+    self.assertTrue(np.isnan(out[1]))
+

--- a/tinygrad/uop/decompositions.py
+++ b/tinygrad/uop/decompositions.py
@@ -444,8 +444,16 @@ def get_late_rewrite_patterns(ops:tuple[Ops, ...], disable_fast_idiv:bool) -> Pa
   pat: list[tuple[UPat, Callable]] = []
   # no real hardware supports THREEFRY, but NullRenderer does
   if Ops.THREEFRY not in ops: pat.append((UPat(Ops.THREEFRY, dtype=dtypes.uint64, src=(UPat.var("x"), UPat.var("key"))), threefry2x32))
-  # MAX can be rewritten as CMPLT + WHERE (max function is annoying on many cstyle backends)
-  if Ops.MAX not in ops and Ops.CMPLT in ops: pat.append((UPat(Ops.MAX, name="m"), lambda m: (m.src[0] < m.src[1]).where(m.src[1], m.src[0])))
+  # MAX can be rewritten as CMPLT + WHERE (max function is annoying on many cstyle backends).
+  # For floats we *always* rewrite to a NaN-propagating form: bare CMPLT (and IEEE fmax / PTX max.f*)
+  # are NaN-suppressing, so reductions like Tensor([1, nan]).max() would silently drop the NaN.
+  def _max_to_cmplt(m: UOp) -> UOp:
+    a, b = m.src
+    base = (a < b).where(b, a)
+    if dtypes.is_float(m.dtype): return a.ne(a).where(a, b.ne(b).where(b, base))
+    return base
+  if Ops.CMPLT in ops and Ops.CMPNE in ops: pat.append((UPat(Ops.MAX, dtype=dtypes.floats, name="m"), _max_to_cmplt))
+  if Ops.MAX not in ops and Ops.CMPLT in ops: pat.append((UPat(Ops.MAX, name="m"), _max_to_cmplt))
   # rewrite MOD to AND (which should always be supported, but not for generic in tests): x % (2**y) -> x & (2**y-1)
   if Ops.AND in ops: pat += [(UPat.var("x", dtypes.ints)%UPat.cvar("c"), lambda x,c: x & (c.arg-1) if c.arg in powers_of_two else None)]
   if Ops.OR in ops: pat += [(UPat.var("x", dtypes.bool).logical_not()&UPat.var("y", dtypes.bool).logical_not(),


### PR DESCRIPTION
## Summary

Fix float `MAX` late rewrites so `NaN` values are propagated instead of being silently dropped on backends that lower `MAX` through compare/select logic.

Closes https://github.com/tinygrad/tinygrad/issues/862

## Problem

`Tensor([1.0, nan]).max()` returned `1.0` instead of `nan`.

The issue came from the late `Ops.MAX` rewrite in `tinygrad/uop/decompositions.py`. For many backends, float `MAX` was lowered to:

```python
(a < b).where(b, a)
```

That behaves like a NaN-suppressing max because comparisons against `NaN` are false, so whichever side is checked in the fallback path wins instead of propagating `NaN`.

This also affected:

- `Tensor.min(...)`, because `min` is implemented through inverse/max/inverse
- elementwise `Tensor.maximum(...)` / `Tensor.minimum(...)`
- axis reductions that pass through the same float `MAX` rewrite

## Fix

For float `Ops.MAX`, rewrite to a NaN-aware select:

- if `a` is `NaN`, return `a`
- else if `b` is `NaN`, return `b`
- else use the existing compare/select max

This keeps the old lowering for non-float dtypes and avoids adding extra boolean ops beyond `CMPNE`.

## Tests

Added regression coverage for:

- scalar `max` with `NaN`
- scalar `min` with `NaN`
- axis `max` with `NaN`
- elementwise `maximum` with `NaN`
- backend op parity tests for `maximum` / `minimum` with `NaN`

## Validation

Ran locally:

```bash
python -m pytest test/unit/test_nan_reductions.py -q
```

Also verified direct runtime repros for:

- `Tensor([1.0, nan, 3.0]).max() -> nan`
- `Tensor([1.0, nan, 3.0]).min() -> nan`
- `Tensor([[nan, 2.0], [1.0, 3.0]]).max(axis=0) -> [nan, 3.0]`
- `Tensor([1.0, nan]).maximum(Tensor([nan, 2.0])) -> [nan, nan]`

I did not run the torch-backed backend suite locally because `torch` is not installed in this environment.
