### PR TITLE
metal: bound `mtl_buffers_in_flight` with addCompletedHandler

### DIFF
--- a/test/unit/test_metal_graph.py
+++ b/test/unit/test_metal_graph.py
@@ -42,5 +42,25 @@ class TestMetalGraph(unittest.TestCase):
     buf.device = Device.DEFAULT
     self.MetalGraph.supports_uop([self.dev], self.call(buf))
 
+  def test_track_inflight(self):
+    # Partially fixes #16595
+    # TODO: Another unit test to make sure per-step time no longer linearly grows?
+    # Need to make sure auto-cleanup of in-flight command buffers works correctly. This test checks
+    # that the completion handler is called and the command buffer is removed from the in-flight set.
+
+    # track_inflight must: (1) register a block that discards cbuf from the set when fired,
+    # (2) stash the handler on cbuf so the C function pointer stays alive, and
+    # (3) call addCompletedHandler before commit (Metal asserts otherwise)
+    cbuf = self.dev.mtl_queue.commandBuffer().retained()
+    self.dev.track_inflight(cbuf)
+    # (2) CFUNCTYPE stashed on cbuf keeps the C function pointer alive
+    self.assertTrue(callable(cbuf._h))
+    cbuf.commit()
+    cbuf.waitUntilCompleted()
+    # (1) the completion handler discarded cbuf from the in-flight set
+    self.assertNotIn(cbuf, self.dev.mtl_buffers_in_flight)
+    # (3) addCompletedHandler before commit is proven by the fact that the set was cleaned
+    # (Metal should assert in track_inflight if called after commit)
+
 if __name__ == "__main__":
   unittest.main()

--- a/tinygrad/runtime/graph/metal.py
+++ b/tinygrad/runtime/graph/metal.py
@@ -86,10 +86,9 @@ class MetalGraph(GraphRunner):
     encoder.executeCommandsInBuffer_withRange(self.icb, self.range)
     encoder.endEncoding()
     command_buffer.setLabel(to_ns_str(f"batched {len(self.calls)}"))
+    self.dev.track_inflight(command_buffer)
     command_buffer.commit()
     self.command_buffer = command_buffer
-
-    self.dev.mtl_buffers_in_flight.append(command_buffer)
     if wait:
       wait_check(command_buffer)
       return command_buffer.GPUEndTime() - command_buffer.GPUStartTime()

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -1,4 +1,4 @@
-import subprocess, pathlib, struct, ctypes, tempfile, functools, decimal, platform
+import subprocess, pathlib, struct, ctypes, ctypes.util, tempfile, functools, decimal, platform
 from tinygrad.helpers import prod, to_mv, round_up, cache_dir, PROFILE, ProfileRangeEvent, cpu_profile, unwrap, suppress_finalizing
 import tinygrad.runtime.support.objc as objc
 from tinygrad.device import Compiled, Compiler, CompileError, LRUAllocator, ProfileDeviceEvent
@@ -11,6 +11,13 @@ REQUEST_TYPE_COMPILE = 13
 
 # Must be loaded for default Metal Device: https://developer.apple.com/documentation/metal/1433401-mtlcreatesystemdefaultdevice?language=objc
 DLL("CoreGraphics", "CoreGraphics")
+
+# https://clang.llvm.org/docs/Block-ABI-Apple.html
+_NSConcreteStackBlock = ctypes.c_void_p.in_dll(ctypes.CDLL(ctypes.util.find_library("System")), "_NSConcreteStackBlock")
+class _BlockDescriptor(ctypes.Structure): _fields_ = [("reserved", ctypes.c_ulong), ("size", ctypes.c_ulong)]
+class _BlockLiteral(ctypes.Structure):
+  _fields_ = [("isa", ctypes.c_void_p), ("flags", ctypes.c_int32), ("reserved", ctypes.c_int32),
+              ("invoke", ctypes.c_void_p), ("descriptor", ctypes.c_void_p)]
 
 # FIXME: these need autogen to support objc categories
 # https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjectiveC/Chapters/ocCategories.html
@@ -33,7 +40,7 @@ class MetalDevice(Compiled):
     self.sysdevice = metal.MTLCreateSystemDefaultDevice()
     self.mtl_queue = self.sysdevice.newCommandQueueWithMaxCommandBufferCount(1024)
     if self.mtl_queue is None: raise RuntimeError("Cannot allocate a new command queue")
-    self.mtl_buffers_in_flight: list[metal.MTLCommandBuffer] = []
+    self.mtl_buffers_in_flight: set[metal.MTLCommandBuffer] = set()
     self.timeline_signal = self.sysdevice.newSharedEvent()
     self.timeline_value = 0
 
@@ -50,13 +57,26 @@ class MetalDevice(Compiled):
       arch=metal.enum_MTLGPUFamily[check_family("Apple") or check_family("Mac")][12:])
 
   def synchronize(self):
-    for cbuf in self.mtl_buffers_in_flight:
+    for cbuf in list(self.mtl_buffers_in_flight):
       wait_check(cbuf)
       st, en = decimal.Decimal(cbuf.GPUStartTime()) * 1000000, decimal.Decimal(cbuf.GPUEndTime()) * 1000000
       # NOTE: command buffers from MetalGraph are not profiled here
       if PROFILE and (lb:=cmdbuf_label(cbuf)) is not None and not lb.startswith("batched"):
         Compiled.profile_events += [ProfileRangeEvent(self.device, lb, st, en)]
     self.mtl_buffers_in_flight.clear()
