### PR TITLE
viz: add CALL -> codegen link

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -126,13 +126,13 @@
     cursor: pointer;
   }
   g.tag.ref circle {
-    fill: #4a4b57;
-    stroke: #8a8fa6;
+    fill: #9FDDE6;
+    stroke: #4a4b57;
   }
   g.tag.ref path {
     fill: none;
-    stroke: #f0f0f5;
-    stroke-width: 1;
+    stroke: #08090e;
+    stroke-width: 0.7;
     stroke-linejoin: miter;
   }
   .label :is(text, p) {

--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -122,6 +122,19 @@
     font-size: 6px;
     fill: #08090e;
   }
+  g.tag.ref * {
+    cursor: pointer;
+  }
+  g.tag.ref circle {
+    fill: #4a4b57;
+    stroke: #8a8fa6;
+  }
+  g.tag.ref path {
+    fill: none;
+    stroke: #f0f0f5;
+    stroke-width: 1;
+    stroke-linejoin: miter;
+  }
   .label :is(text, p) {
     font-weight: 350;
   }

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -56,9 +56,10 @@ function intersectRect(r1, r2) {
   return {x:r1.x+dx*scale, y:r1.y+dy*scale};
 }
 
-function addTags(root) {
+function addTags(root, path) {
   root.selectAll("circle").data(d => [d]).join("circle").attr("r", 5);
-  root.selectAll("text").data(d => [d]).join("text").text(d => d).attr("dy", "0.35em");
+  if (path != null) root.selectAll("path").data(d => [d]).join("path").attr("d", path);
+  else root.selectAll("text").data(d => [d]).join("text").text(d => d).attr("dy", "0.35em");
 }
 
 const drawGraph = (data) => {
@@ -118,10 +119,9 @@ const drawGraph = (data) => {
     .attr("transform", d => `translate(${-d.width/2+8}, ${-d.height/2+8})`).datum(e => e.tag));
   addTags(nodes.selectAll("g.type").data(d => d.callNode ? [d] : []).join("g").attr("class", d => `tag ${d.collapsed ? 'collapsed' : 'expanded'}`)
     .attr("transform", d => `translate(${-d.width/2}, ${0})`).datum(d => d.collapsed ? "+" : "−"));
-  const refTags = nodes.selectAll("g.ref").data(d => d.ref != null ? [d] : []).join("g").attr("class", "tag ref")
-    .attr("transform", d => `translate(${d.width/2-2}, ${-d.height/2+2})`).on("click", (e,d) => { e.stopPropagation(); switchCtx(d.ref); });
-  refTags.selectAll("circle").data(d => [d]).join("circle").attr("r", 5);
-  refTags.selectAll("path").data(d => [d]).join("path").attr("d", "M-2 2 L2 -2 M-0.7 -2 H2 V0.7");
+  addTags(nodes.selectAll("g.ref").data(d => d.ref != null ? [d] : []).join("g").attr("class", "tag ref")
+    .attr("transform", d => `translate(${d.width/2-2}, ${-d.height/2+2})`).on("click", (e,d) => { e.stopPropagation(); switchCtx(d.ref); }),
+    "M-2 2 L2 -2 M-0.7 -2 H2 V0.7");
   // draw edges
   const line = d3.line().x(d => d.x).y(d => d.y).curve(d3.curveBasis), edges = g.edges();
   d3.select("#edges").selectAll("path.edgePath").data(edges).join("path").attr("class", "edgePath").attr("d", (e) => {

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -116,9 +116,12 @@ const drawGraph = (data) => {
   });
   addTags(nodes.selectAll("g.tag").data(d => d.tag != null ? [d] : []).join("g").attr("class", "tag")
     .attr("transform", d => `translate(${-d.width/2+8}, ${-d.height/2+8})`).datum(e => e.tag));
-  addTags(nodes.selectAll("g.type").data(d => d.callNode ? [d] : []).join("g")
-    .attr("class", d => `tag ${d.collapsed ? 'collapsed' : 'expanded'}`)
+  addTags(nodes.selectAll("g.type").data(d => d.callNode ? [d] : []).join("g").attr("class", d => `tag ${d.collapsed ? 'collapsed' : 'expanded'}`)
     .attr("transform", d => `translate(${-d.width/2}, ${0})`).datum(d => d.collapsed ? "+" : "−"));
+  const refTags = nodes.selectAll("g.ref").data(d => d.ref != null ? [d] : []).join("g").attr("class", "tag ref")
+    .attr("transform", d => `translate(${d.width/2-2}, ${-d.height/2+2})`).on("click", (e,d) => { e.stopPropagation(); switchCtx(d.ref); });
+  refTags.selectAll("circle").data(d => [d]).join("circle").attr("r", 5);
+  refTags.selectAll("path").data(d => [d]).join("path").attr("d", "M-2 2 L2 -2 M-0.7 -2 H2 V0.7");
   // draw edges
   const line = d3.line().x(d => d.x).y(d => d.y).curve(d3.curveBasis), edges = g.edges();
   d3.select("#edges").selectAll("path.edgePath").data(edges).join("path").attr("class", "edgePath").attr("d", (e) => {
@@ -946,7 +949,7 @@ async function main() {
       }
       appendSteps(ul, i, steps);
     }
-    return setState({ currentCtx:-1 });
+    return setState({ currentCtx: 2, currentStep: 31, currentRewrite: 0, expandSteps: true});
   }
   // ** center graph
   const { currentCtx, currentStep, currentRewrite, expandSteps } = state;

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -121,7 +121,7 @@ const drawGraph = (data) => {
     .attr("transform", d => `translate(${-d.width/2}, ${0})`).datum(d => d.collapsed ? "+" : "−"));
   addTags(nodes.selectAll("g.ref").data(d => d.ref != null ? [d] : []).join("g").attr("class", "tag ref")
     .attr("transform", d => `translate(${d.width/2-2}, ${-d.height/2+2})`).on("click", (e,d) => { e.stopPropagation(); switchCtx(d.ref); }),
-    "M-2 2 L2 -2 M-0.7 -2 H2 V0.7");
+    "M-1.7 1.7 L1.7 -1.7 M-0.55 -1.7 H1.7 V0.55");
   // draw edges
   const line = d3.line().x(d => d.x).y(d => d.y).curve(d3.curveBasis), edges = g.edges();
   d3.select("#edges").selectAll("path.edgePath").data(edges).join("path").attr("class", "edgePath").attr("d", (e) => {

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -949,7 +949,7 @@ async function main() {
       }
       appendSteps(ul, i, steps);
     }
-    return setState({ currentCtx: 2, currentStep: 31, currentRewrite: 0, expandSteps: true});
+    return setState({ currentCtx:-1 });
   }
   // ** center graph
   const { currentCtx, currentStep, currentRewrite, expandSteps } = state;


### PR DESCRIPTION
Clicking on CALL is still expand / collapse. This new tag is a lot smaller, cursor will change to pointer when hovered on it, and it's positioned a little outside of the node, that should help discoverability.
My alternative has been command+f the name in label, I think click is a lot easier.
<img width="2560" height="1262" alt="image" src="https://github.com/user-attachments/assets/e9df6931-66d4-40f5-8720-8cfa6281eddd" />
