### PR TITLE
add signed int32/int64 mul_hi

### DIFF
--- a/test/test_mul_hi.py
+++ b/test/test_mul_hi.py
@@ -2,8 +2,8 @@ import unittest, numpy as np
 from tinygrad import Tensor, dtypes
 
 
-def ref_mul_hi(x:int, y:int) -> np.int64:
-  return np.int64((int(x)*int(y)) >> 64)
+def ref_mul_hi(x:int, y:int, dtype) -> np.integer:
+  return dtype.type((int(x)*int(y)) >> (dtype.itemsize*8))
 
 
 class TestMulHi(unittest.TestCase):
@@ -14,7 +14,16 @@ class TestMulHi(unittest.TestCase):
     cases += [(int(rng.integers(-(1<<62), 1<<62)), int(rng.integers(-(1<<62), 1<<62))) for _ in range(16)]
     a = Tensor([x for x,_ in cases], dtype=dtypes.int64)
     b = Tensor([y for _,y in cases], dtype=dtypes.int64)
-    expected = np.array([ref_mul_hi(x, y) for x,y in cases], dtype=np.int64)
+    expected = np.array([ref_mul_hi(x, y, np.dtype(np.int64)) for x,y in cases], dtype=np.int64)
+    np.testing.assert_array_equal(a.mul_hi(b).numpy(), expected)
+
+  def test_mul_hi_int32_vs_numpy_reference(self):
+    rng = np.random.default_rng(1)
+    cases = [(2**30, 2), (-(2**30), 3), ((1<<31)-1, (1<<31)-1), (-(1<<31), -(1<<31)), (-1, -1), (12345, 67890)]
+    cases += [(int(rng.integers(-(1<<31), 1<<31)), int(rng.integers(-(1<<31), 1<<31))) for _ in range(16)]
+    a = Tensor([x for x,_ in cases], dtype=dtypes.int32)
+    b = Tensor([y for _,y in cases], dtype=dtypes.int32)
+    expected = np.array([ref_mul_hi(x, y, np.dtype(np.int32)) for x,y in cases], dtype=np.int32)
     np.testing.assert_array_equal(a.mul_hi(b).numpy(), expected)
 
   def test_mul_hi_broadcasts(self):
@@ -22,13 +31,15 @@ class TestMulHi(unittest.TestCase):
     b_vals = [[2, -3]]
     a = Tensor(a_vals, dtype=dtypes.int64)
     b = Tensor(b_vals, dtype=dtypes.int64)
-    expected = np.array([[ref_mul_hi(x, y) for y in b_vals[0]] for x, in a_vals], dtype=np.int64)
+    expected = np.array([[ref_mul_hi(x, y, np.dtype(np.int64)) for y in b_vals[0]] for x, in a_vals], dtype=np.int64)
     np.testing.assert_array_equal(a.mul_hi(b).numpy(), expected)
 
-  def test_mul_hi_rejects_non_int64(self):
-    for dt in (dtypes.float32, dtypes.int32):
-      with self.assertRaisesRegex(RuntimeError, "int64"):
+  def test_mul_hi_rejects_non_int32_int64(self):
+    for dt in (dtypes.float32, dtypes.int16):
+      with self.assertRaisesRegex(RuntimeError, "int32 or int64"):
         Tensor([1, 2], dtype=dt).mul_hi(Tensor([3, 4], dtype=dt))
+    with self.assertRaisesRegex(RuntimeError, "matching"):
+      Tensor([1, 2], dtype=dtypes.int32).mul_hi(Tensor([3, 4], dtype=dtypes.int64))
 
 
 if __name__ == "__main__":

