### PR TITLE
add Ops.WARP_REDUCE for GROUPTOP reductions

### DIFF
--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -13,7 +13,7 @@ from tinygrad.dtype import dtypes
 from tinygrad.codegen.gpudims import pm_add_gpudims
 from tinygrad.uop.symbolic import sym, symbolic_simple, gep_pushing, symbolic, pm_move_where_on_load
 from tinygrad.uop.decompositions import get_late_rewrite_patterns, get_transcendental_patterns, pm_dtype_decomps
-from tinygrad.codegen.late.expander import expander, pm_pre_expander, pm_group_for_reduce
+from tinygrad.codegen.late.expander import expander, pm_pre_expander, pm_group_for_reduce, pm_group_for_reduce_warp
 from tinygrad.codegen.late.devectorizer import load_store_folding, load_store_indexing, devectorize, pm_reduce, \
   ReduceContext, correct_load_store, pm_render, pm_add_loads, pm_make_images
 from tinygrad.codegen.opt.postrange import apply_opts
@@ -50,7 +50,8 @@ def full_rewrite_to_sink(ast:UOp, ren:Renderer, optimize:bool=True) -> UOp:
   sink = graph_rewrite(sink, sym+pm_move_where_on_load, name="postopt symbolic")
 
   # expand
-  sink = graph_rewrite(sink, sym+pm_pre_expander+pm_group_for_reduce+expander, name="expander")
+  pm_gfr = pm_group_for_reduce_warp if ren.has_warp_reduce else pm_group_for_reduce
+  sink = graph_rewrite(sink, sym+pm_pre_expander+pm_gfr+expander, name="expander")
 
   # add locals
   sink = graph_rewrite(sink, pm_add_buffers_local+rangeify_codegen, ctx=itertools.count(0), name="add local buffers")

--- a/tinygrad/codegen/late/expander.py
+++ b/tinygrad/codegen/late/expander.py
@@ -144,6 +144,22 @@ def fix_group_for_reduce(x:UOp):
   # do the final reduce (if/barrier are added in gpudims step)
   return buf.reduce(*reduce_loop, arg=x.arg)
 
