### PR TITLE
cuda: pass kernel dynamic shared memory in the graph runner

### DIFF
--- a/tinygrad/runtime/graph/cuda.py
+++ b/tinygrad/runtime/graph/cuda.py
@@ -21,7 +21,7 @@ class CUDAGraph(MultiGraphRunner):
 
         c_deps, new_node = self.new_node([b.base for b in bufs], ast.arg.outs)
         c_args, vargs = encode_args([b._buf for b in bufs], [device_vars.get(x.expr, 0) for x in ast.arg.vars])
-        kern_params = cuda.CUDA_KERNEL_NODE_PARAMS_v1(runtime.prg, *global_size, *local_size, 0,
+        kern_params = cuda.CUDA_KERNEL_NODE_PARAMS_v1(runtime.prg, *global_size, *local_size, runtime.smem,
                                                       ctypes.cast(0, ctypes.POINTER(ctypes.c_void_p)), vargs)
         check(cuda.cuGraphAddKernelNode(ctypes.byref(new_node), self.graph, c_deps, len(c_deps or []), ctypes.byref(kern_params)))
 


### PR DESCRIPTION
The CUDA graph runner hardcodes `sharedMemBytes=0` in the `CUDA_KERNEL_NODE_PARAMS`
(`tinygrad/runtime/graph/cuda.py`), so a kernel that requests **dynamic** shared memory
(`extern __shared__`) gets 0 bytes on graph replay and dies with `CUDA error 700` (illegal
memory access). The eager path (`CUDAProgram.__call__`) already passes `self.smem`, so the bug
only bites under TinyJit / graph capture.

Pass `runtime.smem` in the kernel node params, matching the eager path:

```diff
-kern_params = cuda.CUDA_KERNEL_NODE_PARAMS_v1(runtime.prg, *global_size, *local_size, 0,
+kern_params = cuda.CUDA_KERNEL_NODE_PARAMS_v1(runtime.prg, *global_size, *local_size, runtime.smem,
                                               ctypes.cast(0, ctypes.POINTER(ctypes.c_void_p)), vargs)
```

No-op for normal tinygrad kernels (they use static shared memory, `smem=0`); needed for
`custom_kernel` graph nodes that declare dynamic shared memory (e.g. a ThunderKittens
flash-attention kernel under JIT, which is what surfaced it).