--- a/test/test_mul_hi.py
+++ b/test/test_mul_hi.py
@@ -1,0 +1,35 @@
+import unittest, numpy as np
+from tinygrad import Tensor, dtypes
+
+
+def ref_mul_hi(x:int, y:int) -> np.int64:
+  return np.int64((int(x)*int(y)) >> 64)
+
+
+class TestMulHi(unittest.TestCase):
+  def test_mul_hi_vs_numpy_reference(self):
+    rng = np.random.default_rng(0)
+    cases = [(2**40, 2**40), (2**62, 2), (-(2**40), 2**40), ((1<<63)-1, (1<<63)-1),
+             (-(1<<63), -(1<<63)), (-1, -1), (12345, 67890), (0, (1<<63)-1)]
+    cases += [(int(rng.integers(-(1<<62), 1<<62)), int(rng.integers(-(1<<62), 1<<62))) for _ in range(16)]
+    a = Tensor([x for x,_ in cases], dtype=dtypes.int64)
+    b = Tensor([y for _,y in cases], dtype=dtypes.int64)
+    expected = np.array([ref_mul_hi(x, y) for x,y in cases], dtype=np.int64)
+    np.testing.assert_array_equal(a.mul_hi(b).numpy(), expected)
+
+  def test_mul_hi_broadcasts(self):
+    a_vals = [[-(1<<63)], [(1<<62)]]
+    b_vals = [[2, -3]]
+    a = Tensor(a_vals, dtype=dtypes.int64)
+    b = Tensor(b_vals, dtype=dtypes.int64)
+    expected = np.array([[ref_mul_hi(x, y) for y in b_vals[0]] for x, in a_vals], dtype=np.int64)
+    np.testing.assert_array_equal(a.mul_hi(b).numpy(), expected)
+
+  def test_mul_hi_rejects_non_int64(self):
+    for dt in (dtypes.float32, dtypes.int32):
+      with self.assertRaisesRegex(RuntimeError, "int64"):
+        Tensor([1, 2], dtype=dt).mul_hi(Tensor([3, 4], dtype=dt))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -103,6 +103,13 @@ def uops_to_dtypes(uops:list[UOp]) -> list[DType]: return dedup(u.dtype for u in
 def wmma_args(uops:list[UOp]):
   return dedup((uop.arg[0], uop.arg[1], uop.arg[2], uop.dtype.scalar(), *(uop.arg[4:8])) for uop in uops if uop.op is Ops.WMMA)
 
+def c_mulhi(a, b, dtype):
+  bits, wide, out = dtype.itemsize*8, "__int128" if dtype == dtypes.int64 else "long long", "long" if dtype == dtypes.int64 else "int"
+  return f"({out})((({wide})({a})*({wide})({b}))>>{bits})"
+
+def cuda_mulhi(a, b, dtype):
+  return f"__mul64hi((long long)({a}), (long long)({b}))" if dtype == dtypes.int64 else f"__mulhi((int)({a}), (int)({b}))"
+
 class CStyleLanguage(Renderer):
   kernel_typedef: str = "void"
   buffer_prefix: str = ""
@@ -233,7 +240,7 @@ class ClangRenderer(CStyleLanguage):
                  Ops.SQRT: lambda x,dtype: f"__builtin_sqrt({x})" if dtype == dtypes.float64 else f"__builtin_sqrtf({x})",
                  Ops.TRUNC: lambda x,dtype: f"__builtin_trunc({x})" if dtype == dtypes.float64 else f"__builtin_truncf({x})",
                  Ops.FDIV: lambda a,b,dtype: f"({a}/{b})",
-                 Ops.MULHI: lambda a,b,dtype: f"(long)(((__int128)({a})*(__int128)({b}))>>64)"}
+                 Ops.MULHI: c_mulhi}
 
   # LLVM legalizes double => half/bf16 cast on systems that don't support it natively (like x86 cpus without AVX512-FP16) into a compiler-rt libcall.
   # there is also no native bfl16 <-> fp16 conversion on those CPUs
@@ -416,7 +423,7 @@ class CUDARenderer(CStyleLanguage):
     Ops.EXP2: lambda x,dtype: f"hexp2({x})" if dtype in (dtypes.half, dtypes.bfloat16) else f"exp2({x})",
     Ops.SQRT: lambda x,dtype: f"hsqrt({x})" if dtype in (dtypes.half, dtypes.bfloat16) else f"sqrt({x})",
     Ops.RECIPROCAL: lambda x,dtype: f"hrcp({x})" if dtype in (dtypes.half, dtypes.bfloat16) else f"(1/{x})",
