### PR TITLE
combine symbolic mask folding with threefry rules

### DIFF
--- a/test/null/test_uop_symbolic.py
+++ b/test/null/test_uop_symbolic.py
@@ -428,6 +428,10 @@ class TestSymbolic(unittest.TestCase):
     x = UOp.variable('x', 0, 255, dtype=dtypes.uint32)
     self.helper_test_variable((x & -4) >> 2, 0, 63, "(x>>2)", test_z3=False)
 
+  def test_masked_cast_fold(self):
+    x = UOp.variable('x', 0, 0xFFFFFFFF, dtype=dtypes.uint64)
+    self.assertEqual((x & 0xFFFFFFFF).cast(dtypes.uint32).simplify(), x.cast(dtypes.uint32))
+
   def test_bool_or_not_tautology(self):
     a = Variable("a", 0, 10)
     c = a<10

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -50,8 +50,9 @@ def fold_add_divmod_recombine(x:UOp) -> UOp|None:
 
 def fold_redundant_mask(root:UOp, x:UOp, mask:UOp) -> UOp|None:
   if root.op is Ops.CAST:
-    return x.cast(root.dtype) if x.dtype.scalar() == dtypes.uint64 and root.dtype.scalar() == dtypes.uint32 and mask.arg == 0xFFFFFFFF else None
+    return x.cast(dtypes.uint32) if x.dtype.scalar() == dtypes.uint64 and mask.arg == 0xFFFFFFFF and root.dtype.scalar() == dtypes.uint32 else None
   if root.op is Ops.SHR and root.src[1].op is Ops.CONST:
+    # (x&mask)>>k -> x>>k when mask only clears bits below k
     return x >> root.src[1].arg if mask.arg | ((1 << root.src[1].arg) - 1) == -1 else None
   return None
 

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -48,6 +48,13 @@ def fold_add_divmod_recombine(x:UOp) -> UOp|None:
           return (base % (div*d)).usum(*[t for k,t in enumerate(terms) if k not in (i,j)])
   return None
 
