### PR TITLE
fix: ONNX Attention is_causal mask ignores past_key/past_value length

### DIFF
--- a/tinygrad/nn/onnx.py
+++ b/tinygrad/nn/onnx.py
@@ -1082,7 +1082,9 @@ def get_onnx_ops() -> dict[str, types.FunctionType|dict[OpSetId, types.FunctionT
     qk_matmul_return_val = scores
 
     if is_causal:
-      causal_mask = Tensor.ones(Q.shape[-2], K.shape[-2], device=Q.device, dtype=dtypes.bool, requires_grad=False).tril(0)
+      # offset the diagonal by past_len so query position i can attend to all keys [0, past_len + i]
+      past_len = cast(int, K.shape[-2]) - cast(int, Q.shape[-2])
+      causal_mask = Tensor.ones(Q.shape[-2], K.shape[-2], device=Q.device, dtype=dtypes.bool, requires_grad=False).tril(past_len)
       scores = scores.masked_fill(causal_mask.logical_not(), -float("inf"))
 
     if attn_mask is not None:


### PR DESCRIPTION
attention_onnx's causal mask was anchored to the start of the extended K axis instead of the diagonal aligned to the current query positions. With KV caching (past_key/past_value provided), tril(0) on a (Q_len, K_len) mask only lets query token i attend to keys [0, i], which leaves the entire past_len window invisible.

Autoregressive decoding through ONNX-exported transformers silently produces wrongoutputs after the first cached step. Every generated token attends to a shifted, incomplete view of the past. Without past inputs, the mask is unchanged, so non-cached forward passes are unaffected.

  ## Fix

  Offset the `tril` diagonal by `past_len = K.shape[-2] - Q.shape[-2]`:

  ```python
   if is_causal:
    # offset the diagonal by past_len so query position i can attend to all keys [0, past_len + i]
     past_len = cast(int, K.shape[-2]) - cast(int, Q.shape[-2])
     causal_mask = Tensor.ones(Q.shape[-2], K.shape[-2], device=Q.device, 
                dtype=dtypes.bool, requires_grad=False).tril(past_len)
     scores = scores.masked_fill(causal_mask.logical_not(), -float("inf"))
```

 ### Tests

- Existing tests continue to pass.
- Spot-check an ONNX-exported decoder model running cached decode against the same model in eager mode.