### PR TITLE
rangeify: no copies for write+read of same slice

### DIFF
--- a/test/unit/test_assign.py
+++ b/test/unit/test_assign.py
@@ -60,6 +60,16 @@ class TestAssign(unittest.TestCase):
     self.assertListEqual(X.tolist(), [1,4,5,4])
     self.assertEqual(GlobalCounters.kernel_count, 2)
 
+  def test_assign_flip(self):
+    ref = np.arange(16, dtype=np.float32)
+    X = Tensor(ref, device="CPU").contiguous().realize()
+    GlobalCounters.reset()
+    xs = X[::-1]
+    xs.assign(xs + X)
+    ref = ref + ref[::-1]
+    np.testing.assert_allclose(X.numpy(), ref)
+    self.assertEqual(GlobalCounters.kernel_count, 2)
+
   def test_assign_add(self):
     for T in (1, 2, 10):#, 100): # this crashes in CI, not sure why
       x = Tensor([0]).realize()

--- a/test/unit/test_assign.py
+++ b/test/unit/test_assign.py
@@ -44,6 +44,17 @@ class TestAssign(unittest.TestCase):
     c.realize()
     self.assertEqual(GlobalCounters.kernel_count, 1)
 
+  def test_assign_slice(self):
+    ref = np.zeros((4, 4), dtype=np.float32)
+    X = Tensor(ref).contiguous().realize()
+    GlobalCounters.reset()
+    xs = X[1:3]
+    xs.assign(xs + 1)
+    X.realize()
+    ref[1:3] = 1
+    np.testing.assert_allclose(X.numpy(), ref)
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+
   def test_assign_add(self):
     for T in (1, 2, 10):#, 100): # this crashes in CI, not sure why
       x = Tensor([0]).realize()

--- a/test/unit/test_assign.py
+++ b/test/unit/test_assign.py
@@ -45,15 +45,20 @@ class TestAssign(unittest.TestCase):
     self.assertEqual(GlobalCounters.kernel_count, 1)
 
   def test_assign_slice(self):
-    ref = np.zeros((4, 4), dtype=np.float32)
-    X = Tensor(ref).contiguous().realize()
+    X = Tensor([1,2,3,4]).realize()
+    xs = X[2:4]
+    xs.assign(xs+1)
     GlobalCounters.reset()
-    xs = X[1:3]
-    xs.assign(xs + 1)
-    X.realize()
-    ref[1:3] = 1
-    np.testing.assert_allclose(X.numpy(), ref)
+    self.assertListEqual(X.tolist(), [1,2,4,5])
     self.assertEqual(GlobalCounters.kernel_count, 1)
+
+  def test_assign_slice_alt(self):
+    X = Tensor([1,2,3,4]).realize()
+    xs1, xs2 = X[1:3], X[2:4]
+    xs1.assign(xs2+1)
+    GlobalCounters.reset()
+    self.assertListEqual(X.tolist(), [1,4,5,4])
+    self.assertEqual(GlobalCounters.kernel_count, 2)
 
   def test_assign_add(self):
     for T in (1, 2, 10):#, 100): # this crashes in CI, not sure why

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -95,7 +95,7 @@ def fix_store_hazard(target:UOp, src:UOp):
   reaches_base: dict[UOp, bool] = {}
   for s in src.toposort(gate=lambda s: s.op is not Ops.CONTIGUOUS):
     reaches_base[s] = s is base or any(reaches_base.get(c) for c in s.src)
-    if reaches_base[s] and s.op in unsafe: return target.store(src.contiguous())
+    if reaches_base[s] and s.op in unsafe and s is not target: return target.store(src.contiguous())
 
 def split_reduceop(reduce:UOp, x:UOp):
   if prod(reduce.shape) == 0: return None

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -95,7 +95,7 @@ def fix_store_hazard(target:UOp, src:UOp):
   reaches_base: dict[UOp, bool] = {}
   for s in src.toposort(gate=lambda s: s.op is not Ops.CONTIGUOUS):
     reaches_base[s] = s is base or any(reaches_base.get(c) for c in s.src)
-    if reaches_base[s] and s.op in unsafe and s is not target: return target.store(src.contiguous())
+    if reaches_base[s] and s.op in unsafe and not (s is target and s.op is Ops.SHRINK): return target.store(src.contiguous())
 
 def split_reduceop(reduce:UOp, x:UOp):
   if prod(reduce.shape) == 0: return None


### PR DESCRIPTION
fix_store_hazard looks pretty conservative,
This removes 384 kernels per step per device in llama. We assign to a shrink in apply_grad. Extra kernels are visible in the NULL device: `NOOPT=1 PYTHONPATH=. NULL_ALLOW_COPYOUT=1 DEV=NULL:HIP:gfx950 JITBEAM=0 examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/profile.sh`, kernels `E_4096n41...E_4096n70`