### PR TITLE
clang: render bf16 as ushort

### DIFF
--- a/test/backend/test_renderer_failures.py
+++ b/test/backend/test_renderer_failures.py
@@ -4,8 +4,8 @@ from tinygrad.device import Device, is_dtype_supported
 from tinygrad.dtype import dtypes, ConstType
 from tinygrad.engine.realize import run_linear
 from tinygrad.codegen import to_program
-from tinygrad.helpers import prod
-from tinygrad.renderer.cstyle import CStyleLanguage
+from tinygrad.helpers import prod, Target
+from tinygrad.renderer.cstyle import CStyleLanguage, ClangRenderer
 from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.renderer.wgsl import WGSLRenderer
 from tinygrad.runtime.ops_python import PythonRenderer
@@ -49,6 +49,22 @@ class TestRendererFailures(unittest.TestCase):
     sink = UOp(Ops.SINK, dtypes.void, (gated_alu_store,), arg=KernelInfo())
     ret = _test_uop_result([], sink, local_size=[4, 2, 1])[0]
     np.testing.assert_equal(ret, [0, 0, 0, 0, 0, 1, 1, 1])
+
+class TestClangRendererFailures(unittest.TestCase):
+  def test_bfloat16_source_uses_ushort_storage(self):
+    const_linear = (Tensor.ones(4, dtype=dtypes.bfloat16) + Tensor.ones(4, dtype=dtypes.bfloat16)).schedule_linear()
+    assert len(const_linear.src) == 1
+    const_src = to_program(const_linear.src[0].src[0], ClangRenderer(Target("CPU"))).src[3].arg
+    self.assertNotIn("__bf16", const_src)
+    self.assertIn("unsigned short* restrict", const_src)
+    self.assertIn("16384u", const_src)
+
+    cast_linear = Tensor.empty(4, dtype=dtypes.bfloat16).cast(dtypes.half).schedule_linear()
+    assert len(cast_linear.src) == 1
+    cast_src = to_program(cast_linear.src[0].src[0], ClangRenderer(Target("CPU"))).src[3].arg
+    self.assertNotIn("__bf16", cast_src)
+    self.assertIn("__fp16* restrict", cast_src)
+    self.assertIn("unsigned short* restrict", cast_src)
 
 @unittest.skipIf(not isinstance(Device[Device.DEFAULT].renderer, CStyleLanguage), "uops are for cstyle")
 class TestCStyleFailures(unittest.TestCase):

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -227,7 +227,11 @@ class ClangRenderer(CStyleLanguage):
 
   # language options
   buffer_suffix = " restrict"
-  type_map = {dtypes.bool:"_Bool", dtypes.half:"__fp16"}
+  type_map = {dtypes.bool:"_Bool", dtypes.half:"__fp16", dtypes.bfloat16:"unsigned short"}
+  string_rewrite = PatternMatcher([
+    (UPat(Ops.CONST, dtypes.bfloat16, name="x"),
+      lambda ctx,x: f"{(struct.unpack('I', struct.pack('f', float_to_bf16(x.arg)))[0] >> 16)}u"),
+  ]) + base_rewrite
   code_for_op = {**({k:v for k,v in CStyleLanguage.code_for_op.items() if k not in [Ops.EXP2, Ops.SIN, Ops.LOG2, Ops.TRUNC, Ops.RECIPROCAL]}),
                  Ops.SQRT: lambda x,dtype: f"__builtin_sqrt({x})" if dtype == dtypes.float64 else f"__builtin_sqrtf({x})",
                  Ops.TRUNC: lambda x,dtype: f"__builtin_trunc({x})" if dtype == dtypes.float64 else f"__builtin_truncf({x})",


### PR DESCRIPTION
Fixes #6909

CPU CLANG now renders bfloat16 storage and constants as ushort payloads, so generated C does not depend on native __bf16 support. Arithmetic still uses the existing bfloat16 rewrite rules.

Tests:
DEV=CPU .venv/bin/python -m pytest test/backend/test_renderer_failures.py -q
DEV=CPU .venv/bin/python -m pytest test/backend/test_dtype.py::TestBFloat16 test/backend/test_dtype.py::TestBFloat16DType -q
DEV=CPU .venv/bin/python -m pytest test/backend/test_dtype_alu.py::TestDTypeALU::test_emulated_bfloat16 -q
.venv/bin/python -m ruff check tinygrad/renderer/cstyle.py test/backend/test_renderer_failures.py
DEV=CPU runtime smoke for bf16 add-to-float and bf16-to-half numpy path
x86_64 core2 ClangJITCompiler compile_to_obj probe for bf16 constant and bf16-to-half kernels
