### PR TITLE
llama: use hipcc 7.1

### DIFF
--- a/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/dev_beam.sh
+++ b/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/dev_beam.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export PYTHONPATH="."
+export PATH="/opt/rocm-7.1.1/bin:$PATH"
 export DEV=${DEV:-AMD}
 export CHECK_OOB=0
 export REWRITE_STACK_LIMIT=5000000 HCQDEV_WAIT_TIMEOUT_MS=240000

--- a/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/dev_beam_mp.sh
+++ b/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/dev_beam_mp.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export PYTHONPATH="."
+export PATH="/opt/rocm-7.1.1/bin:$PATH"
 export DEV=${DEV:-AMD}
 export CHECK_OOB=0
 export REWRITE_STACK_LIMIT=5000000 HCQDEV_WAIT_TIMEOUT_MS=240000

--- a/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/dev_run.sh
+++ b/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/dev_run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export PYTHONPATH="."
+export PATH="/opt/rocm-7.1.1/bin:$PATH"
 export DEV=${DEV:-AMD}
 export CHECK_OOB=0
 export REWRITE_STACK_LIMIT=5000000 HCQDEV_WAIT_TIMEOUT_MS=240000

--- a/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/dev_run_mp.sh
+++ b/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/dev_run_mp.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export PYTHONPATH="."
+export PATH="/opt/rocm-7.1.1/bin:$PATH"
 export DEV=${DEV:-AMD}
 export EMULATE="AMD_CDNA4"
 export CHECK_OOB=0

--- a/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/run_and_time.sh
+++ b/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/run_and_time.sh
@@ -3,6 +3,7 @@ set -e  # Exit on any error
 set -o pipefail  # Make pipeline fail if any command fails
 
 export PYTHONPATH="."
+export PATH="/opt/rocm-7.1.1/bin:$PATH"
 export DEV=AMD
 export CHECK_OOB=0
 export REWRITE_STACK_LIMIT=5000000 HCQDEV_WAIT_TIMEOUT_MS=240000


### PR DESCRIPTION
7.1 used to get ~3 PFLOPS for the FP8 GEMM, 7.2 regressed it to ~900 TFLOPS.
<img width="2560" height="696" alt="image" src="https://github.com/user-attachments/assets/e433c8af-b492-4d4a-9b41-79238a0e8e5e" />