+
+  def track_inflight(self, cbuf:metal.MTLCommandBuffer):
+    @ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p)
+    def handler(_, _cb): self.mtl_buffers_in_flight.discard(cbuf)
+    setattr(cbuf, "_h", handler)  # keep CFUNCTYPE alive while cbuf is in the set
+    d = _BlockDescriptor(0, ctypes.sizeof(_BlockLiteral))
+    b = _BlockLiteral()
+    b.isa = _NSConcreteStackBlock.value
+    b.flags = b.reserved = 0
+    b.invoke = ctypes.cast(handler, ctypes.c_void_p).value
+    b.descriptor = ctypes.cast(ctypes.pointer(d), ctypes.c_void_p).value
+    objc.msg("addCompletedHandler:", None, [ctypes.c_void_p])(cbuf, ctypes.byref(b))
+    self.mtl_buffers_in_flight.add(cbuf)
 
 class MetalCompiler(Compiler):
   # Opening METAL after LLVM doesn't fail because ctypes.CDLL opens with RTLD_LOCAL but MTLCompiler opens it's own llvm with RTLD_GLOBAL
@@ -142,8 +162,8 @@ class MetalProgram:
     encoder.dispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
     encoder.endEncoding()
     command_buffer.setLabel(to_ns_str(self.name)) # TODO: is this always needed?
+    self.dev.track_inflight(command_buffer) # Need to make sure to always track before commit to command buffer
     command_buffer.commit()
-    self.dev.mtl_buffers_in_flight.append(command_buffer)
     if wait:
       wait_check(command_buffer)
       return command_buffer.GPUEndTime() - command_buffer.GPUStartTime()
@@ -173,12 +193,12 @@ class MetalAllocator(LRUAllocator[MetalDevice]):
       src_command_buffer.encodeSignalEvent_value(ctypes.cast(src_dev.timeline_signal, metal.MTLEvent), src_dev.timeline_value)
       dest_command_buffer = dest_dev.mtl_queue.commandBuffer().retained()
       dest_command_buffer.encodeWaitForEvent_value(ctypes.cast(src_dev.timeline_signal, metal.MTLEvent), src_dev.timeline_value)
+      dest_dev.track_inflight(dest_command_buffer)
       dest_command_buffer.commit()
-      dest_dev.mtl_buffers_in_flight.append(dest_command_buffer)
       src_dev.timeline_value += 1
     src_command_buffer.setLabel(to_ns_str(f"COPY {src_dev.device} -> {dest_dev.device}"))
+    src_dev.track_inflight(src_command_buffer)
     src_command_buffer.commit()
-    src_dev.mtl_buffers_in_flight.append(src_command_buffer)
     # Transfers currently synchronize the completion. Otherwise, copies can sometimes lead to incorrect values.
     # There is no real metal multidevice support for now, so transfer is used only for tests.
     src_dev.synchronize()


### PR DESCRIPTION
_Partially_ fixes #16595 
Time is still growing but not as bad as before. Need to do more tests.

1. List membership check in ` MetalGraph.__call__:53` is O(n), PR turns it into a list with O(1) check.
2. Auto-cleanup in-flight buffers after GPU is done: Register an addCompletedHandler and block on every commit so the buffer is discarded automatically when the GPU finishes it.

Please check, in `runtime/ops_metal.py:59` the set is snapshotted in synchronize() to list to avoid mutation-during-iteration when handlers fire on the Metal driver thread. This is an assumption and I have not tested if it's necessary. 


I have added a unit test for auto-cleanup, but couldn't figure out a way to reliably word a test for before vs after of in-flight buffers, so here's a repro:

```python

import time
import numpy as np  
from tinygrad import Device, Tensor, TinyJit  

D = 64
# a deep chain produces many kernels per step; each kernel is its own
# MetalGraph call under the one-kernel graph setting, so the in-flight
# list grows by ~5 entries per step.
weights = [Tensor(np.random.randn(D, D).astype(np.float32)) for _ in range(30)]


@TinyJit
def step(x):
    for w in weights:
        x = x.matmul(w).relu()
    return x.sum()


x = Tensor(np.random.randn(D, D).astype(np.float32))

# warmup: capture the graph
for _ in range(3):
    step(x).realize()

dev = Device["METAL"]
print("iter  step_ms  in_flight")
for i in range(200):
    t0 = time.perf_counter()
    step(x).realize()
    t1 = time.perf_counter()
    if i % 20 == 0 or i >= 195:
        print(f"{i:4d}  {(t1 - t0) * 1000:6.2f}  {len(dev.mtl_buffers_in_flight):4d}")

```

```
=== UNPATCHED ===
iter  step_ms  in_flight
   0    0.92    45
  20    0.66   145
  40    0.65   245
  60    1.15   345
  80    0.59   445
 100    0.66   545
 120    0.60   645
 140    0.65   745
 160    0.61   845
 180    0.59   945
 195    1.95  1020
 196    1.88  1025
 197    7.58  1030
 198    1.42  1035
 199    0.71  1040
 ```
 
 ```
=== PATCHED ===
iter  step_ms  in_flight
   0    1.12     2
  20    1.77     3
  40    4.81     2
  60    0.91     1
  80    1.12     1
 100    0.74     1
 120    0.57     2
 140    0.64     2
 160    0.62     2
 180    1.05     1
 195    0.77     1
 196    0.73     1
 197    0.79     1
 198    0.73     2
 199    0.77     3
 ```
