### PR TITLE
feat(amd): unblock gfx1010 arch recognition (RDNA1)

### DIFF
--- a/test/null/test_amd_gfx1010.py
+++ b/test/null/test_amd_gfx1010.py
@@ -1,0 +1,15 @@
+import unittest
+import tinygrad.runtime.autogen.am as am
+from tinygrad.runtime.support.amd import import_soc
+
+
+class TestGfx1010(unittest.TestCase):
+  def test_gfx1010_target_tuple(self):
+    trgt = 100100
+    target = (trgt // 10000, (trgt // 100) % 100, trgt % 100)
+    self.assertEqual(target, (10, 1, 0))
+    self.assertEqual("gfx%d%x%x" % target, "gfx1010")
+    self.assertTrue((target in ((9, 4, 2), (9, 5, 0))) or target[0] in (10, 11, 12))
+
+  def test_import_soc_rdna1(self):
+    self.assertIs(import_soc((10, 1, 0)), am.soc_11)

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -845,7 +845,7 @@ class KFDIface:
 
 class PCIIface(PCIIfaceBase):
   def __init__(self, dev, dev_id):
-    super().__init__(dev, dev_id, vendor=0x1002, devices=((0xffff, (0x74a1,0x744c,0x7480,0x7550,0x7551,0x7590,0x75a0)),), vram_bar=0,
+    super().__init__(dev, dev_id, vendor=0x1002, devices=((0xffff, (0x731f,0x74a1,0x744c,0x7480,0x7550,0x7551,0x7590,0x75a0)),), vram_bar=0,
       va_start=AMMemoryManager.va_allocator.base, va_size=AMMemoryManager.va_allocator.size, dev_impl_t=AMDev)
     self._compute_props()
 
@@ -959,7 +959,7 @@ class AMDDevice(HCQCompiled):
 
     self.target:tuple[int, ...] = ((trgt:=self.iface.props['gfx_target_version']) // 10000, (trgt // 100) % 100, trgt % 100)
     self.arch = "gfx%d%x%x" % self.target
-    assert (self.target in ((9,4,2),(9,5,0))) or self.target[0] in (11, 12), f"Unsupported arch: {self.arch}"
+    assert (self.target in ((9,4,2),(9,5,0))) or self.target[0] in (10, 11, 12), f"Unsupported arch: {self.arch}"
     if DEBUG >= 1: print(f"AMDDevice: opening {self.device_id} with target {self.target} arch {self.arch}")
 
     self.xccs = self.iface.props.get('num_xcc', 1)

--- a/tinygrad/runtime/support/amd.py
+++ b/tinygrad/runtime/support/amd.py
@@ -36,7 +36,9 @@ def import_module(name:str, target:tuple[int, int, int], submod=""):
     return getattr(mod, children[-1])
   raise ImportError(f"Failed to import {submod+'.' if submod else ''}{name} {'.'.join(map(str, target))}")
 
-def import_soc(ip): return getattr(tinygrad.runtime.autogen.am, f"soc_{ip[0]}")
+def import_soc(ip):
+  # RDNA1 (gfx10xx) reuses soc_11 until dedicated soc_10 headers land
+  return getattr(tinygrad.runtime.autogen.am, f"soc_{11 if ip[0] == 10 else ip[0]}")
 
 def import_pmc(ip) -> dict[str, tuple[str, int]]:
   from tinygrad.runtime.autogen.am import pmc


### PR DESCRIPTION
Fixes #7504 (partial — arch gate + headers).

## Changes
- Allow `gfx10xx` in `AMDDevice` target assert (e.g. RX 5700 XT / gfx1010)
- Map RDNA1 to `soc_11` headers until dedicated `soc_10` lands
- Add Navi 10 PCI ID `0x731f` for future `DEV=PCI+AMD` path
- Null tests for gfx1010 target parsing and `import_soc`

## Notes
Full KFD queue bring-up on real gfx1010 hardware still needs follow-up (CREATE_QUEUE EINVAL on RDNA1 KFD path in testing). This PR unblocks arch recognition and MOCK/null CI validation without requiring hardware.

Tested locally (CPU/NULL only):
`DEV=NULL python3 -m unittest test.null.test_amd_gfx1010 -v`