### PR TITLE
fix: surface a clear dawn-install message when WEBGPU backend imports without libdawn

### DIFF
--- a/test/test_webgpu_import_error.py
+++ b/test/test_webgpu_import_error.py
@@ -1,0 +1,73 @@
+import importlib, sys, types, unittest
+from contextlib import contextmanager
+
+import tinygrad.runtime.autogen as autogen
+
+
+class _Dummy:
+  def __init__(self, *args, **kwargs): pass
+
+
+class _FakeWebGPU(types.ModuleType):
+  def __init__(self):
+    super().__init__("tinygrad.runtime.autogen.webgpu")
+    self.missing = set()
+    self.enum_WGPUBackendType = {0: "WGPUBackendType_Undefined"}
+    self.instance = _Dummy()
+
+  def __getattribute__(self, nm):
+    if nm not in {"__dict__", "__class__", "missing"} and nm in self.__dict__.get("missing", set()): raise AttributeError(nm)
+    return super().__getattribute__(nm)
+
+  def wgpuCreateInstance(self, descriptor): return self.instance
+
+  def __getattr__(self, nm):
+    if nm in self.missing: raise AttributeError(nm)
+    if nm.startswith("enum_"): return {}
+    if nm.startswith("WGPU"): return _Dummy
+    if nm.startswith("wgpu"):
+      def fn(*args, **kwargs): return _Dummy()
+      fn.__name__ = nm
+      fn.argtypes = ()
+      return fn
+    raise AttributeError(nm)
+
+
+@contextmanager
+def _patched_webgpu(webgpu):
+  old_ops_webgpu = sys.modules.pop("tinygrad.runtime.ops_webgpu", None)
+  old_webgpu = sys.modules.get("tinygrad.runtime.autogen.webgpu")
+  old_autogen_webgpu = autogen.__dict__.get("webgpu")
+  had_autogen_webgpu = "webgpu" in autogen.__dict__
+  sys.modules["tinygrad.runtime.autogen.webgpu"] = autogen.webgpu = webgpu
+  try:
+    yield
+  finally:
+    sys.modules.pop("tinygrad.runtime.ops_webgpu", None)
+    if old_ops_webgpu is not None: sys.modules["tinygrad.runtime.ops_webgpu"] = old_ops_webgpu
+    if old_webgpu is not None: sys.modules["tinygrad.runtime.autogen.webgpu"] = old_webgpu
+    else: sys.modules.pop("tinygrad.runtime.autogen.webgpu", None)
+    if had_autogen_webgpu: autogen.webgpu = old_autogen_webgpu
+    else: autogen.__dict__.pop("webgpu", None)
+
+
+class TestWebGPUImportError(unittest.TestCase):
+  def test_missing_dawn_symbols_raise_install_message(self):
+    for missing in ("enum_WGPUBackendType", "wgpuCreateInstance"):
+      with self.subTest(missing=missing):
+        webgpu = _FakeWebGPU()
+        webgpu.missing.add(missing)
+        with _patched_webgpu(webgpu):
+          with self.assertRaisesRegex(RuntimeError, "(?i)dawn.*install"):
+            importlib.import_module("tinygrad.runtime.ops_webgpu")
+
+  def test_import_succeeds_when_dawn_symbols_present(self):
+    webgpu = _FakeWebGPU()
+    with _patched_webgpu(webgpu):
+      ops_webgpu = importlib.import_module("tinygrad.runtime.ops_webgpu")
+    self.assertIs(ops_webgpu.instance, webgpu.instance)
+    self.assertEqual(ops_webgpu.backend_types, {"WGPUBackendType_Undefined": 0})
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -7,8 +7,20 @@ from tinygrad.runtime.support import c
 from typing import Callable
 import ctypes
 
-backend_types = {v: k for k, v in webgpu.enum_WGPUBackendType.items()}
-instance = webgpu.wgpuCreateInstance(webgpu.WGPUInstanceDescriptor(features=webgpu.WGPUInstanceFeatures(timedWaitAnyEnable=True)))
+_WEBGPU_DAWN_ERROR = (
+  "WEBGPU requires Dawn (webgpu_dawn), but the Dawn library was not found or is missing required symbols. "
+  "Install pydawn from https://github.com/wpmed92/pydawn/releases/tag/v0.3.0 or set WEBGPU_PATH to your Dawn library."
+)
+
+def _initialize_webgpu():
+  try:
+    backend_types = {v: k for k, v in webgpu.enum_WGPUBackendType.items()}
+    instance = webgpu.wgpuCreateInstance(webgpu.WGPUInstanceDescriptor(features=webgpu.WGPUInstanceFeatures(timedWaitAnyEnable=True)))
+  except (AttributeError, OSError):
+    raise RuntimeError(_WEBGPU_DAWN_ERROR) from None
+  return backend_types, instance
+
+backend_types, instance = _initialize_webgpu()
 
 def from_wgpu_str(string_view:webgpu.WGPUStringView) -> str: return ctypes.string_at(string_view.data, string_view.length).decode()
 def to_wgpu_str(_str:str) -> webgpu.WGPUStringView: return webgpu.WGPUStringView(data=ctypes.create_string_buffer(_str.encode()), length=len(_str))


### PR DESCRIPTION
## Summary

Running a WEBGPU example without the dawn library installed now raises a clear error that names dawn and how to install it, instead of leaking a bare `AttributeError`. `tinygrad/runtime/ops_webgpu.py` guards the module-level `wgpuCreateInstance` call (and the `enum_WGPUBackendType` access) so the missing-symbol case is re-raised as a descriptive error.

## Why this matters

Issue #13606 reported that on macOS without dawn, importing a WEBGPU example crashed with `AttributeError: module 'tinygrad.runtime.autogen.webgpu' has no attribute 'wgpuCreateInstance'`. The autogen ctypes bindings load but the underlying libdawn symbols are absent, so the attribute access near line 11 of `ops_webgpu.py` raised before any friendly "install dawn" guidance could reach the user. Maintainer wpmed92 noted on the thread that such a message was supposed to exist. This catches the missing-symbol case (AttributeError / OSError from the ctypes binding) at import/init and re-raises with the install guidance, leaving the happy path unchanged when dawn is present.

## Testing

Covered by the new `test/test_webgpu_import_error.py`: importing with the webgpu symbols absent raises an error whose message mentions dawn and how to install it (not a bare AttributeError), the error is raised eagerly at import/init, and with dawn present the backend imports and creates an instance normally. Full suite runs in CI.

Fixes #13606
