### PR TITLE
Add associative tensor scan

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1113,6 +1113,24 @@ class TestOps(unittest.TestCase):
     helper_test_op([(0,3)], lambda x: torch.cumsum(x, dim=0), lambda x: Tensor.cumsum(x, axis=0))
     helper_test_op([(2,3,0)], lambda x: torch.cumsum(x, dim=2), lambda x: Tensor.cumsum(x, axis=2))
 
+  def test_associative_scan_add(self):
+    data = np.arange(12, dtype=np.float32).reshape(3, 4)
+    np.testing.assert_allclose(Tensor(data).associative_scan(lambda a, b: a + b, axis=1).numpy(), np.cumsum(data, axis=1))
+
+  def test_associative_scan_matmul(self):
+    data = (np.arange(1, 33, dtype=np.float32) / 10).reshape(2, 4, 2, 2)
+    expected = np.empty_like(data)
+    for batch in range(data.shape[0]):
+      acc = np.eye(2, dtype=np.float32)
+      for i in range(data.shape[1]):
+        acc = acc @ data[batch, i]
+        expected[batch, i] = acc
+    np.testing.assert_allclose(Tensor(data).associative_scan(lambda a, b: a @ b, axis=1).numpy(), expected, rtol=1e-5)
+
+  def test_associative_scan_shape_check(self):
+    with self.assertRaises(ValueError):
+      Tensor.arange(4).associative_scan(lambda a, b: (a + b).sum(), axis=0)
+
   def test_small_cumprod(self):
     helper_test_op([(10)],lambda x: torch.cumprod(x, dim=0),lambda x: Tensor.cumprod(x, axis=0))
   @slow_test

--- a/tinygrad/mixin/__init__.py
+++ b/tinygrad/mixin/__init__.py
@@ -684,6 +684,38 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     def fix(x: Self) -> Self: return x.flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
     return getattr(fix(ret), {Ops.ADD: "add", Ops.MAX: "maximum", Ops.MUL: "mul"}[op])(fix(base))
 
+  def associative_scan(self, fn:Callable[[Self, Self], Self], axis:int=0) -> Self:
+    """
+    Computes an inclusive associative scan along `axis` using `fn`.
+
+    `fn(prefix, current)` must be associative and return the same shape as its inputs.
+    This supports non-commutative scans such as batched matrix products.
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor.arange(1, 5)
+    print(t.associative_scan(lambda a, b: a + b).numpy())
+    ```
+    """
+    if self.ndim == 0: return self
+    axis = self._resolve_dim(axis)
+    if self.shape[axis] == 0: return self
+    if not isinstance(n:=self.shape[axis], int): raise RuntimeError("associative_scan requires a concrete scan axis")
+
+    ret = self
+    mask_shape = tuple(n if i == axis else 1 for i in range(self.ndim))
+    idx = type(self).arange(n, device=self.device).reshape(mask_shape)
+    for offset in (1 << i for i in itertools.count()):
+      if offset >= n: break
+      head = ret[tuple(slice(0, 1) if i == axis else slice(None) for i in range(ret.ndim))]
+      head = head.expand(tuple(offset if i == axis else s for i, s in enumerate(ret.shape)))
+      tail = ret[tuple(slice(0, n - offset) if i == axis else slice(None) for i in range(ret.ndim))]
+      shifted = head.cat(tail, dim=axis)
+      combined = fn(shifted, ret)
+      if combined.shape != ret.shape:
+        raise ValueError(f"associative_scan fn must preserve shape, got {combined.shape} != {ret.shape}")
+      ret = (idx >= offset).where(combined, ret)
+    return ret
+
   def cumsum(self, axis:int=0) -> Self:
     """
     Computes the cumulative sum of the tensor along the specified `axis`.
@@ -696,7 +728,10 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     print(t.cumsum(1).numpy())
     ```
     """
-    return self._split_cumalu(axis, Ops.ADD)
+    axis = self._resolve_dim(axis)
+    if self.ndim == 0 or 0 in self.shape or not isinstance(self.shape[axis], int): return self._split_cumalu(axis, Ops.ADD)
+    ret = self.cast(sum_acc_dtype(self.dtype)).associative_scan(lambda a, b: a + b, axis)
+    return ret.cast(self.dtype) if self.dtype in (dtypes.float16, dtypes.bfloat16, *dtypes.fp8s) else ret
 
   def cumprod(self, axis:int) -> Self:
     """
@@ -710,7 +745,9 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     print(t.cumprod(axis=0).numpy())
     ```
     """
-    return self._split_cumalu(axis, Ops.MUL)
+    axis = self._resolve_dim(axis)
+    if self.ndim == 0 or 0 in self.shape or not isinstance(self.shape[axis], int): return self._split_cumalu(axis, Ops.MUL)
+    return self.associative_scan(lambda a, b: a * b, axis)
 
   def cummax(self, axis:int=0) -> tuple[Self, Self]:
     """


### PR DESCRIPTION
Adds Tensor.associative_scan(fn, axis) as an inclusive tree-style scan for associative functions. implementation supports non-commutative combine functions such as batched matrix products and cumsum/cumprod use it for concrete scan axes