### PR TITLE
viz: kernel_graph.txt unique is per schedule

### DIFF
--- a/extra/viz/kernel_graph.py
+++ b/extra/viz/kernel_graph.py
@@ -20,13 +20,13 @@ if __name__ == "__main__":
       if (v:=json.loads(next(sys.stdin, "{}")).get("value")): print(v)
     if ref is not None or not isinstance(rec:=next(iter(graph.values()), {}), dict) or "label" not in rec: continue
     sched_num = next(sched_counter)
+    unique:dict[int, int] = {}
     for v in graph.values():
       if not v["label"].startswith("CALL"): continue
       lines = v["label"].splitlines()
       # print the CALL and its kernel name from codegen
       print(f"{lines[0]:<12} {lines[-1]}")
       # print sources (buffer, param, multi)
-      unique:dict[int, int] = {}
       for i,(_,s) in enumerate(v["src"][1:]):
         while get_node(graph, s)["label"].startswith("AFTER"): s = get_node(graph, s)["src"][0][1]
         if (num:=unique.get(s)) is None: unique[s] = num = len(unique)


### PR DESCRIPTION
the unique ID of a kernel source is f"{uop_id}-{schedule_number}". UOp Python ID maps to a small integer mainly to make it easier for humans to read
<img width="3838" height="1650" alt="image" src="https://github.com/user-attachments/assets/0ba5503d-d5ff-4186-adc5-824869735dd0" />

