### PR TITLE
llama: fix missing label_smoothing arg

### DIFF
--- a/extra/llama_kernels/fused_ce/__init__.py
+++ b/extra/llama_kernels/fused_ce/__init__.py
@@ -37,7 +37,7 @@ def _custom_fused_ce_loss_bwd(d_logits:UOp, logits:UOp, lse:UOp, targets:UOp, sc
   return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.DEVICE, arg=dname), UOp(Ops.LINEAR, src=(*sink.src, sink)),
                                UOp(Ops.SOURCE, arg=src), UOp(Ops.BINARY, arg=lib)))
 
-def _fused_ce_loss_bwd(gradient:UOp, kernel:UOp):
+def _fused_ce_loss_bwd(gradient:UOp, kernel:UOp, label_smoothing:float):
   # NOTE: forward inputs are (loss_out, max_out, lse_out, logits, targets)
   # gradient is the upstream grad w.r.t. per-row loss (shape: (rows,) fp32)
   _, _, lse_u, logits_u, targets_u = kernel.src[1:]
@@ -94,5 +94,5 @@ def fused_ce_loss(logits:Tensor, targets:Tensor, label_smoothing:float=0.1) -> T
                           label_smoothing=label_smoothing)
   loss_out, max_out, lse_out, *_ = Tensor.custom_kernel(
     loss_out, max_out, lse_out, logits_flat, targets_flat,
-    fxn=fxn, grad_fxn=_fused_ce_loss_bwd)
+    fxn=fxn, grad_fxn=functools.partial(_fused_ce_loss_bwd, label_smoothing=label_smoothing))
   return loss_out.mean()


### PR DESCRIPTION
running examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama8b/implementations/tinybox_8xMI350X/profile.sh
```
  File "/home/qazal/code/tinygrad/tinygrad/gradient.py", line 28, in call_gradient
    return (None,) + k.arg.grad_fxn(ctx, k)
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/qazal/code/tinygrad/extra/llama_kernels/fused_ce/__init__.py", line 63, in _fused_ce_loss_bwd
    fxn = functools.partial(_custom_fused_ce_loss_bwd, dname=dname, vocab=VOCAB, rows=rows_per_dev, label_smoothing=label_smoothing)
                                                                                                                    ^^^^^^^^^^^^^^^
NameError: name 'label_smoothing' is not defined
```