### PR TITLE
nv: use VRAM offsets for boot memory paddrs

### DIFF
--- a/tinygrad/runtime/support/nv/nvdev.py
+++ b/tinygrad/runtime/support/nv/nvdev.py
@@ -150,7 +150,7 @@ class NVDev:
     if sysmem is True or (sysmem is None and not self.large_bar): view, paddrs = self.pci_dev.alloc_sysmem(size, 0, contiguous=contiguous)
     else:
       paddr = self.mm.palloc(sz, boot=False)
-      view, paddrs = self.vram.view(paddr, sz), [self.pci_dev.bar_info(1)[0] + paddr + i * 0x1000 for i in range(sz // 0x1000)]
+      view, paddrs = self.vram.view(paddr, sz), [paddr + i * 0x1000 for i in range(sz // 0x1000)]
     if data is not None: view[:size] = data
     return view, paddrs[0], paddrs
 


### PR DESCRIPTION
Addresses #16289.

When NV boot memory is allocated from VRAM, pass local framebuffer offsets to the Falcon/GSP boot path instead of BAR1 bus addresses.

On a macOS TinyGPU RTX 3060 eGPU setup, the old `BAR1 + offset` address caused NV device initialization to fail during Falcon init with:

```text
TimeoutError: DMA does not progress
```

Using the VRAM offset directly lets the boot path progress and enables NV tensor execution.

Validation:

```bash
DEV=PCI+NV python3 -c "from tinygrad import Device, Tensor; print(Device.DEFAULT); print(Tensor([1,2,3], device='NV').realize().numpy())"
```

```text
NV
[1 2 3]
```

Additional validation on the same RTX 3060 TinyGPU setup:

```text
EfficientNet inference: pass, device_default NV
9B GGUF LLM benchmark: pass, 8,953,803,264 params, device_default NV
Post-test tensor gate: pass, [1 2 3]
```
