### PR TITLE
jit: error on Tensor.assign to a JIT input not in the return value 

### DIFF
--- a/test/unit/test_jit_footguns.py
+++ b/test/unit/test_jit_footguns.py
@@ -409,6 +409,19 @@ class TestJitCorrectBehavior(unittest.TestCase):
       f(a)
     self.assertEqual(a.item(), 5)
 
+  def test_assign_to_jit_input_raises(self):
+    """Tensor.assign() to a JIT input that is not in the return value is silently dropped on replay.
+    See #16618"""
+    @TinyJit
+    def step(w):
+      r = w.sum()        # depends on w BEFORE the assign
+      w.assign(w + 1)    # orphaned: not connected to the return
+      return r
+    w = Tensor([0])
+    step(w)  # warmup (eager) — works
+    with self.assertRaises(JitError):
+      step(w)  # capture — orphaned assign raises
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -87,6 +87,24 @@ def _check_no_non_tensor_return(ret):
 
 def graph_class(dev): return dev.graph.func if isinstance(dev.graph, functools.partial) else dev.graph
 
+# JIT inputs/outputs can be plain Tensors or nested in tuples/lists/dicts (e.g. model params).
+# We need to find every Tensor object so we can compare identity before/after capture.
+def _collect_tensors(obj):
+  if obj.__class__ is Tensor: yield obj
+  elif isinstance(obj, (tuple, list)): yield from (t for x in obj for t in _collect_tensors(x))
+  elif isinstance(obj, dict): yield from (t for v in obj.values() for t in _collect_tensors(v))
+
+# All UOps reachable from the given Tensors (used to detect orphaned assigns during JIT capture).
+def _reachable_uops(tensors):
+  seen: set[UOp] = set()
+  stack = [t.uop for t in _collect_tensors(tensors)]
+  while stack:
+    u = stack.pop()
+    if u in seen: continue
+    seen.add(u)
+    stack.extend(u.src)
+  return seen
+
 class DepsTracker:
   def __init__(self):
     # tracks (offset, end, dep) ranges per base buffer id to handle suballocated buffers correctly.
@@ -278,9 +296,21 @@ class TinyJit(Generic[ReturnType]):
       assert self.fxn is not None
       if capturing: raise RuntimeError(f"having TinyJit inside another TinyJit is not supported {len(capturing)=} {capturing=}")
       self._linears: list[UOp] = []
+      # snapshot input tensor uops before capture so we can detect in-place mutations after fxn returns
+      # (Tensor.assign replaces self.uop, so a changed uop means an assign happened)
+      input_tensors = list(_collect_tensors((args, kwargs)))
+      orig_uops = {id(t): t.uop for t in input_tensors}
       capturing.append(self)
       try:
         ret = self.fxn(*args, **kwargs)
+        # orphaned assign to a JIT input is silently dropped on replay (see #16618).
+        # the JIT only captures kernels reachable from the return value; if an input tensor's uop
+        # changed (assign) but the new uop is not reachable from the return, the assignment was not
+        # captured and will not be replayed. must check before realize() replaces ret uops.
+        reachable = _reachable_uops(ret)
+        if any(t.uop is not orig_uops[id(t)] and t.uop not in reachable for t in input_tensors):
+          raise JitError("Tensor.assign() to a JIT input inside @TinyJit is not replay-safe; "
+                         "return the new tensor and assign it outside (see #16618)")
         if len(params:=get_parameters(ret)): Tensor.realize(*params)
       finally: capturing.clear()
       if not len(self._linears): raise JitError("didn't JIT anything!")


### PR DESCRIPTION
Edit: Due to error breaking ci, i'm closing this. 4 tests in `test_assign.py` and `test_input_mutation_consistent in test_jit_footguns.py`rely on in-place mutation of JIT inputs (x += 1; x.realize() inside @TinyJit). This pattern is fragile and falls for this exact issue: if the assigned tensor is not reachable from the return value, the assign is silently dropped on replay, causing stale data with no error.  Even if I change them more tests in the ci will break. Hoping someone smarter will tackle this.


Fixes #16618 

Repro:

```python
from tinygrad import Tensor
from tinygrad.engine.jit import TinyJit

x = Tensor.randn(64, 5)
y = x @ Tensor.randn(5, 1)

def step(w):
    loss = (x @ w - y).pow(2).mean()
    gw = loss.gradient(w)[0]
    w.assign(w - 0.1 * gw) # <--- silently ignored on JIT replay
    return loss

w = Tensor.zeros(5, 1)
jit_step = TinyJit(step)
for i in range(5):
    jit_step(w)
    print(f"  step {i}: w_sum={w.numpy().sum():.6f}")
```


Before fix:
```
  step 0: w_sum=-0.120430
  step 1: w_sum=-0.229250
  step 2: w_sum=-0.229250
  step 3: w_sum=-0.229250
  step 4: w_sum=-0.229250
```

After fix:
```
  step 0: w_sum=0.152018
Traceback (most recent call last): ...
tinygrad.engine.jit.JitError: Tensor.assign() to a JIT input inside @TinyJit is not replay-safe; return the new tensor and assign it outside (see #16618)
```

