### PR TITLE
speed up jit buffer input prep [pr] [AI SLOP]

### DIFF
--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -226,7 +226,9 @@ def _prepare_jit_inputs(args, kwargs):
   # collect buffer UOps (including MultiBuffer)
   input_buf_uops: list[UOp] = [u.base for u in input_uops if u.base.realized is not None]
   if len(set(input_buf_uops)) != len(input_buf_uops): raise JitError("duplicate inputs to JIT")
-  inputs = [(*(u.substitute({u.base:UOp(Ops.NOOP)}, extra_pm=mop_cleanup).unbind_all()), u.dtype, u.device) for u in input_uops]
+  noop = UOp(Ops.NOOP)
+  inputs = [(noop, {}, u.dtype, u.device) if u.op is Ops.BUFFER else
+            (*(u.substitute({u.base:noop}, extra_pm=mop_cleanup).unbind_all()), u.dtype, u.device) for u in input_uops]
   _var_vals = merge_dicts([x[1] for x in inputs] + [dict(v.unbind() for v in (args + tuple(kwargs.values())) if isinstance(v, UOp))])
   var_vals = {k.expr:v for k,v in _var_vals.items()}
   expected_input_info = [(x[0], tuple(sorted(x[1].keys(), key=lambda v: v.expr)), x[2], x[3]) for x in inputs]


### PR DESCRIPTION
found this speedup on mac

m4 metal tinyjit replay: 30k calls median 1.34s vs 1.94s with old input prep