### PR TITLE
gradient: add TRUNC backward

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -431,6 +431,9 @@ class TestOps(unittest.TestCase):
     helper_test_op(None, lambda x: x.round(), vals=[[1.499, 1.5, 1.501, 1.0, 2.1, 0.0, -5.0, -2.499, -2.5, -2.501]], forward_only=True)
     helper_test_op(None, lambda x: x.round(), vals=[[2.5, -1.5]], forward_only=True)
 
+  def test_round_quantization_gradient(self):
+    helper_test_op(None, lambda x: x + 0.125 * (x.round() - x), vals=[[-1.2, -0.7, -0.2, 0.2, 0.7, 1.2]])
+
   def test_isinf(self):
     val = [float('-inf'), 0., float('inf'), float('nan'), 1.1]
     helper_test_op(None, torch.isinf, Tensor.isinf, vals=[val], forward_only=True)

--- a/test/unit/test_gradient.py
+++ b/test/unit/test_gradient.py
@@ -76,12 +76,6 @@ class TestTensorGradient(unittest.TestCase):
     x = Tensor.randn(4, 4)
     np.testing.assert_allclose(x.pad(((1,0),(0,0))).gradient(x, gradient=g2)[0].numpy(), np.zeros((4, 4)))
 
-  def test_round_quantization_gradient(self):
-    x = Tensor([-1.2, -0.7, -0.2, 0.2, 0.7, 1.2], requires_grad=True)
-    q = 0.125
-    (x + q * (x.round() - x)).sum().backward()
-    np.testing.assert_allclose(x.grad.numpy(), np.full((6,), 1.0-q, dtype=np.float32))
-
 class TestViewGradient(unittest.TestCase):
   def test_expand(self):
     x = Tensor.randn(5,2)

--- a/test/unit/test_gradient.py
+++ b/test/unit/test_gradient.py
@@ -76,6 +76,12 @@ class TestTensorGradient(unittest.TestCase):
     x = Tensor.randn(4, 4)
     np.testing.assert_allclose(x.pad(((1,0),(0,0))).gradient(x, gradient=g2)[0].numpy(), np.zeros((4, 4)))
 
+  def test_round_quantization_gradient(self):
+    x = Tensor([-1.2, -0.7, -0.2, 0.2, 0.7, 1.2], requires_grad=True)
+    q = 0.125
+    (x + q * (x.round() - x)).sum().backward()
+    np.testing.assert_allclose(x.grad.numpy(), np.full((6,), 1.0-q, dtype=np.float32))
+
 class TestViewGradient(unittest.TestCase):
   def test_expand(self):
     x = Tensor.randn(5,2)

--- a/tinygrad/gradient.py
+++ b/tinygrad/gradient.py
@@ -53,6 +53,7 @@ pm_gradient = PatternMatcher([
   (UPat(Ops.LOG2, name="ret"), lambda ctx, ret: (ctx / (ret.src[0] * math.log(2)),)),
   (UPat(Ops.EXP2, name="ret"), lambda ctx, ret: (ret * ctx * math.log(2),)),
   (UPat(Ops.SQRT, name="ret"), lambda ctx, ret: (ctx / (ret*2),)),
+  (UPat(Ops.TRUNC), lambda ctx: (ctx.const_like(0),)),
   (UPat((Ops.CMPLT, Ops.CMPNE)), lambda: (None, None)),
   (UPat(Ops.ADD), lambda ctx: (ctx, ctx)),
   (UPat(Ops.POW, name="ret", src=(UPat.var("b"), UPat.var("e"))), lambda ctx, ret, b, e:


### PR DESCRIPTION
round() lowers through trunc, so backward was missing

test: python -m unittest test.unit.test_gradient.TestTensorGradient.test_round_quantization_gradient