+def fold_masked(root:UOp, x:UOp, mask:UOp) -> UOp|None:
+  if root.op is Ops.CAST:
+    return x.cast(root.dtype) if x.dtype.scalar() == dtypes.uint64 and root.dtype.scalar() == dtypes.uint32 and mask.arg == 0xFFFFFFFF else None
+  if root.op is Ops.SHR and root.src[1].op is Ops.CONST:
+    return x >> root.src[1].arg if mask.arg | ((1 << root.src[1].arg) - 1) == -1 else None
+  return None
+
 # this needs to be before symbolic so that 0*something_that_might_be_invalid doesnt become 0
 propagate_invalid = PatternMatcher([
   # propagate invalid, push it past children
@@ -100,13 +107,6 @@ symbolic_simple = propagate_invalid + PatternMatcher([
   (UPat.var("x") % UPat.var("x"), lambda x: x.const_like(0)), # x%x -> 0
   (UPat.var("x") ^ UPat.var("x"), lambda x: x.const_like(0)), # x^x -> 0
   (UPat.var("x") & 0, lambda x: x.const_like(0)), # x&0 -> 0
-  # (x&mask)>>k -> x>>k when mask only clears bits below k
-  # (x&mask)<<k -> x<<k when mask only clears bits in the top k (shifted out)
-  # TODO: combine this with "# rules for threefry" below
-  ((UPat.var("x") & UPat.cvar("mask", vec=False)) >> UPat.cvar("k", vec=False),
-   lambda x,mask,k: x >> k.arg if mask.arg | ((1 << k.arg) - 1) == -1 else None),
-  ((UPat.var("x") & UPat.cvar("mask", vec=False)) << UPat.cvar("k", vec=False),
-   lambda x,mask,k: x << k.arg if (mask.arg & (m:=(1<<(x.dtype.scalar().bitsize-k.arg))-1 if x.dtype.scalar().bitsize>k.arg else 0)) == m else None),
   (UPat.var("x", dtype=dtypes.ints+(dtypes.bool, dtypes.weakint)) != UPat.var("x"),
    lambda x: x.const_like(False).cast(dtypes.bool.vec(x.dtype.count))), # x != x -> False (only ints)
   # ** constant folding **
@@ -144,7 +144,7 @@ symbolic_simple = propagate_invalid + PatternMatcher([
   # positive const ** x
   (UPat.cvar("c", vec=False).alu(Ops.POW, UPat.var("x")), lambda c,x: c if c.arg == 1 else (x*math.log2(c.arg)).exp2() if c.arg > 0 else None),
   # rules for threefry
-  ((UPat.var('x', dtypes.uint64)&0xFFFFFFFF).cast(dtypes.uint32), lambda x: x.cast(dtypes.uint32)),
+  (UPat((Ops.CAST, Ops.SHR), name="root", src=(UPat.var("x") & UPat.cvar("mask", vec=False),), allow_any_len=True), fold_masked),
   (((UPat.var(None, dtypes.uint64)*(1<<32)) | UPat.var('y',  dtypes.uint32).cast(dtypes.uint64)).cast(dtypes.uint32), lambda y: y),
   (((UPat.var('x',  dtypes.uint64)*(1<<32)) | UPat.var(None, dtypes.uint32).cast(dtypes.uint64))//(1<<32), lambda x: x),
   (((UPat.var(None, dtypes.uint64)<<32) | UPat.var('y',  dtypes.uint32).cast(dtypes.uint64)).cast(dtypes.uint32), lambda y: y),

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -101,9 +101,12 @@ symbolic_simple = propagate_invalid + PatternMatcher([
   (UPat.var("x") ^ UPat.var("x"), lambda x: x.const_like(0)), # x^x -> 0
   (UPat.var("x") & 0, lambda x: x.const_like(0)), # x&0 -> 0
   # (x&mask)>>k -> x>>k when mask only clears bits below k
+  # (x&mask)<<k -> x<<k when mask only clears bits in the top k (shifted out)
   # TODO: combine this with "# rules for threefry" below
   ((UPat.var("x") & UPat.cvar("mask", vec=False)) >> UPat.cvar("k", vec=False),
    lambda x,mask,k: x >> k.arg if mask.arg | ((1 << k.arg) - 1) == -1 else None),
+  ((UPat.var("x") & UPat.cvar("mask", vec=False)) << UPat.cvar("k", vec=False),
+   lambda x,mask,k: x << k.arg if (mask.arg & (m:=(1<<(x.dtype.scalar().bitsize-k.arg))-1 if x.dtype.scalar().bitsize>k.arg else 0)) == m else None),
   (UPat.var("x", dtype=dtypes.ints+(dtypes.bool, dtypes.weakint)) != UPat.var("x"),
    lambda x: x.const_like(False).cast(dtypes.bool.vec(x.dtype.count))), # x != x -> False (only ints)
   # ** constant folding **

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -48,7 +48,7 @@ def fold_add_divmod_recombine(x:UOp) -> UOp|None:
           return (base % (div*d)).usum(*[t for k,t in enumerate(terms) if k not in (i,j)])
   return None
 
-def fold_masked(root:UOp, x:UOp, mask:UOp) -> UOp|None:
+def fold_redundant_mask(root:UOp, x:UOp, mask:UOp) -> UOp|None:
   if root.op is Ops.CAST:
     return x.cast(root.dtype) if x.dtype.scalar() == dtypes.uint64 and root.dtype.scalar() == dtypes.uint32 and mask.arg == 0xFFFFFFFF else None
   if root.op is Ops.SHR and root.src[1].op is Ops.CONST:
@@ -144,7 +144,7 @@ symbolic_simple = propagate_invalid + PatternMatcher([
   # positive const ** x
   (UPat.cvar("c", vec=False).alu(Ops.POW, UPat.var("x")), lambda c,x: c if c.arg == 1 else (x*math.log2(c.arg)).exp2() if c.arg > 0 else None),
   # rules for threefry
-  (UPat((Ops.CAST, Ops.SHR), name="root", src=(UPat.var("x") & UPat.cvar("mask", vec=False),), allow_any_len=True), fold_masked),
+  (UPat((Ops.CAST, Ops.SHR), name="root", src=(UPat.var("x") & UPat.cvar("mask", vec=False),), allow_any_len=True), fold_redundant_mask),
   (((UPat.var(None, dtypes.uint64)*(1<<32)) | UPat.var('y',  dtypes.uint32).cast(dtypes.uint64)).cast(dtypes.uint32), lambda y: y),
   (((UPat.var('x',  dtypes.uint64)*(1<<32)) | UPat.var(None, dtypes.uint32).cast(dtypes.uint64))//(1<<32), lambda x: x),
   (((UPat.var(None, dtypes.uint64)<<32) | UPat.var('y',  dtypes.uint32).cast(dtypes.uint64)).cast(dtypes.uint32), lambda y: y),


### PR DESCRIPTION
Completed  #TODO asking to combine redundant mask folding rule with rules for threefry. New `test_masked_cast_fold` + existing `test_masked_shr_fold` cover behaviour of the new rule.
```python
# (x & mask) >> k
x = UOp.variable("x", 0, 255, dtypes.weakint)
test = ((x & -8) >> 3).simplify()

# u32(u64(x) & 0xFFFFFFFF) -> u32(x)
y = UOp.variable("y", 0, 0xFFFFFFFF, dtypes.uint64)
test = ((y & 0xFFFFFFFF).cast(dtypes.uint32)).simplify()
```
Speed of simplify is the same between 6460e76 and 9717d3a.
