### PR TITLE
disable process replay by default [PR]

### DIFF
--- a/.github/actions/process-replay/action.yml
+++ b/.github/actions/process-replay/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - name: Run process replay tests
       shell: bash
+      if: env.CAPTURE_PROCESS_REPLAY == '1'
       run: |
         export PR_TITLE=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
         export CURRENT_SHA=${{ github.event.pull_request && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 env:
   # increment this when downloads substantially change to avoid the internet
   CACHE_VERSION: '19'
-  CAPTURE_PROCESS_REPLAY: 1
+  CAPTURE_PROCESS_REPLAY: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[pr]') && '1' || '0' }}
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PYTHONPATH: ${{ github.workspace }}
   CHECK_OOB: 1

--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -4,7 +4,7 @@ import os, multiprocessing, logging, pickle, sqlite3, difflib, warnings, functoo
 from dataclasses import replace
 from typing import Callable, Any
 
-ASSERT_DIFF = int((flag:="[pr]") in os.getenv("COMMIT_MESSAGE", flag) or flag in os.getenv("PR_TITLE", flag))
+ASSERT_DIFF = int((flag:="[PR]") in os.getenv("COMMIT_MESSAGE", flag) or flag in os.getenv("PR_TITLE", flag))
 if not int(os.getenv("ASSERT_PROCESS_REPLAY", "1")): ASSERT_DIFF = 0
 
 try:


### PR DESCRIPTION
enable process replay with `[pr]` and assert with `[PR]`

process replay no longer captures on master (previously it captured but did not run)