### PR TITLE
cleanup: untrack wait Metal buffers

### DIFF
--- a/test/device/test_metal.py
+++ b/test/device/test_metal.py
@@ -50,6 +50,19 @@ kernel void r_5(device int* data0, const device int* data1, uint3 gid [[threadgr
       compiled = compiled[:40] # corrupt the compiled program
       MetalProgram(device, "r_5", compiled)
 
+  def test_wait_skips_in_flight(self):
+    device = MetalDevice("metal")
+    compiled = MetalCompiler().compile("""
+#include <metal_stdlib>
+kernel void noop(uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {}
+""")
+    prg = MetalProgram(device, "noop", compiled)
+    self.assertIsInstance(prg(wait=True), float)
+    self.assertEqual(device.mtl_buffers_in_flight, [])
+    self.assertIsNone(prg(wait=False))
+    self.assertEqual(len(device.mtl_buffers_in_flight), 1)
+    device.synchronize()
+
   def test_free(self):
     size = 2**16
     device = Device['METAL']

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -147,10 +147,10 @@ class MetalProgram:
     encoder.endEncoding()
     command_buffer.setLabel(to_ns_str(self.name)) # TODO: is this always needed?
     command_buffer.commit()
-    self.dev.mtl_buffers_in_flight.append(command_buffer)
     if wait:
       wait_check(command_buffer)
       return command_buffer.GPUEndTime() - command_buffer.GPUStartTime()
+    self.dev.mtl_buffers_in_flight.append(command_buffer)
 
 class MetalBuffer:
   def __init__(self, buf:metal.MTLBuffer, size:int, offset=0): self.buf, self.size, self.offset = buf, size, offset


### PR DESCRIPTION
Metal was tracking kernels we'd already waited on, so synchronize() kept re-checking finished work. Small fix by moving a line to only track buffers that are really still in flight and added a test