### PR TITLE
fuse fp8 scalars with producer kernels

### DIFF
--- a/examples/mlperf/models/flat_llama.py
+++ b/examples/mlperf/models/flat_llama.py
@@ -73,13 +73,11 @@ def matmul(x:Tensor, w:Tensor, fp8:bool=True, amax_x:Tensor|None=None, w_inv_sca
   w_scale = w_inv_scale if w_scale_idx is None else w_inv_scale[w_scale_idx]
   return (x_fp8.dot(w.T, dtype=dtypes.float) * x_scale * w_scale).cast(dtypes.bfloat16), x_new_amax, x_fp8, x_scale
 
-def norm_quantize_matmul(x:Tensor, norm:Tensor, w:Tensor, w_inv_scale:Tensor, eps:float, amax_x:Tensor, grad_amax_state:Tensor,
-                         w_scale_idx:int|None=None):
+def norm_quantize_matmul(x:Tensor, norm:Tensor, w:Tensor, w_inv_scale:Tensor, eps:float, amax_x:Tensor, grad_amax_state:Tensor, w_scale_idx:int|None=None):
   if FUSED_ADD_NORM_MUL_QUANTIZE:
     from extra.llama_kernels.fused_rmsnorm_mul_quantize_fp8 import fused_rmsnorm_mul_quantize_fp8
     x_fp8, x_inv_scale, new_amax, x_normed, rrms = fused_rmsnorm_mul_quantize_fp8(x, norm, amax_x, eps, FP8_DTYPE)
-    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax,
-                       grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
+    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax, grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
     return out, x_normed, rrms, ret
   x_normed, rrms = rmsnorm(x, eps)
   out, *ret = matmul(x_normed * norm, w, amax_x=amax_x, w_inv_scale=w_inv_scale, grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
@@ -90,8 +88,7 @@ def add_norm_quantize_matmul(x:Tensor, residual:Tensor, norm:Tensor, w:Tensor, w
   if FUSED_ADD_NORM_MUL_QUANTIZE:
     from extra.llama_kernels.fused_rmsnorm_mul_quantize_fp8 import fused_add_rmsnorm_mul_quantize_fp8
     x_fp8, x_inv_scale, new_amax, h, x_normed, rrms = fused_add_rmsnorm_mul_quantize_fp8(x, residual, norm, amax_x, eps, FP8_DTYPE)
-    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax,
-                       grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
+    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax, grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
     return out, h, x_normed, rrms, ret
   h = x + residual
   x_normed, rrms = rmsnorm(h, eps)
@@ -99,13 +96,12 @@ def add_norm_quantize_matmul(x:Tensor, residual:Tensor, norm:Tensor, w:Tensor, w
   return out, h, x_normed, rrms, ret
 
 def silu_w13_quantize_matmul(x_w13:Tensor, w2:Tensor, s_2:Tensor,
-                              amax_x2:Tensor,
-                              grad_amax_xw13:Tensor, grad_amax_xout:Tensor, w_scale_idx:int|None=None):
+                             amax_x2:Tensor,
+                             grad_amax_xw13:Tensor, grad_amax_xout:Tensor, w_scale_idx:int|None=None):
   if FUSED_SILU_W13:
     from extra.llama_kernels.cast_amax import fused_quantize_fp8_w13
     x2_fp8, x2_inv_scale, new_amax_x2 = fused_quantize_fp8_w13(x_w13, amax_x2, FP8_DTYPE, grad_amax_state=grad_amax_xw13)
-    out, *ret = matmul(None, w2, w_inv_scale=s_2, x_fp8=x2_fp8, x_scale=x2_inv_scale, x_new_amax=new_amax_x2,
-                       grad_amax_state=grad_amax_xout, w_scale_idx=w_scale_idx)
+    out, *ret = matmul(None, w2, w_inv_scale=s_2, x_fp8=x2_fp8, x_scale=x2_inv_scale, x_new_amax=new_amax_x2, grad_amax_state=grad_amax_xout, w_scale_idx=w_scale_idx)
     return out, ret
   hidden = x_w13.shape[-1] // 2
   x_w1, x_w3 = x_w13[..., :hidden], x_w13[..., hidden:]
@@ -180,8 +176,7 @@ class FlatTransformer:
     amaxs, saves = [], []
 
     xqkv, x_normed, rrms, (new_amax, *s) = norm_quantize_matmul(x, attention_norm, wqkv, s_qkv, self.norm_eps,
-                                                                  amax_x=amax_xqkv, grad_amax_state=grad_amax_xqkv,
-                                                                  w_scale_idx=w_scale_idx)
+                                                                  amax_x=amax_xqkv, grad_amax_state=grad_amax_xqkv, w_scale_idx=w_scale_idx)
     amaxs.append(new_amax)
     saves.extend([x_normed, rrms, *s, xqkv])
     xqkv = xqkv.reshape(bsz, seqlen, self.n_kv_heads, self.n_rep + 2, self.head_dim)
@@ -214,12 +209,10 @@ class FlatTransformer:
       x_normed, rrms = rmsnorm(h, self.norm_eps)
       saves.extend([x_normed, rrms])
       inp = x_normed * kwargs["ffn_norm"]
-      x_w1, new_amax, *s = matmul(inp, kwargs["w1"], amax_x=kwargs["amax_x1"], w_inv_scale=kwargs["s_1"],
-                                  grad_amax_state=kwargs["grad_amax_xw1"], w_scale_idx=w_scale_idx)
+      x_w1, new_amax, *s = matmul(inp, kwargs["w1"], amax_x=kwargs["amax_x1"], w_inv_scale=kwargs["s_1"], grad_amax_state=kwargs["grad_amax_xw1"], w_scale_idx=w_scale_idx)
       amaxs.append(new_amax)
       saves.extend([*s, x_w1])
-      x_w3, new_amax, *s = matmul(inp, kwargs["w3"], amax_x=kwargs["amax_x3"], w_inv_scale=kwargs["s_3"],
-                                  grad_amax_state=kwargs["grad_amax_xw3"], w_scale_idx=w_scale_idx)
+      x_w3, new_amax, *s = matmul(inp, kwargs["w3"], amax_x=kwargs["amax_x3"], w_inv_scale=kwargs["s_3"], grad_amax_state=kwargs["grad_amax_xw3"], w_scale_idx=w_scale_idx)
       amaxs.append(new_amax)
       saves.extend([*s, x_w3])
       out, new_amax, *s = matmul(x_w1.silu() * x_w3, kwargs["w2"], amax_x=kwargs["amax_x2"], w_inv_scale=kwargs["s_2"],
@@ -228,13 +221,12 @@ class FlatTransformer:
       saves.extend([*s, out])
     else:
       x_w13, h, x_normed, rrms, (new_amax, *s) = add_norm_quantize_matmul(x, residual, kwargs["ffn_norm"], kwargs["w13"], kwargs["s_13"],
-                                                                           self.norm_eps, amax_x=kwargs["amax_x13"],
-                                                                           grad_amax_state=kwargs["grad_amax_xw13"], w_scale_idx=w_scale_idx)
+                                                                          self.norm_eps, amax_x=kwargs["amax_x13"],
+                                                                          grad_amax_state=kwargs["grad_amax_xw13"], w_scale_idx=w_scale_idx)
       amaxs.append(new_amax)
       saves.extend([x_normed, rrms, *s, x_w13])
       out, (new_amax, *s) = silu_w13_quantize_matmul(x_w13, kwargs["w2"], kwargs["s_2"], amax_x2=kwargs["amax_x2"],
-                                                     grad_amax_xw13=kwargs["grad_amax_xw13"], grad_amax_xout=kwargs["grad_amax_xout"],
-                                                     w_scale_idx=w_scale_idx)
+                                                     grad_amax_xw13=kwargs["grad_amax_xw13"], grad_amax_xout=kwargs["grad_amax_xout"], w_scale_idx=w_scale_idx)
       amaxs.append(new_amax)
       saves.extend([*s, out])
     return out, h, amaxs, saves

--- a/examples/mlperf/models/flat_llama.py
+++ b/examples/mlperf/models/flat_llama.py
@@ -68,8 +68,8 @@ def matmul(x:Tensor, w:Tensor, fp8:bool=True, amax_x:Tensor|None=None, w_inv_sca
         out = asm_gemm(x_fp8, w.T, x_scale=x_scale, grad_amax_state=grad_amax_state, w_post_scale=w_inv_scale)
       else:
         out = asm_gemm(x_fp8, w.T, x_scale=x_scale, w_scale=w_inv_scale, grad_amax_state=grad_amax_state)
-      return out, x_new_amax, x_fp8
-  return (x_fp8.dot(w.T, dtype=dtypes.float) * x_scale * w_inv_scale).cast(dtypes.bfloat16), x_new_amax, x_fp8
+      return out, x_new_amax, x_fp8, x_scale
+  return (x_fp8.dot(w.T, dtype=dtypes.float) * x_scale * w_inv_scale).cast(dtypes.bfloat16), x_new_amax, x_fp8, x_scale
 
 def norm_quantize_matmul(x:Tensor, norm:Tensor, w:Tensor, w_inv_scale:Tensor, eps:float, amax_x:Tensor, grad_amax_state:Tensor):
   if FUSED_ADD_NORM_MUL_QUANTIZE:

--- a/examples/mlperf/models/flat_llama.py
+++ b/examples/mlperf/models/flat_llama.py
@@ -38,7 +38,7 @@ def quantize_fp8(x:Tensor, amax_state:Tensor|None=None):
 
 def matmul(x:Tensor, w:Tensor, fp8:bool=True, amax_x:Tensor|None=None, w_inv_scale:Tensor|None=None,
            x_fp8:Tensor|None=None, x_scale:Tensor|None=None, x_new_amax:Tensor|None=None,
-           grad_amax_state:Tensor|None=None, w_scale_idx:int|None=None) -> tuple[Tensor,...]:
+           grad_amax_state:Tensor|None=None) -> tuple[Tensor,...]:
   if not fp8:
     if ASM_GEMM:
       from extra.gemm.cdna_asm_gemm import can_use_asm_gemm, asm_gemm
@@ -67,45 +67,43 @@ def matmul(x:Tensor, w:Tensor, fp8:bool=True, amax_x:Tensor|None=None, w_inv_sca
       if COLUMNWISE_WEIGHT_SCALE:
         out = asm_gemm(x_fp8, w.T, x_scale=x_scale, grad_amax_state=grad_amax_state, w_post_scale=w_inv_scale)
       else:
-        out = asm_gemm(x_fp8, w.T, x_scale=x_scale, w_scale=w_inv_scale, grad_amax_state=grad_amax_state,
-                       w_scale_offset=0 if w_scale_idx is None else w_scale_idx)
+        out = asm_gemm(x_fp8, w.T, x_scale=x_scale, w_scale=w_inv_scale, grad_amax_state=grad_amax_state)
       return out, x_new_amax, x_fp8, x_scale
-  w_scale = w_inv_scale if w_scale_idx is None else w_inv_scale[w_scale_idx]
-  return (x_fp8.dot(w.T, dtype=dtypes.float) * x_scale * w_scale).cast(dtypes.bfloat16), x_new_amax, x_fp8, x_scale
+  return (x_fp8.dot(w.T, dtype=dtypes.float) * x_scale * w_inv_scale).cast(dtypes.bfloat16), x_new_amax, x_fp8, x_scale
 
-def norm_quantize_matmul(x:Tensor, norm:Tensor, w:Tensor, w_inv_scale:Tensor, eps:float, amax_x:Tensor, grad_amax_state:Tensor, w_scale_idx:int|None=None):
+def norm_quantize_matmul(x:Tensor, norm:Tensor, w:Tensor, w_inv_scale:Tensor, eps:float, amax_x:Tensor, grad_amax_state:Tensor):
   if FUSED_ADD_NORM_MUL_QUANTIZE:
     from extra.llama_kernels.fused_rmsnorm_mul_quantize_fp8 import fused_rmsnorm_mul_quantize_fp8
     x_fp8, x_inv_scale, new_amax, x_normed, rrms = fused_rmsnorm_mul_quantize_fp8(x, norm, amax_x, eps, FP8_DTYPE)
-    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax, grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
+    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax, grad_amax_state=grad_amax_state)
     return out, x_normed, rrms, ret
   x_normed, rrms = rmsnorm(x, eps)
-  out, *ret = matmul(x_normed * norm, w, amax_x=amax_x, w_inv_scale=w_inv_scale, grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
+  out, *ret = matmul(x_normed * norm, w, amax_x=amax_x, w_inv_scale=w_inv_scale, grad_amax_state=grad_amax_state)
   return out, x_normed, rrms, ret
 
 def add_norm_quantize_matmul(x:Tensor, residual:Tensor, norm:Tensor, w:Tensor, w_inv_scale:Tensor, eps:float, amax_x:Tensor,
-                             grad_amax_state:Tensor|None=None, w_scale_idx:int|None=None):
+                             grad_amax_state:Tensor|None=None):
   if FUSED_ADD_NORM_MUL_QUANTIZE:
     from extra.llama_kernels.fused_rmsnorm_mul_quantize_fp8 import fused_add_rmsnorm_mul_quantize_fp8
     x_fp8, x_inv_scale, new_amax, h, x_normed, rrms = fused_add_rmsnorm_mul_quantize_fp8(x, residual, norm, amax_x, eps, FP8_DTYPE)
-    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax, grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
+    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax, grad_amax_state=grad_amax_state)
     return out, h, x_normed, rrms, ret
   h = x + residual
   x_normed, rrms = rmsnorm(h, eps)
-  out, *ret = matmul(x_normed * norm, w, amax_x=amax_x, w_inv_scale=w_inv_scale, grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
+  out, *ret = matmul(x_normed * norm, w, amax_x=amax_x, w_inv_scale=w_inv_scale, grad_amax_state=grad_amax_state)
   return out, h, x_normed, rrms, ret
 
 def silu_w13_quantize_matmul(x_w13:Tensor, w2:Tensor, s_2:Tensor,
                              amax_x2:Tensor,
-                             grad_amax_xw13:Tensor, grad_amax_xout:Tensor, w_scale_idx:int|None=None):
+                             grad_amax_xw13:Tensor, grad_amax_xout:Tensor):
   if FUSED_SILU_W13:
     from extra.llama_kernels.cast_amax import fused_quantize_fp8_w13
     x2_fp8, x2_inv_scale, new_amax_x2 = fused_quantize_fp8_w13(x_w13, amax_x2, FP8_DTYPE, grad_amax_state=grad_amax_xw13)
-    out, *ret = matmul(None, w2, w_inv_scale=s_2, x_fp8=x2_fp8, x_scale=x2_inv_scale, x_new_amax=new_amax_x2, grad_amax_state=grad_amax_xout, w_scale_idx=w_scale_idx)
+    out, *ret = matmul(None, w2, w_inv_scale=s_2, x_fp8=x2_fp8, x_scale=x2_inv_scale, x_new_amax=new_amax_x2, grad_amax_state=grad_amax_xout)
     return out, ret
   hidden = x_w13.shape[-1] // 2
   x_w1, x_w3 = x_w13[..., :hidden], x_w13[..., hidden:]
-  out, *ret = matmul(x_w1.silu() * x_w3, w2, amax_x=amax_x2, w_inv_scale=s_2, grad_amax_state=grad_amax_xout, w_scale_idx=w_scale_idx)
+  out, *ret = matmul(x_w1.silu() * x_w3, w2, amax_x=amax_x2, w_inv_scale=s_2, grad_amax_state=grad_amax_xout)
   return out, ret
 
 class FlatTransformer:
@@ -171,12 +169,12 @@ class FlatTransformer:
 
   def attention(self, x:Tensor, freqs_cis:Tensor, *, attention_norm:Tensor, wqkv:Tensor, wo:Tensor,
                 amax_xqkv:Tensor, amax_xo:Tensor, s_qkv:Tensor, s_o:Tensor,
-                grad_amax_xqkv:Tensor, grad_amax_xo:Tensor, w_scale_idx:int|None=None):
+                grad_amax_xqkv:Tensor, grad_amax_xo:Tensor):
     bsz, seqlen, _ = x.shape
     amaxs, saves = [], []
 
     xqkv, x_normed, rrms, (new_amax, *s) = norm_quantize_matmul(x, attention_norm, wqkv, s_qkv, self.norm_eps,
-                                                                  amax_x=amax_xqkv, grad_amax_state=grad_amax_xqkv, w_scale_idx=w_scale_idx)
+                                                                  amax_x=amax_xqkv, grad_amax_state=grad_amax_xqkv)
     amaxs.append(new_amax)
     saves.extend([x_normed, rrms, *s, xqkv])
     xqkv = xqkv.reshape(bsz, seqlen, self.n_kv_heads, self.n_rep + 2, self.head_dim)
@@ -195,38 +193,37 @@ class FlatTransformer:
       attn = xq.scaled_dot_product_attention(xk, xv, is_causal=True, enable_gqa=True).transpose(1, 2)
     attn = attn.reshape(bsz, seqlen, -1)
 
-    out, new_amax, *s = matmul(attn, wo, amax_x=amax_xo, w_inv_scale=s_o, grad_amax_state=grad_amax_xo, w_scale_idx=w_scale_idx)
+    out, new_amax, *s = matmul(attn, wo, amax_x=amax_xo, w_inv_scale=s_o, grad_amax_state=grad_amax_xo)
     amaxs.append(new_amax)
     saves.extend([*s, out])
     return out, amaxs, saves
 
   def feed_forward(self, x:Tensor, residual:Tensor, **kwargs):
     amaxs, saves = [], []
-    w_scale_idx = kwargs.get("w_scale_idx")
 
     if SPLIT_W13:
       h = x + residual
       x_normed, rrms = rmsnorm(h, self.norm_eps)
       saves.extend([x_normed, rrms])
       inp = x_normed * kwargs["ffn_norm"]
