### PR TITLE
nv: route falcon HS DMA via sysmem when BAR1 doesn't fully map VRAM

### DIFF
--- a/tinygrad/runtime/support/nv/ip.py
+++ b/tinygrad/runtime/support/nv/ip.py
@@ -235,8 +235,12 @@ class NV_FLCN(NV_IP):
   def execute_hs(self, base, img_paddr, code_off, data_off, imemPa, imemVa, imemSz, dmemPa, dmemVa, dmemSz, pkc_off, engid, ucodeid, mailbox=None):
     self.disable_ctx_req(base)
 
-    # target=0 is FB (not in published headers)
-    self.nvdev.NV_PFALCON_FBIF_TRANSCFG.with_base(base)[ctx_dma:=0].update(target=0, mem_type=self.nvdev.NV_PFALCON_FBIF_TRANSCFG_MEM_TYPE_PHYSICAL)
+    # target=0 is FB (not in published headers); target=1 is COHERENT_SYSMEM.
+    # On small-BAR systems _alloc_boot_mem returns sysmem-backed buffers, so the Falcon
+    # has to DMA from system memory rather than from VRAM through the (too-small) BAR1 window.
+    target = 0 if self.nvdev.large_bar else self.nvdev.NV_PFALCON_FBIF_TRANSCFG_TARGET_COHERENT_SYSMEM
+    self.nvdev.NV_PFALCON_FBIF_TRANSCFG.with_base(base)[ctx_dma:=0].update(target=target,
+      mem_type=self.nvdev.NV_PFALCON_FBIF_TRANSCFG_MEM_TYPE_PHYSICAL)
 
     cmd = self.nvdev.NV_PFALCON_FALCON_DMATRFCMD.with_base(base).encode(write=0, size=self.nvdev.NV_PFALCON_FALCON_DMATRFCMD_SIZE_256B,
       ctxdma=ctx_dma, imem=1, sec=1)

--- a/tinygrad/runtime/support/nv/nvdev.py
+++ b/tinygrad/runtime/support/nv/nvdev.py
@@ -147,6 +147,9 @@ class NVDev:
 
   def _alloc_boot_mem(self, size:int, data:bytes|None=None, contiguous:bool=False, sysmem:bool|None=None) -> tuple[MMIOInterface, int, list[int]]:
     sz = round_up(size, 0x1000)
+    # Small-BAR systems can't safely DMA with target=FB from BAR1-windowed VRAM (the host-side PCIe paddr
+    # is not what the GPU's FB controller sees). Force sysmem for boot allocations in that case.
+    if sysmem is False and not self.large_bar: sysmem = True
     if sysmem is True or (sysmem is None and not self.large_bar): view, paddrs = self.pci_dev.alloc_sysmem(size, 0, contiguous=contiguous)
     else:
       paddr = self.mm.palloc(sz, boot=False)


### PR DESCRIPTION
## Problem

On NV eGPU setups where the host bridge MMIO window is too small for Resizable BAR to grow BAR1 to cover full VRAM (e.g. Apple Silicon + Thunderbolt 3, where macOS assigns a 256 MB MMIO window), `Device['NV']` deterministically times out in `init_hw` → `execute_hs` → `execute_dma`:

```
TimeoutError: DMA does not progress. Timed out after 10000 ms, condition not met: 1 != 0
```

The Falcon HS DMA queue (32 × 256 B = 8 KB) fills and never drains before any firmware runs.

## Root cause

`_alloc_boot_mem` puts FRTS / booter images into VRAM (callers force `sysmem=False` at `ip.py:166` and `ip.py:182`) and returns `paddrs = [bar1_base + paddr]` — host-side PCIe addresses of the partial BAR1 window. `execute_hs` then hardcodes `FBIF_TRANSCFG.target = 0 (FB)` and hands those host paddrs to `DMATRFBASE`. The Falcon's FB controller doesn't see those as valid FB addresses, the reads error / never complete, and the queue stalls.

This works on systems with `large_bar = True` because BAR1 fully maps VRAM and the chipset is set up such that `bar1_base + offset` equals the GPU-side FB physical address. With small-BAR it breaks.

## Fix

Two coordinated changes:

- `nvdev.py::_alloc_boot_mem`: when `large_bar=False`, override callers passing `sysmem=False` to use sysmem. With a partial BAR window the VRAM path can't safely back DMA-from-FB.
- `ip.py::execute_hs`: configure `FBIF_TRANSCFG.target = COHERENT_SYSMEM` when `large_bar=False`, so the Falcon DMA reads from system memory at the host paddrs returned by `_alloc_boot_mem`.

Behaviour on `large_bar=True` systems is unchanged.

## Tested on

- MacBook Pro `Mac14,5`, Apple M2 Max, macOS 26.4.1 (build 25E253), 64 GB
- Razer Core X Chroma (TB3, Intel Titan Ridge), TB link 40 Gb/s
- Gigabyte RTX 3080 10 GB (`10de:2206`)
- `large_bar = False` (BAR1 stuck at 256 MB, ReBAR resize denied by bridge window — ReBAR cap advertises up to 16 GB)
- tinygrad master at \`a12070967\`, TinyGPU.app commit \`c0d024f9\`

Without the patch: \`Device['NV']\` hits the FRTS DMA timeout above 100% of the time.

With the patch:

\`\`\`
$ DEV=NV python3 -c "
from tinygrad import Tensor, Device
import numpy as np
print(Device['NV'])
a = Tensor([1.,2.,3.], device='NV'); b = Tensor([10.,20.,30.], device='NV')
print('add:', (a+b).numpy())
N=512
x = Tensor(np.random.randn(N,N).astype('float32'), device='NV')
y = Tensor(np.random.randn(N,N).astype('float32'), device='NV')
z = (x@y).numpy()
print('matmul std:', float(z.std()))  # expect ~sqrt(N) = 22.6
"
<tinygrad.runtime.ops_nv.NVDevice object at 0x10ad28830>
add: [11. 22. 33.]
matmul std: 22.65
\`\`\`

## Notes

- I'd love a second pair of eyes confirming \`COHERENT_SYSMEM\` is the right choice vs \`NONCOHERENT_SYSMEM\` here. Coherent worked; I didn't try noncoherent.
- The \`_alloc_boot_mem\` override silently changes the meaning of an explicit \`sysmem=False\`. If you'd prefer the change isolated to the FRTS / booter call sites (\`ip.py:166\`, \`ip.py:182\`) instead of \`_alloc_boot_mem\`, happy to refactor.