### PR TITLE
rangeify: fix cost function for AFTER(out, CALL)

### DIFF
--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -265,7 +265,6 @@ class TestCustomKernel(unittest.TestCase):
     qkv = Tensor.empty(B*N, QKV)
 
     qkv = Tensor.custom_kernel(qkv, x, w, fxn=custom_gemm)[0]
-    #qkv = (x @ w).contiguous()
     qkv = qkv.reshape(B, N, H_KV, REP + 2, D)
 
     q = qkv[:, :, :, :REP, :].reshape(B, N, H, D).transpose(1, 2)
@@ -276,7 +275,7 @@ class TestCustomKernel(unittest.TestCase):
 
     GlobalCounters.reset()
     out.realize()
-    self.assertEqual(GlobalCounters.kernel_count, 6)
+    self.assertEqual(GlobalCounters.kernel_count, 5)
 
   def test_multi_after_schedule_order(self):
     """Test correct scheduling order when custom_kernel has multiple outputs.

--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -256,6 +256,28 @@ class TestCustomKernel(unittest.TestCase):
     err = (O_custom - O_ref).square().max()
     self.assertLess(err.item(), 1e-6)
 
+  def test_gemm_qkv(self):
+    B, N, K_DIM, H_KV, REP, D = 2, 7, 6, 2, 2, 6
+    H, QKV = H_KV * REP, H_KV * (REP + 2) * D
+
+    x = Tensor.empty(B*N, K_DIM)
+    w = Tensor.empty(K_DIM, QKV)
+    qkv = Tensor.empty(B*N, QKV)
+
+    qkv = Tensor.custom_kernel(qkv, x, w, fxn=custom_gemm)[0]
+    #qkv = (x @ w).contiguous()
+    qkv = qkv.reshape(B, N, H_KV, REP + 2, D)
+
+    q = qkv[:, :, :, :REP, :].reshape(B, N, H, D).transpose(1, 2)
+    k = qkv[:, :, :, REP, :].transpose(1, 2)
+    v = qkv[:, :, :, REP + 1, :].transpose(1, 2)
+
+    out = q.scaled_dot_product_attention(k, v, enable_gqa=True)
+
+    GlobalCounters.reset()
+    out.realize()
+    self.assertEqual(GlobalCounters.kernel_count, 6)
+
   def test_multi_after_schedule_order(self):
     """Test correct scheduling order when custom_kernel has multiple outputs.
 

--- a/test/unit/test_function.py
+++ b/test/unit/test_function.py
@@ -557,7 +557,7 @@ class TestFunctionGrad(unittest.TestCase):
     GlobalCounters.reset()
     loss.realize(w1.grad, w2.grad, w3.grad)
     print(GlobalCounters.global_ops, GlobalCounters.global_mem)
-    self.assertLessEqual(GlobalCounters.global_ops, 4739073)
+    self.assertLessEqual(GlobalCounters.global_ops, 4739344)
   def test_function_grad_ops_precompile(self): self.test_function_grad_ops(precompile=True)
   def test_function_grad_ops_precompile_backward(self):
     self.test_function_grad_ops(precompile=True, precompile_backward=True)

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -251,6 +251,9 @@ def remove_bufferize(src:UOp, buf:UOp, idx:UOp):
   indexes: list[UOp] = []
   reduces: list[UOp] = []
   def red_gate(x:UOp):
+    if x.op is Ops.AFTER:
+      accessed_buffers.append(x.buf_uop)
+      return False
     if (x.op is Ops.STAGE and x.arg.addrspace == AddrSpace.GLOBAL) or x.op is Ops.MSTACK:
       accessed_buffers.append(x)
       return False
@@ -274,7 +277,7 @@ def remove_bufferize(src:UOp, buf:UOp, idx:UOp):
   buffer_in_reduce = False
   def buf_gate(x:UOp):
     nonlocal buffer_in_reduce
-    if x.op in {Ops.PARAM, Ops.STAGE}: buffer_in_reduce = True
+    if x.op in {Ops.PARAM, Ops.STAGE, Ops.AFTER}: buffer_in_reduce = True
     return not buffer_in_reduce
   UOp.sink(*[x.src[0] for x in reduces]).toposort(gate=buf_gate)
   del buf_gate


### PR DESCRIPTION
remove_bufferize was traversing past AFTER(CALL) and counting its srcs as accessed buffers.
This copied the QKV bf16 GEMM in llama. -454 kernel launches per step.