-      x_w1, new_amax, *s = matmul(inp, kwargs["w1"], amax_x=kwargs["amax_x1"], w_inv_scale=kwargs["s_1"], grad_amax_state=kwargs["grad_amax_xw1"], w_scale_idx=w_scale_idx)
+      x_w1, new_amax, *s = matmul(inp, kwargs["w1"], amax_x=kwargs["amax_x1"], w_inv_scale=kwargs["s_1"], grad_amax_state=kwargs["grad_amax_xw1"])
       amaxs.append(new_amax)
       saves.extend([*s, x_w1])
-      x_w3, new_amax, *s = matmul(inp, kwargs["w3"], amax_x=kwargs["amax_x3"], w_inv_scale=kwargs["s_3"], grad_amax_state=kwargs["grad_amax_xw3"], w_scale_idx=w_scale_idx)
+      x_w3, new_amax, *s = matmul(inp, kwargs["w3"], amax_x=kwargs["amax_x3"], w_inv_scale=kwargs["s_3"], grad_amax_state=kwargs["grad_amax_xw3"])
       amaxs.append(new_amax)
       saves.extend([*s, x_w3])
       out, new_amax, *s = matmul(x_w1.silu() * x_w3, kwargs["w2"], amax_x=kwargs["amax_x2"], w_inv_scale=kwargs["s_2"],
-                                 grad_amax_state=kwargs["grad_amax_xout"], w_scale_idx=w_scale_idx)
+                                 grad_amax_state=kwargs["grad_amax_xout"])
       amaxs.append(new_amax)
       saves.extend([*s, out])
     else:
       x_w13, h, x_normed, rrms, (new_amax, *s) = add_norm_quantize_matmul(x, residual, kwargs["ffn_norm"], kwargs["w13"], kwargs["s_13"],
                                                                           self.norm_eps, amax_x=kwargs["amax_x13"],
-                                                                          grad_amax_state=kwargs["grad_amax_xw13"], w_scale_idx=w_scale_idx)
+                                                                          grad_amax_state=kwargs["grad_amax_xw13"])
       amaxs.append(new_amax)
       saves.extend([x_normed, rrms, *s, x_w13])
       out, (new_amax, *s) = silu_w13_quantize_matmul(x_w13, kwargs["w2"], kwargs["s_2"], amax_x2=kwargs["amax_x2"],
-                                                     grad_amax_xw13=kwargs["grad_amax_xw13"], grad_amax_xout=kwargs["grad_amax_xout"], w_scale_idx=w_scale_idx)
+                                                     grad_amax_xw13=kwargs["grad_amax_xw13"], grad_amax_xout=kwargs["grad_amax_xout"])
       amaxs.append(new_amax)
       saves.extend([*s, out])
     return out, h, amaxs, saves
@@ -275,21 +272,17 @@ class FlatTransformer:
     h = self.tok_embeddings(tokens)
     freqs_cis = self.freqs_cis.cast(h.dtype)[:, :tokens.shape[1], :, :, :]
     a, ga, s = self._fp8_amax, self._fp8_grad_amax, self._fp8_inv_scale
-    scalar_w_scale_offset = not (MXFP8 or COLUMNWISE_WEIGHT_SCALE)
     for i in range(self.n_layers):
-      def ws(name): return s[name] if scalar_w_scale_offset else s[name][i]
       attn_kwargs = dict(attention_norm=self.attention_norm[i], wqkv=self.wqkv[i], wo=self.wo[i],
-                         amax_xqkv=a["xqkv"][i], amax_xo=a["xo"][i], s_qkv=ws("wqkv"), s_o=ws("wo"),
-                         grad_amax_xqkv=ga["xqkv"][i], grad_amax_xo=ga["xo"][i],
-                         w_scale_idx=i if scalar_w_scale_offset else None)
+                         amax_xqkv=a["xqkv"][i], amax_xo=a["xo"][i], s_qkv=s["wqkv"][i], s_o=s["wo"][i],
+                         grad_amax_xqkv=ga["xqkv"][i], grad_amax_xo=ga["xo"][i])
       ffn_kwargs = dict(ffn_norm=self.ffn_norm[i], w2=self.w2[i],
-                        amax_x2=a["x2"][i], s_2=ws("w2"), grad_amax_xout=ga["xout"][i],
-                        w_scale_idx=i if scalar_w_scale_offset else None)
+                        amax_x2=a["x2"][i], s_2=s["w2"][i], grad_amax_xout=ga["xout"][i])
       if SPLIT_W13:
         ffn_kwargs.update(w1=self.w1[i], w3=self.w3[i], amax_x1=a["x1"][i], amax_x3=a["x3"][i],
-                          s_1=ws("w1"), s_3=ws("w3"), grad_amax_xw1=ga["xw1"][i], grad_amax_xw3=ga["xw3"][i])
+                          s_1=s["w1"][i], s_3=s["w3"][i], grad_amax_xw1=ga["xw1"][i], grad_amax_xw3=ga["xw3"][i])
       else:
-        ffn_kwargs.update(w13=self.w13[i], amax_x13=a["x13"][i], s_13=ws("w13"), grad_amax_xw13=ga["xw13"][i])
+        ffn_kwargs.update(w13=self.w13[i], amax_x13=a["x13"][i], s_13=s["w13"][i], grad_amax_xw13=ga["xw13"][i])
       h, *ret = self.run_layer(h, freqs_cis, attn_kwargs, ffn_kwargs, save=save)
       amax_names = ["xqkv", "xo"] + (["x1", "x3"] if SPLIT_W13 else ["x13"]) + ["x2"]
       for name, new_val in zip(amax_names, ret[:len(amax_names)]):

--- a/examples/mlperf/models/flat_llama.py
+++ b/examples/mlperf/models/flat_llama.py
@@ -38,7 +38,7 @@ def quantize_fp8(x:Tensor, amax_state:Tensor|None=None):
 
 def matmul(x:Tensor, w:Tensor, fp8:bool=True, amax_x:Tensor|None=None, w_inv_scale:Tensor|None=None,
            x_fp8:Tensor|None=None, x_scale:Tensor|None=None, x_new_amax:Tensor|None=None,
-           grad_amax_state:Tensor|None=None) -> tuple[Tensor,...]:
+           grad_amax_state:Tensor|None=None, w_scale_idx:int|None=None) -> tuple[Tensor,...]:
   if not fp8:
     if ASM_GEMM:
       from extra.gemm.cdna_asm_gemm import can_use_asm_gemm, asm_gemm
@@ -67,43 +67,49 @@ def matmul(x:Tensor, w:Tensor, fp8:bool=True, amax_x:Tensor|None=None, w_inv_sca
       if COLUMNWISE_WEIGHT_SCALE:
         out = asm_gemm(x_fp8, w.T, x_scale=x_scale, grad_amax_state=grad_amax_state, w_post_scale=w_inv_scale)
       else:
-        out = asm_gemm(x_fp8, w.T, x_scale=x_scale, w_scale=w_inv_scale, grad_amax_state=grad_amax_state)
+        out = asm_gemm(x_fp8, w.T, x_scale=x_scale, w_scale=w_inv_scale, grad_amax_state=grad_amax_state,
+                       w_scale_offset=0 if w_scale_idx is None else w_scale_idx)
       return out, x_new_amax, x_fp8, x_scale
-  return (x_fp8.dot(w.T, dtype=dtypes.float) * x_scale * w_inv_scale).cast(dtypes.bfloat16), x_new_amax, x_fp8, x_scale
+  w_scale = w_inv_scale if w_scale_idx is None else w_inv_scale[w_scale_idx]
+  return (x_fp8.dot(w.T, dtype=dtypes.float) * x_scale * w_scale).cast(dtypes.bfloat16), x_new_amax, x_fp8, x_scale
 
-def norm_quantize_matmul(x:Tensor, norm:Tensor, w:Tensor, w_inv_scale:Tensor, eps:float, amax_x:Tensor, grad_amax_state:Tensor):
+def norm_quantize_matmul(x:Tensor, norm:Tensor, w:Tensor, w_inv_scale:Tensor, eps:float, amax_x:Tensor, grad_amax_state:Tensor,
+                         w_scale_idx:int|None=None):
   if FUSED_ADD_NORM_MUL_QUANTIZE:
     from extra.llama_kernels.fused_rmsnorm_mul_quantize_fp8 import fused_rmsnorm_mul_quantize_fp8
     x_fp8, x_inv_scale, new_amax, x_normed, rrms = fused_rmsnorm_mul_quantize_fp8(x, norm, amax_x, eps, FP8_DTYPE)
-    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax, grad_amax_state=grad_amax_state)
+    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax,
+                       grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
     return out, x_normed, rrms, ret
   x_normed, rrms = rmsnorm(x, eps)
-  out, *ret = matmul(x_normed * norm, w, amax_x=amax_x, w_inv_scale=w_inv_scale, grad_amax_state=grad_amax_state)
+  out, *ret = matmul(x_normed * norm, w, amax_x=amax_x, w_inv_scale=w_inv_scale, grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
   return out, x_normed, rrms, ret
 
 def add_norm_quantize_matmul(x:Tensor, residual:Tensor, norm:Tensor, w:Tensor, w_inv_scale:Tensor, eps:float, amax_x:Tensor,
-                             grad_amax_state:Tensor|None=None):
+                             grad_amax_state:Tensor|None=None, w_scale_idx:int|None=None):
   if FUSED_ADD_NORM_MUL_QUANTIZE:
     from extra.llama_kernels.fused_rmsnorm_mul_quantize_fp8 import fused_add_rmsnorm_mul_quantize_fp8
     x_fp8, x_inv_scale, new_amax, h, x_normed, rrms = fused_add_rmsnorm_mul_quantize_fp8(x, residual, norm, amax_x, eps, FP8_DTYPE)
-    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax, grad_amax_state=grad_amax_state)
+    out, *ret = matmul(None, w, w_inv_scale=w_inv_scale, x_fp8=x_fp8, x_scale=x_inv_scale, x_new_amax=new_amax,
+                       grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
     return out, h, x_normed, rrms, ret
   h = x + residual
   x_normed, rrms = rmsnorm(h, eps)
-  out, *ret = matmul(x_normed * norm, w, amax_x=amax_x, w_inv_scale=w_inv_scale, grad_amax_state=grad_amax_state)
+  out, *ret = matmul(x_normed * norm, w, amax_x=amax_x, w_inv_scale=w_inv_scale, grad_amax_state=grad_amax_state, w_scale_idx=w_scale_idx)
   return out, h, x_normed, rrms, ret
 
 def silu_w13_quantize_matmul(x_w13:Tensor, w2:Tensor, s_2:Tensor,
-                             amax_x2:Tensor,
-                             grad_amax_xw13:Tensor, grad_amax_xout:Tensor):
+                              amax_x2:Tensor,
+                              grad_amax_xw13:Tensor, grad_amax_xout:Tensor, w_scale_idx:int|None=None):
   if FUSED_SILU_W13:
     from extra.llama_kernels.cast_amax import fused_quantize_fp8_w13
     x2_fp8, x2_inv_scale, new_amax_x2 = fused_quantize_fp8_w13(x_w13, amax_x2, FP8_DTYPE, grad_amax_state=grad_amax_xw13)
-    out, *ret = matmul(None, w2, w_inv_scale=s_2, x_fp8=x2_fp8, x_scale=x2_inv_scale, x_new_amax=new_amax_x2, grad_amax_state=grad_amax_xout)
+    out, *ret = matmul(None, w2, w_inv_scale=s_2, x_fp8=x2_fp8, x_scale=x2_inv_scale, x_new_amax=new_amax_x2,
+                       grad_amax_state=grad_amax_xout, w_scale_idx=w_scale_idx)
     return out, ret
   hidden = x_w13.shape[-1] // 2
   x_w1, x_w3 = x_w13[..., :hidden], x_w13[..., hidden:]
-  out, *ret = matmul(x_w1.silu() * x_w3, w2, amax_x=amax_x2, w_inv_scale=s_2, grad_amax_state=grad_amax_xout)
+  out, *ret = matmul(x_w1.silu() * x_w3, w2, amax_x=amax_x2, w_inv_scale=s_2, grad_amax_state=grad_amax_xout, w_scale_idx=w_scale_idx)
   return out, ret
 
 class FlatTransformer:
@@ -169,12 +175,13 @@ class FlatTransformer:
 
   def attention(self, x:Tensor, freqs_cis:Tensor, *, attention_norm:Tensor, wqkv:Tensor, wo:Tensor,
                 amax_xqkv:Tensor, amax_xo:Tensor, s_qkv:Tensor, s_o:Tensor,
-                grad_amax_xqkv:Tensor, grad_amax_xo:Tensor):
+                grad_amax_xqkv:Tensor, grad_amax_xo:Tensor, w_scale_idx:int|None=None):
     bsz, seqlen, _ = x.shape
     amaxs, saves = [], []
 
     xqkv, x_normed, rrms, (new_amax, *s) = norm_quantize_matmul(x, attention_norm, wqkv, s_qkv, self.norm_eps,
-                                                                  amax_x=amax_xqkv, grad_amax_state=grad_amax_xqkv)
+                                                                  amax_x=amax_xqkv, grad_amax_state=grad_amax_xqkv,
+                                                                  w_scale_idx=w_scale_idx)
     amaxs.append(new_amax)
     saves.extend([x_normed, rrms, *s, xqkv])
     xqkv = xqkv.reshape(bsz, seqlen, self.n_kv_heads, self.n_rep + 2, self.head_dim)
@@ -193,37 +200,41 @@ class FlatTransformer:
       attn = xq.scaled_dot_product_attention(xk, xv, is_causal=True, enable_gqa=True).transpose(1, 2)
     attn = attn.reshape(bsz, seqlen, -1)
 
-    out, new_amax, *s = matmul(attn, wo, amax_x=amax_xo, w_inv_scale=s_o, grad_amax_state=grad_amax_xo)
+    out, new_amax, *s = matmul(attn, wo, amax_x=amax_xo, w_inv_scale=s_o, grad_amax_state=grad_amax_xo, w_scale_idx=w_scale_idx)
     amaxs.append(new_amax)
     saves.extend([*s, out])
     return out, amaxs, saves
 
   def feed_forward(self, x:Tensor, residual:Tensor, **kwargs):
     amaxs, saves = [], []
+    w_scale_idx = kwargs.get("w_scale_idx")
 
     if SPLIT_W13:
       h = x + residual
       x_normed, rrms = rmsnorm(h, self.norm_eps)
       saves.extend([x_normed, rrms])
       inp = x_normed * kwargs["ffn_norm"]
-      x_w1, new_amax, *s = matmul(inp, kwargs["w1"], amax_x=kwargs["amax_x1"], w_inv_scale=kwargs["s_1"], grad_amax_state=kwargs["grad_amax_xw1"])
+      x_w1, new_amax, *s = matmul(inp, kwargs["w1"], amax_x=kwargs["amax_x1"], w_inv_scale=kwargs["s_1"],
+                                  grad_amax_state=kwargs["grad_amax_xw1"], w_scale_idx=w_scale_idx)
       amaxs.append(new_amax)
       saves.extend([*s, x_w1])
-      x_w3, new_amax, *s = matmul(inp, kwargs["w3"], amax_x=kwargs["amax_x3"], w_inv_scale=kwargs["s_3"], grad_amax_state=kwargs["grad_amax_xw3"])
+      x_w3, new_amax, *s = matmul(inp, kwargs["w3"], amax_x=kwargs["amax_x3"], w_inv_scale=kwargs["s_3"],
+                                  grad_amax_state=kwargs["grad_amax_xw3"], w_scale_idx=w_scale_idx)
       amaxs.append(new_amax)
       saves.extend([*s, x_w3])
       out, new_amax, *s = matmul(x_w1.silu() * x_w3, kwargs["w2"], amax_x=kwargs["amax_x2"], w_inv_scale=kwargs["s_2"],
-                                 grad_amax_state=kwargs["grad_amax_xout"])
+                                 grad_amax_state=kwargs["grad_amax_xout"], w_scale_idx=w_scale_idx)
       amaxs.append(new_amax)
       saves.extend([*s, out])
     else:
       x_w13, h, x_normed, rrms, (new_amax, *s) = add_norm_quantize_matmul(x, residual, kwargs["ffn_norm"], kwargs["w13"], kwargs["s_13"],
-                                                                          self.norm_eps, amax_x=kwargs["amax_x13"],
-                                                                          grad_amax_state=kwargs["grad_amax_xw13"])
+                                                                           self.norm_eps, amax_x=kwargs["amax_x13"],
+                                                                           grad_amax_state=kwargs["grad_amax_xw13"], w_scale_idx=w_scale_idx)
       amaxs.append(new_amax)
       saves.extend([x_normed, rrms, *s, x_w13])
       out, (new_amax, *s) = silu_w13_quantize_matmul(x_w13, kwargs["w2"], kwargs["s_2"], amax_x2=kwargs["amax_x2"],
-                                                     grad_amax_xw13=kwargs["grad_amax_xw13"], grad_amax_xout=kwargs["grad_amax_xout"])
+                                                     grad_amax_xw13=kwargs["grad_amax_xw13"], grad_amax_xout=kwargs["grad_amax_xout"],
+                                                     w_scale_idx=w_scale_idx)
       amaxs.append(new_amax)
       saves.extend([*s, out])
     return out, h, amaxs, saves
@@ -272,17 +283,21 @@ class FlatTransformer:
     h = self.tok_embeddings(tokens)
     freqs_cis = self.freqs_cis.cast(h.dtype)[:, :tokens.shape[1], :, :, :]
     a, ga, s = self._fp8_amax, self._fp8_grad_amax, self._fp8_inv_scale
+    scalar_w_scale_offset = not (MXFP8 or COLUMNWISE_WEIGHT_SCALE)
     for i in range(self.n_layers):
