### PR TITLE
Fix const_factor() returning negative values for negative inputs

### DIFF
--- a/test/null/test_uop_vmin_vmax.py
+++ b/test/null/test_uop_vmin_vmax.py
@@ -328,6 +328,8 @@ class TestConstFactor(unittest.TestCase):
     # const_factor for a constant
     uop = UOp.const(dtypes.int32, 42)
     self.assertEqual(uop.const_factor(), 42)
+    uop = UOp.const(dtypes.int32, -6)
+    self.assertEqual(uop.const_factor(), 6)
 
   def test_const_factor_addition(self):
     # const_factor for an addition of constants

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -825,11 +825,10 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
     return False  # False if not sure
   def const_factor(self) -> int:
     """largest known int that divides self"""
-    # TODO: for negatives it's not the largest
-    if self.op is Ops.CONST: return self.arg
+    if self.op is Ops.CONST: return abs(self.arg)
     if self.op is Ops.VCONST: return math.gcd(*self.arg)
     if self.op is Ops.ADD: return math.gcd(self.src[0].const_factor(), self.src[1].const_factor())
-    if self.op is Ops.MUL: return self.src[0].arg if self.src[0].op is Ops.CONST else self.src[1].arg if self.src[1].op is Ops.CONST else 1
+    if self.op is Ops.MUL: return abs(self.src[0].arg) if self.src[0].op is Ops.CONST else abs(self.src[1].arg) if self.src[1].op is Ops.CONST else 1
     return 1
   def divides(self, v:int) -> UOp|None:
     if v==1: return self


### PR DESCRIPTION
UOp.const_factor()  returned negative values for negative constants.  Added abs() to the CONST and MUL branches of const_factor() so it always returns a non-negative divisor. (The ADD branch already returns non-negative via math.gcd, and the VCONST branch is non-negative for signed types.) 

Tests: added tests in  test/null/test_uop_vmin_vmax.py