### PR TITLE
fix UOp._min_max for narrowing int casts that wrap

### DIFF
--- a/test/null/test_uop_vmin_vmax.py
+++ b/test/null/test_uop_vmin_vmax.py
@@ -155,6 +155,18 @@ class TestVminVmaxProperties(unittest.TestCase):
     self.assertEqual(x_uint.vmin, dtypes.uint.min)
     self.assertEqual(x_uint.vmax, dtypes.uint.max)
 
+  def test_vmin_vmax_cast_narrowing(self):
+    # narrowing int cast wraps when the source range doesn't fit, so it spans the full dest range
+    x = UOp.variable('x', 0, 255, dtypes.int)
+    x_i8 = x.cast(dtypes.int8)
+    self.assertEqual(x_i8.vmin, dtypes.int8.min)
+    self.assertEqual(x_i8.vmax, dtypes.int8.max)
+    # source that fits is preserved (monotone)
+    y = UOp.variable('y', -5, 5, dtypes.int)
+    y_i8 = y.cast(dtypes.int8)
+    self.assertEqual(y_i8.vmin, -5)
+    self.assertEqual(y_i8.vmax, 5)
+
   def test_vmin_vmax_invalid(self):
     i = UOp.invalid()
     self.assertNotEqual(i.vmin, i.vmax)

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1006,9 +1006,12 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
     if self.op in {Ops.UNROLL, Ops.STACK}: return min(x.vmin for x in self.src), max(x.vmax for x in self.src)
     if self.op is Ops.CONST and self.arg is not Invalid: return self.arg, self.arg
     if self.op is Ops.GEP: return self.src[0]._min_max
-    # TODO: CAST to bool/unsigned is not monotone, still some case can be simplified
-    if self.op is Ops.CAST and self.dtype in dtypes.floats+dtypes.sints+(dtypes.weakint,):
+    if self.op is Ops.CAST and self.dtype in dtypes.floats:
       return max(self.dtype.min, self.src[0].vmin), min(self.src[0].vmax, self.dtype.max)
+    # CAST to signed int is monotone only when the source range fits in the dest, otherwise it wraps to the full range
+    if self.op is Ops.CAST and self.dtype in dtypes.sints+(dtypes.weakint,):
+      if self.dtype.min <= self.src[0].vmin and self.src[0].vmax <= self.dtype.max: return self.src[0].vmin, self.src[0].vmax
+    # TODO: CAST to bool/unsigned is not monotone, still some case can be simplified
     return self.dtype.min, self.dtype.max
 
   @functools.cached_property


### PR DESCRIPTION
A narrowing signed-int `CAST` whose source range exceeds the dest range wraps (modular) and is not monotone, but `_min_max` clamped to the dest bounds.

e.g. `UOp.range(256).cast(int8)` gave vmin/vmax `[0, 127]` instead of `[-128, 127]`, which wrongly const-folded `(x.cast(int8) < 0)` to `False`.

Now only clamp when the source range fits in the dest; otherwise return the full dest range (strictly conservative). `CAST` to float keeps the existing clamp.