### PR TITLE
nn: add TernaryLinear — ternary-quantized weights {-1, 0, +1}

### DIFF
--- a/test/unit/test_ternary_linear.py
+++ b/test/unit/test_ternary_linear.py
@@ -1,0 +1,53 @@
+import numpy as np
+import unittest
+from tinygrad import Tensor, nn
+from tinygrad.helpers import Context
+
+class TestTernaryLinear(unittest.TestCase):
+  def test_weights_are_ternary(self):
+    with Context(DEV="PYTHON"):
+      lin = nn.TernaryLinear(16, 8)
+      w = lin.weight.numpy()
+      assert set(w.flatten().tolist()).issubset({-1.0, 0.0, 1.0}), f"unexpected values: {np.unique(w)}"
+
+  def test_output_shape(self):
+    with Context(DEV="PYTHON"):
+      lin = nn.TernaryLinear(4, 3, bias=False)
+      x = Tensor.rand(2, 4)
+      y = lin(x)
+      assert y.shape == (2, 3), f"expected (2, 3), got {y.shape}"
+
+  def test_threshold_zero_no_zeros(self):
+    # threshold=0 means every weight becomes ±1 (|w| > 0 for all non-zero uniform samples)
+    with Context(DEV="PYTHON"):
+      lin = nn.TernaryLinear(32, 16, bias=False, threshold=0.0)
+      w = lin.weight.numpy()
+      assert 0.0 not in w.flatten().tolist(), "threshold=0 should leave no zero weights"
+      assert set(w.flatten().tolist()).issubset({-1.0, 1.0})
+
+  def test_threshold_large_all_zeros(self):
+    with Context(DEV="PYTHON"):
+      lin = nn.TernaryLinear(8, 4, bias=False, threshold=1e9)
+      w = lin.weight.numpy()
+      np.testing.assert_array_equal(w, np.zeros_like(w))
+
+  def test_forward_matches_manual(self):
+    with Context(DEV="PYTHON"):
+      lin = nn.TernaryLinear(4, 2, bias=False, threshold=1e9)
+      lin.weight = Tensor([[1., 0., -1., 0.], [0., 1., 0., 1.]])
+      x = Tensor([[2., 3., 4., 5.]])
+      y = lin(x).numpy()
+      # row 0: 1*2 + 0*3 + (-1)*4 + 0*5 = -2
+      # row 1: 0*2 + 1*3 + 0*4 + 1*5  = 8
+      np.testing.assert_allclose(y, [[-2., 8.]], atol=1e-5)
+
+  def test_bias_shape(self):
+    lin = nn.TernaryLinear(6, 3, bias=True)
+    assert lin.bias is not None and lin.bias.shape == (3,)
+
+  def test_no_bias(self):
+    lin = nn.TernaryLinear(6, 3, bias=False)
+    assert lin.bias is None
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -176,6 +176,33 @@ class Linear:
 
   def __call__(self, x:Tensor) -> Tensor: return x.linear(self.weight.transpose(), self.bias)
 
+class TernaryLinear:
+  """
+  Linear layer with weights quantized to {-1, 0, +1} at construction time.
+
+  Implements the ternary weight scheme from the BitNet b1.58 paper
+  (arxiv.org/abs/2402.17764). Weights whose absolute value exceeds *threshold*
+  become ±1; those within the threshold become 0. The default threshold is the
+  mean absolute weight value, matching the paper's prescription.
+
+  Quantized weights are stored as a float ``Tensor`` so the forward pass works
+  on any tinygrad backend unchanged.
+
+  ```python exec="true" source="above" session="tensor" result="python"
+  lin = nn.TernaryLinear(8, 4, threshold=0.0)
+  import numpy as np
+  print(np.unique(lin.weight.numpy()))
+  ```
+  """
+  def __init__(self, in_features:int, out_features:int, bias=True, threshold:float|None=None):
+    bound = 1 / math.sqrt(in_features)
+    w = Tensor.uniform(out_features, in_features, low=-bound, high=bound)
+    t = w.abs().mean() if threshold is None else threshold
+    self.weight = (w.abs() > t).where(w.sign(), 0).cast(dtypes.float32)
+    self.bias: Tensor|None = Tensor.zeros(out_features) if bias else None
+
+  def __call__(self, x:Tensor) -> Tensor: return x.linear(self.weight.transpose(), self.bias)
+
 class GroupNorm:
   """
   Applies Group Normalization over a mini-batch of inputs.


### PR DESCRIPTION
## What

Adds `TernaryLinear` to `tinygrad/nn/__init__.py` — a drop-in for `Linear` that stores weights quantized to `{-1, 0, +1}`.

## Why

Modern ternary-weight models (BitNet b1.58, et al.) train directly in `{-γ, 0, +γ}` rather than quantizing post-training. At ≥50% sparsity, zero weights are dead MACs — no multiply needed, just add-or-skip. Storing the quantized weight tensor as float lets backends that exploit structural sparsity benefit without requiring special hardware.

This adds the primitive. Backends can specialize `linear()` on ternary-valued weight tensors independently.

## Design

```python
lin = nn.TernaryLinear(in_features, out_features, bias=True, threshold=None)
```

- `threshold=None`: uses mean absolute weight value as the quantization boundary (the BitNet b1.58 rule: arxiv.org/abs/2402.17764, §3.1)
- `threshold=0.0`: all weights become ±1, no zeros
- `threshold=1e9`: all weights become 0 (degenerate case, useful for manual weight injection in tests)

Quantization at construction:

```
w_ternary = sign(w)  if |w| > threshold
            0        otherwise
```

Stored as `float32` — forward pass identical to `Linear`, works on every backend today.

## Tests

Seven unit tests in `test/unit/test_ternary_linear.py`:

| Test | Checks |
|------|--------|
| `test_weights_are_ternary` | all values in `{-1, 0, 1}` after init |
| `test_output_shape` | `(batch, out_features)` correct |
| `test_threshold_zero_no_zeros` | threshold=0 → no zero weights |
| `test_threshold_large_all_zeros` | threshold=1e9 → all zeros |
| `test_forward_matches_manual` | hand-computed 2×4 result |
| `test_bias_shape` | bias tensor shape |
| `test_no_bias` | `bias=False` → `None` |

All 7 pass on the PYTHON interpreter backend (no clang dependency in CI).