+      def ws(name): return s[name] if scalar_w_scale_offset else s[name][i]
       attn_kwargs = dict(attention_norm=self.attention_norm[i], wqkv=self.wqkv[i], wo=self.wo[i],
-                         amax_xqkv=a["xqkv"][i], amax_xo=a["xo"][i], s_qkv=s["wqkv"][i], s_o=s["wo"][i],
-                         grad_amax_xqkv=ga["xqkv"][i], grad_amax_xo=ga["xo"][i])
+                         amax_xqkv=a["xqkv"][i], amax_xo=a["xo"][i], s_qkv=ws("wqkv"), s_o=ws("wo"),
+                         grad_amax_xqkv=ga["xqkv"][i], grad_amax_xo=ga["xo"][i],
+                         w_scale_idx=i if scalar_w_scale_offset else None)
       ffn_kwargs = dict(ffn_norm=self.ffn_norm[i], w2=self.w2[i],
-                        amax_x2=a["x2"][i], s_2=s["w2"][i], grad_amax_xout=ga["xout"][i])
+                        amax_x2=a["x2"][i], s_2=ws("w2"), grad_amax_xout=ga["xout"][i],
+                        w_scale_idx=i if scalar_w_scale_offset else None)
       if SPLIT_W13:
         ffn_kwargs.update(w1=self.w1[i], w3=self.w3[i], amax_x1=a["x1"][i], amax_x3=a["x3"][i],
-                          s_1=s["w1"][i], s_3=s["w3"][i], grad_amax_xw1=ga["xw1"][i], grad_amax_xw3=ga["xw3"][i])
+                          s_1=ws("w1"), s_3=ws("w3"), grad_amax_xw1=ga["xw1"][i], grad_amax_xw3=ga["xw3"][i])
       else:
-        ffn_kwargs.update(w13=self.w13[i], amax_x13=a["x13"][i], s_13=s["w13"][i], grad_amax_xw13=ga["xw13"][i])
+        ffn_kwargs.update(w13=self.w13[i], amax_x13=a["x13"][i], s_13=ws("w13"), grad_amax_xw13=ga["xw13"][i])
       h, *ret = self.run_layer(h, freqs_cis, attn_kwargs, ffn_kwargs, save=save)
       amax_names = ["xqkv", "xo"] + (["x1", "x3"] if SPLIT_W13 else ["x13"]) + ["x2"]
       for name, new_val in zip(amax_names, ret[:len(amax_names)]):

--- a/extra/gemm/cdna_asm_gemm.py
+++ b/extra/gemm/cdna_asm_gemm.py
@@ -2628,7 +2628,7 @@ def custom_asm_gemm(C:UOp, A:UOp, B:UOp, dname:str) -> UOp:
 # ** FP8 GEMM custom kernel
 
 @functools.cache
-def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int=3) -> UOp:
+def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int=3, scale_offsets:tuple[int,int,int]=(0,0,0)) -> UOp:
   # scale_mode: 0=no scale, 1=x only, 2=w only, 3=x*w, 7=x*w*extra
   n_scales = (1 if scale_mode & 1 else 0) + (1 if scale_mode & 2 else 0) + (1 if scale_mode & 4 else 0)
   scales, extra = args[:n_scales], args[n_scales:]
@@ -2644,8 +2644,9 @@ def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int
   kittens_path = pathlib.Path(__file__).parent.parent/"thunder"/"amd"
   src = (kittens_path/"gemm_fp8.cpp").read_text()
   lib = HIPCCCompiler("gfx950", [f"-I{(kittens_path/'include').as_posix()}", "-std=c++20", "-DKITTENS_CDNA4", "-ffast-math",
-                                 "-DHIP_ENABLE_WARP_SYNC_BUILTINS", f"-DGEMM_M={M}", f"-DGEMM_N={N}", f"-DGEMM_K={K}",
-                                 f"-DSCALE_MODE={scale_mode}"]).compile_cached(src)
+                                  "-DHIP_ENABLE_WARP_SYNC_BUILTINS", f"-DGEMM_M={M}", f"-DGEMM_N={N}", f"-DGEMM_K={K}",
+                                  f"-DSCALE_MODE={scale_mode}", f"-DX_SCALE_OFFSET={scale_offsets[0]}",
+                                  f"-DW_SCALE_OFFSET={scale_offsets[1]}", f"-DZ_SCALE_OFFSET={scale_offsets[2]}"]).compile_cached(src)
   return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.DEVICE, arg=dname), UOp(Ops.LINEAR, src=(*sink.src, sink)), UOp(Ops.SOURCE, arg=src),
                                UOp(Ops.BINARY, arg=lib)))
 
@@ -2802,7 +2803,8 @@ def hk_bf16_atb_gemm(a:Tensor, b:Tensor) -> Tensor:
 
 # ** backward gemm, might use the asm gemm
 
-def custom_gemm_bw(gradient:UOp, kernel:UOp, scale_mode:int=3, has_grad_amax:bool=False, has_w_post:bool=False):
+def custom_gemm_bw(gradient:UOp, kernel:UOp, scale_mode:int=3, scale_offsets:tuple[int,int,int]=(0,0,0),
+                   has_grad_amax:bool=False, has_w_post:bool=False):
   inputs = kernel.src[1:]
   if inputs[1].dtype == FP8_DTYPE:
     out, a, b = inputs[:3]
@@ -2842,9 +2844,11 @@ def custom_gemm_bw(gradient:UOp, kernel:UOp, scale_mode:int=3, has_grad_amax:boo
         g_fp8 = Tensor(g_fp8.contiguous().uop.after(store_effect), device=a.device)
     # dgrad: uses g_scale * x_scale * w_scale (only when scalar)
     if s_z_t is not None: raise NotImplementedError("fp8 gemm backward for 3 forward scales is unsupported")
-    if s_w_t is not None and s_x_t is not None: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_x_t, extra_scale=s_w_t)
-    elif s_w_t is not None: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_w_t)
-    else: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_x_t)
+    if s_w_t is not None and s_x_t is not None:
+      grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_x_t, extra_scale=s_w_t,
+                        w_scale_offset=scale_offsets[0], extra_scale_offset=scale_offsets[1])
+    elif s_w_t is not None: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_w_t, w_scale_offset=scale_offsets[1])
+    else: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_x_t, w_scale_offset=scale_offsets[0])
     # wgrad: no w_scale
     g_fp8_2d = g_fp8.reshape(-1, g_fp8.shape[-1])
     if getenv("FAST_FP8_TRANSPOSE", 0) and g_fp8_2d.shape[0] % 64 == 0 and g_fp8_2d.shape[1] % 64 == 0:
@@ -2852,7 +2856,7 @@ def custom_gemm_bw(gradient:UOp, kernel:UOp, scale_mode:int=3, has_grad_amax:boo
       g_fp8_T = fast_fp8_transpose(g_fp8_2d)
     else:
       g_fp8_T = g_fp8.permute(2, 0, 1).reshape(g_t.shape[-1], -1)
-    grad_b = asm_gemm(g_fp8_T, a_t.reshape(-1, a_t.shape[-1]), x_scale=g_scale, w_scale=s_x_t)
+    grad_b = asm_gemm(g_fp8_T, a_t.reshape(-1, a_t.shape[-1]), x_scale=g_scale, w_scale=s_x_t, w_scale_offset=scale_offsets[0])
     # wgrad: rescale if not scalar
     if w_post_t is not None:
       grad_b = grad_b / w_post_t.reshape(*w_post_t.shape, *([1]*(grad_b.ndim - w_post_t.ndim)))
@@ -2906,7 +2910,7 @@ def custom_mx_gemm_bw(gradient:UOp, kernel:UOp, has_w_post:bool, w_stored:bool=F
 
 def asm_gemm(a:Tensor, b:Tensor, x_scale:Tensor|None=None, w_scale:Tensor|None=None, grad_amax_state:Tensor|None=None,
              w_post_scale:Tensor|None=None, mx:bool=False, mx_scales:tuple|None=None, mx_w_stored:bool=False,
-             extra_scale:Tensor|None=None) -> Tensor:
+             extra_scale:Tensor|None=None, x_scale_offset:int=0, w_scale_offset:int=0, extra_scale_offset:int=0) -> Tensor:
   assert can_use_asm_gemm(a, b), f"{counters['todos'][-1]}"
   counters["used"] += 1
   unfold_batch = a.ndim == 3 and isinstance(a.device, tuple) and a.uop.axis == 2 and b.uop.axis == 0
@@ -2956,9 +2960,11 @@ def asm_gemm(a:Tensor, b:Tensor, x_scale:Tensor|None=None, w_scale:Tensor|None=N
       assert extra_scale is None or (x_scale is not None and w_scale is not None), "extra_scale requires x_scale and w_scale"
       scales = tuple(s for s in (x_scale, w_scale, extra_scale) if s is not None)
       scale_mode = (1 if x_scale is not None else 0) | (2 if w_scale is not None else 0) | (4 if extra_scale is not None else 0)
+      scale_offsets = (x_scale_offset, w_scale_offset, extra_scale_offset)
       extra = ([grad_amax_state] if grad_amax_state is not None else []) + ([w_post_scale] if w_post_scale is not None else [])
-      fxn = functools.partial(custom_hk_fp8_gemm, dname=dname, scale_mode=scale_mode)
-      bw = functools.partial(custom_gemm_bw, scale_mode=scale_mode, has_grad_amax=grad_amax_state is not None, has_w_post=w_post_scale is not None)
+      fxn = functools.partial(custom_hk_fp8_gemm, dname=dname, scale_mode=scale_mode, scale_offsets=scale_offsets)
+      bw = functools.partial(custom_gemm_bw, scale_mode=scale_mode, scale_offsets=scale_offsets,
+                             has_grad_amax=grad_amax_state is not None, has_w_post=w_post_scale is not None)
       out = Tensor.custom_kernel(out, a, b.T, *scales, *extra, fxn=fxn, grad_fxn=bw)[0]
     elif a.dtype == dtypes.bfloat16 and getenv("USE_HK_BF16_GEMM"):
       out = Tensor.custom_kernel(out, a, b.T, b, fxn=functools.partial(custom_hk_bf16_gemm, dname=dname), grad_fxn=custom_gemm_bw)[0]

--- a/extra/gemm/cdna_asm_gemm.py
+++ b/extra/gemm/cdna_asm_gemm.py
@@ -2646,11 +2646,11 @@ def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int
   kittens_path = pathlib.Path(__file__).parent.parent/"thunder"/"amd"
   src = (kittens_path/"gemm_fp8.cpp").read_text()
   lib = HIPCCCompiler("gfx950", [f"-I{(kittens_path/'include').as_posix()}", "-std=c++20", "-DKITTENS_CDNA4", "-ffast-math",
-                                  "-DHIP_ENABLE_WARP_SYNC_BUILTINS", f"-DGEMM_M={M}", f"-DGEMM_N={N}", f"-DGEMM_K={K}",
-                                  f"-DSCALE_MODE={scale_mode}", f"-DX_SCALE_OFFSET={scale_offsets[0]}",
-                                  f"-DW_SCALE_OFFSET={scale_offsets[1]}", f"-DZ_SCALE_OFFSET={scale_offsets[2]}",
-                                  f"-DHAS_GRAD_AMAX={1 if has_grad_amax else 0}",
-                                  f"-DHAS_W_POST={1 if has_w_post else 0}"]).compile_cached(src)
+                                 "-DHIP_ENABLE_WARP_SYNC_BUILTINS", f"-DGEMM_M={M}", f"-DGEMM_N={N}", f"-DGEMM_K={K}",
+                                 f"-DSCALE_MODE={scale_mode}", f"-DX_SCALE_OFFSET={scale_offsets[0]}",
+                                 f"-DW_SCALE_OFFSET={scale_offsets[1]}", f"-DZ_SCALE_OFFSET={scale_offsets[2]}",
+                                 f"-DHAS_GRAD_AMAX={1 if has_grad_amax else 0}",
+                                 f"-DHAS_W_POST={1 if has_w_post else 0}"]).compile_cached(src)
   return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.DEVICE, arg=dname), UOp(Ops.LINEAR, src=(*sink.src, sink)), UOp(Ops.SOURCE, arg=src),
                                UOp(Ops.BINARY, arg=lib)))
 

--- a/extra/gemm/cdna_asm_gemm.py
+++ b/extra/gemm/cdna_asm_gemm.py
@@ -2628,7 +2628,7 @@ def custom_asm_gemm(C:UOp, A:UOp, B:UOp, dname:str) -> UOp:
 # ** FP8 GEMM custom kernel
 
 @functools.cache
-def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int=3, scale_offsets:tuple[int,int,int]=(0,0,0),
+def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int=3,
                        has_grad_amax:bool=False, has_w_post:bool=False) -> UOp:
   # scale_mode: 0=no scale, 1=x only, 2=w only, 3=x*w, 7=x*w*extra
   n_scales = (1 if scale_mode & 1 else 0) + (1 if scale_mode & 2 else 0) + (1 if scale_mode & 4 else 0)
@@ -2647,8 +2647,7 @@ def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int
   src = (kittens_path/"gemm_fp8.cpp").read_text()
   lib = HIPCCCompiler("gfx950", [f"-I{(kittens_path/'include').as_posix()}", "-std=c++20", "-DKITTENS_CDNA4", "-ffast-math",
                                  "-DHIP_ENABLE_WARP_SYNC_BUILTINS", f"-DGEMM_M={M}", f"-DGEMM_N={N}", f"-DGEMM_K={K}",
-                                 f"-DSCALE_MODE={scale_mode}", f"-DX_SCALE_OFFSET={scale_offsets[0]}",
-                                 f"-DW_SCALE_OFFSET={scale_offsets[1]}", f"-DZ_SCALE_OFFSET={scale_offsets[2]}",
+                                 f"-DSCALE_MODE={scale_mode}",
                                  f"-DHAS_GRAD_AMAX={1 if has_grad_amax else 0}",
                                  f"-DHAS_W_POST={1 if has_w_post else 0}"]).compile_cached(src)
   return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.DEVICE, arg=dname), UOp(Ops.LINEAR, src=(*sink.src, sink)), UOp(Ops.SOURCE, arg=src),
@@ -2807,8 +2806,7 @@ def hk_bf16_atb_gemm(a:Tensor, b:Tensor) -> Tensor:
 
 # ** backward gemm, might use the asm gemm
 
-def custom_gemm_bw(gradient:UOp, kernel:UOp, scale_mode:int=3, scale_offsets:tuple[int,int,int]=(0,0,0),
-                   has_grad_amax:bool=False, has_w_post:bool=False):
+def custom_gemm_bw(gradient:UOp, kernel:UOp, scale_mode:int=3, has_grad_amax:bool=False, has_w_post:bool=False):
   inputs = kernel.src[1:]
   if inputs[1].dtype == FP8_DTYPE:
     out, a, b = inputs[:3]
@@ -2849,10 +2847,9 @@ def custom_gemm_bw(gradient:UOp, kernel:UOp, scale_mode:int=3, scale_offsets:tup
     # dgrad: uses g_scale * x_scale * w_scale (only when scalar)
     if s_z_t is not None: raise NotImplementedError("fp8 gemm backward for 3 forward scales is unsupported")
     if s_w_t is not None and s_x_t is not None:
-      grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_x_t, extra_scale=s_w_t,
-                        w_scale_offset=scale_offsets[0], extra_scale_offset=scale_offsets[1])
-    elif s_w_t is not None: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_w_t, w_scale_offset=scale_offsets[1])
-    else: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_x_t, w_scale_offset=scale_offsets[0])
+      grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_x_t, extra_scale=s_w_t)
+    elif s_w_t is not None: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_w_t)
+    else: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_x_t)
     # wgrad: no w_scale
     g_fp8_2d = g_fp8.reshape(-1, g_fp8.shape[-1])
     if getenv("FAST_FP8_TRANSPOSE", 0) and g_fp8_2d.shape[0] % 64 == 0 and g_fp8_2d.shape[1] % 64 == 0:
