### PR TITLE
jit: update bound symbolic return shapes

### DIFF
--- a/test/backend/test_symbolic_jit.py
+++ b/test/backend/test_symbolic_jit.py
@@ -189,6 +189,16 @@ class TestSymbolicJit(unittest.TestCase):
       np.testing.assert_allclose(symbolic, expected, atol=1e-6, rtol=1e-6)
     assert_jit_cache_len(jf, 1)
 
+  def test_jit_updates_bound_symbolic_return_shape(self):
+    def f(a): return (a+1).realize()
+    jf = TinyJit(f)
+    for i in range(1, 5):
+      vi = Variable("i", 1, 10).bind(i)
+      out = jf(Tensor.arange(10).shrink(((0, vi),)))
+      self.assertEqual(out.shape[0].val, i)
+      np.testing.assert_equal(out[:i].numpy(), np.arange(1, i+1))
+    assert_jit_cache_len(jf, 1)
+
   def test_slice(self):
     # slice is a movement, so we pair it with a simple function to test the JIT interaction
     def f(a): return (a+1).realize()

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -178,8 +178,10 @@ class MultiGraphRunner(GraphRunner):
 
 ReturnType = TypeVar('ReturnType')
 def _update_return_bind_values(ret:ReturnType, var_vals:dict[str, int]) -> ReturnType:
+  if not var_vals: return ret
   def update_tensor(t:Tensor):
-    replacements = {u:u.src[0].bind(var_vals[u.src[0].expr]) for u in t.uop.toposort()
+    shape_uops = [s for s in t.shape if isinstance(s, UOp)]
+    replacements = {u:u.src[0].bind(var_vals[u.src[0].expr]) for s in shape_uops for u in s.toposort()
                     if u.op is Ops.BIND and u.src[0].op is Ops.DEFINE_VAR and u.src[1].op is Ops.CONST
                     and u.src[0].expr in var_vals and u.src[1].arg != var_vals[u.src[0].expr]}
     if replacements: t.uop = t.uop.substitute(replacements)

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -177,6 +177,19 @@ class MultiGraphRunner(GraphRunner):
     return new_call.src[0].op in (Ops.PROGRAM, Ops.COPY) and len(dedup([type(d) for d in GraphRunner._all_devs(batch_devs, new_call)])) == 1
 
 ReturnType = TypeVar('ReturnType')
+def _update_return_bind_values(ret:ReturnType, var_vals:dict[str, int]) -> ReturnType:
+  def update_tensor(t:Tensor):
+    replacements = {u:u.src[0].bind(var_vals[u.src[0].expr]) for u in t.uop.toposort()
+                    if u.op is Ops.BIND and u.src[0].op is Ops.DEFINE_VAR and u.src[1].op is Ops.CONST
+                    and u.src[0].expr in var_vals and u.src[1].arg != var_vals[u.src[0].expr]}
+    if replacements: t.uop = t.uop.substitute(replacements)
+  if isinstance(ret, Tensor): update_tensor(ret)
+  elif isinstance(ret, (tuple, list)):
+    for item in ret: _update_return_bind_values(item, var_vals)
+  elif isinstance(ret, dict):
+    for item in ret.values(): _update_return_bind_values(item, var_vals)
+  return ret
+
 @dataclass
 class CapturedJit(Generic[ReturnType]):
   ret: Any  # includes the Tensors or any other returned object
@@ -200,7 +213,7 @@ class CapturedJit(Generic[ReturnType]):
     concrete = tuple(_copy_input(u) if u in self._written_uops else u for u in input_uops)
     if DEBUG >= 1 and len(self.linear.src) >= 10: print(f"jit execs {len(self.linear.src)} calls")
     run_linear(self.linear, var_vals, input_uops=concrete, jit=True)
-    return self.ret
+    return _update_return_bind_values(self.ret, var_vals)
 
   def free_intermediates(self):
     # drop graph runners


### PR DESCRIPTION
min fix for #5360

Tests:
DEV=CPU .venv/bin/python -m pytest test/backend/test_symbolic_jit.py::TestSymbolicJit::test_jit_updates_bound_symbolic_return_shape -q
DEV=CPU .venv/bin/python -m pytest test/backend/test_symbolic_jit.py -q
DEV=METAL .venv/bin/python -m pytest test/backend/test_symbolic_jit.py::TestSymbolicJit::test_jit_updates_bound_symbolic_return_shape -q
DEV=CPU .venv/bin/python -m pytest test/backend/test_jit.py -q
.venv/bin/python -m ruff check tinygrad/engine/jit.py test/backend/test_symbolic_jit.py
