### PR TITLE
fix TYPED=1 runtime checks

### DIFF
--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -360,12 +360,12 @@ def _to_np_dtype(dtype:DType) -> type|None:
   import numpy as np
   if dtype in { dtypes.bfloat16, *dtypes.fp8s }: return np.float32
   return np.dtype(dtype.fmt).type if dtype.fmt is not None else None
-def _from_np_dtype(npdtype:'np.dtype') -> DType: # type: ignore [name-defined] # noqa: F821
+def _from_np_dtype(npdtype) -> DType:
   import numpy as np
   return DTYPES_DICT[np.dtype(npdtype).name]
 
 @functools.cache
-def _to_torch_dtype(dtype:DType) -> 'torch.dtype'|None:  # type: ignore [name-defined] # noqa: F821
+def _to_torch_dtype(dtype:DType) -> object|None:
   import numpy as np, torch
   if dtype == dtypes.uint64: return torch.uint64
   if dtype == dtypes.bfloat16: return torch.bfloat16
@@ -374,5 +374,5 @@ def _to_torch_dtype(dtype:DType) -> 'torch.dtype'|None:  # type: ignore [name-de
   try: return torch.from_numpy(np.array([], dtype=_to_np_dtype(dtype))).dtype
   except TypeError: return None
 @functools.cache
-def _from_torch_dtype(torchdtype:'torch.dtype') -> DType: # type: ignore [name-defined] # noqa: F821
+def _from_torch_dtype(torchdtype:object) -> DType:
   return {v:k for k in DTYPES_DICT.values() if (v:=_to_torch_dtype(k)) is not None}[torchdtype]

--- a/tinygrad/mixin/__init__.py
+++ b/tinygrad/mixin/__init__.py
@@ -620,7 +620,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     padded = [t.pad(tuple((dim_cumsum[i], dim_cumsum[-1]-dim_cumsum[i+1]) if j==dim else None for j in range(t.ndim))) for i,t in enumerate(tensors)]
     return padded[0].usum(*padded[1:])
 
-  def stack(self, *args:Self, dim:int=0) -> Self:
+  def stack(self, *args, dim:int=0):
     """
     Concatenates self with other tensors in `args` along a new dimension specified by `dim`.
 
@@ -653,7 +653,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     ret = self.transpose(axis,-1)._pad_constant((None,)*(self.ndim-1)+((round_up(s,SPLIT)-s,0),), value).unflatten(-1,(-1,SPLIT))._cumalu(-1, op)
     base = ret[..., -1]._cumalu(-1, op)._pad_constant((None,)*(ret.ndim-2) + ((1, -1),), value)
     base = base.unsqueeze(-1).expand(*base.shape, ret.shape[-1])
-    def fix(x: Self) -> Self: return x.flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
+    def fix(x): return x.flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
     return getattr(fix(ret), {Ops.ADD: "add", Ops.MAX: "maximum", Ops.MUL: "mul"}[op])(fix(base))
 
   def cumsum(self, axis:int=0) -> Self:
@@ -843,7 +843,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     x = x.flatten(dim, dim+n_stages-1).shrink_to(self.shape)
     # compute indices for sorted values
     mask = type(self).ones(orig_len, orig_len, dtype=dtypes.bool, device=self.device).tril().reshape((None, None) + (1,)*(self.ndim-dim-1))
-    def compute_counts(t:Self): return (mask & t.unsqueeze(dim).eq(t.unsqueeze(dim+1))).sum(dim+1)
+    def compute_counts(t): return (mask & t.unsqueeze(dim).eq(t.unsqueeze(dim+1))).sum(dim+1)
     count_orig, count_sorted = compute_counts(self), compute_counts(x)
     cond = self.unsqueeze(dim+1).eq(x.unsqueeze(dim)) & count_orig.unsqueeze(dim+1).eq(count_sorted.unsqueeze(dim))
     idx = type(self).arange(orig_len, device=self.device).reshape(tuple(orig_len if i == dim else 1 for i in range(x.ndim)))
@@ -878,7 +878,8 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     ```
     """
     if not sorted_: raise NotImplementedError("topk with sorted_=False is not supported")
