### PR TITLE
fix: remove numpy dtype annotation under TYPED=1

### DIFF
--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -360,7 +360,7 @@ def _to_np_dtype(dtype:DType) -> type|None:
   import numpy as np
   if dtype in { dtypes.bfloat16, *dtypes.fp8s }: return np.float32
   return np.dtype(dtype.fmt).type if dtype.fmt is not None else None
-def _from_np_dtype(npdtype:'np.dtype') -> DType: # type: ignore [name-defined] # noqa: F821
+def _from_np_dtype(npdtype) -> DType:
   import numpy as np
   return DTYPES_DICT[np.dtype(npdtype).name]
 


### PR DESCRIPTION
This fixes part of #7889 by avoiding a Typeguard failure in the NumPy dtype conversion path when TYPED=1 is enabled. The parameter was annotated as 'np.dtype', but numpy is only imported inside the function, so runtime type checking can fail before the local import is usable.

The function behavior is unchanged. It still converts the input through np.dtype(npdtype).name and returns the matching tinygrad dtype.

Tested with:

PYTHONPATH=. TYPED=1 python3 test/null/test_tensor.py

I also checked that the dtype conversion still works for normal NumPy dtype inputs with and without TYPED=1. Any feedback is appreciated.