### PR TITLE
schedule/rangeify: don't count scalar buffers against fusion limit

### DIFF
--- a/test/backend/test_symbolic_jit.py
+++ b/test/backend/test_symbolic_jit.py
@@ -80,7 +80,7 @@ class TestSymbolicJit(unittest.TestCase):
       symbolic = jf(q, k[:, :vi], v[:, :vi])[:2, :4, :1, :8].numpy()
       expected = f(q, k[:, :i], v[:, :i]).numpy()
       np.testing.assert_allclose(symbolic, expected, atol=1e-6, rtol=1e-6)
-    assert_jit_cache_len(jf, 5)
+    assert_jit_cache_len(jf, 4)
 
   def test_cat_dim0(self):
     def f(a, b): return a.cat(b, dim=0).realize()

--- a/test/null/test_schedule.py
+++ b/test/null/test_schedule.py
@@ -457,7 +457,7 @@ class TestSchedule(unittest.TestCase):
 
   def test_fold_conv_batchnorm_optim(self, adam=False):
     # 2 is too low?
-    optim, cnt = (nn.optim.Adam, 16) if adam else (nn.optim.SGD, 2)
+    optim, cnt = (nn.optim.Adam, 14) if adam else (nn.optim.SGD, 2)
     with Tensor.train():
       img = Tensor.ones(1,3,4,4)
       c1 = nn.Conv2d(3,32,3)
@@ -822,6 +822,11 @@ class TestSchedule(unittest.TestCase):
     out = Tensor.scaled_dot_product_attention(x, y, z, is_causal=True)
     check_schedule(out, 4)
 
+  def test_assign_scalar_buffers_dont_block_fusion(self):
+    a, b, c = (Tensor.empty(16).realize() for _ in range(3))
+    lr = Tensor([1e-3], device=Device.DEFAULT).realize()
+    check_schedule(a.assign(a - lr * (b / (c + 1))), 1)
+
   def test_adam_step_fusion(self):
     with Tensor.train():
       x = Tensor.empty(4, 64, 32)
@@ -829,7 +834,7 @@ class TestSchedule(unittest.TestCase):
       _realize_weights(layer)
       opt = nn.optim.Adam(nn.state.get_parameters(layer), lr=1e-4)
       layer(x).relu().sum().backward()
-      check_schedule(opt.schedule_step(), 13)
+      check_schedule(opt.schedule_step(), 12)
 
   def test_adam_conv_fuse(self):
     with Tensor.train():
@@ -839,7 +844,7 @@ class TestSchedule(unittest.TestCase):
       opt = nn.optim.Adam(nn.state.get_parameters(c1), lr=1e-4)
       opt.zero_grad()
       c1(img).relu().sum().backward()
-      check_schedule(opt.schedule_step(), 13)
+      check_schedule(opt.schedule_step(), 11)
 
   def test_adam_2convs_fuse(self):
     with Tensor.train():
@@ -850,7 +855,7 @@ class TestSchedule(unittest.TestCase):
       opt = nn.optim.Adam(nn.state.get_parameters([c1, c2]), lr=1e-4)
       opt.zero_grad()
       c2(c1(img).relu()).relu().sum().backward()
-      check_schedule(opt.schedule_step(), 15)
+      check_schedule(opt.schedule_step(), 14)
 
   def test_sgd_conv_fuse(self):
     with Tensor.train():
@@ -882,7 +887,7 @@ class TestSchedule(unittest.TestCase):
       opt = nn.optim.SGD(nn.state.get_parameters([c1, c2]), nesterov=True, momentum=0.9, weight_decay=0.1)
       opt.zero_grad()
       c2(c1(img).relu()).relu().sum().backward()
-      check_schedule(opt.schedule_step(), 11)
+      check_schedule(opt.schedule_step(), 10)
 
   def test_sgd_4convs_fuse(self):
     with Tensor.train():

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -263,8 +263,8 @@ def remove_bufferize(src:UOp, buf:UOp, idx:UOp):
   del red_gate
   accessed_buffers = dedup(accessed_buffers)
 
-  # if this is generated from multiple buffers, don't remove this buffer
-  if len(accessed_buffers) > 3 and not (PCONTIG > 2): return None
+  # if this is generated from multiple non-scalar buffers, don't remove this buffer
+  if len([x for x in accessed_buffers if x.numel() != 1]) > 3 and not (PCONTIG > 2): return None
 
   # if any reduces access a buffer, don't remove this buffer
   buffer_in_reduce = False


### PR DESCRIPTION
## Summary

`remove_bufferize` was counting scalar buffers the same as full tensor buffers when deciding whether to keep a temporary.

For expressions like:

```python
a.assign(a - lr * (b / (c + 1)))
```

`lr` is a scalar buffer, but it pushed the expression over the buffer-count heuristic and caused an extra temporary/kernel. This changes the heuristic to count only non-scalar buffers. For Adam-style parameter updates, this removes one full parameter-sized temporary from the update schedule.

## Testing

```bash
DEV=NULL NULL_ALLOW_COPYOUT=1 PYTHONPATH=. python -m pytest -q test/null/test_schedule.py
# 159 passed, 7 skipped, 6 xfailed

RUN_SLOW=1 DEV=CPU PYTHONPATH=. python -m pytest -q test/backend/test_optim.py -k 'adam or adamw'
# 9 passed, 30 deselected
```