### PR TITLE
fix @function input assign mutation

### DIFF
--- a/test/unit/test_function.py
+++ b/test/unit/test_function.py
@@ -190,7 +190,7 @@ class TestFunction(unittest.TestCase):
 
     a = Tensor([1,2,3]).realize()
     np.testing.assert_equal(f(a).numpy(), [2,3,4])
-    np.testing.assert_equal(a.numpy(), [3,4,5])  # TODO: should be [1,2,3]
+    np.testing.assert_equal(a.numpy(), [1,2,3])
 
   def test_implicit_assign(self):
     a = Tensor([1,2,3])
@@ -210,7 +210,7 @@ class TestFunction(unittest.TestCase):
     a = Tensor([1,2,3]).realize()
     b = Tensor([10,20,30]).realize()
     np.testing.assert_equal(f(a,b).numpy(), [11,21,31])
-    np.testing.assert_equal(a.numpy(), [11,21,31])  # TODO: should be [1,2,3]
+    np.testing.assert_equal(a.numpy(), [1,2,3])
     np.testing.assert_equal(b.numpy(), [10,20,30])
 
   def test_view_assign_explicit_buffer(self):

--- a/tinygrad/function.py
+++ b/tinygrad/function.py
@@ -22,6 +22,10 @@ pm_ctx = PatternMatcher([
    lambda ctx,x: add_to_ctx(ctx,x) if not x.op_in_backward_slice_with_self(Ops.PARAM) and x.op_in_backward_slice_with_self(Ops.BUFFER) else None),
 ])+pm_transform_unique_const
 
+pm_functionalize_param_assign = PatternMatcher([
+  (UPat(Ops.AFTER, src=(UPat(Ops.PARAM, name="x"), UPat(Ops.STORE, src=(UPat.var("x"), UPat.var("val"))))), lambda x,val: val),
+])
+
 ReturnType = TypeVar('ReturnType')
 class _function(Generic[ReturnType]):
   depth = 0
@@ -41,24 +45,29 @@ class _function(Generic[ReturnType]):
 
     # deduplicate input_uops, keeping the first occurrence index for each unique uop
     call_uops: list[UOp] = dedup([u for t in params if (u:=(t.uop if isinstance(t, Tensor) else t)).device is not None])
+    saved_uops = {t:t.uop for t in params if isinstance(t, Tensor)}
 
     # disable realize/schedule while this is running
     # run it and do surgery later
-    with Context(ALLOW_DEVICE_USAGE=getenv("DEVICE_IN_FUNCTION_BUG", 0)):
-      _function.depth += 1
-      ret = self.fxn(*args, **kwargs)
-      _function.depth -= 1
-    if isinstance(ret, Tensor):
-      uret = ret.uop
-    elif isinstance(ret, tuple) and all(isinstance(x, Tensor) for x in ret):
-      uret = UOp.maketuple(*[x.uop for x in ret])
-    else:
-      raise RuntimeError(f"function return type {type(ret)} not supported")
+    try:
+      with Context(ALLOW_DEVICE_USAGE=getenv("DEVICE_IN_FUNCTION_BUG", 0)):
+        _function.depth += 1
+        try: ret = self.fxn(*args, **kwargs)
+        finally: _function.depth -= 1
+      if isinstance(ret, Tensor):
+        uret = ret.uop
+      elif isinstance(ret, tuple) and all(isinstance(x, Tensor) for x in ret):
+        uret = UOp.maketuple(*[x.uop for x in ret])
+      else:
+        raise RuntimeError(f"function return type {type(ret)} not supported")
+    finally:
+      for t,u in saved_uops.items(): t.uop = u
 
     # replace the known inputs with params (using deduplicated slots)
     subs = {}
     for i,x in enumerate(call_uops): subs[x] = x.param_like(i)
     uret = uret.substitute(subs)
+    uret = graph_rewrite(uret, pm_functionalize_param_assign, name="functionalize_param_assign")
 
     # add contiguous to call_uops
     #call_uops = [x.contiguous() for x in call_uops]


### PR DESCRIPTION
## What changed

Fixes `@function` tracing so direct full-buffer assigns to explicit input tensors behave like pure returned values instead of mutating the caller's tensor.

This does two things:

- restores explicit tensor arguments after tracing the Python function body
- functionalizes direct `AFTER(PARAM, STORE(PARAM, value))` returns into `value` before implicit inputs are collected

The existing TODO assertions in `test/unit/test_function.py` are now regression tests for preserving caller inputs after `x += 1` and `a.assign(b + 1)` inside `@function`.

## Why

Previously, tracing a mutating function body leaked the temporary assignment into the caller's tensor object. Realizing the returned function output could then mutate it again.

Closes #16497

## Validation

- `.venv/bin/python -m unittest test.unit.test_function`
- `.venv/bin/python -m unittest test.unit.test_call`
- `.venv/bin/python -m unittest test.backend.test_setitem.TestSetitem.test_lazy_sum_between_writes test.backend.test_setitem.TestSetitem.test_cross_assign_independence`
- `.venv/bin/python -m pytest -q test/unit/test_function.py::TestFunction::test_iadd test/unit/test_function.py::TestFunction::test_assign_input test/unit/test_call.py::TestCallSchedule::test_call_precompiled`
- `.venv/bin/python -m ruff check tinygrad/function.py test/unit/test_function.py`
- `.venv/bin/python -m mypy tinygrad/function.py`

## AI disclosure

I used Codex to inspect the repo, implement this patch, and run the focused validation above.