### PR TITLE
filter by base_class in pci_scan_bus on macOS

### DIFF
--- a/tinygrad/runtime/support/system.py
+++ b/tinygrad/runtime/support/system.py
@@ -62,7 +62,9 @@ class _System:
         return int.from_bytes(bytes(buf), "little")
 
       iokit.IOServiceGetMatchingServices(0, iokit.IOServiceMatching(b"IOPCIDevice"), ctypes.byref(iterator:=ctypes.c_uint()))
-      while svc:=iokit.IOIteratorNext(iterator): all_devs.append((v:=read_prop(svc, "vendor-id"), d:=read_prop(svc, "device-id"), f"{v:x}:{d:x}"))
+      while svc:=iokit.IOIteratorNext(iterator):
+        if base_class is not None and read_prop(svc, "class-code") >> 16 != base_class: continue
+        all_devs.append((v:=read_prop(svc, "vendor-id"), d:=read_prop(svc, "device-id"), f"{v:x}:{d:x}"))
     else:
       try: devs = FileIOInterface("/sys/bus/pci/devices")
       except FileNotFoundError: raise RuntimeError("no pcie")


### PR DESCRIPTION
The Linux path of `pci_scan_bus` reads `/sys/bus/pci/devices/.../class` and skips devices whose base class doesn't match (line 70). The macOS (IOKit) path appended every `IOPCIDevice` unconditionally, so callers that supplied `base_class` to narrow down to e.g. display devices would also get the audio companion function of a multifunction GPU.

Concretely, an NVIDIA RTX Pro 6000 Blackwell exposes:

| device id | class | function |
|---|---|---|
| `10de:2bb1` | `0x030000` | display |
| `10de:22e8` | `0x040300` | multimedia audio |

`pci_scan_bus(0x10de, ..., base_class=3)` returned both. With the `sorted()` at the end of `pci_scan_bus`, `22e8` (audio) came first, so the NV runtime picked the audio function as device 0 and stalled on `RESIZE_BAR`.

This mirrors the Linux filter using the existing `read_prop` helper.

### Verified on M4 Max + RTX Pro 6000 Blackwell

Before:
```
>>> System.pci_scan_bus(0x10de, ((0xff00, (0x2200, 0x2b00)),), base_class=3)
['10de:22e8', '10de:2bb1']
```

After:
```
>>> System.pci_scan_bus(0x10de, ((0xff00, (0x2200, 0x2b00)),), base_class=3)
['10de:2bb1']
>>> System.pci_scan_bus(0x10de, ((0xff00, (0x2200, 0x2b00)),), base_class=4)
['10de:22e8']
>>> System.pci_scan_bus(0x10de, ((0xff00, (0x2200, 0x2b00)),))
['10de:22e8', '10de:2bb1']
```

Related to #15813 (Dwellverse first identified the missing class filter on macOS).