### PR TITLE
add Tensor.associative_scan

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1107,6 +1107,33 @@ class TestOps(unittest.TestCase):
     helper_test_op([(0,3)], lambda x: torch.cumsum(x, dim=0), lambda x: Tensor.cumsum(x, axis=0))
     helper_test_op([(2,3,0)], lambda x: torch.cumsum(x, dim=2), lambda x: Tensor.cumsum(x, axis=2))
 
+  def test_associative_scan(self):
+    helper_test_op([(10,)], lambda x: torch.cumsum(x, dim=0), lambda x: x.associative_scan(lambda a,b: a+b, axis=0))
+    helper_test_op([(5,7)], lambda x: torch.cumsum(x, dim=1), lambda x: x.associative_scan(lambda a,b: a+b, axis=1))
+    helper_test_op([(10,)], lambda x: torch.cumprod(x, dim=0), lambda x: x.associative_scan(lambda a,b: a*b, axis=0))
+    helper_test_op([(10,)], lambda x: torch.cummax(x, dim=0).values, lambda x: x.associative_scan(lambda a,b: a.maximum(b), axis=0))
+    helper_test_op([(10,)], lambda x: torch.flip(torch.cumsum(torch.flip(x, (0,)), dim=0), (0,)),
+                   lambda x: x.associative_scan(lambda a,b: a+b, axis=0, reverse=True))
+    helper_test_op([(2,0,4)], lambda x: torch.cumsum(x, dim=1), lambda x: x.associative_scan(lambda a,b: a+b, axis=1))
+
+  def test_associative_scan_affine(self):
+    vals = np.array([[1.2, 0.5], [-0.7, 1.0], [0.3, -2.0], [1.5, 0.25]], dtype=np.float32)
+    expected, acc = [], np.array([1, 0], dtype=np.float32)
+    for a, b in vals:
+      acc = np.array([a*acc[0], a*acc[1]+b], dtype=np.float32)
+      expected.append(acc)
+    expected_rev = []
+    for start in range(len(vals)):
+      acc = np.array([1, 0], dtype=np.float32)
+      for a, b in vals[start:]:
+        acc = np.array([a*acc[0], a*acc[1]+b], dtype=np.float32)
+      expected_rev.append(acc)
+    def compose(left, right):
+      la, lb, ra, rb = left[:, 0:1], left[:, 1:2], right[:, 0:1], right[:, 1:2]
+      return (ra*la).cat(ra*lb+rb, dim=1)
+    np.testing.assert_allclose(Tensor(vals).associative_scan(compose, axis=0).numpy(), np.array(expected), rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(Tensor(vals).associative_scan(compose, axis=0, reverse=True).numpy(), np.array(expected_rev), rtol=1e-6, atol=1e-6)
+
   def test_small_cumprod(self):
     helper_test_op([(10)],lambda x: torch.cumprod(x, dim=0),lambda x: Tensor.cumprod(x, axis=0))
   @slow_test

--- a/test/null/test_tensor_uop_mixin.py
+++ b/test/null/test_tensor_uop_mixin.py
@@ -98,6 +98,12 @@ class TestTensorUOpCumalu(unittest.TestCase):
   def test_cumsum_non_last(self): _check(self, _t(3, 4), lambda x: x.cumsum(0))
   def test_cumsum_large(self):    _check(self, _t(600), lambda x: x.cumsum())  # exercises _split_cumalu
   def test_cumprod(self):         _check(self, _t(4), lambda x: x.cumprod(0))
+  def test_associative_scan(self):          _check(self, _t(5), lambda x: x.associative_scan(lambda a,b: a+b))
+  def test_associative_scan_non_last(self): _check(self, _t(3, 4), lambda x: x.associative_scan(lambda a,b: a+b, 0))
+  def test_associative_scan_reverse(self):  _check(self, _t(5), lambda x: x.associative_scan(lambda a,b: a*b, reverse=True))
+  def test_associative_scan_schedule_size(self):
+    linear = Tensor.empty(256).associative_scan(lambda a,b: a+b).schedule_linear().src
+    self.assertLess(sum(len(si.toposort()) for si in linear), 512)
 
 class TestTensorUOpCumMinMax(unittest.TestCase):
   def _check_pair(self, t, fn):

--- a/tinygrad/mixin/__init__.py
+++ b/tinygrad/mixin/__init__.py
@@ -656,6 +656,18 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     def fix(x: Self) -> Self: return x.flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
     return getattr(fix(ret), {Ops.ADD: "add", Ops.MAX: "maximum", Ops.MUL: "mul"}[op])(fix(base))
 
+  def associative_scan(self, combine_fn:Callable[[Self, Self], Self], axis:int=0, reverse:bool=False) -> Self:
+    axis = self._resolve_dim(axis)
+    if self.ndim == 0 or 0 in self.shape: return self
+    if not isinstance(n:=self.shape[axis], int): raise RuntimeError("associative_scan requires a concrete scan axis")
+    def slc(x:Self, start:int, end:int) -> Self: return x.shrink(tuple((start, end) if i == axis else None for i in range(x.ndim)))
+    ret = self.flip(axis) if reverse else self
+    fn = (lambda left, right: combine_fn(right, left)) if reverse else combine_fn
+    for stride in itertools.takewhile(lambda x: x < n, (1 << i for i in itertools.count())):
+      # keep codegen from fusing every doubling stage into one large tree
+      ret = slc(ret, 0, stride).cat(fn(slc(ret, 0, n-stride), slc(ret, stride, n)), dim=axis).contiguous()
+    return ret.flip(axis) if reverse else ret
+
   def cumsum(self, axis:int=0) -> Self:
     """
     Computes the cumulative sum of the tensor along the specified `axis`.


### PR DESCRIPTION
Adds a first pass at `Tensor.associative_scan(combine_fn, axis=0, reverse=False)` using existing tensor ops.

This references #3039 for tracking. Opening as a draft for API and implementation feedback.

Covered so far:
- inclusive scan for single Tensor inputs
- arbitrary axis and empty scan axes
- add, mul, max comparisons against torch cumulative ops
- affine composition as a non-commutative scan case
- reverse scan order for non-commutative functions
- UOp/null coverage
- schedule-size regression for the staged scan path

Tests:
- `.venv/bin/python -m pytest -q test/backend/test_ops.py::TestOps::test_associative_scan test/backend/test_ops.py::TestOps::test_associative_scan_affine`
- `.venv/bin/python -m pytest -q test/null/test_tensor_uop_mixin.py::TestTensorUOpCumalu test/null/test_dtype_spec.py::TestAutoCastType::test_cumsum`
- `git diff --check`