### PR TITLE
[NOT FOR MERGE] Proposal: Add some infra to tinygrad for modern LLM pretraining

### DIFF
--- a/test/distributed/test_bootstrap.py
+++ b/test/distributed/test_bootstrap.py
@@ -1,0 +1,85 @@
+"""
+Test distributed bootstrap functionality.
+"""
+import unittest
+import os
+from tinygrad.distributed import init_distributed, DistributedConfig, get_world_info, get_all_capabilities, reset_global_config
+
+
+class TestBootstrap(unittest.TestCase):
+    def setUp(self):
+        """Clean up environment variables before each test."""
+        reset_global_config()
+        
+        env_vars_to_reset = [
+            "RANK", "WORLD_SIZE", "LOCAL_RANK", "MASTER_ADDR", "MASTER_PORT",
+            "SLURM_PROCID", "SLURM_NTASKS", "SLURM_JOB_GPUS", "SLURM_JOB_ID"
+        ]
+        for var in env_vars_to_reset:
+            if var in os.environ:
+                del os.environ[var]
+    
+    def tearDown(self):
+        """Clean up after each test."""
+        reset_global_config()
+    
+    def test_get_world_info_single_node(self):
+        """Test world info in single-node (non-distributed) mode."""
+        info = get_world_info()
+        self.assertEqual(info["rank"], 0)
+        self.assertEqual(info["world_size"], 1)
+        self.assertEqual(info["local_rank"], 0)
+        self.assertEqual(info["num_nodes"], 1)
+        self.assertTrue("node_name" in info)
+    
+    def test_get_all_capabilities_single_node(self):
+        """Test all capabilities in single-node mode."""
+        caps = get_all_capabilities()
+        self.assertIsInstance(caps, list)
+        self.assertEqual(len(caps), 1)
+        self.assertTrue("rank" in caps[0])
+        self.assertTrue("gpus" in caps[0])
+    
+    def test_init_distributed_single_node(self):
+        """Test init_distributed in single-node mode."""
+        config = init_distributed()
+        self.assertIsNone(config)  # Should return None when no distributed backend
+    
+    def test_env_bootstrap(self):
+        """Test bootstrap using environment variables (stub)."""
+        # Save original env vars
+        original_env = {
+            "RANK": os.getenv("RANK"),
+            "WORLD_SIZE": os.getenv("WORLD_SIZE"),
+            "LOCAL_RANK": os.getenv("LOCAL_RANK"),
+            "MASTER_ADDR": os.getenv("MASTER_ADDR"),
+            "MASTER_PORT": os.getenv("MASTER_PORT"),
+        }
+        
+        try:
+            # Set env vars
+            os.environ["RANK"] = "0"
+            os.environ["WORLD_SIZE"] = "2"
+            os.environ["LOCAL_RANK"] = "0"
+            
+            # This should return a DistributedConfig with env backend
+            config = init_distributed(backend="env")
+            
+            # Verify config
+            self.assertIsNotNone(config)
+            self.assertEqual(config.rank, 0)
+            self.assertEqual(config.world_size, 2)
+            self.assertEqual(config.local_rank, 0)
+            self.assertEqual(config.backend, "env")
+            
+        finally:
+            # Restore original env vars
+            for k, v in original_env.items():
+                if v is not None:
+                    os.environ[k] = v
+                elif k in os.environ:
+                    del os.environ[k]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -1,0 +1,61 @@
+"""
+Test DeviceMesh functionality.
+"""
+import unittest
+from tinygrad.distributed import DeviceMesh, create_data_parallel_mesh, create_tensor_parallel_mesh
+from tinygrad.tensor import Tensor
+
+
+class TestDeviceMesh(unittest.TestCase):
+    def test_create_default_mesh(self):
+        """Test creating a default DeviceMesh."""
+        mesh = DeviceMesh()
+        self.assertIsNotNone(mesh)
+        self.assertIsInstance(mesh.devices, list)
+        self.assertGreaterEqual(len(mesh.devices), 1)
+    
+    def test_get_device_coordinates(self):
+        """Test converting devices to coordinates and back."""
+        mesh = DeviceMesh(shape=(2, 2), devices=["d0", "d1", "d2", "d3"])
+        self.assertEqual(mesh.get_device(0, 0), "d0")
+        self.assertEqual(mesh.get_device(1, 1), "d3")
+        self.assertEqual(mesh.get_coordinates("d2"), (1, 0))
+    
+    def test_submesh(self):
+        """Test creating a submesh."""
+        mesh = DeviceMesh(shape=(2, 2), devices=["d0", "d1", "d2", "d3"])
+        submesh = mesh.submesh(dim=0, index=0)
+        self.assertEqual(len(submesh.devices), 2)
+        self.assertEqual(submesh.devices[0], "d0")
+    
+    def test_all_submeshes(self):
+        """Test getting all submeshes along a dimension."""
+        mesh = DeviceMesh(shape=(2, 2), devices=["d0", "d1", "d2", "d3"])
+        submeshes = mesh.all_submeshes(dim=0)
+        self.assertEqual(len(submeshes), 2)
+        self.assertEqual(len(submeshes[0].devices), 2)
+    
+    def test_peer_group(self):
+        """Test getting peer group for devices."""
+        mesh = DeviceMesh()
+        peer_group = mesh.peer_group("CPU:0")
+        self.assertEqual(peer_group, "localhost")
+    
+    def test_same_peer_group(self):
+        """Test checking if two devices are in the same peer group."""
+        mesh = DeviceMesh()
+        self.assertTrue(mesh.is_same_peer_group("CPU:0", "CPU:0"))
+    
+    def test_create_data_parallel_mesh(self):
+        """Test create_data_parallel_mesh (stub)."""
+        mesh = create_data_parallel_mesh()
+        self.assertIsNotNone(mesh)
+    
+    def test_create_tensor_parallel_mesh(self):
+        """Test create_tensor_parallel_mesh (stub)."""
+        mesh = create_tensor_parallel_mesh()
+        self.assertIsNotNone(mesh)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_checkpointing.py
+++ b/test/test_checkpointing.py
@@ -1,0 +1,59 @@
+"""
+Test activation checkpointing functionality.
+"""
+import unittest
+from tinygrad import Tensor
+from tinygrad.checkpoint import checkpoint, checkpoint_sequential
+
+
+class TestCheckpoint(unittest.TestCase):
+    def test_checkpoint_basic(self):
+        """Test basic checkpoint API."""
+        x = Tensor.rand(4, 4)
+        out = checkpoint(lambda a: a @ a, x)
+        ref = x @ x
+        # Checkpoint preserves output shape
+        self.assertEqual(out.shape, ref.shape)
+    
+    def test_checkpoint_sequential(self):
+        """Test checkpoint_sequential API."""
+        w = Tensor.rand(4, 8)
+        def matmul(x):
+            return x @ w
+        
+        def identity(x):
+            return x
+        
+        layers = [matmul, identity]
+        
+        x = Tensor.rand(4, 4)
+        out = checkpoint_sequential(layers, x)
+        self.assertEqual(out.shape, (4, 8))
+    
+    def test_checkpoint_gradient_flow(self):
+        """Test that checkpoint preserves gradient flow."""
+        Tensor.training = True
+        x = Tensor.rand(4, 8, requires_grad=True)
+        
+        out = checkpoint(lambda a: a * 2.0 + 1.0, x)
+        loss = out.sum()
+        loss.backward()
+        
+        self.assertIsNotNone(x.grad)
+        Tensor.training = False
+    
+    def test_checkpoint_tuple_output(self):
+        """Test checkpoint with function returning tuple."""
+        x = Tensor.rand(4, 4)
+        y = Tensor.rand(4, 4)
+        
+        def compute_two(a, b):
+            return a @ b, a + b
+        
+        out_a, out_b = checkpoint(compute_two, x, y)
+        self.assertEqual(out_a.shape, (4, 4))
+        self.assertEqual(out_b.shape, (4, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_moe.py
+++ b/test/test_moe.py
@@ -1,0 +1,39 @@
+"""
+Test MoE (Mixture of Experts) functionality.
+"""
+import unittest
+from tinygrad import Tensor
+from tinygrad.nn.moe import MoELayer, AllToAll
+
+
+class TestMoE(unittest.TestCase):
+    def test_moe_layer_creation(self):
+        """Test creating MoELayer."""
+        moe = MoELayer(num_experts=8, dim=64, hidden_dim=256, activated_experts=2)
+        self.assertEqual(moe.num_experts, 8)
+        self.assertEqual(moe.dim, 64)
+        self.assertEqual(moe.hidden_dim, 256)
+        self.assertEqual(moe.activated_experts, 2)
+    
+    def test_moe_layer_forward(self):
+        """Test forward pass of MoELayer."""
+        moe = MoELayer(num_experts=4, dim=32, hidden_dim=128, activated_experts=2)
+        x = Tensor.rand(2, 16, 32)  # (batch, seq_len, dim)
+        out = moe(x)
+        self.assertEqual(out.shape, (2, 16, 32))
+    
+    def test_moe_layer_forward_single_expert(self):
+        """Test forward pass with single active expert."""
+        moe = MoELayer(num_experts=2, dim=16, hidden_dim=64, activated_experts=1)
+        x = Tensor.rand(4, 8, 16)
+        out = moe(x)
+        self.assertEqual(out.shape, (4, 8, 16))
+    
+    def test_all_to_all_creation(self):
+        """Test creating AllToAll primitive (stub)."""
+        all2all = AllToAll(["d0", "d1"])
+        self.assertEqual(len(all2all.devices), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_tensor_parallel.py
+++ b/test/test_tensor_parallel.py
@@ -1,0 +1,56 @@
+"""
+Test tensor parallelism functionality.
+"""
+import unittest
+import math
+from tinygrad import Tensor
+from tinygrad.nn.parallel import TensorParallelLinear, TensorParallelColumnLinear, TensorParallelRowLinear, TensorParallelMLP
+
+
+class TestTensorParallel(unittest.TestCase):
+    def test_tensor_parallel_linear_creation(self):
+        """Test creating TensorParallelLinear."""
+        tp = TensorParallelLinear(32, 64)
+        self.assertEqual(tp.in_features, 32)
+        self.assertEqual(tp.out_features, 64)
+    
+    def test_column_parallel_linear(self):
+        """Test creating TensorParallelColumnLinear."""
+        tp_col = TensorParallelColumnLinear(32, 64)
+        self.assertEqual(tp_col.parallel_dim, 0)
+    
+    def test_row_parallel_linear(self):
+        """Test creating TensorParallelRowLinear."""
+        tp_row = TensorParallelRowLinear(32, 64)
+        self.assertEqual(tp_row.parallel_dim, 1)
+    
+    def test_tensor_parallel_mlp_creation(self):
+        """Test creating TensorParallelMLP."""
+        mlp = TensorParallelMLP(64, 256)
+        self.assertEqual(mlp.dim, 64)
+        self.assertEqual(mlp.hidden_dim, 256)
+    
+    def test_linear_forward(self):
+        """Test forward pass of TensorParallelLinear."""
+        tp = TensorParallelLinear(32, 64)
+        x = Tensor.rand(2, 32)
+        out = tp(x)
+        self.assertEqual(out.shape, (2, 64))
+    
+    def test_column_linear_forward(self):
+        """Test forward pass of TensorParallelColumnLinear."""
+        tp_col = TensorParallelColumnLinear(32, 64)
+        x = Tensor.rand(2, 32)
+        out = tp_col(x)
+        self.assertEqual(out.shape, (2, 64))
+    
+    def test_row_linear_forward(self):
+        """Test forward pass of TensorParallelRowLinear."""
+        tp_row = TensorParallelRowLinear(32, 64)
+        x = Tensor.rand(2, 32)
+        out = tp_row(x)
+        self.assertEqual(out.shape, (2, 64))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_zero.py
+++ b/test/test_zero.py
@@ -1,0 +1,97 @@
+"""
+Test ZeRO optimizer functionality.
+"""
+import unittest
+import shutil
+import numpy as np
+from tinygrad import Tensor
+from tinygrad.nn import Linear
+from tinygrad.nn.optim import ZeroAdam, ZeroSGD, AdamW
+
+_CLANG_AVAILABLE = shutil.which("clang") is not None
+
+class TestZeRO(unittest.TestCase):
+    def test_zero_adam_creation(self):
+        """Test creating ZeroAdam."""
+        model = Linear(32, 64)
+        optimizer = ZeroAdam([model.weight, model.bias], lr=1e-3)
+        self.assertIsNotNone(optimizer)
+
+    def test_zero_sgd_creation(self):
+        """Test creating ZeroSGD."""
+        model = Linear(32, 64)
+        optimizer = ZeroSGD([model.weight, model.bias], lr=1e-3)
+        self.assertIsNotNone(optimizer)
+
+    def test_zero_adam_zero_stage(self):
+        """Test creating ZeroAdam with explicit zero_stage."""
+        model = Linear(32, 64)
+        optimizer = ZeroAdam([model.weight, model.bias], lr=1e-3, zero_stage=1)
+        self.assertIsNotNone(optimizer)
+        self.assertEqual(optimizer.zero_stage, 1)
+
+    @unittest.skipUnless(_CLANG_AVAILABLE, "clang compiler not available")
+    def test_zero_step(self):
+        """Verify ZeroAdam reduces loss and updates parameters functionally."""
+        Tensor.training = True
+
+        model = Linear(2, 1)
+        optimizer = ZeroAdam([model.weight, model.bias], lr=0.1, weight_decay=0)
+
+        w_before = model.weight.numpy().copy()
+        b_before = model.bias.numpy().copy()
+
+        losses = []
+        for _ in range(20):
+            x = Tensor.rand(8, 2).realize()
+            y = (x.sum(axis=1, keepdim=True) * 2).realize()
+
+            out = model(x)
+            loss = (out - y).square().mean()
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+            losses.append(loss.numpy().item())
+
+        w_after = model.weight.numpy().copy()
+        b_after = model.bias.numpy().copy()
+
+        self.assertLess(losses[-1], losses[0] * 0.5, "loss should decrease by at least 50%")
+        self.assertFalse(np.allclose(w_before, w_after), "weight should change after training")
+        self.assertFalse(np.allclose(b_before, b_after), "bias should change after training")
+
+        Tensor.training = False
+
+    @unittest.skipUnless(_CLANG_AVAILABLE, "clang compiler not available")
+    def test_zero_identical_to_adam(self):
+        """ZeroAdam without zero_devices should be identical to Adam."""
+        Tensor.training = True
+
+        m1, m2 = Linear(2, 1), Linear(2, 1)
+        m2.weight.assign(m1.weight.detach()).realize()
+        m2.bias.assign(m1.bias.detach()).realize()
+
+        opt_za = ZeroAdam([m1.weight, m1.bias], lr=0.1, weight_decay=0)
+        opt_a = AdamW([m2.weight, m2.bias], lr=0.1, weight_decay=0)
+
+        for _ in range(5):
+            x = Tensor.rand(8, 2).realize()
+            y = (x.sum(axis=1, keepdim=True) * 2).realize()
+
+            for model, opt in [(m1, opt_za), (m2, opt_a)]:
+                out = model(x)
+                loss = (out - y).square().mean()
+                loss.backward()
+                opt.step()
+                opt.zero_grad()
+
+        self.assertTrue(np.allclose(m1.weight.numpy(), m2.weight.numpy(), atol=1e-5),
+                        "ZeroAdam and Adam should produce identical weights")
+        self.assertTrue(np.allclose(m1.bias.numpy(), m2.bias.numpy(), atol=1e-5),
+                        "ZeroAdam and Adam should produce identical biases")
+
+        Tensor.training = False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tinygrad/checkpoint.py
+++ b/tinygrad/checkpoint.py
@@ -1,0 +1,149 @@
+"""
+Activation Checkpointing for tinygrad.
+
+Provides memory-saving checkpoint APIs for distributed training.
+Instead of saving intermediate activations, they are recomputed during backward pass.
+"""
+
+from __future__ import annotations
+from typing import Callable, Any, Optional, List, Tuple, Union
+from tinygrad.tensor import Tensor
+from tinygrad.uop.ops import UOp, Ops
+
+_CHECKPOINT_COUNTER = 0
+
+def checkpoint(fn: Callable[..., Tensor], *args: Any, **kwargs: Any) -> Tensor:
+    """
+    Checkpoint a computation to save memory.
+
+    During forward, only inputs are saved. Intermediate activations are discarded.
+    During backward, the forward pass is recomputed to obtain the activations needed for gradients.
+
+    This trades compute for memory, typically saving ~50% memory at ~20% compute overhead.
+
+    Args:
+        fn: Function to checkpoint. Should return one or more Tensors.
+        *args: Arguments to pass to fn.
+        **kwargs: Keyword arguments to pass to fn.
+
+    Returns:
+        Result of fn(*args, **kwargs).
+
+    Example:
+        >>> x = Tensor.rand(1024, 1024)
+        >>> y = Tensor.rand(1024, 1024)
+        >>> def compute():
+        ...     a = x @ y
+        ...     return a @ a.T
+        >>> result = checkpoint(compute)
+    """
+    global _CHECKPOINT_COUNTER
+    _CHECKPOINT_COUNTER += 1
+
+    result = fn(*args, **kwargs)
+
+    if isinstance(result, (tuple, list)):
+        return tuple(single_checkpoint(r) for r in result) if isinstance(result, tuple) else [single_checkpoint(r) for r in result]
+
+    return single_checkpoint(result)
+
+def single_checkpoint(x: Tensor) -> Tensor:
+    """Mark a single tensor operation for checkpointing."""
+    global _CHECKPOINT_COUNTER
+    _CHECKPOINT_COUNTER += 1
+    return x  # Pass through for now; UOp-level checkpointing TBD
+
+def checkpoint_sequential(modules: List[Callable], *inputs: Tensor) -> Tensor:
+    """
+    Apply activation checkpointing to a sequence of modules.
+
+    This is more memory-efficient than checkpointing each module individually
+    because it only saves the input to the sequence, not outputs between modules.
+
+    Args:
+        modules: List of functions/modules to apply sequentially.
+        *inputs: Input tensors.
+
+    Returns:
+        Output tensor after passing through all modules.
+
+    Example:
+        >>> layers = [nn.Linear(256, 256), nn.Linear(256, 256), nn.Linear(256, 256)]
+        >>> x = Tensor.rand(32, 256)
+        >>> def forward():
+        ...     out = x
+        ...     for layer in layers:
+        ...         out = layer(out).relu()
+        ...     return out
+        >>> result = checkpoint(forward)
+    """
+    def sequential_fn(*inp):
+        out = inp[0] if len(inp) == 1 else inp
+        for module in modules:
+            out = module(out)
+        return out
+
+    return checkpoint(sequential_fn, *inputs)
+
+class CheckpointFunction:
+    """
+    A function wrapper that marks a subgraph for checkpointing.
+
+    During forward pass, intermediate values are not saved.
+    During backward pass, the forward function is re-run to recompute them.
+    """
+
+    def __init__(self, fn: Callable[..., Tensor], *args: Any, **kwargs: Any):
+        self.fn = fn
+        self.args = args
+        self.kwargs = kwargs
+
+    def forward(self) -> Tensor:
+        return checkpoint(self.fn, *self.args, **self.kwargs)
+
+class CheckpointBuilder:
+    """
+    Builder for creating checkpointed computations.
+
+    Provides fine-grained control over checkpoint boundaries and recomputation strategies.
+    """
+
+    def __init__(self):
+        self.checkpoint_boundaries: List[UOp] = []
+
+    def add_boundary(self, uop: UOp) -> 'CheckpointBuilder':
+        """Add a checkpoint boundary at the given UOp."""
+        self.checkpoint_boundaries.append(uop)
+        return self
+
+    def build(self) -> 'CheckpointBuilder':
+        """Build and return the checkpoint configuration."""
+        return self
+
+def create_checkpoint(source: str = "global") -> UOp:
+    """
+    Create a CHECKPOINT UOp marker.
+
+    Args:
+        source: Identifier for the checkpoint region.
+
+    Returns:
+        A UOp with CHECKPOINT op that marks a checkpoint boundary.
+    """
+    global _CHECKPOINT_COUNTER
+    name = f"{source}_{_CHECKPOINT_COUNTER}"
+    _CHECKPOINT_COUNTER += 1
+    return UOp(Ops.CHECKPOINT, arg=name)
+
+def is_checkpointed(uop: UOp) -> bool:
+    """Check if a UOp is marked as a checkpoint boundary."""
+    return uop.op == Ops.CHECKPOINT
+
+__all__ = [
+    "checkpoint",
+    "checkpoint_sequential",
+    "CheckpointFunction",
+    "CheckpointBuilder",
+    "create_checkpoint",
+    "is_checkpointed",
+]

--- a/tinygrad/distributed/__init__.py
+++ b/tinygrad/distributed/__init__.py
@@ -1,0 +1,45 @@
+"""
+Distributed training module for tinygrad.
+
+Provides DeepSpeed-style distributed training capabilities with multi-node support.
+"""
+
+from .bootstrap import init_distributed, DistributedConfig, get_world_info, get_all_capabilities, reset_global_config
+from .mesh import DeviceMesh, create_data_parallel_mesh, create_tensor_parallel_mesh, create_pipeline_parallel_mesh
+from .rdma_config import RDMAConfig, patch_rdma_ip_assignment, RDMANetwork
+from tinygrad.checkpoint import checkpoint, checkpoint_sequential, CheckpointFunction, CheckpointBuilder, create_checkpoint, is_checkpointed
+
+# Try to patch RDMA IP assignment automatically
+try:
+    patch_rdma_ip_assignment()
+except Exception as e:
+    # RDMA module might not be available
+    pass
+
+__all__ = [
+    # Bootstrap
+    "init_distributed",
+    "DistributedConfig",
+    "get_world_info",
+    "get_all_capabilities",
+    "reset_global_config",
+
+    # DeviceMesh
+    "DeviceMesh",
+    "create_data_parallel_mesh",
+    "create_tensor_parallel_mesh",
+    "create_pipeline_parallel_mesh",
+
+    # RDMA
+    "RDMAConfig",
+    "patch_rdma_ip_assignment",
+    "RDMANetwork",
+
+    # Checkpointing
+    "checkpoint",
+    "checkpoint_sequential",
+    "CheckpointFunction",
+    "CheckpointBuilder",
+    "create_checkpoint",
+    "is_checkpointed",
+]

--- a/tinygrad/distributed/bootstrap.py
+++ b/tinygrad/distributed/bootstrap.py
@@ -1,0 +1,395 @@
+"""
+Distributed bootstrap module for tinygrad.
+
+Provides rank discovery and process coordination for multi-node training.
+Supports MPI, Slurm, and environment variable-based bootstrapping.
+"""
+
+from __future__ import annotations
+import os
+import socket
+import subprocess
+from typing import Dict, List, Optional, Any
+
+try:
+    from mpi4py import MPI
+    HAS_MPI = True
+except ImportError:
+    HAS_MPI = False
+    MPI = None
+
+GLOBAL_CONFIG: Optional[DistributedConfig] = None
+
+def reset_global_config():
+    """Reset the global config (for testing)."""
+    global GLOBAL_CONFIG
+    GLOBAL_CONFIG = None
+
+class DistributedConfig:
+    """Configuration for distributed training."""
+
+    def __init__(self):
+        self.rank = 0
+        self.world_size = 1
+        self.local_rank = 0
+        self.local_size = 1
+        self.node_rank = 0
+        self.num_nodes = 1
+        self.master_addr = "127.0.0.1"
+        self.master_port = 29500
+        self.gpus_per_node = 1
+        self.node_name = socket.gethostname()
+        self.capabilities: Dict[str, Any] = {}
+        self.backend = "auto"
+        self.all_caps: List[Dict[str, Any]] = []
+
+    def __repr__(self) -> str:
+        return (f"DistributedConfig(rank={self.rank}/{self.world_size}, "
+                f"local_rank={self.local_rank}/{self.local_size}, "
+                f"node={self.node_rank}/{self.num_nodes}, "
+                f"node_name={self.node_name})")
+
+def _detect_gpus() -> List[str]:
+    """Detect available GPUs on this node."""
+    gpus = []
+
+    try:
+        import pyopencl as cl
+        platforms = cl.get_platforms()
+        for platform in platforms:
+            if "AMD" in platform.name or "Advanced Micro Devices" in platform.name:
+                devices = platform.get_devices(cl.device_type.GPU)
+                gpus.extend([f"AMD:{i}" for i in range(len(devices))])
+    except ImportError:
+        pass
+
+    try:
+        import pycuda.driver as cuda
+        cuda.init()
+        gpus.extend([f"NV:{i}" for i in range(cuda.Device.count())])
+    except ImportError:
+        pass
+
+    try:
+        import metal
+        gpus.append("METAL:0")
+    except ImportError:
+        pass
+
+    if not gpus:
+        visible_devices = os.getenv("CUDA_VISIBLE_DEVICES") or os.getenv("ROCR_VISIBLE_DEVICES")
+        if visible_devices:
+            device_count = len(visible_devices.split(","))
+            gpus = [f"UNKNOWN:{i}" for i in range(device_count)]
+        else:
+            gpus = ["CPU:0"]
+
+    return gpus
+
+def _discover_rdma_addr() -> Optional[str]:
+    """Discover RDMA-capable network interface address."""
+    rdma_addr = os.getenv("RDMA_ADDR")
+    if rdma_addr:
+        return rdma_addr
+
+    try:
+        import netifaces
+        for iface in netifaces.interfaces():
+            addrs = netifaces.ifaddresses(iface)
+            if netifaces.AF_INET in addrs:
+                for addr_info in addrs[netifaces.AF_INET]:
+                    addr = addr_info.get('addr')
+                    if addr and (addr.startswith("10.0.0.") or addr.startswith("192.168.") or addr.startswith("172.")):
+                        return f"{addr}"
+    except ImportError:
+        pass
+
+    return None
+
+def _parse_slurm_nodelist(nodelist: str) -> List[str]:
+    """Parse Slurm nodelist format (supports basic patterns like node[1-3], node1,node2,node3)."""
+    if not nodelist:
+        return [socket.gethostname()]
+
+    nodes = []
+    parts = nodelist.split(',')
+
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+
+        if '[' in part and ']' in part:
+            prefix = part[:part.index('[')]
+            range_str = part[part.index('[')+1:part.index(']')]
+            suffix = part[part.index(']')+1:]
+
+            for r in range_str.split(','):
+                r = r.strip()
+                if '-' in r:
+                    start, end = r.split('-', 1)
+                    for i in range(int(start), int(end) + 1):
+                        nodes.append(f"{prefix}{i}{suffix}")
+                else:
+                    nodes.append(f"{prefix}{r}{suffix}")
+        else:
+            nodes.append(part)
+
+    return nodes if nodes else [socket.gethostname()]
+
+def _get_slurm_node_names() -> List[str]:
+    """Get list of node names from Slurm."""
+    try:
+        nodelist = os.getenv("SLURM_NODELIST", "")
+        if nodelist:
+            return _parse_slurm_nodelist(nodelist)
+    except Exception:
+        pass
+
+    try:
+        result = subprocess.run(
+            ["scontrol", "show", "hostname"],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0:
+            nodes = result.stdout.strip().split('\n')
+            if nodes:
+                return nodes
+    except Exception:
+        pass
+
+    return [socket.gethostname()]
+
+def _bootstrap_mpi() -> Optional[DistributedConfig]:
+    """Bootstrap using MPI4Py."""
+    if not HAS_MPI:
+        return None
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    world_size = comm.Get_size()
+
+    node_name = MPI.Get_processor_name()
+
+    all_node_names = comm.allgather(node_name)
+    unique_nodes = sorted(set(all_node_names))
+    node_rank = unique_nodes.index(node_name)
+    num_nodes = len(unique_nodes)
+
+    local_ranks = [i for i, name in enumerate(all_node_names) if name == node_name]
+    local_rank = local_ranks.index(rank)
+    local_size = len(local_ranks)
+
+    config = DistributedConfig()
+    config.rank = rank
+    config.world_size = world_size
+    config.local_rank = local_rank
+    config.local_size = local_size
+    config.node_rank = node_rank
+    config.num_nodes = num_nodes
+    config.node_name = node_name
+    config.backend = "mpi"
+
+    if rank == 0:
+        config.master_addr = socket.gethostbyname(node_name)
+    config.master_addr = comm.bcast(config.master_addr, root=0)
+
+    return config
+
+def _bootstrap_slurm() -> Optional[DistributedConfig]:
+    """Bootstrap using Slurm environment variables."""
+    if not all(os.getenv(var) for var in ["SLURM_PROCID", "SLURM_NTASKS"]):
+        return None
+
+    rank = int(os.getenv("SLURM_PROCID", "0"))
+    world_size = int(os.getenv("SLURM_NTASKS", "1"))
+    node_name = socket.gethostname()
+
+    node_names = _get_slurm_node_names()
+    unique_nodes = sorted(set(node_names))
+    num_nodes = len(unique_nodes)
+    node_rank = unique_nodes.index(node_name) if node_name in unique_nodes else 0
+
+    local_rank = int(os.getenv("SLURM_LOCALID", "0"))
+    gpus_on_node_env = os.getenv("SLURM_GPUS_ON_NODE")
+    local_size = int(gpus_on_node_env if gpus_on_node_env else os.getenv("SLURM_JOB_GPUS", "1").count(',') + 1 if os.getenv("SLURM_JOB_GPUS") else 1)
+
+    config = DistributedConfig()
+    config.rank = rank
+    config.world_size = world_size
+    config.local_rank = local_rank
+    config.local_size = local_size
+    config.node_rank = node_rank
+    config.num_nodes = num_nodes
+    config.node_name = node_name
+    config.backend = "slurm"
+
+    if rank == 0:
+        config.master_addr = socket.gethostbyname(node_name)
+
+    return config
+
+def _bootstrap_env() -> Optional[DistributedConfig]:
+    """Bootstrap using environment variables."""
+    rank = int(os.getenv("RANK", "0"))
+    world_size = int(os.getenv("WORLD_SIZE", "1"))
+    local_rank = int(os.getenv("LOCAL_RANK", "0"))
+    local_size = int(os.getenv("LOCAL_SIZE", "1"))
+    node_rank = int(os.getenv("NODE_RANK", "0"))
+    num_nodes = int(os.getenv("NUM_NODES", "1"))
+    master_addr = os.getenv("MASTER_ADDR", "127.0.0.1")
+    master_port = int(os.getenv("MASTER_PORT", "29500"))
+
+    if world_size <= 1 and num_nodes <= 1:
+        return None
+
+    config = DistributedConfig()
+    config.rank = rank
+    config.world_size = world_size
+    config.local_rank = local_rank
+    config.local_size = local_size
+    config.node_rank = node_rank
+    config.num_nodes = num_nodes
+    config.node_name = socket.gethostname()
+    config.master_addr = master_addr
+    config.master_port = master_port
+    config.backend = "env"
+
+    return config
+
+def _exchange_capabilities(config: DistributedConfig) -> List[Dict[str, Any]]:
+    """Exchange capabilities across all ranks using the bootstrap backend."""
+    gpus = _detect_gpus()
+    config.gpus_per_node = len(gpus)
+
+    rdma_addr = _discover_rdma_addr()
+    tcp_addr = f"{socket.gethostbyname(config.node_name)}:{20000 + config.rank}"
+
+    my_caps = {
+        "rank": config.rank,
+        "node": config.node_name,
+        "node_rank": config.node_rank,
+        "gpus": gpus,
+        "rdma_addr": rdma_addr,
+        "tcp_addr": tcp_addr,
+        "backend": config.backend,
+    }
+    config.capabilities = my_caps
+
+    if config.world_size <= 1:
+        config.all_caps = [my_caps]
+        return [my_caps]
+
+    if config.backend == "mpi" and HAS_MPI:
+        comm = MPI.COMM_WORLD
+        config.all_caps = list(comm.allgather(my_caps))
+    elif config.backend == "slurm":
+        local_node_ranks = [i for i, caps in enumerate(config.all_caps) if caps["node"] == config.node_name] if config.all_caps else list(range(config.world_size))
+        config.all_caps = [my_caps] * config.world_size
+    else:
+        config.all_caps = [my_caps]
+
+    return config.all_caps
+
+def init_distributed(backend: str = "auto") -> Optional[DistributedConfig]:
+    """
+    Initialize distributed training.
+
+    Args:
+        backend: Bootstrap backend to use ("auto", "mpi", "slurm", "env")
+
+    Returns:
+        DistributedConfig if distributed training is enabled, None otherwise.
+    """
+    global GLOBAL_CONFIG
+
+    if GLOBAL_CONFIG is not None:
+        return GLOBAL_CONFIG
+
+    config = None
+
+    backends_to_try = []
+    if backend == "auto":
+        backends_to_try = ["mpi", "slurm", "env"]
+    else:
+        backends_to_try = [backend]
+
+    for backend_name in backends_to_try:
+        if backend_name == "mpi":
+            config = _bootstrap_mpi()
+        elif backend_name == "slurm":
+            config = _bootstrap_slurm()
+        elif backend_name == "env":
+            config = _bootstrap_env()
+
+        if config is not None:
+            break
+
+    if config is None:
+        return None
+
+    _exchange_capabilities(config)
+
+    os.environ["RANK"] = str(config.rank)
+    os.environ["WORLD_SIZE"] = str(config.world_size)
+    os.environ["LOCAL_RANK"] = str(config.local_rank)
+    os.environ["MASTER_ADDR"] = config.master_addr
+    os.environ["MASTER_PORT"] = str(config.master_port)
+
+    print(f"[tinygrad.distributed] Initialized rank {config.rank}/{config.world_size} "
+          f"(local {config.local_rank}/{config.local_size}) on node {config.node_name} "
+          f"using {config.backend} backend")
+
+    GLOBAL_CONFIG = config
+    return config
+
+def get_world_info() -> Dict[str, Any]:
+    """
+    Get world information for debugging.
+
+    Returns:
+        Dictionary with world information.
+    """
+    global GLOBAL_CONFIG
+
+    if GLOBAL_CONFIG is not None:
+        return {
+            "rank": GLOBAL_CONFIG.rank,
+            "world_size": GLOBAL_CONFIG.world_size,
+            "local_rank": GLOBAL_CONFIG.local_rank,
+            "local_size": GLOBAL_CONFIG.local_size,
+            "node_rank": GLOBAL_CONFIG.node_rank,
+            "num_nodes": GLOBAL_CONFIG.num_nodes,
+            "node_name": GLOBAL_CONFIG.node_name,
+            "master_addr": GLOBAL_CONFIG.master_addr,
+            "master_port": GLOBAL_CONFIG.master_port,
+            "backend": GLOBAL_CONFIG.backend,
+            "gpus_per_node": GLOBAL_CONFIG.gpus_per_node,
+            "gpus": GLOBAL_CONFIG.capabilities.get("gpus", []),
+        }
+
+    config = DistributedConfig()
+    gpus = _detect_gpus()
+    return {
+        "rank": config.rank,
+        "world_size": config.world_size,
+        "local_rank": config.local_rank,
+        "local_size": config.local_size,
+        "node_rank": config.node_rank,
+        "num_nodes": config.num_nodes,
+        "node_name": config.node_name,
+        "master_addr": config.master_addr,
+        "master_port": config.master_port,
+        "backend": config.backend,
+        "gpus_per_node": len(gpus),
+        "gpus": gpus,
+    }
+
+def get_all_capabilities() -> List[Dict[str, Any]]:
+    """Get all capabilities from all ranks."""
+    global GLOBAL_CONFIG
+    if GLOBAL_CONFIG is not None and GLOBAL_CONFIG.all_caps:
+        return GLOBAL_CONFIG.all_caps
+    return [get_world_info()]
+
+__all__ = ["init_distributed", "DistributedConfig", "get_world_info", "get_all_capabilities", "reset_global_config"]

--- a/tinygrad/distributed/mesh.py
+++ b/tinygrad/distributed/mesh.py
@@ -1,0 +1,460 @@
+"""
+DeviceMesh for logical topology abstraction in tinygrad.
+
+Provides a logical mesh abstraction over physical devices for distributed training.
+"""
+
+from __future__ import annotations
+from typing import List, Optional, Tuple, Dict, Any, Union
+import itertools
+
+from tinygrad.uop.ops import Ops
+from .bootstrap import DistributedConfig, init_distributed, get_all_capabilities, HAS_MPI
+
+class DeviceMesh:
+    """
+    Logical mesh of devices for distributed training.
+
+    A DeviceMesh represents a logical topology of devices (GPUs) across
+    potentially multiple nodes. It provides methods for sharding tensors
+    and coordinating collective operations.
+
+    Example:
+        >>> config = init_distributed()
+        >>> mesh = DeviceMesh(config=config)
+        >>> # Shard a tensor along the first axis (data parallelism)
+        >>> x = Tensor.randn(128, 256).shard_(mesh, axis=0)
+    """
+
+    def __init__(self,
+                 shape: Optional[Tuple[int, ...]] = None,
+                 devices: Optional[List[str]] = None,
+                 config: Optional[DistributedConfig] = None):
+        """
+        Initialize a DeviceMesh.
+
+        Args:
+            shape: Logical mesh shape (e.g., (2, 4) for 2 nodes × 4 GPUs).
+                   If None, auto-detected from distributed config.
+            devices: List of device strings (e.g., ["AMD:0", "AMD:1", ...]).
+                     If None, auto-discovered from system or built from config.
+            config: DistributedConfig from bootstrap. If None, will try to
+                    initialize distributed or create single-node mesh.
+        """
+        self.config = config
+        self._global_config = init_distributed() if config is None else config
+
+        if devices is not None:
+            self.devices = devices
+            self.shape = shape or (len(devices),)
+        else:
+            self._discover_devices()
+            if shape is None:
+                if self._global_config and self._global_config.num_nodes > 1:
+                    self.shape = (self._global_config.num_nodes, self._global_config.gpus_per_node)
+                else:
+                    self.shape = (len(self.devices),)
+            else:
+                self.shape = shape
+
+            total_devices = 1
+            for dim in self.shape:
+                total_devices *= dim
+
+            if total_devices != len(self.devices):
+                self._build_devices_from_topology()
+                total_devices = 1
+                for dim in self.shape:
+                    total_devices *= dim
+                if total_devices != len(self.devices):
+                    raise ValueError(
+                        f"Shape {self.shape} requires {total_devices} devices, "
+                        f"but found {len(self.devices)} devices"
+                    )
+
+        self._coord_to_device: Dict[Tuple[int, ...], str] = {}
+        self._device_to_coord: Dict[str, Tuple[int, ...]] = {}
+        self._build_coordinate_mapping()
+        self._submeshes: Dict[Tuple[int, ...], 'DeviceMesh'] = {}
+        self._peer_groups: Dict[str, List[str]] = {}
+        self._setup_peer_groups()
+
+    def _discover_devices(self) -> None:
+        """Discover available devices for this mesh."""
+        if self._global_config is None or self._global_config.world_size <= 1:
+            devices = []
+
+            if os.getenv("CUDA_VISIBLE_DEVICES"):
+                cuda_count = len(os.getenv("CUDA_VISIBLE_DEVICES").split(","))
+                devices.extend([f"NV:{i}" for i in range(cuda_count)])
+
+            if os.getenv("ROCR_VISIBLE_DEVICES"):
+                amd_count = len(os.getenv("ROCR_VISIBLE_DEVICES").split(","))
+                devices.extend([f"AMD:{i}" for i in range(amd_count)])
+
+            if not devices:
+                devices = ["CPU:0"]
+
+            self.devices = devices
+        else:
+            all_caps = get_all_capabilities()
+            if all_caps and len(all_caps) > 0:
+                self.devices = all_caps[0].get("gpus", [f"AMD:{i}" for i in range(self._global_config.gpus_per_node)])
+            else:
+                local_rank = self._global_config.local_rank
+                self.devices = [f"AMD:{local_rank}"]
+
+    def _build_devices_from_topology(self) -> None:
+        """Build device list from exchanged capabilities."""
+        if self._global_config is None or self._global_config.world_size <= 1:
+            return
+
+        all_caps = get_all_capabilities()
+        if not all_caps:
+            return
+
+        self.devices = []
+        for caps in all_caps:
+            self.devices.extend(caps.get("gpus", []))
+
+    def _build_coordinate_mapping(self) -> None:
+        """Build mapping between mesh coordinates and devices."""
+        ranges = [range(dim) for dim in self.shape]
+        coordinates = list(itertools.product(*ranges))
+
+        if len(coordinates) != len(self.devices):
+            return
+
+        for coord, device in zip(coordinates, self.devices):
+            self._coord_to_device[coord] = device
+            self._device_to_coord[device] = coord
+
+    def _setup_peer_groups(self) -> None:
+        """Set up peer groups on HCQCompiled devices."""
+        try:
+            from tinygrad.runtime.support.hcq import HCQCompiled
+        except ImportError:
+            return
+
+        all_caps = get_all_capabilities() if self._global_config and self._global_config.world_size > 1 else []
+
+        for caps in all_caps:
+            node_name = caps.get("node", "")
+            for gpu in caps.get("gpus", []):
+                try:
+                    dev = None
+                    try:
+                        from tinygrad.device import Device
+                        dev = Device[gpu]
+                    except (KeyError, IndexError):
+                        continue
+
+                    if hasattr(dev, 'peer_group'):
+                        dev.peer_group = node_name
+                        if node_name not in self._peer_groups:
+                            self._peer_groups[node_name] = []
+                        if gpu not in self._peer_groups[node_name]:
+                            self._peer_groups[node_name].append(gpu)
+                except Exception:
+                    continue
+
+        if not self._peer_groups:
+            self._peer_groups["localhost"] = self.devices
+
+    def get_device(self, *coords: int) -> str:
+        """
+        Get device at given mesh coordinates.
+
+        Args:
+            *coords: Mesh coordinates (e.g., (0, 1) for row 0, column 1)
+
+        Returns:
+            Device string.
+
+        Raises:
+            KeyError: If coordinates are out of bounds.
+        """
+        if len(coords) != len(self.shape):
+            raise ValueError(
+                f"Expected {len(self.shape)} coordinates, got {len(coords)}"
+            )
+
+        coord = tuple(coords)
+        if coord not in self._coord_to_device:
+            raise KeyError(f"Coordinates {coord} out of bounds for shape {self.shape}")
+
+        return self._coord_to_device[coord]
+
+    def get_coordinates(self, device: str) -> Tuple[int, ...]:
+        """
+        Get mesh coordinates for a device.
+
+        Args:
+            device: Device string.
+
+        Returns:
+            Mesh coordinates.
+
+        Raises:
+            KeyError: If device not in mesh.
+        """
+        if device not in self._device_to_coord:
+            raise KeyError(f"Device {device} not in mesh")
+
+        return self._device_to_coord[device]
+
+    def submesh(self, dim: int, index: int) -> 'DeviceMesh':
+        """
+        Get a submesh along a dimension.
+
+        Useful for creating sub-groups for collective operations.
+
+        Args:
+            dim: Dimension to slice along.
+            index: Index in that dimension.
+
+        Returns:
+            DeviceMesh representing the submesh.
+
+        Example:
+            >>> mesh = DeviceMesh(shape=(2, 4))  # 2 nodes × 4 GPUs
+            >>> node0 = mesh.submesh(dim=0, index=0)  # All GPUs on node 0
+            >>> node1 = mesh.submesh(dim=0, index=1)  # All GPUs on node 1
+        """
+        key = (dim, index)
+        if key in self._submeshes:
+            return self._submeshes[key]
+
+        sub_devices = []
+        for device in self.devices:
+            coords = self.get_coordinates(device)
+            if coords[dim] == index:
+                sub_devices.append(device)
+
+        new_shape = tuple(s for i, s in enumerate(self.shape) if i != dim)
+
+        submesh = DeviceMesh(shape=new_shape if new_shape else (len(sub_devices),), devices=sub_devices, config=self.config)
+        self._submeshes[key] = submesh
+        return submesh
+
+    def all_submeshes(self, dim: int) -> List['DeviceMesh']:
+        """
+        Get all submeshes along a dimension.
+
+        Args:
+            dim: Dimension to slice along.
+
+        Returns:
+            List of DeviceMeshes, one for each index in the dimension.
+        """
+        return [self.submesh(dim, i) for i in range(self.shape[dim])]
+
+    def peer_group(self, device: str) -> str:
+        """
+        Get peer group for a device.
+
+        In tinygrad's HCQ system, devices in the same peer group use P2P
+        (PCIe/NVLink/Infinity Fabric), while devices in different peer
+        groups use RDMA or TCP.
+
+        By default, devices on the same node are in the same peer group.
+
+        Args:
+            device: Device string.
+
+        Returns:
+            Peer group identifier (typically node name).
+        """
+        if self._global_config is None:
+            return "localhost"
+
+        if len(self.shape) >= 2:
+            coords = self.get_coordinates(device)
+            node_index = coords[0]
+            return f"node_{node_index}"
+        else:
+            if self._global_config.num_nodes > 1:
+                return f"node_{self._global_config.node_rank}"
+            else:
+                return "localhost"
+
+    def is_same_peer_group(self, device1: str, device2: str) -> bool:
+        """
+        Check if two devices are in the same peer group.
+
+        Args:
+            device1: First device string.
+            device2: Second device string.
+
+        Returns:
+            True if devices are in same peer group (can use P2P).
+        """
+        return self.peer_group(device1) == self.peer_group(device2)
+
+    def get_node_devices(self, node_rank: Optional[int] = None) -> List[str]:
+        """Get all devices on a specific node."""
+        if node_rank is None:
+            node_rank = self._global_config.node_rank if self._global_config else 0
+
+        if len(self.shape) >= 2:
+            return [self.get_device(node_rank, i) for i in range(self.shape[1])]
+        else:
+            return self.devices
+
+    def allreduce(self, data: Any, op: str = "sum") -> Any:
+        """
+        Allreduce collective operation across devices in the mesh.
+        
+        Args:
+            data: Input tensor (should be sharded or multi-device).
+            op: Reduction operation ("sum", "max", "min", "prod").
+        
+        Returns:
+            Tensor with allreduce applied across all devices.
+        """
+        if self._global_config is None or self._global_config.world_size <= 1:
+            return data
+        
+        op_map = {
+            "sum": Ops.ADD,
+            "max": Ops.MAX,
+            "min": None,
+            "prod": None
+        }
+        if op not in op_map or op_map[op] is None:
+            raise NotImplementedError(f"Allreduce op {op} not supported")
+        
+        if hasattr(data, "allreduce"):
+            return data.allreduce(op_map[op], tuple(self.devices))
+        return data
+
+    def allgather(self, data: Any) -> Any:
+        """
+        Allgather collective operation across devices in the mesh.
+        
+        Args:
+            data: Input tensor (sharded across devices).
+        
+        Returns:
+            Tensor with all shards gathered.
+        """
+        if self._global_config is None or self._global_config.world_size <= 1:
+            return data
+        
+        if hasattr(data, "mselect") and hasattr(data, "_unshard"):
+            # Use multi op to unshard (allgather)
+            return data._unshard(axis=self._global_config.local_rank)
+        return data
+
+    def barrier(self) -> None:
+        """
+        Barrier synchronization across all devices/ranks in the mesh.
+        
+        Wait for all ranks to reach this point before proceeding.
+        """
+        if self._global_config is None or self._global_config.world_size <= 1:
+            return
+        
+        if HAS_MPI and self._global_config.backend == "mpi":
+            from .bootstrap import MPI
+            MPI.COMM_WORLD.barrier()
+        elif self._global_config.backend == "slurm":
+            # Simple debug print for Slurm (no real barrier yet)
+            print(f"[Slurm barrier] Rank {self._global_config.rank}")
+        else:
+            # Fallback: nothing to do (single-node/local)
+            pass
+
+    def __repr__(self) -> str:
+        return (f"DeviceMesh(shape={self.shape}, devices={self.devices}, "
+                f"config={self._global_config})")
+
+    def __len__(self) -> int:
+        return len(self.devices)
+
+    def __iter__(self):
+        return iter(self.devices)
+
+    def __getitem__(self, idx: int) -> str:
+        return self.devices[idx]
+
+import os
+
+def create_data_parallel_mesh() -> DeviceMesh:
+    """
+    Create a DeviceMesh for data parallelism.
+
+    All devices are arranged in a 1D mesh for data parallel sharding.
+
+    Returns:
+        DeviceMesh for data parallelism.
+    """
+    config = init_distributed()
+    return DeviceMesh(config=config)
+
+def create_tensor_parallel_mesh() -> DeviceMesh:
+    """
+    Create a DeviceMesh for tensor parallelism.
+
+    Devices are arranged to optimize for tensor parallel operations.
+    For multi-node, tries to keep tensor parallel groups within nodes
+    to minimize cross-node communication.
+
+    Returns:
+        DeviceMesh for tensor parallelism.
+    """
+    config = init_distributed()
+
+    if config is None:
+        return DeviceMesh()
+
+    if config.num_nodes > 1:
+        shape = (config.num_nodes, config.gpus_per_node)
+    else:
+        shape = (config.gpus_per_node,)
+
+    return DeviceMesh(shape=shape, config=config)
+
+def create_pipeline_parallel_mesh(stages: int) -> DeviceMesh:
+    """
+    Create a DeviceMesh for pipeline parallelism.
+
+    Devices are arranged for pipeline parallel stages.
+
+    Args:
+        stages: Number of pipeline stages.
+
+    Returns:
+        DeviceMesh for pipeline parallelism.
+
+    Raises:
+        ValueError: If number of devices not divisible by stages.
+    """
+    config = init_distributed()
+
+    if config is None:
+        mesh = DeviceMesh()
+        devices = mesh.devices
+    else:
+        all_caps = get_all_capabilities()
+        devices = []
+        for caps in all_caps:
+            devices.extend(caps.get("gpus", []))
+
+    if len(devices) % stages != 0:
+        raise ValueError(
+            f"Number of devices ({len(devices)}) must be divisible by "
+            f"pipeline stages ({stages})"
+        )
+
+    devices_per_stage = len(devices) // stages
+    shape = (stages, devices_per_stage)
+
+    return DeviceMesh(shape=shape, devices=devices, config=config)
+
+__all__ = [
+    "DeviceMesh",
+    "create_data_parallel_mesh",
+    "create_tensor_parallel_mesh",
+    "create_pipeline_parallel_mesh",
+]

--- a/tinygrad/distributed/rdma_config.py
+++ b/tinygrad/distributed/rdma_config.py
@@ -1,0 +1,203 @@
+"""
+RDMA configuration for tinygrad distributed training.
+
+Provides RDMA endpoint discovery and configuration using bootstrap capabilities.
+"""
+
+from __future__ import annotations
+import os
+from typing import Optional, Dict, List, Tuple
+
+class RDMAConfig:
+    """Configuration for RDMA endpoints."""
+
+    def __init__(self, config: Optional[Any] = None):
+        self.config = config
+        self.endpoints: Dict[int, str] = {}
+        self._discover_endpoints()
+
+    def _discover_endpoints(self) -> None:
+        """Discover RDMA endpoints for all ranks from bootstrap config."""
+        try:
+            from tinygrad.distributed import get_all_capabilities, get_world_info
+
+            all_caps = get_all_capabilities()
+            world_info = get_world_info()
+
+            if not all_caps or world_info["world_size"] <= 1:
+                self.endpoints = {0: "127.0.0.1:10000"}
+                return
+
+            rdma_endpoints_env = os.getenv("RDMA_ENDPOINTS")
+            if rdma_endpoints_env:
+                endpoints_list = rdma_endpoints_env.split(",")
+                for i, endpoint in enumerate(endpoints_list):
+                    self.endpoints[i] = endpoint
+                return
+
+            for caps in all_caps:
+                rank = caps.get("rank")
+                rdma_addr = caps.get("rdma_addr")
+                if rank is not None and rdma_addr:
+                    port = 10000 + rank
+                    self.endpoints[rank] = f"{rdma_addr}:{port}"
+
+        except ImportError:
+            pass
+
+        if not self.endpoints:
+            try:
+                world_size = int(os.getenv("WORLD_SIZE", "1"))
+                if world_size <= 1:
+                    self.endpoints = {0: "127.0.0.1:10000"}
+                    return
+
+                for rank in range(world_size):
+                    if os.getenv("RDMA_ADDR"):
+                        ip = os.getenv("RDMA_ADDR")
+                    elif os.getenv(f"RDMA_ADDR_{rank}"):
+                        ip = os.getenv(f"RDMA_ADDR_{rank}")
+                    else:
+                        num_nodes = int(os.getenv("NUM_NODES", "1"))
+                        if num_nodes > 1:
+                            ip = f"10.0.0.{rank + 1}"
+                        else:
+                            ip = "127.0.0.1"
+                    self.endpoints[rank] = f"{ip}:{10000 + rank}"
+            except Exception:
+                self.endpoints = {0: "127.0.0.1:10000"}
+
+    def get_endpoint(self, rank: int) -> str:
+        """Get RDMA endpoint for a rank."""
+        if rank not in self.endpoints:
+            raise KeyError(f"No RDMA endpoint configured for rank {rank}")
+        return self.endpoints[rank]
+
+    def get_ip_port(self, rank: int) -> Tuple[str, int]:
+        """Get IP and port for a rank."""
+        endpoint = self.get_endpoint(rank)
+        parts = endpoint.rsplit(":", 1)
+        if len(parts) == 2:
+            return parts[0], int(parts[1])
+        return endpoint, 10000 + rank
+
+    def get_local_endpoint(self) -> Optional[str]:
+        """Get RDMA endpoint for local rank."""
+        try:
+            from tinygrad.distributed import get_world_info
+            world_info = get_world_info()
+            return self.get_endpoint(world_info["rank"])
+        except Exception:
+            return self.get_endpoint(0)
+
+def patch_rdma_ip_assignment():
+    """Monkey-patch MLXIface to use configurable IPs from bootstrap config."""
+    try:
+        from tinygrad.runtime.ops_rdma import MLXIface
+        from tinygrad.runtime.support.mlx.mlxdev import MLXDev
+    except ImportError:
+        print("[tinygrad.distributed.rdma] RDMA not available, skipping IP patch")
+        return
+
+    original_init = MLXIface.__init__
+
+    def patched_init(self, dev, dev_id):
+        original_init(self, dev, dev_id)
+
+        try:
+            from tinygrad.distributed import get_world_info
+            world_info = get_world_info()
+
+            if world_info["world_size"] > 1:
+                rdma_config = RDMAConfig()
+                ip, _ = rdma_config.get_ip_port(world_info["rank"])
+            else:
+                ip = "127.0.0.1"
+
+            self.mlx_dev = MLXDev(self.pci_dev, ip=ip)
+
+            self.uar_buf = self._buf([self.mlx_dev.pci_dev.bar_info(0)[0] + self.mlx_dev.uar * 0x1000])
+            self.dbr_buf = self._buf(self.mlx_dev.dbr_paddrs)
+
+            if hasattr(self, 'qp'):
+                self.qp = None
+
+        except Exception as e:
+            print(f"[tinygrad.distributed.rdma] Failed to patch RDMA IP: {e}")
+
+    MLXIface.__init__ = patched_init
+
+    print("[tinygrad.distributed.rdma] Patched RDMA IP assignment")
+
+class RDMANetwork:
+    """Manages RDMA network connections for distributed training."""
+
+    def __init__(self, config: Optional[Any] = None):
+        self.config = config
+        self.rdma_config = RDMAConfig(config)
+        self.connections: Dict[int, Any] = {}
+        self._initialized = False
+
+    def initialize(self) -> None:
+        """Initialize RDMA network connections."""
+        if self._initialized:
+            return
+
+        try:
+            from tinygrad.distributed import get_world_info
+            world_info = get_world_info()
+            print(f"[tinygrad.distributed.rdma] Initializing RDMA for rank {world_info['rank']}")
+        except Exception:
+            print("[tinygrad.distributed.rdma] Initializing RDMA")
+
+        self._initialized = True
+
+    def connect_to_rank(self, rank: int) -> Optional[Any]:
+        """Connect to a specific rank."""
+        if rank == (self.config.rank if self.config else 0):
+            raise ValueError("Cannot connect to self")
+
+        if rank in self.connections:
+            return self.connections[rank]
+
+        ip, port = self.rdma_config.get_ip_port(rank)
+
+        try:
+            from tinygrad.distributed import get_world_info
+            print(f"[tinygrad.distributed.rdma] Connecting to rank {rank} at {ip}:{port}")
+        except Exception:
+            pass
+
+        connection = {"rank": rank, "ip": ip, "port": port, "connected": True}
+        self.connections[rank] = connection
+
+        return connection
+
+    def get_peer_group_connections(self) -> List[Any]:
+        """Get connections to all ranks in the same peer group."""
+        connections = []
+        try:
+            from tinygrad.distributed import get_world_info
+            world_info = get_world_info()
+            my_rank = world_info["rank"]
+
+            for rank in range(world_info["world_size"]):
+                if rank != my_rank:
+                    connections.append(self.connect_to_rank(rank))
+        except Exception:
+            pass
+
+        return connections
+
+    def barrier(self) -> None:
+        """Synchronize all ranks using RDMA."""
+        if self.config and self.config.world_size <= 1:
+            return
+
+        print("[tinygrad.distributed.rdma] Barrier")
+
+import typing
+if typing.TYPE_CHECKING:
+    from tinygrad.distributed.bootstrap import DistributedConfig
+
+__all__ = ["RDMAConfig", "patch_rdma_ip_assignment", "RDMANetwork"]

--- a/tinygrad/gradient.py
+++ b/tinygrad/gradient.py
@@ -79,6 +79,7 @@ pm_gradient = PatternMatcher([
   (UPat(Ops.AFTER), lambda ctx: (ctx, ctx)),
   # there's no gradient for bitcast
   (UPat(Ops.BITCAST), lambda: (None,)),
+  (UPat(Ops.CHECKPOINT, name="ret"), lambda ctx, ret: (ctx,)),  # Checkpoint just passes through gradients
 ])
 
 def _deepwalk(root:UOp, targets:set[UOp]) -> tuple[list[UOp], dict[UOp, bool]]:

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -3,7 +3,7 @@ import math, functools
 from tinygrad.tensor import Tensor
 from tinygrad.dtype import dtypes
 from tinygrad.helpers import prod, make_tuple, flatten, USE_ATOMICS
-from tinygrad.nn import optim, state, datasets  # noqa: F401
+from tinygrad.nn import optim, state, datasets, parallel  # noqa: F401
 
 class BatchNorm:
   """

--- a/tinygrad/nn/moe.py
+++ b/tinygrad/nn/moe.py
@@ -1,0 +1,292 @@
+"""
+Mixture of Experts (MoE) for tinygrad.
+
+Provides distributed MoE layer with expert parallelism across multiple GPUs/nodes.
+"""
+
+from __future__ import annotations
+from typing import Optional, List, Tuple, Callable
+from tinygrad.tensor import Tensor
+from tinygrad.dtype import dtypes
+from tinygrad.helpers import getenv
+
+class MoELayer:
+    """
+    Distributed Mixture of Experts layer.
+
+    Routes tokens to different expert subnetworks, with experts placed on different devices.
+    Uses all-to-all communication for token routing across devices.
+
+    For multi-node MoE, tokens are sent to remote experts via RDMA/TCP.
+    """
+
+    def __init__(self, num_experts: int, dim: int, hidden_dim: int,
+                 activated_experts: int = 1, bias: bool = False,
+                 devices: Optional[List[str]] = None,
+                 gate_bias: bool = False):
+        """
+        Args:
+            num_experts: Total number of experts.
+            dim: Input dimension.
+            hidden_dim: Hidden dimension.
+            activated_experts: Number of experts to activate per token (top-k).
+            bias: Whether to use bias in linear layers.
+            devices: Devices to place experts on. If None, all experts on same device.
+            gate_bias: Whether to use bias in gate.
+        """
+        self.num_experts = num_experts
+        self.dim = dim
+        self.hidden_dim = hidden_dim
+        self.activated_experts = activated_experts
+        self.devices = devices
+
+        self.gate = Tensor.uniform(num_experts, dim, low=-0.1, high=0.1)
+
+        self.experts_per_device = 1
+        if devices is not None:
+            self.experts_per_device = (num_experts + len(devices) - 1) // len(devices)
+
+        self.up_proj = Tensor.uniform(num_experts, hidden_dim, dim, low=-0.1, high=0.1)
+        self.gate_proj = Tensor.uniform(num_experts, hidden_dim, dim, low=-0.1, high=0.1)
+        self.down_proj = Tensor.uniform(num_experts, dim, hidden_dim, low=-0.1, high=0.1)
+
+    def __call__(self, x: Tensor) -> Tensor:
+        """
+        Forward pass with optional distributed expert routing.
+
+        Args:
+            x: Input tensor of shape (batch, seq_len, dim).
+
+        Returns:
+            Output tensor of shape (batch, seq_len, dim).
+        """
+        if self.devices is None or len(self.devices) == 1:
+            return self._local_forward(x)
+
+        return self._distributed_forward(x)
+
+    def _local_forward(self, x: Tensor) -> Tensor:
+        """Forward pass with all experts on same device."""
+        bsz, seqlen, dim = x.shape
+
+        gate_out = x @ self.gate.transpose()
+        gate_out = gate_out.reshape(bsz * seqlen, self.num_experts).softmax(-1)
+
+        topk_probs, topk_indices = gate_out.topk(self.activated_experts, dim=-1)
+
+        x_flat = x.reshape(bsz * seqlen, dim)
+        out = Tensor.zeros(bsz * seqlen, dim)
+        for k in range(self.activated_experts):
+            expert_idx = topk_indices[:, k]
+            expert_weight = topk_probs[:, k].reshape(-1, 1)
+
+            for e in range(self.num_experts):
+                mask = (expert_idx == e).cast(dtypes.float).reshape(-1, 1)
+
+                expert_input = mask * x_flat
+
+                up = (expert_input @ self.up_proj[e].permute(1, 0))
+                gate = (expert_input @ self.gate_proj[e].permute(1, 0))
+                hidden = (up * gate.silu())
+
+                down = (hidden @ self.down_proj[e].permute(1, 0))
+
+                out += mask * (down * expert_weight)
+
+        return out.reshape(bsz, seqlen, -1)
+
+    def _distributed_forward(self, x: Tensor) -> Tensor:
+        """Forward pass with experts distributed across devices."""
+        raise NotImplementedError("Distributed MoE requires all-to-all primitive")
+
+class GroupedMoELayer(MoELayer):
+    """
+    Grouped Mixture of Experts with shared experts.
+
+    Some experts are shared across all tokens, while others are routed.
+    """
+
+    def __init__(self, num_experts: int, num_shared_experts: int, dim: int, hidden_dim: int,
+                 activated_experts: int = 1, bias: bool = False,
+                 devices: Optional[List[str]] = None):
+        super().__init__(num_experts, dim, hidden_dim, activated_experts, bias, devices)
+
+        self.num_shared_experts = num_shared_experts
+        self.shared_up = Tensor.uniform(num_shared_experts, hidden_dim, dim, low=-0.1, high=0.1)
+        self.shared_down = Tensor.uniform(num_shared_experts, dim, hidden_dim, low=-0.1, high=0.1)
+
+    def __call__(self, x: Tensor) -> Tensor:
+        """Forward pass with shared experts computed for all tokens."""
+        bsz, seqlen, dim = x.shape
+
+        shared_out = Tensor.zeros(bsz, seqlen, dim)
+        for e in range(self.num_shared_experts):
+            up = x @ self.shared_up[e].permute(1, 0)
+            hidden = up.silu()
+            shared_out += x @ self.hidden @ self.shared_down[e].permute(1, 0)
+
+        routed_out = self._local_forward(x)
+
+        return shared_out + routed_out
+
+class AllToAll:
+    """
+    All-to-all communication primitive for distributed MoE.
+
+    Each device sends different data to every other device.
+    In MoE context, this is used for token routing: each token is sent to
+    the device holding the selected expert.
+    """
+
+    def __init__(self, devices: List[str]):
+        """
+        Args:
+            devices: List of devices participating in all-to-all.
+        """
+        self.devices = devices
+        self.n_devices = len(devices)
+
+    def forward(self, data: Tensor, expert_mapping: Tensor) -> Tuple[Tensor, Tensor]:
+        """
+        Send data to appropriate experts via all-to-all.
+
+        Args:
+            data: Input tensor of shape (total_tokens, dim).
+            expert_mapping: Tensor of shape (total_tokens,) with expert indices.
+
+        Returns:
+            Tuple of (tokens_per_expert, data_per_expert) where each is a list
+            of tensors, one per expert.
+        """
+        raise NotImplementedError("All-to-all requires RDMA/TCP integration")
+
+    def backward(self, grad_output: List[Tensor]) -> Tensor:
+        """
+        Gather gradients back via reverse all-to-all.
+
+        Args:
+            grad_output: List of gradients, one per expert.
+
+        Returns:
+            Combined gradient tensor.
+        """
+        raise NotImplementedError("All-to-all backward requires RDMA/TCP integration")
+
+def all_to_all(tokens: Tensor, expert_ids: Tensor, num_experts: int,
+               devices: List[str]) -> Tuple[List[Tensor], List[int]]:
+    """
+    All-to-all token routing for distributed MoE.
+
+    Routes each token to the device containing its selected expert.
+
+    Args:
+        tokens: Input tokens of shape (batch, seq_len, dim).
+        expert_ids: Expert indices for each token, shape (batch, seq_len, activated_experts).
+        num_experts: Total number of experts.
+        devices: List of devices.
+
+    Returns:
+        Tuple of (tokens_list, expert_counts) where tokens_list is a list of tensors
+        (one per target device) and expert_counts indicates how many tokens go to each device.
+    """
+    raise NotImplementedError("all_to_all requires multi-device support")
+
+def all_to_all_reverse(grads: List[Tensor], expert_counts: List[int],
+                       devices: List[str]) -> Tensor:
+    """
+    Reverse all-to-all for gradients.
+
+    Gathers gradients from all devices back to the original token locations.
+
+    Args:
+        grads: List of gradient tensors, one per source device.
+        expert_counts: Number of tokens that came from each device.
+        devices: List of devices.
+
+    Returns:
+        Combined gradient tensor.
+    """
+    raise NotImplementedError("all_to_all_reverse requires multi-device support")
+
+class PipelineStage:
+    """
+    Pipeline parallelism stage.
+
+    Wraps a set of layers to form a stage in pipeline parallelism.
+    Handles forward/backward pass and communication between stages.
+    """
+
+    def __init__(self, layers: List[Callable], stage_id: int, num_stages: int,
+                 devices: Optional[List[str]] = None):
+        """
+        Args:
+            layers: List of layers/modules in this stage.
+            stage_id: Index of this stage in the pipeline.
+            num_stages: Total number of pipeline stages.
+            devices: Devices to place this stage on.
+        """
+        self.layers = layers
+        self.stage_id = stage_id
+        self.num_stages = num_stages
+        self.devices = devices
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward pass through this stage."""
+        out = x
+        for layer in self.layers:
+            out = layer(out)
+        return out
+
+    def backward(self, grad_output: Tensor) -> Tensor:
+        """Backward pass through this stage."""
+        grad = grad_output
+        for layer in reversed(self.layers):
+            if hasattr(layer, 'backward'):
+                grad = layer.backward(grad)
+            else:
+                grad = grad
+        return grad
+
+    def __call__(self, x: Tensor) -> Tensor:
+        return self.forward(x)
+
+class PipelineSchedule:
+    """
+    Pipeline parallelism scheduler.
+
+    Manages micro-batch scheduling for pipeline parallelism (GPipe/PipeDream).
+    """
+
+    def __init__(self, stages: List[PipelineStage], num_microbatches: int = 1,
+                 schedule_type: str = "gpipe"):
+        """
+        Args:
+            stages: List of pipeline stages.
+            num_microbatches: Number of microbatches for pipeline.
+            schedule_type: "gpipe" for GPipe or "pipedream" for PipeDream.
+        """
+        self.stages = stages
+        self.num_microbatches = num_microbatches
+        self.schedule_type = schedule_type
+
+    def forward_backward(self, inputs: List[Tensor]) -> List[Tensor]:
+        """
+        Run forward and backward pass through the pipeline.
+
+        Args:
+            inputs: List of input tensors (one per microbatch).
+
+        Returns:
+            List of output tensors.
+        """
+        raise NotImplementedError("Pipeline scheduling requires distributed support")
+
+__all__ = [
+    "MoELayer",
+    "GroupedMoELayer",
+    "AllToAll",
+    "all_to_all",
+    "all_to_all_reverse",
+    "PipelineStage",
+    "PipelineSchedule",
+]

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -3,6 +3,7 @@ import itertools
 from tinygrad.helpers import dedup, flatten, getenv, unwrap, FUSE_OPTIM
 from tinygrad.tensor import Tensor
 from tinygrad.dtype import dtypes, least_upper_dtype, to_dtype
+from typing import Optional, List
 
 class Optimizer:
   """
@@ -181,3 +182,209 @@ class LAMB(Optimizer):
         r = 1.0
       ret.append((self.lr * r * up).cast(t.dtype))
     return ret, [self.b1_t, self.b2_t] + self.m + self.v
+
+class ZeroLAMB(LAMB):
+  """
+  LAMB optimizer with ZeRO stage 1 (optimizer state sharding).
+
+  Each GPU only stores 1/N of the optimizer states (m, v), reducing memory usage by N.
+
+  - Paper: https://arxiv.org/abs/1910.02054v3 (ZeRO)
+  """
+  def __init__(self, params: list[Tensor], lr=0.001, b1=0.9, b2=0.999, eps=1e-6, weight_decay=0.0, adam=False, device=None, fused=FUSE_OPTIM,
+               zero_stage: int = 1, zero_devices: Optional[List[str]] = None):
+    if zero_stage < 1 or zero_stage > 3:
+      raise ValueError(f"ZeRO stage must be 1, 2, or 3, got {zero_stage}")
+    if zero_devices is not None and len(zero_devices) < 2:
+      raise ValueError("ZeRO requires at least 2 devices")
+    self.zero_stage = zero_stage
+    self.zero_devices = zero_devices
+    super().__init__(params, lr, b1, b2, eps, weight_decay, adam, device, fused)
+
+  def _new_optim_param(self) -> list[Tensor]:
+    if self.zero_devices is None:
+      return super()._new_optim_param()
+    n_devs = len(self.zero_devices)
+    if self.fused:
+      total_size = self.pos_params[-1]
+      shard_size = (total_size + n_devs - 1) // n_devs
+      ret = []
+      for i, d in enumerate(self.zero_devices):
+        start = i * shard_size
+        end = min(start + shard_size, total_size)
+        if start < total_size:
+          ret.append(Tensor.zeros(end - start, dtype=self.param_dtype, device=d, requires_grad=False))
+      return ret
+    ret = []
+    for t in self.params:
+      shard_size = (t.numel() + n_devs - 1) // n_devs
+      for i, d in enumerate(self.zero_devices):
+        start = i * shard_size
+        end = min(start + shard_size, t.numel())
+        if start < t.numel():
+          ret.append(Tensor.zeros(end - start, dtype=self.param_dtype, device=d, requires_grad=False))
+    return ret
+
+    def _step(self, params: list[Tensor], grads: list[Tensor]) -> tuple[list[Tensor], list[Tensor]]:
+        if self.zero_devices is None or self.zero_stage == 0:
+            return super()._step(params, grads)
+        
+        n_devices = len(self.zero_devices)
+        ret = []
+        
+        for i, (t, g) in enumerate(zip(params, grads)):
+            shard_size = (t.numel() + n_devices - 1) // n_devices
+            device_idx = i % n_devices
+            
+            if self.fused:
+                # Fused path
+                pass
+            else:
+                # Non-fused ZeRO-1: optimizer states are sharded across devices
+                m_shard = self.m[i]
+                v_shard = self.v[i]
+                
+                # Compute local update
+                self.b1_t *= self.b1
+                self.b2_t *= self.b2
+                
+                m_shard.assign((self.b1 * m_shard + (1.0 - self.b1) * g).cast(m_shard.dtype))
+                v_shard.assign((self.b2 * v_shard + (1.0 - self.b2) * (g * g)).cast(v_shard.dtype))
+                
+                m_hat = m_shard / (1.0 - self.b1_t)
+                v_hat = v_shard / (1.0 - self.b2_t)
+                
+                up = (m_hat / (v_hat.sqrt() + self.eps)).shard_like(t) + self.wd * t.detach()
+                
+                if not self.adam:
+                    r1 = t.detach().square().sum().sqrt()
+                    r2 = up.square().sum().sqrt()
+                    r = t.where(r1 > 0, t.where(r2 > 0, r1 / r2, 1.0), 1.0)
+                else:
+                    r = 1.0
+                
+                ret.append((self.lr * r * up).cast(t.dtype))
+        
+        return ret, [self.b1_t, self.b2_t] + self.m + self.v
+
+def ZeroAdam(params: list[Tensor], lr=0.001, b1=0.9, b2=0.999, eps=1e-8, weight_decay=0.01, device=None, fused=FUSE_OPTIM,
+             zero_stage: int = 1, zero_devices: Optional[List[str]] = None):
+  """
+  AdamW optimizer with ZeRO (Zero Redundancy Optimizer) support.
+
+  - ZeRO-1: Shard optimizer states across GPUs
+  - ZeRO-2: Shard gradients + optimizer states (not implemented)
+  - ZeRO-3: Shard parameters + gradients + optimizer states (not implemented)
+
+  Args:
+      params: List of parameters to optimize.
+      lr: Learning rate.
+      b1: Beta1 coefficient for momentum.
+      b2: Beta2 coefficient for second moment.
+      eps: Epsilon for numerical stability.
+      weight_decay: Weight decay coefficient.
+      device: Device for optimizer state.
+      fused: Whether to use fused optimizer.
+      zero_stage: ZeRO stage (1, 2, or 3).
+      zero_devices: List of devices for ZeRO sharding.
+
+  Returns:
+      ZeroLAMB optimizer instance.
+  """
+  return ZeroLAMB(params, lr, b1, b2, eps, weight_decay, adam=True, device=device, fused=fused,
+                  zero_stage=zero_stage, zero_devices=zero_devices)
+
+def ZeroSGD(params: list[Tensor], lr=0.001, momentum=0.0, weight_decay=0.0, nesterov=False, device=None, fused=FUSE_OPTIM,
+            zero_stage: int = 1, zero_devices: Optional[List[str]] = None):
+  """
+  SGD optimizer with ZeRO support.
+
+  Args:
+      params: List of parameters to optimize.
+      lr: Learning rate.
+      momentum: Momentum coefficient.
+      weight_decay: Weight decay coefficient.
+      nesterov: Whether to use Nesterov momentum.
+      device: Device for optimizer state.
+      fused: Whether to use fused optimizer.
+      zero_stage: ZeRO stage (1, 2, or 3).
+      zero_devices: List of devices for ZeRO sharding.
+
+  Returns:
+      ZeroLARS optimizer instance (SGD is LARS with trust coefficient 0).
+  """
+  return ZeroLARS(params, lr, momentum, weight_decay, 0, None, nesterov, classic=True, pre_wd=True, tcoef=0.0,
+                  device=device, fused=fused, zero_stage=zero_stage, zero_devices=zero_devices)
+
+class ZeroLARS(LARS):
+  """
+  LARS optimizer with ZeRO stage 1 (optimizer state sharding).
+  """
+  def __init__(self, params: list[Tensor], lr=0.001, momentum=0.9, weight_decay=1e-4, ns_steps=0, ns_coefficients=None,
+               nesterov=False, classic=True, pre_wd=True, tcoef=0.001, device=None, fused=FUSE_OPTIM,
+               zero_stage: int = 1, zero_devices: Optional[List[str]] = None):
+    if zero_devices is not None and len(zero_devices) < 2:
+      raise ValueError("ZeRO requires at least 2 devices")
+    self.zero_stage = zero_stage
+    self.zero_devices = zero_devices
+    super().__init__(params, lr, momentum, weight_decay, ns_steps, ns_coefficients, nesterov, classic, pre_wd, tcoef, device, fused)
+
+    def _new_optim_param(self) -> list[Tensor]:
+        if self.zero_devices is None:
+            return super()._new_optim_param()
+        n_devs = len(self.zero_devices)
+        if self.fused:
+            total_size = self.pos_params[-1]
+            shard_size = (total_size + n_devs - 1) // n_devs
+            ret = []
+            for i, d in enumerate(self.zero_devices):
+                start = i * shard_size
+                end = min(start + shard_size, total_size)
+                if start < total_size:
+                    ret.append(Tensor.zeros(end - start, dtype=self.param_dtype, device=d, requires_grad=False))
+            return ret
+        if not self.momentum:
+            return []
+        ret = []
+        for t in self.params:
+            shard_size = (t.numel() + n_devs - 1) // n_devs
+            for i, d in enumerate(self.zero_devices):
+                start = i * shard_size
+                end = min(start + shard_size, t.numel())
+                if start < t.numel():
+                    ret.append(Tensor.zeros(end - start, dtype=self.param_dtype, device=d, requires_grad=False))
+        return ret
+
+    def _step(self, params: list[Tensor], grads: list[Tensor]) -> tuple[list[Tensor], list[Tensor]]:
+        if self.zero_devices is None or self.zero_stage == 0:
+            return super()._step(params, grads)
+        
+        n_devices = len(self.zero_devices)
+        ret = []
+        
+        for i, (t, g) in enumerate(zip(params, grads)):
+            if not self.momentum:
+                # No momentum: just return the update
+                if self.pre_wd and self.wd > 0:
+                    g = g + self.wd * t.detach()
+                if self.classic:
+                    g = g * self.lr
+                if not self.classic:
+                    g = g * self.lr
+                ret.append(g.cast(t.dtype))
+            else:
+                shard_idx = i % n_devices
+                b_shard = self.b[i]
+                
+                # Local update on shard
+                if self.pre_wd and self.wd > 0:
+                    g = g + self.wd * t.detach()
+                if self.classic:
+                    g = g * self.lr
+                b_shard.assign(self.momentum * b_shard + g)
+                g = (g + self.momentum * b_shard) if self.nesterov else b_shard
+                if not self.classic:
+                    g = g * self.lr
+                ret.append(g.cast(t.dtype))
+        
+        return ret, self.b

--- a/tinygrad/nn/parallel.py
+++ b/tinygrad/nn/parallel.py
@@ -1,0 +1,292 @@
+"""
+Tensor Parallelism for tinygrad.
+
+Provides tensor parallel layer wrappers for distributed LLM training across multiple GPUs.
+"""
+
+from __future__ import annotations
+import math
+from typing import Optional, List, Union, Tuple
+from tinygrad.helpers import getenv
+from tinygrad.tensor import Tensor
+
+class TensorParallelLinear:
+    """
+    Tensor-parallel linear layer.
+
+    Supports column-parallel (split output features) and row-parallel (split input features)
+    transformations needed for efficient tensor parallelism in LLMs.
+
+    For column-parallel: weight is sharded along output dimension (dim=0)
+    For row-parallel: weight is sharded along input dimension (dim=1)
+    """
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = True,
+                 parallel_dim: int = 0, devices: Optional[List[str]] = None):
+        """
+        Args:
+            in_features: Size of input features.
+            out_features: Size of output features.
+            bias: Whether to include bias.
+            parallel_dim: Dimension along which to shard (0=column, 1=row).
+            devices: List of devices for sharding.
+        """
+        self.parallel_dim = parallel_dim
+        self.in_features = in_features
+        self.out_features = out_features
+
+        bound = 1 / math.sqrt(in_features)
+
+        if devices is None:
+            self.weight = Tensor.uniform(out_features, in_features, low=-bound, high=bound)
+        else:
+            n_devices = len(devices)
+            if parallel_dim == 0:
+                shard_size = (out_features + n_devices - 1) // n_devices
+                self.weight = Tensor.uniform(shard_size, in_features, low=-bound, high=bound)
+            else:
+                shard_size = (in_features + n_devices - 1) // n_devices
+                self.weight = Tensor.uniform(out_features, shard_size, low=-bound, high=bound)
+
+        self._original_weight = self.weight
+        self._devices = devices
+        self.bias = Tensor.uniform(out_features, low=-bound, high=bound) if bias else None
+
+    def shard_(self, devices: List[str], axis: int = 0) -> 'TensorParallelLinear':
+        """Shard this layer across devices."""
+        if self._devices is not None and self._devices != devices:
+            raise ValueError(f"Already sharded on {self._devices}, cannot reshard to {devices}")
+
+        self._devices = devices
+        self.weight = self._original_weight
+        return self
+
+    def __call__(self, x: Tensor) -> Tensor:
+        if self._devices is not None and len(self._devices) > 1:
+            result = x.linear(self.weight.transpose(), None)
+            if self.parallel_dim == 0:
+                return result
+            else:
+                raise NotImplementedError("Row-parallel linear requires all-gather")
+        return x.linear(self.weight.transpose(), self.bias)
+
+class TensorParallelColumnLinear(TensorParallelLinear):
+    """
+    Column-parallel linear layer.
+
+    The weight matrix is split along the output dimension (dim=0) across GPUs.
+    Each GPU computes a partial output; results are typically gathered or reduced.
+    """
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = True,
+                 devices: Optional[List[str]] = None):
+        super().__init__(in_features, out_features, bias, parallel_dim=0, devices=devices)
+
+    def __call__(self, x: Tensor) -> Tensor:
+        if self._devices is not None and len(self._devices) > 1:
+            return x.linear(self.weight.transpose(), None)
+        return x.linear(self.weight.transpose(), self.bias)
+
+class TensorParallelRowLinear(TensorParallelLinear):
+    """
+    Row-parallel linear layer.
+
+    The weight matrix is split along the input dimension (dim=1) across GPUs.
+    Each GPU computes a partial result; results are summed via allreduce.
+    """
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = True,
+                 devices: Optional[List[str]] = None):
+        super().__init__(in_features, out_features, bias, parallel_dim=1, devices=devices)
+
+    def __call__(self, x: Tensor) -> Tensor:
+        if self._devices is not None and len(self._devices) > 1:
+            result = x.linear(self.weight.transpose(), None)
+            return result
+        return x.linear(self.weight.transpose(), self.bias)
+
+class TensorParallelMLP:
+    """
+    Tensor-parallel MLP layer (LLaMA-style).
+
+    Consists of gate and up projections (column-parallel), a silu activation,
+    and a down projection (row-parallel).
+    """
+
+    def __init__(self, dim: int, hidden_dim: int, bias: bool = False,
+                 devices: Optional[List[str]] = None):
+        """
+        Args:
+            dim: Input dimension.
+            hidden_dim: Hidden dimension (intermediate size).
+            bias: Whether to use bias in linear layers.
+            devices: Devices to shard across.
+        """
+        self.dim = dim
+        self.hidden_dim = hidden_dim
+        self._devices = devices
+
+        bound = 1 / math.sqrt(dim)
+        self.w1 = Tensor.uniform(hidden_dim, dim, low=-bound, high=bound)
+        self.w2 = Tensor.uniform(dim, hidden_dim, low=-bound, high=bound)
+        self.w3 = Tensor.uniform(hidden_dim, dim, low=-bound, high=bound)
+
+        self._original_w1 = self.w1
+        self._original_w2 = self.w2
+        self._original_w3 = self.w3
+
+    def shard_(self, devices: List[str], axis: int = 0) -> 'TensorParallelMLP':
+        """Shard this MLP across devices."""
+        self._devices = devices
+        return self
+
+    def __call__(self, x: Tensor) -> Tensor:
+        if self._devices is not None and len(self._devices) > 1:
+            raise NotImplementedError("Sharded MLP requires custom parallel implementation")
+        return (self.w2 @ (self.w1(x) * self.w3(x)).silu())
+
+class TensorParallelAttention:
+    """
+    Tensor-parallel attention layer.
+
+    Supports sharding Q/K/V projections and the output projection.
+    For multi-head attention, heads are split across GPUs.
+    """
+
+    def __init__(self, dim: int, n_heads: int, n_kv_heads: Optional[int] = None,
+                 max_context: int = 0, qk_norm: Optional[float] = None,
+                 devices: Optional[List[str]] = None):
+        """
+        Args:
+            dim: Model dimension.
+            n_heads: Number of attention heads.
+            n_kv_heads: Number of key/value heads (for GQA). If None, same as n_heads.
+            max_context: Maximum context length for KV cache.
+            qk_norm: If not None, apply RMSNorm with this epsilon to Q and K.
+            devices: Devices to shard across.
+        """
+        self.dim = dim
+        self.n_heads = n_heads
+        self.n_kv_heads = n_kv_heads if n_kv_heads is not None else n_heads
+        self.head_dim = dim // n_heads
+        self.n_rep = self.n_heads // self.n_kv_heads
+        self.max_context = max_context
+        self.qk_norm = qk_norm
+        self._devices = devices
+
+        bound = 1 / math.sqrt(dim)
+        self.wq = Tensor.uniform(n_heads * self.head_dim, dim, low=-bound, high=bound)
+        self.wk = Tensor.uniform(self.n_kv_heads * self.head_dim, dim, low=-bound, high=bound)
+        self.wv = Tensor.uniform(self.n_kv_heads * self.head_dim, dim, low=-bound, high=bound)
+        self.wo = Tensor.uniform(dim, n_heads * self.head_dim, low=-bound, high=bound)
+
+        self._original_wq = self.wq
+        self._original_wk = self.wk
+        self._original_wv = self.wv
+        self._original_wo = self.wo
+
+    def shard_(self, devices: List[str], axis: int = 0) -> 'TensorParallelAttention':
+        """Shard this attention layer across devices."""
+        if self._devices is not None and self._devices != devices:
+            raise ValueError(f"Already sharded on {self._devices}, cannot reshard to {devices}")
+
+        self._devices = devices
+        return self
+
+    def __call__(self, x: Tensor, start_pos: Union[int, Tensor],
+                 freqs_cis: Tensor, mask: Optional[Tensor] = None) -> Tensor:
+        if self._devices is not None and len(self._devices) > 1:
+            raise NotImplementedError("Sharded attention requires parallel implementation")
+
+        xq = self.wq @ x
+        xk = self.wk @ x
+        xv = self.wv @ x
+
+        if self.qk_norm is not None:
+            from tinygrad.nn import RMSNorm
+            q_norm = RMSNorm(self.dim, eps=self.qk_norm)
+            k_norm = RMSNorm(self.dim, eps=self.qk_norm)
+            xq = q_norm(xq)
+            xk = k_norm(xk)
+
+        bsz, seqlen, _, _ = xq.shape
+        xq = xq.reshape(bsz, seqlen, self.n_heads, self.head_dim)
+        xk = xk.reshape(bsz, seqlen, self.n_kv_heads, self.head_dim)
+        xv = xv.reshape(bsz, seqlen, self.n_kv_heads, self.head_dim)
+
+        if start_pos.__class__.__name__ == 'Tensor':
+            raise NotImplementedError("Variable start_pos not supported in basic TP")
+
+        if self.max_context and hasattr(self, 'cache_kv'):
+            self.cache_kv[:, :, start_pos:start_pos+seqlen, :, :].assign(Tensor.stack(xk, xv)).realize()
+            keys = self.cache_kv[0, :, 0:start_pos+seqlen, :, :]
+            values = self.cache_kv[1, :, 0:start_pos+seqlen, :, :]
+        else:
+            keys, values = xk, xv
+
+        xq = xq.transpose(1, 2)
+        keys = keys.transpose(1, 2)
+        values = values.transpose(1, 2)
+
+        if self.n_rep > 1:
+            keys = keys.repeat((1, 1, 1, self.n_rep)).reshape(bsz, seqlen, self.n_heads, self.head_dim)
+            values = values.repeat((1, 1, 1, self.n_rep)).reshape(bsz, seqlen, self.n_heads, self.head_dim)
+
+        attn = xq.scaled_dot_product_attention(keys, values, mask)
+        attn = attn.transpose(1, 2).reshape(bsz, seqlen, -1)
+
+        return (self.wo @ attn)
+
+class FusedTensorParallelLinear(TensorParallelLinear):
+    """
+    Fused tensor-parallel linear for Q/K/V projections.
+
+    Combines Q, K, V projections into a single weight matrix for efficiency.
+    """
+
+    def __init__(self, dim: int, n_heads: int, n_kv_heads: Optional[int] = None,
+                 bias: bool = False, devices: Optional[List[str]] = None):
+        """
+        Args:
+            dim: Model dimension.
+            n_heads: Number of attention heads.
+            n_kv_heads: Number of key/value heads.
+            bias: Whether to include bias.
+            devices: Devices to shard across.
+        """
+        self.n_heads = n_heads
+        self.n_kv_heads = n_kv_heads if n_kv_heads is not None else n_heads
+        self.head_dim = dim // n_heads
+        self.n_rep = self.n_heads // self.n_kv_heads
+
+        total_q = n_heads * self.head_dim
+        total_kv = self.n_kv_heads * self.head_dim * 2
+
+        super().__init__(dim, total_q + total_kv, bias=bias, parallel_dim=0, devices=devices)
+
+        self.q_start = 0
+        self.k_start = total_q
+        self.v_start = total_q + self.n_kv_heads * self.head_dim
+
+    def __call__(self, x: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+        """Returns (xq, xk, xv) projections."""
+        if self._devices is not None and len(self._devices) > 1:
+            raise NotImplementedError("Sharded fused linear requires parallel implementation")
+
+        out = x.linear(self.weight.transpose(), self.bias)
+
+        bsz, seqlen, _ = x.shape
+        xq = out[..., self.q_start:self.q_start + self.n_heads * self.head_dim]
+        xk = out[..., self.k_start:self.k_start + self.n_kv_heads * self.head_dim]
+        xv = out[..., self.v_start:]
+
+        return xq, xk, xv
+
+__all__ = [
+    "TensorParallelLinear",
+    "TensorParallelColumnLinear",
+    "TensorParallelRowLinear",
+    "TensorParallelMLP",
+    "TensorParallelAttention",
+    "FusedTensorParallelLinear",
+]

--- a/tinygrad/runtime/ops_rdma.py
+++ b/tinygrad/runtime/ops_rdma.py
@@ -48,10 +48,37 @@ class RDMACopyQueue(HWQueue):
 
 class MLXIface(PCIIfaceBase):
   def __init__(self, dev:RDMADevice, dev_id:int):
-    cl, pcibus = System.list_devices(vendor=0x15b3, devices=((0xffff, (0x101b,)),))[dev_id]
+    from tinygrad.helpers import getenv
+    
+    # Configurable vendor/device IDs for RDMA devices
+    vendor_id = getenv("RDMA_VENDOR_ID", 0x15b3)  # Default: Mellanox
+    device_mask = getenv("RDMA_DEVICE_MASK", 0xffff)
+    device_ids_str = getenv("RDMA_DEVICE_IDS", "0x101b")  # Default: ConnectX-5
+    
+    # Parse device IDs
+    device_ids = tuple(int(x.strip(), 0) for x in device_ids_str.split(","))
+    devices = ((device_mask, device_ids),)
+    
+    cl, pcibus = System.list_devices(vendor=vendor_id, devices=devices)[dev_id]
     self.dev = dev
     self.pci_dev = cl("mlx", pcibus)
-    self.mlx_dev = MLXDev(self.pci_dev, ip=f"10.0.0.{dev_id}")
+    
+    # Get IP from environment or distributed config
+    # Try to get from distributed config if available
+    ip = None
+    try:
+        from tinygrad.distributed import get_world_info
+        world_info = get_world_info()
+        if world_info["world_size"] > 1:
+            # In distributed mode, use rank-based IP assignment
+            # This should be enhanced with proper RDMA endpoint discovery
+            rank = world_info["rank"]
+            ip = getenv(f"MLX_IP_RANK_{rank}", getenv("MLX_IP", f"10.0.0.{rank+1}"))
+    except (ImportError, KeyError):
+        # Fallback to environment variable or default
+        ip = getenv("MLX_IP", f"10.0.0.{dev_id}")
+    
+    self.mlx_dev = MLXDev(self.pci_dev, ip=ip)
     self.uar_buf = self._buf([self.mlx_dev.pci_dev.bar_info(0)[0] + self.mlx_dev.uar * 0x1000])
     self.dbr_buf = self._buf(self.mlx_dev.dbr_paddrs)
 

--- a/tinygrad/runtime/ops_tcp.py
+++ b/tinygrad/runtime/ops_tcp.py
@@ -1,0 +1,349 @@
+"""
+TCP fallback transport for tinygrad distributed training.
+
+Provides TCP-based data transfer for cross-node communication when RDMA is not available.
+"""
+
+from __future__ import annotations
+import socket
+import struct
+import threading
+import queue
+import ctypes
+from typing import Optional, Tuple, List, Dict, Any
+from tinygrad.helpers import getenv, DEBUG, GlobalCounters
+from tinygrad.runtime.support.hcq import HCQCompiled, HCQAllocatorBase, HCQBuffer, HWQueue, HCQSignal
+from tinygrad.runtime.support.system import PCIIfaceBase, RemoteCmd
+from tinygrad.runtime.support.memory import VirtMapping, AddrSpace
+from tinygrad.device import Buffer, BufferSpec
+
+CHUNK_SIZE = getenv("TCP_CHUNK_SIZE", 1024 * 1024)  # 1MB chunks
+MAX_INFLIGHT = getenv("TCP_MAX_INFLIGHT", 4)
+
+class TCPServer:
+    """TCP server for receiving remote transfers."""
+
+    def __init__(self, host: str, port: int):
+        self.host = host
+        self.port = port
+        self.sock: Optional[socket.socket] = None
+        self.running = False
+        self.thread: Optional[threading.Thread] = None
+        self.pending_transfers: queue.Queue = queue.Queue()
+
+    def start(self):
+        """Start the TCP server thread."""
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind((self.host, self.port))
+        self.sock.listen(16)
+        self.running = True
+        self.thread = threading.Thread(target=self._server_loop, daemon=True)
+        self.thread.start()
+        if DEBUG >= 1:
+            print(f"[TCPServer] Listening on {self.host}:{self.port}")
+
+    def _server_loop(self):
+        """Main server loop to handle incoming connections."""
+        while self.running:
+            try:
+                client_sock, addr = self.sock.accept()
+                if DEBUG >= 2:
+                    print(f"[TCPServer] Connection from {addr}")
+                threading.Thread(target=self._handle_client, args=(client_sock, addr), daemon=True).start()
+            except Exception as e:
+                if self.running:
+                    if DEBUG >= 1:
+                        print(f"[TCPServer] Accept error: {e}")
+
+    def _handle_client(self, client_sock: socket.socket, addr: tuple):
+        """Handle a client connection for data transfer."""
+        try:
+            client_sock.settimeout(30.0)
+            while True:
+                header = self._recv_exact(client_sock, 24)
+                if not header:
+                    break
+
+                cmd, va_addr, size, remote_offset = struct.unpack('=IIQQ', header)
+
+                if cmd == RemoteCmd.SYSMEM_WRITE:
+                    data = self._recv_exact(client_sock, size)
+                    if len(data) != size:
+                        break
+
+                    ctypes.memmove(va_addr + remote_offset, ctypes.addressof(ctypes.c_char.from_buffer(bytearray(data))), size)
+
+                    client_sock.sendall(struct.pack('=I', 0))
+
+                    if DEBUG >= 3:
+                        print(f"[TCPServer] Wrote {size} bytes to {va_addr:#x}+{remote_offset}")
+                else:
+                    break
+        except Exception as e:
+            if DEBUG >= 1:
+                print(f"[TCPServer] Client handler error: {e}")
+        finally:
+            client_sock.close()
+
+    def _recv_exact(self, sock: socket.socket, size: int) -> bytes:
+        """Receive exact number of bytes."""
+        data = b''
+        while len(data) < size:
+            chunk = sock.recv(min(size - len(data), 65536))
+            if not chunk:
+                break
+            data += chunk
+        return data
+
+    def stop(self):
+        """Stop the server."""
+        self.running = False
+        if self.sock:
+            try:
+                self.sock.close()
+            except Exception:
+                pass
+        if self.thread:
+            self.thread.join(timeout=2.0)
+
+class TCPConnection:
+    """TCP connection to a remote node."""
+
+    def __init__(self, host: str, port: int):
+        self.host = host
+        self.port = port
+        self.sock: Optional[socket.socket] = None
+        self.lock = threading.Lock()
+
+    def connect(self) -> socket.socket:
+        """Establish TCP connection."""
+        with self.lock:
+            if self.sock is None:
+                self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                self.sock.settimeout(getenv("TCP_TIMEOUT", 30))
+                self.sock.connect((self.host, self.port))
+                self.sock.settimeout(None)
+
+                buf_size = getenv("TCP_BUFFER_SIZE", 16 * 1024 * 1024)
+                self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, buf_size)
+                self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, buf_size)
+
+                if DEBUG >= 1:
+                    print(f"[TCPConnection] Connected to {self.host}:{self.port}")
+
+        return self.sock
+
+    def send_buffer(self, va_addr: int, remote_va_addr: int, size: int, remote_port: int):
+        """Send buffer contents to remote node via TCP."""
+        sock = self.connect()
+
+        header = struct.pack('=IIQQ', RemoteCmd.SYSMEM_WRITE, remote_va_addr, size, 0)
+
+        with self.lock:
+            sock.sendall(header)
+
+            ctypes.memmove_out = ctypes.memmove
+            data = bytearray(size)
+            ctypes.memmove(ctypes.addressof(data), va_addr, size)
+
+            sent = 0
+            while sent < size:
+                chunk = data[sent:sent + CHUNK_SIZE]
+                sock.sendall(chunk)
+                sent += len(chunk)
+
+            response = sock.recv(4)
+            if DEBUG >= 3:
+                print(f"[TCPConnection] Sent {size} bytes to {self.host}:{remote_port}")
+
+    def close(self):
+        """Close the connection."""
+        with self.lock:
+            if self.sock:
+                try:
+                    self.sock.close()
+                except Exception:
+                    pass
+                self.sock = None
+
+class TCPCopyQueue(HWQueue):
+    """TCP-based copy queue for cross-node transfers without RDMA."""
+
+    def __init__(self, dev: 'TCPDevice'):
+        self.dev = dev
+        super().__init__()
+        self.chunk_size = CHUNK_SIZE
+        self.max_inflight = MAX_INFLIGHT
+
+    def copy(self, dest: HCQBuffer, src: HCQBuffer, sz: int) -> 'TCPCopyQueue':
+        """Enqueue a TCP copy operation."""
+        remote_dev = dest.owner
+        if not isinstance(remote_dev, HCQCompiled):
+            raise RuntimeError("Destination buffer must be owned by an HCQCompiled device")
+
+        self._q.append((dest, src, sz, remote_dev))
+        return self
+
+    def _submit(self, dev: 'TCPDevice'):
+        """Submit all enqueued TCP copy operations."""
+        for dest, src, sz, remote_dev in self._q:
+            self._perform_tcp_copy(dest, src, sz, remote_dev)
+        self._q.clear()
+
+    def _perform_tcp_copy(self, dest: HCQBuffer, src: HCQBuffer, sz: int, remote_dev: HCQCompiled):
+        """Perform actual TCP copy operation."""
+        if not hasattr(remote_dev, 'iface') or not hasattr(remote_dev.iface, 'peer_group'):
+            raise RuntimeError(f"Remote device {remote_dev.device} missing proper interface for TCP transfer")
+
+        remote_iface = remote_dev.iface
+        peer_group = remote_iface.peer_group
+
+        conn = self.dev.get_connection(peer_group)
+        if conn is None:
+            raise RuntimeError(f"No TCP connection to peer group {peer_group}")
+
+        if hasattr(src, 'va_addr') and hasattr(dest, 'va_addr'):
+            remote_va = dest.va_addr
+            local_va = src.va_addr
+
+            try:
+                tcp_addr = self.dev.get_remote_tcp_addr(peer_group)
+                if tcp_addr:
+                    host, port = tcp_addr
+                    conn.send_buffer(local_va, remote_va, sz, port)
+            except Exception as e:
+                if DEBUG >= 1:
+                    print(f"[TCPCopyQueue] TCP copy failed: {e}")
+                raise
+
+class TCPIface(PCIIfaceBase):
+    """TCP interface for remote device communication."""
+
+    def __init__(self, dev: 'TCPDevice', host: str, port: int, peer_group: str):
+        self.dev = dev
+        self.host = host
+        self.port = port
+        self.peer_group = peer_group
+        self.sock: Optional[socket.socket] = None
+
+    def is_local(self) -> bool:
+        return False
+
+class TCPAllocator(HCQAllocatorBase):
+    """TCP-based allocator for remote memory management."""
+
+    def __init__(self, dev: 'TCPDevice'):
+        super().__init__(dev, batch_cnt=0)
+
+    def _transfer(self, dest: HCQBuffer, src: HCQBuffer, sz: int,
+                 src_dev: HCQCompiled, dest_dev: HCQCompiled):
+        """Transfer data between devices using TCP."""
+        tcq = TCPCopyQueue(self.dev)
+        tcq.copy(dest, src, sz).submit(self.dev)
+
+class TCPDevice(HCQCompiled):
+    """TCP device for fallback cross-node communication."""
+
+    _instances: Dict[str, 'TCPDevice'] = {}
+    _connections: Dict[str, TCPConnection] = {}
+    _tcp_addrs: Dict[str, Tuple[str, int]] = {}
+    _server: Optional[TCPServer] = None
+    _lock = threading.Lock()
+
+    def __new__(cls, device: str):
+        if device in cls._instances:
+            return cls._instances[device]
+
+        instance = super().__new__(cls)
+        cls._instances[device] = instance
+        return instance
+
+    def __init__(self, device: str):
+        if hasattr(self, '_initialized'):
+            return
+
+        parts = device.split(":")
+        if len(parts) < 2:
+            raise ValueError(f"Invalid TCP device string: {device}")
+
+        if parts[0] != "TCP":
+            raise ValueError(f"TCP device must start with 'TCP:', got {device}")
+
+        host = "localhost"
+        port = 7000
+        self_peer_group = "default"
+
+        try:
+            from tinygrad.distributed import get_world_info, get_all_capabilities
+            world_info = get_world_info()
+            if world_info["world_size"] > 1:
+                all_caps = get_all_capabilities()
+                rank = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else world_info["rank"]
+
+                if rank < len(all_caps):
+                    caps = all_caps[rank]
+                    tcp_addr = caps.get("tcp_addr", "")
+                    if tcp_addr:
+                        tcp_parts = tcp_addr.rsplit(":", 1)
+                        if len(tcp_parts) == 2:
+                            host, port = tcp_parts[0], int(tcp_parts[1])
+                    self_peer_group = caps.get("node", f"node_{rank}")
+                    port = 8000 + rank
+        except Exception:
+            if len(parts) == 3:
+                host, port_str = parts[1], parts[2]
+                port = int(port_str)
+            self_peer_group = parts[1] if len(parts) > 1 else "default"
+
+        self.peer_group = self_peer_group
+        self.host = host
+        self.port = port
+        self.iface = TCPIface(self, host, port, self_peer_group)
+        self.allocator = TCPAllocator(self)
+        self._initialized = True
+
+        super().__init__(device, allocator=self.allocator)
+
+        TCPDevice._tcp_addrs[self_peer_group] = (host, port)
+
+        with TCPDevice._lock:
+            if TCPDevice._server is None:
+                TCPDevice._server = TCPServer(host, port)
+                TCPDevice._server.start()
+
+    @classmethod
+    def get_connection(cls, peer_group: str) -> Optional[TCPConnection]:
+        """Get or create TCP connection to a peer group."""
+        if peer_group not in cls._connections:
+            tcp_addr = cls._tcp_addrs.get(peer_group)
+            if tcp_addr:
+                host, port = tcp_addr
+                cls._connections[peer_group] = TCPConnection(host, port)
+            else:
+                return None
+        return cls._connections[peer_group]
+
+    @classmethod
+    def get_remote_tcp_addr(cls, peer_group: str) -> Optional[Tuple[str, int]]:
+        """Get TCP address for a peer group."""
+        return cls._tcp_addrs.get(peer_group)
+
+    def rdma_dev(self):
+        """TCP device doesn't have RDMA."""
+        raise RuntimeError("TCP device has no RDMA capability")
+
+    def finalize(self):
+        """Clean up TCP resources."""
+        super().finalize()
+        with TCPDevice._lock:
+            if TCPDevice._server and len(TCPDevice._instances) == 1:
+                TCPDevice._server.stop()
+                TCPDevice._server = None
+
+def register_tcp_device():
+    """Register TCP device with tinygrad's device system."""
+    pass
+
+__all__ = ["TCPCopyQueue", "TCPIface", "TCPAllocator", "TCPDevice", "register_tcp_device", "TCPServer", "TCPConnection"]

--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -502,6 +502,12 @@ class HCQCompiled(Compiled, Generic[SignalType]):
       try: Device[f'RDMA:{i}']
       except IndexError: raise RuntimeError(f"No RDMA found for peer group '{self.peer_group}'")
 
+  def tcp_dev(self):
+    for i in itertools.count():
+      if (dev:=next((d for d in HCQCompiled.peer_groups[self.peer_group] if type(d).__name__ == 'TCPDevice'), None)): return dev
+      try: Device[f'TCP:{i}']
+      except IndexError: raise RuntimeError(f"No TCP device found for peer group '{self.peer_group}'")
+
   def finalize(self):
     try: self.synchronize() # Try to finalize device in any case.
     except RuntimeError as e: print(f"{self.device} synchronization failed before finalizing: {e}")
@@ -618,7 +624,16 @@ class HCQAllocator(HCQAllocatorBase, Generic[HCQDeviceType]):
         dest.cast('B')[i:i+lsize] = self.b[0].cpu_view().view(size=lsize, fmt='B')[:]
 
   def _transfer(self, dest:HCQBuffer, src:HCQBuffer, sz:int, src_dev:HCQDeviceType, dest_dev:HCQDeviceType):
-    if src_dev.peer_group != dest_dev.peer_group: return src_dev.rdma_dev().allocator._transfer(dest, src, sz, src_dev, dest_dev)
+    if src_dev.peer_group != dest_dev.peer_group:
+      try:
+        return src_dev.rdma_dev().allocator._transfer(dest, src, sz, src_dev, dest_dev)
+      except RuntimeError:
+        pass
+      try:
+        return src_dev.tcp_dev().allocator._transfer(dest, src, sz, src_dev, dest_dev)
+      except RuntimeError:
+        pass
+      raise RuntimeError(f"No cross-peer-group transfer available between {src_dev.device} and {dest_dev.device}")
 
     cast(HCQAllocator, src_dev.allocator).map(dest)
 

--- a/tinygrad/schedule/multi.py
+++ b/tinygrad/schedule/multi.py
@@ -160,8 +160,11 @@ multi_pm = PatternMatcher([
   (UPat(Ops.CALL, dtype=dtypes.void, name="root", custom_early_reject=set([Ops.MULTI])), lambda root:
     UOp(root.op, root.dtype, tuple(x.src[0] if x.op is Ops.MULTI else x for x in root.src), root.arg)
     if root.src[0].op is not Ops.TUPLE else None),
-  (UPat((Ops.CAST, Ops.BITCAST, Ops.CONTIGUOUS, Ops.DETACH, Ops.CONTIGUOUS_BACKWARD),
+  (UPat((Ops.CAST, Ops.BITCAST, Ops.CONTIGUOUS, Ops.DETACH, Ops.CONTIGUOUS_BACKWARD, Ops.CHECKPOINT),
         src=(UPat(Ops.MULTI, name="multi"), ), name="root"), passthrough_multi),
+  
+  # ALLTOALL, SEND, RECV primitives passthrough for now
+  (UPat((Ops.ALLTOALL, Ops.SEND, Ops.RECV), src=(UPat(Ops.MULTI, name="multi"), ), name="root"), passthrough_multi),
   # remove MULTI from STORE
   (UPat(Ops.STORE, src=(UPat(Ops.MULTI, name="multi"), ), name="root", allow_any_len=True),
     lambda root,multi: UOp(root.op, root.dtype, (multi.src[0],)+tuple(x.src[0] if x.op is Ops.MULTI else x for x in root.src[1:]), root.arg)),

--- a/tinygrad/uop/__init__.py
+++ b/tinygrad/uop/__init__.py
@@ -102,6 +102,9 @@ class Ops(FastEnum):
 
   # reduce
   REDUCE_AXIS = auto(); REDUCE = auto(); ALLREDUCE = auto()
+  
+  # distributed primitives
+  ALLTOALL = auto(); SEND = auto(); RECV = auto(); CHECKPOINT = auto()
 
   # expander ops
   UNROLL = auto(); CONTRACT = auto(); VCAT = auto(); PTRCAT = auto()


### PR DESCRIPTION
> Disclaimer: I have no adequate servers so these patches didn't go through anything other than smoke tests. Also, they're immature so they couldn't be treated as a formal pull request. 

Seems that tinygrad is actively working on some multi-GPU or multi-node training infra. I would like to propose some features that seems to be good for it?

1. tinygrad needs to support AMD and NVIDIA GPUs, while not fully utilizing CUDA or ROCm, so RCCL and NCCL is limited to some extent? (Please tell me if I'm wrong, but https://docs.pytorch.org/docs/main/distributed.html). Many GPU clusters are managed with slurm or PBS (say, the one I've used in The University of Tokyo, the miyabi-G), and MPI provides a good bootstrap for spawning multi-nodes. 
2. Also, if RDMA is not available (for some strange beowulf clusters I have built or designed..., say, clusters with 10G NiC, a project to utilize vacant 2080Ti x40 somewhere)
3. Seems that currently there's sharding in models (not sure if it could be taken as pipeline parallel), but I think maybe a light wrapper for tensor parallel is also good to have?
4. DeepSpeed Zero-1/2/3 and CPU offload is definitely good to have. 
5. A light wrapper on gradient checkpointing is good to have too. 

Sorry for the sudden "not that PR", more of a request, not sure if I have opportunities to turn them into more reasonable patches. 

Thanks. 
