### PR TITLE
perf: fast path for Tensor.cat with many NPY-backed tensors

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -38,6 +38,21 @@ def _apply_map_to_tensors(applied_map:dict[UOp, UOp], name:str, walk:bool=False)
 
 # **** Tensor helper functions ****
 
+def _is_realized_npy(t) -> bool:
+  u = t.uop
+  while u.op is Ops.RESHAPE: u = u.src[0]
+  if u.op is not Ops.COPY: return False
+  src = u.src[0]
+  while src.op is Ops.RESHAPE: src = src.src[0]
+  return src.op is Ops.BUFFER and src.buffer.is_allocated() and src.buffer.device == "NPY"
+
+def _get_npy_data(t):
+  u = t.uop
+  while u.op is Ops.RESHAPE: u = u.src[0]
+  src = u.src[0]
+  while src.op is Ops.RESHAPE: src = src.src[0]
+  return src.buffer._buf.reshape(t.shape)
+
 def _fromnp(x: 'numpy.ndarray') -> UOp:
   ret = UOp.new_buffer("NPY", x.size, _from_np_dtype(x.dtype))
   # fake realize
@@ -893,6 +908,28 @@ class Tensor(OpMixin):
     return self
 
   # ***** movement ops *****
+
+  def cat(self, *args:Tensor, dim:int=0) -> Tensor:
+    """
+    Concatenates self with other tensors in `args` along an axis specified by `dim`.
+    All tensors must have the same shape except in the concatenating dimension.
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    t0, t1, t2 = Tensor([[1, 2]]), Tensor([[3, 4]]), Tensor([[5, 6]])
+    print(t0.cat(t1, t2, dim=0).numpy())
+    ```
+    ```python exec="true" source="above" session="tensor" result="python"
+    print(t0.cat(t1, t2, dim=1).numpy())
+    ```
+    """
+    dim = self._resolve_dim(dim)
+    tensors = [self, *args]
+    for arg in args: assert arg.ndim==self.ndim and all(ti==ai for i,(ti,ai) in enumerate(zip(self.shape, arg.shape)) if i!=dim)
+    if len(tensors) > 4 and not any(t.requires_grad for t in tensors) and all(_is_realized_npy(t) for t in tensors):
+      import numpy as np
+      arrays = [_get_npy_data(t) for t in tensors]
+      return Tensor(np.concatenate(arrays, axis=dim))
+    return super().cat(*args, dim=dim)
 
   def _mop(self, op:Ops, arg) -> Tensor: return self._apply_uop(UOp._mop, extra_args=(op,), arg=arg)
   def _rop(self, op:Ops, axis:tuple[int, ...]) -> Tensor: return self._apply_uop(UOp._rop, op=op, axis=axis)


### PR DESCRIPTION
## Fast path for `Tensor.cat` with many NPY-backed tensors

### Problem

`Tensor.cat` uses pad+sum, which generates O(K) kernel dispatches when concatenating K tensors. Each input becomes a separate copy kernel (NPY→device), plus compute kernels with K buffer arguments and conditional bounds checks. For K=50, this produces 56 kernel dispatches and ~5ms of scheduling overhead for what should be a single memcpy.

Scaling:
| K | Time (warm) | Kernels | vs numpy |
|---|---|---|---|
| 10 | 1.4ms | 12 | 430x slower |
| 50 | 4.7ms | 56 | 1229x slower |
| 100 | 8.6ms | 107 | 1972x slower |

### Solution

Add a fast path in `Tensor.cat` that activates when:
- More than 4 input tensors
- None require gradients
- All are realized NPY-backed buffers

The fast path walks each tensor's UOp graph (RESHAPE→COPY→RESHAPE→BUFFER) to find the underlying NPY buffer, reads `buffer._buf` directly (no GPU realize), concatenates with `np.concatenate`, and wraps in a single `Tensor`. This reduces K copies + compute to 1 copy + 1 identity kernel.

Falls back to the existing pad+sum for all other cases (gradients, non-NPY tensors, few tensors).

### Results

K=50, N=1000, Metal, warm cache:
- Before: 4.7ms, 56 kernels
- After: 0.5ms, 2 kernels (10x speedup)

All existing tests pass, including gradients and `Tensor.stack`.

### Changes

- `tinygrad/tensor.py`: Two module-level helpers (`_is_realized_npy`, `_get_npy_data`) and a `cat` override on `Tensor`
