### PR TITLE
revert amd beam timeout recovery

### DIFF
--- a/tinygrad/runtime/support/am/ip.py
+++ b/tinygrad/runtime/support/am/ip.py
@@ -304,10 +304,9 @@ class AM_GFX(AM_IP):
   def reset_mec(self):
     self._dequeue_hqds()
 
-    if self.adev.ip_ver[am.GC_HWIP] < (10,0,0): # gfx10+ uses mec_pipe0_reset
-      for xcc in range(self.xccs): self.adev.regGRBM_SOFT_RESET.write(soft_reset_cp=1, soft_reset_cpc=1, inst=xcc)
-      time.sleep(0.05)
-      for xcc in range(self.xccs): self.adev.regGRBM_SOFT_RESET.write(0x0, inst=xcc)
+    for xcc in range(self.xccs): self.adev.regGRBM_SOFT_RESET.write(soft_reset_cp=1, soft_reset_cpc=1, inst=xcc)
+    time.sleep(0.05)
+    for xcc in range(self.xccs): self.adev.regGRBM_SOFT_RESET.write(0x0, inst=xcc)
 
     self._config_mec()
     self._enable_mec()


### PR DESCRIPTION
reverts https://github.com/tinygrad/tinygrad/commit/f6d92b55e68fabb3ef0a639b0aeb6944afa952da

this makes test/external/external_fuzz_beam_timeout_recovery.py pass and BEAM work again on my RX 7600

I don't have access to any other AMD hardware so I'm not sure if the condition should be changed to < (12, 0, 0) or removed like this