### PR TITLE
[runtime] acknowledge TinyGPU MMIO writes

### DIFF
--- a/extra/usbgpu/tbgpu/installer/Shared/server.c
+++ b/extra/usbgpu/tbgpu/installer/Shared/server.c
@@ -242,9 +242,9 @@ static void handle_client(int fd) {
 
     case CMD_MMIO_WRITE:
       recvall(fd, g_bulk_buf, req.arg1);
-      if (!validate_bar(req.bar, req.arg0, req.arg1))
-        mmio_copy((void*)(g_bars[req.bar].addr + req.arg0), g_bulk_buf, req.arg1);
-      continue;
+      if (validate_bar(req.bar, req.arg0, req.arg1)) { resp.status = 1; break; }
+      mmio_copy((void*)(g_bars[req.bar].addr + req.arg0), g_bulk_buf, req.arg1);
+      break;
 
     default:
       resp.status = 1;


### PR DESCRIPTION
Fixes the TinyGPU installer server MMIO write RPC path so a valid write sends the normal RPC response instead of leaving the client waiting until timeout.

Why this should be merged:
- `CMD_MMIO_WRITE` currently uses `continue`, so it skips the shared `send_response` at the bottom of `handle_client`.
- The client RPC path waits for that response, which turns a completed MMIO write into an RPC timeout.
- `validate_bar` returns nonzero on invalid ranges, matching the `CMD_MMIO_READ` path. This change makes writes use the same validation shape and response behavior.

Validation:
- `git diff --check`
- Source-level review against the existing `CMD_MMIO_READ` and shared `send_response` paths.

References:
- tinygrad contribution policy: https://github.com/tinygrad/tinygrad#contributing
- TinyGPU server handler: https://github.com/tinygrad/tinygrad/blob/master/extra/usbgpu/tbgpu/installer/Shared/server.c

AI disclosure:
AI assistance was used to inspect the RPC control flow, compare the read/write cases, and draft this PR text. The change is intentionally kept to the single source-level protocol fix.