-    Ops.MULHI: lambda a,b,dtype: f"__mul64hi((long long)({a}), (long long)({b}))" }
+    Ops.MULHI: cuda_mulhi }
   type_map = {dtypes.bfloat16: "nv_bfloat16", dtypes.fp8e4m3: "__nv_fp8_e4m3", dtypes.fp8e5m2: "__nv_fp8_e5m2"}
   extra_matcher = create_non_native_float_pats(dtypes.fp8s, casting=False) + PatternMatcher([
     (UPat(Ops.CAST, dtypes.fp8s, UPat.var("x", dtypes.fp8s), name='y'), lambda x,y: x.cast(dtypes.float).cast(y.dtype) if x.dtype!=y.dtype else None),

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -232,7 +232,8 @@ class ClangRenderer(CStyleLanguage):
   code_for_op = {**({k:v for k,v in CStyleLanguage.code_for_op.items() if k not in [Ops.EXP2, Ops.SIN, Ops.LOG2, Ops.TRUNC, Ops.RECIPROCAL]}),
                  Ops.SQRT: lambda x,dtype: f"__builtin_sqrt({x})" if dtype == dtypes.float64 else f"__builtin_sqrtf({x})",
                  Ops.TRUNC: lambda x,dtype: f"__builtin_trunc({x})" if dtype == dtypes.float64 else f"__builtin_truncf({x})",
-                 Ops.FDIV: lambda a,b,dtype: f"({a}/{b})"}
+                 Ops.FDIV: lambda a,b,dtype: f"({a}/{b})",
+                 Ops.MULHI: lambda a,b,dtype: f"(long)(((__int128)({a})*(__int128)({b}))>>64)"}
 
   # LLVM legalizes double => half/bf16 cast on systems that don't support it natively (like x86 cpus without AVX512-FP16) into a compiler-rt libcall.
   # there is also no native bfl16 <-> fp16 conversion on those CPUs
@@ -359,7 +360,8 @@ class MetalRenderer(CStyleLanguage):
   type_map = {dtypes.bfloat16: "bfloat"}
 
   # precise::sin
-  code_for_op = {**CStyleLanguage.code_for_op, Ops.SIN: lambda x,dtype: f"precise::sin({x})"}
+  code_for_op = {**CStyleLanguage.code_for_op, Ops.SIN: lambda x,dtype: f"precise::sin({x})",
+                 Ops.MULHI: lambda a,b,dtype: f"mulhi({a},{b})"}
 
   # upcast to float32 all the ops that don't support bfloat16
   extra_matcher = PatternMatcher([
@@ -413,7 +415,8 @@ class CUDARenderer(CStyleLanguage):
     Ops.LOG2: lambda x,dtype: f"hlog2({x})" if dtype in (dtypes.half, dtypes.bfloat16) else f"log2({x})",
     Ops.EXP2: lambda x,dtype: f"hexp2({x})" if dtype in (dtypes.half, dtypes.bfloat16) else f"exp2({x})",
     Ops.SQRT: lambda x,dtype: f"hsqrt({x})" if dtype in (dtypes.half, dtypes.bfloat16) else f"sqrt({x})",
-    Ops.RECIPROCAL: lambda x,dtype: f"hrcp({x})" if dtype in (dtypes.half, dtypes.bfloat16) else f"(1/{x})" }
+    Ops.RECIPROCAL: lambda x,dtype: f"hrcp({x})" if dtype in (dtypes.half, dtypes.bfloat16) else f"(1/{x})",
+    Ops.MULHI: lambda a,b,dtype: f"__mul64hi((long long)({a}), (long long)({b}))" }
   type_map = {dtypes.bfloat16: "nv_bfloat16", dtypes.fp8e4m3: "__nv_fp8_e4m3", dtypes.fp8e5m2: "__nv_fp8_e5m2"}
   extra_matcher = create_non_native_float_pats(dtypes.fp8s, casting=False) + PatternMatcher([
     (UPat(Ops.CAST, dtypes.fp8s, UPat.var("x", dtypes.fp8s), name='y'), lambda x,y: x.cast(dtypes.float).cast(y.dtype) if x.dtype!=y.dtype else None),

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -100,6 +100,10 @@ base_rewrite = PatternMatcher([
   (UPat(Ops.CAST, name="x"), lambda ctx,x: f"  {ctx[x]} = {lcast(x.src[0].dtype, x.dtype)} {ldt(x.src[0].dtype)} {ctx[x.src[0]]} to {ldt(x.dtype)}"),
   (UPat(Ops.TRUNC, name="x"),
    lambda ctx,x: f"  {ctx[x]} = call {ldt(x.dtype)} @llvm.trunc.{ldt(x.dtype.scalar())}({ldt(x.src[0].dtype)} {ctx[x.src[0]]})"),
+  (UPat(Ops.MULHI, name="x"), lambda ctx,x:
+   f"  {ctx[x]}_a = sext i64 {ctx[x.src[0]]} to i128\n  {ctx[x]}_b = sext i64 {ctx[x.src[1]]} to i128\n"
+   f"  {ctx[x]}_m = mul i128 {ctx[x]}_a, {ctx[x]}_b\n  {ctx[x]}_s = ashr i128 {ctx[x]}_m, 64\n"
+   f"  {ctx[x]} = trunc i128 {ctx[x]}_s to i64"),
   (UPat(GroupOp.Binary, name="x"), lambda ctx,x:
    f"  {ctx[x]} = {lop[x.src[0].dtype.scalar()][x.op]} {ldt(x.src[0].dtype)} {ctx[x.src[0]]}, {ctx[x.src[1]]}"),
   (UPat(Ops.WHERE, name="x"), lambda ctx,x:

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -100,10 +100,12 @@ base_rewrite = PatternMatcher([
   (UPat(Ops.CAST, name="x"), lambda ctx,x: f"  {ctx[x]} = {lcast(x.src[0].dtype, x.dtype)} {ldt(x.src[0].dtype)} {ctx[x.src[0]]} to {ldt(x.dtype)}"),
   (UPat(Ops.TRUNC, name="x"),
    lambda ctx,x: f"  {ctx[x]} = call {ldt(x.dtype)} @llvm.trunc.{ldt(x.dtype.scalar())}({ldt(x.src[0].dtype)} {ctx[x.src[0]]})"),
-  (UPat(Ops.MULHI, name="x"), lambda ctx,x:
-   f"  {ctx[x]}_a = sext i64 {ctx[x.src[0]]} to i128\n  {ctx[x]}_b = sext i64 {ctx[x.src[1]]} to i128\n"
-   f"  {ctx[x]}_m = mul i128 {ctx[x]}_a, {ctx[x]}_b\n  {ctx[x]}_s = ashr i128 {ctx[x]}_m, 64\n"
-   f"  {ctx[x]} = trunc i128 {ctx[x]}_s to i64"),
+  (UPat(Ops.MULHI, name="x"), lambda ctx,x: "\n".join([
+   f"  {ctx[x]}_a = sext {ldt(x.dtype)} {ctx[x.src[0]]} to i{x.dtype.itemsize*16}",
+   f"  {ctx[x]}_b = sext {ldt(x.dtype)} {ctx[x.src[1]]} to i{x.dtype.itemsize*16}",
+   f"  {ctx[x]}_m = mul i{x.dtype.itemsize*16} {ctx[x]}_a, {ctx[x]}_b",
+   f"  {ctx[x]}_s = ashr i{x.dtype.itemsize*16} {ctx[x]}_m, {x.dtype.itemsize*8}",
+   f"  {ctx[x]} = trunc i{x.dtype.itemsize*16} {ctx[x]}_s to {ldt(x.dtype)}"])),
   (UPat(GroupOp.Binary, name="x"), lambda ctx,x:
    f"  {ctx[x]} = {lop[x.src[0].dtype.scalar()][x.op]} {ldt(x.src[0].dtype)} {ctx[x.src[0]]}, {ctx[x.src[1]]}"),
   (UPat(Ops.WHERE, name="x"), lambda ctx,x:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -162,8 +162,8 @@ class Tensor(OpMixin):
 
   # alu and const_like are used by the mixins
   def mul_hi(self, x: Tensor) -> Tensor:
-    if self.dtype != dtypes.int64 or x.dtype != dtypes.int64:
-      raise RuntimeError(f"mul_hi requires int64 inputs, got {self.dtype} and {x.dtype}")
+    if self.dtype != x.dtype or self.dtype not in (dtypes.int32, dtypes.int64):
+      raise RuntimeError(f"mul_hi requires matching int32 or int64 inputs, got {self.dtype} and {x.dtype}")
     return self._binop(Ops.MULHI, x, False)
   def alu(self, op: Ops, *src: Tensor) -> Tensor: return self._apply_uop(lambda *u: u[0].alu(op, *u[1:]), *src)
   def const_like(self, b:ConstType) -> Tensor: return Tensor(self.uop.const_like(b), requires_grad=False)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -161,6 +161,10 @@ class Tensor(OpMixin):
     return ret
 
   # alu and const_like are used by the mixins
+  def mul_hi(self, x: Tensor) -> Tensor:
+    if self.dtype != dtypes.int64 or x.dtype != dtypes.int64:
+      raise RuntimeError(f"mul_hi requires int64 inputs, got {self.dtype} and {x.dtype}")
+    return self._binop(Ops.MULHI, x, False)
   def alu(self, op: Ops, *src: Tensor) -> Tensor: return self._apply_uop(lambda *u: u[0].alu(op, *u[1:]), *src)
   def const_like(self, b:ConstType) -> Tensor: return Tensor(self.uop.const_like(b), requires_grad=False)
   @staticmethod

--- a/tinygrad/uop/__init__.py
+++ b/tinygrad/uop/__init__.py
@@ -61,7 +61,7 @@ class Ops(FastEnum):
   SQRT = auto(); RECIPROCAL = auto(); NEG = auto(); TRUNC = auto()
 
   # BinaryOps
-  ADD = auto(); MUL = auto(); SHL = auto(); SHR = auto(); IDIV = auto(); MAX = auto(); MOD = auto()
+  ADD = auto(); MUL = auto(); MULHI = auto(); SHL = auto(); SHR = auto(); IDIV = auto(); MAX = auto(); MOD = auto()
   CMPLT = auto(); CMPNE = auto(); CMPEQ = auto()
   XOR = auto(); OR = auto(); AND = auto()
   THREEFRY = auto(); SUB = auto(); FDIV = auto(); POW = auto()
@@ -109,7 +109,7 @@ class Ops(FastEnum):
 
 class GroupOp:
   Unary = {Ops.EXP2, Ops.LOG2, Ops.SIN, Ops.SQRT, Ops.RECIPROCAL, Ops.NEG, Ops.TRUNC}
-  Binary = {Ops.ADD, Ops.MUL, Ops.IDIV, Ops.MAX, Ops.MOD, Ops.CMPLT, Ops.CMPNE, Ops.CMPEQ,
+  Binary = {Ops.ADD, Ops.MUL, Ops.MULHI, Ops.IDIV, Ops.MAX, Ops.MOD, Ops.CMPLT, Ops.CMPNE, Ops.CMPEQ,
             Ops.XOR, Ops.SHL, Ops.SHR, Ops.OR, Ops.AND, Ops.THREEFRY, Ops.SUB, Ops.FDIV, Ops.POW}
   Ternary = {Ops.WHERE, Ops.MULACC}
   ALU = set.union(Unary, Binary, Ternary)

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1047,7 +1047,8 @@ python_alu: dict[Ops, Callable]  = {
   Ops.LOG2: lambda x: math.log2(x) if x > 0 else -math.inf if x == 0 else math.nan, Ops.EXP2: safe_exp2,
   Ops.SQRT: lambda x: math.sqrt(x) if x >= 0 else math.nan, Ops.RECIPROCAL: lambda x: 1/x if x != 0 else math.copysign(math.inf, x),
   Ops.SIN: lambda x: math.sin(x) if not math.isinf(x) else math.nan, Ops.POW: safe_pow, Ops.TRUNC: math.trunc,
-  Ops.NEG: operator.neg, Ops.ADD: operator.add, Ops.SUB: operator.sub, Ops.MUL: operator.mul, Ops.CMPNE: operator.ne, Ops.CMPLT: operator.lt,
+  Ops.NEG: operator.neg, Ops.ADD: operator.add, Ops.SUB: operator.sub, Ops.MUL: operator.mul,
+  Ops.MULHI: lambda x,y: (int(x)*int(y)) >> 64, Ops.CMPNE: operator.ne, Ops.CMPLT: operator.lt,
   Ops.XOR: operator.xor, Ops.OR: operator.or_, Ops.AND: operator.and_, Ops.SHR: operator.rshift, Ops.SHL: operator.lshift, Ops.MAX: max,
   Ops.MOD: cmod, Ops.IDIV: cdiv, Ops.MULACC: lambda x,y,z: (x*y)+z, Ops.WHERE: lambda x,y,z: y if x else z, Ops.CMPEQ: operator.eq}
 

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1048,7 +1048,7 @@ python_alu: dict[Ops, Callable]  = {
   Ops.SQRT: lambda x: math.sqrt(x) if x >= 0 else math.nan, Ops.RECIPROCAL: lambda x: 1/x if x != 0 else math.copysign(math.inf, x),
   Ops.SIN: lambda x: math.sin(x) if not math.isinf(x) else math.nan, Ops.POW: safe_pow, Ops.TRUNC: math.trunc,
   Ops.NEG: operator.neg, Ops.ADD: operator.add, Ops.SUB: operator.sub, Ops.MUL: operator.mul,
-  Ops.MULHI: lambda x,y: (int(x)*int(y)) >> 64, Ops.CMPNE: operator.ne, Ops.CMPLT: operator.lt,
+  Ops.MULHI: lambda x,y,bits=64: (int(x)*int(y)) >> bits, Ops.CMPNE: operator.ne, Ops.CMPLT: operator.lt,
   Ops.XOR: operator.xor, Ops.OR: operator.or_, Ops.AND: operator.and_, Ops.SHR: operator.rshift, Ops.SHL: operator.lshift, Ops.MAX: max,
   Ops.MOD: cmod, Ops.IDIV: cdiv, Ops.MULACC: lambda x,y,z: (x*y)+z, Ops.WHERE: lambda x,y,z: y if x else z, Ops.CMPEQ: operator.eq}
 
@@ -1056,6 +1056,7 @@ def exec_alu(op:Ops, dtype:DType, operands, truncate_output=True):
   if dtype.count > 1:
     return tuple([exec_alu(op, dtype.scalar(), [x[i] if isinstance(x, tuple) else x for x in operands]) for i in range(dtype.count)])
   if dtype==dtypes.weakint and op in GroupOp.Binary and Invalid in operands: return Invalid
+  if op is Ops.MULHI: operands = (*operands, dtype.itemsize*8)
   alu = python_alu[op](*operands)
   return truncate.get(dtype, lambda x: x)(alu) if truncate_output else alu
 


### PR DESCRIPTION
Add `Tensor.mul_hi(a, b)` returning the upper half of a signed integer product for matching `int32` or `int64` inputs.

tinygrad currently cannot express the upper half of a wide integer product in-kernel without manual decomposition. This is useful for compiler-style reciprocal multiply in integer division/modulo lowering, fixed-point rescale after integer quantized accumulators, and multiword integer arithmetic.

**Lowerings:**
- CPU/Clang: widened multiply, arithmetic shift, truncate
- CUDA: `__mulhi` / `__mul64hi`
- Metal: `mulhi`
- LLVM IR: signed widen, multiply, arithmetic shift, truncate

Restricted to matching `int32` or `int64`. Errors on other dtypes.

**Tests:**
- `DEV=CPU python3 -m pytest test/test_mul_hi.py`
- `DEV=METAL python3 -m pytest test/test_mul_hi.py`

Also checked broader CPU and Metal randomized/reference cases for signed `int32` and `int64`, including min/max/sign edges.

## Microbenchmarks

Both benchmarks use `N=256, C=4096` (`1,048,576` elements). The script below is self-contained and can be run from the repo root with `DEV=CUDA python3 bench_mul_hi.py` or `DEV=METAL python3 bench_mul_hi.py`.

```python
# bench_mul_hi.py
import statistics, time
from tinygrad import Tensor, dtypes
from tinygrad.device import Device

N, C = 256, 4096
Tensor.manual_seed(0)

def bench(name, fn, iters=50, warmup=10):
  for _ in range(warmup):
    out = fn()
    Device.default.synchronize()
  times = []
  for _ in range(iters):
    st = time.perf_counter()
    out = fn()
    Device.default.synchronize()
    times.append(time.perf_counter() - st)
  best, med = min(times), statistics.median(times)
  elems = N*C
  print(f"{name:24s} best={best*1e3:.3f} ms median={med*1e3:.3f} ms ns/elem={best*1e9/elems:.3f}")

acc = Tensor.randint(N, C, low=-(1<<30), high=(1<<30), dtype=dtypes.int32).realize()
scale = Tensor.randint(C, low=-(1<<31), high=(1<<31)-1, dtype=dtypes.int32).realize()
Device.default.synchronize()
bench("int32 mul_hi", lambda: acc.mul_hi(scale).realize())
bench("int64 widen fallback", lambda: ((acc.cast(dtypes.int64) * scale.cast(dtypes.int64)) >> 32).cast(dtypes.int32).realize())

def limb32_high64(a, b):
  mask = (1 << 32) - 1
  a0, a1 = a & mask, a >> 32
  b0, b1 = b & mask, b >> 32
  return a1*b1 + ((a0*b1 + a1*b0 + ((a0*b0) >> 32)) >> 32)

a = Tensor.randint(N, C, low=0, high=1<<60, dtype=dtypes.int64).realize()
b = Tensor.randint(C, low=0, high=1<<60, dtype=dtypes.int64).realize()
Device.default.synchronize()
assert int((a.mul_hi(b) != limb32_high64(a, b)).sum().numpy().item()) == 0
bench("int64 mul_hi", lambda: a.mul_hi(b).realize())
bench("32-bit limb fallback", lambda: limb32_high64(a, b).realize())
```

**Results:**

| Device | Case | mul_hi best | fallback best | speedup |
| --- | --- | ---: | ---: | ---: |
| CUDA | int32 fixed-point rescale | 1.025 ms | 1.325 ms | 1.29x |
| CUDA | int64 high half for 60-bit limbs | 1.141 ms | 2.536 ms | 2.22x |
| Metal | int32 fixed-point rescale | 0.884 ms | 1.095 ms | 1.24x |
| Metal | int64 high half for 60-bit limbs | 1.289 ms | 1.941 ms | 1.51x |

**Full timing output:**

```text
CUDA:
int32 mul_hi             best=1.025 ms median=1.106 ms ns/elem=0.977
int64 widen fallback     best=1.325 ms median=1.431 ms ns/elem=1.264
int64 mul_hi             best=1.141 ms median=1.166 ms ns/elem=1.088
32-bit limb fallback     best=2.536 ms median=2.572 ms ns/elem=2.419

Metal:
int32 mul_hi             best=0.884 ms median=0.916 ms ns/elem=0.843
int64 widen fallback     best=1.095 ms median=1.146 ms ns/elem=1.044
int64 mul_hi             best=1.289 ms median=2.086 ms ns/elem=1.229
32-bit limb fallback     best=1.941 ms median=2.133 ms ns/elem=1.851
```