### PR TITLE
system: apply base_class filter to macOS pci_scan_bus

### DIFF
--- a/tinygrad/runtime/support/system.py
+++ b/tinygrad/runtime/support/system.py
@@ -62,7 +62,9 @@ class _System:
         return int.from_bytes(bytes(buf), "little")
 
       iokit.IOServiceGetMatchingServices(0, iokit.IOServiceMatching(b"IOPCIDevice"), ctypes.byref(iterator:=ctypes.c_uint()))
-      while svc:=iokit.IOIteratorNext(iterator): all_devs.append((v:=read_prop(svc, "vendor-id"), d:=read_prop(svc, "device-id"), f"{v:x}:{d:x}"))
+      while svc:=iokit.IOIteratorNext(iterator):
+        if base_class is not None and read_prop(svc, "class-code") >> 16 != base_class: continue
+        all_devs.append((v:=read_prop(svc, "vendor-id"), d:=read_prop(svc, "device-id"), f"{v:x}:{d:x}"))
     else:
       try: devs = FileIOInterface("/sys/bus/pci/devices")
       except FileNotFoundError: raise RuntimeError("no pcie")


### PR DESCRIPTION
## Summary
- The Linux path in `pci_scan_bus()` filters PCI devices by `base_class` (class-code >> 16), but the macOS IOKit enumeration path was missing this filter
- On systems with NVIDIA GPUs, the audio device (`10de:228e`, class `0x04`) gets enumerated before the GPU (`10de:2504`, class `0x03`), causing TinyGPU to initialize the wrong device
- Adds the same `class-code` check to the macOS path that already exists on Linux

## Test plan
- [x] Tested on Mac Mini M4 + RTX 3060 via Sonnet Breakaway Box (USB4/Thunderbolt)
- [x] With fix: GPU correctly targeted, initialization proceeds to Falcon firmware loading
- [x] Without fix: audio device selected first, immediate BAR read failure

Related: #15813

🤖 Generated with [Claude Code](https://claude.com/claude-code)