+def fix_group_for_reduce_warp(x:UOp):
+  """When GROUP_REDUCE exactly matches warp size, is the only local/warp dim, no other reduce ranges, ADD/MAX only, use WARP_REDUCE."""
+  if x.arg[0] not in (Ops.ADD, Ops.MAX): return None
+  reduce_gfr, reduce_r = partition(x.src[1:], lambda u: u.op is Ops.RANGE and u.arg[1] == AxisType.GROUP_REDUCE)
+  if len(reduce_gfr) != 1: return None
+  if len(reduce_r) != 0: return None
+  group_size = reduce_gfr[0].vmax + 1
+  if not isinstance(group_size, int) or group_size != 32: return None
+  if x.dtype != dtypes.float: return None
+  topo = list(x.toposort())
+  other_local_dims = [u for u in topo if u.op is Ops.RANGE and u.arg[1] in {AxisType.LOCAL, AxisType.WARP, AxisType.GROUP_REDUCE}
+                      and u not in reduce_gfr]
+  if len(other_local_dims) != 0: return None
+  if any(u.op in {Ops.UNROLL, Ops.CONTRACT} for u in topo): return None
+  return UOp(Ops.WARP_REDUCE, x.dtype, (x.src[0],), x.arg[0])
+
 pm_pre_expander = PatternMatcher([
   # rewrite UPCAST/UNROLL range to something to be expanded
   (UPat(Ops.RANGE, name="r"),
@@ -156,5 +172,10 @@ pm_pre_expander = PatternMatcher([
 
 pm_group_for_reduce = PatternMatcher([
   # fix group for reduce
+  (UPat(Ops.REDUCE, name="x"), fix_group_for_reduce),
+])
+
+pm_group_for_reduce_warp = PatternMatcher([
+  (UPat(Ops.REDUCE, name="x"), fix_group_for_reduce_warp),
   (UPat(Ops.REDUCE, name="x"), fix_group_for_reduce),
 ])

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -68,6 +68,8 @@ class Renderer:
   has_threads: bool = False
   has_shared: bool = True
   has_aux: bool = False # additional program info, eg. image shapes
+  has_warp_reduce: bool = False
+  warp_size: int = 32
   # NOTE: these two should be in (x,y,z) order to match the max_sizes argument in get_grouped_dims
   global_max: tuple[int, ...]|None = (0x8FFFFFFF,) * (3) # TODO: Ops.SPECIAL int32 indexes right now
   local_max: tuple[int, ...]|None = (0x8FFFFFFF,) * (3) # TODO: Ops.SPECIAL int32 indexes right now

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -14,6 +14,7 @@ base_rewrite = PatternMatcher([
   (UPat(Ops.IF, name="x"), lambda ctx,x: f"if ({ctx[x.src[0]]}) {{"),
   (UPat((Ops.ENDIF, Ops.END)), lambda ctx: "}"),
   (UPat(Ops.WMMA, name="x"), lambda ctx,x: f"__{x.arg[0]}({ctx[x.src[0]]}, {ctx[x.src[1]]}, {ctx[x.src[2]]})"),
+  (UPat(Ops.WARP_REDUCE, name="x"), lambda ctx,x: ctx.render_warp_reduce(ctx[x.src[0]], x.arg)),
   # r method accesses
   (UPat(Ops.RANGE, name="x"),
    lambda ctx,x: f"for ({ctx.render_dtype(x.dtype)} {ctx[x]} = 0; {ctx[x]} < {ctx[x.src[0]]}; {ctx[x]}++) {{"),
@@ -132,6 +133,8 @@ class CStyleLanguage(Renderer):
 
   string_rewrite = base_rewrite
   extra_matcher = extra_pm
+
+  def render_warp_reduce(self, val:str, op:Ops) -> str: raise NotImplementedError("WARP_REDUCE not supported on this backend")
 
   def render_kernel(self, function_name:str, kernel:list[str], bufs:list[tuple[str,tuple[DType,bool]]], uops:list[UOp], prefix=None) -> str:
     tmp = ""
@@ -341,10 +344,15 @@ class IntelRenderer(OpenCLRenderer):
 
 class MetalRenderer(CStyleLanguage):
   shared_max = 32768
+  has_warp_reduce = True
+  warp_size = 32
   def __init__(self, target:Target):
     super().__init__(target)
     from tinygrad.runtime.ops_metal import MetalCompiler
     self.compiler, self.tensor_cores = MetalCompiler(), tc.metal if target.arch == "arm64" else []
+
+  def render_warp_reduce(self, val:str, op:Ops) -> str:
+    return f"simd_sum({val})" if op == Ops.ADD else f"simd_max({val})"
 
   # language options
   kernel_typedef = "kernel void"
@@ -387,6 +395,12 @@ _nms = list("xyzwabcdefghijkl") + [f'v{i}' for i in range(16, 32)]
 
 class CUDARenderer(CStyleLanguage):
   global_max = (2147483647, 65535, 65535)
+  has_warp_reduce = True
+  warp_size = 32
+
+  def render_warp_reduce(self, val:str, op:Ops) -> str:
+    fn = "__warp_reduce_add" if op == Ops.ADD else "__warp_reduce_max"
+    return f"{fn}({val})"
   local_max = (1024, 1024, 64)
   shared_max = 49152
 
@@ -431,6 +445,11 @@ class CUDARenderer(CStyleLanguage):
     # TODO: why is dtypes.bfloat16.name == "__bf16"? would be easier not override dtypes.name
     prefix = ["#define INFINITY (__int_as_float(0x7f800000))", "#define NAN (__int_as_float(0x7fffffff))",
               "template <class T, class F> __device__ __forceinline__ T tg_bitcast(F v) { union U { F f; T t; }; U u; u.f = v; return u.t; }"]
+    if any(u.op is Ops.WARP_REDUCE for u in uops):
+      prefix.append("__device__ __forceinline__ float __warp_reduce_add(float v) {"
+        " for (int o=16;o>=1;o>>=1) v+=__shfl_down_sync(0xffffffff,v,o); return v; }")
+      prefix.append("__device__ __forceinline__ float __warp_reduce_max(float v) {"
+        " for (int o=16;o>=1;o>>=1) v=max(v,__shfl_down_sync(0xffffffff,v,o)); return v; }")
     used_dtypes = uops_to_dtypes(uops)
     if any(dt.scalar() in dtypes.fp8s for dt in used_dtypes): prefix.append("#include <cuda_fp8.h>")
     if any(dt.scalar() == dtypes.half for dt in used_dtypes): prefix.append("#include <cuda_fp16.h>")

--- a/tinygrad/uop/__init__.py
+++ b/tinygrad/uop/__init__.py
@@ -56,6 +56,9 @@ class Ops(FastEnum):
   # tensor core math op, not elementwise
   WMMA = auto(); SHAPED_WMMA = auto()
 
+  # warp-level reduction (simd_sum on Metal, __shfl_down_sync loop on CUDA)
+  WARP_REDUCE = auto()
+
   # UnaryOps
   CAST = auto(); BITCAST = auto(); EXP2 = auto(); LOG2 = auto(); SIN = auto()
   SQRT = auto(); RECIPROCAL = auto(); NEG = auto(); TRUNC = auto()

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -258,7 +258,7 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
       case Ops.WMMA | Ops.SHAPED_WMMA: return self.src[2]._shape
 
       # passthrough ops
-      case Ops.MSTACK | Ops.MSELECT | Ops.DETACH | Ops.CONTIGUOUS | Ops.CONTIGUOUS_BACKWARD | Ops.AFTER | Ops.LOAD:
+      case Ops.MSTACK | Ops.MSELECT | Ops.DETACH | Ops.CONTIGUOUS | Ops.CONTIGUOUS_BACKWARD | Ops.AFTER | Ops.LOAD | Ops.WARP_REDUCE:
         return self.src[0]._shape
       # REDUCE with empty axis is passthrough (lowered form)
       case Ops.REDUCE if len(self.arg[1]) == 0:

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -170,6 +170,9 @@ shared_codegen_spec = PatternMatcher([
   # WMMA has a <a, b, acc>
   (UPat(Ops.WMMA, src=(UPat(), UPat(), UPat()), name="x"), lambda x: isinstance(x.arg, tuple) and len(x.arg) == 8),
 
+  # WARP_REDUCE has a single float32 source and an Ops arg (ADD or MAX)
+  (UPat(Ops.WARP_REDUCE, dtype=dtypes.float, src=(UPat(dtype=dtypes.float),), name="x"), lambda x: x.arg in (Ops.ADD, Ops.MAX)),
+
   # VECTORIZE/GEP
   (UPat(Ops.STACK, name="x"), lambda x: len(x.src)>1 and len(x.src) == x.dtype.vcount and all(x.dtype == y.dtype.vec(len(x.src)) for y in x.src)),
   (UPat(Ops.GEP, src=(UPat.var("src"),), name="gep"), lambda gep,src: gep.dtype == src.dtype.scalar()),


### PR DESCRIPTION
replace scalar shared-memory reduction loop with simd_sum (Metal) / __shfl_down_sync (CUDA) when GROUPTOP=32, float32, single GROUP_REDUCE axis, ADD/MAX only.

2.1-4.2x faster on the reduction step: https://github.com/kimjune01/simd-sum-experiment

HIP disabled until tested on AMD hardware.