### PR TITLE
fix __del__ crash on partial __init__ failure

### DIFF
--- a/tinygrad/runtime/support/compiler_cpu.py
+++ b/tinygrad/runtime/support/compiler_cpu.py
@@ -69,9 +69,9 @@ class LLVMCompiler(Compiler):
     super().__init__(cache_key or f"compile_llvm_{processor}_{feats}{'_jit' if self.jit else ''}{'_opt' if opt else ''}")
 
   def __del__(self):
-    if(hasattr(self, "pbo")):
+    if hasattr(self, "pbo"):
         llvm.LLVMDisposePassBuilderOptions(self.pbo)
-    if(hasattr(self, "context")):
+    if hasattr(self, "context"):
         llvm.LLVMContextDispose(self.context)
 
   def compile_to_obj(self, src:str) -> bytes:

--- a/tinygrad/runtime/support/compiler_cpu.py
+++ b/tinygrad/runtime/support/compiler_cpu.py
@@ -69,8 +69,10 @@ class LLVMCompiler(Compiler):
     super().__init__(cache_key or f"compile_llvm_{processor}_{feats}{'_jit' if self.jit else ''}{'_opt' if opt else ''}")
 
   def __del__(self):
-    llvm.LLVMDisposePassBuilderOptions(self.pbo)
-    llvm.LLVMContextDispose(self.context)
+    if(hasattr(self, "pbo")):
+        llvm.LLVMDisposePassBuilderOptions(self.pbo)
+    if(hasattr(self, "context")):
+        llvm.LLVMContextDispose(self.context)
 
   def compile_to_obj(self, src:str) -> bytes:
     self.diag_msgs.clear()


### PR DESCRIPTION
In compiler_cpu.py, if LLVM is not found, `__init__` fails before 
`self.pbo` and `self.context` are set. `__del__` then raises an 
`AttributeError` during garbage collection. Added `hasattr` guards 
to prevent destruction of uninitialized attributes.

Fixes #16307