### PR TITLE
bug fix: UOp cache delete on duplicate keys

### DIFF
--- a/test/null/test_uops.py
+++ b/test/null/test_uops.py
@@ -297,6 +297,14 @@ class TestUopsObject(unittest.TestCase):
     for _ in range(10_000): a = a+a
     self.assertEqual(a.device, Device.DEFAULT)
 
+  def test_uop_del_duplicate_key(self):
+    u = UOp(Ops.CONST, dtypes.int, arg=10000001)
+    key = (u.op, u.dtype, u.src, u.arg, u.tag)
+    v = UOp.__new__(UOp)
+    UOp.__init__(v, *key)
+    del v
+    self.assertIs(UOp(*key), u)
+
 class TestUOpRender(unittest.TestCase):
   def test_render_vectorize_empty(self):
     u = UOp(Ops.STACK, dtype=dtypes.int.vec(0), src=())

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -133,8 +133,10 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
   arg:Any = None
   tag:Any = None
   def __del__(self):
-    if Ops is not None and self.op is Ops.BUFFER and (buffer:=buffers.get(self)) is not None: buffer.ref(-1)
-    try: del UOpMetaClass.ucache[(self.op, self.dtype, self.src, self.arg, self.tag)]
+    try:
+      if Ops is not None and self.op is Ops.BUFFER and (buffer:=buffers.get(self)) is not None: buffer.ref(-1)
+      key = (self.op, self.dtype, self.src, self.arg, self.tag)
+      if (wret:=UOpMetaClass.ucache.get(key)) is not None and wret() is self: del UOpMetaClass.ucache[key]
     except AttributeError: pass
   def __reduce__(self):
     args = [self.op, self.dtype, self.src, self.arg, self.tag, self.metadata]

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -133,11 +133,10 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
   arg:Any = None
   tag:Any = None
   def __del__(self):
-    try:
-      if Ops is not None and self.op is Ops.BUFFER and (buffer:=buffers.get(self)) is not None: buffer.ref(-1)
-      key = (self.op, self.dtype, self.src, self.arg, self.tag)
-      if (wret:=UOpMetaClass.ucache.get(key)) is not None and wret() is self: del UOpMetaClass.ucache[key]
-    except AttributeError: pass
+    if Ops is None or UOpMetaClass is None or not hasattr(self, "tag"): return
+    if self.op is Ops.BUFFER and (buffer:=buffers.get(self)) is not None: buffer.ref(-1)
+    key = (self.op, self.dtype, self.src, self.arg, self.tag)
+    if (wret:=UOpMetaClass.ucache.get(key)) is not None and wret() is self: del UOpMetaClass.ucache[key]
   def __reduce__(self):
     args = [self.op, self.dtype, self.src, self.arg, self.tag, self.metadata]
     if self.op is Ops.BUFFER and self.realized is not None: args.append(self.realized)


### PR DESCRIPTION
addressing geohot's bug on discord. [
<img width="1374" height="572" alt="imagekeyerror" src="https://github.com/user-attachments/assets/de11d653-5cca-433b-9f5c-dab55c229449" />
](url)

i think the issue was that `UOp.__del__` deletes a cache entry just by key. If another same key UOp existed, one object could delete the cache entry for the other, and later deletion caused the ignored `KeyError`.

The fix makes deletion conditional: look up the weakref, and only delete the cache entry if it still points to self.
