### PR TITLE
Add ONNX LSTM support

### DIFF
--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -126,8 +126,11 @@ backend_test.exclude('test_regex_*')
 # no rnn
 backend_test.exclude('test_gru_*')
 backend_test.exclude('test_rnn_*')
-backend_test.exclude('test_lstm_*')
 backend_test.exclude('test_simple_rnn_*')
+
+# lstm: forward direction with default activations only; peephole and layout=1 raise
+backend_test.exclude('test_lstm_with_peepholes_cpu')
+backend_test.exclude('test_lstm_batchwise_cpu')
 
 # no control flow
 # control flow uses AttributeProto.GRAPH

--- a/test/external/external_test_onnx_ops.py
+++ b/test/external/external_test_onnx_ops.py
@@ -364,6 +364,15 @@ class TestMainOnnxOps(TestOnnxOps):
     inputs = {"data": np.random.randn(1, 1, 32, 32, 32).astype(np.half)*100}
     self.helper_test_single_op("ReduceL2", inputs, {}, ["reduced"])
 
+  def test_lstm_forward(self):
+    seq, batch, in_size, hid = 1, 1, 128, 128
+    inputs = {
+      "X": np.random.randn(seq, batch, in_size).astype(np.float32),
+      "W": np.random.randn(1, 4*hid, in_size).astype(np.float32),
+      "R": np.random.randn(1, 4*hid, hid).astype(np.float32),
+    }
+    self.helper_test_single_op("LSTM", inputs, {"hidden_size": hid}, ["Y", "Y_h", "Y_c"])
+
 class TestTrainingOnnxOps(TestOnnxOps):
   # NOTE: ORT doesn't actually support training ops on cpu so we test using functions provided by onnx
   DOMAIN = AI_ONNX_PREVIEW_TRAINING_DOMAIN

--- a/tinygrad/nn/onnx.py
+++ b/tinygrad/nn/onnx.py
@@ -910,6 +910,27 @@ def get_onnx_ops() -> dict[str, types.FunctionType|dict[OpSetId, types.FunctionT
 
       return X.batchnorm(scale, B, current_mean, current_invstd).cast(X.dtype),running_mean.cast(input_mean.dtype),running_var.cast(input_var.dtype)
     return X.batchnorm(scale, B, input_mean, (input_var + epsilon).rsqrt())
+  def LSTM(X:Tensor, W:Tensor, R:Tensor, B:Tensor|None=None, sequence_lens:Tensor|None=None, initial_h:Tensor|None=None,
+           initial_c:Tensor|None=None, P:Tensor|None=None, hidden_size:int|None=None, activation_alpha:list|None=None,
+           activation_beta:list|None=None, activations:list|None=None, clip:float|None=None, direction:str="forward",
+           input_forget:int=0, layout:int=0):
+    if sequence_lens is not None or P is not None: raise NotImplementedError("LSTM sequence_lens / peephole weights (P) not supported")
+    if direction != "forward": raise NotImplementedError(f"LSTM direction={direction!r} not supported")
+    if activations is not None or activation_alpha is not None or activation_beta is not None: raise NotImplementedError("LSTM custom activations not supported")
+    if clip is not None: raise NotImplementedError("LSTM clip not supported")
+    if input_forget: raise NotImplementedError("LSTM input_forget=1 not supported")
+    if layout: raise NotImplementedError("LSTM layout=1 (batchwise) not supported")
+    if hidden_size is None: hidden_size = cast(int, W.shape[1] // 4)
+    if initial_h is None: initial_h = Tensor.zeros(1, X.shape[1], hidden_size, dtype=X.dtype, device=X.device, requires_grad=False)
+    if initial_c is None: initial_c = Tensor.zeros(1, X.shape[1], hidden_size, dtype=X.dtype, device=X.device, requires_grad=False)
+    bias = B[0, :hidden_size*4] + B[0, hidden_size*4:] if B is not None else 0
+    h_t, c_t, outs = initial_h[0], initial_c[0], []
+    for step in range(cast(int, X.shape[0])):
+      i, o, f, c = (X[step] @ W[0].T + h_t @ R[0].T + bias).chunk(4, dim=-1)
+      c_t = f.sigmoid() * c_t + i.sigmoid() * c.tanh()
+      h_t = o.sigmoid() * c_t.tanh()
+      outs.append(h_t)
+    return Tensor.stack(*outs, dim=0).unsqueeze(1), h_t.unsqueeze(0), c_t.unsqueeze(0)
   def GroupNormalization(x:Tensor, scale:Tensor, bias:Tensor, num_groups:int, epsilon:float=1e-05, stash_type:int=1):
     assert stash_type == 1, "only float32 is supported"
     x = x.reshape(x.shape[0], num_groups, -1).cast(dtypes.float).layernorm(eps=epsilon).cast(x.dtype).reshape(x.shape)


### PR DESCRIPTION
ONNX LSTM op for [silero VAD](https://github.com/snakers4/silero-vad) v5, the model from #10897. Forward direction only, default activations. +14 tokenised lines.

Closes #10897
