### PR TITLE
llama: profile.sh BENCHMARK=3

### DIFF
--- a/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/profile.sh
+++ b/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/profile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-export BENCHMARK=5
+export BENCHMARK=${BENCHMARK:-5}
 export EVAL_BS=0
 VIZ=${VIZ:--1} FULL_LAYERS=1 DEBUG=${DEBUG:--0} examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/dev_beam.sh
 SRC="AMD"; [[ $DEV == NULL* ]] && SRC="NULL"
-python -m tinygrad.viz.cli -s "$SRC" -t --interval "train @ 2" "train @ 3"
+[ $BENCHMARK -gt 3 ] && python -m tinygrad.viz.cli -s "$SRC" -t --interval "train @ 2" "train @ 3"


### PR DESCRIPTION
completes in 8-9 seconds on my macbook
`time BENCHMARK=3 LLAMA_LAYERS=2 NOOPT=1 PYTHONPATH=. NULL_ALLOW_COPYOUT=1 DEV=NULL:HIP:gfx950 JITBEAM=0 examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/profile.sh`
enough to verify the full 8B training run's schedule for E kernels.