### PR TITLE
flux2: text-to-image (DiT, Qwen3, conv VAE, q8)

### DIFF
--- a/examples/flux2.py
+++ b/examples/flux2.py
@@ -1,0 +1,179 @@
+"""FLUX.2-klein-4B text->image in tinygrad: generate + warm steady-state benchmark.
+
+Runs on any tinygrad backend (set DEV=METAL, CUDA, ...): attention uses the ThunderMittens
+Metal flash kernel on METAL and Tensor.scaled_dot_product_attention on every other backend.
+
+  # generate one image (downloads weights from HuggingFace on first run):
+  PYTHONPATH=. DEV=METAL python examples/flux2.py --prompt "a photo of a cat" --size 128
+
+  # known-good ids, no tokenizer dependency:
+  PYTHONPATH=. DEV=METAL python examples/flux2.py --input-ids /tmp/flux2_qwen_ref.safetensors
+
+  # warm steady-state benchmark (JITBEAM autotunes the replayed kernels; gen 0 cold, gens 1.. warm):
+  PYTHONPATH=. DEV=METAL JITBEAM=2 python examples/flux2.py --input-ids /tmp/flux2_qwen_ref.safetensors --gens 5
+
+Ties together the three validated FLUX.2 pieces (Qwen3 encoder, DiT denoiser, conv VAE).
+All three load once with optional int8 (q8) weights (~7GB resident, fits a 16GB box), stay
+resident, and every stage is JIT-captured: gen 0 is cold (the JITs capture), gens 1.. are the
+warm steady-state. The sampler / latent packing / schedule mirror mflux Flux2Klein.generate_image.
+"""
+from __future__ import annotations
+import argparse, gc, tempfile, time
+from pathlib import Path
+
+from tinygrad import Tensor, Device, GlobalCounters, dtypes
+from tinygrad.helpers import fetch
+from tinygrad.nn import Linear
+from tinygrad.nn.state import safe_load
+from tinygrad.engine.jit import TinyJit
+
+from extra.models.flux2 import HF_BASE
+from extra.models.flux2.text_encoder import load_text_encoder, prepare_text_ids, OUT_LAYERS
+from extra.models.flux2 import dit as dit_mod
+from extra.models.flux2.dit import load_dit
+from extra.models.flux2.vae import load_vae_decoder
+from extra.models.flux2.pipeline import (make_schedule, prepare_packed_latents,
+                                         unpack_to_decoder_layout, postprocess_image)
+# q8: reuse examples/llama3.py's Int8Linear (int8 weight + per-out-channel f16 scale, dequant
+# fused into the dot). llama3 quantizes a state_dict by name; here the models are already built,
+# so the only addition is an in-place module-tree walk that swaps each bias-free Linear.
+from examples.llama3 import Int8Linear
+
+MAX_SEQUENCE_LENGTH = 512        # qwen3 prompt padded to this
+TOKENIZER_BASE_URL = HF_BASE + "tokenizer/"
+TOKENIZER_FILES = ("tokenizer.json", "tokenizer_config.json", "vocab.json", "merges.txt",
+                   "added_tokens.json", "special_tokens_map.json", "chat_template.jinja")
+
+
+def quantize_int8(model, scale_dtype=dtypes.float16) -> int:
+  """Replace every bias-free nn.Linear reachable from `model` (attrs + list/tuple/dict
+  containers) with a populated llama3 Int8Linear, in place. Returns the count quantized;
+  the freed f16 weight has no other reference, so it is released on the next gc."""
+  return _walk(model, set(), scale_dtype)
+
+def _walk(obj, seen: set, scale_dtype) -> int:
+  if id(obj) in seen or isinstance(obj, Tensor): return 0
+  if not (hasattr(obj, "__dict__") or isinstance(obj, (list, tuple, dict))): return 0
+  seen.add(id(obj))
+  items = (list(enumerate(obj)) if isinstance(obj, (list, tuple)) else
+           list(obj.items()) if isinstance(obj, dict) else list(vars(obj).items()))
+  count = 0
+  for key, child in items:
+    if isinstance(child, Linear) and child.bias is None:
+      out_f, in_f = child.weight.shape
+      w = child.weight.cast(scale_dtype)
+      scale = w.abs().max(axis=1, keepdim=True) / 127.0                 # (out, 1), per-out-channel
+      q = Int8Linear(in_f, out_f)
+      q.weight = (w / scale).round().clip(-127, 127).cast(dtypes.int8).realize()  # (out, in)
+      q.scale = scale.reshape(-1).cast(scale_dtype).realize()                     # (out,)
+      if isinstance(obj, (list, dict)): obj[key] = q
+      else: setattr(obj, key, q)
+      count += 1
+    else:
+      count += _walk(child, seen, scale_dtype)
+  return count
+
+
+def tokenize_prompt(prompt: str, tokenizer_dir: Path) -> tuple[Tensor, Tensor]:
+  # transformers AutoTokenizer (needs the qwen3 chat template). Mirrors mflux LanguageTokenizer:
+  # use_chat_template, enable_thinking=False, padding=max_length(512), truncation, add_special_tokens.
+  from transformers import AutoTokenizer
+  tok = AutoTokenizer.from_pretrained(str(tokenizer_dir))
+  text = tok.apply_chat_template([{"role": "user", "content": prompt}], tokenize=False,
+                                 add_generation_prompt=True, enable_thinking=False)
+  enc = tok(text, padding="max_length", max_length=MAX_SEQUENCE_LENGTH, truncation=True,
+            add_special_tokens=True, return_tensors="np")
+  return Tensor(enc["input_ids"]).cast(dtypes.int32), Tensor(enc["attention_mask"]).cast(dtypes.int32)
+
+def fetch_tokenizer_dir() -> Path:
+  last = None
+  for fn in TOKENIZER_FILES:
+    last = fetch(TOKENIZER_BASE_URL + fn, fn, subdir="flux2-klein-4b/tokenizer")
+  return last.parent
+
+def load_input_ids(path: str) -> tuple[Tensor, Tensor]:
+  sd = safe_load(path)
+  return (sd["input_ids"].to(Device.DEFAULT).cast(dtypes.int32),
+          sd["attention_mask"].to(Device.DEFAULT).cast(dtypes.int32))
+
+
+def main():
+  p = argparse.ArgumentParser(description="FLUX.2-klein text->image (generate + warm bench)",
+                              formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  p.add_argument("--prompt", type=str, default="a photo of a cat", help="text prompt")
+  p.add_argument("--input-ids", type=str, default=None, help="safetensors w/ input_ids+attention_mask (skips tokenizer)")
+  p.add_argument("--steps", type=int, default=4, help="num inference steps (klein default 4)")
+  p.add_argument("--size", type=int, default=128, help="square image size (snapped to /16)")
+  p.add_argument("--seed", type=int, default=0, help="latent noise seed")
+  p.add_argument("--gens", type=int, default=1, help="generations to run (gen 0 cold, rest warm steady-state)")
+  p.add_argument("--out", type=str, default=str(Path(tempfile.gettempdir()) / "flux2.png"), help="output PNG")
+  p.add_argument("--quantize", type=int, default=8, choices=[8], help="int8-quantize qwen+DiT Linears (fits 16GB)")
+  p.add_argument("--flash", action="store_true", help="use the ThunderKittens flash kernel (METAL/CUDA) instead of SDPA")
+  args = p.parse_args()
+  if args.flash: dit_mod.USE_FLASH = True     # default: scaled_dot_product_attention
+  use_flash = dit_mod.USE_FLASH and dit_mod.flash_attention is not None
+  print(f"  attention: {'flash' if use_flash else 'sdpa'}", flush=True)
+
+  height = width = 16 * (args.size // 16)              # snap to a multiple of 16 (mflux Config)
+  image_seq_len = (height // 16) * (width // 16)
+  q8 = args.quantize == 8
+  def sync(): Device[Device.DEFAULT].synchronize()
+
+  # ---- load all three models once, keep resident (q8 keeps the ~7GB footprint inside 16GB) ----
+  t0 = time.perf_counter()
+  text_model = load_text_encoder(n_layers=max(OUT_LAYERS))   # only depth max(OUT_LAYERS)=27 of 36
+  if q8: print(f"  q8 qwen: {quantize_int8(text_model)} Linears -> int8", flush=True); gc.collect()
+  dit = load_dit()
+  if q8: print(f"  q8 DiT: {quantize_int8(dit)} Linears -> int8", flush=True); gc.collect()
+  decoder = load_vae_decoder()                               # ~0.2GB conv VAE, not quantized
+  sync(); print(f"  loaded qwen+DiT+VAE (q8={q8}) in {time.perf_counter()-t0:.1f}s", flush=True)
+
+  # ---- fixed inputs (prompt + size are constant across gens) ----
+  if args.input_ids: input_ids, attention_mask = load_input_ids(args.input_ids)
+  else:
+    input_ids, attention_mask = tokenize_prompt(args.prompt, fetch_tokenizer_dir())
+    input_ids, attention_mask = input_ids.to(Device.DEFAULT), attention_mask.to(Device.DEFAULT)
+  txt_ids = prepare_text_ids(input_ids.shape[1])[0]          # (512, 4); DiT wants 2D ids
+  _, img_ids, lh, lw = prepare_packed_latents(args.seed, height, width)
+  timesteps, sigmas = make_schedule(image_seq_len, args.steps)
+
+  # the qwen output is identical every gen, so the DiT JIT closes over it through a cell that
+  # each gen rebinds (so the captured graph reads fresh values).
+  enc_cell: dict[str, Tensor] = {}
+  jit_qwen = TinyJit(lambda ids, mask: text_model.get_prompt_embeds(ids, mask).realize())
+  jit_dit = TinyJit(lambda h, ts: dit(hidden_states=h, encoder_hidden_states=enc_cell["enc"],
+                                      timestep=ts, img_ids=img_ids, txt_ids=txt_ids).realize())
+  jit_vae = TinyJit(lambda packed: decoder.decode_packed_latents(packed).realize())
+
+  print(f"  size {height}x{width}  steps {args.steps}  gens {args.gens}", flush=True)
+  img = None
+  for g in range(args.gens):
+    GlobalCounters.reset(); sync(); g0 = time.perf_counter()
+    # 1. qwen encode.
+    enc_cell["enc"] = jit_qwen(input_ids, attention_mask).cast("bfloat16").realize()
+    sync(); t_qwen = time.perf_counter()
+    # 2. DiT flow-match euler denoise (mflux: latents += (sigma[t+1]-sigma[t]) * model_pred).
+    latents, _, _, _ = prepare_packed_latents(args.seed, height, width)
+    for t in range(args.steps):
+      noise = jit_dit(latents.cast("bfloat16"), Tensor([timesteps[t]]))
+      latents = (latents + (sigmas[t + 1] - sigmas[t]) * noise.float()).realize()
+    sync(); t_dit = time.perf_counter()
+    # 3. VAE decode + post-process.
+    decoded = jit_vae(unpack_to_decoder_layout(latents, lh, lw))
+    img = postprocess_image(decoded, height, width).realize()
+    sync(); t_vae = time.perf_counter()
+    tag = "COLD" if g == 0 else "warm"
+    print(f"  gen {g} [{tag}]: {(t_vae-g0)*1e3:7.0f} ms  | qwen {(t_qwen-g0)*1e3:6.0f}  "
+          f"dit {(t_dit-t_qwen)*1e3:7.0f}  vae {(t_vae-t_dit)*1e3:5.0f} ms  "
+          f"(kernels {GlobalCounters.kernel_count})", flush=True)
+
+  try:
+    from PIL import Image
+    Image.fromarray(img.numpy()).save(args.out)
+    print(f"device {Device.DEFAULT}  saved {args.out}", flush=True)
+  except ImportError:
+    print(f"device {Device.DEFAULT}  done (pip install pillow to save {args.out})", flush=True)
+
+
+if __name__ == "__main__":
+  main()

--- a/extra/models/flux2/__init__.py
+++ b/extra/models/flux2/__init__.py
@@ -1,0 +1,3 @@
+# FLUX.2-klein-4B weights live under one HuggingFace repo; the per-component loaders
+# (dit/text_encoder/vae) and the example tokenizer fetch all build their URLs from this base.
+HF_BASE = "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B/resolve/main/"

--- a/extra/models/flux2/dit.py
+++ b/extra/models/flux2/dit.py
@@ -1,0 +1,291 @@
+"""FLUX.2-klein-4B DiT (transformer) forward pass in tinygrad.
+
+Mirrors mflux's mflux/models/flux2/model/flux2_transformer/* exactly (arch, weight key names,
+RoPE, modulation/AdaLN, joint attention). Attention defaults to Tensor.scaled_dot_product_attention;
+examples/flux2.py --flash opts into the ThunderKittens flash kernel on METAL (extra/thunder/metal/fa.py)
+or CUDA (extra/thunder/cuda/fa.py).
+
+Dims (from transformer/config.json):
+  hidden (inner_dim) = num_attention_heads(24) * attention_head_dim(128) = 3072
+  num_layers (double-stream)        = 5
+  num_single_layers (single-stream) = 20
+  mlp_ratio = 3.0  -> double-stream FF inner = 9216, single MLP hidden = 9216
+  in_channels = 128, joint_attention_dim = 7680, timestep_guidance_channels = 256
+  axes_dims_rope = (32,32,32,32) -> head_dim/2 = 64 rope freqs total, rope_theta = 2000
+  guidance_embeds = False
+"""
+import math
+from tinygrad import Tensor, Device
+from tinygrad.nn import Linear, RMSNorm
+from tinygrad.helpers import fetch
+from tinygrad.nn.state import safe_load, load_state_dict
+from extra.models.flux2 import HF_BASE
+
+# ThunderKittens flash kernels: the Metal one (extra/thunder/metal/fa.py) on METAL, the CUDA one
+# (extra/thunder/cuda/fa.py) on CUDA, loaded when the backend supports it. Default attention is
+# Tensor.scaled_dot_product_attention (which BEAM autotunes well); opt into the flash kernel by
+# setting USE_FLASH=True (examples/flux2.py --flash).
+flash_attention = None
+if Device.DEFAULT in ("METAL", "CUDA"):
+  try:
+    if Device.DEFAULT == "METAL": from extra.thunder.metal.fa import flash_attention
+    elif Device.DEFAULT == "CUDA": from extra.thunder.cuda.fa import flash_attention_cuda as flash_attention
+  except Exception: flash_attention = None  # kernel/toolchain unavailable
+USE_FLASH = False                           # default SDPA; opt in with --flash (set USE_FLASH=True)
+
+def _ln(x: Tensor) -> Tensor:
+  # affine-free LayerNorm. mflux computes the stats in fp32 and casts back to the
+  # input dtype (bf16); that rounding cadence keeps the 25-block residual stream
+  # bit-close to the reference, so upcast around the built-in layernorm.
+  return x.float().layernorm(eps=1e-6).cast(x.dtype)
+
+def apply_rope_interleaved(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+  """x: (B, H, S, D). cos/sin: (S, D/2). Interleaved (paired) rotation matching
+  mflux AttentionUtils.apply_rope_bshd: reshape D into (D/2, 2) pairs (real,imag),
+  rotate each pair by (cos,sin)."""
+  B, H, S, D = x.shape
+  xf = x.float().reshape(B, H, S, D // 2, 2)
+  real, imag = xf[:, :, :, :, 0], xf[:, :, :, :, 1]
+  cos_b, sin_b = cos.float().reshape(1, 1, S, D // 2), sin.float().reshape(1, 1, S, D // 2)
+  out = Tensor.stack(real * cos_b - imag * sin_b, imag * cos_b + real * sin_b, dim=-1)
+  return out.reshape(B, H, S, D).cast(x.dtype)
+
+# ---------------------------------------------------------------------------
+# positional embedding (RoPE)
+# ---------------------------------------------------------------------------
+class PosEmbed:
+  def __init__(self, theta: int = 2000, axes_dim=(32, 32, 32, 32)):
+    self.theta, self.axes_dim = theta, axes_dim
+
+  def __call__(self, ids: Tensor):
+    # ids: (seq, 4) int.  returns (cos,sin) each (seq, sum(axes_dim)//2)
+    pos = ids.float()
+    cos_out, sin_out = [], []
+    for i, dim in enumerate(self.axes_dim):
+      omega = 1.0 / (self.theta ** (Tensor.arange(0, dim, 2).float() / dim))  # (dim/2,)
+      out = pos[:, i:i + 1] * omega.reshape(1, -1)                            # (seq, dim/2)
+      cos_out.append(out.cos()); sin_out.append(out.sin())
+    return Tensor.cat(*cos_out, dim=-1), Tensor.cat(*sin_out, dim=-1)
+
+# ---------------------------------------------------------------------------
+# timestep + guidance embedding
+# ---------------------------------------------------------------------------
+def timestep_embedding(t: Tensor, dim: int) -> Tensor:
+  # same freq schedule as extra/models/unet.py:10-15 (flip_sin_to_cos=True -> [cos, sin] order);
+  # kept in fp32 here (unet force-casts to mixed_precision f16) for the bit-close residual stream.
+  half = dim // 2
+  freqs = (-math.log(10000.0) * Tensor.arange(0, half).float() / half).exp()
+  args = t.float().reshape(-1, 1) * freqs.reshape(1, -1)
+  return Tensor.cat(args.cos(), args.sin(), dim=-1)
+
+class TimestepEmbedder:
+  def __init__(self, in_channels: int, embedding_dim: int):
+    self.linear_1 = Linear(in_channels, embedding_dim, bias=False)
+    self.linear_2 = Linear(embedding_dim, embedding_dim, bias=False)
+
+  def __call__(self, t: Tensor) -> Tensor:
+    return self.linear_2(self.linear_1(t).silu())
+
+class TimestepGuidanceEmbeddings:
+  def __init__(self, in_channels: int, embedding_dim: int):
+    self.in_channels = in_channels
+    self.timestep_embedder = TimestepEmbedder(in_channels, embedding_dim)
+
+  def __call__(self, timestep: Tensor) -> Tensor:
+    return self.timestep_embedder(timestep_embedding(timestep, self.in_channels))
+
+# ---------------------------------------------------------------------------
+# modulation (AdaLN parameter producer)
+# ---------------------------------------------------------------------------
+class Modulation:
+  def __init__(self, dim: int, mod_param_sets: int = 2):
+    self.mod_param_sets = mod_param_sets
+    self.linear = Linear(dim, dim * 3 * mod_param_sets, bias=False)
+
+  def __call__(self, temb: Tensor):
+    mod = self.linear(temb.silu())
+    if mod.ndim == 2: mod = mod.reshape(mod.shape[0], 1, mod.shape[1])
+    parts = mod.chunk(3 * self.mod_param_sets, dim=-1)
+    return tuple(parts[3 * i: 3 * (i + 1)] for i in range(self.mod_param_sets))
+
+# ---------------------------------------------------------------------------
+# feed-forward (SwiGLU)
+# ---------------------------------------------------------------------------
+def swiglu(x: Tensor) -> Tensor:
+  # fused-projection SwiGLU: up+gate come from a single Linear (mflux layout), so chunk here.
+  # cf. extra/models/llama.py FeedForward, which keeps gate/up as separate Linears.
+  x1, x2 = x.chunk(2, dim=-1)
+  return x1.silu() * x2
+
+class FeedForward:
+  def __init__(self, dim: int, mult: float = 3.0):
+    inner = int(dim * mult)
+    self.linear_in = Linear(dim, inner * 2, bias=False)
+    self.linear_out = Linear(inner, dim, bias=False)
+
+  def __call__(self, x: Tensor) -> Tensor:
+    return self.linear_out(swiglu(self.linear_in(x)))
+
+# ---------------------------------------------------------------------------
+# attention building blocks
+# ---------------------------------------------------------------------------
+def _to_bhsd(x: Tensor, heads: int, dim_head: int) -> Tensor:
+  B, S, _ = x.shape
+  return x.reshape(B, S, heads, dim_head).permute(0, 2, 1, 3)  # (B,H,S,D)
+
+def _joint_flash(q: Tensor, k: Tensor, v: Tensor) -> Tensor:
+  # q,k,v: (B,H,S,D). returns (B, S, H*D).
+  B, H, S, D = q.shape
+  if flash_attention is None or not USE_FLASH:
+    out = q.scaled_dot_product_attention(k, v)              # (B,H,S,D)
+  elif Device.DEFAULT == "CUDA":
+    out = flash_attention(q, k, v)                          # CUDA kernel takes (B,H,S,D) natively
+  else:
+    qf, kf, vf = (t.reshape(B * H, S, D) for t in (q, k, v))
+    out = flash_attention(qf, kf, vf).reshape(B, H, S, D)   # METAL: folded (B*H,S,D)
+  return out.cast(q.dtype).permute(0, 2, 1, 3).reshape(B, S, H * D)
+
+class DoubleAttention:
+  def __init__(self, dim: int, heads: int, dim_head: int):
+    self.heads, self.dim_head = heads, dim_head
+    inner = heads * dim_head
+    self.to_q = Linear(dim, inner, bias=False)
+    self.to_k = Linear(dim, inner, bias=False)
+    self.to_v = Linear(dim, inner, bias=False)
+    self.norm_q = RMSNorm(dim_head, eps=1e-5)
+    self.norm_k = RMSNorm(dim_head, eps=1e-5)
+    self.to_out = [Linear(inner, dim, bias=False)]        # to_out.0 in weights
+    self.add_q_proj = Linear(dim, inner, bias=False)
+    self.add_k_proj = Linear(dim, inner, bias=False)
+    self.add_v_proj = Linear(dim, inner, bias=False)
+    self.norm_added_q = RMSNorm(dim_head, eps=1e-5)
+    self.norm_added_k = RMSNorm(dim_head, eps=1e-5)
+    self.to_add_out = Linear(inner, dim, bias=False)
+
+  def __call__(self, hidden: Tensor, enc: Tensor, cos: Tensor, sin: Tensor):
+    H, D = self.heads, self.dim_head
+    q = self.norm_q(_to_bhsd(self.to_q(hidden), H, D))
+    k = self.norm_k(_to_bhsd(self.to_k(hidden), H, D))
+    v = _to_bhsd(self.to_v(hidden), H, D)
+    eq = self.norm_added_q(_to_bhsd(self.add_q_proj(enc), H, D))
+    ek = self.norm_added_k(_to_bhsd(self.add_k_proj(enc), H, D))
+    ev = _to_bhsd(self.add_v_proj(enc), H, D)
+    # concat encoder (text) first, then image -- mflux order [enc, img] on seq axis
+    q = apply_rope_interleaved(eq.cat(q, dim=2), cos, sin)
+    k = apply_rope_interleaved(ek.cat(k, dim=2), cos, sin)
+    v = ev.cat(v, dim=2)
+    attn = _joint_flash(q, k, v)                          # (B, S_txt+S_img, inner)
+    txt_len = enc.shape[1]
+    return self.to_out[0](attn[:, txt_len:]), self.to_add_out(attn[:, :txt_len])
+
+class ParallelSelfAttention:
+  def __init__(self, dim: int, heads: int, dim_head: int, mlp_ratio: float = 3.0):
+    self.heads, self.dim_head = heads, dim_head
+    self.inner = heads * dim_head
+    self.mlp_hidden = int(dim * mlp_ratio)
+    self.to_qkv_mlp_proj = Linear(dim, self.inner * 3 + self.mlp_hidden * 2, bias=False)
+    self.norm_q = RMSNorm(dim_head, eps=1e-5)
+    self.norm_k = RMSNorm(dim_head, eps=1e-5)
+    self.to_out = Linear(self.inner + self.mlp_hidden, dim, bias=False)
+
+  def __call__(self, x: Tensor, cos: Tensor, sin: Tensor):
+    H, D = self.heads, self.dim_head
+    qkv, mlp_hidden = self.to_qkv_mlp_proj(x).split([self.inner * 3, self.mlp_hidden * 2], dim=-1)
+    q, k, v = qkv.chunk(3, dim=-1)
+    q = apply_rope_interleaved(self.norm_q(_to_bhsd(q, H, D)), cos, sin)
+    k = apply_rope_interleaved(self.norm_k(_to_bhsd(k, H, D)), cos, sin)
+    v = _to_bhsd(v, H, D)
+    attn = _joint_flash(q, k, v)                          # (B,S,inner)
+    return self.to_out(attn.cat(swiglu(mlp_hidden), dim=-1))
+
+# ---------------------------------------------------------------------------
+# transformer blocks
+# ---------------------------------------------------------------------------
+class DoubleBlock:
+  def __init__(self, dim: int, heads: int, dim_head: int, mlp_ratio: float = 3.0):
+    self.attn = DoubleAttention(dim, heads, dim_head)
+    self.ff = FeedForward(dim, mlp_ratio)
+    self.ff_context = FeedForward(dim, mlp_ratio)
+
+  def __call__(self, hidden, enc, mod_img, mod_txt, cos, sin):
+    (shift_msa, scale_msa, gate_msa), (shift_mlp, scale_mlp, gate_mlp) = mod_img
+    (cshift_msa, cscale_msa, cgate_msa), (cshift_mlp, cscale_mlp, cgate_mlp) = mod_txt
+    attn_out, enc_attn_out = self.attn((1 + scale_msa) * _ln(hidden) + shift_msa,
+                                       (1 + cscale_msa) * _ln(enc) + cshift_msa, cos, sin)
+    hidden = hidden + gate_msa * attn_out
+    enc = enc + cgate_msa * enc_attn_out
+    hidden = hidden + gate_mlp * self.ff((1 + scale_mlp) * _ln(hidden) + shift_mlp)
+    enc = enc + cgate_mlp * self.ff_context((1 + cscale_mlp) * _ln(enc) + cshift_mlp)
+    return enc, hidden
+
+class SingleBlock:
+  def __init__(self, dim: int, heads: int, dim_head: int, mlp_ratio: float = 3.0):
+    self.attn = ParallelSelfAttention(dim, heads, dim_head, mlp_ratio)
+
+  def __call__(self, hidden, mod, cos, sin):
+    shift, scale, gate = mod
+    return hidden + gate * self.attn((1 + scale) * _ln(hidden) + shift, cos, sin)
+
+class AdaLayerNormContinuous:
+  def __init__(self, embedding_dim: int, cond_dim: int):
+    self.embedding_dim = embedding_dim
+    self.linear = Linear(cond_dim, embedding_dim * 2, bias=False)
+
+  def __call__(self, x: Tensor, temb: Tensor) -> Tensor:
+    scale, shift = self.linear(temb.silu()).reshape(temb.shape[0], 1, -1).chunk(2, dim=-1)
+    return _ln(x) * (1 + scale) + shift
+
+# ---------------------------------------------------------------------------
+# full transformer
+# ---------------------------------------------------------------------------
+class Flux2Transformer:
+  def __init__(self, in_channels=128, num_layers=5, num_single_layers=20,
+               attention_head_dim=128, num_attention_heads=24, joint_attention_dim=7680,
+               timestep_guidance_channels=256, mlp_ratio=3.0,
+               axes_dims_rope=(32, 32, 32, 32), rope_theta=2000, patch_size=1):
+    self.heads, self.dim_head = num_attention_heads, attention_head_dim
+    self.inner_dim = num_attention_heads * attention_head_dim
+    self.out_channels, self.patch_size = in_channels, patch_size
+    self.pos_embed = PosEmbed(theta=rope_theta, axes_dim=axes_dims_rope)
+    self.time_guidance_embed = TimestepGuidanceEmbeddings(timestep_guidance_channels, self.inner_dim)
+    self.double_stream_modulation_img = Modulation(self.inner_dim, 2)
+    self.double_stream_modulation_txt = Modulation(self.inner_dim, 2)
+    self.single_stream_modulation = Modulation(self.inner_dim, 1)
+    self.x_embedder = Linear(in_channels, self.inner_dim, bias=False)
+    self.context_embedder = Linear(joint_attention_dim, self.inner_dim, bias=False)
+    self.transformer_blocks = [DoubleBlock(self.inner_dim, self.heads, self.dim_head, mlp_ratio) for _ in range(num_layers)]
+    self.single_transformer_blocks = [SingleBlock(self.inner_dim, self.heads, self.dim_head, mlp_ratio) for _ in range(num_single_layers)]
+    self.norm_out = AdaLayerNormContinuous(self.inner_dim, self.inner_dim)
+    self.proj_out = Linear(self.inner_dim, patch_size * patch_size * self.out_channels, bias=False)
+
+  def __call__(self, hidden_states: Tensor, encoder_hidden_states: Tensor,
+               timestep: Tensor, img_ids: Tensor, txt_ids: Tensor) -> Tensor:
+    temb = self.time_guidance_embed(timestep.float()).cast(hidden_states.dtype)
+    hidden_states = self.x_embedder(hidden_states)
+    encoder_hidden_states = self.context_embedder(encoder_hidden_states)
+
+    img_cos, img_sin = self.pos_embed(img_ids)
+    txt_cos, txt_sin = self.pos_embed(txt_ids)
+    cos, sin = txt_cos.cat(img_cos, dim=0), txt_sin.cat(img_sin, dim=0)
+
+    mod_img = self.double_stream_modulation_img(temb)
+    mod_txt = self.double_stream_modulation_txt(temb)
+    for blk in self.transformer_blocks:
+      encoder_hidden_states, hidden_states = blk(hidden_states, encoder_hidden_states, mod_img, mod_txt, cos, sin)
+
+    hidden_states = encoder_hidden_states.cat(hidden_states, dim=1)
+    mod_single = self.single_stream_modulation(temb)[0]
+    for blk in self.single_transformer_blocks:
+      hidden_states = blk(hidden_states, mod_single, cos, sin)
+
+    hidden_states = hidden_states[:, encoder_hidden_states.shape[1]:]
+    return self.proj_out(self.norm_out(hidden_states, temb))
+
+
+DIT_WEIGHTS_URL = HF_BASE + "transformer/diffusion_pytorch_model.safetensors"
+
+def load_dit() -> Flux2Transformer:
+  model = Flux2Transformer()
+  load_state_dict(model, safe_load(fetch(DIT_WEIGHTS_URL, "diffusion_pytorch_model.safetensors",
+                                         subdir="flux2-klein-4b/transformer")), strict=True)
+  return model

--- a/extra/models/flux2/pipeline.py
+++ b/extra/models/flux2/pipeline.py
@@ -1,0 +1,73 @@
+"""FLUX.2-klein sampling glue: flow-match euler schedule, latent pack/unpack, ids, post-process.
+
+Mirrors mflux `Flux2Klein.generate_image` + `FlowMatchEulerDiscreteScheduler` (the
+get_timesteps_and_sigmas path, since flux2-klein-4b has requires_sigma_shift=True) and
+`Flux2LatentCreator`. Kept with the model (not in the example) so the full pipeline is
+importable as `extra.models.flux2`.
+"""
+from __future__ import annotations
+import math
+from tinygrad import Tensor, dtypes
+
+# mflux flux2-klein-4b constants.
+VAE_SCALE_FACTOR = 8             # VAE downsamples 8x
+LATENT_CHANNELS = 32             # latent channels before 2x2 patchify (packed = 4*32 = 128)
+NUM_TRAIN_TIMESTEPS = 1000
+
+
+# ---------------------------------------------------------------------------
+# flow-match euler schedule (mflux FlowMatchEulerDiscreteScheduler).
+# ---------------------------------------------------------------------------
+def _empirical_mu(image_seq_len: int, num_steps: int) -> float:
+  a1, b1 = 8.73809524e-05, 1.89833333
+  a2, b2 = 0.00016927, 0.45666666
+  if image_seq_len > 4300:
+    return float(a2 * image_seq_len + b2)
+  m_200 = a2 * image_seq_len + b2
+  m_10 = a1 * image_seq_len + b1
+  a = (m_200 - m_10) / 190.0
+  b = m_200 - 200.0 * a
+  return float(a * num_steps + b)
+
+
+def make_schedule(image_seq_len: int, num_inference_steps: int) -> tuple[list[float], list[float]]:
+  """Returns (timesteps, sigmas). timesteps has num_steps entries (value passed to the DiT,
+  already in the 0..1000 range); sigmas has num_steps+1 entries (last 0.0) for euler
+  dt = sigmas[t+1]-sigmas[t]."""
+  n = num_inference_steps
+  sigmas = [1.0 + i * ((1.0 / n) - 1.0) / (n - 1) for i in range(n)] if n > 1 else [1.0]  # linspace(1, 1/n, n)
+  em = math.exp(_empirical_mu(image_seq_len, n))
+  sigmas = [em / (em + (1.0 / s - 1.0)) for s in sigmas]  # exponential time-shift
+  timesteps = [s * NUM_TRAIN_TIMESTEPS for s in sigmas]
+  return timesteps, sigmas + [0.0]
+
+
+# ---------------------------------------------------------------------------
+# latent pack / unpack / ids (mflux Flux2LatentCreator).
+# ---------------------------------------------------------------------------
+def prepare_packed_latents(seed: int, height: int, width: int) -> tuple[Tensor, Tensor, int, int]:
+  # height/width snapped to a multiple of 16 by the caller; latent grid is /16.
+  lh, lw = height // (VAE_SCALE_FACTOR * 2), width // (VAE_SCALE_FACTOR * 2)
+  Tensor.manual_seed(seed)
+  latents = Tensor.randn(1, LATENT_CHANNELS * 4, lh, lw, dtype=dtypes.float32)   # (1, 128, lh, lw)
+  packed = latents.reshape(1, LATENT_CHANNELS * 4, lh * lw).permute(0, 2, 1)     # (1, seq, 128)
+  return packed, prepare_grid_ids(lh, lw), lh, lw
+
+
+def prepare_grid_ids(lh: int, lw: int) -> Tensor:
+  # mflux prepare_grid_ids (t=0, h, w, layer=0) -> (seq, 4) int32 (2D for the DiT pos_embed).
+  rows = Tensor.arange(lh).reshape(lh, 1).expand(lh, lw).reshape(-1)
+  cols = Tensor.arange(lw).reshape(1, lw).expand(lh, lw).reshape(-1)
+  z = Tensor.zeros(lh * lw)
+  return Tensor.stack(z, rows, cols, z, dim=1).cast(dtypes.int32)
+
+
+def unpack_to_decoder_layout(packed: Tensor, lh: int, lw: int) -> Tensor:
+  # mflux: latents.reshape(b, lh, lw, C).transpose(0,3,1,2) -> (1, 128, lh, lw) for decode_packed_latents.
+  return packed.reshape(1, lh, lw, packed.shape[-1]).permute(0, 3, 1, 2)
+
+
+def postprocess_image(decoded: Tensor, height: int, width: int) -> Tensor:
+  # mflux ImageUtil: clip(x/2 + 0.5, 0, 1) -> CHW -> HWC uint8.
+  img = (decoded.float() / 2 + 0.5).clip(0, 1)
+  return img.reshape(3, height, width).permute(1, 2, 0).mul(255).round().cast(dtypes.uint8)

--- a/extra/models/flux2/text_encoder.py
+++ b/extra/models/flux2/text_encoder.py
@@ -1,0 +1,201 @@
+"""FLUX.2-klein Qwen3 text encoder in tinygrad.
+
+The FLUX.2 prompt encoder is a Qwen3 causal LM run as a prefill encoder. The DiT's
+`encoder_hidden_states` (dim 7680 = 3 * 2560) is the residual-stream hidden states
+captured after layers 9, 18 and 27, concatenated on the feature axis. So only the
+first 27 transformer layers need to run.
+
+Mirrors mflux (MLX) `Flux2PromptEncoder` / `Qwen3TextEncoder`:
+  - HF-style rotate_half RoPE (cos/sin from concat([freqs, freqs])), theta 1e6
+  - per-head q/k RMSNorm over head_dim (Qwen3 specific)
+  - GQA (32 query heads, 8 kv heads, head_dim 128)
+  - causal attention + a padding mask (pad tokens get -inf), attention in float32
+  - SwiGLU MLP, RMSNorm
+  - hidden-state list = [embeddings] + [output of each layer]; capture indices 9/18/27
+
+  PYTHONPATH=. DEV=METAL python -m extra.models.flux2.text_encoder
+"""
+from __future__ import annotations
+import os
+from tinygrad import Tensor, dtypes, nn
+from tinygrad.helpers import getenv, fetch
+from tinygrad.nn.state import safe_load, load_state_dict
+from extra.models.flux2 import HF_BASE
+
+
+# --- config (text_encoder/config.json) ---
+VOCAB_SIZE = 151936
+HIDDEN_SIZE = 2560
+NUM_LAYERS = 36
+NUM_HEADS = 32
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+INTERMEDIATE = 9728
+ROPE_THETA = 1000000.0
+RMS_EPS = 1e-6
+OUT_LAYERS = (9, 18, 27)
+PAD_TOKEN_ID = 151643  # Qwen pad == bos; mflux pads input_ids to max_length with this
+
+
+def qwen3_rotary_emb(seq_len: int, head_dim: int, theta: float = ROPE_THETA) -> tuple[Tensor, Tensor]:
+  # HF-style: inv_freq over even dims, freqs = pos * inv_freq, emb = concat([freqs, freqs]).
+  inv_freq = 1.0 / (theta ** (Tensor.arange(0, head_dim, 2, dtype=dtypes.float32) / head_dim))
+  pos = Tensor.arange(seq_len, dtype=dtypes.float32).reshape(seq_len, 1)
+  freqs = pos * inv_freq.reshape(1, -1)           # (seq_len, head_dim/2)
+  emb = freqs.cat(freqs, dim=-1)                   # (seq_len, head_dim)
+  return emb.cos(), emb.sin()
+
+
+def rotate_half(x: Tensor) -> Tensor:
+  half = x.shape[-1] // 2
+  x1, x2 = x[..., :half], x[..., half:]
+  return (-x2).cat(x1, dim=-1)
+
+
+def apply_rotary_pos_emb(q: Tensor, k: Tensor, cos: Tensor, sin: Tensor) -> tuple[Tensor, Tensor]:
+  # q,k: (b, n_heads, seq, head_dim); cos,sin: (seq, head_dim) -> broadcast over (b, heads)
+  cos = cos.reshape(1, 1, *cos.shape)
+  sin = sin.reshape(1, 1, *sin.shape)
+  q_embed = (q * cos) + (rotate_half(q) * sin)
+  k_embed = (k * cos) + (rotate_half(k) * sin)
+  return q_embed, k_embed
+
+
+class Qwen3Attention:
+  def __init__(self):
+    self.q_proj = nn.Linear(HIDDEN_SIZE, NUM_HEADS * HEAD_DIM, bias=False)
+    self.k_proj = nn.Linear(HIDDEN_SIZE, NUM_KV_HEADS * HEAD_DIM, bias=False)
+    self.v_proj = nn.Linear(HIDDEN_SIZE, NUM_KV_HEADS * HEAD_DIM, bias=False)
+    self.o_proj = nn.Linear(NUM_HEADS * HEAD_DIM, HIDDEN_SIZE, bias=False)
+    self.q_norm = nn.RMSNorm(HEAD_DIM, RMS_EPS)  # per-head RMSNorm over head_dim
+    self.k_norm = nn.RMSNorm(HEAD_DIM, RMS_EPS)
+
+  def __call__(self, x: Tensor, cos: Tensor, sin: Tensor, mask: Tensor) -> Tensor:
+    bsz, q_len, _ = x.shape
+    q = self.q_proj(x).reshape(bsz, q_len, NUM_HEADS, HEAD_DIM)
+    k = self.k_proj(x).reshape(bsz, q_len, NUM_KV_HEADS, HEAD_DIM)
+    v = self.v_proj(x).reshape(bsz, q_len, NUM_KV_HEADS, HEAD_DIM)
+
+    q = self.q_norm(q)  # normalize over the last (head_dim) axis, before transpose
+    k = self.k_norm(k)
+
+    q = q.transpose(1, 2)  # (b, n_heads, seq, head_dim)
+    k = k.transpose(1, 2)
+    v = v.transpose(1, 2)
+
+    q, k = apply_rotary_pos_emb(q, k, cos, sin)
+
+    # mflux runs attention in float32; mask is an additive float32 (causal + padding) bias.
+    attn = q.float().scaled_dot_product_attention(k.float(), v.float(), attn_mask=mask, enable_gqa=True)
+    attn = attn.cast(x.dtype).transpose(1, 2).reshape(bsz, q_len, NUM_HEADS * HEAD_DIM)
+    return self.o_proj(attn)
+
+
+class Qwen3MLP:
+  def __init__(self):
+    self.gate_proj = nn.Linear(HIDDEN_SIZE, INTERMEDIATE, bias=False)
+    self.up_proj = nn.Linear(HIDDEN_SIZE, INTERMEDIATE, bias=False)
+    self.down_proj = nn.Linear(INTERMEDIATE, HIDDEN_SIZE, bias=False)
+
+  def __call__(self, x: Tensor) -> Tensor:
+    return self.down_proj(self.gate_proj(x).silu() * self.up_proj(x))
+
+
+class Qwen3DecoderLayer:
+  def __init__(self):
+    self.input_layernorm = nn.RMSNorm(HIDDEN_SIZE, RMS_EPS)
+    self.self_attn = Qwen3Attention()
+    self.post_attention_layernorm = nn.RMSNorm(HIDDEN_SIZE, RMS_EPS)
+    self.mlp = Qwen3MLP()
+
+  def __call__(self, x: Tensor, cos: Tensor, sin: Tensor, mask: Tensor) -> Tensor:
+    x = x + self.self_attn(self.input_layernorm(x), cos, sin, mask)
+    x = x + self.mlp(self.post_attention_layernorm(x))
+    return x
+
+
+class Qwen3TextEncoder:
+  def __init__(self, n_layers: int = NUM_LAYERS, out_layers: tuple[int, ...] = OUT_LAYERS):
+    # only run as deep as the deepest captured layer (default 27 of 36)
+    self.n_run = max(out_layers)
+    self.out_layers = out_layers
+    self.embed_tokens = nn.Embedding(VOCAB_SIZE, HIDDEN_SIZE)
+    self.layers = [Qwen3DecoderLayer() for _ in range(n_layers)]
+    self.norm = nn.RMSNorm(HIDDEN_SIZE, RMS_EPS)  # final norm (unused for captured states)
+
+  def get_prompt_embeds(self, input_ids: Tensor, attention_mask: Tensor | None = None) -> Tensor:
+    bsz, seq_len = input_ids.shape
+    h = self.embed_tokens(input_ids)
+
+    cos, sin = qwen3_rotary_emb(seq_len, HEAD_DIM)
+    cos, sin = cos.cast(h.dtype), sin.cast(h.dtype)
+
+    # additive float32 mask: causal (upper triangle -inf) + padding (pad cols -inf)
+    neg = -float("inf")
+    causal = Tensor.full((seq_len, seq_len), neg, dtype=dtypes.float32).triu(1)
+    mask = causal.reshape(1, 1, seq_len, seq_len)
+    if attention_mask is not None:
+      pad = (attention_mask.reshape(bsz, 1, 1, seq_len) == 0).where(neg, 0.0).cast(dtypes.float32)
+      mask = mask + pad
+
+    captured = [h]  # mflux: hidden_states_list[0] is the embedding output
+    for i, layer in enumerate(self.layers):
+      h = layer(h, cos, sin, mask)
+      captured.append(h)
+      if i + 1 == self.n_run: break
+
+    # stack captured layer outputs on a new axis, reorder to (b, seq, n_layers, hidden), flatten feature
+    picks = [captured[i] for i in self.out_layers]
+    stacked = Tensor.stack(*picks, dim=1)                       # (b, n_layers, seq, hidden)
+    prompt_embeds = stacked.permute(0, 2, 1, 3).reshape(bsz, seq_len, len(self.out_layers) * HIDDEN_SIZE)
+    return prompt_embeds
+
+
+def prepare_text_ids(seq_len: int, bsz: int = 1) -> Tensor:
+  # mflux prepare_text_ids: coords (t,h,w,token_id) with t=h=w=0, token_id=arange(seq_len)
+  z = Tensor.zeros(seq_len, dtype=dtypes.int32)
+  tid = Tensor.arange(seq_len, dtype=dtypes.int32)
+  coords = Tensor.stack(z, z, z, tid, dim=1)  # (seq_len, 4)
+  return coords.reshape(1, seq_len, 4).expand(bsz, seq_len, 4)
+
+
+# 2-shard text encoder; fetch downloads on first use (symlink the local cache into the fetch dir to reuse it).
+TEXT_ENCODER_SHARDS = tuple(HF_BASE + f"text_encoder/model-{i:05d}-of-00002.safetensors" for i in (1, 2))
+
+def load_text_encoder(n_layers: int = NUM_LAYERS) -> Qwen3TextEncoder:
+  model = Qwen3TextEncoder(n_layers=n_layers)
+  sd = {}
+  for url in TEXT_ENCODER_SHARDS:
+    sd.update(safe_load(fetch(url, url.rsplit("/", 1)[1], subdir="flux2-klein-4b/text_encoder")))
+  # HF key -> module path: drop "model." prefix; lm_head not needed (tied, and we stop at layer 27)
+  remap = {k[len("model."):]: v for k, v in sd.items() if k.startswith("model.")}
+  load_state_dict(model, remap, strict=False, consume=True)
+  return model
+
+
+def encode_prompt_from_ids(model: Qwen3TextEncoder, input_ids: Tensor, attention_mask: Tensor | None = None):
+  """input_ids: (1, N) int32. Returns (prompt_embeds (1,N,7680), text_ids (1,N,4))."""
+  prompt_embeds = model.get_prompt_embeds(input_ids, attention_mask)
+  text_ids = prepare_text_ids(input_ids.shape[1], input_ids.shape[0])
+  return prompt_embeds, text_ids
+
+
+if __name__ == "__main__":
+  from tinygrad import Device, GlobalCounters
+  ref_path = getenv("FLUX2_QWEN_REF", "/tmp/flux2_qwen_ref.safetensors")
+  ref = {k: v.to(Device.DEFAULT) for k, v in safe_load(ref_path).items()}
+  input_ids = ref["input_ids"].cast(dtypes.int32)
+  attention_mask = ref["attention_mask"].cast(dtypes.int32)
+
+  model = load_text_encoder()
+  GlobalCounters.reset()
+  embeds, text_ids = encode_prompt_from_ids(model, input_ids, attention_mask)
+  embeds = embeds.realize()
+  print(f"device {Device.DEFAULT}  prompt_embeds {embeds.shape}  kernels {GlobalCounters.kernel_count}")
+
+  out = embeds.float()
+  refp = ref["prompt_embeds"].float()
+  diff = (out - refp).abs()
+  a, b = out.reshape(-1), refp.reshape(-1)
+  cos = (a * b).sum() / (a.square().sum().sqrt() * b.square().sum().sqrt())
+  print(f"vs mflux: cosine {cos.item():.6f}  max {diff.max().item():.5f}  mean {diff.mean().item():.6f}")

--- a/extra/models/flux2/vae.py
+++ b/extra/models/flux2/vae.py
@@ -1,0 +1,255 @@
+"""FLUX.2-klein conv VAE decoder, ported to tinygrad from mflux.
+
+Mirrors mflux's `Flux2VAE` / `Flux2Decoder` (an mlx port of the diffusers
+`AutoencoderKL`-style FLUX.2 VAE) exactly, so the diffusers safetensors weights
+(`decoder.*`, `bn.*`, `post_quant_conv.*`) load directly via `load_state_dict`.
+
+Architecture (config.json verified):
+  latent_channels=32, block_out_channels=[128,256,512,512], layers_per_block=2,
+  out_channels=3, norm_num_groups=32, act=silu, scaling_factor=1.0, shift_factor=0.0.
+
+Decodes on the default backend (METAL / CUDA / CPU).
+"""
+from __future__ import annotations
+
+from tinygrad import Tensor
+from tinygrad.helpers import fetch
+from tinygrad.nn import Conv2d, GroupNorm, Linear
+from tinygrad.nn.state import safe_load, load_state_dict
+from extra.models.flux2 import HF_BASE
+
+
+# diffusers / mflux VAE config for FLUX.2-klein
+LATENT_CHANNELS = 32
+BLOCK_OUT_CHANNELS = (128, 256, 512, 512)
+LAYERS_PER_BLOCK = 2
+OUT_CHANNELS = 3
+NORM_NUM_GROUPS = 32
+RESNET_EPS = 1e-6
+BN_EPS = 1e-4
+SCALING_FACTOR = 1.0
+SHIFT_FACTOR = 0.0
+
+
+class ResnetBlock2D:
+  """mflux Flux2ResnetBlock2D: norm1 -> silu -> conv1 -> norm2 -> silu -> conv2 + (conv_shortcut?) residual."""
+  def __init__(self, in_channels: int, out_channels: int, eps: float = RESNET_EPS, groups: int = NORM_NUM_GROUPS):
+    self.norm1 = GroupNorm(groups, in_channels, eps=eps)
+    self.conv1 = Conv2d(in_channels, out_channels, kernel_size=3, stride=1, padding=1)
+    self.norm2 = GroupNorm(groups, out_channels, eps=eps)
+    self.conv2 = Conv2d(out_channels, out_channels, kernel_size=3, stride=1, padding=1)
+    # diffusers names the projection `conv_shortcut`; present only when channels change.
+    self.conv_shortcut = Conv2d(in_channels, out_channels, kernel_size=1, stride=1) if in_channels != out_channels else None
+
+  def __call__(self, x: Tensor) -> Tensor:
+    h = self.conv1(self.norm1(x).silu())
+    h = self.conv2(self.norm2(h).silu())
+    residual = self.conv_shortcut(x) if self.conv_shortcut is not None else x
+    return h + residual
+
+
+class AttentionBlock:
+  """mflux Flux2AttentionBlock: group_norm -> (q,k,v Linear, 1 head) SDPA -> to_out Linear + residual.
+
+  Operates in NCHW; the channel axis is the attention feature dim, spatial is the sequence.
+  Weight keys are diffusers-style: group_norm.*, to_q.*, to_k.*, to_v.*, to_out.0.*.
+  """
+  def __init__(self, channels: int, groups: int = NORM_NUM_GROUPS, eps: float = RESNET_EPS):
+    self.group_norm = GroupNorm(groups, channels, eps=eps)
+    self.to_q = Linear(channels, channels)
+    self.to_k = Linear(channels, channels)
+    self.to_v = Linear(channels, channels)
+    # diffusers stores the output projection as `to_out.0` (a 1-element Sequential).
+    self.to_out = [Linear(channels, channels)]
+
+  def __call__(self, x: Tensor) -> Tensor:
+    b, c, hgt, wdt = x.shape
+    # NCHW -> NHWC so the channel axis is the feature dim for the Linear projections.
+    normed = self.group_norm(x).permute(0, 2, 3, 1)
+    q = self.to_q(normed).reshape(b, hgt * wdt, 1, c).permute(0, 2, 1, 3)
+    k = self.to_k(normed).reshape(b, hgt * wdt, 1, c).permute(0, 2, 1, 3)
+    v = self.to_v(normed).reshape(b, hgt * wdt, 1, c).permute(0, 2, 1, 3)
+    attended = Tensor.scaled_dot_product_attention(q, k, v)  # scale defaults to 1/sqrt(head_dim)=1/sqrt(c)
+    attended = attended.permute(0, 2, 1, 3).reshape(b, hgt, wdt, c)
+    attended = self.to_out[0](attended).permute(0, 3, 1, 2)  # back to NCHW
+    return x + attended
+
+
+class UNetMidBlock2D:
+  """mflux Flux2UNetMidBlock2D: resnet -> attention -> resnet."""
+  def __init__(self, channels: int, eps: float = RESNET_EPS, groups: int = NORM_NUM_GROUPS, add_attention: bool = True):
+    self.resnets = [ResnetBlock2D(channels, channels, eps=eps, groups=groups),
+                    ResnetBlock2D(channels, channels, eps=eps, groups=groups)]
+    self.attentions = [AttentionBlock(channels, groups=groups, eps=eps)] if add_attention else []
+
+  def __call__(self, x: Tensor) -> Tensor:
+    x = self.resnets[0](x)
+    if self.attentions: x = self.attentions[0](x)
+    return self.resnets[1](x)
+
+
+class Upsample2D:
+  """mflux Flux2Upsample2D: nearest 2x (repeat on H and W) then a 3x3 conv."""
+  def __init__(self, channels: int, out_channels: int | None = None):
+    out_channels = out_channels or channels
+    self.conv = Conv2d(channels, out_channels, kernel_size=3, stride=1, padding=1)
+
+  def __call__(self, x: Tensor) -> Tensor:
+    b, c, py, px = x.shape
+    # nearest-neighbour 2x: matches mflux mx.repeat(x,2,axis=2) then axis=3.
+    x = x.reshape(b, c, py, 1, px, 1).expand(b, c, py, 2, px, 2).reshape(b, c, py * 2, px * 2)
+    return self.conv(x)
+
+
+class UpDecoderBlock2D:
+  """mflux Flux2UpDecoderBlock2D: num_layers resnets then an optional upsampler."""
+  def __init__(self, in_channels: int, out_channels: int, num_layers: int, eps: float = RESNET_EPS,
+               groups: int = NORM_NUM_GROUPS, add_upsample: bool = True):
+    self.resnets = [ResnetBlock2D(in_channels if i == 0 else out_channels, out_channels, eps=eps, groups=groups)
+                    for i in range(num_layers)]
+    self.upsamplers = [Upsample2D(out_channels, out_channels)] if add_upsample else []
+
+  def __call__(self, x: Tensor) -> Tensor:
+    for resnet in self.resnets: x = resnet(x)
+    for upsampler in self.upsamplers: x = upsampler(x)
+    return x
+
+
+class Flux2Decoder:
+  """mflux Flux2Decoder: conv_in -> mid_block -> up_blocks -> conv_norm_out -> silu -> conv_out."""
+  def __init__(self, in_channels: int = LATENT_CHANNELS, out_channels: int = OUT_CHANNELS,
+               block_out_channels: tuple[int, ...] = BLOCK_OUT_CHANNELS, layers_per_block: int = LAYERS_PER_BLOCK,
+               norm_num_groups: int = NORM_NUM_GROUPS, eps: float = RESNET_EPS):
+    self.conv_in = Conv2d(in_channels, block_out_channels[-1], kernel_size=3, stride=1, padding=1)
+    self.mid_block = UNetMidBlock2D(block_out_channels[-1], eps=eps, groups=norm_num_groups, add_attention=True)
+
+    self.up_blocks = []
+    reversed_channels = list(reversed(block_out_channels))  # (512, 512, 256, 128)
+    for i, output_channel in enumerate(reversed_channels):
+      prev_output_channel = output_channel if i == 0 else reversed_channels[i - 1]
+      is_final_block = i == len(reversed_channels) - 1
+      self.up_blocks.append(UpDecoderBlock2D(
+        in_channels=prev_output_channel, out_channels=output_channel,
+        num_layers=layers_per_block + 1, eps=eps, groups=norm_num_groups,
+        add_upsample=not is_final_block))
+
+    self.conv_norm_out = GroupNorm(norm_num_groups, block_out_channels[0], eps=eps)
+    self.conv_out = Conv2d(block_out_channels[0], out_channels, kernel_size=3, stride=1, padding=1)
+
+  def __call__(self, x: Tensor) -> Tensor:
+    x = self.conv_in(x)
+    x = self.mid_block(x)
+    for up_block in self.up_blocks: x = up_block(x)
+    x = self.conv_norm_out(x).silu()
+    return self.conv_out(x)
+
+
+class Flux2VAEDecoder:
+  """Top-level FLUX.2 VAE decoder.
+
+  Holds the buffers/modules whose weight keys live above `decoder.*` in the diffusers
+  state dict: `bn.running_mean`, `bn.running_var`, and `post_quant_conv`. `decode_packed_latents`
+  reproduces mflux's exact pipeline (bn un-normalize -> 2x2 unpatchify -> post_quant_conv -> decoder).
+  """
+  def __init__(self, latent_channels: int = LATENT_CHANNELS, bn_eps: float = BN_EPS):
+    self.latent_channels = latent_channels
+    self.bn_eps = bn_eps
+    self.decoder = Flux2Decoder(in_channels=latent_channels)
+    # 1x1 post-quant projection applied inside decode(), before the conv decoder.
+    self.post_quant_conv = Conv2d(latent_channels, latent_channels, kernel_size=1, stride=1, padding=0)
+    # BatchNorm running stats over 4*latent_channels features (the packed channel count).
+    self.bn = _BatchNormStats(4 * latent_channels)
+
+  def decode(self, latents: Tensor) -> Tensor:
+    # latents/scaling_factor + shift_factor is a no-op (1.0 / 0.0) but kept for faithfulness.
+    latents = latents / SCALING_FACTOR + SHIFT_FACTOR
+    latents = self.post_quant_conv(latents)
+    return self.decoder(latents)
+
+  def decode_packed_latents(self, packed_latents: Tensor) -> Tensor:
+    if packed_latents.ndim == 5:
+      packed_latents = packed_latents[:, :, 0, :, :]
+    # 1. bn un-normalize: latents = packed * std + mean, std = sqrt(var + eps).
+    bn_mean = self.bn.running_mean.reshape(1, -1, 1, 1)
+    bn_std = (self.bn.running_var.reshape(1, -1, 1, 1) + self.bn_eps).sqrt()
+    latents = packed_latents * bn_std + bn_mean
+    # 2. 2x2 unpatchify: (b, 4c, h, w) -> (b, c, 2h, 2w).
+    latents = self._unpatchify_latents(latents)
+    # 3. decode.
+    return self.decode(latents)
+
+  @staticmethod
+  def _unpatchify_latents(latents: Tensor) -> Tensor:
+    b, c, h, w = latents.shape
+    # mlx: reshape (b, c//4, 2, 2, h, w) -> transpose (0,1,4,2,5,3) -> reshape (b, c//4, h*2, w*2).
+    latents = latents.reshape(b, c // 4, 2, 2, h, w)
+    latents = latents.permute(0, 1, 4, 2, 5, 3)
+    return latents.reshape(b, c // 4, h * 2, w * 2)
+
+  def __call__(self, packed_latents: Tensor) -> Tensor:
+    return self.decode_packed_latents(packed_latents)
+
+
+class _BatchNormStats:
+  """Holds bn.running_mean / bn.running_var so they bind from the state dict keys `bn.*`."""
+  def __init__(self, num_features: int):
+    self.running_mean = Tensor.zeros(num_features)
+    self.running_var = Tensor.ones(num_features)
+
+
+# fetch downloads on first use (symlink the local cache into the fetch dir to reuse it).
+VAE_WEIGHTS_URL = HF_BASE + "vae/diffusion_pytorch_model.safetensors"
+
+
+def load_vae_decoder() -> Flux2VAEDecoder:
+  """Build a Flux2VAEDecoder and load the diffusers safetensors weights into it.
+
+  The module tree (decoder.*, post_quant_conv.*, bn.running_mean/var) mirrors the diffusers
+  key names exactly, so we filter the full state dict to those keys and `load_state_dict`.
+  Encoder / quant_conv / bn.num_batches_tracked are dropped (unused by the decode path).
+  """
+  model = Flux2VAEDecoder()
+  full = safe_load(fetch(VAE_WEIGHTS_URL, "diffusion_pytorch_model.safetensors", subdir="flux2-klein-4b/vae"))
+  wanted = set(get_decoder_state_keys(model))
+  filtered = {k: v for k, v in full.items() if k in wanted}
+  load_state_dict(model, filtered, strict=True, verbose=False)
+  return model
+
+
+def get_decoder_state_keys(model: Flux2VAEDecoder) -> list[str]:
+  from tinygrad.nn.state import get_state_dict
+  return list(get_state_dict(model).keys())
+
+
+def decode_packed_latents(packed_latents: Tensor, model: Flux2VAEDecoder | None = None) -> Tensor:
+  """Convenience helper: decode packed latents with a (cached or freshly loaded) decoder."""
+  if model is None:
+    model = load_vae_decoder()
+  return model.decode_packed_latents(packed_latents)
+
+
+if __name__ == "__main__":
+  # Numerical check vs the mflux reference if present (FLUX2_VAE_REF), else a CPU shape check.
+  import os
+  from tinygrad import Device, GlobalCounters
+  print("default device:", Device.DEFAULT)
+
+  model = load_vae_decoder()
+  ref_path = os.environ.get("FLUX2_VAE_REF", "/tmp/flux2_vae_ref.safetensors")
+  if os.path.exists(ref_path):
+    ref = {k: v.to(Device.DEFAULT) for k, v in safe_load(ref_path).items()}
+    packed = ref["packed_latents"].float()
+    GlobalCounters.reset()
+    out = model.decode_packed_latents(packed).realize()
+    print(f"device {Device.DEFAULT}  decoded {out.shape}  kernels {GlobalCounters.kernel_count}")
+    o, r = out.float().reshape(-1), ref["decoded_image"].float().reshape(-1)
+    diff = (o - r).abs()
+    cos = (o * r).sum() / (o.square().sum().sqrt() * r.square().sum().sqrt())
+    print(f"vs mflux: cosine {cos.item():.6f}  max {diff.max().item():.5f}  mean {diff.mean().item():.6f}")
+  else:
+    # For a 128x128 image: VAE downsample 8 -> 16x16 latent -> 2x2 patchify -> packed (1,128,8,8).
+    packed = Tensor.randn(1, 128, 8, 8)
+    out = model.decode_packed_latents(packed).realize()
+    print("output image shape:", out.shape)
+    assert tuple(out.shape) == (1, 3, 128, 128), f"unexpected output shape {out.shape}"
+    print("OK: output is (1, 3, 128, 128)")

--- a/extra/thunder/cuda/fa.cu
+++ b/extra/thunder/cuda/fa.cu
@@ -10,14 +10,14 @@ constexpr int ATTN_N = 1024;
 constexpr int ATTN_H = 16;
 constexpr int ATTN_D = 64;
 
-template<int D> constexpr size_t ROWS = 16*(64/D); // height of each worker tile (rows)
+template<int D> constexpr size_t ROWS = (D >= 128) ? 16 : (16*64)/D; // tile rows; kittens needs %16 so D=128 uses 16 (not 8)
 template<int D, typename T=bf16, typename L=row_l> using qkvo_tile = rt<T, ROWS<D>, D, L>;
 template<int D, typename T=float> using attn_tile = rt<T, ROWS<D>, ROWS<D>>;
 template<int D> using shared_tile = st_bf<ROWS<D>, D>;
 template<int D> using global_layout = gl<bf16, -1, -1, -1, D>; // B, N, H, specified at runtime, D known at compile time for this kernel
 template<int D> struct globals { global_layout<D> Qg, Kg, Vg, Og; };
 
-__launch_bounds__(NUM_WORKERS*WARP_THREADS, 1)
+extern "C" __launch_bounds__(NUM_WORKERS*WARP_THREADS, 1)
 __global__ void attend_ker(bf16 *O_ptr, bf16 *Q_ptr, bf16 *K_ptr, bf16 *V_ptr) {
     constexpr int D = ATTN_D;
     global_layout<D> Qg{Q_ptr, ATTN_B, ATTN_N, ATTN_H, nullptr};

--- a/extra/thunder/cuda/fa.py
+++ b/extra/thunder/cuda/fa.py
@@ -1,43 +1,93 @@
-import pathlib
+# ThunderKittens (CUDA) flash-attention, wired as a tinygrad Ops.PROGRAM graph node so it survives
+# TinyJit/graph capture (mirroring extra/thunder/metal/fa.py and extra/thunder/amd/fa.py). The kernel
+# is fa.cu; B/N/H/D are baked per shape (constexpr substitution), it is compiled with NVCC (kittens.cuh
+# needs the full toolchain, not nvrtc), and its 48KB dynamic shared memory is passed to the launch via
+# ProgramInfo aux -> CUDAProgram.smem.
+import pathlib, functools, re
 from tinygrad import Device, Tensor
-from tinygrad.helpers import Context
-from tinygrad.runtime.support.compiler_cuda import pretty_ptx, NVCCCompiler
+from tinygrad.dtype import dtypes
+from tinygrad.renderer import Estimates
+from tinygrad.runtime.support.compiler_cuda import NVCCCompiler
+from tinygrad.uop.ops import UOp, Ops, KernelInfo, ProgramInfo
+
+_DIR = pathlib.Path(__file__).parent
+_INC = (_DIR / "include").as_posix()
+NUM_WORKERS, WARP_THREADS = 4, 32
+
+def compute_rows(D:int) -> int: return 16 if D >= 128 else (16 * 64) // D   # tile rows; kittens needs %16
+
+def _kittens_define(arch:str) -> str:
+  # ThunderKittens arch profile. sm_90(H100)->HOPPER, sm_80(A100)->A100, sm_86/89(A6000/4090)->4090.
+  cc = int(arch.removeprefix("sm_"))
+  if cc >= 90: return "-DKITTENS_HOPPER"
+  if cc == 80: return "-DKITTENS_A100"
+  return "-DKITTENS_4090"
+
+def _bake(code:str, B:int, N:int, H:int, D:int) -> str:
+  # fa.cu uses `constexpr int ATTN_x = <n>;` (not #define), so substitute the literals per shape.
+  for name, val in (("ATTN_B", B), ("ATTN_N", N), ("ATTN_H", H), ("ATTN_D", D)):
+    code = re.sub(rf"constexpr int {name} = \d+;", f"constexpr int {name} = {val};", code)
+  return code
+
+@functools.cache
+def custom_fa_forward_cuda(o:UOp, q:UOp, k:UOp, v:UOp, device:str, arch:str, B:int, H:int, N:int, D:int):
+  ROWS = compute_rows(D)
+  assert N % (ROWS * NUM_WORKERS) == 0, (f"N={N} must be a multiple of ROWS*NUM_WORKERS={ROWS*NUM_WORKERS} "
+    f"for D={D}; the right-fill -inf mask in fa.cu is disabled, so partial query/kv tiles are unsupported.")
+  code = _bake((_DIR / "fa.cu").read_text(), B=B, N=N, H=H, D=D)
+  kitten_args = [f"-I{_INC}", "-std=c++20", "--expt-relaxed-constexpr", _kittens_define(arch)]
+  lib = NVCCCompiler(arch, ptx=False, extra_options=kitten_args).compile_cached(code)  # cubin (dynamic smem)
+
+  gsz = (N // (ROWS * NUM_WORKERS), H, B)              # blockIdx.x/y/z = (q_blocks, head, batch)
+  lsz = (NUM_WORKERS * WARP_THREADS, 1, 1)            # 128 threads (4 warps) -- matches __launch_bounds__
+  threadIdx_x = UOp.special(lsz[0], "lidx0")
+  blockIdx_x, blockIdx_y, blockIdx_z = (UOp.special(gsz[i], f"gidx{i}") for i in range(3))
+
+  mem = (4 * B * H * N * D) * q.dtype.itemsize         # Q,K,V read + O written
+  estimates = Estimates(ops=2 * B * H * N * N * D, lds=mem, mem=mem)
+  # buffer order O,Q,K,V MUST match attend_ker(O_ptr,Q_ptr,K_ptr,V_ptr).
+  sink = UOp.sink(o.base, q.base, k.base, v.base, threadIdx_x, blockIdx_x, blockIdx_y, blockIdx_z,
+                  arg=KernelInfo(name="attend_ker", estimates=estimates))
+  smem = 16384 * 3                                     # 49152B dynamic shared (fa.cu extern __shm[])
+  prog = ProgramInfo.from_sink(sink, aux=(smem,))      # aux[0] -> CUDAProgram.smem (sharedMemBytes + setattr)
+  return UOp(Ops.PROGRAM,
+             src=(sink, UOp(Ops.DEVICE, arg=device), UOp(Ops.LINEAR, src=(*sink.src, sink)),
+                  UOp(Ops.SOURCE, arg=code), UOp(Ops.BINARY, arg=lib)), arg=prog)
+
+def flash_attention_cuda(q:Tensor, k:Tensor, v:Tensor) -> Tensor:
+  """q,k,v: (B,H,S,D) (already RoPE'd). D in {64,128}, S a multiple of 16*(64//D)*4. Returns (B,H,S,D) bf16.
+  fa.cu's global layout is (B,N,H,D), so we move H<->S in and out. Graph-node version (survives TinyJit)."""
+  B, H, S, D = q.shape
+  qn, kn, vn = (t.permute(0, 2, 1, 3).contiguous().cast(dtypes.bfloat16) for t in (q, k, v))  # (B,S,H,D)
+  out = Tensor.empty(B, S, H, D, dtype=dtypes.bfloat16, device=q.device)
+  arch = Device[q.device].compiler.arch
+  out, *_ = Tensor.custom_kernel(out, qn, kn, vn,
+              fxn=functools.partial(custom_fa_forward_cuda, device=q.device, arch=arch, B=B, H=H, N=S, D=D))
+  return out.permute(0, 2, 1, 3)   # (B,S,H,D) -> (B,H,S,D)
+
 
 if __name__ == "__main__":
-  code = (pathlib.Path(__file__).parent / "fa.cu").read_text()
-  device = Device["CUDA"]
-  kitten_args = [f"-I{(pathlib.Path(__file__).parent / 'include').as_posix()}", "-std=c++20", "--expt-relaxed-constexpr", "-DKITTENS_4090"]
-  lib = NVCCCompiler(device.compiler.arch, kitten_args).compile(code)
-  kernel_name = lib.decode().split(".globl\t")[1].split("\n")[0]
-  print("kernel name", kernel_name)
-  print(pretty_ptx(lib.decode()))
+  import time
+  from tinygrad import GlobalCounters
+  from tinygrad.engine.jit import TinyJit
 
-  prg = device.runtime(kernel_name, lib)
-  prg.smem = 16384 * 3
+  def test_shape(B, H, S, D, label):
+    print(f"\n=== {label}: B={B} H={H} S={S} D={D} ===")
+    Tensor.manual_seed(0)
+    q, k, v = (Tensor.randn(B, H, S, D).cast("bfloat16") for _ in range(3))
+    Tensor.realize(q, k, v)
+    ref = q.scaled_dot_product_attention(k, v).float().realize()    # (B,H,S,D)
+    out = flash_attention_cuda(q, k, v).float().realize()
+    num, den = (out * ref).sum(), (out.square().sum().sqrt() * ref.square().sum().sqrt())
+    print(f"  cosine {(num/den).item():.6f}   max abs err {(out-ref).abs().max().item():.6f}")
+    # JIT replay must not KeyError / recompile (the whole reason for the graph node)
+    jf = TinyJit(lambda a, b, c: flash_attention_cuda(a, b, c).realize())
+    for _ in range(3): jf(q, k, v)
+    Device[Device.DEFAULT].synchronize()
+    t0 = time.perf_counter()
+    for _ in range(50): jf(q, k, v)
+    Device[Device.DEFAULT].synchronize()
+    print(f"  JIT replay OK: {(time.perf_counter()-t0)/50*1e3:.4f} ms/call")
 
-  B, N, H, D = 16, 1024, 16, 64
-  q = Tensor.randn(B, N, H, D, device='CUDA', dtype="bfloat16")
-  k = Tensor.randn(B, N, H, D, device='CUDA', dtype="bfloat16")
-  v = Tensor.randn(B, N, H, D, device='CUDA', dtype="bfloat16")
-  out = Tensor.empty(B, N, H, D, device='CUDA', dtype="bfloat16")
-  Tensor.realize(q, k, v, out)
-
-  NUM_WORKERS = 4
-  ROWS = 16 * (64 // D)
-
-  gsz = (N // (ROWS*NUM_WORKERS), H, B)
-  for _ in range(5):
-    et = prg(out.uop.buffer.ensure_allocated()._buf, q.uop.buffer._buf, k.uop.buffer._buf, v.uop.buffer._buf,
-             global_size=gsz, local_size=(ROWS*NUM_WORKERS,1,1), wait=True)
-
-    attn_flops = 2 * B * H * N * N * D + \
-                 4 * B * H * N * N + \
-                 2 * B * H * N * N * D
-    print(f"{attn_flops/(et*1e9):2f} GFLOPS")
-
-  for _ in range(5):
-    with Context(DEBUG=2):
-      ref = q.scaled_dot_product_attention(k, v)
-
-  ref, out = ref.float(), out.float()
-  print((ref-out).mean().item(), (ref-out).max().item())
+  test_shape(1, 16, 1024, 64, "canonical D=64")
+  test_shape(1, 24, 576, 128, "FLUX D=128 (512 txt + 64 img)")

--- a/extra/thunder/metal/fa.py
+++ b/extra/thunder/metal/fa.py
@@ -1,0 +1,239 @@
+# ThunderMittens (Metal) flash-attention kernel.
+# Ported from the CUDA ThunderKittens kernel extra/thunder/cuda/fa.cu, built the same
+# way extra/thunder/metal/gemm.py builds its GEMM. Two surfaces:
+#   - the raw Metal C++ string (`fa`), compiled with Device["METAL"].compiler.compile.
+#   - a tinygrad graph node: `custom_fa_forward_metal` returns an Ops.PROGRAM UOp wired
+#     through Tensor.custom_kernel, mirroring extra/thunder/amd/fa.py:86-114. The graph
+#     node survives TinyJit (the raw prg(...) form does not -- the manual buffers aren't a
+#     graph node, so JIT replay errors KeyError 'METAL').
+#
+# Online-softmax (flash) attention, one simdgroup (warp) per threadgroup, one query block
+# per threadgroup. Q/K/V are reshaped to [B*H, N, D] (contiguous) so a [ROWS, D] register
+# tile loads with the natural row_stride = D (the global layout convention scales the rows
+# coord by TILE::rows and uses row_stride = cols).
+#
+# BH (=B*H) and N are baked into the kernel as ATTN_BH / ATTN_N #defines (prepended per
+# shape before compiling), mirroring how the AMD kernel bakes B/N/H via -DATTN_*. This drops
+# the BH/N `const constant int&` buffer args so the kernel has ONLY O/Q/K/V `device bf16*`
+# args at [[buffer(0..3)]] -- which is what the custom_kernel buffer-binding order needs.
+
+import pathlib, math, functools, statistics
+_INC = (pathlib.Path(__file__).parent / "include" / "tk.metal").as_posix()
+
+def compute_rows(D:int) -> int: return (16 * 64) // D  # query/key block height for head dim D
+
+fa = """
+#include <metal_stdlib>
+#include \"""" + _INC + """\"
+using namespace mittens;
+
+// D is the head dim (compile-time). ROWS = 16*(64/D): the query/key block height.
+// ATTN_BH (batch*heads) and ATTN_N (sequence length) are baked in per shape via #define.
+template<int D, int ROWS>
+kernel void flash_attend(
+    device bf16* O      [[buffer(0)]],
+    device bf16* Q      [[buffer(1)]],
+    device bf16* K      [[buffer(2)]],
+    device bf16* V      [[buffer(3)]],
+    uint3 tg_id            [[threadgroup_position_in_grid]],
+    uint  simd_lane_id    [[thread_index_in_simdgroup]])
+{
+  const int BH = ATTN_BH;   // batch*heads (baked)
+  const int N  = ATTN_N;    // sequence length, a multiple of ROWS (baked)
+
+  // global layout: (batch=BH, depth=1, rows=N, cols=D). cols=D is compile-time.
+  using gl_t = gl<bf16, -1, 1, -1, D>;
+  gl_t Qg(Q, (size_t)BH, nullptr, (size_t)N, nullptr);
+  gl_t Kg(K, (size_t)BH, nullptr, (size_t)N, nullptr);
+  gl_t Vg(V, (size_t)BH, nullptr, (size_t)N, nullptr);
+  gl_t Og(O, (size_t)BH, nullptr, (size_t)N, nullptr);
+
+  const int bh    = (int)tg_id.y;          // which (batch, head)
+  const int q_blk = (int)tg_id.x;          // which query block
+  const short laneid = (short)simd_lane_id;
+
+  // register tiles
+  rt<bf16, ROWS, D,    ducks::rt_layout::row> q_reg;   // Q tile [queries, D]
+  rt<bf16, ROWS, D,    ducks::rt_layout::col> k_reg;   // K tile [keys, D] in col layout for mma_ABt
+  rt<bf16, ROWS, D,    ducks::rt_layout::row> v_reg;   // V tile [keys, D] in row layout for mma_AB
+  rt<float, ROWS, D,   ducks::rt_layout::row> o_reg;   // output accumulator [queries, D]
+  rt<float, ROWS, ROWS, ducks::rt_layout::row> att;    // attention scores [queries, keys]
+  rt<bf16, ROWS, ROWS, ducks::rt_layout::row> att_bf;  // bf16 copy of att for the second mma
+
+  typename rt<float, ROWS, ROWS, ducks::rt_layout::row>::col_vec max_vec, max_vec_last, norm_vec;
+
+  // load Q tile, fold the softmax scale * log2(e) into Q so we can use exp2.
+  load(q_reg, Qg, {bh, 0, q_blk, 0}, laneid);
+  if (D == 64)       mul(q_reg, q_reg, (bf16)(0.125f        * 1.44269504089f));
+  else if (D == 128) mul(q_reg, q_reg, (bf16)(0.08838834764f * 1.44269504089f));
+
+  // running softmax state
+  neg_infty(max_vec);
+  zero(norm_vec);
+  zero(o_reg);
+
+  const int kv_blocks = N / ROWS;
+  for (int kv = 0; kv < kv_blocks; kv++) {
+    // att = Q @ K^T   (mma_ABt: b is col layout)
+    load(k_reg, Kg, {bh, 0, kv, 0}, laneid);
+    zero(att);
+    mma_ABt(att, q_reg, k_reg, att);
+
+    // online softmax update
+    max_vec_last = max_vec;
+    row_max(max_vec, att, max_vec, laneid);          // running row max (over keys)
+    sub_row(att, att, max_vec);                       // att -= max_vec (broadcast over rows)
+    exp2(att, att);                                   // att = exp2(att - max)
+    sub(max_vec_last, max_vec_last, max_vec);         // max_last - max
+    exp2(max_vec_last, max_vec_last);                 // corr = exp2(max_last - max)
+    mul(norm_vec, norm_vec, max_vec_last);            // norm *= corr
+    row_sum(norm_vec, att, norm_vec, laneid);         // norm += rowsum(att)
+
+    copy(att_bf, att);                                // cast att -> bf16
+    load(v_reg, Vg, {bh, 0, kv, 0}, laneid);
+    mul_row(o_reg, o_reg, max_vec_last);              // o *= corr
+    mma_AB(o_reg, att_bf, v_reg, o_reg);              // o += att @ V
+  }
+
+  div_row(o_reg, o_reg, norm_vec);                    // o /= norm
+  store(Og, o_reg, {bh, 0, q_blk, 0}, laneid);
+}
+
+#define instantiate_fa(suffix, D, ROWS) \
+  template [[host_name("flash_attend_" #suffix)]] [[kernel]] \
+  void flash_attend<D, ROWS>( \
+    device bf16*, device bf16*, device bf16*, device bf16*, \
+    uint3, uint);
+
+instantiate_fa(d64,  64,  16);
+instantiate_fa(d128, 128, 8);
+"""
+
+from tinygrad import Device, Tensor
+from tinygrad.dtype import dtypes
+from tinygrad.renderer import Estimates
+from tinygrad.uop.ops import UOp, Ops, KernelInfo
+
+# ---- tinygrad graph-node flash-attention ------------------------------------
+# Returns an Ops.PROGRAM UOp that Tensor.custom_kernel wires into the graph (so it
+# survives TinyJit), mirroring extra/thunder/amd/fa.py:86-114. There is no ELF rodata
+# patching here -- that's AMD shared-mem-specific; this Metal flash kernel is register-only.
+
+@functools.cache
+def custom_fa_forward_metal(o:UOp, q:UOp, k:UOp, v:UOp, device:str, B:int, H:int, N:int, D:int):
+  ROWS = compute_rows(D)
+  assert N % ROWS == 0, (f"N={N} must be a multiple of ROWS={ROWS} for D={D}; partial query/kv "
+    f"blocks need a right-fill -inf mask (see extra/thunder/cuda/fa.cu:84-85). FLUX has N=120, "
+    f"ROWS=8 so the multiple-of-ROWS assert suffices for now.")
+  BH = B * H
+  # bake BH/N in as #defines so the kernel has only O/Q/K/V device-pointer args.
+  code = f"#define ATTN_BH {BH}\n#define ATTN_N {N}\n" + fa
+
+  gsz = (N // ROWS, BH, 1)
+  lsz = (32, 1, 1)
+  threadIdx_x = UOp.special(lsz[0], "lidx0")
+  blockIdx_x, blockIdx_y, blockIdx_z = UOp.special(gsz[0], "gidx0"), UOp.special(gsz[1], "gidx1"), UOp.special(gsz[2], "gidx2")
+
+  el = q.dtype.itemsize
+  mem = (3*BH*N*D + BH*N*D) * el   # Q + K + V read, O written
+  estimates = Estimates(ops=2*B*H*N*N*D, lds=mem, mem=mem)
+  # buffer order o,q,k,v MUST match the kernel's [[buffer(0..3)]] = O,Q,K,V.
+  sink = UOp.sink(o.base, q.base, k.base, v.base,
+                  threadIdx_x, blockIdx_x, blockIdx_y, blockIdx_z,
+                  arg=KernelInfo(name=f"flash_attend_d{D}", estimates=estimates))
+
+  lib = Device["METAL"].compiler.compile(code)
+
+  return UOp(Ops.PROGRAM,
+             src=(sink, UOp(Ops.DEVICE, arg=device), UOp(Ops.LINEAR, src=(*sink.src, sink)), UOp(Ops.SOURCE, arg=code), UOp(Ops.BINARY, arg=lib)))
+
+def flash_attention(q, k, v):
+  """q,k,v: (B*H, N, D) tensors (already RoPE'd). D in {64,128}.
+  N must be a multiple of ROWS = (16*64)//D. Returns (B*H, N, D) bf16.
+  This is the graph-node version (survives TinyJit)."""
+  BH, N, D = q.shape
+  out = Tensor.empty(BH, N, D, dtype=dtypes.bfloat16)
+  out, *_ = Tensor.custom_kernel(out, q.cast(dtypes.bfloat16), k.cast(dtypes.bfloat16), v.cast(dtypes.bfloat16),
+                                 fxn=functools.partial(custom_fa_forward_metal, device=q.device, B=1, H=BH, N=N, D=D))
+  return out
+
+# ---- standalone validation + benchmark --------------------------------------
+def reshape_bhnd(t):  # (B, N, H, D) -> (B*H, N, D) contiguous
+  B, N, H, D = t.shape
+  return t.permute(0, 2, 1, 3).reshape(B * H, N, D).contiguous()
+
+def _rand_qkv(B, N, H, D):
+  # (B,N,H,D) bf16 randoms + their (B*H,N,D) reshape; shared by test_shape/benchmark.
+  Tensor.manual_seed(0)
+  q4, k4, v4 = (Tensor.randn(B, N, H, D).cast("bfloat16") for _ in range(3))
+  q, k, v = reshape_bhnd(q4), reshape_bhnd(k4), reshape_bhnd(v4)
+  Tensor.realize(q, k, v)
+  return q4, k4, v4, q, k, v
+
+def reference_sdpa(q, k, v, scale):
+  # q,k,v: (B*H, N, D). returns (B*H, N, D) float
+  qf, kf, vf = q.cast("float"), k.cast("float"), v.cast("float")
+  att = (qf @ kf.transpose(-1, -2)) * scale
+  return (att.softmax(-1) @ vf)
+
+def test_shape(B, N, H, D, label):
+  ROWS = compute_rows(D)
+  scale = 1.0 / math.sqrt(D)
+  print(f"\n=== {label}: B={B} N={N} H={H} D={D} (ROWS={ROWS}) ===")
+  assert N % ROWS == 0, f"test shape N={N} must be a multiple of ROWS={ROWS}"
+
+  _, _, _, q, k, v = _rand_qkv(B, N, H, D)                         # (B*H, N, D)
+  ref = reference_sdpa(q, k, v, scale).realize()  # (B*H, N, D) float
+  out = flash_attention(q, k, v).realize()
+
+  of, rf = out.cast("float").realize(), ref
+  diff = (of - rf).abs()
+  max_err = diff.max().item()
+  mean_err = diff.mean().item()
+  print(f"max abs err = {max_err:.6f}   mean abs err = {mean_err:.6f}")
+  return max_err, mean_err
+
+if __name__ == "__main__":
+  import time as _t
+  # correctness
+  test_shape(1, 1024, 16, 64, "canonical D=64")
+  test_shape(1, 576, 24, 128, "FLUX D=128")
+
+  def benchmark(B, N, H, D, label):
+    ROWS = compute_rows(D)
+    assert N % ROWS == 0, "benchmark shape must be a multiple of ROWS"
+    scale = 1.0 / math.sqrt(D)
+    print(f"\n=== benchmark {label}: B={B} N={N} H={H} D={D} ===")
+    q4, k4, v4, q, k, v = _rand_qkv(B, N, H, D)
+
+    for _ in range(3): flash_attention(q, k, v).realize()  # warmup
+    ts = []
+    for _ in range(20):
+      t0 = _t.perf_counter(); flash_attention(q, k, v).realize(); ts.append((_t.perf_counter()-t0)*1e3)
+    ms = statistics.median(ts)
+    attn_flops = 2 * B * H * N * N * D + 4 * B * H * N * N + 2 * B * H * N * N * D
+    print(f"TK flash:        {ms:.4f} ms   ({attn_flops/(ms*1e-3)/1e9:.1f} GFLOPS)")
+
+    for _ in range(3): reference_sdpa(q, k, v, scale).realize()
+    ts = []
+    for _ in range(20):
+      t0 = _t.perf_counter(); reference_sdpa(q, k, v, scale).realize(); ts.append((_t.perf_counter()-t0)*1e3)
+    print(f"tinygrad SDPA:   {statistics.median(ts):.4f} ms")
+
+    try:
+      import mlx.core as mx
+      qm = mx.array(q4.permute(0,2,1,3).cast("float").tolist()).astype(mx.bfloat16)
+      km = mx.array(k4.permute(0,2,1,3).cast("float").tolist()).astype(mx.bfloat16)
+      vm = mx.array(v4.permute(0,2,1,3).cast("float").tolist()).astype(mx.bfloat16)
+      def mlx_flash():
+        o = mx.fast.scaled_dot_product_attention(qm, km, vm, scale=scale); mx.eval(o); return o
+      for _ in range(3): mlx_flash()
+      ts = []
+      for _ in range(20):
+        t0 = _t.perf_counter(); mlx_flash(); ts.append((_t.perf_counter()-t0)*1e3)
+      print(f"MLX flash:       {statistics.median(ts):.4f} ms")
+    except Exception as e:
+      print(f"MLX flash:       unavailable ({type(e).__name__}: {e})")
+
+  benchmark(1, 1024, 16, 64, "canonical D=64")
+  benchmark(1, 576, 24, 128, "FLUX D=128")


### PR DESCRIPTION
A full **FLUX.2-klein-4B** text-to-image pipeline, validated against the MLX reference (mflux).

> **Depends on #16699** (CUDA graph-runner dynamic shared memory) — for the CUDA `--flash` path only. The default SDPA path and Metal `--flash` work without it.

## What

- **`extra/models/flux2/`**
  - `dit.py` — the MMDiT transformer (5 double + 20 single stream blocks, hidden 3072, 24 heads, head_dim 128): interleaved RoPE, joint image/text attention. Attention defaults to `Tensor.scaled_dot_product_attention`; `--flash` opts into the ThunderKittens kernel.
  - `text_encoder.py` — the Qwen3 prompt encoder (27 of 36 layers, hidden 2560, GQA 32/8; the layer-9/18/27 hidden states concat to the 7680-dim conditioning).
  - `vae.py` — the conv VAE decoder (latent 32ch, 2×2 unpatchify, bn-unnormalize).
  - `pipeline.py` — flow-match euler schedule, latent pack/unpack/ids, image post-process.
  - `__init__.py` — the shared HuggingFace repo base URL the loaders build their fetch URLs from.
- **`examples/flux2.py`** — one entry point for both one-shot generation and the warm steady-state benchmark (all three models resident, every stage JIT-captured). Weight-only int8 (q8) reuses `examples/llama3.py`'s `Int8Linear`.
- **`extra/thunder/{metal,cuda}/fa.py`** — optional JIT-capturable ThunderKittens flash-attention kernels (`--flash`). The CUDA path additionally needs the graph-runner fix in #16699.

Weights are fetched from HuggingFace via `fetch` on first run (~16 GB).

## Usage

```sh
# generate an image
DEV=METAL PYTHONPATH=. uv run python examples/flux2.py --prompt "a photo of a cat" --size 128

# warm steady-state benchmark (default SDPA attention, BEAM-autotuned)
DEV=METAL JITBEAM=2 PYTHONPATH=. uv run python examples/flux2.py --prompt "a photo of a cat" --gens 5

# opt into the flash-attention kernel
DEV=METAL JITBEAM=2 PYTHONPATH=. uv run python examples/flux2.py --prompt "a photo of a cat" --gens 5 --flash

# CUDA (same flags; --flash additionally needs nvcc on PATH)
DEV=CUDA JITBEAM=2 PATH=/usr/local/cuda/bin:$PATH PYTHONPATH=. uv run python examples/flux2.py --prompt "a photo of a cat" --gens 5 --flash
```

Optional deps: `uv pip install transformers pillow` (`transformers` for the `--prompt` tokenizer, `pillow` to save the PNG).

## Performance

Warm steady-state per-gen wall time (q8, JITBEAM, 4 steps, 128×128). Attention defaults to SDPA; `--flash` is the ThunderKittens kernel:

| box | SDPA | flash | DiT ×4 (SDPA / flash) |
|-----|-----:|------:|----------------------:|
| Apple M1, 16 GB     | 12.5 s | 13.0 s | 8.90 / 9.34 |
| Apple M3 Max, 48 GB |  2.36 s |  1.90 s | 1.96 / 1.51 |
| NVIDIA A6000, 48 GB |  3.00 s |  2.94 s | 2.48 / 2.43 |
| NVIDIA A100, 80 GB  |  1.99 s |  2.17 s | 1.50 / 1.68 |

The hand-written flash kernel only wins on the M3 Max (~20%); on the M1 and A100 it loses, and on the A6000 it ties. Everywhere else tinygrad's BEAM-autotuned SDPA — the matmul→softmax→matmul decomposition, each kernel autotuned per device — is as fast or faster, so SDPA is the default and the kernel is opt-in. vs mflux q8 on the M1: ~1.3–1.4× faster (mflux ~17 s).

Levers:

1. **q8** — int8 weight + per-output-channel f16 scale; the `int8.cast(half)*scale` dequant fuses into the matmul (reuses `examples/llama3.py` `Int8Linear`). ~7 GB resident, which fits the model on the 16 GB M1.
2. **JIT** — each stage is JIT-captured, so the warm gen is a graph replay (one dispatch); `JITBEAM` then beam-searches those captured kernels (~2–3× on the DiT step vs the heuristic), cached to disk.

## Flash-attention kernels (`extra/thunder/{metal,cuda}/fa.py`, optional)

Both are ThunderKittens online-softmax kernels wrapped as `Ops.PROGRAM` `custom_kernel` graph nodes so they survive TinyJit capture (the raw `prg(...)` form does not). Shapes are baked per call so the kernel takes only O/Q/K/V buffer args.

- **Metal** (mittens): ~10 TFLOPS standalone on M1; D=128 uses an 8-row tile.
- **CUDA** (kittens): the existing `fa.cu` was only reachable from a `__main__` raw-`prg` driver; wiring it up needed three fixes to the kernel itself, plus the graph-node wrapper:
  - **`ROWS = 16*(64/D)` → `(16*64)/D`.** The original truncated to `0` for D=128 (integer division), so the kernel never actually ran at FLUX's head_dim. kittens also requires tile dims divisible by 16, so D=128 is clamped to a 16-row tile (not the 8 mittens allows — part of why CUDA flash doesn't win).
  - **`extern "C"`** on `attend_ker`, so the compiled symbol is unmangled and the graph node can name it.
  - **launch 128 threads** (`NUM_WORKERS*WARP_THREADS`, 4 warps) — the old driver launched 64, half the warps the kernel's `__launch_bounds__` expects.
  - Compiled with NVCC (kittens.cuh needs the full toolchain), B/N/H/D baked per shape; its 48 KB dynamic shared memory reaches the launch via `ProgramInfo` aux, which needs the CUDA graph-runner fix in #16699 to work under JIT.

Per the table these only beat BEAM-autotuned SDPA on the M3 Max, so they ship opt-in.

## Notes

- Builds on the existing `extra/thunder` ThunderKittens scaffolding.
- Depends on #16699 (CUDA graph-runner dynamic shared memory) for the CUDA `--flash` path only; the default SDPA path and Metal `--flash` work without it.
- 3 commits: the flash kernels; the FLUX.2 model + pipeline; the example.
