### PR TITLE
add Ops.SCAN for cumsum/cumprod and Tensor.associative_scan

### DIFF
--- a/test/null/test_tensor_uop_mixin.py
+++ b/test/null/test_tensor_uop_mixin.py
@@ -59,7 +59,7 @@ class TestTensorUOpCumalu(unittest.TestCase):
   def test_cumsum_1d(self):       _check(self, _t(5), lambda x: x.cumsum())
   def test_cumsum_2d(self):       _check(self, _t(3, 4), lambda x: x.cumsum(1))
   def test_cumsum_non_last(self): _check(self, _t(3, 4), lambda x: x.cumsum(0))
-  def test_cumsum_large(self):    _check(self, _t(600), lambda x: x.cumsum())  # exercises _split_cumalu
+  def test_cumsum_large(self):    _check(self, _t(600), lambda x: x.cumsum())
   def test_cumprod(self):         _check(self, _t(4), lambda x: x.cumprod(0))
 
 class TestTensorUOpCat(unittest.TestCase):

--- a/test/unit/test_gradient.py
+++ b/test/unit/test_gradient.py
@@ -76,6 +76,11 @@ class TestTensorGradient(unittest.TestCase):
     x = Tensor.randn(4, 4)
     np.testing.assert_allclose(x.pad(((1,0),(0,0))).gradient(x, gradient=g2)[0].numpy(), np.zeros((4, 4)))
 