-    if k > self.shape[dim:=self._resolve_dim(dim)]: raise ValueError(f"selected index {k=} is out of range")
+    dim = self._resolve_dim(dim)
+    if k > self.shape[dim]: raise ValueError(f"selected index {k=} is out of range")
     x, idx = self.sort(dim, descending=largest)
     topk_shape = tuple(k if i == dim else None for i in range(self.ndim))
     return x.shrink_to(topk_shape), idx.shrink_to(topk_shape)
@@ -977,7 +978,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     # pad src and mask to self.shape so that reduce can be done with padded values as no-ops
     return src.pad_to(*self.shape, None), mask.pad_to(*self.shape, None)
 
-  def scatter_reduce(self, dim:int, index:Self, src:Self, reduce:Literal["sum", "prod", "mean", "amax", "amin"],
+  def scatter_reduce(self, dim:int, index:Self, src:Self, reduce:str,
                      include_self:bool=True) -> Self:
     """
     Scatters `src` values along an axis specified by `dim`.
@@ -1008,7 +1009,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     ```
     """
     src, mask = self._pre_scatter(dim, index, src)
-    def _inv_mask(a:Self|PyConst, b:Self|PyConst) -> Self: return mask.any(-1).logical_not().where(a, b)
+    def _inv_mask(a, b): return mask.any(-1).logical_not().where(a, b)
     if reduce == "sum": return mask.where(src, 0).sum(-1).add(self if include_self else _inv_mask(self, 0))
     if reduce == "prod": return mask.where(src, 1).prod(-1).mul(self if include_self else _inv_mask(self, 1))
     if reduce == "amax": return mask.where(src, m := src.dtype.min).max(-1).maximum(self if include_self else _inv_mask(self, m))
@@ -1018,7 +1019,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
       return mask.where(src, 0).sum(-1).add(self if include_self else _inv_mask(self, 0)).div(count)
     raise RuntimeError(f"{reduce=} must be one of 'sum', 'prod', 'mean', 'amax', 'amin'")
 
-  def scatter(self, dim:int, index:Self, src:Self|PyConst, reduce:Literal['multiply', 'add']|None=None) -> Self:
+  def scatter(self, dim:int, index:Self, src:Self|PyConst, reduce:str|None=None) -> Self:
     """
     Scatters `src` values along an axis specified by `dim`.
     Apply `add` or `multiply` reduction operation with `reduce`.
@@ -1107,7 +1108,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     return flatten(reversed(grouped_pads))
 
   # NOTE: these work for more than 2D
-  def avg_pool2d(self, kernel_size:tuple[int, ...]=(2,2), stride=None, dilation=1, padding:int|tuple[int, ...]=0,
+  def avg_pool2d(self, kernel_size:int|tuple[int, ...]=(2,2), stride=None, dilation=1, padding:int|tuple[int, ...]=0,
                  ceil_mode=False, count_include_pad=True) -> Self:
     """
     Applies average pooling over a tensor.
@@ -1145,7 +1146,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     """
     axis = tuple(range(-len(k_ := make_tuple(kernel_size, 2)), 0))
     s_ = stride if stride is not None else k_
-    def pool(x:Self, padding_:Sequence[int]) -> Self:
+    def pool(x, padding_:Sequence[int]):
       return x._pad_constant(((0,0),)*(x.ndim-len(k_)) + flat_to_grouped(padding_), 0.0)._pool(k_, s_, dilation)
     reg_pads = resolve_pool_pads(padding, len(k_))
     pads = self._apply_ceil_mode(reg_pads, k_, s_, dilation) if ceil_mode else reg_pads
@@ -1155,7 +1156,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     return pool(self, pads).sum(axis) / pool(self._pad_constant(((0,0),)*(self.ndim-len(k_)) + flat_to_grouped(reg_pads), 0.0).ones_like(),
                                               tuple(cp-rp for cp,rp in zip(pads, reg_pads))).sum(axis)
 
-  def max_pool2d(self, kernel_size:tuple[int, ...]=(2,2), stride=None, dilation=1, padding:int|tuple[int, ...]=0,
+  def max_pool2d(self, kernel_size:int|tuple[int, ...]=(2,2), stride=None, dilation=1, padding:int|tuple[int, ...]=0,
                  ceil_mode=False, return_indices=False) -> Self | tuple[Self, Self]:
     """
     Applies max pooling over a tensor.
@@ -1200,7 +1201,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     idx = m * idx._pad_constant(((0,0),)*(idx.ndim-len(k_)) + flat_to_grouped(pads), idx.dtype.min)._pool(k_, s_, dilation)
     return pooled.max(axis), spatial_sz - idx.max(axis)
 
-  def max_unpool2d(self, indices:Self, kernel_size:tuple[int, ...]=(2,2), stride=None, dilation=1, padding:int|tuple[int, ...]=0,
+  def max_unpool2d(self, indices:Self, kernel_size:int|tuple[int, ...]=(2,2), stride=None, dilation=1, padding:int|tuple[int, ...]=0,
                    output_size=None) -> Self:
     """
     Performs a partial inverse of `max_pool2d` using the indices from the argmax.
@@ -1329,13 +1330,13 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
 
   # ***** loss ops *****
 
-  def _do_reduction(self, reduction:ReductionStr="mean") -> Self:
+  def _do_reduction(self, reduction:str="mean") -> Self:
     if reduction == "none": return self
     if reduction == "sum": return self.sum()
     if reduction == "mean": return self.mean()
     raise ValueError(f"{reduction=} must be one of {get_args(ReductionStr)}")
 
-  def binary_crossentropy(self, Y:Self, reduction:ReductionStr="mean") -> Self:
+  def binary_crossentropy(self, Y:Self, reduction:str="mean") -> Self:
     """
     Computes the binary cross-entropy loss between `self` and `Y`.
 
@@ -1349,7 +1350,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     """
     return (-Y*self.log() - (1-Y)*(1-self).log())._do_reduction(reduction)
 
-  def binary_crossentropy_logits(self, Y:Self, reduction:ReductionStr="mean", pos_weight:Self|None=None) -> Self:
+  def binary_crossentropy_logits(self, Y:Self, reduction:str="mean", pos_weight:Self|None=None) -> Self:
     """
     Computes the binary cross-entropy loss between `self` and `Y` where `self` is logits.
 
@@ -1364,7 +1365,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     log_p, log_1_minus_p = self.logsigmoid(), (-self).logsigmoid()
     return (-((1 if pos_weight is None else pos_weight) * Y * log_p + (1-Y) * log_1_minus_p))._do_reduction(reduction)
 
-  def sparse_categorical_crossentropy(self, Y:Self, ignore_index:int=-1, label_smoothing=0.0, reduction:ReductionStr="mean") -> Self:
+  def sparse_categorical_crossentropy(self, Y:Self, ignore_index:int=-1, label_smoothing=0.0, reduction:str="mean") -> Self:
     """
     Computes the sparse categorical cross-entropy loss between `self` and `Y`.
 
@@ -1388,7 +1389,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     unreduced = ((1 - label_smoothing) * (log_probs * y).sum(-1) + smoothing)
     return -unreduced.sum() / loss_mask.sum() if reduction == "mean" else -unreduced._do_reduction(reduction)
 
-  def cross_entropy(self, Y:Self, reduction:ReductionStr="mean", label_smoothing:float=0.0) -> Self:
+  def cross_entropy(self, Y:Self, reduction:str="mean", label_smoothing:float=0.0) -> Self:
     """
     Computes the cross entropy loss between input logits and target.
 
@@ -1415,7 +1416,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     Y = (1 - label_smoothing)*Y + label_smoothing / int(Y.shape[classes_dim])
     return -self.log_softmax(classes_dim).mul(Y).sum(classes_dim)._do_reduction(reduction)
 
-  def nll_loss(self, Y:Self, weight:Self|None=None, ignore_index:int|None=None, reduction:ReductionStr="mean") -> Self:
+  def nll_loss(self, Y:Self, weight:Self|None=None, ignore_index:int|None=None, reduction:str="mean") -> Self:
     """
     Computes the negative log likelihood loss between log-probabilities and target labels.
 
@@ -1441,7 +1442,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
 
   # ***** matrix ops *****
 
-  def newton_schulz(self, steps:int, params:tuple[int, ...], eps:float=1.0e-7) -> Self:
+  def newton_schulz(self, steps:int, params:tuple[float, ...], eps:float=1.0e-7) -> Self:
     """
     Performs the newton-schulz algorithm for odd polynomials. The degree of the odd polynomial depends on the number of params.
 

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -1,7 +1,7 @@
 import math, functools, operator
-from typing import Literal, Self
+from typing import Self, cast
 from tinygrad.uop import Ops
-from tinygrad.dtype import dtypes, ConstType, PyConst, least_upper_dtype, least_upper_float
+from tinygrad.dtype import dtypes, PyConst, least_upper_dtype, least_upper_float
 from tinygrad.helpers import argfix, polyN
 from tinygrad.mixin.dtype import DTypeMixin
 from tinygrad.mixin.creation import CreationMixin
@@ -12,14 +12,14 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
   def alu(self, op: Ops, *src: Self) -> Self:
     raise NotImplementedError
 
-  def _broadcasted(self, y: Self | ConstType, reverse: bool = False) -> tuple[Self, Self]:
+  def _broadcasted(self, y, reverse: bool = False) -> tuple[Self, Self]:
     raise NotImplementedError
 
   # great functions you get!
-  def ufix(self, x: Self | ConstType) -> Self:
-    return self.const_like(x) if not isinstance(x, ElementwiseMixin) else x
+  def ufix(self, x) -> Self:
+    return self.const_like(x) if not isinstance(x, ElementwiseMixin) else cast(Self, x)
 
-  def _binop(self, op: Ops, x: Self | ConstType, reverse: bool) -> Self:
+  def _binop(self, op: Ops, x, reverse: bool) -> Self:
     return self.ufix(x).alu(op, self) if reverse else self.alu(op, self.ufix(x))
 
   def usum(self, *uops) -> Self: return functools.reduce(operator.or_ if self.dtype is dtypes.bool else operator.add, argfix(*uops), self)
@@ -61,7 +61,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     if not (dtypes.is_bool(self.dtype) or dtypes.is_int(self.dtype)):
       raise RuntimeError(f"{self.dtype} is not supported")
 
-  def add(self, x: Self | ConstType, reverse: bool = False) -> Self:
+  def add(self, x, reverse: bool = False) -> Self:
     """
     Adds `self` and `x`.
     Equivalent to `self + x`.
@@ -80,7 +80,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     """
     return self._binop(Ops.ADD, x, reverse)
 
-  def sub(self, x: Self | ConstType, reverse: bool = False) -> Self:
+  def sub(self, x, reverse: bool = False) -> Self:
     """
     Subtracts `x` from `self`.
     Equivalent to `self - x`.
@@ -101,7 +101,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     a, b = self._broadcasted(x, reverse)
     return a + (-b)
 
-  def mul(self, x: Self | ConstType, reverse: bool = False) -> Self:
+  def mul(self, x, reverse: bool = False) -> Self:
     """
     Multiplies `self` and `x`.
     Equivalent to `self * x`.
@@ -135,7 +135,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     self._check_dtype()
     return self.logical_not() if self.dtype == dtypes.bool else self ^ -1
 
-  def bitwise_and(self, x: Self | ConstType, reverse: bool = False) -> Self:
+  def bitwise_and(self, x, reverse: bool = False) -> Self:
     """
     Computes the bitwise AND of `self` and `x`.
     Equivalent to `self & x`.
@@ -150,7 +150,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     self._check_dtype()
     return self._binop(Ops.AND, x, reverse)
 
-  def bitwise_or(self, x: Self | ConstType, reverse: bool = False) -> Self:
+  def bitwise_or(self, x, reverse: bool = False) -> Self:
     """
     Computes the bitwise OR of `self` and `x`.
     Equivalent to `self | x`.
@@ -165,7 +165,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     self._check_dtype()
     return self._binop(Ops.OR, x, reverse)
 
-  def bitwise_xor(self, x: Self | ConstType, reverse: bool = False) -> Self:
+  def bitwise_xor(self, x, reverse: bool = False) -> Self:
     """
     Computes bitwise xor of `self` and `x`.
     Equivalent to `self ^ x`.
@@ -181,7 +181,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     self._check_dtype()
     return self._binop(Ops.XOR, x, reverse)
 
-  def mod(self, x: Self | ConstType, reverse: bool = False) -> Self:
+  def mod(self, x, reverse: bool = False) -> Self:
     """
     Mod `self` by `x`.
     Equivalent to `self % x`.
@@ -195,7 +195,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     if dtypes.is_int(a.dtype): return a.alu(Ops.FLOORMOD, b)
     return a - a.div(b, rounding_mode="floor") * b
 
-  def fmod(self, x: Self | ConstType) -> Self:
+  def fmod(self, x) -> Self:
     """
     C-style remainder of `self` divided by `x` (sign follows the dividend), using truncating division.
     Differs from `mod`/`%`, which uses Python floor remainder.
@@ -208,7 +208,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     if dtypes.is_int(a.dtype): return a.alu(Ops.CMOD, b)
     return a - a.div(b, rounding_mode="trunc") * b
 
-  def div(self, x: Self | ConstType, reverse: bool = False, rounding_mode: Literal["trunc", "floor"] | None = None) -> Self:
+  def div(self, x, reverse: bool = False, rounding_mode: str | None = None) -> Self:
     """
     Divides `self` by `x`.
     Equivalent to `self / x`.
@@ -244,84 +244,84 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
   def __invert__(self) -> Self:
     return self.bitwise_not()
 
-  def __add__(self, x: Self | ConstType) -> Self:
+  def __add__(self, x) -> Self:
     return self.add(x)
 
-  def __sub__(self, x: Self | ConstType) -> Self:
+  def __sub__(self, x) -> Self:
     return self.sub(x)
 
-  def __mul__(self, x: Self | ConstType) -> Self:
+  def __mul__(self, x) -> Self:
     return self.mul(x)
 
-  def __truediv__(self, x: Self | ConstType) -> Self:
+  def __truediv__(self, x) -> Self:
     return self.div(x)
 
-  def __floordiv__(self, x: Self | ConstType) -> Self:
+  def __floordiv__(self, x) -> Self:
     return self.div(x, rounding_mode="floor")
 
-  def __mod__(self, x: Self | ConstType) -> Self:
+  def __mod__(self, x) -> Self:
     return self.mod(x)
 
-  def __and__(self, x: Self | ConstType) -> Self:
+  def __and__(self, x) -> Self:
     return self.bitwise_and(x)
 
-  def __or__(self, x: Self | ConstType) -> Self:
+  def __or__(self, x) -> Self:
     return self.bitwise_or(x)
 
-  def __xor__(self, x: Self | ConstType) -> Self:
+  def __xor__(self, x) -> Self:
     return self.bitwise_xor(x)
 
-  def __radd__(self, x: Self | ConstType) -> Self:
+  def __radd__(self, x) -> Self:
     return self.add(x, True)
 
-  def __rsub__(self, x: Self | ConstType) -> Self:
+  def __rsub__(self, x) -> Self:
     return self.sub(x, True)
 
-  def __rmul__(self, x: Self | ConstType) -> Self:
+  def __rmul__(self, x) -> Self:
     return self.mul(x, True)
 
-  def __rtruediv__(self, x: Self | ConstType) -> Self:
+  def __rtruediv__(self, x) -> Self:
     return self.div(x, True)
 
-  def __rfloordiv__(self, x: Self | ConstType) -> Self:
+  def __rfloordiv__(self, x) -> Self:
     return self.div(x, reverse=True, rounding_mode="floor")
 
-  def __rand__(self, x: Self | ConstType) -> Self:
+  def __rand__(self, x) -> Self:
     return self.bitwise_and(x, True)
 
-  def __ror__(self, x: Self | ConstType) -> Self:
+  def __ror__(self, x) -> Self:
     return self.bitwise_or(x, True)
 
-  def __rxor__(self, x: Self | ConstType) -> Self:
+  def __rxor__(self, x) -> Self:
     return self.bitwise_xor(x, True)
 
-  def __rmod__(self, x: Self | ConstType) -> Self:
+  def __rmod__(self, x) -> Self:
     return self.mod(x, True)
 
-  def __lt__(self, x: Self | ConstType) -> Self:
+  def __lt__(self, x) -> Self:
     return self._binop(Ops.CMPLT, x, False)
 
-  def __gt__(self, x: Self | ConstType) -> Self:
+  def __gt__(self, x) -> Self:
     return self._binop(Ops.CMPLT, x, True)
 
-  def __ge__(self, x: Self | ConstType) -> Self:
+  def __ge__(self, x) -> Self:
     return (self < x).logical_not()
 
-  def __le__(self, x: Self | ConstType) -> Self:
+  def __le__(self, x) -> Self:
     return (self > x).logical_not()
 
-  def ne(self, x: Self | ConstType) -> Self:
+  def ne(self, x) -> Self:
     return self._binop(Ops.CMPNE, x, False)
 
-  def eq(self, x: Self | ConstType) -> Self:
+  def eq(self, x) -> Self:
     return self.ne(x).logical_not()
 
-  def __ne__(self, x: Self | ConstType) -> Self:  # type: ignore[override]
+  def __ne__(self, x) -> Self:  # type: ignore[override]
     return self.ne(x)
 
   # NOTE: __eq__ isn't overridden, and means the same thing as is by default
 
-  def lshift(self, x: Self | int, reverse: bool = False) -> Self:
+  def lshift(self, x, reverse: bool = False) -> Self:
     """
     Computes left arithmetic shift of `self` by `x` bits. `self` must have integer dtype.
     Equivalent to `self << x`.
@@ -332,7 +332,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     """
     return self._binop(Ops.SHL, x, reverse)
 
-  def rshift(self, x: Self | int, reverse: bool = False) -> Self:
+  def rshift(self, x, reverse: bool = False) -> Self:
     """
     Computes right arithmetic shift of `self` by `x` bits. `self` must have integer dtype.
     Equivalent to `self >> x`.
@@ -343,19 +343,19 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     """
     return self._binop(Ops.SHR, x, reverse)
 
-  def __lshift__(self, x: Self | int) -> Self:
+  def __lshift__(self, x) -> Self:
     return self.lshift(x)
 
-  def __rshift__(self, x: Self | int) -> Self:
+  def __rshift__(self, x) -> Self:
     return self.rshift(x)
 
-  def __rlshift__(self, x: Self | int) -> Self:
+  def __rlshift__(self, x) -> Self:
     return self.lshift(x, True)
 
-  def __rrshift__(self, x: Self | int) -> Self:
+  def __rrshift__(self, x) -> Self:
     return self.rshift(x, True)
 
-  def maximum(self, x: Self | ConstType) -> Self:
+  def maximum(self, x) -> Self:
     """
     Computes element-wise maximum of `self` and `x`.
 
@@ -370,7 +370,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
 
   def _inverse(self) -> Self: return -self if self.is_floating_point() else ~self
 
-  def minimum(self, x: Self | ConstType) -> Self:
+  def minimum(self, x) -> Self:
     """
     Computes element-wise minimum of `self` and `x`.
 
@@ -384,7 +384,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     t, x = self._broadcasted(x)
     return t._inverse().maximum(x._inverse())._inverse()
 
-  def copysign(self, other: Self | ConstType) -> Self:
+  def copysign(self, other) -> Self:
     """
     Returns a tensor of with the magnitude of `self` and the sign of `other`, elementwise.
     """
@@ -392,7 +392,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     a, b = self._broadcasted(other)
     return a.abs() * ((b < 0) | (b.reciprocal() < 0)).where(-1, 1)
 
-  def logaddexp(self, other: Self | ConstType) -> Self:
+  def logaddexp(self, other) -> Self:
     """
     Calculates (self.exp()+other.exp()).log(), elementwise.
     """
@@ -400,7 +400,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     m = a.maximum(b)
     return ((a-m).exp() + (b-m).exp()).log() + m
 
-  def where(self, x: Self | ConstType, y: Self | ConstType) -> Self:
+  def where(self, x, y) -> Self:
     ref: Self = x if isinstance(x, type(self)) else y if isinstance(y, type(self)) else \
       self.cast(least_upper_dtype(dtypes.from_py(x), dtypes.from_py(y)))
     return self.alu(Ops.WHERE, ref.ufix(x), ref.ufix(y))
@@ -518,7 +518,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     """
     return self._ensure_float().alu(Ops.EXP2)
 
-  def pow(self, x: Self | ConstType, reverse: bool = False) -> Self:
+  def pow(self, x, reverse: bool = False) -> Self:
     """
     Computes power of `self` with `x`.
     Equivalent to `self ** x`.
@@ -541,10 +541,10 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     # NOTE: pow(int, float) -> int
     return ret.round().cast(self.dtype) if not reverse and not dtypes.is_float(self.dtype) and dtypes.is_float(exponent.dtype) else ret
 
-  def __pow__(self, x: Self | ConstType) -> Self:
+  def __pow__(self, x) -> Self:
     return self.pow(x)
 
-  def __rpow__(self, x: Self | ConstType) -> Self:
+  def __rpow__(self, x) -> Self:
     return self.pow(x, True)
 
   def square(self) -> Self:
@@ -1047,7 +1047,7 @@ class ElementwiseMixin(DTypeMixin, CreationMixin):
     """
     return self / (1 + self.abs())
 
-  def lerp(self, end: Self, weight: Self | ConstType) -> Self:
+  def lerp(self, end: Self, weight) -> Self:
     """
     Linearly interpolates between `self` and `end` by `weight`.
 

--- a/tinygrad/mixin/movement.py
+++ b/tinygrad/mixin/movement.py
@@ -175,13 +175,13 @@ class MovementMixin:
     ret = self._mop(Ops.RESHAPE, arg=new_shape)
     return self if ret.shape == self.shape else ret
 
-  def pad(self, arg:tuple[tuple[sint, sint] | None, ...]) -> Self:
+  def pad(self, arg:Sequence[tuple[sint, sint] | None]) -> Self:
     if self.ndim != len(arg):
       raise ValueError(f"{self.ndim=} != {len(arg)=}")
     ret = self._mop(Ops.PAD, tuple(x if x is not None else (0, 0) for x in arg))
     return self if ret.shape == self.shape else ret
 
-  def shrink(self, arg: tuple[tuple[sint, sint] | None, ...]) -> Self:
+  def shrink(self, arg:Sequence[tuple[sint, sint] | None]) -> Self:
     """
     Returns a tensor that shrinks the each axis based on input arg.
     `arg` must have the same length as `self.ndim`.
@@ -498,7 +498,8 @@ class MovementMixin:
     print(t.diagonal(offset=1).numpy())
     ```
     """
-    if (dim1:=self._resolve_dim(dim1)) == (dim2:=self._resolve_dim(dim2)): raise RuntimeError("dim1 and dim2 cannot be the same dimension")
+    dim1, dim2 = self._resolve_dim(dim1), self._resolve_dim(dim2)
+    if dim1 == dim2: raise RuntimeError("dim1 and dim2 cannot be the same dimension")
     x = self.permute(*[i for i in range(self.ndim) if i != dim1 and i != dim2], dim1, dim2)
     if offset >= 0: x = x.shrink(tuple(None for _ in x.shape[:-1]) + ((offset, x.shape[-1]),))
     else: x = x.shrink(tuple(None for _ in x.shape[:-2]) + ((-offset, x.shape[-2]), None))

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -84,7 +84,7 @@ def safe_save(tensors:dict[str, Tensor], fn:str, metadata:dict[str, Any]|None=No
 
 # state dict
 
-def get_state_dict(obj, prefix:str='', tensor_type=Tensor) -> dict[str, Tensor]:
+def get_state_dict(obj, prefix:str='', tensor_type=Tensor) -> dict[str, Any]:
   """
   Returns a `state_dict` of the object, with optional prefix.
 
@@ -200,10 +200,10 @@ def tar_extract(t: Tensor) -> dict[str, Tensor]:
 # torch support!
 
 @accept_filename
-def torch_load(t:Tensor) -> dict[str, Tensor]:
+def torch_load(t:Tensor) -> Any:
   """
   ```python
-  torch_load(fn: Tensor | str | Path) -> dict[str, Tensor]
+  torch_load(fn: Tensor | str | Path) -> Any
   ```
 
   Loads a torch .pth file, returning the `state_dict`.

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -254,7 +254,7 @@ class Tensor(OpMixin):
     self.uop = x.uop
     return self
 
-  def assign(self, x:Tensor|PyConst|list|tuple) -> Tensor:
+  def assign(self, x:Any) -> Tensor:
     is_disk = isinstance(self.device, str) and self.device.startswith("DISK")
     if not isinstance(x, Tensor): x = Tensor(x, device="CPU" if is_disk else self.device, dtype=self.dtype)
     if self.uop is x.uop: return self  # a self assign is a NOOP
@@ -371,7 +371,8 @@ class Tensor(OpMixin):
     """
     Moves the tensor to the given device.
     """
-    if (device:=canonicalize_device(device)) == self.device: return self
+    device = canonicalize_device(device)
+    if device == self.device: return self
     ret = Tensor(self.uop.copy_to_device(device), requires_grad=self.requires_grad)
     if self.grad is not None: ret.grad = self.grad.to(device)
     return ret
@@ -1280,7 +1281,6 @@ class Tensor(OpMixin):
   # ***** broadcasted elementwise ops *****
 
   def ufix(self, x) -> Tensor:
-    # TODO: x:ConstType|UOp does not work because mixin only accepts Self | ConstType
     assert isinstance(x, (*get_args(ConstType), UOp)), f"{type(x)=}, {x=}"
     return Tensor(x, self.device, self.dtype if self._ufix_keep_dtype(x) else None, requires_grad=False)
 


### PR DESCRIPTION
Fixes #7889.

TYPED=1 now gets through backend ops, test_tiny, and unit tests by aligning runtime-checkable annotations with the inputs tinygrad already accepts at normalization boundaries.

Local validation:
TYPED=1 .venv/bin/python -m pytest test/backend/test_ops.py -q -x
TYPED=1 .venv/bin/python -m pytest test/test_tiny.py -q -x
TYPED=1 .venv/bin/python -m pytest test/unit -q -x
.venv/bin/ruff check tinygrad/dtype.py tinygrad/mixin/__init__.py tinygrad/mixin/elementwise.py tinygrad/mixin/movement.py tinygrad/nn/state.py tinygrad/tensor.py
.venv/bin/mypy tinygrad/dtype.py tinygrad/mixin/__init__.py tinygrad/mixin/elementwise.py tinygrad/mixin/movement.py tinygrad/nn/state.py tinygrad/tensor.py