### PR TITLE
Add Tensor.associative_scan

### DIFF
--- a/docs/tensor/ops.md
+++ b/docs/tensor/ops.md
@@ -32,6 +32,7 @@
 ::: tinygrad.Tensor.einsum
 ::: tinygrad.Tensor.cumsum
 ::: tinygrad.Tensor.cumprod
+::: tinygrad.Tensor.associative_scan
 ::: tinygrad.Tensor.cummax
 ::: tinygrad.Tensor.cummin
 ::: tinygrad.Tensor.triu

--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1114,6 +1114,33 @@ class TestOps(unittest.TestCase):
     helper_test_op([(0,3)], lambda x: torch.cumsum(x, dim=0), lambda x: Tensor.cumsum(x, axis=0))
     helper_test_op([(2,3,0)], lambda x: torch.cumsum(x, dim=2), lambda x: Tensor.cumsum(x, axis=2))
 
+  def test_associative_scan(self):
+    if COMPILE_ONLY: self.skipTest("requires execution")
+    x = Tensor.arange(12).reshape(3, 4)
+    xn = np.arange(12).reshape(3, 4)
+    np.testing.assert_equal(x.associative_scan(lambda a,b: a+b, axis=1).numpy(), np.cumsum(xn, axis=1))
+    m = Tensor([[2, 5, 1], [1, 7, 0], [3, 4, 9]])
+    mn = np.array([[2, 5, 1], [1, 7, 0], [3, 4, 9]])
+    np.testing.assert_equal(m.associative_scan(lambda a,b: a.maximum(b), axis=0).numpy(), np.maximum.accumulate(mn, axis=0))
+
+    y = Tensor.arange(1, 7).reshape(2, 3)
+    yn = np.arange(1, 7).reshape(2, 3)
+    expected = np.flip(np.cumprod(np.flip(yn, axis=1), axis=1), axis=1)
+    np.testing.assert_equal(y.associative_scan(lambda a,b: a*b, axis=-1, reverse=True).numpy(), expected)
+    self.assertEqual(Tensor.zeros(2, 0, 3).associative_scan(lambda a,b: a+b, axis=1).shape, (2, 0, 3))
+
+  def test_associative_scan_tuple(self):
+    if COMPILE_ONLY: self.skipTest("requires execution")
+    a, b = Tensor([2.0, 3.0, 4.0, 5.0]), Tensor([1.0, -1.0, 2.0, 0.5])
+    got_a, got_b = a.associative_scan(lambda x,y: (y[0]*x[0], y[0]*x[1]+y[1]), b)
+    exp_a, exp_b, cur_a, cur_b = [], [], 1.0, 0.0
+    for ai, bi in zip([2.0, 3.0, 4.0, 5.0], [1.0, -1.0, 2.0, 0.5]):
+      cur_a, cur_b = ai * cur_a, ai * cur_b + bi
+      exp_a.append(cur_a)
+      exp_b.append(cur_b)
+    np.testing.assert_allclose(got_a.numpy(), exp_a)
+    np.testing.assert_allclose(got_b.numpy(), exp_b)
+
   def test_small_cumprod(self):
     helper_test_op([(10)],lambda x: torch.cumprod(x, dim=0),lambda x: Tensor.cumprod(x, axis=0))
   @slow_test

--- a/test/null/test_tensor_uop_mixin.py
+++ b/test/null/test_tensor_uop_mixin.py
@@ -109,6 +109,14 @@ class TestTensorUOpCumalu(unittest.TestCase):
   def test_cumsum_non_last(self): _check(self, _t(3, 4), lambda x: x.cumsum(0))
   def test_cumsum_large(self):    _check(self, _t(600), lambda x: x.cumsum())  # exercises _split_cumalu
   def test_cumprod(self):         _check(self, _t(4), lambda x: x.cumprod(0))
