### PR TITLE
more readable null graph profile in VIZ

### DIFF
--- a/test/null/test_viz.py
+++ b/test/null/test_viz.py
@@ -452,6 +452,12 @@ class TestVizIntegration(unittest.TestCase):
     self.assertEqual(len(out["layout"]["NULL"]["events"]), 2*3)
     self.assertEqual(len(out["layout"]["NULL:SDMA:0"]["events"]), 3)
     self.assertEqual(len(out["layout"]["NULL Graph"]["events"]), 2)
+    for graph in out["layout"]["NULL Graph"]["events"]:
+      graph_st, graph_et = graph["st"], graph["st"]+graph["dur"]
+      for k in ["NULL", "NULL:SDMA:0", "NULL:1", "NULL:1:SDMA:0"]:
+        events = [e for e in out["layout"][k]["events"] if graph_st <= e["st"] and e["st"]+e["dur"] <= graph_et]
+        self.assertGreater(len(events), 0)
+        self.assertEqual([e["st"] for e in events], [graph_st+i*events[0]["dur"] for i in range(len(events))])
 
 from tinygrad.device import ProfileDeviceEvent, ProfileGraphEvent, ProfileGraphEntry
 from tinygrad.viz.serve import get_profile

--- a/test/null/test_viz.py
+++ b/test/null/test_viz.py
@@ -454,7 +454,7 @@ class TestVizIntegration(unittest.TestCase):
     self.assertEqual(len(out["layout"]["NULL Graph"]["events"]), 2)
     for graph in out["layout"]["NULL Graph"]["events"]:
       graph_st, graph_et = graph["st"], graph["st"]+graph["dur"]
-      for k in ["NULL", "NULL:SDMA:0", "NULL:1", "NULL:1:SDMA:0"]:
+      for k in ["NULL", "NULL:1", "NULL:SDMA:0", "NULL:1:SDMA:0"]:
         events = [e for e in out["layout"][k]["events"] if graph_st <= e["st"] and e["st"]+e["dur"] <= graph_et]
         self.assertGreater(len(events), 0)
         self.assertEqual([e["st"] for e in events], [graph_st+i*events[0]["dur"] for i in range(len(events))])

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -203,9 +203,9 @@ class TestSafetensors(TempDirTestCase):
       "weight_I16": torch.tensor([127, 64], dtype=torch.short),
       "weight_BF16": torch.randn((2, 2), dtype=torch.bfloat16),
     }
-    save_file(tensors, self.tmp("dtypes.safetensors"))
+    save_file(tensors, self.tmp("dtypes_torch.safetensors"))
 
-    loaded = safe_load(self.tmp("dtypes.safetensors"))
+    loaded = safe_load(self.tmp("dtypes_torch.safetensors"))
     for k,v in loaded.items():
       if v.dtype != dtypes.bfloat16:
         assert v.numpy().dtype == tensors[k].numpy().dtype
@@ -217,9 +217,9 @@ class TestSafetensors(TempDirTestCase):
       "weight_U32": np.array([1, 2, 3], dtype=np.uint32),
       "weight_U64": np.array([1, 2, 3], dtype=np.uint64),
     }
-    np_save_file(tensors, self.tmp("dtypes.safetensors"))
+    np_save_file(tensors, self.tmp("dtypes_numpy.safetensors"))
 
-    loaded = safe_load(self.tmp("dtypes.safetensors"))
+    loaded = safe_load(self.tmp("dtypes_numpy.safetensors"))
     for k,v in loaded.items():
       assert v.numpy().dtype == tensors[k].dtype
       np.testing.assert_allclose(v.numpy(), tensors[k])

--- a/tinygrad/runtime/ops_null.py
+++ b/tinygrad/runtime/ops_null.py
@@ -1,4 +1,4 @@
-import inspect, functools
+import inspect, functools, math
 from tinygrad.device import Compiled, Allocator, ProfileGraphEntry, ProfileGraphEvent
 from tinygrad.engine.jit import MultiGraphRunner
 from tinygrad.renderer import Renderer, cstyle, nir, ptx, llvmir, wgsl
@@ -32,10 +32,20 @@ class NullAllocator(Allocator['NullDevice']):
 
 class NullGraph(MultiGraphRunner):
   def __call__(self, input_uops:tuple[UOp, ...], var_vals:dict[str, int], wait=False) -> float|None:
-    # description based on command, copied from HCQ graph
-    if PROFILE: cpu_events.append(ProfileGraphEvent(ents:=[ProfileGraphEntry(runtime.device if runtime is not None else f"{bufs[1].device}:SDMA:0", \
-        runtime.name if runtime is not None else f"{bufs[1].device} -> {bufs[0].device}", i, i+1) \
-        for i,((_,_,bufs,_),runtime) in enumerate(zip(self.calls, self.runtimes))], [], [perf_counter_us() for _ in range(len(ents)+1)]))
+    if PROFILE:
+      st, descs = perf_counter_us(), []
+      event_count:dict[str, int] = {}
+      for (_,_,bufs,_),runtime in zip(self.calls, self.runtimes):
+        # description based on command, copied from HCQ graph
+        device = runtime.device if runtime is not None else f"{bufs[1].device}:SDMA:0"
+        descs.append((device, runtime.name if runtime is not None else f"{bufs[1].device} -> {bufs[0].device}", count:=event_count.get(device, 0)))
+        event_count[device] = count+1
+      # pack events evenly per device
+      dur, sigs, ents = max(1, math.ceil((perf_counter_us()-st)/max(event_count.values()))), [], []
+      for i,(device,name,count) in enumerate(descs):
+        sigs += [st+count*dur, st+(count+1)*dur]
+        ents.append(ProfileGraphEntry(device, name, 2*i, 2*i+1))
+      cpu_events.append(ProfileGraphEvent(ents, [], sigs))
     return 1e-1
 
 class NullDevice(Compiled):


### PR DESCRIPTION
it used to sample perf_counter timestamp per graph entry, but in a real graph kernels run with little gaps in between.
new viz:
<img width="3840" height="1532" alt="image" src="https://github.com/user-attachments/assets/9ee8953c-45b6-4d69-9946-b445249e7878" />
