### PR TITLE
fold direct nested where with same condition

### DIFF
--- a/test/backend/test_renderer_failures.py
+++ b/test/backend/test_renderer_failures.py
@@ -11,6 +11,7 @@ from tinygrad.renderer.wgsl import WGSLRenderer
 from tinygrad.runtime.ops_python import PythonRenderer
 from tinygrad.uop.ops import UOp, Ops, KernelInfo, python_alu
 from tinygrad.tensor import Tensor, _to_np_dtype
+from test.helpers import replace_opts
 
 def _test_uop_result(inputs:list[Tensor], sink:UOp, local_size=None):
   for x in inputs: x.realize()
@@ -74,6 +75,17 @@ class TestCStyleFailures(unittest.TestCase):
   @unittest.skipIf(isinstance(Device[Device.DEFAULT].renderer, WGSLRenderer), "wgsl ends up with '(' * 5")
   def test_repeat_and(self): self._test_src_strip_paren(Ops.AND)
   def test_repeat_sub(self): self._test_src_strip_paren(Ops.SUB, should_strip_paren=False)
+
+class TestCPUSourceFailures(unittest.TestCase):
+  def test_where_closure_fold_direct_branch_source(self):
+    x = Tensor.empty(3, device="CPU")
+    y = Tensor.empty(3, device="CPU")
+    z = Tensor.empty(3, device="CPU")
+    out = (x<0).where((x<0).where(y, z), (x<0).where(y+1, z+1))
+    linear = out.schedule_linear()
+    assert len(linear.src) == 1
+    src = to_program(replace_opts(linear.src[0].src[0], []), Device["CPU"].renderer).src[3].arg
+    self.assertEqual(src.count("?"), 1)
 
 @unittest.skipUnless(isinstance(Device[Device.DEFAULT].renderer, WGSLRenderer), "tests for wgsl renderer")
 class TestWGSLFailures(unittest.TestCase):

--- a/test/backend/test_renderer_failures.py
+++ b/test/backend/test_renderer_failures.py
@@ -4,8 +4,8 @@ from tinygrad.device import Device, is_dtype_supported
 from tinygrad.dtype import dtypes, ConstType
 from tinygrad.engine.realize import run_linear
 from tinygrad.codegen import to_program
-from tinygrad.helpers import prod
-from tinygrad.renderer.cstyle import CStyleLanguage
+from tinygrad.helpers import prod, Target
+from tinygrad.renderer.cstyle import CStyleLanguage, ClangRenderer
 from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.renderer.wgsl import WGSLRenderer
 from tinygrad.runtime.ops_python import PythonRenderer
@@ -84,7 +84,7 @@ class TestCPUSourceFailures(unittest.TestCase):
     out = (x<0).where((x<0).where(y, z), (x<0).where(y+1, z+1))
     linear = out.schedule_linear()
     assert len(linear.src) == 1
-    src = to_program(replace_opts(linear.src[0].src[0], []), Device["CPU"].renderer).src[3].arg
+    src = to_program(replace_opts(linear.src[0].src[0], []), ClangRenderer(Target("CPU"))).src[3].arg
     self.assertEqual(src.count("?"), 1)
 
 @unittest.skipUnless(isinstance(Device[Device.DEFAULT].renderer, WGSLRenderer), "tests for wgsl renderer")

--- a/test/null/test_uop_symbolic.py
+++ b/test/null/test_uop_symbolic.py
@@ -974,6 +974,16 @@ class TestSymbolic(unittest.TestCase):
     # (a if ((s<5)&(s<6)) else b) -> (a if (s<5) else b)
     self.helper_test_variable(expr, 0, 3, "(s<5).where(a, b)")
 
