### PR TITLE
use Any for _from_np_dtype TYPED=1

### DIFF
--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Final, ClassVar, Callable, Literal
+from typing import Final, ClassVar, Callable, Literal, Any
 import math, struct, ctypes, functools
 from dataclasses import dataclass, fields
 from tinygrad.helpers import ceildiv, getenv, prod, round_up, OSX
@@ -360,7 +360,7 @@ def _to_np_dtype(dtype:DType) -> type|None:
   import numpy as np
   if dtype in { dtypes.bfloat16, *dtypes.fp8s }: return np.float32
   return np.dtype(dtype.fmt).type if dtype.fmt is not None else None
-def _from_np_dtype(npdtype:'np.dtype') -> DType: # type: ignore [name-defined] # noqa: F821
+def _from_np_dtype(npdtype:Any) -> DType:
   import numpy as np
   return DTYPES_DICT[np.dtype(npdtype).name]
 


### PR DESCRIPTION
This fixes a small part of #7889 by making the existing dtype spec test pass with TYPED=1.

_from_np_dtype was annotated as 'np.dtype', but NumPy is imported inside the function. With Typeguard enabled, that annotation can be checked before the local import is usable, causing an UnboundLocalError.

I changed the parameter annotation to Any because the function immediately normalizes the input with np.dtype(npdtype).name. I tried object first, but mypy rejects that because of the np.dtype overloads. This keeps the conversion behavior unchanged while making the annotation work with runtime type checking.