@@ -2860,7 +2857,7 @@ def custom_gemm_bw(gradient:UOp, kernel:UOp, scale_mode:int=3, scale_offsets:tup
       g_fp8_T = fast_fp8_transpose(g_fp8_2d)
     else:
       g_fp8_T = g_fp8.permute(2, 0, 1).reshape(g_t.shape[-1], -1)
-    grad_b = asm_gemm(g_fp8_T, a_t.reshape(-1, a_t.shape[-1]), x_scale=g_scale, w_scale=s_x_t, w_scale_offset=scale_offsets[0])
+    grad_b = asm_gemm(g_fp8_T, a_t.reshape(-1, a_t.shape[-1]), x_scale=g_scale, w_scale=s_x_t)
     # wgrad: rescale if not scalar
     if w_post_t is not None:
       grad_b = grad_b / w_post_t.reshape(*w_post_t.shape, *([1]*(grad_b.ndim - w_post_t.ndim)))
@@ -2914,7 +2911,7 @@ def custom_mx_gemm_bw(gradient:UOp, kernel:UOp, has_w_post:bool, w_stored:bool=F
 
 def asm_gemm(a:Tensor, b:Tensor, x_scale:Tensor|None=None, w_scale:Tensor|None=None, grad_amax_state:Tensor|None=None,
              w_post_scale:Tensor|None=None, mx:bool=False, mx_scales:tuple|None=None, mx_w_stored:bool=False,
-             extra_scale:Tensor|None=None, x_scale_offset:int=0, w_scale_offset:int=0, extra_scale_offset:int=0) -> Tensor:
+             extra_scale:Tensor|None=None) -> Tensor:
   assert can_use_asm_gemm(a, b), f"{counters['todos'][-1]}"
   counters["used"] += 1
   unfold_batch = a.ndim == 3 and isinstance(a.device, tuple) and a.uop.axis == 2 and b.uop.axis == 0
@@ -2964,12 +2961,11 @@ def asm_gemm(a:Tensor, b:Tensor, x_scale:Tensor|None=None, w_scale:Tensor|None=N
       assert extra_scale is None or (x_scale is not None and w_scale is not None), "extra_scale requires x_scale and w_scale"
       scales = tuple(s for s in (x_scale, w_scale, extra_scale) if s is not None)
       scale_mode = (1 if x_scale is not None else 0) | (2 if w_scale is not None else 0) | (4 if extra_scale is not None else 0)
-      scale_offsets = (x_scale_offset, w_scale_offset, extra_scale_offset)
       extra = ([grad_amax_state] if grad_amax_state is not None else []) + ([w_post_scale] if w_post_scale is not None else [])
-      fxn = functools.partial(custom_hk_fp8_gemm, dname=dname, scale_mode=scale_mode, scale_offsets=scale_offsets,
+      fxn = functools.partial(custom_hk_fp8_gemm, dname=dname, scale_mode=scale_mode,
                               has_grad_amax=grad_amax_state is not None, has_w_post=w_post_scale is not None)
-      bw = functools.partial(custom_gemm_bw, scale_mode=scale_mode, scale_offsets=scale_offsets,
-                             has_grad_amax=grad_amax_state is not None, has_w_post=w_post_scale is not None)
+      bw = functools.partial(custom_gemm_bw, scale_mode=scale_mode, has_grad_amax=grad_amax_state is not None,
+                             has_w_post=w_post_scale is not None)
       out = Tensor.custom_kernel(out, a, b.T, *scales, *extra, fxn=fxn, grad_fxn=bw)[0]
     elif a.dtype == dtypes.bfloat16 and getenv("USE_HK_BF16_GEMM"):
       out = Tensor.custom_kernel(out, a, b.T, b, fxn=functools.partial(custom_hk_bf16_gemm, dname=dname), grad_fxn=custom_gemm_bw)[0]

--- a/extra/gemm/cdna_asm_gemm.py
+++ b/extra/gemm/cdna_asm_gemm.py
@@ -2628,17 +2628,19 @@ def custom_asm_gemm(C:UOp, A:UOp, B:UOp, dname:str) -> UOp:
 # ** FP8 GEMM custom kernel
 
 @functools.cache
-def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int=3, scale_offsets:tuple[int,int,int]=(0,0,0)) -> UOp:
+def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int=3, scale_offsets:tuple[int,int,int]=(0,0,0),
+                       has_grad_amax:bool=False, has_w_post:bool=False) -> UOp:
   # scale_mode: 0=no scale, 1=x only, 2=w only, 3=x*w, 7=x*w*extra
   n_scales = (1 if scale_mode & 1 else 0) + (1 if scale_mode & 2 else 0) + (1 if scale_mode & 4 else 0)
   scales, extra = args[:n_scales], args[n_scales:]
+  assert len(extra) == int(has_grad_amax) + int(has_w_post), f"unexpected fp8 gemm metadata args: {len(extra)}"
   M, K = A.shape[0]*A.shape[1], A.shape[2]
   N, K2 = B.shape[(1 if B.ndim == 3 else 0):]
   assert K == K2, f"{A.shape} {B.shape}"
   block_size = 256
   threads = UOp.special(64 * 8, "lidx0")
   workgroups = UOp.special((M // block_size) * (N // block_size), "gidx0")
-  sink_inputs = (C.base, A.base, B.base) + tuple(s.base for s in scales) + (threads, workgroups)
+  sink_inputs = (C.base, A.base, B.base) + tuple(s.base for s in scales) + tuple(e.base for e in extra) + (threads, workgroups)
   sink = UOp.sink(*sink_inputs,
                   arg=KernelInfo(f"hk_fp8_gemm_{M}_{N}_{K}", estimates=Estimates(ops=2*M*N*K, mem=(M*K+N*K)*A.dtype.itemsize+M*N*C.dtype.itemsize)))
   kittens_path = pathlib.Path(__file__).parent.parent/"thunder"/"amd"
@@ -2646,7 +2648,9 @@ def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int
   lib = HIPCCCompiler("gfx950", [f"-I{(kittens_path/'include').as_posix()}", "-std=c++20", "-DKITTENS_CDNA4", "-ffast-math",
                                   "-DHIP_ENABLE_WARP_SYNC_BUILTINS", f"-DGEMM_M={M}", f"-DGEMM_N={N}", f"-DGEMM_K={K}",
                                   f"-DSCALE_MODE={scale_mode}", f"-DX_SCALE_OFFSET={scale_offsets[0]}",
-                                  f"-DW_SCALE_OFFSET={scale_offsets[1]}", f"-DZ_SCALE_OFFSET={scale_offsets[2]}"]).compile_cached(src)
+                                  f"-DW_SCALE_OFFSET={scale_offsets[1]}", f"-DZ_SCALE_OFFSET={scale_offsets[2]}",
+                                  f"-DHAS_GRAD_AMAX={1 if has_grad_amax else 0}",
+                                  f"-DHAS_W_POST={1 if has_w_post else 0}"]).compile_cached(src)
   return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.DEVICE, arg=dname), UOp(Ops.LINEAR, src=(*sink.src, sink)), UOp(Ops.SOURCE, arg=src),
                                UOp(Ops.BINARY, arg=lib)))
 
@@ -2962,7 +2966,8 @@ def asm_gemm(a:Tensor, b:Tensor, x_scale:Tensor|None=None, w_scale:Tensor|None=N
       scale_mode = (1 if x_scale is not None else 0) | (2 if w_scale is not None else 0) | (4 if extra_scale is not None else 0)
       scale_offsets = (x_scale_offset, w_scale_offset, extra_scale_offset)
       extra = ([grad_amax_state] if grad_amax_state is not None else []) + ([w_post_scale] if w_post_scale is not None else [])
-      fxn = functools.partial(custom_hk_fp8_gemm, dname=dname, scale_mode=scale_mode, scale_offsets=scale_offsets)
+      fxn = functools.partial(custom_hk_fp8_gemm, dname=dname, scale_mode=scale_mode, scale_offsets=scale_offsets,
+                              has_grad_amax=grad_amax_state is not None, has_w_post=w_post_scale is not None)
       bw = functools.partial(custom_gemm_bw, scale_mode=scale_mode, scale_offsets=scale_offsets,
                              has_grad_amax=grad_amax_state is not None, has_w_post=w_post_scale is not None)
       out = Tensor.custom_kernel(out, a, b.T, *scales, *extra, fxn=fxn, grad_fxn=bw)[0]

--- a/extra/gemm/cdna_asm_gemm.py
+++ b/extra/gemm/cdna_asm_gemm.py
@@ -2629,8 +2629,8 @@ def custom_asm_gemm(C:UOp, A:UOp, B:UOp, dname:str) -> UOp:
 
 @functools.cache
 def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int=3) -> UOp:
-  # scale_mode: 0=no scale, 1=x only, 2=w only, 3=both
-  n_scales = (1 if scale_mode & 1 else 0) + (1 if scale_mode & 2 else 0)
+  # scale_mode: 0=no scale, 1=x only, 2=w only, 3=x*w, 7=x*w*extra
+  n_scales = (1 if scale_mode & 1 else 0) + (1 if scale_mode & 2 else 0) + (1 if scale_mode & 4 else 0)
   scales, extra = args[:n_scales], args[n_scales:]
   M, K = A.shape[0]*A.shape[1], A.shape[2]
   N, K2 = B.shape[(1 if B.ndim == 3 else 0):]
@@ -2802,19 +2802,21 @@ def hk_bf16_atb_gemm(a:Tensor, b:Tensor) -> Tensor:
 
 # ** backward gemm, might use the asm gemm
 
-def custom_gemm_bw(gradient:UOp, kernel:UOp, n_scales:int=2, has_grad_amax:bool=False, has_w_post:bool=False):
+def custom_gemm_bw(gradient:UOp, kernel:UOp, scale_mode:int=3, has_grad_amax:bool=False, has_w_post:bool=False):
   inputs = kernel.src[1:]
   if inputs[1].dtype == FP8_DTYPE:
     out, a, b = inputs[:3]
     i = 3
-    s_x = inputs[i]; i += 1
-    has_w = n_scales == 2
+    has_x, has_w, has_z = (scale_mode & 1) != 0, (scale_mode & 2) != 0, (scale_mode & 4) != 0
+    s_x = inputs[i] if has_x else None; i += has_x
     s_w = inputs[i] if has_w else None; i += has_w
+    s_z = inputs[i] if has_z else None; i += has_z
     grad_amax_state = inputs[i] if has_grad_amax else None; i += has_grad_amax
     w_post = inputs[i] if has_w_post else None
     a_t, b_t, g_t = Tensor(a, device=a.device), Tensor(b, device=a.device), Tensor(gradient, device=a.device)
-    s_x_t = Tensor(s_x, device=a.device)
+    s_x_t = Tensor(s_x, device=a.device) if has_x else None
     s_w_t = Tensor(s_w, device=a.device) if has_w else None
+    s_z_t = Tensor(s_z, device=a.device) if s_z is not None else None
     w_post_t = Tensor(w_post, device=a.device) if has_w_post else None
     g_t = g_t[:a.shape[0]]
     from extra.llama_kernels.cast_amax import _grad_fp8_mailbox
@@ -2839,7 +2841,10 @@ def custom_gemm_bw(gradient:UOp, kernel:UOp, n_scales:int=2, has_grad_amax:bool=
         store_effect = grad_amax_state.store(new_grad_amax.uop)
         g_fp8 = Tensor(g_fp8.contiguous().uop.after(store_effect), device=a.device)
     # dgrad: uses g_scale * x_scale * w_scale (only when scalar)
-    grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale * s_x_t, w_scale=s_w_t) if has_w else asm_gemm(g_fp8, b_t, x_scale=g_scale * s_x_t)
+    if s_z_t is not None: raise NotImplementedError("fp8 gemm backward for 3 forward scales is unsupported")
+    if s_w_t is not None and s_x_t is not None: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_x_t, extra_scale=s_w_t)
+    elif s_w_t is not None: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_w_t)
+    else: grad_a = asm_gemm(g_fp8, b_t, x_scale=g_scale, w_scale=s_x_t)
     # wgrad: no w_scale
     g_fp8_2d = g_fp8.reshape(-1, g_fp8.shape[-1])
     if getenv("FAST_FP8_TRANSPOSE", 0) and g_fp8_2d.shape[0] % 64 == 0 and g_fp8_2d.shape[1] % 64 == 0:
@@ -2847,7 +2852,7 @@ def custom_gemm_bw(gradient:UOp, kernel:UOp, n_scales:int=2, has_grad_amax:bool=
       g_fp8_T = fast_fp8_transpose(g_fp8_2d)
     else:
       g_fp8_T = g_fp8.permute(2, 0, 1).reshape(g_t.shape[-1], -1)
-    grad_b = asm_gemm(g_fp8_T, a_t.reshape(-1, a_t.shape[-1]), x_scale=g_scale * s_x_t)
+    grad_b = asm_gemm(g_fp8_T, a_t.reshape(-1, a_t.shape[-1]), x_scale=g_scale, w_scale=s_x_t)
     # wgrad: rescale if not scalar
     if w_post_t is not None:
       grad_b = grad_b / w_post_t.reshape(*w_post_t.shape, *([1]*(grad_b.ndim - w_post_t.ndim)))
@@ -2900,7 +2905,8 @@ def custom_mx_gemm_bw(gradient:UOp, kernel:UOp, has_w_post:bool, w_stored:bool=F
 # ** main gemm function
 
 def asm_gemm(a:Tensor, b:Tensor, x_scale:Tensor|None=None, w_scale:Tensor|None=None, grad_amax_state:Tensor|None=None,
-             w_post_scale:Tensor|None=None, mx:bool=False, mx_scales:tuple|None=None, mx_w_stored:bool=False) -> Tensor:
+             w_post_scale:Tensor|None=None, mx:bool=False, mx_scales:tuple|None=None, mx_w_stored:bool=False,
+             extra_scale:Tensor|None=None) -> Tensor:
   assert can_use_asm_gemm(a, b), f"{counters['todos'][-1]}"
   counters["used"] += 1
   unfold_batch = a.ndim == 3 and isinstance(a.device, tuple) and a.uop.axis == 2 and b.uop.axis == 0
@@ -2947,11 +2953,12 @@ def asm_gemm(a:Tensor, b:Tensor, x_scale:Tensor|None=None, w_scale:Tensor|None=N
       out = Tensor.custom_kernel(out, a_q.reshape(a.shape), b_q, a_si, b_si, a_e8, b_e8, *extra, fxn=fxn, grad_fxn=grad_fxn)[0]
     # fp8 gemm computes a@b.T, kernel multiplies output by x_scale * w_scale before bf16 store
     elif a.dtype == FP8_DTYPE:
-      scales = tuple(s for s in (x_scale, w_scale) if s is not None)
-      scale_mode = (1 if x_scale is not None else 0) | (2 if w_scale is not None else 0)
+      assert extra_scale is None or (x_scale is not None and w_scale is not None), "extra_scale requires x_scale and w_scale"
+      scales = tuple(s for s in (x_scale, w_scale, extra_scale) if s is not None)
+      scale_mode = (1 if x_scale is not None else 0) | (2 if w_scale is not None else 0) | (4 if extra_scale is not None else 0)
       extra = ([grad_amax_state] if grad_amax_state is not None else []) + ([w_post_scale] if w_post_scale is not None else [])
       fxn = functools.partial(custom_hk_fp8_gemm, dname=dname, scale_mode=scale_mode)
-      bw = functools.partial(custom_gemm_bw, n_scales=len(scales), has_grad_amax=grad_amax_state is not None, has_w_post=w_post_scale is not None)
+      bw = functools.partial(custom_gemm_bw, scale_mode=scale_mode, has_grad_amax=grad_amax_state is not None, has_w_post=w_post_scale is not None)
       out = Tensor.custom_kernel(out, a, b.T, *scales, *extra, fxn=fxn, grad_fxn=bw)[0]
     elif a.dtype == dtypes.bfloat16 and getenv("USE_HK_BF16_GEMM"):
       out = Tensor.custom_kernel(out, a, b.T, b, fxn=functools.partial(custom_hk_bf16_gemm, dname=dname), grad_fxn=custom_gemm_bw)[0]

--- a/extra/llama_kernels/cast_amax/__init__.py
+++ b/extra/llama_kernels/cast_amax/__init__.py
@@ -25,21 +25,21 @@ def _custom_fused_bwd_w13(grad_xw13_fp8:UOp, grad_amax_buf:UOp,
                                UOp(Ops.SOURCE, arg=src), UOp(Ops.BINARY, arg=lib)))
 
 @functools.cache
-def _custom_fused_cast_amax_w13(fp8_out:UOp, amax_buf:UOp, xw13:UOp, amax_state:UOp, grad_amax_state:UOp,
-                                inv_scale_out:UOp, dname:str) -> UOp:
+def _custom_fused_cast_amax_w13(fp8_out:UOp, amax_buf:UOp, inv_scale_out:UOp,
+                                xw13:UOp, amax_state:UOp, grad_amax_state:UOp, dname:str) -> UOp:
   # NOTE: grad_amax_state is unused by fwd math, but kept as a HIP arg for bwd metadata lifetime/ABI.
   hidden = xw13.shape[2] // 2
   n_elems = xw13.shape[0] * xw13.shape[1] * hidden
   threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
   mem = n_elems * 2 * 2 + n_elems + NUM_WG * 4 + 8
-  sink = UOp.sink(fp8_out.base, amax_buf.base, xw13.base, amax_state.base, grad_amax_state.base, inv_scale_out.base, threads, workgroups,
+  sink = UOp.sink(fp8_out.base, amax_buf.base, inv_scale_out.base, xw13.base, amax_state.base, grad_amax_state.base, threads, workgroups,
                   arg=KernelInfo(f"fused_silu_mul_cast_amax_w13_{n_elems}", estimates=Estimates(ops=5*n_elems, mem=mem)))
   src, lib = compile_cpp(pathlib.Path(__file__).parent, "cast_amax_fwd_w13.cpp", n_elems, hidden)
   return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.DEVICE, arg=dname), UOp(Ops.LINEAR, src=(*sink.src, sink)),
                                UOp(Ops.SOURCE, arg=src), UOp(Ops.BINARY, arg=lib)))
 
 def _fused_quantize_bwd_w13(gradient:UOp, kernel:UOp):
-  _, _, xw13, amax_state, grad_amax_state, _ = kernel.src[1:]
+  _, _, _, xw13, amax_state, grad_amax_state = kernel.src[1:]
   device = xw13.device
   axis = xw13.axis if isinstance(device, tuple) else None
   grad_xw13_fp8 = alloc_like(xw13.shape, dtypes.fp8e4m3,  device, axis)
@@ -58,7 +58,7 @@ def _fused_quantize_bwd_w13(gradient:UOp, kernel:UOp):
   grad_xw13_fp8_uop = grad_xw13_fp8.uop.replace(src=grad_xw13_fp8.uop.src + (store_effect,))
   # Stash fp8 companion for cdna_asm_gemm's bwd to attach to grad_a.
   _grad_fp8_mailbox[grad_xw13_uop] = (grad_xw13_fp8_uop, inv_scale.uop)
-  return (None, None, grad_xw13_uop, None, None, None)
+  return (None, None, None, grad_xw13_uop, None, None)
 
 def fused_quantize_fp8_w13(xw13:Tensor, amax_state:Tensor, fp8_dtype, grad_amax_state:Tensor) -> tuple[Tensor, Tensor, Tensor]:
   # NOTE: silu(xw1)*xw3 -> fp8 + amax over fused xw13 layout. Returns (fp8, inv_scale, new_amax)