+  def test_where_closure_folding_direct_branch(self):
+    x = Variable("x", 0, 10)
+    cond = x < 5
+    a = Variable("a", 0, 3)
+    b = Variable("b", 0, 3)
+    d = Variable("d", 0, 3)
+    e = Variable("e", 0, 3)
+    expr = cond.where(cond.where(a, b), cond.where(d, e))
+    self.helper_test_variable(expr, 0, 3, "(x<5).where(a, e)")
+
   @unittest.expectedFailure
   def test_where_closure_folding(self):
     # cond.where(t, f) where f contains cond.where(a, b) should fold the inner where to b in false branch

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -150,6 +150,8 @@ symbolic_simple = propagate_invalid + PatternMatcher([
   # a conditional with the same results either way is a noop, also fold const conditionals
   (UPat.var().where(UPat.var("val"), UPat.var("val")), lambda val: val),
   (UPat.cvar("gate", vec=False).where(UPat.var("c0"), UPat.var("c1")), lambda gate, c0, c1: c0 if gate.arg else c1),
+  (UPat.var("c").where(UPat.var("c").where(UPat.var("a"), UPat.var()), UPat.var("f")), lambda c,a,f: c.where(a,f)),
+  (UPat.var("c").where(UPat.var("t"), UPat.var("c").where(UPat.var(), UPat.var("b"))), lambda c,t,b: c.where(t,b)),
   # a.where(b.where(c, d), d) -> (a & b).where(c, d)
   (UPat.var("a").where(UPat.var("b").where(UPat.var("c"), UPat.var("d")), UPat.var("d")), lambda a,b,c,d: (a&b).where(c,d)),
 ])
@@ -412,15 +414,6 @@ def gated_given_valid(cond:UOp, x:UOp, i:UOp) -> UOp|None:
   if IMAGE.value > 0 and x.op_in_backward_slice_with_self(Ops.CDIV, Ops.CMOD, Ops.FLOORDIV, Ops.FLOORMOD): return None
   return cond.where(uop_given_valid(cond, x, try_simplex=False), i)
 
-# TODO: this is O(number of WHERE * number of node)
-# def fold_where_closure(cond:UOp, t:UOp, f:UOp) -> UOp|None:
-#   """In cond.where(t, f), fold nested cond.where(a, b) -> a in t, -> b in f"""
-#   def is_valid_where(u:UOp) -> bool: return u.op is Ops.WHERE and u.src[0] is cond and Invalid not in (u.src[1].arg, u.src[2].arg)
-#   t_subs, f_subs = {u: u.src[1] for u in t.toposort() if is_valid_where(u)}, {u: u.src[2] for u in f.toposort() if is_valid_where(u)}
-#   if not t_subs and not f_subs: return None
-#   new_t, new_f = t.substitute(t_subs).simplify() if t_subs else t, f.substitute(f_subs).simplify() if f_subs else f
-#   return None if new_t is t and new_f is f else cond.where(new_t, new_f)
-
 pm_simplify_valid = PatternMatcher([
   # simplify valid
   (UPat(Ops.AND, name="valid"), simplify_valid),
@@ -434,8 +427,6 @@ sym = symbolic+pm_simplify_valid+PatternMatcher([
   (UPat(GroupOp.ALU, src=(UPat(Ops.STACK, src=UPat(name='x')), UPat(Ops.STACK, src=UPat(name='y'))), name='alu'),
    lambda x,y,alu: UOp(Ops.STACK, alu.dtype, (UOp(alu.op, alu.dtype.scalar(), (x,y)),)*alu.dtype.count)),
   # ** where **
-  # # fold nested where with same condition: in cond.where(t,f), cond.where(a,b)->a in t, ->b in f
-  # (UPat.var("cond").where(UPat.var("t"), UPat.var("f")), fold_where_closure),
   # push cast to branches
   (UPat.var("s").where(UPat.var("a"), UPat.var("b")).cast().named("cast"), lambda s,a,b,cast: s.where(a.cast(cast.dtype), b.cast(cast.dtype))),
   # ** pow **


### PR DESCRIPTION
Fixes #12485

Adds direct symbolic folds for nested where with the same condition in either direct branch, only handling the direct issue scope

Tested with DEV=CPU .venv/bin/python -m pytest test/null/test_uop_symbolic.py::TestSymbolic::test_where_closure_folding_direct_branch -q. Tested with DEV=CPU .venv/bin/python -m pytest test/backend/test_renderer_failures.py::TestCPUSourceFailures::test_where_closure_fold_direct_branch_source -q. Tested with DEV=CPU .venv/bin/python -m pytest test/null/test_uop_symbolic.py test/backend/test_renderer_failures.py -q. Tested with DEV=METAL .venv/bin/python -m pytest test/backend/test_renderer_failures.py::TestCPUSourceFailures::test_where_closure_fold_direct_branch_source -q. Tested with .venv/bin/python -m ruff check tinygrad/uop/symbolic.py test/null/test_uop_symbolic.py test/backend/test_renderer_failures.py.