### PR TITLE
failing test for llama useless copies

### DIFF
--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -1,5 +1,5 @@
 import unittest
-from tinygrad import Tensor, UOp
+from tinygrad import Tensor, UOp, GlobalCounters
 from tinygrad.dtype import AddrSpace, dtypes
 from tinygrad.uop.ops import KernelInfo, AxisType
 
@@ -307,6 +307,22 @@ class TestCustomKernel(unittest.TestCase):
     result = run(a, b).flatten().tolist()
     expected = (3+2)*2+2
     assert all(x == expected for x in result), f"expected all {expected}, got {result}"
+
+  def test_custom_kernel_sched(self, use_custom=False):
+    x = Tensor.arange(32).reshape(8, 4).realize()
+    y = Tensor.empty_like(x)
+    y = Tensor.custom_kernel(y, x, fxn=custom_add_one_kernel)[0]
+    if use_custom:
+      z = Tensor.empty_like(x)
+      z = Tensor.custom_kernel(y, y.T.T, fxn=custom_add_one_kernel)[0]
+    else: z = y.T.T+1
+    GlobalCounters.reset()
+    z.realize()
+    self.assertEqual(GlobalCounters.kernel_count, 2)
+    self.assertEqual(z.tolist(), x.add(2).tolist())
+
+  @unittest.expectedFailure
+  def test_custom_kernel_sched_copy(self): self.test_custom_kernel_sched(use_custom=True)
 
 class TestUOpReduce(unittest.TestCase):
   def test_uop_sum(self):


### PR DESCRIPTION
it happens when there's back to back custom kernels. there's 655 of these useless copies per llama step.

To repro in full llama:
`JITBEAM=0 NULL_ALLOW_COPYOUT=1 DEV=NULL:HIP:gfx950 time examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama8b/implementations/tinybox_8xMI350X/profile.sh`
For example the output of custom_fa_forward goes through a double permute - that simplifies as a no op - to the second amax custom kernel (call hash is abda752a).
<img width="2560" height="500" alt="image" src="https://github.com/user-attachments/assets/fc02876e-684b-48e3-b4d0-adf8e665dcb6" />
the contiguous in the middle never gets removed and becomes a useless copy. In this case copying the output of custom_fa_fw before it's consumed by the amax kernel.