### PR TITLE
Add `uv.lock` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ mutants
 .mutmut-cache
 dagre/
 graphlib/
+uv.lock


### PR DESCRIPTION
Added `uv.lock` to `.gitignore `to avoid accidental commits during local development with uv (e.g. `uv run python -m tinygrad.llm`.)