### PR TITLE
[WIP] sketch: Ops.CONCAT for native tensor concatenation

### DIFF
--- a/bench_ops.py
+++ b/bench_ops.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Benchmark numpy-algorithms ported to tinygrad vs numpy."""
+import time
+import numpy as np
+from tinygrad import Tensor, dtypes
+
+def bench(name, fn_tg, fn_np, warmup=2, runs=5):
+    """Benchmark tinygrad vs numpy, print results."""
+    # Warmup
+    for _ in range(warmup):
+        fn_tg()
+        fn_np()
+
+    # Tinygrad
+    times_tg = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        result_tg = fn_tg()
+        if hasattr(result_tg, 'numpy'):
+            result_tg.numpy()  # force realize
+        times_tg.append(time.perf_counter() - t0)
+
+    # Numpy
+    times_np = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        fn_np()
+        times_np.append(time.perf_counter() - t0)
+
+    tg_med = sorted(times_tg)[len(times_tg)//2]
+    np_med = sorted(times_np)[len(times_np)//2]
+    ratio = tg_med / np_med if np_med > 0 else float('inf')
+    print(f"{name:<30} tinygrad: {tg_med*1000:8.2f}ms  numpy: {np_med*1000:8.2f}ms  ratio: {ratio:6.1f}x")
+    return tg_med, np_med
+
+
+# ─── Test cases ───
+
+def bench_batch_normalize():
+    N, D = 256, 512
+    X_np = np.random.randn(N, D).astype(np.float32)
+    gamma_np = np.random.randn(D).astype(np.float32)
+    beta_np = np.random.randn(D).astype(np.float32)
+
+    X_tg = Tensor(X_np)
+    gamma_tg = Tensor(gamma_np)
+    beta_tg = Tensor(beta_np)
+
+    def tg():
+        mean = X_tg.mean(axis=0)
+        var = ((X_tg - mean) ** 2).mean(axis=0)
+        norm = (X_tg - mean) / (var + 1e-5).sqrt()
+        return (gamma_tg * norm + beta_tg).realize()
+
+    def np_fn():
+        mean = X_np.mean(axis=0)
+        var = X_np.var(axis=0)
+        norm = (X_np - mean) / np.sqrt(var + 1e-5)
+        return gamma_np * norm + beta_np
+
+    bench("batch_normalize", tg, np_fn)
+
+
+def bench_softmax_cross_entropy():
+    N, C = 256, 100
+    logits_np = np.random.randn(N, C).astype(np.float32)
+    targets_np = np.random.randint(0, C, size=N)
+
+    logits_tg = Tensor(logits_np)
+
+    def tg():
+        mx = logits_tg.max(axis=1, keepdim=True)
+        shifted = logits_tg - mx
+        lse = shifted.exp().sum(axis=1).log()
+        return lse.mean().realize()
+
+    def np_fn():
+        mx = logits_np.max(axis=1, keepdims=True)
+        shifted = logits_np - mx
+        lse = np.log(np.exp(shifted).sum(axis=1))
+        return lse.mean()
+
+    bench("softmax_cross_entropy", tg, np_fn)
+
+
+def bench_matmul():
+    N = 512
+    A_np = np.random.randn(N, N).astype(np.float32)
+    B_np = np.random.randn(N, N).astype(np.float32)
+
+    A_tg = Tensor(A_np)
+    B_tg = Tensor(B_np)
+
+    def tg():
+        return (A_tg @ B_tg).realize()
+
+    def np_fn():
+        return A_np @ B_np
+
+    bench("matmul 512x512", tg, np_fn)
+
+
+def bench_conv2d():
+    H, W = 64, 64
+    kH, kW = 5, 5
+    X_np = np.random.randn(1, 1, H, W).astype(np.float32)
+    K_np = np.random.randn(1, 1, kH, kW).astype(np.float32)
+
+    X_tg = Tensor(X_np)
+    K_tg = Tensor(K_np)
+
+    def tg():
+        return X_tg.conv2d(K_tg).realize()
+
+    def np_fn():
+        # im2col conv2d
+        x = X_np[0, 0]
+        k = K_np[0, 0]
+        out_H = H - kH + 1
+        out_W = W - kW + 1
+        i0 = np.repeat(np.arange(kH), kW)
+        j0 = np.tile(np.arange(kW), kH)
+        i1 = np.arange(out_H)
+        j1 = np.arange(out_W)
+        rows = i0[:, None, None] + i1[None, :, None]
+        cols = j0[:, None, None] + j1[None, None, :]
+        col = x[rows, cols]
+        return np.tensordot(k.ravel(), col, axes=([0], [0]))
+
+    bench("conv2d 64x64 k=5", tg, np_fn)
+
+
+def bench_reduction_chain():
+    """Chain of reductions — tests scheduler fusion."""
+    N = 10000
+    X_np = np.random.randn(N, N).astype(np.float32)
+    X_tg = Tensor(X_np)
+
+    def tg():
+        # sum rows, then normalize, then sum again
+        row_sums = X_tg.sum(axis=1)
+        normed = row_sums / row_sums.max()
+        return normed.sum().realize()
+
+    def np_fn():
+        row_sums = X_np.sum(axis=1)
+        normed = row_sums / row_sums.max()
+        return normed.sum()
+
+    bench("reduction_chain 10kx10k", tg, np_fn)
+
+
+def bench_elementwise_chain():
+    """Long chain of elementwise ops — tests fusion."""
+    N = 1_000_000
+    X_np = np.random.randn(N).astype(np.float32)
+    X_tg = Tensor(X_np)
+
+    def tg():
+        x = X_tg
+        x = x.sin()
+        x = x.cos()
+        x = x.exp()
+        x = x.log()
+        x = x * 2.0
+        x = x + 1.0
+        x = x.relu()
+        x = x.sigmoid()
+        return x.realize()
+
+    def np_fn():
+        x = X_np
+        x = np.sin(x)
+        x = np.cos(x)
+        x = np.exp(x)
+        x = np.log(x)
+        x = x * 2.0
+        x = x + 1.0
+        x = np.maximum(x, 0)
+        x = 1 / (1 + np.exp(-x))
+        return x
+
+    bench("elementwise_chain 1M", tg, np_fn)
+
+
+def bench_gather_scatter():
+    """Indexing / gather pattern."""
+    N, D = 10000, 256
+    X_np = np.random.randn(N, D).astype(np.float32)
+    idx_np = np.random.randint(0, N, size=1000)
+
+    X_tg = Tensor(X_np)
+    idx_tg = Tensor(idx_np)
+
+    def tg():
+        return X_tg[idx_tg].realize()
+
+    def np_fn():
+        return X_np[idx_np]
+
+    bench("gather 10k x 256", tg, np_fn)
+
+
+def bench_broadcasting():
+    """Heavy broadcasting pattern."""
+    M, N = 1000, 1000
+    A_np = np.random.randn(M, 1).astype(np.float32)
+    B_np = np.random.randn(1, N).astype(np.float32)
+
+    A_tg = Tensor(A_np)
+    B_tg = Tensor(B_np)
+
+    def tg():
+        return (A_tg * B_tg + A_tg - B_tg).sum().realize()
+
+    def np_fn():
+        return (A_np * B_np + A_np - B_np).sum()
+
+    bench("broadcast 1kx1k", tg, np_fn)
+
+
+if __name__ == "__main__":
+    print(f"{'Benchmark':<30} {'tinygrad':>16}  {'numpy':>14}  {'slowdown':>10}")
+    print("-" * 78)
+    bench_batch_normalize()
+    bench_softmax_cross_entropy()
+    bench_matmul()
+    bench_conv2d()
+    bench_elementwise_chain()
+    bench_reduction_chain()
+    bench_gather_scatter()
+    bench_broadcasting()

--- a/bench_scaling.py
+++ b/bench_scaling.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Find ops where tinygrad scales worse than numpy even at large sizes."""
+import numpy as np, time
+from tinygrad import Tensor
+
+def bench(fn, warmup=2, runs=5):
+    for _ in range(warmup):
+        r = fn()
+        if hasattr(r, 'numpy'): r.numpy()
+    times = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        r = fn()
+        if hasattr(r, 'numpy'): r.numpy()
+        times.append(time.perf_counter() - t0)
+    return sorted(times)[runs//2]
+
+def run_scaling(name, make_tg, make_np, sizes):
+    print(f"\n{'='*80}")
+    print(f"  {name}")
+    print(f"{'='*80}")
+    print(f"{'Size':<25} {'tinygrad':>10} {'numpy':>10} {'ratio':>8}")
+    print("-" * 58)
+    for label, args in sizes:
+        tg_fn = make_tg(*args)
+        np_fn = make_np(*args)
+        tg_t = bench(tg_fn) * 1000
+        np_t = bench(np_fn) * 1000
+        ratio = tg_t / np_t if np_t > 0.001 else float('inf')
+        winner = "TG" if ratio < 1 else ""
+        print(f"{label:<25} {tg_t:>8.2f}ms {np_t:>8.2f}ms {ratio:>7.1f}x {winner}")
+
+
+# ─── 1. Matmul scaling ───
+def matmul_scaling():
+    def make_tg(N):
+        A, B = Tensor.randn(N, N), Tensor.randn(N, N)
+        def fn(): return (A @ B).realize()
+        return fn
+    def make_np(N):
+        A, B = np.random.randn(N, N).astype(np.float32), np.random.randn(N, N).astype(np.float32)
+        def fn(): return A @ B
+        return fn
+    run_scaling("Matmul (NxN @ NxN)", make_tg, make_np, [
+        ("32x32", (32,)), ("128x128", (128,)), ("512x512", (512,)),
+        ("1024x1024", (1024,)), ("2048x2048", (2048,)), ("4096x4096", (4096,)),
+    ])
+
+# ─── 2. Reduction scaling ───
+def reduction_scaling():
+    def make_tg(N):
+        X = Tensor.randn(N)
+        def fn(): return X.sum().realize()
+        return fn
+    def make_np(N):
+        X = np.random.randn(N).astype(np.float32)
+        def fn(): return X.sum()
+        return fn
+    run_scaling("Sum reduction (1D)", make_tg, make_np, [
+        ("1K", (1000,)), ("10K", (10000,)), ("100K", (100000,)),
+        ("1M", (1000000,)), ("10M", (10000000,)), ("100M", (100000000,)),
+    ])
+
+# ─── 3. Multi-axis reduction ───
+def multiaxis_reduction_scaling():
+    def make_tg(M, N):
+        X = Tensor.randn(M, N)
+        def fn(): return X.sum(axis=1).realize()
+        return fn
+    def make_np(M, N):
+        X = np.random.randn(M, N).astype(np.float32)
+        def fn(): return X.sum(axis=1)
+        return fn
+    run_scaling("Row-wise sum (MxN).sum(axis=1)", make_tg, make_np, [
+        ("100x100", (100, 100)), ("1000x100", (1000, 100)),
+        ("100x10000", (100, 10000)), ("10000x1000", (10000, 1000)),
+        ("1000x10000", (1000, 10000)), ("10000x10000", (10000, 10000)),
+    ])
+
+# ─── 4. Chained elementwise ───
+def elementwise_scaling():
+    def make_tg(N):
+        X = Tensor.randn(N)
+        def fn(): return (X.sin().cos().exp().log() * 2 + 1).realize()
+        return fn
+    def make_np(N):
+        X = np.random.randn(N).astype(np.float32)
+        def fn():
+            x = np.sin(X); x = np.cos(x); x = np.exp(x); x = np.log(x)
+            return x * 2 + 1
+        return fn
+    run_scaling("Elementwise chain sin→cos→exp→log→mul→add", make_tg, make_np, [
+        ("1K", (1000,)), ("10K", (10000,)), ("100K", (100000,)),
+        ("1M", (1000000,)), ("10M", (10000000,)),
+    ])
+
+# ─── 5. Broadcasting ───
+def broadcast_scaling():
+    def make_tg(M, N):
+        A = Tensor.randn(M, 1)
+        B = Tensor.randn(1, N)
+        def fn(): return (A * B).sum().realize()
+        return fn
+    def make_np(M, N):
+        A = np.random.randn(M, 1).astype(np.float32)
+        B = np.random.randn(1, N).astype(np.float32)
+        def fn(): return (A * B).sum()
+        return fn
+    run_scaling("Broadcast outer product sum", make_tg, make_np, [
+        ("100x100", (100, 100)), ("1000x1000", (1000, 1000)),
+        ("5000x5000", (5000, 5000)), ("10000x10000", (10000, 10000)),
+    ])
+
+# ─── 6. Conv2d scaling ───
+def conv2d_scaling():
+    def make_tg(H, K):
+        X = Tensor.randn(1, 1, H, H)
+        W = Tensor.randn(1, 1, K, K)
+        def fn(): return X.conv2d(W).realize()
+        return fn
+    def make_np(H, K):
+        X = np.random.randn(H, H).astype(np.float32)
+        W = np.random.randn(K, K).astype(np.float32)
+        def fn():
+            oH, oW = H-K+1, H-K+1
+            i0 = np.repeat(np.arange(K), K)
+            j0 = np.tile(np.arange(K), K)
+            i1, j1 = np.arange(oH), np.arange(oW)
+            rows = i0[:, None, None] + i1[None, :, None]
+            cols = j0[:, None, None] + j1[None, None, :]
+            return np.tensordot(W.ravel(), X[rows, cols], axes=([0], [0]))
+        return fn
+    run_scaling("Conv2d (1x1xHxH, k=K)", make_tg, make_np, [
+        ("32x32 k=3", (32, 3)), ("64x64 k=3", (64, 3)), ("128x128 k=3", (128, 3)),
+        ("256x256 k=3", (256, 3)), ("512x512 k=3", (512, 3)),
+        ("64x64 k=7", (64, 7)), ("128x128 k=7", (128, 7)),
+    ])
+
+# ─── 7. Softmax scaling ───
+def softmax_scaling():
+    def make_tg(N, C):
+        X = Tensor.randn(N, C)
+        def fn():
+            mx = X.max(axis=1, keepdim=True)
+            shifted = X - mx
+            e = shifted.exp()
+            return (e / e.sum(axis=1, keepdim=True)).realize()
+        return fn
+    def make_np(N, C):
+        X = np.random.randn(N, C).astype(np.float32)
+        def fn():
+            mx = X.max(axis=1, keepdims=True)
+            shifted = X - mx
+            e = np.exp(shifted)
+            return e / e.sum(axis=1, keepdims=True)
+        return fn
+    run_scaling("Softmax (NxC)", make_tg, make_np, [
+        ("10x100", (10, 100)), ("100x100", (100, 100)),
+        ("1000x100", (1000, 100)), ("1000x1000", (1000, 1000)),
+        ("10000x1000", (10000, 1000)), ("10000x10000", (10000, 10000)),
+    ])
+
+# ─── 8. Where/select scaling ───
+def where_scaling():
+    def make_tg(N):
+        X = Tensor.randn(N)
+        Y = Tensor.randn(N)
+        cond = X > 0
+        def fn(): return cond.where(X, Y).realize()
+        return fn
+    def make_np(N):
+        X = np.random.randn(N).astype(np.float32)
+        Y = np.random.randn(N).astype(np.float32)
+        cond = X > 0
+        def fn(): return np.where(cond, X, Y)
+        return fn
+    run_scaling("Where/select", make_tg, make_np, [
+        ("1K", (1000,)), ("10K", (10000,)), ("100K", (100000,)),
+        ("1M", (1000000,)), ("10M", (10000000,)),
+    ])
+
+# ─── 9. Concatenation scaling ───
+def concat_scaling():
+    def make_tg(N, K):
+        tensors = [Tensor.randn(N) for _ in range(K)]
+        def fn(): return Tensor.cat(*tensors).realize()
+        return fn
+    def make_np(N, K):
+        arrays = [np.random.randn(N).astype(np.float32) for _ in range(K)]
+        def fn(): return np.concatenate(arrays)
+        return fn
+    run_scaling("Concatenation (K arrays of N)", make_tg, make_np, [
+        ("1K x 2", (1000, 2)), ("1K x 10", (1000, 10)), ("1K x 100", (1000, 100)),
+        ("100K x 2", (100000, 2)), ("100K x 10", (100000, 10)),
+        ("1M x 2", (1000000, 2)), ("1M x 10", (1000000, 10)),
+    ])
+
+# ─── 10. Transpose + matmul ───
+def transpose_matmul_scaling():
+    def make_tg(N):
+        A = Tensor.randn(N, N)
+        def fn(): return (A.T @ A).realize()
+        return fn
+    def make_np(N):
+        A = np.random.randn(N, N).astype(np.float32)
+        def fn(): return A.T @ A
+        return fn
+    run_scaling("A^T @ A (gram matrix)", make_tg, make_np, [
+        ("64x64", (64,)), ("256x256", (256,)), ("512x512", (512,)),
+        ("1024x1024", (1024,)), ("2048x2048", (2048,)),
+    ])
+
+
+if __name__ == "__main__":
+    matmul_scaling()
+    reduction_scaling()
+    multiaxis_reduction_scaling()
+    elementwise_scaling()
+    broadcast_scaling()
+    conv2d_scaling()
+    softmax_scaling()
+    where_scaling()
+    concat_scaling()
+    transpose_matmul_scaling()

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -19,6 +19,7 @@ def get_call_outs_ins(call:UOp) -> tuple[tuple[int, ...], tuple[int, ...]]:
   ast = call.src[0]
   if ast.op is Ops.PROGRAM: return tuple(ast.arg.outs), tuple(ast.arg.ins)
   if ast.op in (Ops.COPY, Ops.BUFFER_VIEW): return (0,), (1,)
+  if ast.op is Ops.CONCAT: return (0,), tuple(range(1, len(get_call_arg_uops(call))))
   if ast.op is Ops.CUSTOM_FUNCTION and ast.arg == "encdec": return (0,), tuple(range(1, len(get_call_arg_uops(call))))
   return (), ()
 
@@ -29,6 +30,7 @@ def get_call_name(call:UOp, bufs:list[Buffer], var_vals:dict[str, int]|None=None
   if ast.op is Ops.PROGRAM: return ast.arg.name
   if ast.op is Ops.BUFFER_VIEW: return colored(f"view {_uop_sz_to_str(arg_uops[0]):>10} @ {ast.arg[1] * arg_uops[1].dtype.itemsize:<10d}", "yellow")
   if ast.op is Ops.COPY: return colored(f"copy {_uop_sz_to_str(arg_uops[0]):>10}, {bufs[0].device[:7]:>7s} <- {bufs[1].device[:7]:7s}", "yellow")
+  if ast.op is Ops.CONCAT: return colored(f"concat {len(arg_uops)-1} srcs -> {_uop_sz_to_str(arg_uops[0]):>10}", "green")
   if ast.op is Ops.CUSTOM_FUNCTION and ast.arg == "encdec": return colored(f"enc/dec {_uop_sz_to_str(arg_uops[0])}", "yellow")
   if ast.op is Ops.CUSTOM_FUNCTION and ast.arg == "graph": return colored(f"batched {len(ast.src[0].src)}", "cyan")
   raise NotImplementedError("get_call_name is not implemented")
@@ -163,6 +165,18 @@ def exec_copy(ctx:ExecContext, call, ast):
         src.allocator._copyout(dest.allocator._as_buffer(dest._buf), src._buf)
       else: dest.copyin(src.as_memoryview(allow_zero_copy=True))
 
+def exec_concat(ctx:ExecContext, call, ast):
+  """Execute CONCAT by concatenating source buffers and copying into dest in one shot."""
+  import numpy as np
+  resolved = resolve_params(call, ctx.input_uops)
+  bufs = [cast(Buffer, b.buffer) for b in resolved]
+  dest = bufs[0].ensure_allocated()
+  srcs = [b.ensure_allocated() for b in bufs[1:]]
+  with track_stats(ctx, call, dest.device, [dest] + srcs, ctx.var_vals):
+    # concatenate all source data on the host, then single copyin
+    combined = np.concatenate([s.numpy() for s in srcs], axis=ast.arg[0])
+    dest.copyin(memoryview(combined))
+
 def exec_kernel(ctx:ExecContext, call, ast):
   for bufs, device_vars in unwrap_multi(call, resolve_params(call, ctx.input_uops)):
     var_vals = {**ctx.var_vals, **device_vars}
@@ -223,6 +237,7 @@ pm_optimize_local_size = PatternMatcher([
 pm_exec = PatternMatcher([
   (UPat(Ops.CALL, src=(UPat(Ops.BUFFER_VIEW, name="ast"),), name="call", allow_any_len=True), exec_view),
   (UPat(Ops.CALL, src=(UPat(Ops.COPY, name="ast"),), name="call", allow_any_len=True), exec_copy),
+  (UPat(Ops.CALL, src=(UPat(Ops.CONCAT, name="ast"),), name="call", allow_any_len=True), exec_concat),
   (UPat(Ops.CALL, src=(UPat(Ops.PROGRAM, name="ast"),), name="call", allow_any_len=True), exec_kernel),
   (UPat(Ops.CALL, src=(UPat(Ops.CUSTOM_FUNCTION, arg="encdec", name="ast"),), name="call", allow_any_len=True), exec_encdec),
   (UPat(Ops.CALL, src=(UPat(Ops.CUSTOM_FUNCTION, arg="graph", name="ast"),), name="call", allow_any_len=True), exec_graph),

--- a/tinygrad/mixin/__init__.py
+++ b/tinygrad/mixin/__init__.py
@@ -616,6 +616,13 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     dim = self._resolve_dim(dim)
     for arg in args: assert arg.ndim==self.ndim and all(ti==ai for i,(ti,ai) in enumerate(zip(self.shape, arg.shape)) if i!=dim)
     tensors = [self, *args]
+    # CONCAT: single op instead of pad+sum. arg=(dim, tuple of sizes along dim)
+    # TODO: currently only dim=0 with concrete shapes; fall back to pad+sum otherwise
+    if dim == 0 and all(isinstance(s, int) for t in tensors for s in t.shape):
+      from tinygrad.uop.ops import UOp, Ops
+      out_shape = list(self.shape)
+      out_shape[0] = sum(t.shape[0] for t in tensors)
+      return self.__class__(UOp(Ops.CONCAT, self.uop.dtype, tuple(t.uop for t in tensors), arg=(0, tuple(out_shape))))
     dim_cumsum = list(itertools.accumulate([t.shape[dim] for t in tensors], initial=0))
     padded = [t.pad(tuple((dim_cumsum[i], dim_cumsum[-1]-dim_cumsum[i+1]) if j==dim else None for j in range(t.ndim))) for i,t in enumerate(tensors)]
     return padded[0].usum(*padded[1:])

--- a/tinygrad/schedule/indexing.py
+++ b/tinygrad/schedule/indexing.py
@@ -7,7 +7,7 @@ from tinygrad.uop.ops import consumer_map_from_toposort, gate_kernel_sink
 from tinygrad.uop.symbolic import symbolic, pm_simplify_valid, pm_drop_and_clauses
 from tinygrad.helpers import argsort, all_same, cpu_profile, PCONTIG, colored, Context, SPEC
 
-ALWAYS_CONTIGUOUS: set[Ops] = {Ops.CONTIGUOUS, Ops.AFTER, Ops.COPY, Ops.BUFFER, Ops.BUFFER_VIEW,
+ALWAYS_CONTIGUOUS: set[Ops] = {Ops.CONTIGUOUS, Ops.AFTER, Ops.COPY, Ops.CONCAT, Ops.BUFFER, Ops.BUFFER_VIEW,
                      Ops.CONST, Ops.BIND, Ops.DEVICE, Ops.MSELECT, Ops.MSTACK, Ops.PARAM,
                      Ops.DEFINE_LOCAL, Ops.DEFINE_REG, Ops.LOAD, Ops.CALL, Ops.FUNCTION}
 
@@ -27,9 +27,9 @@ def realize_store_after_src(ctx:dict[UOp, None], dest:UOp, src:UOp):
 
 pm_generate_realize_map = PatternMatcher([
   # always realize
-  (UPat({Ops.COPY, Ops.CONTIGUOUS, Ops.STORE}, name="tr"), realize),
+  (UPat({Ops.COPY, Ops.CONCAT, Ops.CONTIGUOUS, Ops.STORE}, name="tr"), realize),
   # realize srcs of these
-  (UPat((Ops.COPY, Ops.MSELECT, Ops.MSTACK), name="rb"), realize_srcs),
+  (UPat((Ops.COPY, Ops.CONCAT, Ops.MSELECT, Ops.MSTACK), name="rb"), realize_srcs),
   # sometimes we need to realize the src of STORE if there's a self-access
   (UPat(Ops.STORE, src=(UPat.var("dest"), UPat.var("src"))), realize_store_after_src),
 ])

--- a/tinygrad/uop/__init__.py
+++ b/tinygrad/uop/__init__.py
@@ -96,7 +96,8 @@ class Ops(FastEnum):
   CONTIGUOUS = auto(); CONTIGUOUS_BACKWARD = auto(); DETACH = auto()
 
   # buffer ops
-  BUFFERIZE = auto(); COPY = auto(); BUFFER = auto(); BUFFER_VIEW = auto(); MSELECT = auto(); MSTACK = auto(); CUSTOM_FUNCTION = auto()
+  BUFFERIZE = auto(); COPY = auto(); CONCAT = auto()
+  BUFFER = auto(); BUFFER_VIEW = auto(); MSELECT = auto(); MSTACK = auto(); CUSTOM_FUNCTION = auto()
 
   # the core 6 movement ops! these only exist in the tensor graph
   RESHAPE = auto(); PERMUTE = auto(); EXPAND = auto(); PAD = auto(); SHRINK = auto(); FLIP = auto()

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -28,7 +28,7 @@ axis_to_pos = {AxisType.LOOP: -1, AxisType.THREAD: 0, AxisType.GLOBAL: 0, AxisTy
                AxisType.GROUP_REDUCE: 2, AxisType.REDUCE: 4, AxisType.UNROLL: 5}
 
 range_start = {Ops.BUFFERIZE: 1, Ops.REDUCE: 1, Ops.WMMA: 3, Ops.END: 1, Ops.CALL: 1, Ops.FUNCTION: 1,
-               Ops.COPY: 2, Ops.BUFFER_VIEW: 1, Ops.LINEAR: 0}
+               Ops.COPY: 2, Ops.CONCAT: 2, Ops.BUFFER_VIEW: 1, Ops.LINEAR: 0}
 
 # https://en.wikipedia.org/wiki/Identity_element
 def identity_element(op:Ops, dt:DType) -> PyConst: return dt.const({Ops.ADD:0, Ops.MUL:1, Ops.MAX:dt.min}[op])
@@ -245,6 +245,8 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
         # HACK: BUFFER_VIEW is used inside kernels, so we set the shape to () if it's on an INDEX
         if self.src[0].op is Ops.INDEX: return ()
         return (self.arg[0],)
+      case Ops.CONCAT:
+        return self.arg[1]  # arg = (dim, output_shape)
       case Ops.CUSTOM_FUNCTION: return None
       case Ops.BUFFERIZE: return tuple([int(r.vmax+1) for r in self.src[1:]])
       case Ops.DEFINE_LOCAL | Ops.DEFINE_REG: return (self.ptrdtype.size,)
@@ -681,6 +683,7 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
       return self.src[0].device[self.arg]
     if self.op is Ops.MSTACK: return tuple(cast(str, x.device) for x in self.src)
     if self.op in {Ops.COPY, Ops.BUFFER, Ops.ALLREDUCE}: return self.src[1].device
+    if self.op is Ops.CONCAT: return self.src[0]._device
     for x in self.src:
       if x._device is not None: return x._device
     return None
@@ -961,7 +964,7 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
     return p
 
   # opaque bodies stay as Ops.CALL; value-producing bodies become Ops.FUNCTION (wrapped in TUPLE)
-  _OPAQUE_CALL_BODIES = {Ops.SINK, Ops.PROGRAM, Ops.LINEAR, Ops.COPY, Ops.BUFFER_VIEW, Ops.CUSTOM_FUNCTION}
+  _OPAQUE_CALL_BODIES = {Ops.SINK, Ops.PROGRAM, Ops.LINEAR, Ops.COPY, Ops.CONCAT, Ops.BUFFER_VIEW, Ops.CUSTOM_FUNCTION}
   def call(self, *srcs:UOp, grad_fxn:Callable|None=None, metadata:tuple[Metadata, ...]=(),
            name:str|None=None, precompile:bool=False, precompile_backward:bool=False) -> UOp:
     assert len(self.ranges) == 0, f"ranges {self.ranges} are leaking out of the call in {self.pyrender()}"

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -79,7 +79,7 @@ movement_ops = PatternMatcher([
   (UPat({Ops.ADD, Ops.MUL, Ops.IDIV, Ops.FLOORDIV}, dtype=dtypes.weakint), lambda: True),
 
   # AFTER on Movement Op, INDEX, BUFFER, COPY, or BITCAST
-  (UPat(Ops.AFTER, src=(UPat(GroupOp.Movement.union({Ops.INDEX, Ops.MULTI, Ops.CONTIGUOUS, Ops.BUFFER, Ops.BITCAST, Ops.COPY})),),
+  (UPat(Ops.AFTER, src=(UPat(GroupOp.Movement.union({Ops.INDEX, Ops.MULTI, Ops.CONTIGUOUS, Ops.BUFFER, Ops.BITCAST, Ops.COPY, Ops.CONCAT})),),
    allow_any_len=True), lambda: True),
 ])
 
@@ -124,6 +124,8 @@ _tensor_spec = PatternMatcher([
 
   # COPY/ALLREDUCE/MULTI
   (UPat(Ops.COPY, name="copy", src=(UPat.var("x"), UPat(Ops.DEVICE)), arg=None), lambda copy,x: copy.dtype == x.dtype),
+  # CONCAT: K sources, arg=(dim, sizes)
+  (UPat(Ops.CONCAT, allow_any_len=True, name="c"), lambda c: isinstance(c.arg, tuple) and len(c.arg) == 2),
   (UPat(Ops.ALLREDUCE, name="red", src=(UPat.var("x"), UPat(Ops.DEVICE))), lambda red,x: red.dtype == x.dtype and isinstance(red.arg, Ops)),
   (UPat(Ops.MULTI, name="multi"), lambda multi: all(x.dtype == multi.dtype for x in multi.src) and isinstance(multi.arg, int)),
 


### PR DESCRIPTION
## [WIP] Sketch: `Ops.CONCAT` for native tensor concatenation

Draft exploring what a first-class CONCAT op would look like. Not working e2e yet — posting for directional feedback.

### Problem (from #16090)

`cat(K=50)` warm-cache takes 12.5ms. Profiling shows:
- Metal copies: 0.6ms
- Scheduling (cached): ~0ms
- Python overhead (callify traversing K UOp subtrees): **12ms**

The pad+sum decomposition creates ~3K UOp nodes. The bottleneck is Python iterating over them, not GPU work.

### This sketch

Adds `Ops.CONCAT` that represents concatenation as a single UOp node:
- `cat()` emits `CONCAT` (1 node) instead of K PADs + K-1 ADDs (~3K nodes)
- Scheduler treats it like `COPY` (always realize, realize sources)
- Executor does `np.concatenate` on source buffers + single `copyin`

### What works
- Op enum, shape, priority, spec validation, executor, display
- `cat()` emits CONCAT for dim=0 with concrete shapes

### What's missing (where I need guidance)
- **rangeify**: CONCAT needs COPY-like treatment (`ALWAYS_RUN_OPS`, movement rewrites). Currently it gets lowered through rangeify into INDEX ops which hit codegen.
- **callify**: may need tag handling like COPY
- **gradient**: backward through CONCAT (= split) not implemented
- **dim>0**: falls back to pad+sum

### Question

Is this the right direction? The alternative approaches I explored in #16090 (scheduler copy batching, runtime batching) are blocked by the memory planner compacting buffer views. A first-class op avoids that by never creating K separate buffers in the first place.

Supersedes #16090.