### PR TITLE
fix: skip incompatible ELF-class shared libraries

### DIFF
--- a/test/unit/test_c_dll_findlib.py
+++ b/test/unit/test_c_dll_findlib.py
@@ -1,0 +1,59 @@
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+from tinygrad.runtime.support.c import DLL
+
+
+class TestCDLLFindlib(unittest.TestCase):
+  def test_findlib_does_not_require_path_on_linux(self):
+    with tempfile.TemporaryDirectory() as td:
+      td_path = pathlib.Path(td)
+      libc = td_path / "libc.so.6"
+      libc.write_bytes(b"\x7fELF" + bytes([2]) + b"ok")
+
+      orig_iterdir = pathlib.Path.iterdir
+      def fake_iterdir(path_obj):
+        if path_obj == td_path: return iter([libc])
+        return orig_iterdir(path_obj)
+
+      with mock.patch("tinygrad.runtime.support.c.os.name", "posix"), \
+           mock.patch("tinygrad.runtime.support.c.sys.platform", "linux"), \
+           mock.patch("tinygrad.runtime.support.c.sys.maxsize", 2**63 - 1), \
+           mock.patch("tinygrad.runtime.support.c.sysconfig.get_config_var", return_value=None), \
+           mock.patch.dict("tinygrad.runtime.support.c.os.environ", {}, clear=True), \
+           mock.patch("tinygrad.runtime.support.c.pathlib.Path.is_dir", new=lambda self: self == td_path), \
+           mock.patch("tinygrad.runtime.support.c.pathlib.Path.iterdir", new=fake_iterdir):
+        found = DLL.findlib("libc", ["c"], extra_paths=[str(td_path)])
+
+      self.assertEqual(found, str(libc))
+
+  def test_findlib_skips_wrong_elf_class_and_uses_matching_candidate(self):
+    with tempfile.TemporaryDirectory() as td:
+      td_path = pathlib.Path(td)
+      wrong = td_path / "libc.so.6"
+      right = td_path / "libc.so.7"
+
+      wrong.write_bytes(b"\x7fELF" + bytes([1]) + b"wrong-class")
+      right.write_bytes(b"\x7fELF" + bytes([2]) + b"right-class")
+
+      orig_iterdir = pathlib.Path.iterdir
+      def fake_iterdir(path_obj):
+        if path_obj == td_path: return iter([wrong, right])
+        return orig_iterdir(path_obj)
+
+      with mock.patch("tinygrad.runtime.support.c.os.name", "posix"), \
+           mock.patch("tinygrad.runtime.support.c.sys.platform", "linux"), \
+           mock.patch("tinygrad.runtime.support.c.sys.maxsize", 2**63 - 1), \
+           mock.patch("tinygrad.runtime.support.c.sysconfig.get_config_var", return_value=None), \
+           mock.patch.dict("tinygrad.runtime.support.c.os.environ", {"LD_LIBRARY_PATH": ""}, clear=False), \
+           mock.patch("tinygrad.runtime.support.c.pathlib.Path.is_dir", new=lambda self: self == td_path), \
+           mock.patch("tinygrad.runtime.support.c.pathlib.Path.iterdir", new=fake_iterdir):
+        found = DLL.findlib("libc", ["c"], extra_paths=[str(td_path)])
+
+      self.assertEqual(found, str(right))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tinygrad/runtime/support/c.py
+++ b/tinygrad/runtime/support/c.py
@@ -86,6 +86,18 @@ def init_c_struct_t(sz:int, fields: tuple[tuple, ...]):
   return CStruct
 def init_c_var(ty, creat_cb): return (creat_cb(v:=ty()), v)[1]
 
+def _host_elf_class() -> int:
+  return 2 if sys.maxsize > 2**32 else 1
+
+def _is_compatible_elf(path:pathlib.Path) -> bool:
+  try:
+    with open(path, 'rb') as f:
+      hdr = f.read(5)
+  except OSError:
+    return False
+  if len(hdr) < 5 or hdr[:4] != b'\x7FELF': return False
+  return hdr[4] == _host_elf_class()
+
 class DLL(ctypes.CDLL):
   _loaded_: set[str] = set()
 
@@ -95,7 +107,7 @@ class DLL(ctypes.CDLL):
     if pathlib.Path(path:=getenv(nm.replace('-', '_').upper()+"_PATH", '')).is_file(): return path
     for p in paths:
       libpaths = {"posix": [d for d in os.environ.get('LD_LIBRARY_PATH', '').split(os.pathsep) if d] + ["/usr/lib64", "/usr/lib", "/usr/local/lib"],
-                  "nt": os.environ['PATH'].split(os.pathsep),
+                  "nt": [d for d in os.environ.get('PATH', '').split(os.pathsep) if d],
                   "darwin": ["/opt/homebrew/lib", f"/System/Library/Frameworks/{p}.framework", f"/System/Library/PrivateFrameworks/{p}.framework"],
                   'linux': ['/lib', '/lib64', f"/lib/{sysconfig.get_config_var('MULTIARCH')}", "/usr/lib/wsl/lib/"]}
       if (pth:=pathlib.Path(p)).is_absolute():
@@ -108,9 +120,8 @@ class DLL(ctypes.CDLL):
             if (l:=pre / base).is_file() or (OSX and 'framework' in str(l) and l.is_symlink()): return str(l)
         else:
           for l in (l for l in pre.iterdir() if l.is_file() and re.fullmatch(f"lib{p}\\.so\\.?[0-9]*", l.name)):
-            # filter out linker scripts
-            with open(l, 'rb') as f:
-              if f.read(4) == b'\x7FELF': return str(l)
+            # filter out linker scripts and wrong-arch ELF candidates
+            if _is_compatible_elf(l): return str(l)
 
   def __init__(self, nm:str, paths:str|list[str], extra_paths=[], emsg="", **kwargs):
     self.nm, self.emsg = nm, emsg or f"try setting {nm.upper()+'_PATH'}?"


### PR DESCRIPTION
## Summary
- skip incompatible ELF-class candidates during Linux shared library resolution
- keep searching after linker scripts or wrong-architecture ELF files
- add a pure-Python regression test for libc candidate selection

## Test Plan
- [x] `python3 -m pytest -o addopts='' -q test/unit/test_c_dll_findlib.py`

Fixes #16315
