### PR TITLE
viz/cli: ux tweaks

### DIFF
--- a/test/null/test_viz.py
+++ b/test/null/test_viz.py
@@ -924,7 +924,7 @@ class TestCLI(unittest.TestCase):
       self.assertIn("TINY", times)
       self.assertIn("NULL", times)
       with Context(DEBUG=3):
-        json_lines = run_cli("--rewrites-path", str(r), "--profile-path", str(p), "-p", "-s", "ALL", "--jsonl")
+        json_lines = run_cli("--rewrites-path", str(r), "--profile-path", str(p), "-p", "-s", "ALL", "--json")
       for line in json_lines.split("\n"): _ = json.loads(line)
 
 if __name__ == "__main__":

--- a/tinygrad/viz/README
+++ b/tinygrad/viz/README
@@ -21,7 +21,7 @@ By default, VIZ UIs automatically load the latest files.
 user story: viewing profiling data
 * tinygrad ran 32 LLM decode steps:
 web: click "profiler", view the timeline of all python codegen and GPU kernels.
-cli: Run `DEBUG=3 python -m tinygrad.viz.cli --profile -s ALL --jsonl` to extract kernel timing info and ASTs in JSONL format.
+cli: Run `DEBUG=3 python -m tinygrad.viz.cli --profile -s ALL --json` to extract kernel timing info and ASTs in JSON format.
   - note: Make sure to add NO_COLOR=1 to disable colored output.
 
 user story: viewing code

--- a/tinygrad/viz/cli.py
+++ b/tinygrad/viz/cli.py
@@ -6,7 +6,7 @@ from typing import Iterator
 from tinygrad.viz import serve as viz
 from tinygrad.uop.ops import RewriteTrace
 from tinygrad.helpers import temp, ansistrip, colored, time_to_str, ansilen, ProfilePointEvent, ProfileRangeEvent, TracingKey, unwrap, NO_COLOR
-from tinygrad.helpers import DEBUG
+from tinygrad.helpers import DEBUG, Context
 
 # profile decoder used in CLI and tests
 def decode_profile(data:bytes) -> dict:
@@ -56,7 +56,8 @@ def get(data:dict, key:str):
   raise RuntimeError(f'item "{key}" not found in list'+(f", did you mean {match[0]!r}?" if match else ''))
 
 def main(args) -> None:
-  viz.load_rewrites(viz_data:=viz.VizData(viz.load_pickle(args.rewrites_path, default=RewriteTrace([], [], {}))))
+  with Context(DEBUG=0):
+    viz.load_rewrites(viz_data:=viz.VizData(viz.load_pickle(args.rewrites_path, default=RewriteTrace([], [], {}))))
 
   def fmt(val, to_str=str) -> str: return json.dumps(val if isinstance(val, dict) else {"value":val}) if args.json else to_str(val)
 
@@ -81,7 +82,7 @@ def main(args) -> None:
     else: print_step(get(steps, args.item))
     return None
 
-  events:list = viz.load_pickle(args.profile_path, default=[])
+  with Context(DEBUG=0): events:list = viz.load_pickle(args.profile_path, default=[])
   if (profile_bytes:=viz.get_profile(viz_data, events)) is None: raise RuntimeError(f"empty profile in {args.profile_path}")
   profile = decode_profile(profile_bytes)
   profile["layout"].update([(f'{c["name"][5:]}{" SQTT" if s["name"].endswith("PKTS") else ""} {s["name"]}', s["data"]) for c in viz_data.ctxs

--- a/tinygrad/viz/cli.py
+++ b/tinygrad/viz/cli.py
@@ -164,7 +164,7 @@ def main(args) -> None:
       marker_stream = sorted([(m["ts"], "MARKER", m) for m in profile.get("markers", [])], key=lambda t:t[0])
       for ts,dev,e in heapq.merge(*event_streams, marker_stream, key=lambda t:t[0]):
         if dev == "MARKER":
-          yield {"device":dev, "name":fmt_colored(e["name"]), "et_ms":ts*1e-3, "ref":None, "ext":None}
+          yield {"device":dev, "name":fmt_colored(e["name"]), "st_ms":ts*1e-3, "ref":None, "ext":None}
           continue
         ext:list[str] = []
         if (fmt:=e["fmt"]).startswith("TB:"):
@@ -175,15 +175,15 @@ def main(args) -> None:
             if fmt: ext.append(f"{line} {code}")
             elif not file.startswith("<") and not fxn.startswith("<"): fmt = line
         yield {"device":dev, "name":fmt_colored(e["name"]), "dur_ms":e["dur"]*1e-3,
-               "et_ms":(e["st"]+e["dur"])*1e-3, "fmt":fmt, "ref":e["ref"], "ext":"\n".join(ext)}
+               "st_ms":e["st"]*1e-3, "fmt":fmt, "ref":e["ref"], "ext":"\n".join(ext)}
     def fmt_top(k:dict) -> str:
       return f"{fmt_colored(k['name'])}{' ' * max(0, 36-ansilen(k['name']))} {time_to_str(k['dur_ms']*1e-3, w=9)} {k['count']:7d} {k['pct']:6.2f}%"
     def fmt_all(k:dict) -> str:
-      if k["device"] == "MARKER": return f"--- MARKER {k['name']} /{k['et_ms']:9.2f}ms"
+      if k["device"] == "MARKER": return f"--- MARKER {k['name']} /{k['st_ms']:9.2f}ms"
       ptm = colored(time_to_str(k["dur_ms"]*1e-3, w=9), "yellow" if k["dur_ms"] > 10 else None)
       fmt_str = "  ".join(p+" "*max(0, 14-ansilen(p)) for p in k["fmt"].split("\n"))
       name = f"*** {k['device'][:7]:7s} "+k["name"]+" "*(46-ansilen(k["name"]))
-      return f"{name} tm {ptm}/{k['et_ms']:9.2f}ms"+(f" ({fmt_str})" if k["fmt"] else "")
+      return f"{name} tm {ptm}/{k['st_ms']:9.2f}ms"+(f" ({fmt_str})" if k["fmt"] else "")
     fmt_row = fmt_top if args.top else fmt_all
     seen_refs:set[int] = set()
     for k in (produce_top_kernels if args.top else produce_all_kernels)():

--- a/tinygrad/viz/cli.py
+++ b/tinygrad/viz/cli.py
@@ -58,7 +58,7 @@ def get(data:dict, key:str):
 def main(args) -> None:
   viz.load_rewrites(viz_data:=viz.VizData(viz.load_pickle(args.rewrites_path, default=RewriteTrace([], [], {}))))
 
-  def fmt(val, to_str=str) -> str: return json.dumps(val if isinstance(val, dict) else {"value":val}) if args.jsonl else to_str(val)
+  def fmt(val, to_str=str) -> str: return json.dumps(val if isinstance(val, dict) else {"value":val}) if args.json else to_str(val)
 
   rewrites = {c["name"]:{s["name"]:s for s in c["steps"]} for c in viz_data.ctxs if c.get("steps")}
   def print_step(step:dict) -> None:
@@ -209,7 +209,7 @@ def get_arg_parser() -> argparse.ArgumentParser:
                       default=pathlib.Path(temp("profile.pkl", append_user=True)))
   g_opts.add_argument("--rewrites-path", type=pathlib.Path, metavar="PATH", help="Optional path to rewrites.pkl (default: latest rewrites)",
                       default=pathlib.Path(temp("rewrites.pkl", append_user=True)))
