### PR TITLE
add bfloat16 support for np data

### DIFF
--- a/test/backend/test_tensor.py
+++ b/test/backend/test_tensor.py
@@ -496,11 +496,7 @@ class TestTinygrad(unittest.TestCase):
   def test_copy_from_numpy_dtype(self):
     data = np.array([1.0, 2, 3], dtype=np.float32)
     t = Tensor(data, dtype=dtypes.bfloat16)
-    try:
-      # TODO: fix dtype in tinygrad space
-      assert t.dtype == dtypes.bfloat16
-    except AssertionError:
-      assert t.dtype == dtypes.float32
+    assert t.dtype == dtypes.bfloat16
     np.testing.assert_equal(t.tolist(), data)
     np.testing.assert_equal((t+1).tolist(), data+1)
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -37,8 +37,8 @@ def _apply_map_to_tensors(applied_map:dict[UOp, UOp], name:str, walk:bool=False)
 
 # **** Tensor helper functions ****
 
-def _fromnp(x: 'numpy.ndarray') -> UOp:
-  ret = UOp.new_buffer("NPY", x.size, _from_np_dtype(x.dtype))
+def _fromnp(x: 'numpy.ndarray', dtype: DType|None=None) -> UOp:
+  ret = UOp.new_buffer("NPY", x.size, dtype or _from_np_dtype(x.dtype))
   # fake realize
   ret.buffer.allocate(x)
   return ret.reshape(x.shape)
@@ -108,11 +108,17 @@ class Tensor(RandMixin):
       if data.shape == ():
         data = UOp.const(_dtype or _from_np_dtype(data.dtype), data.item())
       else:
-        data = _fromnp(data.astype(npdtype) if _dtype is not None and (npdtype:=_to_np_dtype(_dtype)) is not None else data)
+        if _dtype is dtypes.bfloat16:
+          x = data.astype(np.float32, copy=False)
+          u = x.view(np.uint32)
+          u = u + np.uint32(0x7FFF) + ((u >> np.uint32(16)) & np.uint32(1))
+          bf16 = (u >> np.uint32(16)).astype(np.uint16)
+          data = _fromnp(bf16, _dtype)
+        else:
+          data = _fromnp(data.astype(npdtype) if _dtype is not None and (npdtype:=_to_np_dtype(_dtype)) is not None else data)
     elif isinstance(data, pathlib.Path):
       _dtype = _dtype or dtypes.uint8
       data = UOp.new_buffer(f"DISK:{data.resolve()}", data.stat().st_size // _dtype.itemsize, _dtype)
-
     # by this point, it has to be a UOp
     if not isinstance(data, UOp): raise RuntimeError(f"can't create Tensor from {data!r} with type {type(data)}")
 


### PR DESCRIPTION
Attempt to preserve dtypes.bfloat16 when constructing tensors from NumPy arrays.

Before:
```
data = np.array([1.0, 2, 3], dtype=np.float32)
t = Tensor(data, dtype=dtypes.bfloat16)
```
Returned a Tensor with dtype float32.

My fix was to convert input values before _fromnp (```tensor.py:40```) creates a new buffer using the formula from float_to_bf16 in ```dtype.py:284```.

I had to modify _fromnp to accept an optional dtype override to do this, and I also modified the existing test_copy_from_numpy_dtype test (```test/backend/test_tensor.py:496```) to assert t.dtype == dtypes.bfloat16

Testing:

python -m pytest test/backend/test_tensor.py -q

I also verified the dtype was successfully passed via a simple print statement. For value, conversions, I verified using the float_to_bf16 helper in a small script:

```
expected = np.array([float_to_bf16(float(x)) for x in data.flat], dtype=np.float32).reshape(data.shape)
np.testing.assert_allclose(t.tolist(), expected.tolist(), rtol=0, atol=0)
```

I used AI to help learn the codebase e.g. explain helpers, find related material, suggest a few ideas, and debug some of the code. However, the idea for the final solution was mine even though I used AI to help debug my implementation.

Open to any feedback or improvements on this solution