### PR TITLE
fix MATVEC pattern: reject equal-range elementwise reduces

### DIFF
--- a/tinygrad/codegen/opt/heuristic.py
+++ b/tinygrad/codegen/opt/heuristic.py
@@ -69,8 +69,7 @@ def hand_coded_optimizations(k:Scheduler) -> Scheduler:
     idx0, idx1 = mulop.src[0].src[1].get_idx(), mulop.src[1].src[1].get_idx()
     if k.ranges_of(AxisType.REDUCE):
       first_reduce_rng = k.ranges_of(AxisType.REDUCE)[0]
-      if any(u is first_reduce_rng for u in idx0.split_uop(Ops.ADD)) and all(r in idx1.ranges for r in idx0.ranges) \
-          and set(idx0.ranges) != set(idx1.ranges):
+      if any(u is first_reduce_rng for u in idx0.split_uop(Ops.ADD)) and idx0.ranges != idx1.ranges and all(r in idx1.ranges for r in idx0.ranges):
         for global_idx in k.axes_of(AxisType.GLOBAL):
           if first_reduce_rng.src[0].divides(MV_THREADS_PER_ROW) is not None and k.full_shape[global_idx]%(MV_BLOCKSIZE*MV_ROWS_PER_THREAD) == 0:
             if DEBUG >= 3:

--- a/tinygrad/codegen/opt/heuristic.py
+++ b/tinygrad/codegen/opt/heuristic.py
@@ -69,7 +69,8 @@ def hand_coded_optimizations(k:Scheduler) -> Scheduler:
     idx0, idx1 = mulop.src[0].src[1].get_idx(), mulop.src[1].src[1].get_idx()
     if k.ranges_of(AxisType.REDUCE):
       first_reduce_rng = k.ranges_of(AxisType.REDUCE)[0]
-      if any(u is first_reduce_rng for u in idx0.split_uop(Ops.ADD)) and all(r in idx1.ranges for r in idx0.ranges):
+      if any(u is first_reduce_rng for u in idx0.split_uop(Ops.ADD)) and all(r in idx1.ranges for r in idx0.ranges) \
+          and set(idx0.ranges) != set(idx1.ranges):
         for global_idx in k.axes_of(AxisType.GLOBAL):
           if first_reduce_rng.src[0].divides(MV_THREADS_PER_ROW) is not None and k.full_shape[global_idx]%(MV_BLOCKSIZE*MV_ROWS_PER_THREAD) == 0:
             if DEBUG >= 3:


### PR DESCRIPTION
The MATVEC subset check `all(r in idx1.ranges for r in idx0.ranges)` is trivially true when both buffers share identical ranges (e.g. `(a*b).sum()`). A true matvec has asymmetric access — vector ranges are a strict subset of matrix ranges. Adding `set(idx0.ranges) != set(idx1.ranges)` rejects the equal case.

Evidence & provenance: [HYPOTHESIS_GRAPH.md §H5.2](https://github.com/kimjune01/tinygrad-abduction-engine/blob/master/HYPOTHESIS_GRAPH.md#h52-matvec-pattern-matching-is-a-liability)