### PR TITLE
Add associative_scan

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1113,6 +1113,25 @@ class TestOps(unittest.TestCase):
     helper_test_op([(0,3)], lambda x: torch.cumsum(x, dim=0), lambda x: Tensor.cumsum(x, axis=0))
     helper_test_op([(2,3,0)], lambda x: torch.cumsum(x, dim=2), lambda x: Tensor.cumsum(x, axis=2))
 
+  def test_associative_scan_sum(self):
+    helper_test_op([(17,)], lambda x: torch.cumsum(x, dim=0), lambda x: x.associative_scan(lambda a,b: a+b, axis=0))
+    helper_test_op([(4,5)], lambda x: torch.cumsum(x, dim=1), lambda x: x.associative_scan(lambda a,b: a+b, axis=1))
+
+  def test_associative_scan_reverse(self):
+    helper_test_op([(4,5)], lambda x: torch.flip(torch.cumsum(torch.flip(x, dims=(1,)), dim=1), dims=(1,)),
+                   lambda x: x.associative_scan(lambda a,b: a+b, axis=1, reverse=True))
+
+  def test_associative_scan_noncommutative(self):
+    x = Tensor([[2, 1], [3, 4], [5, 6]], dtype=dtypes.float32)
+    def compose(a, b):
+      return (a[..., 0] * b[..., 0]).unsqueeze(-1).cat((a[..., 0] * b[..., 1] + a[..., 1]).unsqueeze(-1), dim=-1)
+    fwd, rev = x.associative_scan(compose, axis=0), x.associative_scan(compose, axis=0, reverse=True)
+    if COMPILE_ONLY:
+      Tensor.realize(fwd, rev)
+      return
+    np.testing.assert_allclose(fwd.numpy(), np.array([[2, 1], [6, 9], [30, 45]], dtype=np.float32))
+    np.testing.assert_allclose(rev.numpy(), np.array([[30, 45], [15, 22], [5, 6]], dtype=np.float32))
+
   def test_small_cumprod(self):
     helper_test_op([(10)],lambda x: torch.cumprod(x, dim=0),lambda x: Tensor.cumprod(x, axis=0))
   @slow_test

--- a/tinygrad/mixin/__init__.py
+++ b/tinygrad/mixin/__init__.py
@@ -680,6 +680,21 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     def fix(x: Self) -> Self: return x.flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
     return getattr(fix(ret), {Ops.ADD: "add", Ops.MAX: "maximum", Ops.MUL: "mul"}[op])(fix(base))
 
+  def associative_scan(self, fxn:Callable[[Self, Self], Self], axis:int=0, reverse:bool=False) -> Self:
+    axis = self._resolve_dim(axis)
+    if self.ndim == 0 or 0 in self.shape: return self
+    x, n = (self.flip(axis) if reverse else self), self.shape[axis]
+    assert isinstance(n, int), f"does not support symbolic shape in associative_scan axis {axis}: {self.shape}"
+    step = 1
+    scan_fxn = (lambda a,b: fxn(b, a)) if reverse else fxn
+    while step < n:
+      leading = tuple((0, step) if i == axis else None for i in range(x.ndim))
+      left = tuple((0, s-step) if i == axis else None for i,s in enumerate(x.shape))
+      right = tuple((step, s) if i == axis else None for i,s in enumerate(x.shape))
+      x = x.shrink(leading).cat(scan_fxn(x.shrink(left), x.shrink(right)), dim=axis)
+      step *= 2
+    return x.flip(axis) if reverse else x
+
   def cumsum(self, axis:int=0) -> Self:
     """
     Computes the cumulative sum of the tensor along the specified `axis`.


### PR DESCRIPTION
## Summary
- adds `Tensor.associative_scan(fxn, axis=0, reverse=False)` as an inclusive Hillis-Steele scan over any associative binary tensor function
- preserves operand order for reverse scans so non-commutative associative functions work correctly
- covers sum, reverse scans, and a non-commutative affine-composition scan in backend tests

Fixes #3039

## Validation
- `.venv-lint/bin/python -m pytest test/backend/test_ops.py -k 'associative_scan or cumsum'`
- `.venv-lint/bin/python -m ruff check tinygrad/mixin/__init__.py test/backend/test_ops.py`
- `.venv-lint/bin/python -m mypy tinygrad/mixin/__init__.py`
- `python3 -m compileall -q tinygrad/mixin/__init__.py test/backend/test_ops.py`