-  g_opts.add_argument("--jsonl", action="store_true", help="Emit profiler output as JSONL")
+  g_opts.add_argument("--json", action="store_true", help="Emit profiler output as JSON")
   g_opts.add_argument("-h", "--help", action="help", help="show this help message and exit")
   return parser
 

--- a/tinygrad/viz/cli.py
+++ b/tinygrad/viz/cli.py
@@ -6,7 +6,7 @@ from typing import Iterator
 from tinygrad.viz import serve as viz
 from tinygrad.uop.ops import RewriteTrace
 from tinygrad.helpers import temp, ansistrip, colored, time_to_str, ansilen, ProfilePointEvent, ProfileRangeEvent, TracingKey, unwrap, NO_COLOR
-from tinygrad.helpers import DEBUG, Context
+from tinygrad.helpers import DEBUG
 
 # profile decoder used in CLI and tests
 def decode_profile(data:bytes) -> dict:
@@ -56,8 +56,7 @@ def get(data:dict, key:str):
   raise RuntimeError(f'item "{key}" not found in list'+(f", did you mean {match[0]!r}?" if match else ''))
 
 def main(args) -> None:
-  with Context(DEBUG=0):
-    viz.load_rewrites(viz_data:=viz.VizData(viz.load_pickle(args.rewrites_path, default=RewriteTrace([], [], {}))))
+  viz.load_rewrites(viz_data:=viz.VizData(viz.load_pickle(args.rewrites_path, default=RewriteTrace([], [], {}))))
 
   def fmt(val, to_str=str) -> str: return json.dumps(val if isinstance(val, dict) else {"value":val}) if args.json else to_str(val)
 
@@ -82,7 +81,7 @@ def main(args) -> None:
     else: print_step(get(steps, args.item))
     return None
 
-  with Context(DEBUG=0): events:list = viz.load_pickle(args.profile_path, default=[])
+  events:list = viz.load_pickle(args.profile_path, default=[])
   if (profile_bytes:=viz.get_profile(viz_data, events)) is None: raise RuntimeError(f"empty profile in {args.profile_path}")
   profile = decode_profile(profile_bytes)
   profile["layout"].update([(f'{c["name"][5:]}{" SQTT" if s["name"].endswith("PKTS") else ""} {s["name"]}', s["data"]) for c in viz_data.ctxs

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -744,10 +744,11 @@ def reloader():
     time.sleep(0.1)
 
 T = TypeVar("T")
+# unpickling may load libraries, turn off DEBUG=3 output
 @Context(DEBUG=0)
 def load_pickle(path:pathlib.Path, default:T) -> T:
   if not path.exists(): return default
-  with path.open("rb") as f: return pickle.load(f)
+  with path.open("rb") as f:return pickle.load(f)
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -744,6 +744,7 @@ def reloader():
     time.sleep(0.1)
 
 T = TypeVar("T")
+@Context(DEBUG=0)
 def load_pickle(path:pathlib.Path, default:T) -> T:
   if not path.exists(): return default
   with path.open("rb") as f: return pickle.load(f)


### PR DESCRIPTION
the et_ms -> st_ms change is because it also confuses humans in the 1D view.
Like it's obvious in 2D the .item() overlaps with kernels
<img width="2550" height="674" alt="image" src="https://github.com/user-attachments/assets/bf94e5bf-9abc-4d88-b169-f3f0616d5456" />
but in CLI is looks weird if the numbers aren't all increasing as you go down:
<img width="1280" height="427" alt="Screenshot 2026-04-21 at 10 21 43 PM" src="https://github.com/user-attachments/assets/bcd79cb8-aa93-46fc-a45c-b4fd0d365eaf" />
branch:
<img width="2560" height="402" alt="image" src="https://github.com/user-attachments/assets/a3ac8c14-401c-4856-b919-ec1917e7ffe3" />