@@ -72,6 +72,6 @@ def fused_quantize_fp8_w13(xw13:Tensor, amax_state:Tensor, fp8_dtype, grad_amax_
   amax_buf = alloc_local((NUM_WG,),         dtypes.float32, xw13.device, axis)
   inv_scale = alloc_like((),                dtypes.float32, xw13.device)
   fxn = functools.partial(_custom_fused_cast_amax_w13, dname=dname_of(xw13.device))
-  fp8_out, amax_buf, _, _, _, inv_scale = Tensor.custom_kernel(fp8_out, amax_buf, xw13, amax_state, grad_amax_state, inv_scale,
+  fp8_out, amax_buf, inv_scale, _, _, _ = Tensor.custom_kernel(fp8_out, amax_buf, inv_scale, xw13, amax_state, grad_amax_state,
                                                                fxn=fxn, grad_fxn=_fused_quantize_bwd_w13)
   return fp8_out, inv_scale, scalar_amax(amax_buf)

--- a/extra/llama_kernels/cast_amax/__init__.py
+++ b/extra/llama_kernels/cast_amax/__init__.py
@@ -27,12 +27,12 @@ def _custom_fused_bwd_w13(grad_xw13_fp8:UOp, grad_amax_buf:UOp,
 @functools.cache
 def _custom_fused_cast_amax_w13(fp8_out:UOp, amax_buf:UOp, xw13:UOp, amax_state:UOp, grad_amax_state:UOp,
                                 inv_scale_out:UOp, dname:str) -> UOp:
-  # NOTE: grad_amax_state is plumbed through as an unused fwd input so the bwd kernel can read it via kernel.src
+  # NOTE: grad_amax_state is a call input for bwd metadata, but not a fwd kernel argument.
   hidden = xw13.shape[2] // 2
   n_elems = xw13.shape[0] * xw13.shape[1] * hidden
   threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
   mem = n_elems * 2 * 2 + n_elems + NUM_WG * 4 + 4
-  sink = UOp.sink(fp8_out.base, amax_buf.base, xw13.base, amax_state.base, grad_amax_state.base, inv_scale_out.base, threads, workgroups,
+  sink = UOp.sink(fp8_out.base, amax_buf.base, xw13.base, amax_state.base, inv_scale_out.base, threads, workgroups,
                   arg=KernelInfo(f"fused_silu_mul_cast_amax_w13_{n_elems}", estimates=Estimates(ops=5*n_elems, mem=mem)))
   src, lib = compile_cpp(pathlib.Path(__file__).parent, "cast_amax_fwd_w13.cpp", n_elems, hidden)
   return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.DEVICE, arg=dname), UOp(Ops.LINEAR, src=(*sink.src, sink)),

--- a/extra/llama_kernels/cast_amax/__init__.py
+++ b/extra/llama_kernels/cast_amax/__init__.py
@@ -12,12 +12,12 @@ _grad_fp8_mailbox:dict[UOp, tuple[UOp, UOp]] = {}
 
 @functools.cache
 def _custom_fused_bwd_w13(grad_xw13_fp8:UOp, grad_amax_buf:UOp,
-                          xw13:UOp, grad_x2:UOp, amax_state:UOp, grad_amax_state:UOp, dname:str) -> UOp:
+                          inv_scale_out:UOp, xw13:UOp, grad_x2:UOp, amax_state:UOp, grad_amax_state:UOp, dname:str) -> UOp:
   hidden = xw13.shape[2] // 2
   n_elems = xw13.shape[0] * xw13.shape[1] * hidden
   threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
-  mem = n_elems * 2 * 3 + n_elems * 2 + NUM_WG * 4 + 4
-  sink = UOp.sink(grad_xw13_fp8.base, grad_amax_buf.base,
+  mem = n_elems * 2 * 3 + n_elems * 2 + NUM_WG * 4 + 8
+  sink = UOp.sink(grad_xw13_fp8.base, grad_amax_buf.base, inv_scale_out.base,
                   xw13.base, grad_x2.base, amax_state.base, grad_amax_state.base, threads, workgroups,
                   arg=KernelInfo(f"fused_silu_mul_bwd_w13_{n_elems}", estimates=Estimates(ops=10*n_elems, mem=mem)))
   src, lib = compile_cpp(pathlib.Path(__file__).parent, "cast_amax_bwd_w13.cpp", n_elems, hidden)
@@ -44,14 +44,14 @@ def _fused_quantize_bwd_w13(gradient:UOp, kernel:UOp):
   axis = xw13.axis if isinstance(device, tuple) else None
   grad_xw13_fp8 = alloc_like(xw13.shape, dtypes.fp8e4m3,  device, axis)
   grad_amax_buf = alloc_local((NUM_WG,), dtypes.float32,  device, axis)
+  inv_scale = alloc_like((), dtypes.float32, device)
   grad_amax_state_t = Tensor(grad_amax_state, device=device)
   fxn = functools.partial(_custom_fused_bwd_w13, dname=dname_of(device))
-  grad_xw13_fp8, grad_amax_buf, *_ = Tensor.custom_kernel(
-    grad_xw13_fp8, grad_amax_buf,
+  grad_xw13_fp8, grad_amax_buf, inv_scale, *_ = Tensor.custom_kernel(
+    grad_xw13_fp8, grad_amax_buf, inv_scale,
     Tensor(xw13, device=device), Tensor(gradient, device=device).cast(dtypes.bfloat16),
     Tensor(amax_state, device=device), grad_amax_state_t, fxn=fxn)
   grad_xw13_uop = grad_xw13_fp8.uop.cast(dtypes.bfloat16)
-  inv_scale = (grad_amax_state_t.float() + 1e-8) / FP8_MAX
   new_grad_amax = scalar_amax(grad_amax_buf)
   store_effect = grad_amax_state_t.uop.store(new_grad_amax.uop)
   assert grad_xw13_fp8.uop.op is Ops.AFTER, f"expected AFTER, got {grad_xw13_fp8.uop.op}"

--- a/extra/llama_kernels/cast_amax/__init__.py
+++ b/extra/llama_kernels/cast_amax/__init__.py
@@ -25,20 +25,21 @@ def _custom_fused_bwd_w13(grad_xw13_fp8:UOp, grad_amax_buf:UOp,
                                UOp(Ops.SOURCE, arg=src), UOp(Ops.BINARY, arg=lib)))
 
 @functools.cache
-def _custom_fused_cast_amax_w13(fp8_out:UOp, amax_buf:UOp, xw13:UOp, amax_state:UOp, grad_amax_state:UOp, dname:str) -> UOp:
+def _custom_fused_cast_amax_w13(fp8_out:UOp, amax_buf:UOp, xw13:UOp, amax_state:UOp, grad_amax_state:UOp,
+                                inv_scale_out:UOp, dname:str) -> UOp:
   # NOTE: grad_amax_state is plumbed through as an unused fwd input so the bwd kernel can read it via kernel.src
   hidden = xw13.shape[2] // 2
   n_elems = xw13.shape[0] * xw13.shape[1] * hidden
   threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
-  mem = n_elems * 2 * 2 + n_elems + NUM_WG * 4
-  sink = UOp.sink(fp8_out.base, amax_buf.base, xw13.base, amax_state.base, threads, workgroups,
+  mem = n_elems * 2 * 2 + n_elems + NUM_WG * 4 + 4
+  sink = UOp.sink(fp8_out.base, amax_buf.base, xw13.base, amax_state.base, grad_amax_state.base, inv_scale_out.base, threads, workgroups,
                   arg=KernelInfo(f"fused_silu_mul_cast_amax_w13_{n_elems}", estimates=Estimates(ops=5*n_elems, mem=mem)))
   src, lib = compile_cpp(pathlib.Path(__file__).parent, "cast_amax_fwd_w13.cpp", n_elems, hidden)
   return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.DEVICE, arg=dname), UOp(Ops.LINEAR, src=(*sink.src, sink)),
                                UOp(Ops.SOURCE, arg=src), UOp(Ops.BINARY, arg=lib)))
 
 def _fused_quantize_bwd_w13(gradient:UOp, kernel:UOp):
-  _, _, xw13, amax_state, grad_amax_state = kernel.src[1:]
+  _, _, xw13, amax_state, grad_amax_state, _ = kernel.src[1:]
   device = xw13.device
   axis = xw13.axis if isinstance(device, tuple) else None
   grad_xw13_fp8 = alloc_like(xw13.shape, dtypes.fp8e4m3,  device, axis)
@@ -57,7 +58,7 @@ def _fused_quantize_bwd_w13(gradient:UOp, kernel:UOp):
   grad_xw13_fp8_uop = grad_xw13_fp8.uop.replace(src=grad_xw13_fp8.uop.src + (store_effect,))
   # Stash fp8 companion for cdna_asm_gemm's bwd to attach to grad_a.
   _grad_fp8_mailbox[grad_xw13_uop] = (grad_xw13_fp8_uop, inv_scale.uop)
-  return (None, None, grad_xw13_uop, None, None)
+  return (None, None, grad_xw13_uop, None, None, None)
 
 def fused_quantize_fp8_w13(xw13:Tensor, amax_state:Tensor, fp8_dtype, grad_amax_state:Tensor) -> tuple[Tensor, Tensor, Tensor]:
   # NOTE: silu(xw1)*xw3 -> fp8 + amax over fused xw13 layout. Returns (fp8, inv_scale, new_amax)
@@ -69,8 +70,8 @@ def fused_quantize_fp8_w13(xw13:Tensor, amax_state:Tensor, fp8_dtype, grad_amax_
   axis = xw13.uop.axis if isinstance(xw13.device, tuple) else None
   fp8_out  = alloc_like((MBS, SEQ, HIDDEN), fp8_dtype,      xw13.device, axis)
   amax_buf = alloc_local((NUM_WG,),         dtypes.float32, xw13.device, axis)
+  inv_scale = alloc_like((),                dtypes.float32, xw13.device)
   fxn = functools.partial(_custom_fused_cast_amax_w13, dname=dname_of(xw13.device))
-  fp8_out, amax_buf, *_ = Tensor.custom_kernel(fp8_out, amax_buf, xw13, amax_state, grad_amax_state,
-                                                fxn=fxn, grad_fxn=_fused_quantize_bwd_w13)
-  inv_scale = (amax_state.float() + 1e-8) / FP8_MAX
+  fp8_out, amax_buf, _, _, _, inv_scale = Tensor.custom_kernel(fp8_out, amax_buf, xw13, amax_state, grad_amax_state, inv_scale,
+                                                               fxn=fxn, grad_fxn=_fused_quantize_bwd_w13)
   return fp8_out, inv_scale, scalar_amax(amax_buf)

--- a/extra/llama_kernels/cast_amax/__init__.py
+++ b/extra/llama_kernels/cast_amax/__init__.py
@@ -27,12 +27,12 @@ def _custom_fused_bwd_w13(grad_xw13_fp8:UOp, grad_amax_buf:UOp,
 @functools.cache
 def _custom_fused_cast_amax_w13(fp8_out:UOp, amax_buf:UOp, xw13:UOp, amax_state:UOp, grad_amax_state:UOp,
                                 inv_scale_out:UOp, dname:str) -> UOp:
-  # NOTE: grad_amax_state is a call input for bwd metadata, but not a fwd kernel argument.
+  # NOTE: grad_amax_state is unused by fwd math, but kept as a HIP arg for bwd metadata lifetime/ABI.
   hidden = xw13.shape[2] // 2
   n_elems = xw13.shape[0] * xw13.shape[1] * hidden
   threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
-  mem = n_elems * 2 * 2 + n_elems + NUM_WG * 4 + 4
-  sink = UOp.sink(fp8_out.base, amax_buf.base, xw13.base, amax_state.base, inv_scale_out.base, threads, workgroups,
+  mem = n_elems * 2 * 2 + n_elems + NUM_WG * 4 + 8
+  sink = UOp.sink(fp8_out.base, amax_buf.base, xw13.base, amax_state.base, grad_amax_state.base, inv_scale_out.base, threads, workgroups,
                   arg=KernelInfo(f"fused_silu_mul_cast_amax_w13_{n_elems}", estimates=Estimates(ops=5*n_elems, mem=mem)))
   src, lib = compile_cpp(pathlib.Path(__file__).parent, "cast_amax_fwd_w13.cpp", n_elems, hidden)
   return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.DEVICE, arg=dname), UOp(Ops.LINEAR, src=(*sink.src, sink)),

--- a/extra/llama_kernels/cast_amax/__init__.py
+++ b/extra/llama_kernels/cast_amax/__init__.py
@@ -72,6 +72,6 @@ def fused_quantize_fp8_w13(xw13:Tensor, amax_state:Tensor, fp8_dtype, grad_amax_
   amax_buf = alloc_local((NUM_WG,),         dtypes.float32, xw13.device, axis)
   inv_scale = alloc_like((),                dtypes.float32, xw13.device)
   fxn = functools.partial(_custom_fused_cast_amax_w13, dname=dname_of(xw13.device))
-  fp8_out, amax_buf, inv_scale, _, _, _ = Tensor.custom_kernel(fp8_out, amax_buf, inv_scale, xw13, amax_state, grad_amax_state,
-                                                               fxn=fxn, grad_fxn=_fused_quantize_bwd_w13)
+  fp8_out, amax_buf, inv_scale, _, _, _ = Tensor.custom_kernel(fp8_out, amax_buf, inv_scale, xw13, amax_state, grad_amax_state, fxn=fxn,
+                                                               grad_fxn=_fused_quantize_bwd_w13)
   return fp8_out, inv_scale, scalar_amax(amax_buf)

--- a/extra/llama_kernels/cast_amax/cast_amax_bwd_w13.cpp
+++ b/extra/llama_kernels/cast_amax/cast_amax_bwd_w13.cpp
@@ -24,12 +24,14 @@ static_assert(HIDDEN % VEC == 0, "HIDDEN must be divisible by VEC");
 // fused silu*mul backward, two outputs in a single HBM pass:
 //   1) fp8  grad_xw13_fp8  — delayed-scale quantize using grad_amax_state (mailbox to matmul bwd)
 //   2) fp32 grad_amax_buf  — per-WG partial |grad_xw13|, reduced into next step's grad_amax_state
+//   3) fp32 inv_scale_out  — delayed grad inv_scale used by matmul bwd
 // grad_amax_state is read for the fp8 scale. The store of new_grad_amax into grad_amax_state's
 // buffer is built in Python as a separate effect and threaded into grad_a via .after(store).
 extern "C" __global__ __launch_bounds__(THREADS_PER_WG) void
 fused_silu_mul_bwd_w13(
     __hip_fp8_storage_t*  __restrict__ grad_xw13_fp8_out,    // fp8,  2*N_ELEMS
     float*                __restrict__ grad_amax_buf,        // fp32, NUM_WG per-WG partials
+    float*                __restrict__ inv_scale_out,        // fp32 scalar
     const __hip_bfloat16* __restrict__ xw13,                 // bf16, 2*N_ELEMS
     const __hip_bfloat16* __restrict__ grad_x2,              // bf16, N_ELEMS
     const float*          __restrict__ amax_state,           // fp32 scalar (fwd x2 amax)
@@ -43,8 +45,11 @@ fused_silu_mul_bwd_w13(
   const int stride_elems = NUM_WG * THREADS_PER_WG * VEC;
 
   const float scale = FP8_MAX / (static_cast<float>(*amax_state) + 1e-8f);
-  const float g_scale = FP8_MAX / (static_cast<float>(*grad_amax_state) + 1e-8f);
+  const float g_inv_scale = (static_cast<float>(*grad_amax_state) + 1e-8f) / FP8_MAX;
+  const float g_scale = 1.0f / g_inv_scale;
   float local_max = 0.0f;
+
+  if (tid == 0 && wg == 0) inv_scale_out[0] = g_inv_scale;
 
   for (int base = gid * VEC; base < N_ELEMS; base += stride_elems) {
     const int outer = base / HIDDEN;

--- a/extra/llama_kernels/cast_amax/cast_amax_fwd_w13.cpp
+++ b/extra/llama_kernels/cast_amax/cast_amax_fwd_w13.cpp
@@ -27,6 +27,7 @@ fused_silu_mul_cast_amax_w13(
     float*                __restrict__ amax_buf,        // fp32, NUM_WG (per-WG amaxes)
     const __hip_bfloat16* __restrict__ xw13,            // bf16, 2*N_ELEMS
     const float*          __restrict__ amax_state,      // fp32 scalar
+    const float*          __restrict__ grad_amax_state, // fp32 scalar, kept as fwd ABI arg for bwd metadata
     float*                __restrict__ inv_scale_out)   // fp32 scalar
 {
   __shared__ float sdata[THREADS_PER_WG];

--- a/extra/llama_kernels/cast_amax/cast_amax_fwd_w13.cpp
+++ b/extra/llama_kernels/cast_amax/cast_amax_fwd_w13.cpp
@@ -27,7 +27,6 @@ fused_silu_mul_cast_amax_w13(
     float*                __restrict__ amax_buf,        // fp32, NUM_WG (per-WG amaxes)
     const __hip_bfloat16* __restrict__ xw13,            // bf16, 2*N_ELEMS
     const float*          __restrict__ amax_state,      // fp32 scalar
-    const float*          __restrict__ grad_amax_state, // fp32 scalar, unused fwd input for bwd metadata
     float*                __restrict__ inv_scale_out)   // fp32 scalar
 {
   __shared__ float sdata[THREADS_PER_WG];

--- a/extra/llama_kernels/cast_amax/cast_amax_fwd_w13.cpp
+++ b/extra/llama_kernels/cast_amax/cast_amax_fwd_w13.cpp
@@ -25,10 +25,10 @@ extern "C" __global__ __launch_bounds__(THREADS_PER_WG) void
 fused_silu_mul_cast_amax_w13(
     __hip_fp8_storage_t*  __restrict__ fp8_out,         // fp8, N_ELEMS
     float*                __restrict__ amax_buf,        // fp32, NUM_WG (per-WG amaxes)
+    float*                __restrict__ inv_scale_out,   // fp32 scalar
     const __hip_bfloat16* __restrict__ xw13,            // bf16, 2*N_ELEMS
     const float*          __restrict__ amax_state,      // fp32 scalar
-    const float*          __restrict__ grad_amax_state, // fp32 scalar, kept as fwd ABI arg for bwd metadata
-    float*                __restrict__ inv_scale_out)   // fp32 scalar
+    const float*          __restrict__ grad_amax_state) // fp32 scalar, kept as fwd ABI arg for bwd metadata
 {
   __shared__ float sdata[THREADS_PER_WG];
 

--- a/extra/llama_kernels/cast_amax/cast_amax_fwd_w13.cpp
+++ b/extra/llama_kernels/cast_amax/cast_amax_fwd_w13.cpp
@@ -26,7 +26,9 @@ fused_silu_mul_cast_amax_w13(
     __hip_fp8_storage_t*  __restrict__ fp8_out,         // fp8, N_ELEMS
     float*                __restrict__ amax_buf,        // fp32, NUM_WG (per-WG amaxes)
     const __hip_bfloat16* __restrict__ xw13,            // bf16, 2*N_ELEMS
-    const float*          __restrict__ amax_state)      // fp32 scalar
+    const float*          __restrict__ amax_state,      // fp32 scalar
+    const float*          __restrict__ grad_amax_state, // fp32 scalar, unused fwd input for bwd metadata
+    float*                __restrict__ inv_scale_out)   // fp32 scalar
 {
   __shared__ float sdata[THREADS_PER_WG];
 
@@ -35,8 +37,12 @@ fused_silu_mul_cast_amax_w13(
   const int gid = wg * THREADS_PER_WG + tid;
   const int stride_elems = NUM_WG * THREADS_PER_WG * VEC;
 
-  const float scale = FP8_MAX / (static_cast<float>(*amax_state) + 1e-8f);
+  const float amax = static_cast<float>(*amax_state) + 1e-8f;
+  const float inv_scale = amax / FP8_MAX;
+  const float scale = 1.0f / inv_scale;
   float local_max = 0.0f;
+
+  if (tid == 0 && wg == 0) inv_scale_out[0] = inv_scale;
 
   // grid-stride over 8-element groups
   for (int base = gid * VEC; base < N_ELEMS; base += stride_elems) {

--- a/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/__init__.py
+++ b/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/__init__.py
@@ -10,13 +10,13 @@ def _src_bwd() -> str: return (pathlib.Path(__file__).parent/"fused_rmsnorm_mul_
 
 @functools.cache
 def _custom_fwd(fp8_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
-                x:UOp, weight:UOp, amax_state:UOp, inv_scale_out:UOp, dname:str, eps_val:float) -> UOp:
+                inv_scale_out:UOp, x:UOp, weight:UOp, amax_state:UOp, dname:str, eps_val:float) -> UOp:
   MBS, SEQ, HIDDEN = x.shape
   n_elems = MBS * SEQ * HIDDEN
   threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
   mem = n_elems * 2 + n_elems + MBS * SEQ * 4 + n_elems + HIDDEN * 2 + NUM_WG * 4 + 8
-  sink = UOp.sink(fp8_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
-                  x.base, weight.base, amax_state.base, inv_scale_out.base, threads, workgroups,
+  sink = UOp.sink(fp8_out.base, x_normed_out.base, rrms_out.base, amax_buf.base, inv_scale_out.base,
+                  x.base, weight.base, amax_state.base, threads, workgroups,
                   arg=KernelInfo(f"fused_rmsnorm_mul_quantize_fp8_{n_elems}_h{HIDDEN}_eps{eps_val:.0e}",
                                  estimates=Estimates(ops=6*n_elems, mem=mem)))
   defines = [f"-DN_ELEMS={n_elems}", f"-DHIDDEN={HIDDEN}", f"-DNUM_WG={NUM_WG}", f"-DTHREADS_PER_WG={THREADS_PER_WG}",
@@ -27,13 +27,13 @@ def _custom_fwd(fp8_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
 
 @functools.cache
 def _custom_fwd_add(fp8_out:UOp, h_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
-                    x:UOp, residual:UOp, weight:UOp, amax_state:UOp, inv_scale_out:UOp, dname:str, eps_val:float) -> UOp:
+                    inv_scale_out:UOp, x:UOp, residual:UOp, weight:UOp, amax_state:UOp, dname:str, eps_val:float) -> UOp:
   MBS, SEQ, HIDDEN = x.shape
   n_elems = MBS * SEQ * HIDDEN
   threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
   mem = n_elems * 2 * 4 + MBS * SEQ * 4 + HIDDEN * 2 + NUM_WG * 4 + 8
-  sink = UOp.sink(fp8_out.base, h_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
-                  x.base, residual.base, weight.base, amax_state.base, inv_scale_out.base, threads, workgroups,
+  sink = UOp.sink(fp8_out.base, h_out.base, x_normed_out.base, rrms_out.base, amax_buf.base, inv_scale_out.base,
+                  x.base, residual.base, weight.base, amax_state.base, threads, workgroups,
                   arg=KernelInfo(f"fused_add_rmsnorm_mul_quantize_fp8_{n_elems}_h{HIDDEN}_eps{eps_val:.0e}",
                                  estimates=Estimates(ops=7*n_elems, mem=mem)))
   defines = [f"-DN_ELEMS={n_elems}", f"-DHIDDEN={HIDDEN}", f"-DNUM_WG={NUM_WG}", f"-DTHREADS_PER_WG={THREADS_PER_WG}",
@@ -85,10 +85,10 @@ def _bwd_common(fp8_grad_u, h_grad_u, x_u, x_normed_u, rrms_u, weight_u, amax_st
   return grad_total.uop, grad_weight_uop
 
 def _fused_bwd(gradient:UOp, kernel:UOp):
-  # NOTE: fwd inputs (fp8_out, x_normed_out, rrms_out, amax_buf, x, weight, amax_state, inv_scale_out)
-  _, x_normed_u, rrms_u, _, x_u, weight_u, amax_state_u, _ = kernel.src[1:]
+  # NOTE: fwd inputs (fp8_out, x_normed_out, rrms_out, amax_buf, inv_scale_out, x, weight, amax_state)
+  _, x_normed_u, rrms_u, _, _, x_u, weight_u, amax_state_u = kernel.src[1:]
   grad_x, grad_w = _bwd_common(gradient, None, x_u, x_normed_u, rrms_u, weight_u, amax_state_u, kernel)
-  return (None, None, None, None, grad_x, grad_w, None, None)
+  return (None, None, None, None, None, grad_x, grad_w, None)
 
 def _fused_add_bwd(*args, **kwargs):
   # Two invocation modes: 1 grad => positional; >1 grads => kwarg `call=`.
@@ -108,9 +108,9 @@ def _fused_add_bwd(*args, **kwargs):
     g = all_grads[0]
     if g.dtype == dtypes.bfloat16: h_grad_u = g
     else: fp8_grad_u = g
-  _, _, x_normed_u, rrms_u, _, x_u, _, weight_u, amax_state_u, _ = kernel.src[1:]
+  _, _, x_normed_u, rrms_u, _, _, x_u, _, weight_u, amax_state_u = kernel.src[1:]
   grad_h, grad_w = _bwd_common(fp8_grad_u, h_grad_u, x_u, x_normed_u, rrms_u, weight_u, amax_state_u, kernel)
-  return (None, None, None, None, None, grad_h, grad_h, grad_w, None, None)
+  return (None, None, None, None, None, None, grad_h, grad_h, grad_w, None)
 
 def fused_rmsnorm_mul_quantize_fp8(x:Tensor, weight:Tensor, amax_state:Tensor, eps:float, fp8_dtype) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
   # NOTE: rmsnorm(x) * weight -> fp8 + amax. Returns (fp8, inv_scale, new_amax, x_normed, rrms).
@@ -126,8 +126,8 @@ def fused_rmsnorm_mul_quantize_fp8(x:Tensor, weight:Tensor, amax_state:Tensor, e
   amax_buf     = alloc_local((NUM_WG,),         dtypes.float32,  x.device, axis)
   inv_scale    = alloc_like((),                 dtypes.float32,  x.device)
   fxn = functools.partial(_custom_fwd, dname=dname_of(x.device), eps_val=eps)
-  fp8_out, x_normed_out, rrms_out, amax_buf, _, _, _, inv_scale = Tensor.custom_kernel(
-    fp8_out, x_normed_out, rrms_out, amax_buf, x, weight, amax_state, inv_scale, fxn=fxn, grad_fxn=_fused_bwd)
+  fp8_out, x_normed_out, rrms_out, amax_buf, inv_scale, _, _, _ = Tensor.custom_kernel(
+    fp8_out, x_normed_out, rrms_out, amax_buf, inv_scale, x, weight, amax_state, fxn=fxn, grad_fxn=_fused_bwd)
   return fp8_out, inv_scale, scalar_amax(amax_buf), x_normed_out, rrms_out
 
 def fused_add_rmsnorm_mul_quantize_fp8(x:Tensor, residual:Tensor, weight:Tensor, amax_state:Tensor,
@@ -147,7 +147,7 @@ def fused_add_rmsnorm_mul_quantize_fp8(x:Tensor, residual:Tensor, weight:Tensor,
   amax_buf     = alloc_local((NUM_WG,),         dtypes.float32,  x.device, axis)
   inv_scale    = alloc_like((),                 dtypes.float32,  x.device)
   fxn = functools.partial(_custom_fwd_add, dname=dname_of(x.device), eps_val=eps)
-  fp8_out, h_out, x_normed_out, rrms_out, amax_buf, _, _, _, _, inv_scale = Tensor.custom_kernel(
-    fp8_out, h_out, x_normed_out, rrms_out, amax_buf, x, residual, weight, amax_state, inv_scale,
+  fp8_out, h_out, x_normed_out, rrms_out, amax_buf, inv_scale, _, _, _, _ = Tensor.custom_kernel(
+    fp8_out, h_out, x_normed_out, rrms_out, amax_buf, inv_scale, x, residual, weight, amax_state,
     fxn=fxn, grad_fxn=_fused_add_bwd)
   return fp8_out, inv_scale, scalar_amax(amax_buf), h_out, x_normed_out, rrms_out

--- a/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/__init__.py
+++ b/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/__init__.py
@@ -3,19 +3,19 @@ import functools, pathlib
 from tinygrad import Tensor, dtypes
 from tinygrad.uop.ops import UOp, Ops, KernelInfo
 from tinygrad.renderer import Estimates
-from extra.llama_kernels import FP8_MAX, NUM_WG, THREADS_PER_WG, alloc_like, alloc_local, scalar_amax, dname_of, compile_hip
+from extra.llama_kernels import NUM_WG, THREADS_PER_WG, alloc_like, alloc_local, scalar_amax, dname_of, compile_hip
 
 def _src() -> str: return (pathlib.Path(__file__).parent/"fused_rmsnorm_mul_quantize_fp8.cpp").read_text()
 def _src_bwd() -> str: return (pathlib.Path(__file__).parent/"fused_rmsnorm_mul_quantize_fp8_bwd.cpp").read_text()
 
 @functools.cache
-def _custom_fwd(fp8_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
+def _custom_fwd(fp8_out:UOp, inv_scale_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
                 x:UOp, weight:UOp, amax_state:UOp, dname:str, eps_val:float) -> UOp:
   MBS, SEQ, HIDDEN = x.shape
   n_elems = MBS * SEQ * HIDDEN
   threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
-  mem = n_elems * 2 + n_elems + MBS * SEQ * 4 + n_elems + HIDDEN * 2 + NUM_WG * 4 + 4
-  sink = UOp.sink(fp8_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
+  mem = n_elems * 2 + n_elems + MBS * SEQ * 4 + n_elems + HIDDEN * 2 + NUM_WG * 4 + 8
+  sink = UOp.sink(fp8_out.base, inv_scale_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
                   x.base, weight.base, amax_state.base, threads, workgroups,
                   arg=KernelInfo(f"fused_rmsnorm_mul_quantize_fp8_{n_elems}_h{HIDDEN}_eps{eps_val:.0e}",
                                  estimates=Estimates(ops=6*n_elems, mem=mem)))
@@ -26,13 +26,13 @@ def _custom_fwd(fp8_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
                                UOp(Ops.SOURCE, arg=src), UOp(Ops.BINARY, arg=compile_hip(src, defines))))
 
 @functools.cache
-def _custom_fwd_add(fp8_out:UOp, h_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
+def _custom_fwd_add(fp8_out:UOp, inv_scale_out:UOp, h_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
                     x:UOp, residual:UOp, weight:UOp, amax_state:UOp, dname:str, eps_val:float) -> UOp:
   MBS, SEQ, HIDDEN = x.shape
   n_elems = MBS * SEQ * HIDDEN
   threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
-  mem = n_elems * 2 * 4 + MBS * SEQ * 4 + HIDDEN * 2 + NUM_WG * 4 + 4
-  sink = UOp.sink(fp8_out.base, h_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
+  mem = n_elems * 2 * 4 + MBS * SEQ * 4 + HIDDEN * 2 + NUM_WG * 4 + 8
+  sink = UOp.sink(fp8_out.base, inv_scale_out.base, h_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
                   x.base, residual.base, weight.base, amax_state.base, threads, workgroups,
                   arg=KernelInfo(f"fused_add_rmsnorm_mul_quantize_fp8_{n_elems}_h{HIDDEN}_eps{eps_val:.0e}",
                                  estimates=Estimates(ops=7*n_elems, mem=mem)))
@@ -85,14 +85,14 @@ def _bwd_common(fp8_grad_u, h_grad_u, x_u, x_normed_u, rrms_u, weight_u, amax_st
   return grad_total.uop, grad_weight_uop
 
 def _fused_bwd(gradient:UOp, kernel:UOp):
-  # NOTE: fwd inputs (fp8_out, x_normed_out, rrms_out, amax_buf, x, weight, amax_state)
-  _, x_normed_u, rrms_u, _, x_u, weight_u, amax_state_u = kernel.src[1:]
+  # NOTE: fwd inputs (fp8_out, inv_scale_out, x_normed_out, rrms_out, amax_buf, x, weight, amax_state)
+  _, _, x_normed_u, rrms_u, _, x_u, weight_u, amax_state_u = kernel.src[1:]
   grad_x, grad_w = _bwd_common(gradient, None, x_u, x_normed_u, rrms_u, weight_u, amax_state_u, kernel)
-  return (None, None, None, None, grad_x, grad_w, None)
+  return (None, None, None, None, None, grad_x, grad_w, None)
 
 def _fused_add_bwd(*args, **kwargs):
   # Two invocation modes: 1 grad => positional; >1 grads => kwarg `call=`.
-  # Outputs: (fp8_out, h_out, x_normed_out, rrms_out, amax_buf). Both fp8 and h may be consumed
+  # Outputs: (fp8_out, inv_scale_out, h_out, x_normed_out, rrms_out, amax_buf). Both fp8 and h may be consumed
   # downstream — TUPLE order in gradient.py preserves kernel-output slot order.
   # Don't dispatch by dtype: matmul's bwd emits fp8 grad as bf16 (no explicit cast), so
   # dtype-detection collapses both into h_grad and silently drops the rmsnorm-bwd path.
@@ -108,9 +108,9 @@ def _fused_add_bwd(*args, **kwargs):
     g = all_grads[0]
     if g.dtype == dtypes.bfloat16: h_grad_u = g
     else: fp8_grad_u = g
-  _, _, x_normed_u, rrms_u, _, x_u, _, weight_u, amax_state_u = kernel.src[1:]
+  _, _, _, x_normed_u, rrms_u, _, x_u, _, weight_u, amax_state_u = kernel.src[1:]
   grad_h, grad_w = _bwd_common(fp8_grad_u, h_grad_u, x_u, x_normed_u, rrms_u, weight_u, amax_state_u, kernel)
-  return (None, None, None, None, None, grad_h, grad_h, grad_w, None)
+  return (None, None, None, None, None, None, grad_h, grad_h, grad_w, None)
 
 def fused_rmsnorm_mul_quantize_fp8(x:Tensor, weight:Tensor, amax_state:Tensor, eps:float, fp8_dtype) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
   # NOTE: rmsnorm(x) * weight -> fp8 + amax. Returns (fp8, inv_scale, new_amax, x_normed, rrms).
@@ -121,13 +121,13 @@ def fused_rmsnorm_mul_quantize_fp8(x:Tensor, weight:Tensor, amax_state:Tensor, e
   axis = x.uop.axis if isinstance(x.device, tuple) else None
   if isinstance(x.device, tuple): assert axis in (None, 0, 1), f"unsupported sharding axis={axis}"
   fp8_out      = alloc_like((MBS, SEQ, HIDDEN), fp8_dtype,       x.device, axis)
+  inv_scale    = alloc_like((),                 dtypes.float32,  x.device)
   x_normed_out = alloc_like((MBS, SEQ, HIDDEN), dtypes.bfloat16, x.device, axis)
   rrms_out     = alloc_like((MBS, SEQ),         dtypes.float32,  x.device, axis)
   amax_buf     = alloc_local((NUM_WG,),         dtypes.float32,  x.device, axis)
   fxn = functools.partial(_custom_fwd, dname=dname_of(x.device), eps_val=eps)
-  fp8_out, x_normed_out, rrms_out, amax_buf, *_ = Tensor.custom_kernel(
-    fp8_out, x_normed_out, rrms_out, amax_buf, x, weight, amax_state, fxn=fxn, grad_fxn=_fused_bwd)
-  inv_scale = (amax_state.float() + 1e-8) / FP8_MAX
+  fp8_out, inv_scale, x_normed_out, rrms_out, amax_buf, *_ = Tensor.custom_kernel(
+    fp8_out, inv_scale, x_normed_out, rrms_out, amax_buf, x, weight, amax_state, fxn=fxn, grad_fxn=_fused_bwd)
   return fp8_out, inv_scale, scalar_amax(amax_buf), x_normed_out, rrms_out
 
 def fused_add_rmsnorm_mul_quantize_fp8(x:Tensor, residual:Tensor, weight:Tensor, amax_state:Tensor,
@@ -141,13 +141,13 @@ def fused_add_rmsnorm_mul_quantize_fp8(x:Tensor, residual:Tensor, weight:Tensor,
   axis = x.uop.axis if isinstance(x.device, tuple) else None
   if isinstance(x.device, tuple): assert axis in (None, 0, 1), f"unsupported sharding axis={axis}"
   fp8_out      = alloc_like((MBS, SEQ, HIDDEN), fp8_dtype,       x.device, axis)
+  inv_scale    = alloc_like((),                 dtypes.float32,  x.device)
   h_out        = alloc_like((MBS, SEQ, HIDDEN), dtypes.bfloat16, x.device, axis)
   x_normed_out = alloc_like((MBS, SEQ, HIDDEN), dtypes.bfloat16, x.device, axis)
   rrms_out     = alloc_like((MBS, SEQ),         dtypes.float32,  x.device, axis)
   amax_buf     = alloc_local((NUM_WG,),         dtypes.float32,  x.device, axis)
   fxn = functools.partial(_custom_fwd_add, dname=dname_of(x.device), eps_val=eps)
-  fp8_out, h_out, x_normed_out, rrms_out, amax_buf, *_ = Tensor.custom_kernel(
-    fp8_out, h_out, x_normed_out, rrms_out, amax_buf, x, residual, weight, amax_state,
+  fp8_out, inv_scale, h_out, x_normed_out, rrms_out, amax_buf, *_ = Tensor.custom_kernel(
+    fp8_out, inv_scale, h_out, x_normed_out, rrms_out, amax_buf, x, residual, weight, amax_state,
     fxn=fxn, grad_fxn=_fused_add_bwd)
-  inv_scale = (amax_state.float() + 1e-8) / FP8_MAX
   return fp8_out, inv_scale, scalar_amax(amax_buf), h_out, x_normed_out, rrms_out

--- a/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/__init__.py
+++ b/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/__init__.py
@@ -9,14 +9,14 @@ def _src() -> str: return (pathlib.Path(__file__).parent/"fused_rmsnorm_mul_quan
 def _src_bwd() -> str: return (pathlib.Path(__file__).parent/"fused_rmsnorm_mul_quantize_fp8_bwd.cpp").read_text()
 
 @functools.cache
-def _custom_fwd(fp8_out:UOp, inv_scale_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
-                x:UOp, weight:UOp, amax_state:UOp, dname:str, eps_val:float) -> UOp:
+def _custom_fwd(fp8_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
+                x:UOp, weight:UOp, amax_state:UOp, inv_scale_out:UOp, dname:str, eps_val:float) -> UOp:
   MBS, SEQ, HIDDEN = x.shape
   n_elems = MBS * SEQ * HIDDEN
   threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
   mem = n_elems * 2 + n_elems + MBS * SEQ * 4 + n_elems + HIDDEN * 2 + NUM_WG * 4 + 8
-  sink = UOp.sink(fp8_out.base, inv_scale_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
-                  x.base, weight.base, amax_state.base, threads, workgroups,
+  sink = UOp.sink(fp8_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
+                  x.base, weight.base, amax_state.base, inv_scale_out.base, threads, workgroups,
                   arg=KernelInfo(f"fused_rmsnorm_mul_quantize_fp8_{n_elems}_h{HIDDEN}_eps{eps_val:.0e}",
                                  estimates=Estimates(ops=6*n_elems, mem=mem)))
   defines = [f"-DN_ELEMS={n_elems}", f"-DHIDDEN={HIDDEN}", f"-DNUM_WG={NUM_WG}", f"-DTHREADS_PER_WG={THREADS_PER_WG}",
@@ -26,14 +26,14 @@ def _custom_fwd(fp8_out:UOp, inv_scale_out:UOp, x_normed_out:UOp, rrms_out:UOp, 
                                UOp(Ops.SOURCE, arg=src), UOp(Ops.BINARY, arg=compile_hip(src, defines))))
 
 @functools.cache
-def _custom_fwd_add(fp8_out:UOp, inv_scale_out:UOp, h_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
-                    x:UOp, residual:UOp, weight:UOp, amax_state:UOp, dname:str, eps_val:float) -> UOp:
+def _custom_fwd_add(fp8_out:UOp, h_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
+                    x:UOp, residual:UOp, weight:UOp, amax_state:UOp, inv_scale_out:UOp, dname:str, eps_val:float) -> UOp:
   MBS, SEQ, HIDDEN = x.shape
   n_elems = MBS * SEQ * HIDDEN
   threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
   mem = n_elems * 2 * 4 + MBS * SEQ * 4 + HIDDEN * 2 + NUM_WG * 4 + 8
-  sink = UOp.sink(fp8_out.base, inv_scale_out.base, h_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
-                  x.base, residual.base, weight.base, amax_state.base, threads, workgroups,
+  sink = UOp.sink(fp8_out.base, h_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
+                  x.base, residual.base, weight.base, amax_state.base, inv_scale_out.base, threads, workgroups,
                   arg=KernelInfo(f"fused_add_rmsnorm_mul_quantize_fp8_{n_elems}_h{HIDDEN}_eps{eps_val:.0e}",
                                  estimates=Estimates(ops=7*n_elems, mem=mem)))
   defines = [f"-DN_ELEMS={n_elems}", f"-DHIDDEN={HIDDEN}", f"-DNUM_WG={NUM_WG}", f"-DTHREADS_PER_WG={THREADS_PER_WG}",
@@ -85,14 +85,14 @@ def _bwd_common(fp8_grad_u, h_grad_u, x_u, x_normed_u, rrms_u, weight_u, amax_st
   return grad_total.uop, grad_weight_uop
 
 def _fused_bwd(gradient:UOp, kernel:UOp):
-  # NOTE: fwd inputs (fp8_out, inv_scale_out, x_normed_out, rrms_out, amax_buf, x, weight, amax_state)
-  _, _, x_normed_u, rrms_u, _, x_u, weight_u, amax_state_u = kernel.src[1:]
+  # NOTE: fwd inputs (fp8_out, x_normed_out, rrms_out, amax_buf, x, weight, amax_state, inv_scale_out)
+  _, x_normed_u, rrms_u, _, x_u, weight_u, amax_state_u, _ = kernel.src[1:]
   grad_x, grad_w = _bwd_common(gradient, None, x_u, x_normed_u, rrms_u, weight_u, amax_state_u, kernel)
-  return (None, None, None, None, None, grad_x, grad_w, None)
+  return (None, None, None, None, grad_x, grad_w, None, None)
 
 def _fused_add_bwd(*args, **kwargs):
   # Two invocation modes: 1 grad => positional; >1 grads => kwarg `call=`.
-  # Outputs: (fp8_out, inv_scale_out, h_out, x_normed_out, rrms_out, amax_buf). Both fp8 and h may be consumed
+  # Outputs: (fp8_out, h_out, x_normed_out, rrms_out, amax_buf). Both fp8 and h may be consumed
   # downstream — TUPLE order in gradient.py preserves kernel-output slot order.
   # Don't dispatch by dtype: matmul's bwd emits fp8 grad as bf16 (no explicit cast), so
   # dtype-detection collapses both into h_grad and silently drops the rmsnorm-bwd path.
@@ -108,9 +108,9 @@ def _fused_add_bwd(*args, **kwargs):
     g = all_grads[0]
     if g.dtype == dtypes.bfloat16: h_grad_u = g
     else: fp8_grad_u = g
-  _, _, _, x_normed_u, rrms_u, _, x_u, _, weight_u, amax_state_u = kernel.src[1:]
+  _, _, x_normed_u, rrms_u, _, x_u, _, weight_u, amax_state_u, _ = kernel.src[1:]
   grad_h, grad_w = _bwd_common(fp8_grad_u, h_grad_u, x_u, x_normed_u, rrms_u, weight_u, amax_state_u, kernel)
-  return (None, None, None, None, None, None, grad_h, grad_h, grad_w, None)
+  return (None, None, None, None, None, grad_h, grad_h, grad_w, None, None)
 
 def fused_rmsnorm_mul_quantize_fp8(x:Tensor, weight:Tensor, amax_state:Tensor, eps:float, fp8_dtype) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
   # NOTE: rmsnorm(x) * weight -> fp8 + amax. Returns (fp8, inv_scale, new_amax, x_normed, rrms).
@@ -121,13 +121,13 @@ def fused_rmsnorm_mul_quantize_fp8(x:Tensor, weight:Tensor, amax_state:Tensor, e
   axis = x.uop.axis if isinstance(x.device, tuple) else None
   if isinstance(x.device, tuple): assert axis in (None, 0, 1), f"unsupported sharding axis={axis}"
   fp8_out      = alloc_like((MBS, SEQ, HIDDEN), fp8_dtype,       x.device, axis)
-  inv_scale    = alloc_like((),                 dtypes.float32,  x.device)
   x_normed_out = alloc_like((MBS, SEQ, HIDDEN), dtypes.bfloat16, x.device, axis)
   rrms_out     = alloc_like((MBS, SEQ),         dtypes.float32,  x.device, axis)
   amax_buf     = alloc_local((NUM_WG,),         dtypes.float32,  x.device, axis)
+  inv_scale    = alloc_like((),                 dtypes.float32,  x.device)
   fxn = functools.partial(_custom_fwd, dname=dname_of(x.device), eps_val=eps)
-  fp8_out, inv_scale, x_normed_out, rrms_out, amax_buf, *_ = Tensor.custom_kernel(
-    fp8_out, inv_scale, x_normed_out, rrms_out, amax_buf, x, weight, amax_state, fxn=fxn, grad_fxn=_fused_bwd)
+  fp8_out, x_normed_out, rrms_out, amax_buf, _, _, _, inv_scale = Tensor.custom_kernel(
+    fp8_out, x_normed_out, rrms_out, amax_buf, x, weight, amax_state, inv_scale, fxn=fxn, grad_fxn=_fused_bwd)
   return fp8_out, inv_scale, scalar_amax(amax_buf), x_normed_out, rrms_out
 
 def fused_add_rmsnorm_mul_quantize_fp8(x:Tensor, residual:Tensor, weight:Tensor, amax_state:Tensor,
@@ -141,13 +141,13 @@ def fused_add_rmsnorm_mul_quantize_fp8(x:Tensor, residual:Tensor, weight:Tensor,
   axis = x.uop.axis if isinstance(x.device, tuple) else None
   if isinstance(x.device, tuple): assert axis in (None, 0, 1), f"unsupported sharding axis={axis}"
   fp8_out      = alloc_like((MBS, SEQ, HIDDEN), fp8_dtype,       x.device, axis)
-  inv_scale    = alloc_like((),                 dtypes.float32,  x.device)
   h_out        = alloc_like((MBS, SEQ, HIDDEN), dtypes.bfloat16, x.device, axis)
   x_normed_out = alloc_like((MBS, SEQ, HIDDEN), dtypes.bfloat16, x.device, axis)
   rrms_out     = alloc_like((MBS, SEQ),         dtypes.float32,  x.device, axis)
   amax_buf     = alloc_local((NUM_WG,),         dtypes.float32,  x.device, axis)
+  inv_scale    = alloc_like((),                 dtypes.float32,  x.device)
   fxn = functools.partial(_custom_fwd_add, dname=dname_of(x.device), eps_val=eps)
-  fp8_out, inv_scale, h_out, x_normed_out, rrms_out, amax_buf, *_ = Tensor.custom_kernel(
-    fp8_out, inv_scale, h_out, x_normed_out, rrms_out, amax_buf, x, residual, weight, amax_state,
+  fp8_out, h_out, x_normed_out, rrms_out, amax_buf, _, _, _, _, inv_scale = Tensor.custom_kernel(
+    fp8_out, h_out, x_normed_out, rrms_out, amax_buf, x, residual, weight, amax_state, inv_scale,
     fxn=fxn, grad_fxn=_fused_add_bwd)
   return fp8_out, inv_scale, scalar_amax(amax_buf), h_out, x_normed_out, rrms_out

--- a/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/fused_rmsnorm_mul_quantize_fp8.cpp
+++ b/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/fused_rmsnorm_mul_quantize_fp8.cpp
@@ -6,6 +6,7 @@
 //   y = rmsnorm(x) * weight            (reduce-mean-square + rsqrt + per-elem mul)
 //   fp8 = fp8_sat(y * (FP8_MAX / amax_state))
 // Also writes:
+//   inv_scale       — reciprocal quantization scale consumed by the fp8 matmul
 //   rrms[row]        — saved for the rmsnorm backward
 //   amax_buf[wg]     — per-WG |y| partials, reduced later to update amax_state
 //
@@ -45,6 +46,7 @@ constexpr int VECS_PER_THREAD = ELEMS_PER_THREAD / VEC;    // number of 8-wide v
 extern "C" __global__ __launch_bounds__(THREADS_PER_WG) void
 fused_add_rmsnorm_mul_quantize_fp8(
     __hip_fp8_storage_t*  __restrict__ fp8_out,         // fp8, ROWS*HIDDEN
+    float*                __restrict__ inv_scale_out,   // fp32 scalar
     __hip_bfloat16*       __restrict__ h_out,           // bf16, ROWS*HIDDEN — x + residual (saved for downstream)
     __hip_bfloat16*       __restrict__ x_normed_out,    // bf16, ROWS*HIDDEN
     float*                __restrict__ rrms_out,        // fp32, ROWS
@@ -58,6 +60,7 @@ fused_add_rmsnorm_mul_quantize_fp8(
 extern "C" __global__ __launch_bounds__(THREADS_PER_WG) void
 fused_rmsnorm_mul_quantize_fp8(
     __hip_fp8_storage_t*  __restrict__ fp8_out,         // fp8, ROWS*HIDDEN
+    float*                __restrict__ inv_scale_out,   // fp32 scalar
     __hip_bfloat16*       __restrict__ x_normed_out,    // bf16, ROWS*HIDDEN (saved for rmsnorm bwd)
     float*                __restrict__ rrms_out,        // fp32, ROWS (fp32 to match rmsnorm_bwd.cpp expectation)
     float*                __restrict__ amax_buf,        // fp32, NUM_WG per-WG partials
@@ -71,9 +74,12 @@ fused_rmsnorm_mul_quantize_fp8(
   const int tid = threadIdx.x;
   const int wg  = blockIdx.x;
 
-  const float scale = FP8_MAX / (static_cast<float>(*amax_state) + 1e-8f);
+  const float amax = static_cast<float>(*amax_state) + 1e-8f;
+  const float scale = FP8_MAX / amax;
   const float inv_hidden = 1.0f / static_cast<float>(HIDDEN);
   float local_max = 0.0f;
+
+  if (tid == 0 && wg == 0) inv_scale_out[0] = amax / FP8_MAX;
 
   // Grid-stride over rows. Each WG processes rows (wg, wg+NUM_WG, wg+2*NUM_WG, ...).
   for (int row = wg; row < ROWS; row += NUM_WG) {

--- a/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/fused_rmsnorm_mul_quantize_fp8.cpp
+++ b/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/fused_rmsnorm_mul_quantize_fp8.cpp
@@ -46,7 +46,6 @@ constexpr int VECS_PER_THREAD = ELEMS_PER_THREAD / VEC;    // number of 8-wide v
 extern "C" __global__ __launch_bounds__(THREADS_PER_WG) void
 fused_add_rmsnorm_mul_quantize_fp8(
     __hip_fp8_storage_t*  __restrict__ fp8_out,         // fp8, ROWS*HIDDEN
-    float*                __restrict__ inv_scale_out,   // fp32 scalar
     __hip_bfloat16*       __restrict__ h_out,           // bf16, ROWS*HIDDEN — x + residual (saved for downstream)
     __hip_bfloat16*       __restrict__ x_normed_out,    // bf16, ROWS*HIDDEN
     float*                __restrict__ rrms_out,        // fp32, ROWS
@@ -54,19 +53,20 @@ fused_add_rmsnorm_mul_quantize_fp8(
     const __hip_bfloat16* __restrict__ x,               // bf16, ROWS*HIDDEN
     const __hip_bfloat16* __restrict__ residual,        // bf16, ROWS*HIDDEN — added into x before rmsnorm
     const __hip_bfloat16* __restrict__ weight,          // bf16, HIDDEN
-    const float*          __restrict__ amax_state)      // fp32 scalar
+    const float*          __restrict__ amax_state,      // fp32 scalar
+    float*                __restrict__ inv_scale_out)   // fp32 scalar
 {
 #else
 extern "C" __global__ __launch_bounds__(THREADS_PER_WG) void
 fused_rmsnorm_mul_quantize_fp8(
     __hip_fp8_storage_t*  __restrict__ fp8_out,         // fp8, ROWS*HIDDEN
-    float*                __restrict__ inv_scale_out,   // fp32 scalar
     __hip_bfloat16*       __restrict__ x_normed_out,    // bf16, ROWS*HIDDEN (saved for rmsnorm bwd)
     float*                __restrict__ rrms_out,        // fp32, ROWS (fp32 to match rmsnorm_bwd.cpp expectation)
     float*                __restrict__ amax_buf,        // fp32, NUM_WG per-WG partials
     const __hip_bfloat16* __restrict__ x,               // bf16, ROWS*HIDDEN
     const __hip_bfloat16* __restrict__ weight,          // bf16, HIDDEN (per-hidden scale)
-    const float*          __restrict__ amax_state)      // fp32 scalar
+    const float*          __restrict__ amax_state,      // fp32 scalar
+    float*                __restrict__ inv_scale_out)   // fp32 scalar
 {
 #endif
   __shared__ float sdata[THREADS_PER_WG];

--- a/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/fused_rmsnorm_mul_quantize_fp8.cpp
+++ b/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/fused_rmsnorm_mul_quantize_fp8.cpp
@@ -50,11 +50,11 @@ fused_add_rmsnorm_mul_quantize_fp8(
     __hip_bfloat16*       __restrict__ x_normed_out,    // bf16, ROWS*HIDDEN
     float*                __restrict__ rrms_out,        // fp32, ROWS
     float*                __restrict__ amax_buf,        // fp32, NUM_WG
+    float*                __restrict__ inv_scale_out,   // fp32 scalar
     const __hip_bfloat16* __restrict__ x,               // bf16, ROWS*HIDDEN
     const __hip_bfloat16* __restrict__ residual,        // bf16, ROWS*HIDDEN — added into x before rmsnorm
     const __hip_bfloat16* __restrict__ weight,          // bf16, HIDDEN
-    const float*          __restrict__ amax_state,      // fp32 scalar
-    float*                __restrict__ inv_scale_out)   // fp32 scalar
+    const float*          __restrict__ amax_state)      // fp32 scalar
 {
 #else
 extern "C" __global__ __launch_bounds__(THREADS_PER_WG) void
@@ -63,10 +63,10 @@ fused_rmsnorm_mul_quantize_fp8(
     __hip_bfloat16*       __restrict__ x_normed_out,    // bf16, ROWS*HIDDEN (saved for rmsnorm bwd)
     float*                __restrict__ rrms_out,        // fp32, ROWS (fp32 to match rmsnorm_bwd.cpp expectation)
     float*                __restrict__ amax_buf,        // fp32, NUM_WG per-WG partials
+    float*                __restrict__ inv_scale_out,   // fp32 scalar
     const __hip_bfloat16* __restrict__ x,               // bf16, ROWS*HIDDEN
     const __hip_bfloat16* __restrict__ weight,          // bf16, HIDDEN (per-hidden scale)
-    const float*          __restrict__ amax_state,      // fp32 scalar
-    float*                __restrict__ inv_scale_out)   // fp32 scalar
+    const float*          __restrict__ amax_state)      // fp32 scalar
 {
 #endif
   __shared__ float sdata[THREADS_PER_WG];

--- a/extra/llama_kernels/quantize_fp8_delayed/__init__.py
+++ b/extra/llama_kernels/quantize_fp8_delayed/__init__.py
@@ -6,7 +6,7 @@ from tinygrad.uop.ops import UOp, Ops, KernelInfo, AxisType
 from extra.llama_kernels import FP8_MAX, NUM_WG, THREADS_PER_WG, alloc_like, alloc_local, scalar_amax
 
 @functools.cache
-def _custom_quantize_fp8_with_amax(fp8_out:UOp, amax_partial:UOp, x:UOp, amax_state:UOp) -> UOp:
+def _custom_quantize_fp8_with_amax(fp8_out:UOp, amax_partial:UOp, x:UOp, amax_state:UOp, inv_scale_out:UOp) -> UOp:
   VEC = 8
   n_elems = prod(x.shape)
   assert n_elems % (NUM_WG * THREADS_PER_WG * VEC) == 0
@@ -22,7 +22,9 @@ def _custom_quantize_fp8_with_amax(fp8_out:UOp, amax_partial:UOp, x:UOp, amax_st
 
   idx = (((it * NUM_WG + wg) * THREADS_PER_WG + tid) * VEC) + lane
 
-  scale = FP8_MAX / (amax_state[0].cast(dtypes.float) + 1e-8)
+  amax = amax_state[0].cast(dtypes.float) + 1e-8
+  inv_scale = amax / FP8_MAX
+  scale = 1.0 / inv_scale
   x_f = x[idx].cast(dtypes.float)
   abs_x = (x_f < 0.0).where(-x_f, x_f)
   scaled = (x_f * scale).maximum(-FP8_MAX).minimum(FP8_MAX)
@@ -47,7 +49,8 @@ def _custom_quantize_fp8_with_amax(fp8_out:UOp, amax_partial:UOp, x:UOp, amax_st
     step //= 2
 
   amax_store = amax_partial[tid.eq(0).where(wg, UOp.invalid())].store(lds[0])
-  return amax_store.end(tid, wg).sink(arg=KernelInfo(f"quantize_fp8_with_amax_{n_elems}", opts_to_apply=()))
+  inv_scale_store = inv_scale_out.index(UOp.const(dtypes.int, 0), ptr=True).store(inv_scale, gate=tid.eq(0) & wg.eq(0))
+  return UOp.group(amax_store, inv_scale_store).end(tid, wg).sink(arg=KernelInfo(f"quantize_fp8_with_amax_{n_elems}", opts_to_apply=()))
 
 @functools.cache
 def _custom_quantize_fp8_scalar(fp8_out:UOp, x:UOp, amax_state:UOp) -> UOp:
@@ -63,11 +66,11 @@ def _custom_quantize_fp8_scalar(fp8_out:UOp, x:UOp, amax_state:UOp) -> UOp:
 def _quantize_fp8_delayed_bwd(gradient:UOp, kernel:UOp):
   # NOTE: STE-equivalent backward — grad_x = grad_fp8 * scale, scale = FP8_MAX / amax_state.
   # `gradient` is bf16 grad w.r.t. fp8 output (asm_gemm bwd already applied x_scale).
-  _, _, x, amax_state = kernel.src[1:]
+  _, _, x, amax_state, _ = kernel.src[1:]
   device = x.device
   scale = FP8_MAX / (Tensor(amax_state, device=device).float() + 1e-8)
   grad_x = (Tensor(gradient, device=device).float() * scale).cast(dtypes.bfloat16)
-  return (None, None, grad_x.uop, None)
+  return (None, None, grad_x.uop, None, None)
 
 def quantize_fp8_delayed(x:Tensor, amax_state:Tensor, fp8_dtype=dtypes.fp8e4m3) -> tuple[Tensor, Tensor, Tensor, UOp]:
   # NOTE: one-pass bf16 -> fp8 quantize with delayed scaling. Returns (fp8, inv_scale, new_amax, store_effect).
@@ -81,11 +84,11 @@ def quantize_fp8_delayed(x:Tensor, amax_state:Tensor, fp8_dtype=dtypes.fp8e4m3) 
   n_elems = prod(x.uop.shard_shape)
   assert n_elems % NUM_WG == 0, f"{n_elems=} must divide over {NUM_WG=}"
   amax_partial = alloc_local((NUM_WG,), dtypes.float32, x.device, axis)
+  inv_scale = alloc_like((), dtypes.float32, x.device)
   fxn = _custom_quantize_fp8_with_amax
-  fp8_out, amax_partial, *_ = Tensor.custom_kernel(fp8_out, amax_partial, x, amax_state,
-                                                    fxn=fxn, grad_fxn=_quantize_fp8_delayed_bwd)
+  fp8_out, amax_partial, _, _, inv_scale = Tensor.custom_kernel(fp8_out, amax_partial, x, amax_state, inv_scale,
+                                                                 fxn=fxn, grad_fxn=_quantize_fp8_delayed_bwd)
   new_amax = scalar_amax(amax_partial)
-  inv_scale = (amax_state.float() + 1e-8) / FP8_MAX
   store_effect = amax_state.uop.store(new_amax.uop)
   return fp8_out, inv_scale, new_amax, store_effect
 

--- a/extra/llama_kernels/quantize_fp8_delayed/__init__.py
+++ b/extra/llama_kernels/quantize_fp8_delayed/__init__.py
@@ -6,7 +6,7 @@ from tinygrad.uop.ops import UOp, Ops, KernelInfo, AxisType
 from extra.llama_kernels import FP8_MAX, NUM_WG, THREADS_PER_WG, alloc_like, alloc_local, scalar_amax
 
 @functools.cache
-def _custom_quantize_fp8_with_amax(fp8_out:UOp, amax_partial:UOp, x:UOp, amax_state:UOp, inv_scale_out:UOp) -> UOp:
+def _custom_quantize_fp8_with_amax(fp8_out:UOp, amax_partial:UOp, inv_scale_out:UOp, x:UOp, amax_state:UOp) -> UOp:
   VEC = 8
   n_elems = prod(x.shape)
   assert n_elems % (NUM_WG * THREADS_PER_WG * VEC) == 0
@@ -66,11 +66,11 @@ def _custom_quantize_fp8_scalar(fp8_out:UOp, x:UOp, amax_state:UOp) -> UOp:
 def _quantize_fp8_delayed_bwd(gradient:UOp, kernel:UOp):
   # NOTE: STE-equivalent backward — grad_x = grad_fp8 * scale, scale = FP8_MAX / amax_state.
   # `gradient` is bf16 grad w.r.t. fp8 output (asm_gemm bwd already applied x_scale).
-  _, _, x, amax_state, _ = kernel.src[1:]
+  _, _, _, x, amax_state = kernel.src[1:]
   device = x.device
   scale = FP8_MAX / (Tensor(amax_state, device=device).float() + 1e-8)
   grad_x = (Tensor(gradient, device=device).float() * scale).cast(dtypes.bfloat16)
-  return (None, None, grad_x.uop, None, None)
+  return (None, None, None, grad_x.uop, None)
 
 def quantize_fp8_delayed(x:Tensor, amax_state:Tensor, fp8_dtype=dtypes.fp8e4m3) -> tuple[Tensor, Tensor, Tensor, UOp]:
   # NOTE: one-pass bf16 -> fp8 quantize with delayed scaling. Returns (fp8, inv_scale, new_amax, store_effect).
@@ -86,7 +86,7 @@ def quantize_fp8_delayed(x:Tensor, amax_state:Tensor, fp8_dtype=dtypes.fp8e4m3) 
   amax_partial = alloc_local((NUM_WG,), dtypes.float32, x.device, axis)
   inv_scale = alloc_like((), dtypes.float32, x.device)
   fxn = _custom_quantize_fp8_with_amax
-  fp8_out, amax_partial, _, _, inv_scale = Tensor.custom_kernel(fp8_out, amax_partial, x, amax_state, inv_scale,
+  fp8_out, amax_partial, inv_scale, _, _ = Tensor.custom_kernel(fp8_out, amax_partial, inv_scale, x, amax_state,
                                                                  fxn=fxn, grad_fxn=_quantize_fp8_delayed_bwd)
   new_amax = scalar_amax(amax_partial)
   store_effect = amax_state.uop.store(new_amax.uop)

--- a/extra/llama_kernels/quantize_fp8_delayed/__init__.py
+++ b/extra/llama_kernels/quantize_fp8_delayed/__init__.py
@@ -86,8 +86,7 @@ def quantize_fp8_delayed(x:Tensor, amax_state:Tensor, fp8_dtype=dtypes.fp8e4m3) 
   amax_partial = alloc_local((NUM_WG,), dtypes.float32, x.device, axis)
   inv_scale = alloc_like((), dtypes.float32, x.device)
   fxn = _custom_quantize_fp8_with_amax
-  fp8_out, amax_partial, inv_scale, _, _ = Tensor.custom_kernel(fp8_out, amax_partial, inv_scale, x, amax_state,
-                                                                 fxn=fxn, grad_fxn=_quantize_fp8_delayed_bwd)
+  fp8_out, amax_partial, inv_scale, _, _ = Tensor.custom_kernel(fp8_out, amax_partial, inv_scale, x, amax_state, fxn=fxn, grad_fxn=_quantize_fp8_delayed_bwd)
   new_amax = scalar_amax(amax_partial)
   store_effect = amax_state.uop.store(new_amax.uop)
   return fp8_out, inv_scale, new_amax, store_effect

--- a/extra/thunder/amd/gemm_fp8.cpp
+++ b/extra/thunder/amd/gemm_fp8.cpp
@@ -93,7 +93,7 @@ constexpr int NUM_WARPS = 8;
 
 using G = kittens::group<NUM_WARPS>;
 
-// scale_mode: 0=no scale, 1=x only, 2=w only, 3=both
+// scale_mode: 0=no scale, 1=x only, 2=w only, 3=both, 7=three scales
 #ifndef SCALE_MODE
 #define SCALE_MODE 3
 #endif
@@ -105,6 +105,10 @@ __global__ __launch_bounds__(512, 2) void hk_fp8_gemm(bf16 *C_ptr, fp8e4m3 *A_pt
     , float *w_scale_ptr
 #elif SCALE_MODE == 3
     , float *x_scale_ptr, float *w_scale_ptr
+#elif SCALE_MODE == 7
+    , float *x_scale_ptr, float *w_scale_ptr, float *z_scale_ptr
+#elif SCALE_MODE != 0
+#error "Unsupported SCALE_MODE"
 #endif
 ) {
     constexpr int M = GEMM_M, N = GEMM_N, K = GEMM_K;
@@ -353,6 +357,10 @@ __global__ __launch_bounds__(512, 2) void hk_fp8_gemm(bf16 *C_ptr, fp8e4m3 *A_pt
     float scale = *w_scale_ptr;
 #elif SCALE_MODE == 3
     float scale = *x_scale_ptr * *w_scale_ptr;
+#elif SCALE_MODE == 7
+    float scale = *x_scale_ptr * *w_scale_ptr * *z_scale_ptr;
+#else
+#error "Unsupported SCALE_MODE"
 #endif
 
     mul(cA, cA, scale);

--- a/extra/thunder/amd/gemm_fp8.cpp
+++ b/extra/thunder/amd/gemm_fp8.cpp
@@ -106,6 +106,12 @@ using G = kittens::group<NUM_WARPS>;
 #ifndef Z_SCALE_OFFSET
 #define Z_SCALE_OFFSET 0
 #endif
+#ifndef HAS_GRAD_AMAX
+#define HAS_GRAD_AMAX 0
+#endif
+#ifndef HAS_W_POST
+#define HAS_W_POST 0
+#endif
 
 __global__ __launch_bounds__(512, 2) void hk_fp8_gemm(bf16 *C_ptr, fp8e4m3 *A_ptr, fp8e4m3 *B_ptr
 #if SCALE_MODE == 1
@@ -118,6 +124,12 @@ __global__ __launch_bounds__(512, 2) void hk_fp8_gemm(bf16 *C_ptr, fp8e4m3 *A_pt
     , float *x_scale_ptr, float *w_scale_ptr, float *z_scale_ptr
 #elif SCALE_MODE != 0
 #error "Unsupported SCALE_MODE"
+#endif
+#if HAS_GRAD_AMAX
+    , float *grad_amax_state_ptr
+#endif
+#if HAS_W_POST
+    , float *w_post_scale_ptr
 #endif
 ) {
     constexpr int M = GEMM_M, N = GEMM_N, K = GEMM_K;

--- a/extra/thunder/amd/gemm_fp8.cpp
+++ b/extra/thunder/amd/gemm_fp8.cpp
@@ -97,6 +97,15 @@ using G = kittens::group<NUM_WARPS>;
 #ifndef SCALE_MODE
 #define SCALE_MODE 3
 #endif
+#ifndef X_SCALE_OFFSET
+#define X_SCALE_OFFSET 0
+#endif
+#ifndef W_SCALE_OFFSET
+#define W_SCALE_OFFSET 0
+#endif
+#ifndef Z_SCALE_OFFSET
+#define Z_SCALE_OFFSET 0
+#endif
 
 __global__ __launch_bounds__(512, 2) void hk_fp8_gemm(bf16 *C_ptr, fp8e4m3 *A_ptr, fp8e4m3 *B_ptr
 #if SCALE_MODE == 1
@@ -352,13 +361,13 @@ __global__ __launch_bounds__(512, 2) void hk_fp8_gemm(bf16 *C_ptr, fp8e4m3 *A_pt
     // apply x_scale * w_scale before bf16 store to prevent overflow
 #if SCALE_MODE != 0
 #if SCALE_MODE == 1
-    float scale = *x_scale_ptr;
+    float scale = x_scale_ptr[X_SCALE_OFFSET];
 #elif SCALE_MODE == 2
-    float scale = *w_scale_ptr;
+    float scale = w_scale_ptr[W_SCALE_OFFSET];
 #elif SCALE_MODE == 3
-    float scale = *x_scale_ptr * *w_scale_ptr;
+    float scale = x_scale_ptr[X_SCALE_OFFSET] * w_scale_ptr[W_SCALE_OFFSET];
 #elif SCALE_MODE == 7
-    float scale = *x_scale_ptr * *w_scale_ptr * *z_scale_ptr;
+    float scale = x_scale_ptr[X_SCALE_OFFSET] * w_scale_ptr[W_SCALE_OFFSET] * z_scale_ptr[Z_SCALE_OFFSET];
 #else
 #error "Unsupported SCALE_MODE"
 #endif

--- a/extra/thunder/amd/gemm_fp8.cpp
+++ b/extra/thunder/amd/gemm_fp8.cpp
@@ -97,15 +97,6 @@ using G = kittens::group<NUM_WARPS>;
 #ifndef SCALE_MODE
 #define SCALE_MODE 3
 #endif
-#ifndef X_SCALE_OFFSET
-#define X_SCALE_OFFSET 0
-#endif
-#ifndef W_SCALE_OFFSET
-#define W_SCALE_OFFSET 0
-#endif
-#ifndef Z_SCALE_OFFSET
-#define Z_SCALE_OFFSET 0
-#endif
 #ifndef HAS_GRAD_AMAX
 #define HAS_GRAD_AMAX 0
 #endif
@@ -373,13 +364,13 @@ __global__ __launch_bounds__(512, 2) void hk_fp8_gemm(bf16 *C_ptr, fp8e4m3 *A_pt
     // apply x_scale * w_scale before bf16 store to prevent overflow
 #if SCALE_MODE != 0
 #if SCALE_MODE == 1
-    float scale = x_scale_ptr[X_SCALE_OFFSET];
+    float scale = *x_scale_ptr;
 #elif SCALE_MODE == 2
-    float scale = w_scale_ptr[W_SCALE_OFFSET];
+    float scale = *w_scale_ptr;
 #elif SCALE_MODE == 3
-    float scale = x_scale_ptr[X_SCALE_OFFSET] * w_scale_ptr[W_SCALE_OFFSET];
+    float scale = *x_scale_ptr * *w_scale_ptr;
 #elif SCALE_MODE == 7
-    float scale = x_scale_ptr[X_SCALE_OFFSET] * w_scale_ptr[W_SCALE_OFFSET] * z_scale_ptr[Z_SCALE_OFFSET];
+    float scale = *x_scale_ptr * *w_scale_ptr * *z_scale_ptr;
 #else
 #error "Unsupported SCALE_MODE"
 #endif


### PR DESCRIPTION
in master two E scalar kernels run per fp8 gemm, producing inv_scale and wscale's getitem.

This diff fuses inv_scale with producer kernels, and pre compiles the layer offset for wscale in the gemm source code, -1,280 kernels per device per step.

I tried a couple other approaches:
for inv scale, the alternative is recomputing in the gemm prologue, which makes compute O(threads) instead of O(1).
for wscale, it could store per layer tensors. but it adds kernels elsewhere. This approach does not add any new kernels.