+  def test_associative_scan(self): _check(self, _t(5), lambda x: x.associative_scan(lambda a,b: a+b))
+  def test_associative_scan_2d(self): _check(self, _t(3, 4), lambda x: x.associative_scan(lambda a,b: a.maximum(b), axis=1))
+  def test_associative_scan_tuple(self):
+    t, u = _t(5).float() + 1, _t(5).float()
+    vt, vu = t.associative_scan(lambda x,y: (y[0]*x[0], y[0]*x[1]+y[1]), u)
+    ut, uu = t.uop.associative_scan(lambda x,y: (y[0]*x[0], y[0]*x[1]+y[1]), u.uop)
+    self.assertIs(_strip_unique(vt.uop), _strip_unique(ut))
+    self.assertIs(_strip_unique(vu.uop), _strip_unique(uu))
 
 class TestTensorUOpCumMinMax(unittest.TestCase):
   def _check_pair(self, t, fn):

--- a/tinygrad/mixin/__init__.py
+++ b/tinygrad/mixin/__init__.py
@@ -704,6 +704,45 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     """
     return self._split_cumalu(axis, Ops.MUL)
 
+  def associative_scan(self, fn:Callable, *others:Self, axis:int=0, reverse:bool=False) -> Self|tuple[Self, ...]:
+    """
+    Computes an inclusive scan along `axis` with associative binary function `fn`.
+
+    `fn` is called with either two tensors or, when `others` are supplied, two tuples of tensors.
+    It must return the same structure it receives.
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor.arange(1, 7).reshape(2, 3)
+    print(t.associative_scan(lambda a, b: a + b, axis=1).numpy())
+    ```
+    """
+    tensors = (self, *others)
+    axis = self._resolve_dim(axis)
+    assert all(t.shape == self.shape for t in tensors), "associative_scan tensors must have the same shape"
+    if self.ndim == 0 or 0 in self.shape: return tensors if others else tensors[0]
+    if reverse: tensors = tuple(t.flip(axis) for t in tensors)
+    n = self.shape[axis]
+    assert isinstance(n, int), "associative_scan requires a static axis length"
+
+    def s(t:Self, start:int|None, end:int|None) -> Self:
+      idx = [slice(None)] * t.ndim
+      idx[axis] = slice(start, end)
+      return t[tuple(idx)]
+    def structure(x) -> tuple[Self, ...]:
+      if len(tensors) == 1: return (x,)
+      assert isinstance(x, (tuple, list)) and len(x) == len(tensors), "associative_scan fn must return one tensor per input tensor"
+      return tuple(x)
+
+    out, step = tensors, 1
+    while step < n:
+      left, right = tuple(s(t, 0, n-step) for t in out), tuple(s(t, step, n) for t in out)
+      combined: tuple[Self, ...] = structure(fn(left, right) if len(tensors) != 1 else fn(left[0], right[0]))
+      out = tuple(s(t, 0, step).cat(c, dim=axis) for t,c in zip(out, combined))
+      step *= 2
+
+    if reverse: out = tuple(t.flip(axis) for t in out)
+    return out if others else out[0]
+
   def cummax(self, axis:int=0) -> tuple[Self, Self]:
     """
     Computes the cumulative max of the tensor along `axis`, returning (values, indices).


### PR DESCRIPTION
## Summary
Addresses #3039. This adds `Tensor.associative_scan`, an inclusive parallel prefix scan over an axis using a Hillis-Steele-style doubling loop built from existing tensor slicing and `cat` primitives.

The API supports:
- single-tensor associative functions, e.g. add/product/max
- tuple inputs for state-pair style scans used by Mamba/CRF-style recurrences
- `reverse=True` scans
- scalar and empty-shape passthroughs

## Tests
- `python3 -m compileall -q tinygrad/mixin/__init__.py test/backend/test_ops.py test/null/test_tensor_uop_mixin.py`
- `git diff --check`
- `python3 -m unittest test.null.test_tensor_uop_mixin.TestTensorUOpCumalu`
- manual Tensor checks for add, max, reverse product, tuple affine composition, and empty-axis passthrough
- GitHub Actions: all required checks passing on the PR head
