### PR TITLE
fix numpy dtype conversion under TYPED=1

### DIFF
--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -360,7 +360,7 @@ def _to_np_dtype(dtype:DType) -> type|None:
   import numpy as np
   if dtype in { dtypes.bfloat16, *dtypes.fp8s }: return np.float32
   return np.dtype(dtype.fmt).type if dtype.fmt is not None else None
-def _from_np_dtype(npdtype:'np.dtype') -> DType: # type: ignore [name-defined] # noqa: F821
+def _from_np_dtype(npdtype:object) -> DType:
   import numpy as np
   return DTYPES_DICT[np.dtype(npdtype).name]
 


### PR DESCRIPTION
This fixes part of #7889 by making the NumPy dtype conversion helper work with TYPED=1 runtime type checking.

The issue was that _from_np_dtype used 'np.dtype' as the parameter annotation, but NumPy is imported inside the function instead of at the top of the file. That seems intentional because NumPy is only needed for the dtype conversion path, but with Typeguard enabled the annotation can be checked before that local import is usable, which caused an UnboundLocalError.

I changed the annotation to object because the function immediately normalizes the input with np.dtype(npdtype).name anyway. This keeps the actual conversion behavior the same while avoiding an annotation that depends on a local import.

I also checked that _from_np_dtype still works for normal NumPy dtype inputs with and without TYPED=1.