### PR TITLE
yellow

### DIFF
--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -23,7 +23,7 @@ def update_stats(display_name:str, device:str, estimates:Estimates, var_vals:dic
     ptm = colored(time_to_str(et, w=9), "yellow" if et > 0.01 else None) if et is not None else ""
     flops, membw, ldsbw = op_est/(et or 1e-20), mem_est/(et or 1e-20), lds_est/(et or 1e-20)
     flops_str = f"{flops*1e-9:7.0f} GFLOPS" if flops < 1e14 else colored(f"{flops*1e-12:7.0f} TFLOPS", 'green')
-    mem_str = colored(f"{mem_to_str(membw, 4, False)}|{mem_to_str(ldsbw, 6)}", 'green' if membw > 1e13 else 'yellow' if membw >= 1e6 else None)
+    mem_str = colored(f"{mem_to_str(membw, 4, False)}|{mem_to_str(ldsbw, '<6')}", 'green' if membw > 1e13 else 'yellow' if membw >= 1e6 else None)
     print(f"{colored(f'*** {device[:7]:7s} {GlobalCounters.kernel_count:4d}', header_color)}"+
       f" {display_name+' '*(46-ansilen(display_name))} arg {buf_count:2d} mem {GlobalCounters.mem_used/1e9:6.2f} GB"+
       ("" if et is None else f" tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({flops_str} {mem_str})")+

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -3,7 +3,7 @@ import time, pprint, random, itertools, math, contextlib, weakref
 from dataclasses import dataclass, replace, field
 from tinygrad.helpers import all_same, colored, DEBUG, GlobalCounters, ansilen, NOOPT, all_int, Metadata, TRACEMETA, TracingKey
 from tinygrad.helpers import BEAM, DEVECTORIZE, size_to_str, time_to_str, VALIDATE_WITH_CPU, cpu_profile, PROFILE, ProfilePointEvent, cpu_events
-from tinygrad.helpers import prod, unwrap, EMULATED_DTYPES, flatten
+from tinygrad.helpers import prod, unwrap, EMULATED_DTYPES, flatten, mem_to_str
 from tinygrad.uop.ops import Ops, PatternMatcher, UOp, UPat, sym_infer, buffers, graph_rewrite
 from tinygrad.device import Device, Buffer, MultiBuffer
 from tinygrad.renderer import ProgramSpec, Estimates
@@ -23,8 +23,7 @@ def update_stats(display_name:str, device:str, estimates:Estimates, var_vals:dic
     ptm = colored(time_to_str(et, w=9), "yellow" if et > 0.01 else None) if et is not None else ""
     flops, membw, ldsbw = op_est/(et or 1e-20), mem_est/(et or 1e-20), lds_est/(et or 1e-20)
     flops_str = f"{flops*1e-9:7.0f} GFLOPS" if flops < 1e14 else colored(f"{flops*1e-12:7.0f} TFLOPS", 'green')
-    mem_str = f"{membw*1e-9:4.0f}|{ldsbw*1e-9:<6.0f} GB/s" if membw < 1e13 and ldsbw < 1e15 else \
-      colored(f"{membw*1e-12:4.0f}|{ldsbw*1e-12:<6.0f} TB/s", 'green')
+    mem_str = colored(f"{mem_to_str(membw, 4, False)}|{mem_to_str(ldsbw, 6)}", 'green' if membw > 1e13 else 'yellow' if membw >= 1e6 else None)
     print(f"{colored(f'*** {device[:7]:7s} {GlobalCounters.kernel_count:4d}', header_color)}"+
       f" {display_name+' '*(46-ansilen(display_name))} arg {buf_count:2d} mem {GlobalCounters.mem_used/1e9:6.2f} GB"+
       ("" if et is None else f" tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({flops_str} {mem_str})")+

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -23,7 +23,7 @@ def update_stats(display_name:str, device:str, estimates:Estimates, var_vals:dic
     ptm = colored(time_to_str(et, w=9), "yellow" if et > 0.01 else None) if et is not None else ""
     flops, membw, ldsbw = op_est/(et or 1e-20), mem_est/(et or 1e-20), lds_est/(et or 1e-20)
     flops_str = f"{flops*1e-9:7.0f} GFLOPS" if flops < 1e14 else colored(f"{flops*1e-12:7.0f} TFLOPS", 'green')
-    mem_str = colored(f"{mem_to_str(membw, 4, False)}|{mem_to_str(ldsbw, '<6')}", 'green' if membw > 1e13 else 'yellow' if membw >= 1e6 else None)
+    mem_str = colored(f"{mem_to_str(membw, 4, False)}|{mem_to_str(ldsbw, '<6')}", 'green' if membw >= 1e13 else 'yellow' if membw >= 1e6 else None)
     print(f"{colored(f'*** {device[:7]:7s} {GlobalCounters.kernel_count:4d}', header_color)}"+
       f" {display_name+' '*(46-ansilen(display_name))} arg {buf_count:2d} mem {GlobalCounters.mem_used/1e9:6.2f} GB"+
       ("" if et is None else f" tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({flops_str} {mem_str})")+

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -23,7 +23,7 @@ def update_stats(display_name:str, device:str, estimates:Estimates, var_vals:dic
     ptm = colored(time_to_str(et, w=9), "yellow" if et > 0.01 else None) if et is not None else ""
     flops, membw, ldsbw = op_est/(et or 1e-20), mem_est/(et or 1e-20), lds_est/(et or 1e-20)
     flops_str = f"{flops*1e-9:7.0f} GFLOPS" if flops < 1e14 else colored(f"{flops*1e-12:7.0f} TFLOPS", 'green')
-    mem_str = colored(f"{mem_to_str(membw, 4, False)}|{mem_to_str(ldsbw, '<6')}", 'green' if membw >= 1e13 else 'yellow' if membw >= 1e6 else None)
+    mem_str = colored(f"{mem_to_str(membw, 4, False)}|{mem_to_str(ldsbw, '<6')}", 'green' if membw >= 1e12 else None if membw >= 1e9 else 'yellow')
     print(f"{colored(f'*** {device[:7]:7s} {GlobalCounters.kernel_count:4d}', header_color)}"+
       f" {display_name+' '*(46-ansilen(display_name))} arg {buf_count:2d} mem {GlobalCounters.mem_used/1e9:6.2f} GB"+
       ("" if et is None else f" tm {ptm}/{GlobalCounters.time_sum_s*1e3:9.2f}ms ({flops_str} {mem_str})")+

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -38,6 +38,8 @@ def colored(st, color:str|None, background=False): # replace the termcolor libra
 def colorize_float(x: float): return colored(f"{x:7.2f}x", 'green' if x < 0.75 else 'red' if x > 1.15 else 'yellow')
 def time_to_str(t:float, w=8) -> str: return next((f"{t * d:{w}.2f}{pr}" for d,pr in [(1, "s "),(1e3, "ms")] if t > 10/d), f"{t * 1e6:{w}.2f}us")
 def size_to_str(s:int) -> str: return next((f"{s / d:.2f} {pr}" for d,pr in [(1<<30, "GB"),(1<<20, "MB"),(1<<10, "KB")] if s >= d), f"{s} B")
+def mem_to_str(bw:int|float, w=0, units=True) -> str:
+  return next((f"{bw*d:{w}.0f}{(' '+pr)*units}" for d,pr in [(1e-12, "TB/s"), (1e-9, "GB/s")] if bw>=1/d), f"{int(bw*1e-6):{w}.0f}{(' MB/s')*units}")
 def ansistrip(s:str): return re.sub('\x1b\\[(K|.*?m)', '', s)
 def ansilen(s:str): return len(ansistrip(s))
 def make_tuple(x:int|Sequence[int], cnt:int) -> tuple[int, ...]: return (x,)*cnt if isinstance(x, int) else tuple(x)

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -39,7 +39,8 @@ def colorize_float(x: float): return colored(f"{x:7.2f}x", 'green' if x < 0.75 e
 def time_to_str(t:float, w=8) -> str: return next((f"{t * d:{w}.2f}{pr}" for d,pr in [(1, "s "),(1e3, "ms")] if t > 10/d), f"{t * 1e6:{w}.2f}us")
 def size_to_str(s:int) -> str: return next((f"{s / d:.2f} {pr}" for d,pr in [(1<<30, "GB"),(1<<20, "MB"),(1<<10, "KB")] if s >= d), f"{s} B")
 def mem_to_str(bw:int|float, w:int|str=0, units=True) -> str:
-  return next((f"{bw*d:{w}.0f}{pr*units}" for d,pr in [(1e-12, " TB/s"), (1e-9, " GB/s"), (1e-6, " MB/s"), (1e-3, " KB/s")] if bw>=1/d), f"{bw*1e-6:{w}.0f}{(' B/s')*units}")
+  bw_units = [(1e-12, " TB/s"), (1e-9, " GB/s"), (1e-6, " MB/s"), (1e-3, " KB/s")]
+  return next((f"{bw*d:{w}.0f}{pr*units}" for d,pr in bw_units if bw>=1/d), f"{bw*1e-6:{w}.0f}{(' B/s')*units}")
 def ansistrip(s:str): return re.sub('\x1b\\[(K|.*?m)', '', s)
 def ansilen(s:str): return len(ansistrip(s))
 def make_tuple(x:int|Sequence[int], cnt:int) -> tuple[int, ...]: return (x,)*cnt if isinstance(x, int) else tuple(x)

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -40,7 +40,7 @@ def time_to_str(t:float, w=8) -> str: return next((f"{t * d:{w}.2f}{pr}" for d,p
 def size_to_str(s:int) -> str: return next((f"{s / d:.2f} {pr}" for d,pr in [(1<<30, "GB"),(1<<20, "MB"),(1<<10, "KB")] if s >= d), f"{s} B")
 def mem_to_str(bw:int|float, w:int|str=0, units=True) -> str:
   bw_units = [(1e-12, " TB/s"), (1e-9, " GB/s"), (1e-6, " MB/s"), (1e-3, " KB/s")]
-  return next((f"{bw*d:{w}.0f}{pr*units}" for d,pr in bw_units if bw>=1/d), f"{bw*1e-6:{w}.0f}{(' B/s')*units}")
+  return next((f"{bw*d:{w}.0f}{pr*units}" for d,pr in bw_units if bw>=1/d), f"{bw:{w}.0f}{(' B/s')*units}")
 def ansistrip(s:str): return re.sub('\x1b\\[(K|.*?m)', '', s)
 def ansilen(s:str): return len(ansistrip(s))
 def make_tuple(x:int|Sequence[int], cnt:int) -> tuple[int, ...]: return (x,)*cnt if isinstance(x, int) else tuple(x)

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -39,7 +39,7 @@ def colorize_float(x: float): return colored(f"{x:7.2f}x", 'green' if x < 0.75 e
 def time_to_str(t:float, w=8) -> str: return next((f"{t * d:{w}.2f}{pr}" for d,pr in [(1, "s "),(1e3, "ms")] if t > 10/d), f"{t * 1e6:{w}.2f}us")
 def size_to_str(s:int) -> str: return next((f"{s / d:.2f} {pr}" for d,pr in [(1<<30, "GB"),(1<<20, "MB"),(1<<10, "KB")] if s >= d), f"{s} B")
 def mem_to_str(bw:int|float, w:int|str=0, units=True) -> str:
-  return next((f"{bw*d:{w}.0f}{(' '+pr)*units}" for d,pr in [(1e-12, "TB/s"), (1e-9, "GB/s")] if bw>=1/d), f"{int(bw*1e-6):{w}.0f}{(' MB/s')*units}")
+  return next((f"{bw*d:{w}.0f}{pr*units}" for d,pr in [(1e-12, " TB/s"), (1e-9, " GB/s"), (1e-6, " MB/s"), (1e-3, " KB/s")] if bw>=1/d), f"{bw*1e-6:{w}.0f}{(' B/s')*units}")
 def ansistrip(s:str): return re.sub('\x1b\\[(K|.*?m)', '', s)
 def ansilen(s:str): return len(ansistrip(s))
 def make_tuple(x:int|Sequence[int], cnt:int) -> tuple[int, ...]: return (x,)*cnt if isinstance(x, int) else tuple(x)

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -38,7 +38,7 @@ def colored(st, color:str|None, background=False): # replace the termcolor libra
 def colorize_float(x: float): return colored(f"{x:7.2f}x", 'green' if x < 0.75 else 'red' if x > 1.15 else 'yellow')
 def time_to_str(t:float, w=8) -> str: return next((f"{t * d:{w}.2f}{pr}" for d,pr in [(1, "s "),(1e3, "ms")] if t > 10/d), f"{t * 1e6:{w}.2f}us")
 def size_to_str(s:int) -> str: return next((f"{s / d:.2f} {pr}" for d,pr in [(1<<30, "GB"),(1<<20, "MB"),(1<<10, "KB")] if s >= d), f"{s} B")
-def mem_to_str(bw:int|float, w=0, units=True) -> str:
+def mem_to_str(bw:int|float, w:int|str=0, units=True) -> str:
   return next((f"{bw*d:{w}.0f}{(' '+pr)*units}" for d,pr in [(1e-12, "TB/s"), (1e-9, "GB/s")] if bw>=1/d), f"{int(bw*1e-6):{w}.0f}{(' MB/s')*units}")
 def ansistrip(s:str): return re.sub('\x1b\\[(K|.*?m)', '', s)
 def ansilen(s:str): return len(ansistrip(s))


### PR DESCRIPTION
The color is green for TB/s, none for GB/s, and yellow for MB/s and lower.

The color is green if `membw > 1e13` but it used to be green `if membw < 1e13 and ldsbw < 1e15`. Do we still want to depend on `ldsbw`? Should we do `max(membw, ldsbw)`?

my branch
<img width="1319" height="254" alt="Screenshot 2026-04-23 at 9 02 59 PM" src="https://github.com/user-attachments/assets/da11c06d-36f0-4c97-b32b-0fe04d8fc642" />


master
<img width="1325" height="257" alt="Screenshot 2026-04-23 at 8 39 22 PM" src="https://github.com/user-attachments/assets/794b43be-5164-4e8a-b284-9f7b421c2573" />