### PR TITLE
remove contiguous(param)

### DIFF
--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -1,5 +1,5 @@
 import unittest
-from tinygrad import Tensor, UOp, GlobalCounters
+from tinygrad import Tensor, UOp, GlobalCounters, Device
 from tinygrad.dtype import AddrSpace, dtypes
 from tinygrad.uop.ops import KernelInfo, AxisType
 
@@ -334,7 +334,7 @@ class TestCustomKernel(unittest.TestCase):
     GlobalCounters.reset()
     y = run(x[0]).realize()
     # TODO: it's copying the output
-    self.assertEqual(GlobalCounters.kernel_count, 2)
+    self.assertEqual(GlobalCounters.kernel_count, 2 if hasattr(Device[Device.DEFAULT].allocator, "_offset") else 3)
     self.assertEqual(y.tolist(), [1, 2, 3, 4])
 
 class TestUOpReduce(unittest.TestCase):

--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -324,7 +324,6 @@ class TestCustomKernel(unittest.TestCase):
   @unittest.expectedFailure
   def test_custom_kernel_sched_copy(self): self.test_custom_kernel_sched(use_custom=True)
 
-  @unittest.expectedFailure
   def test_sliced_buffer_function(self):
     x = Tensor.arange(32).reshape(8, 4).realize()
     from tinygrad import function
@@ -334,8 +333,8 @@ class TestCustomKernel(unittest.TestCase):
       return Tensor.custom_kernel(y, x, fxn=custom_add_one_kernel)[0]
     GlobalCounters.reset()
     y = run(x[0]).realize()
-    # it's copying the input and the output
-    self.assertEqual(GlobalCounters.kernel_count, 1)
+    # TODO: it's copying the output
+    self.assertEqual(GlobalCounters.kernel_count, 2)
     self.assertEqual(y.tolist(), [1, 2, 3, 4])
 
 class TestUOpReduce(unittest.TestCase):

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -157,6 +157,9 @@ earliest_rewrites = mop_cleanup+PatternMatcher([
   # remove DETACH/CONTIGUOUS_BACKWARD (TODO: this is copied in allocations)
   (UPat((Ops.DETACH, Ops.CONTIGUOUS_BACKWARD), name="x"), lambda x: x.src[0]),
 
+  # remove CONTIGUOUS on PARAM
+  (UPat(Ops.CONTIGUOUS, src=(UPat(Ops.PARAM, name="p"),), name="c"), lambda p,c: p),
+
   # remove contiguous on movement ops before a copy on disk
   (UPat(GroupOp.Movement-{Ops.SHRINK, Ops.RESHAPE}, name="x").f(Ops.CONTIGUOUS).f(Ops.COPY, allow_any_len=True, name="copy"),
    lambda x,copy: copy.replace(src=(x,)+copy.src[1:]) if isinstance(x.device, str) and x.device.startswith("DISK") else None),


### PR DESCRIPTION
1259 -> 1067 copy E_ kernels in llama.
It's not a systematic fix though. The only real way to deal with this is doing less early contiguous in Tensor.custom_kernel.