### PR TITLE
recover from client disconnect in remote serve

### DIFF
--- a/extra/remote/serve.py
+++ b/extra/remote/serve.py
@@ -72,7 +72,8 @@ def handle(conn, cmd, dev_id, bar, arg0, arg1, arg2):
 def serve(conn:socket.socket):
   REQ = '<BIIQQQ'
   while True:
-    hdr = conn.recv(struct.calcsize(REQ), socket.MSG_WAITALL)
+    hdr = b''
+    while len(hdr) < struct.calcsize(REQ) and (c:=conn.recv(struct.calcsize(REQ)-len(hdr))): hdr += c
     if len(hdr) < struct.calcsize(REQ): raise ConnectionError("client disconnected")
     cmd, dev_id, bar, arg0, arg1, arg2 = struct.unpack(REQ, hdr)
     if DEBUG >= 4: print(f"cmd={RemoteCmd(cmd).name} dev={dev_id} bar={bar} arg0={arg0:#x} arg1={arg1:#x} arg2={arg2:#x}")
@@ -99,3 +100,4 @@ if __name__ == "__main__":
     for bt in [socket.SO_SNDBUF, socket.SO_RCVBUF]: conn.setsockopt(socket.SOL_SOCKET, bt, 64 << 20)
     try: serve(conn)
     except ConnectionError: print("disconnected")
+    finally: conn.close()


### PR DESCRIPTION
Two small issues in `extra/remote/serve.py` meant a single client crash left the server unable to accept further connections.

### 1. `MSG_WAITALL` hangs on half-closed sockets on macOS

The main loop reads the 33-byte command header with `conn.recv(N, socket.MSG_WAITALL)`. On macOS, when the peer half-closes the socket while a `MSG_WAITALL` recv is outstanding, the recv blocks indefinitely instead of returning the partial bytes. That means the `if len(hdr) < ...` short-read check never fires and the connection never raises `ConnectionError`.

Fixed by reading the header byte-loop-style (matching `RemotePCIDevice._recvall` in `runtime/support/system.py`).

### 2. No `conn.close()` on the per-client socket

The accept loop:
```python
try: serve(conn)
except ConnectionError: print("disconnected")
```

… leaks `conn` even when `ConnectionError` does fire. The kernel keeps the connection in `CLOSE_WAIT` and (because of `server.listen(1)`) the next client may queue but not be served until the leaked conn is collected.

Added `finally: conn.close()`.

### Verified on macOS 15 (M4 Max)

Before:
```
$ python3 extra/remote/serve.py 6667 &
$ python3 -c "import socket; s=socket.socket(); s.connect(('127.0.0.1',6667)); s.send(b'\\0'*5); s.close()"
# serve.py prints nothing, hangs
$ lsof -iTCP:6667
... CLOSE_WAIT
$ python3 -c "import socket; s=socket.socket(); s.settimeout(3); s.connect(('127.0.0.1',6667))"
# TCP connect succeeds (queued by kernel) but server never accepts
```

After:
```
# serve.py prints "disconnected" immediately
# lsof shows only LISTEN
# new client connects and is served immediately
```