### PR TITLE
hotfix: prepend LD_LIBRARY_PATH to DLL posix search dirs

### DIFF
--- a/tinygrad/runtime/support/c.py
+++ b/tinygrad/runtime/support/c.py
@@ -94,7 +94,8 @@ class DLL(ctypes.CDLL):
     if nm == 'libc' and OSX: return '/usr/lib/libc.dylib'
     if pathlib.Path(path:=getenv(nm.replace('-', '_').upper()+"_PATH", '')).is_file(): return path
     for p in paths:
-      libpaths = {"posix": ["/usr/lib64", "/usr/lib", "/usr/local/lib"], "nt": os.environ['PATH'].split(os.pathsep),
+      libpaths = {"posix": [d for d in os.environ.get('LD_LIBRARY_PATH', '').split(os.pathsep) if d] + ["/usr/lib64", "/usr/lib", "/usr/local/lib"],
+                  "nt": os.environ['PATH'].split(os.pathsep),
                   "darwin": ["/opt/homebrew/lib", f"/System/Library/Frameworks/{p}.framework", f"/System/Library/PrivateFrameworks/{p}.framework"],
                   'linux': ['/lib', '/lib64', f"/lib/{sysconfig.get_config_var('MULTIARCH')}", "/usr/lib/wsl/lib/"]}
       if (pth:=pathlib.Path(p)).is_absolute():


### PR DESCRIPTION
Colab T4 (CUDA 13, driver 580) injects the real driver at `/usr/lib64-nvidia` via LD_LIBRARY_PATH, but findlib misses it. This prepends LD_LIBRARY_PATH before the hardcoded posix dirs.
