### PR TITLE
ci: standardize runs-on

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,17 @@ concurrency:
   group: test-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# runs-on definitions, all jobs should use one of these
+_runners:
+  linux: &linux ${{ github.repository == 'tinygrad/tinygrad' && github.event_name == 'pull_request' && github.event.pull_request.author_association == 'COLLABORATOR' && 'namespace-profile-tinygrad' || 'ubuntu-24.04' }}
+  linux-arm: &linux-arm ${{ github.repository == 'tinygrad/tinygrad' && github.event_name == 'pull_request' && github.event.pull_request.author_association == 'COLLABORATOR' && 'namespace-profile-tinygrad-arm64' || 'ubuntu-24.04-arm' }}
+  macos: &macos macos-26
+  windows: &windows windows-2025
+
 jobs:
   docs:
     name: Docs
-    runs-on: &linux ${{ github.repository == 'tinygrad/tinygrad' && github.event_name == 'pull_request' && github.event.pull_request.author_association == 'COLLABORATOR' && 'namespace-profile-tinygrad' || 'ubuntu-24.04' }}
+    runs-on: *linux
     timeout-minutes: 10
     env:
       CHECK_OOB: 0
@@ -517,7 +524,7 @@ jobs:
 
   testmetalmodels:
     name: Models (metal)
-    runs-on: macos-14
+    runs-on: *macos
     timeout-minutes: 20
     steps:
     - name: Checkout Code
@@ -749,7 +756,7 @@ jobs:
 
   unittestmacos:
     name: MacOS (unit)
-    runs-on: macos-14
+    runs-on: *macos
     timeout-minutes: 20
     steps:
     - name: Checkout Code
@@ -805,7 +812,7 @@ jobs:
           - 'WEBGPU'
 
     name: MacOS (DEV=${{ matrix.dev }})
-    runs-on: macos-15
+    runs-on: *macos
     timeout-minutes: 20
     steps:
     - name: Checkout Code
@@ -843,7 +850,7 @@ jobs:
           - 'WEBGPU'
 
     name: Windows (DEV=${{ matrix.dev }})
-    runs-on: windows-latest
+    runs-on: *windows
     timeout-minutes: 15
     steps:
       - name: Checkout Code
@@ -906,7 +913,7 @@ jobs:
           python -m pytest -n=auto test/backend/test_ops.py --durations=20
   qcomclcompiletests:
     name: Compile-only (QCOM CL)
-    runs-on: ${{ github.repository == 'tinygrad/tinygrad' && github.event_name == 'pull_request' && github.event.pull_request.author_association == 'MEMBER' && 'namespace-profile-tinygrad-arm64' || 'ubuntu-24.04-arm' }}
+    runs-on: *linux-arm
     timeout-minutes: 15
     steps:
       - name: Checkout Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -906,7 +906,7 @@ jobs:
           python -m pytest -n=auto test/backend/test_ops.py --durations=20
   qcomclcompiletests:
     name: Compile-only (QCOM CL)
-    runs-on: ${{ github.repository == 'tinygrad/tinygrad' && github.event_name == 'pull_request' && github.event.pull_request.author_association == 'COLLABORATOR' && 'namespace-profile-tinygrad-arm64' || 'ubuntu-24.04-arm' }}
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
       - name: Checkout Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,17 +18,10 @@ concurrency:
   group: test-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# runs-on definitions, all jobs should use one of these
-_runners:
-  linux: &linux ${{ github.repository == 'tinygrad/tinygrad' && github.event_name == 'pull_request' && github.event.pull_request.author_association == 'COLLABORATOR' && 'namespace-profile-tinygrad' || 'ubuntu-24.04' }}
-  linux-arm: &linux-arm ${{ github.repository == 'tinygrad/tinygrad' && github.event_name == 'pull_request' && github.event.pull_request.author_association == 'COLLABORATOR' && 'namespace-profile-tinygrad-arm64' || 'ubuntu-24.04-arm' }}
-  macos: &macos macos-26
-  windows: &windows windows-2025
-
 jobs:
   docs:
     name: Docs
-    runs-on: *linux
+    runs-on: &linux ${{ github.repository == 'tinygrad/tinygrad' && github.event_name == 'pull_request' && github.event.pull_request.author_association == 'COLLABORATOR' && 'namespace-profile-tinygrad' || 'ubuntu-24.04' }}
     timeout-minutes: 10
     env:
       CHECK_OOB: 0
@@ -524,7 +517,7 @@ jobs:
 
   testmetalmodels:
     name: Models (metal)
-    runs-on: *macos
+    runs-on: &macos macos-26
     timeout-minutes: 20
     steps:
     - name: Checkout Code
@@ -850,7 +843,7 @@ jobs:
           - 'WEBGPU'
 
     name: Windows (DEV=${{ matrix.dev }})
-    runs-on: *windows
+    runs-on: windows-2025
     timeout-minutes: 15
     steps:
       - name: Checkout Code
@@ -913,7 +906,7 @@ jobs:
           python -m pytest -n=auto test/backend/test_ops.py --durations=20
   qcomclcompiletests:
     name: Compile-only (QCOM CL)
-    runs-on: *linux-arm
+    runs-on: ${{ github.repository == 'tinygrad/tinygrad' && github.event_name == 'pull_request' && github.event.pull_request.author_association == 'COLLABORATOR' && 'namespace-profile-tinygrad-arm64' || 'ubuntu-24.04-arm' }}
     timeout-minutes: 15
     steps:
       - name: Checkout Code


### PR DESCRIPTION
switch macos to 26, namespace arm runners are slower than github's