### PR TITLE
fix UOp.divides to return x instead of x*1

### DIFF
--- a/test/null/test_uop_vmin_vmax.py
+++ b/test/null/test_uop_vmin_vmax.py
@@ -378,7 +378,6 @@ class TestDivides(unittest.TestCase):
     result = uop.divides(5)
     self.assertIsNone(result)  # 42 is not divisible by 5
 
-  @unittest.skip("broken")
   def test_divides_variable_and_constant(self):
     # Multiplying a variable by a constant, then dividing by the same constant
     x = UOp.variable('x', 10, 20)

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -934,8 +934,8 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
       return None if any(s is None for s in srcs) else UOp(Ops.STACK, self.dtype, cast(tuple[UOp, ...], srcs))
     if self.op is Ops.ADD: return d0+d1 if (d0:=self.src[0].divides(v)) is not None and (d1:=self.src[1].divides(v)) is not None else None
     if self.op is Ops.MUL:
-      if (d0:=self.src[0].divides(v)) is not None: return d0 * self.src[1]
-      if (d1:=self.src[1].divides(v)) is not None: return self.src[0] * d1
+      if (d0:=self.src[0].divides(v)) is not None: return self.src[1] if d0.op is Ops.CONST and d0.arg == 1 else d0 * self.src[1]
+      if (d1:=self.src[1].divides(v)) is not None: return self.src[0] if d1.op is Ops.CONST and d1.arg == 1 else self.src[0] * d1
     return None # generic None if we aren't sure
   def pop_const(self, op=Ops.ADD) -> tuple[UOp, PyConst]:  # NOTE: assume Invalid ALU is resolved
     return (self.src[0], self.src[1].arg) if self.op is op and self.src[1].op is Ops.CONST else (self, identity_element(op, self.dtype))


### PR DESCRIPTION
`(x*6).divides(6)` returned a redundant `x*1` instead of `x`: the MUL branch multiplied by the quotient even when it folded to 1. Now it returns the other factor directly when the quotient is 1.

Unskips the existing `test_divides_variable_and_constant`, which documents `(x*6)/6 == x`.