### PR TITLE
fix TinyJit instance method sharing

### DIFF
--- a/test/unit/test_jit.py
+++ b/test/unit/test_jit.py
@@ -162,6 +162,21 @@ class TestJit(unittest.TestCase):
       np.testing.assert_allclose(c.numpy(), fun.a.numpy()+b.numpy(), atol=1e-4, rtol=1e-5)
     assert_jit_cache_len(fun.__call__.func.__self__, 1)
 
+  def test_jit_instance_method_isolation(self):
+    class Model:
+      def __init__(self, scale):
+        self.scale = Tensor([scale])
+      @TinyJit
+      def forward(self, x):
+        return (x * self.scale).realize()
+
+    m1, m2 = Model(2), Model(3)
+
+    # each instance must warm up, capture, and replay with its own state
+    for _ in range(4):
+      self.assertEqual(m1.forward(Tensor([5])).item(), 10)
+      self.assertEqual(m2.forward(Tensor([5])).item(), 15)
+
   def test_jit_size1_input(self):
     @TinyJit
     def f(a, b): return (a+b).realize()

--- a/test/unit/test_jit_footguns.py
+++ b/test/unit/test_jit_footguns.py
@@ -6,7 +6,6 @@ Each test shows behavior that works without JIT but changes with JIT.
 Comments marked "should be X!" indicate the intuitively expected value.
 
 SILENT MISMATCHES (highest priority - wrong results, no error):
-  class_method_shared_across_instances EASY could check if first arg is self and warn
   slice_assign_requires_realize      MED    assign graph not connected to read during JIT replay
   output_buffer_reuse                MED    performance tradeoff, could add option or better docs
   symbolic_pad_view_frozen           MED    pad view BIND values baked in at capture time
@@ -270,23 +269,6 @@ class TestJitFootguns(unittest.TestCase):
 
     with self.assertRaises(JitError):
       f(a=Tensor([3]), b=Tensor([4]))  # kwargs fail
-
-  def test_class_method_shared_across_instances(self):
-    """JIT on instance methods is shared at class level."""
-    class Model:
-      def __init__(self, scale):
-        self.scale = Tensor([scale])
-      @TinyJit
-      def forward(self, x):
-        return (x * self.scale).realize()
-
-    m1, m2 = Model(2), Model(3)
-
-    m1.forward(Tensor([5]))  # warmup
-    m1.forward(Tensor([5]))  # capture with m1.scale=2
-
-    self.assertEqual(m1.forward(Tensor([5])).item(), 10)
-    self.assertEqual(m2.forward(Tensor([5])).item(), 10)  # should be 15!
 
   def test_side_effects_only_during_capture(self):
     """Function body not executed during JIT replay."""

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -266,7 +266,13 @@ class TinyJit(Generic[ReturnType]):
     assert self.captured is not None, "can't pickle an uncaptured JIT"
     return self.__class__, (None, self.captured)
 
-  def __get__(self, obj, objtype): return functools.partial(self.__call__, obj) # add support for instance methods
+  def __get__(self, obj, objtype=None):
+    if obj is None or self.fxn is None: return self
+    # cache on obj, not self: the bound JIT holds obj, so caching on self would keep every instance alive
+    try: cache = obj.__dict__.setdefault("_jit_bound", {})
+    except AttributeError: cache = {}
+    if self not in cache: cache[self] = type(self)(self.fxn.__get__(obj, objtype), prune=self.prune)
+    return functools.partial(cache[self].__call__)
 
   @disable_gc()
   def __call__(self, *args, **kwargs) -> ReturnType:


### PR DESCRIPTION
@TinyJit on instance methods was reusing the descriptor-level JIT, so a capture on one instance could replay on another one.

test: python -m unittest test.backend.test_jit.TestJit.test_jit_instance_method_isolation
test: python -m unittest test.backend.test_jit_footguns -q