+  def test_cumsum_backward(self):
+    x = Tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
+    x.cumsum(0).sum().backward()
+    np.testing.assert_allclose(x.grad.numpy(), [4.0, 3.0, 2.0, 1.0])
+
 class TestViewGradient(unittest.TestCase):
   def test_expand(self):
     x = Tensor.randn(5,2)

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -58,7 +58,8 @@ def full_rewrite_to_sink(sink:UOp, ren:Renderer|None=None, optimize:bool=True, b
 
   # ** devectorizer (full_graph_rewrite) **
   # remove reduce
-  sink = graph_rewrite(sink, pm_reduce+gep_pushing, ctx=ReduceContext(), name="remove_reduce")
+  scan_ranges = tuple(sorted({x.src[1] for x in sink.toposort() if x.op is Ops.SCAN and x.src[1].op is Ops.RANGE}, key=lambda r: r.arg))
+  sink = graph_rewrite(sink, pm_reduce+gep_pushing, ctx=ReduceContext(scan_ranges=scan_ranges), name="remove_reduce")
 
   # add gpu dims (late). this works after devectorize, but it's faster here
   sink = graph_rewrite(sink, pm_add_gpudims, ctx=ren, name="add gpudims")

--- a/tinygrad/codegen/gpudims.py
+++ b/tinygrad/codegen/gpudims.py
@@ -100,7 +100,7 @@ def add_gpudims(ctx:Renderer, s:UOp):
     if r.op is not Ops.RANGE: continue
     try:
       ii = (global_dims+local_dims).index(r.arg[0:-1])
-      if r.arg[1] == AxisType.REDUCE: continue
+      if r.arg[1] in (AxisType.REDUCE, AxisType.SCAN): continue
       subs[r] = idxs[ii]
     except ValueError: continue
   return s.substitute(subs)

--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -3,7 +3,7 @@ import functools, itertools
 from collections import defaultdict
 from dataclasses import dataclass
 from tinygrad.dtype import dtypes, ImageDType, DType, AddrSpace, Invalid, PtrDType
-from tinygrad.uop.ops import UOp, Ops, UPat, PatternMatcher, GroupOp, identity_element
+from tinygrad.uop.ops import UOp, Ops, UPat, PatternMatcher, GroupOp, identity_element, AxisType
 from tinygrad.uop.symbolic import uop_given_valid, parse_valid, invalid_gate
 from tinygrad.helpers import getenv, flatten, AMX, prod
 from tinygrad.renderer import Renderer
@@ -299,6 +299,7 @@ pm_render = PatternMatcher([
 @dataclass
 class ReduceContext:
   acc_num: int = 0
+  scan_ranges: tuple[UOp, ...] = tuple()
 
 def horizontal_reduce(inp:UOp, out_dtype:DType) -> list[UOp]:
   # if this has a horizontal reduction component, do that first
@@ -345,11 +346,33 @@ def merge_reduce_ends(ctx:ReduceContext, sink:UOp):
       mapped = [e.substitute(dict(zip(r, tr))) if i > 0 else e for e in group]
       merged = mapped[0] if len(mapped) == 1 else UOp.group(*(e.src[0] for e in mapped)).end(*tr)
       for e in group: subs[e] = merged
-  return sink.substitute(subs) if subs else None
+  ret = sink.substitute(subs) if subs else sink
+  closed_scan_ranges = {r for u in ret.backward_slice if u.op is Ops.END for r in u.src[1:] if r.op is Ops.RANGE and r.arg[-1] is AxisType.SCAN}
+  open_scan_ranges = [r for r in ret.ranges if r.arg[-1] is AxisType.SCAN and r not in closed_scan_ranges]
+  if not open_scan_ranges: return ret if ret is not sink else None
+  body = ret.src[0] if len(ret.src) == 1 else UOp.group(*ret.src)
+  for r in sorted(open_scan_ranges, key=lambda x: x.arg, reverse=True): body = body.end(r)
+  return ret.replace(src=(body,))
+
+def scan_to_acc(ctx:ReduceContext, scan:UOp):
+  inp, scan_range = scan.src[0], scan.src[1]
+  identity = scan.const(scan.dtype, identity_element(scan.arg, scan.dtype.scalar()))
+  topo = inp.toposort()
+  ended_ranges = flatten([x.ended_ranges for x in topo if x.op is Ops.END])
+  input_ranges = tuple(dict.fromkeys([x for x in topo if x.op is Ops.RANGE and x is not scan_range and x not in ended_ranges] +
+                                     [r for r in ctx.scan_ranges if r.arg[0] < scan_range.arg[0]]))
+  acc = UOp.placeholder((1,), scan.dtype, ctx.acc_num, AddrSpace.REG)
+  acc_init = acc.after(*input_ranges).index(UOp.const(dtypes.int, 0)).store(identity)
+  acc_load = acc.after(acc_init, scan_range).index(UOp.const(dtypes.int, 0))
+  ctx.acc_num += 1
+  ret = acc_load.alu(scan.arg, inp)
+  acc_store = acc.index(UOp.const(dtypes.int, 0)).store(ret)
+  return acc.after(acc_store).index(UOp.const(dtypes.int, 0))
 
 pm_reduce = PatternMatcher([
   # REDUCE -> DEFINE_ACC+ASSIGN, then merge ENDs with same range
   (UPat(Ops.REDUCE, name="red"), reduce_to_acc),
+  (UPat(Ops.SCAN, name="scan"), scan_to_acc),
   (UPat(Ops.SINK, name="sink"), merge_reduce_ends),
   # tensor core built in accumulate
   (UPat(Ops.WMMA, name="wmma") + UPat.var("add"),

--- a/tinygrad/codegen/opt/postrange.py
+++ b/tinygrad/codegen/opt/postrange.py
@@ -72,6 +72,11 @@ class Scheduler:
     return ret
 
   def convert_loop_to_global(self) -> None:
+    scan_ranges = {x.src[1] for x in self.ast.toposort() if x.op is Ops.SCAN and x.src[1].op is Ops.RANGE}
+    if scan_ranges:
+      scan_subs = {r: r.replace(arg=r.arg[0:-1]+(AxisType.SCAN,)) for r in scan_ranges if r.arg[-1] == AxisType.LOOP}
+      if scan_subs: self.ast = self.ast.substitute(scan_subs)
+
     if not self.ren.has_local: return
 
     globalizible_rngs = self._globalizable_rngs()
@@ -107,8 +112,10 @@ class Scheduler:
 
   # copied from kernel.py
   @property
-  def upcastable_dims(self) -> list[int]: return [i for i in self.axes_of(AxisType.GLOBAL, AxisType.LOCAL, AxisType.LOOP) \
-                                                  if isinstance(s:=self.full_shape[i], int) and s > 1]
+  def upcastable_dims(self) -> list[int]:
+    if any(x.arg[-1] is AxisType.SCAN for x in self.rngs): return []
+    return [i for i in self.axes_of(AxisType.GLOBAL, AxisType.LOCAL, AxisType.LOOP) \
+            if isinstance(s:=self.full_shape[i], int) and s > 1]
   @property
   def unrollable_dims(self) -> list[int]: return [i for i in self.axes_of(AxisType.GROUP_REDUCE, AxisType.REDUCE) \
                                                   if isinstance(s:=self.full_shape[i], int) and s > 1]

--- a/tinygrad/gradient.py
+++ b/tinygrad/gradient.py
@@ -4,6 +4,14 @@ from tinygrad.uop.ops import UOp, PatternMatcher, UPat, Ops, all_metadata, graph
 from tinygrad.helpers import argsort
 from tinygrad.dtype import sum_acc_dtype
 
+def scan_gradient(ctx:UOp, ret:UOp):
+  op, axis, x = ret.arg[0], ret.arg[1], ret.src[0]
+  if op == Ops.ADD: return (ctx.flip(axis)._scanop(Ops.ADD, axis).flip(axis),)
+  if op == Ops.MUL:
+    safe_x = x.eq(0).where(x.const_like(1), x)
+    return ((ctx * ret).flip(axis)._scanop(Ops.ADD, axis).flip(axis) / safe_x,)
+  if op == Ops.MAX: return (None,)
+
 def reduce_gradient(ctx:UOp, ret:UOp, op:Ops):
   def broadcast_to_input(x): return x.reshape(x.shape+(1,)*(len(ret.src[0].shape)-len(x.shape))).expand(ret.src[0].shape)
   if op == Ops.ADD: return (broadcast_to_input(ctx),)
@@ -62,6 +70,7 @@ pm_gradient = PatternMatcher([
   (UPat(Ops.MUL, name="ret"), lambda ctx, ret: (ret.src[1]*ctx, ret.src[0]*ctx)),
   (UPat(Ops.WHERE, name="ret"), lambda ctx, ret: (None, ret.src[0].where(ctx, ctx.const_like(0)), ret.src[0].where(ctx.const_like(0), ctx))),
   (UPat(Ops.REDUCE_AXIS, name="ret"), lambda ctx, ret: reduce_gradient(ctx, ret, ret.arg[0])),
+  (UPat(Ops.SCAN_AXIS, name="ret"), lambda ctx, ret: scan_gradient(ctx, ret)),
   (UPat(Ops.CONTIGUOUS), lambda ctx: (ctx,)),
   (UPat(Ops.CONTIGUOUS_BACKWARD), lambda ctx: (ctx.contiguous(),)),
   (UPat(Ops.RESHAPE, name="ret"), lambda ctx, ret: (ctx.reshape(ret.src[0].shape), None)),

--- a/tinygrad/mixin/__init__.py
+++ b/tinygrad/mixin/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import functools, itertools
+import functools, itertools, math
 from typing import TYPE_CHECKING, Self, Sequence, Literal, get_args
 from tinygrad.mixin.elementwise import ElementwiseMixin
 from tinygrad.mixin.movement import MovementMixin
@@ -378,20 +378,6 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     pooled = self.transpose(axis,-1)._pad_constant(pads, identity_element(op, self.dtype))._pool((self.shape[axis],))
     return getattr(pooled, {Ops.ADD: "sum", Ops.MAX: "max", Ops.MUL: "prod"}[op])(-1).transpose(axis, -1)
 
-  def _split_cumalu(self, axis:int, op:Ops) -> Self:
-    axis = self._resolve_dim(axis)
-    if self.ndim == 0 or 0 in self.shape: return self
-    # TODO: someday the optimizer will find this on its own
-    # for now this is a two stage cumsum
-    SPLIT = 256
-    value = identity_element(op, self.dtype)
-    if not isinstance(s:=self.shape[axis], int) or s <= SPLIT*2: return self._cumalu(axis, op)
-    ret = self.transpose(axis,-1)._pad_constant((None,)*(self.ndim-1)+((round_up(s,SPLIT)-s,0),), value).unflatten(-1,(-1,SPLIT))._cumalu(-1, op)
-    base = ret[..., -1]._cumalu(-1, op)._pad_constant((None,)*(ret.ndim-2) + ((1, -1),), value)
-    base = base.unsqueeze(-1).expand(*base.shape, ret.shape[-1])
-    def fix(x: Self) -> Self: return x.flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
-    return getattr(fix(ret), {Ops.ADD: "add", Ops.MAX: "maximum", Ops.MUL: "mul"}[op])(fix(base))
-
   def cumsum(self, axis:int=0) -> Self:
     """
     Computes the cumulative sum of the tensor along the specified `axis`.
@@ -404,7 +390,8 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     print(t.cumsum(1).numpy())
     ```
     """
-    return self._split_cumalu(axis, Ops.ADD)
+    ret = self.cast(sum_acc_dtype(self.dtype))._scan(axis, Ops.ADD)
+    return ret.cast(self.dtype) if self.dtype in (dtypes.float16, dtypes.bfloat16, *dtypes.fp8s) else ret
 
   def cumprod(self, axis:int) -> Self:
     """
@@ -418,7 +405,48 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     print(t.cumprod(axis=0).numpy())
     ```
     """
-    return self._split_cumalu(axis, Ops.MUL)
+    return self._scan(axis, Ops.MUL)
+
+  def _scan(self, axis:int, op:Ops, TILE=1024) -> Self:
+    axis = self._resolve_dim(axis)
+    if self.ndim == 0 or 0 in self.shape: return self
+    n = self.shape[axis]
+    assert n != 0 and op in (Ops.ADD, Ops.MAX, Ops.MUL)
+    if not isinstance(n, int) or n <= TILE: return self._scanop(op, (axis,))
+    # two-level parallel scan: tile along scan axis, scan each tile, propagate tile totals
+    combine = {Ops.ADD: "add", Ops.MAX: "maximum", Ops.MUL: "mul"}[op]
+    pad_to = round_up(n, TILE)
+    x = self.transpose(axis, -1)
+    if pad_to != n: x = x._pad_constant((None,)*(self.ndim-1)+((0, pad_to-n),), identity_element(op, self.dtype))
+    x = x.unflatten(-1, (-1, TILE))
+    tiled = x._scanop(op, (x.ndim-1,))                                         # scan within each tile
+    totals = tiled[..., -1]._scanop(op, (tiled.ndim-2,))                       # scan tile totals
+    prefix = totals._pad_constant((None,)*(tiled.ndim-2)+((1,-1),), identity_element(op, self.dtype))
+    result = getattr(tiled, combine)(prefix.unsqueeze(-1).expand(tiled.shape))  # add prefix to each tile
+    return result.flatten(start_dim=-2)[..., :n].transpose(axis, -1)
+
+  def associative_scan(self, fn, axis:int=0, reverse:bool=False) -> Self:
+    """
+    Inclusive scan along `axis` with an associative binary function `fn`.
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor([1, 2, 3, 4, 5])
+    print(t.associative_scan(lambda a, b: a + b).numpy())
+    ```
+    ```python exec="true" source="above" session="tensor" result="python"
+    print(t.associative_scan(lambda a, b: a * b).numpy())
+    ```
+    """
+    axis = self._resolve_dim(axis)
+    n = self.shape[axis]
+    if n <= 1: return self
+    x = self.flip(axis) if reverse else self
+    for d in range(math.ceil(math.log2(n))):
+      stride = 1 << d
+      left = x.shrink(tuple((0, s - stride) if i == axis else None for i, s in enumerate(x.shape)))
+      right = x.shrink(tuple((stride, s) if i == axis else None for i, s in enumerate(x.shape)))
+      x = x.shrink(tuple((0, stride) if i == axis else None for i, s in enumerate(x.shape))).cat(fn(left, right), dim=axis).contiguous()
+    return x.flip(axis) if reverse else x
 
   # ***** functional nn ops *****
 

--- a/tinygrad/schedule/indexing.py
+++ b/tinygrad/schedule/indexing.py
@@ -27,7 +27,7 @@ def realize_store_after_src(ctx:dict[UOp, None], dest:UOp, src:UOp):
 
 pm_generate_realize_map = PatternMatcher([
   # always realize
-  (UPat({Ops.COPY, Ops.CONTIGUOUS, Ops.STORE}, name="tr"), realize),
+  (UPat({Ops.COPY, Ops.CONTIGUOUS, Ops.STORE, Ops.SCAN_AXIS}, name="tr"), realize),
   # realize srcs of these
   (UPat((Ops.COPY, Ops.MSELECT, Ops.MSTACK), name="rb"), realize_srcs),
   # sometimes we need to realize the src of STORE if there's a self-access
@@ -94,12 +94,22 @@ def convert_reduce_axis_to_reduce_with_ranges(ctx:IndexingContext, x:UOp):
   ctx.range_map[ret] = ctx.range_map[x]
   return ret
 
+def convert_scan_axis_to_scan_with_ranges(ctx:IndexingContext, x:UOp):
+  assert len(x.arg[1]) == 1, "SCAN only supports single axis"
+  scan_range = [r for r in ctx.range_map[x][0][x.arg[1][0]].ranges if r.op is Ops.RANGE]
+  assert len(scan_range) == 1, f"SCAN axis must have a live range"
+  ret = UOp(Ops.SCAN, x.dtype, src=(x.src[0], scan_range[0]), arg=x.arg[0])
+  ctx.range_map[ret] = ctx.range_map[x]
+  return ret
+
 def remove_movement_op_after_rangeify(ctx:IndexingContext, x:UOp):
   if x in ctx.range_map or x.src[0].op is Ops.INDEX: return x.src[0]
 
 pm_apply_rangeify = PatternMatcher([
   # REDUCE_AXIS -> REDUCE
   (UPat(Ops.REDUCE_AXIS, name="x"), convert_reduce_axis_to_reduce_with_ranges),
+  # SCAN_AXIS -> SCAN
+  (UPat(Ops.SCAN_AXIS, name="x"), convert_scan_axis_to_scan_with_ranges),
   # PAD -> WHERE
   (UPat(Ops.PAD, name="x"), convert_pad_to_where_to_keep_behavior_local),
   # finally, apply_rangeify
@@ -225,7 +235,7 @@ def run_rangeify(tsink:UOp, debug:bool=False) -> tuple[UOp, IndexingContext]:
       if len(_realize_axis): rctx.realize_map[x] = _realize_axis
 
     # if this element is a reduce and there's ended ranges, we might have to end some other ranges
-    if len(ending_ranges[x]) and x.op in GroupOp.Elementwise.union({Ops.REDUCE_AXIS}):
+    if len(ending_ranges[x]) and x.op in GroupOp.Elementwise.union({Ops.REDUCE_AXIS, Ops.SCAN_AXIS}):
       _realize_axis = rctx.realize_map.get(x) or []
       for i,r in enumerate(out_rngs):
         if i in _realize_axis: continue

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -204,7 +204,7 @@ earliest_rewrites = mop_cleanup+PatternMatcher([
 # *****************
 # 3.5 cleanups
 
-ALWAYS_RUN_OPS = {Ops.CONTIGUOUS, Ops.COPY, Ops.NOOP}
+ALWAYS_RUN_OPS = {Ops.CONTIGUOUS, Ops.COPY, Ops.NOOP, Ops.SCAN}
 
 # you don't know in the first pass if axes are going to die, this happens if there's an EXPAND to the left
 def cleanup_dead_axes(b:UOp):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1032,6 +1032,7 @@ class Tensor(OpMixin):
 
   def _mop(self, op:Ops, arg) -> Tensor: return self._apply_uop(UOp._mop, extra_args=(op,), arg=arg)
   def _rop(self, op:Ops, axis:tuple[int, ...]) -> Tensor: return self._apply_uop(UOp._rop, op=op, axis=axis)
+  def _scanop(self, op:Ops, axis:tuple[int, ...]) -> Tensor: return self._apply_uop(UOp._scanop, op=op, axis=axis)
 
   def _pad_circular(self, pX:tuple[tuple[sint, sint], ...]) -> Tensor:
     if any(pB>sh or pA>sh for (pB,pA),sh in zip(pX, self.shape)): raise ValueError('Padding value causes wrapping around more than once.')
@@ -1723,8 +1724,8 @@ class Tensor(OpMixin):
     print(indices.numpy())
     ```
     """
-    if self.ndim == 0: return self._split_cumalu(axis, Ops.MAX), Tensor.zeros(self.shape, dtype=dtypes.int32, device=self.device)
-    values, n = self._split_cumalu(axis, Ops.MAX), int(self.shape[axis])
+    if self.ndim == 0: return self._scan(axis, Ops.MAX), Tensor.zeros(self.shape, dtype=dtypes.int32, device=self.device)
+    values, n = self._scan(axis, Ops.MAX), int(self.shape[axis])
     x, values_t = self.transpose(axis, -1), values.transpose(axis, -1)
     match = (x.unsqueeze(-1) == values_t.unsqueeze(-2)) * Tensor.ones(n, n, requires_grad=False, device=self.device).triu()
     idx = (-(match * Tensor.arange(n, 0, -1, requires_grad=False, device=self.device).reshape(n, 1)).max(-2) + n).cast(dtypes.int32)

--- a/tinygrad/uop/__init__.py
+++ b/tinygrad/uop/__init__.py
@@ -104,6 +104,9 @@ class Ops(FastEnum):
   # reduce
   REDUCE_AXIS = auto(); REDUCE = auto(); ALLREDUCE = auto()
 
+  # scan
+  SCAN_AXIS = auto(); SCAN = auto()
+
   # expander ops
   UNROLL = auto(); CONTRACT = auto(); VCAT = auto(); PTRCAT = auto()
 

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -16,15 +16,15 @@ if TYPE_CHECKING:
 class AxisType(Enum):
   def __repr__(self): return str(self)
   GLOBAL = auto(); WARP = auto(); LOCAL = auto(); LOOP = auto(); GROUP_REDUCE = auto(); REDUCE = auto(); UPCAST = auto(); UNROLL = auto() # noqa: E702
-  THREAD = auto(); PLACEHOLDER = auto() # noqa: E702
+  THREAD = auto(); PLACEHOLDER = auto(); SCAN = auto() # noqa: E702
 axis_letters = {AxisType.GLOBAL: "g", AxisType.THREAD: "t", AxisType.LOCAL: "l", AxisType.WARP: "w", AxisType.LOOP: "L", AxisType.UPCAST: "u",
-                AxisType.GROUP_REDUCE: "G", AxisType.REDUCE: "R", AxisType.UNROLL: "r"}
+                AxisType.GROUP_REDUCE: "G", AxisType.REDUCE: "R", AxisType.UNROLL: "r", AxisType.SCAN: "S"}
 axis_colors = {AxisType.GLOBAL: "blue", AxisType.THREAD: "BLUE", AxisType.LOCAL: "cyan", AxisType.WARP: "CYAN", AxisType.LOOP: "WHITE",
-               AxisType.UPCAST: "yellow", AxisType.GROUP_REDUCE: "RED", AxisType.REDUCE: "red", AxisType.UNROLL: "magenta"}
+               AxisType.UPCAST: "yellow", AxisType.GROUP_REDUCE: "RED", AxisType.REDUCE: "red", AxisType.UNROLL: "magenta", AxisType.SCAN: "green"}
 
 # NOTE: LOCAL and GROUP_REDUCE have the same priority. the order here matters
 axis_to_pos = {AxisType.LOOP: -1, AxisType.THREAD: 0, AxisType.GLOBAL: 0, AxisType.WARP: 1, AxisType.LOCAL: 2, AxisType.UPCAST: 3,
-               AxisType.GROUP_REDUCE: 2, AxisType.REDUCE: 4, AxisType.UNROLL: 5}
+               AxisType.GROUP_REDUCE: 2, AxisType.REDUCE: 4, AxisType.SCAN: 4, AxisType.UNROLL: 5}
 
 range_start = {Ops.BUFFERIZE: 1, Ops.REDUCE: 1, Ops.STORE: 2, Ops.WMMA: 3, Ops.END: 1, Ops.CALL: 1, Ops.FUNCTION: 1,
                Ops.COPY: 2, Ops.BUFFER_VIEW: 1}
@@ -257,7 +257,7 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
       case Ops.SHAPED_WMMA: return self.src[2]._shape
 
       # passthrough ops
-      case Ops.REDUCE | Ops.MSTACK | Ops.MSELECT | Ops.DETACH | Ops.CONTIGUOUS | Ops.CONTIGUOUS_BACKWARD | Ops.AFTER | Ops.END:
+      case Ops.REDUCE | Ops.SCAN | Ops.MSTACK | Ops.MSELECT | Ops.DETACH | Ops.CONTIGUOUS | Ops.CONTIGUOUS_BACKWARD | Ops.AFTER | Ops.END:
         return self.src[0]._shape
 
       # TODO: disallow shape changing bitcast
@@ -273,7 +273,7 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
 
     # movement ops change the shape
     # NOTE: ssimplify is required because the shape needs to be canonical for broadcasting and same shape checking
-    if self.op in GroupOp.Movement.union({Ops.MULTI, Ops.REDUCE_AXIS, Ops.WMMA}):
+    if self.op in GroupOp.Movement.union({Ops.MULTI, Ops.REDUCE_AXIS, Ops.SCAN_AXIS, Ops.WMMA}):
       ps = self.src[0]._shape
       # TODO: WMMA is used for both axis WMMA and op WMMA. fix this and remove this hack. tested by BERT on AMD LLVM
       if ps is None and self.op is Ops.WMMA: return None
@@ -308,6 +308,11 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
           if not isinstance(axis_arg, tuple) or not all(isinstance(x, int) and x>=0 and x<len(ps) for x in axis_arg):
             raise ValueError(f"invalid type for axis: {axis_arg}")
           return tuple(1 if i in axis_arg else s for i,s in enumerate(ps))
+        case Ops.SCAN_AXIS:
+          axis_arg = self.arg[1]
+          if not isinstance(axis_arg, tuple) or not all(isinstance(x, int) and x>=0 and x<len(ps) for x in axis_arg):
+            raise ValueError(f"invalid type for axis: {axis_arg}")
+          return ps  # SCAN preserves shape
 
     # elementwise ops keep the shape the same. all inputs with shape must match
     if self.op in GroupOp.ALU.union({Ops.CAST, Ops.COPY, Ops.NOOP, Ops.GROUP, Ops.SINK, Ops.ALLREDUCE}):
@@ -504,6 +509,9 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
   def _rop(self, op:Ops, axis:tuple[int, ...]):
     axis = tuple(sorted([x for x in axis if resolve(self.shape[x] != 1)]))
     return UOp(Ops.REDUCE_AXIS, self.dtype, (self,), (op, axis)) if len(axis) else self
+  def _scanop(self, op:Ops, axis:tuple[int, ...]):
+    axis = tuple(sorted([x for x in axis if resolve(self.shape[x] != 1)]))
+    return UOp(Ops.SCAN_AXIS, self.dtype, (self,), (op, axis)) if len(axis) else self
   @staticmethod
   def invalid(count=1): return UOp(Ops.CONST, dtypes.weakint.vec(count), src=(), arg=Invalid)
   def valid(self, cond): return self if cond.op is Ops.WHERE and cond.arg else cond.where(self, UOp.invalid(self.dtype.count))

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -128,6 +128,7 @@ _tensor_spec = PatternMatcher([
 
   # REDUCE_AXIS is the reduce in the tensor graph
   (UPat(Ops.REDUCE_AXIS, name="x"), lambda x: isinstance(x.arg, tuple) and len(x.arg) >= 2 and x.arg[0] in {Ops.ADD, Ops.MUL, Ops.MAX}),
+  (UPat(Ops.SCAN_AXIS, name="x"), lambda x: isinstance(x.arg, tuple) and len(x.arg) >= 2 and x.arg[0] in {Ops.ADD, Ops.MUL, Ops.MAX}),
 
   # AFTER if things were kernelized
   (UPat(Ops.AFTER, src=(UPat((Ops.BUFFER, Ops.AFTER)),), allow_any_len=True), lambda: True),
@@ -219,6 +220,7 @@ kernel_spec = PatternMatcher([
 
   # reduce must be on ranges
   (UPat(Ops.REDUCE, src=(UPat(),), allow_any_len=True, name="x"), lambda x: all(y.dtype in (dtypes.weakint, dtypes.int) for y in x.src[1:])),
+  (UPat(Ops.SCAN, src=(UPat(), UPat()), name="x"), lambda x: x.src[1].dtype in (dtypes.weakint, dtypes.int)),
 
   # COPY/BUFFER_VIEW can have ranges appended
   (UPat(Ops.COPY, name="x", src=(UPat.var("s"), UPat(Ops.DEVICE)), allow_any_len=True, arg=None),


### PR DESCRIPTION
new SCAN UOp replaces pad+pool+reduce for cumulative ops. two-level tiling for large inputs.
Tensor.associative_scan(fn, axis, reverse) for arbitrary associative binary functions.

fixes #3039