### PR TITLE
llm: contiguous weights + rollout prune for quantized GGUF inference

### DIFF
--- a/tinygrad/llm/model.py
+++ b/tinygrad/llm/model.py
@@ -306,7 +306,7 @@ class Transformer:
     self._cached_tokens: list[int] = []
     # we specialize the JIT for prefill and rollout
     self.prefill_jit = TinyJit(self.forward)
-    self.rollout_jit = TinyJit(self.forward)
+    self.rollout_jit = TinyJit(self.forward, prune=True)
 
   def forward(self, tokens:Tensor, start_pos:int|UOp, temperature:Tensor) -> Tensor:
     x = self.token_embd(tokens).float()                   # (B, T, D)
@@ -381,9 +381,9 @@ class Transformer:
       expert_bias=f"blk.{kv.get(f'{arch}.leading_dense_block_count', 0)}.exp_probs_b.bias" in state_dict)
     model = Transformer(config)
     nn.state.load_state_dict(model, state_dict, verbose=False, consume=True, realize=False)  # NOTE: rope_freqs.weight (32,) is unused
-    # NOTE: without this contiguous, it unpacks the weights from the model every time. we shouldn't need this, but for now it's faster
+    # contiguous breaks dequant-matmul fusion so prune can classify dequant kernels as onetime
+    for s in (params:=nn.state.get_parameters(model)): s.replace(s.contiguous())
     if realize:
-      for s in (params:=nn.state.get_parameters(model)): s.replace(s.contiguous())
       Tensor.realize(*params)
     return model, kv
 


### PR DESCRIPTION
Quantized GGUF weights are lazy dequant chains that fuse into matmul kernels; contiguous breaks the fusion and prune makes the dequant onetime during JIT capture.

| Backend | Model | Before | After | Speedup |
|---------|-------|--------|-------|---------|
| Metal (M5 Max) | LLaMA 1B Q6_K | 10.5 tok/s | 147 tok/s | 14.0x |
| NV (RTX 5000 Ada) | LLaMA 1B Q6_K | 10.4 tok/s | 85.8 tok/s | 8.2x |

Bit-exact output on both backends.

https://github.com/kimjune01/tinygrad-realize-experiment