### PR TITLE
Disable bus mastering on AMD PCIe device teardown

### DIFF
--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -908,7 +908,12 @@ class PCIIface(PCIIfaceBase):
     self._collect_interrupts(reset=True)
     raise RuntimeError("Device hang detected")
 
-  def device_fini(self): self.dev_impl.fini()
+  def device_fini(self): 
+    self.dev_impl.fini()
+    #bit2: BusMaster → off
+    #bit10: Interrupt Disable → on
+    cmd = (self.pci_dev.read_config(pci.PCI_COMMAND, 2) & ~pci.PCI_COMMAND_MASTER) | pci.PCI_COMMAND_INTX_DISABLE
+    self.pci_dev.write_config(pci.PCI_COMMAND, cmd, 2)
 
 class USBIface(PCIIface):
   def __init__(self, dev, dev_id): # pylint: disable=super-init-not-called
@@ -943,6 +948,8 @@ class USBIface(PCIIface):
     return super().create_queue(queue_type, ring, gart, rptr, wptr, eop_buffer, cwsr_buffer, ctl_stack_size, ctx_save_restore_size, xcc_id, idx)
 
   def sleep(self, timeout): pass
+
+  def device_fini(self): self.dev_impl.fini()
 
 def _mock(iface, name=None): return type(name or f"MOCK{iface.__name__}", (iface,), {})
 

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -908,12 +908,7 @@ class PCIIface(PCIIfaceBase):
     self._collect_interrupts(reset=True)
     raise RuntimeError("Device hang detected")
 
-  def device_fini(self): 
-    self.dev_impl.fini()
-    #bit2: BusMaster → off
-    #bit10: Interrupt Disable → on
-    cmd = (self.pci_dev.read_config(pci.PCI_COMMAND, 2) & ~pci.PCI_COMMAND_MASTER) | pci.PCI_COMMAND_INTX_DISABLE
-    self.pci_dev.write_config(pci.PCI_COMMAND, cmd, 2)
+  def device_fini(self): self.dev_impl.fini()
 
 class USBIface(PCIIface):
   def __init__(self, dev, dev_id): # pylint: disable=super-init-not-called
@@ -948,8 +943,6 @@ class USBIface(PCIIface):
     return super().create_queue(queue_type, ring, gart, rptr, wptr, eop_buffer, cwsr_buffer, ctl_stack_size, ctx_save_restore_size, xcc_id, idx)
 
   def sleep(self, timeout): pass
-
-  def device_fini(self): self.dev_impl.fini()
 
 def _mock(iface, name=None): return type(name or f"MOCK{iface.__name__}", (iface,), {})
 

--- a/tinygrad/runtime/support/am/amdev.py
+++ b/tinygrad/runtime/support/am/amdev.py
@@ -178,8 +178,9 @@ class AMDev:
           if reset_mode: return # in reset mode, do not raise
           raise RuntimeError("Malformed state. Use extra/amdpci/hive_reset.py to reset the hive")
         self.smu.mode1_reset()
-      self.pci_dev.write_config_flush(pci.PCI_COMMAND, self.pci_dev.read_config(pci.PCI_COMMAND, 2) | pci.PCI_COMMAND_MASTER, 2)
       self.init_hw(self.soc, self.gmc, self.ih, self.psp, self.smu)
+
+    self.pci_dev.write_config_flush(pci.PCI_COMMAND, self.pci_dev.read_config(pci.PCI_COMMAND, 2) | pci.PCI_COMMAND_MASTER, 2)
 
     # Booting done
     self.is_booting = False
@@ -227,6 +228,7 @@ class AMDev:
     for ip in [self.sdma, self.gfx]: ip.fini_hw()
     self.smu.set_clocks(level=0)
     self.ih.interrupt_handler()
+    self.pci_dev.write_config_flush(pci.PCI_COMMAND, self.pci_dev.read_config(pci.PCI_COMMAND, 2) & ~pci.PCI_COMMAND_MASTER, 2)
     self.reg("regSCRATCH_REG6").write(self.is_err_state) # set finalized state.
 
   def recover(self, force=False) -> bool:


### PR DESCRIPTION
**Summary**
Toggle the PCI command register's Bus Master Enable bit (bit 2) around the device lifecycle in AMDev:
- In fini(), clear Bus Master Enable after ih.interrupt_handler(), so the device stops issuing DMA/interrupts to the host once it's finalized.
- In boot, move the Bus Master Enable write to after init_hw() (outside the partial_boot branch) so it's enabled consistently on every boot path.

**Motivation**
On a PCIe-attached AMD GPU, without this teardown the host got flooded with interrupts after the device was closed. Disabling bus mastering on shutdown stops the device from raising interrupts to the host.

**Environment**
- Host: Jetson Orin
- GPU: AMD Radeon RX 9070 XT, connected directly over PCIe