### PR TITLE
cpu: normalize ARM64 arch alias

### DIFF
--- a/test/null/test_device.py
+++ b/test/null/test_device.py
@@ -66,6 +66,11 @@ class TestDevice(unittest.TestCase):
     self.assertNotEqual(result.returncode, 0)
     self.assertIn(b"deprecated", result.stderr)
 
+  def test_cpu_device_normalizes_arm64_machine_name(self):
+    from tinygrad.runtime.ops_cpu import CPUDevice
+    with patch("platform.machine", return_value="ARM64"):
+      self.assertEqual(CPUDevice().arch, "arm64,native")
+
   @unittest.skipIf(WIN and CI, "skipping windows test") # TODO: subprocess causes memory violation?
   def test_env_overwrite_default_compiler(self):
     if Device.DEFAULT == "CPU":

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -10,6 +10,8 @@ from tinygrad.renderer.nir import LVPRenderer
 from tinygrad.runtime.support.elf import jit_loader
 from tinygrad.uop.ops import sint
 
+def cpu_arch() -> str: return {'AMD64':'x86_64', 'aarch64':'arm64', 'ARM64':'arm64'}.get(m:=platform.machine(), m)
+
 class CPUSignal(HCQSignal):
   def _sleep(self, time_spent_since_last_sleep_ms:int):
     if self.is_timeline and self.owner is not None:
@@ -44,7 +46,7 @@ class CPUComputeQueue(HWQueue):
   def _exec(self, tid, prg, bufs, *args):
     vals = list(args[bufs:])
     if 'core_id' in prg.runtimevars: vals[prg.runtimevars['core_id']] = tid
-    prg.fxn(*map(ctypes.c_uint64, args[:bufs]), *map(ctypes.c_int64 if platform.machine() == "arm64" else ctypes.c_int32, vals))
+    prg.fxn(*map(ctypes.c_uint64, args[:bufs]), *map(ctypes.c_int64 if cpu_arch() == "arm64" else ctypes.c_int32, vals))
   def _signal(self, tid, signal_addr, value): to_mv(signal_addr, 4).cast('I')[0] = value
   def _wait(self, tid, tmpl_sig, signal_addr, value):
     tmpl_sig.base_buf = HCQBuffer(signal_addr, 16, view=MMIOInterface(signal_addr, 16))
@@ -136,4 +138,4 @@ class CPUDevice(HCQCompiled):
     self.tasks:queue.Queue = queue.Queue()
     CPUWorker(self, self.tasks, thread_id=0).start()
     super().__init__(device, CPUAllocator(self), [ClangJITRenderer, CPULLVMRenderer, LVPRenderer], functools.partial(CPUProgram, self), CPUSignal,
-                     CPUComputeQueue, arch={'AMD64':'x86_64', 'aarch64':'arm64'}.get(m:=platform.machine(), m)+",native")
+                     CPUComputeQueue, arch=cpu_arch()+",native")


### PR DESCRIPTION
windows arm64 was passing ARM64,native into cpu

test: python -m unittest test.null.test_device.TestDevice.test_cpu_device_normalizes_arm64_machine_name