### PR TITLE
Fix Tensor.to list device type check under TYPED=1

### DIFF
--- a/test/null/test_tensor.py
+++ b/test/null/test_tensor.py
@@ -190,6 +190,11 @@ class TestTensorDevice(unittest.TestCase):
   def test_create_from_single_device_tuple(self):
     (Tensor([1.0], device=(Device.DEFAULT,)) + Tensor([2.0])).realize()
 
+  def test_to_list_device(self):
+    x = Tensor([1,2,3])
+    y = x.to(["CPU"])
+    self.assertEqual(y.device, "CPU")
+
 class TestTensorPad(unittest.TestCase):
   # padding int tensor with float-only value (like -inf) must promote dtype to fit value
   def test_pad_int_with_neg_inf(self):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -364,16 +364,17 @@ class Tensor(OpMixin):
     if self.grad is not None: ret.grad = self.grad.clone()
     return ret.assign(self)
 
-  def to(self, device:str|tuple[str, ...]|None) -> Tensor:
+  def to(self, device:str|tuple[str, ...]|list[str]|None) -> Tensor:
     """
     Moves the tensor to the given device.
     """
-    if (device:=canonicalize_device(device)) == self.device: return self
+    device = canonicalize_device(device)
+    if device == self.device: return self
     ret = Tensor(self.uop.copy_to_device(device), requires_grad=self.requires_grad)
     if self.grad is not None: ret.grad = self.grad.to(device)
     return ret
 
-  def to_(self, device:str|tuple[str, ...]|None) -> Tensor:
+  def to_(self, device:str|tuple[str, ...]|list[str]|None) -> Tensor:
     """
     Moves the tensor to the given device in place.
     """


### PR DESCRIPTION
This fixes part of #7889 by fixing a runtime type checking failure when calling Tensor.to(["CPU"]) with TYPED=1 enabled. canonicalize_device already accepts list devices, but Tensor.to and Tensor.to_ did not include list[str] in their annotations, so Typeguard rejected the input before canonicalization.

I also replaced the walrus assignment with a normal assignment because the previous form produced incorrect behavior under TYPED=1 before reaching copy_to_device. This keeps the behavior the same while making the type-checked path work correctly. 

Tested with:

PYTHONPATH=. TYPED=1 python3 -m unittest test.null.test_tensor.TestTensorDevice

PYTHONPATH=. TYPED=1 python3 -c "from tinygrad import Tensor; x=Tensor([1,2,3]); print(x.to(['CPU']))"

This is my first PR to tinygrad, so I would appreciate feedback if there is a better way to structure this fix. If this PR is not a good fit, I would appreciate knowing why so my future contributions have a higher chance of getting accepted.