### PR TITLE
fix const_factor for negative constants

### DIFF
--- a/test/null/test_uop_symbolic.py
+++ b/test/null/test_uop_symbolic.py
@@ -106,6 +106,10 @@ class TestSymbolic(unittest.TestCase):
     self.assertEqual(UOp.gcd(a*a*10, b*a*5, a*a*5).simplify(), a*5)
     self.assertEqual(UOp.gcd(a*10, b*5, a*5).simplify(), a.const_like(5))
     self.assertEqual(UOp.gcd(a, b*5, a*5).simplify(), a.const_like(1))
+    c = Variable("c", -8, 0)
+    d = Variable("d", -8, 0)
+    self.assertEqual(UOp.gcd(c*-6, c*-3).simplify(), c*3)
+    self.assertEqual(UOp.gcd(c*-10, d*-5, c*-5).simplify(), c.const_like(5))
 
   def test_divides_exact(self):
     a = Variable("a", 1, 8)

--- a/test/null/test_uops.py
+++ b/test/null/test_uops.py
@@ -239,6 +239,8 @@ class TestUOpMethod(unittest.TestCase):
     self.assertEqual((gidx0*3).const_factor(), 3)
     self.assertEqual((gidx0*3+6).const_factor(), 3)
     self.assertEqual((gidx0*3+1).const_factor(), 1)
+    self.assertEqual(UOp.const(dtypes.int, -17).const_factor(), 17)
+    self.assertEqual((gidx0*-3).const_factor(), 3)
 
   def test_replace(self):
     x = UOp(Ops.PARAM, dtypes.int.ptr(), (), 0)

--- a/tinygrad/uop/divandmod.py
+++ b/tinygrad/uop/divandmod.py
@@ -65,7 +65,7 @@ def fold_divmod_general(d: UOp, correct_divmod_folding: bool) -> UOp|None:
     # nest_by_factor: x//c -> (x//f)//(c//f), x%c -> (x//f%(c//f))*f + b where b=x%f
     if x.vmin >= 0:
       results = []
-      for div in {abs(f) for u, f in zip(uops_no_const, factors) if u.op not in (Ops.CONST, Ops.VCONST) and 1 < abs(f) < c and (c%f)==0}:
+      for div in {f for u, f in zip(uops_no_const, factors) if u.op not in (Ops.CONST, Ops.VCONST) and 1 < f < c and (c%f)==0}:
         if (newxs := fold_divmod_general(x//div, correct_divmod_folding)) is not None and newxs.vmin >= 0:
           if d.op is Ops.IDIV:
             results.append((len(newxs.backward_slice), newxs // (c // div)))

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -802,11 +802,10 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
     return False  # False if not sure
   def const_factor(self) -> int:
     """largest known int that divides self"""
-    # TODO: for negatives it's not the largest
-    if self.op is Ops.CONST: return self.arg
-    if self.op is Ops.VCONST: return math.gcd(*self.arg)
+    if self.op is Ops.CONST: return abs(self.arg)
+    if self.op is Ops.VCONST: return abs(math.gcd(*self.arg))
     if self.op is Ops.ADD: return math.gcd(self.src[0].const_factor(), self.src[1].const_factor())
-    if self.op is Ops.MUL: return self.src[0].arg if self.src[0].op is Ops.CONST else self.src[1].arg if self.src[1].op is Ops.CONST else 1
+    if self.op is Ops.MUL: return abs(self.src[0].arg) if self.src[0].op is Ops.CONST else abs(self.src[1].arg) if self.src[1].op is Ops.CONST else 1
     return 1
   def divides(self, v:int) -> UOp|None:
     if v==1: return self
@@ -823,7 +822,8 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
   def gcd(*uops: UOp) -> UOp:
     terms, factors = zip(*[(u.divides(f:=u.const_factor()),f) for u in uops])
     count = functools.reduce(operator.and_, [collections.Counter(term.split_uop(Ops.MUL)) for term in terms])
-    return math.prod([*count.elements(), terms[0].const_like(math.gcd(*factors))])  # put the const at the top
+    elements = [e.const_like(abs(e.arg)) if e.op is Ops.CONST else e for e in count.elements()]
+    return math.prod([*elements, terms[0].const_like(math.gcd(*factors))])  # put the const at the top
   def divide_exact(self, v:UOp) -> UOp|None:
     if self is v: return self.const_like(1)
     if v.op is Ops.CONST: return self.divides(v.arg)


### PR DESCRIPTION
Adds `abs` to `CONST`, `VCONST`, and `MUL` in `const_factor` and to `CONST` elements in `gcd`.
Removes `abs` wrapping `const_factor` output in divandmod. 
Update tests.

Also adds `if e.op is Ops.CONST` check to `gcd` because now CONST(-1) can appear in `elements`.