### PR TITLE
llm shard TP

### DIFF
--- a/test/backend/test_multitensor.py
+++ b/test/backend/test_multitensor.py
@@ -472,5 +472,18 @@ class TestMultiTransformer(unittest.TestCase):
     shard_tok = shard_model(Tensor([[last_tok]], device=device), 0)
     self.assertEqual(real_tok.item(), shard_tok.item())
 
+@unittest.skipIf(not_support_multi_device(), "need multi")
+class TestMstackFactorOp(unittest.TestCase):
+  def test_lazy_dequant_gather_numerics(self):
+    Tensor.manual_seed(0)
+    E, O, I = 16, 8, 6
+    quant = (Tensor.rand(E, O, I)*200 - 100).cast(dtypes.int8).realize()
+    scale = (Tensor.rand(E, 1, 1) + 0.5).realize()
+    parts = [(quant[:, i*(O//2):(i+1)*(O//2)].contiguous().to(d).cast(dtypes.float32) * scale.to(d)).uop for i, d in enumerate(devices_2)]
+    w = Tensor(parts[0].mstack(parts[1]).multi(1))
+    sel = Tensor([1, 4, 7], dtype=dtypes.int32)
+    ref = (quant.cast(dtypes.float32) * scale)[sel]
+    self.assertLess((w[sel.to(devices_2)].to(Device.DEFAULT) - ref).abs().max().item(), 1e-4)
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/null/test_multitensor.py
+++ b/test/null/test_multitensor.py
@@ -2,6 +2,7 @@ import gc, unittest
 from tinygrad import Tensor, GlobalCounters, dtypes
 from tinygrad.engine.jit import TinyJit
 from tinygrad.helpers import Context
+from tinygrad.uop.ops import UOp
 
 class TestMultiRamUsage(unittest.TestCase):
   def setUp(self):
@@ -217,6 +218,27 @@ class TestMultiAxis(unittest.TestCase):
     self.assertEqual(e.device, t.device)
     self.assertEqual(e.uop.axis, 0)
     self.assertTrue(e.uop.has_buffer_identity())
+
+class TestMstackFactorOp(unittest.TestCase):
+  def test_lazy_dequant_gather_fused(self):
+    devs, (E, O, I, k) = ("NULL:1", "NULL:2"), (64, 32, 32, 4)
+    parts = [Tensor.empty(E, O//2, I, dtype=dtypes.int8, device=d).cast(dtypes.float32).uop for d in devs]
+    w = Tensor(parts[0].mstack(parts[1]).multi(1))
+    GlobalCounters.reset()
+    w[Tensor.empty(k, dtype=dtypes.int32).to(devs)].realize()
+    self.assertLess(GlobalCounters.global_mem, E*O*I*4)
+
+class TestSymbolicShard(unittest.TestCase):
+  def test_symbolic_allreduce_over_sharded_axis(self):
+    devs = ("NULL:1", "NULL:2")
+    v = UOp.variable("T", 1, 8).bind(4)
+    Tensor.empty(8, 8).shard(devs, axis=1)[:v].sum(axis=1).realize()
+
+  def test_symbolic_sharded_reshape_axis(self):
+    devs = ("NULL:1", "NULL:2")
+    n = UOp.variable("n", 1, 4)
+    x = Tensor.empty(4, 2).shard(devs, axis=1)[:n]
+    self.assertEqual(x.reshape(n, 1, 2).uop.axis, 2)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/unit/test_gguf.py
+++ b/test/unit/test_gguf.py
@@ -1,7 +1,8 @@
 import os, struct, unittest, tempfile, pathlib, sys
 from tinygrad import dtypes, Tensor, fetch, Device
-from tinygrad.helpers import disable_gc
-from tinygrad.llm.gguf import _ggml_iq_grid, ggml_data_to_tensor, gguf_load
+from tinygrad.helpers import disable_gc, prod
+from tinygrad.llm.gguf import _ggml_iq_grid, ggml_data_to_tensor, gguf_load, _shard_tensor
+from test.helpers import not_support_multi_device
 from tinygrad.runtime.autogen import ggml_common as _ggml
 import numpy as np
 from gguf import GGUFReader, GGUFValueType, GGMLQuantizationType, GGML_QUANT_SIZES, dequantize, quantize
@@ -60,6 +61,24 @@ class TestGGUF(unittest.TestCase):
   def test_dequantization_iq2_s(self): self._test_dequantization(GGMLQuantizationType.IQ2_S)
   def test_dequantization_iq4_xs(self): self._test_dequantization(GGMLQuantizationType.IQ4_XS)
   def test_dequantization_mxfp4(self): self._test_dequantization(GGMLQuantizationType.MXFP4)
+
+  @unittest.skipIf(not_support_multi_device(), "no multi device")
+  def test_shard_tensor(self):
+    devices = tuple(f"{Device.DEFAULT}:{i}" for i in range(2))
+    def q8_0_bytes(shape):
+      nblk = prod(shape)//32
+      scale = Tensor.ones(nblk, 1, dtype=dtypes.float16).bitcast(dtypes.uint8)
+      quants = (Tensor.arange(nblk*32) % 256).cast(dtypes.uint8).reshape(nblk, 32)
+      return scale.cat(quants, dim=1).flatten()
+    def f16_bytes(shape): return Tensor([i % 64 for i in range(prod(shape))], dtype=dtypes.float16).bitcast(dtypes.uint8)
+    for ggml_type, mkbytes in ((GGMLQuantizationType.Q8_0.value, q8_0_bytes), (GGMLQuantizationType.F16.value, f16_bytes)):
+      for shape, shard_axis in (((64,128),0), ((4,32,64),1), ((4,32,64),2)):
+        data = mkbytes(shape)
+        unsharded = ggml_data_to_tensor(data, prod(shape), ggml_type).reshape(shape)
+        sharded = _shard_tensor(data, 0, ("w", tuple(reversed(shape)), ggml_type, 0), devices, shard_axis)
+        self.assertEqual(sharded.uop.axis, shard_axis)
+        self.assertEqual(sharded.tolist(), unsharded.tolist())
+
   @unittest.skipUnless(dtypes.bfloat16 in supported_dtypes, "Backend must support bfloat16")
   def test_dequantization_bf16(self): self._test_dequantization(GGMLQuantizationType.BF16)
   def test_dequantization_mxfp4_old(self):

--- a/tinygrad/llm/cli.py
+++ b/tinygrad/llm/cli.py
@@ -68,7 +68,9 @@ class SimpleTokenizer:
     if self.preset == 'olmo': return self.encode("<|" + role + "|>\n")  # OLMoE Instruct format
     if self.preset == 'kimi-k2': return self.encode("<|im_" + role + "|>" + role + "<|im_middle|>")
     if self.preset == 'qwen2': return self.encode("<|im_start|>" + role + "\n")
-    if self.preset == 'glm4': return self.encode("<|" + role + "|>")
+    if self.preset == 'glm4':
+      if role == 'assistant' and '<think>' in self._special_tokens: return self.encode("<|assistant|><think></think>")
+      return self.encode("<|" + role + "|>")
     if self.preset == 'tekken':
       if role == 'user': return self.encode("[INST]")
       if role == 'assistant': return []
@@ -188,10 +190,11 @@ def main():
   parser.add_argument("--serve", nargs='?', type=int, const=8000, metavar="PORT", help="Run OpenAI compatible API (optional port, default 8000)")
   parser.add_argument("--warmup", action="store_true", help="warmup the JIT")
   parser.add_argument("--benchmark", nargs='?', type=int, const=20, metavar="COUNT", help="Benchmark tok/s (optional count, default 20)")
+  parser.add_argument("--shard", type=int, default=1, help="Tensor-parallel model across N devices")
   args = parser.parse_args()
 
   # load the model
-  model, kv = Transformer.from_gguf(fetch(models.get(args.model, args.model)), args.max_context)
+  model, kv = Transformer.from_gguf(fetch(models.get(args.model, args.model)), args.max_context, shard=args.shard)
   model_name = kv.get('general.name') or kv.get('general.basename') or args.model
   file_sizes = [y.nbytes() for y in UOp.sink(*[x.uop for x in nn.state.get_parameters(model)]).toposort() if y.op is Ops.BUFFER]
   print(f"using model \"{model_name}\" with {sum(file_sizes):,} bytes and {sum(x.numel() for x in nn.state.get_parameters(model)):,} params")

--- a/tinygrad/llm/gguf.py
+++ b/tinygrad/llm/gguf.py
@@ -145,12 +145,11 @@ def _shard_tensor(tensor:Tensor, data_start:int, t_info:tuple[str, tuple[int, ..
     Tensor.realize(*raws)
     parts = [ggml_data_to_tensor(r, row_count*row_elems, typ).reshape(row_count, *shape[1:]) for r in raws]
     return Tensor(parts[0].uop.mstack(*[p.uop for p in parts[1:]]).multi(0))
-  assert typ in _GGML_QUANT, f"{name}: native type {typ} only supports axis-0 shard"
-  nelems, nbytes = _GGML_QUANT[typ]
-  assert shape[-1] % nelems == 0, f"{name}: quantized last dim {shape[-1]} does not divide {nelems}"
+  nelems, nbytes = _GGML_QUANT[typ] if typ in _GGML_QUANT else (1, _GGML_NATIVE[typ].itemsize)
+  assert shape[-1] % nelems == 0, f"{name}: last dim {shape[-1]} does not divide block size {nelems}"
   nblk, per_dev = shape[-1] // nelems, shape[axis] // ndev
   blk = tensor[start:start + (prod(shape)//nelems)*nbytes].to("CPU").realize().reshape(*shape[:-1], nblk*nbytes)
-  assert axis != len(dims)-1 or nblk % ndev == 0, f"{name}: quantized shard axis size {shape[-1]//ndev} does not divide {nelems}"
+  assert axis != len(dims)-1 or nblk % ndev == 0, f"{name}: last dim {nblk} blocks does not divide {ndev} devices"
   cnt, shard_shape = blk.shape[axis] // ndev, (*shape[:axis], per_dev, *shape[axis+1:])
   raws = [blk[tuple(slice(i*cnt, (i+1)*cnt) if a==axis else slice(None) for a in range(len(shape)))].contiguous().to(d) for i,d in enumerate(devices)]
   Tensor.realize(*raws)

--- a/tinygrad/llm/gguf.py
+++ b/tinygrad/llm/gguf.py
@@ -130,9 +130,37 @@ readers: dict[int, Callable[[io.BufferedIOBase], Any]] = { 8: read_str, 9: read_
     [ (0,"c",1), (1,"b",1), (2,"H",2), (3,"h",2), (4,"I",4), (5,"i",4), (6,"f",4), (7,"?",1), (10,"Q",8), (11,"q",8), (12,"d",8) ] } }
 read_uint32, read_int32, read_uint64, read_int64 = readers[4], readers[5], readers[10], readers[11]
 
-def _gguf_parse(tensor: Tensor) -> tuple[dict, dict[str, Tensor]]:
+def _ggml_nbytes(n:int, typ:int) -> int:
+  return n * _GGML_NATIVE[typ].itemsize if typ in _GGML_NATIVE else (n // _GGML_QUANT[typ][0]) * _GGML_QUANT[typ][1]
+
+def _shard_tensor(tensor:Tensor, data_start:int, t_info:tuple[str, tuple[int, ...], int, int], devices:tuple[str, ...], axis:int) -> Tensor:
+  name, dims, typ, off = t_info
+  shape = tuple(reversed(dims))
+  ndev, start = len(devices), data_start + off
+  assert shape[axis] % ndev == 0, f"{name}: axis {axis} size {shape[axis]} does not divide {ndev} devices"
+  if axis == 0:
+    row_count, row_elems = shape[0]//ndev, prod(shape[1:])
+    row_nbytes = _ggml_nbytes(row_elems, typ)
+    raws = [tensor[start+i*row_count*row_nbytes:start+(i+1)*row_count*row_nbytes].to(d) for i,d in enumerate(devices)]
+    Tensor.realize(*raws)
+    parts = [ggml_data_to_tensor(r, row_count*row_elems, typ).reshape(row_count, *shape[1:]) for r in raws]
+    return Tensor(parts[0].uop.mstack(*[p.uop for p in parts[1:]]).multi(0))
+  assert typ in _GGML_QUANT, f"{name}: native type {typ} only supports axis-0 shard"
+  nelems, nbytes = _GGML_QUANT[typ]
+  assert shape[-1] % nelems == 0, f"{name}: quantized last dim {shape[-1]} does not divide {nelems}"
+  nblk, per_dev = shape[-1] // nelems, shape[axis] // ndev
+  blk = tensor[start:start + (prod(shape)//nelems)*nbytes].to("CPU").realize().reshape(*shape[:-1], nblk*nbytes)
+  assert axis != len(dims)-1 or nblk % ndev == 0, f"{name}: quantized shard axis size {shape[-1]//ndev} does not divide {nelems}"
+  cnt, shard_shape = blk.shape[axis] // ndev, (*shape[:axis], per_dev, *shape[axis+1:])
+  raws = [blk[tuple(slice(i*cnt, (i+1)*cnt) if a==axis else slice(None) for a in range(len(shape)))].contiguous().to(d) for i,d in enumerate(devices)]
+  Tensor.realize(*raws)
+  parts = [ggml_data_to_tensor(r.reshape(-1), prod(shard_shape), typ).reshape(*shard_shape) for r in raws]
+  return Tensor(parts[0].uop.mstack(*[p.uop for p in parts[1:]]).multi(axis))
+
+def _gguf_parse(tensor: Tensor, devices:tuple[str, ...]|None=None,
+                shard_policy:Callable[[str], int|str|None]|None=None) -> tuple[dict, dict[str, Tensor]]:
   # TODO: remove the need for copy to default device
-  tensor = tensor.to(None).realize()
+  if devices is None: tensor = tensor.to(None).realize()
   r = io.BufferedReader(TensorIO(tensor), 1_000_000)
   magic, version, n_tensors, n_kv = r.read(4), read_int32(r), read_int64(r), read_int64(r)
   if magic != b"GGUF" or version not in [2, 3]: raise ValueError("Invalid GGUF format!")
@@ -146,7 +174,19 @@ def _gguf_parse(tensor: Tensor) -> tuple[dict, dict[str, Tensor]]:
   alignment, pos = kv_data.get("general.alignment", 32), r.tell()
   data_start = round_up(pos, alignment)
 
-  state_dict = {name: ggml_data_to_tensor(tensor[data_start + off:], prod(dims), typ).reshape(*reversed(dims)) for name, dims, typ, off in t_infos}
+  if devices is None:
+    state_dict = {name: ggml_data_to_tensor(tensor[data_start + off:], prod(dims), typ).reshape(*reversed(dims)) for name, dims, typ, off in t_infos}
+    return kv_data, state_dict
+  state_dict = {}
+  for t_info in t_infos:
+    name, dims, typ, off = t_info
+    spec = shard_policy(name) if shard_policy is not None else None
+    if isinstance(spec, int):
+      state_dict[name] = _shard_tensor(tensor, data_start, t_info, devices, spec)
+    else:
+      n = prod(dims)
+      raw = tensor[data_start + off:data_start + off + _ggml_nbytes(n, typ)].to(devices if spec == "replicate" else devices[0]).realize()
+      state_dict[name] = ggml_data_to_tensor(raw, n, typ).reshape(*reversed(dims))
   return kv_data, state_dict
 
 def _gguf_split_paths(path: pathlib.Path, kv: dict) -> list[pathlib.Path]:
@@ -155,7 +195,8 @@ def _gguf_split_paths(path: pathlib.Path, kv: dict) -> list[pathlib.Path]:
   if not (m := re.match(r"^(.*)-00001-of-\d{5}\.gguf$", str(path))): raise ValueError(f"first split path must end with -00001-of-NNNNN.gguf: {path}")
   return [pathlib.Path(f"{m.group(1)}-{i:05d}-of-{total:05d}.gguf") for i in range(1, total+1)]
 
-def gguf_load(fn: Tensor|str|pathlib.Path) -> tuple[dict, dict[str, Tensor]]:
+def gguf_load(fn: Tensor|str|pathlib.Path, devices:tuple[str, ...]|None=None,
+              shard_policy:Callable[[str], int|str|None]|None=None) -> tuple[dict, dict[str, Tensor]]:
   """
   Loads a .gguf file, returning the `kv_data` and `state_dict`. Multi-part splits are auto-merged when loaded by path.
 
@@ -170,8 +211,8 @@ def gguf_load(fn: Tensor|str|pathlib.Path) -> tuple[dict, dict[str, Tensor]]:
 
   NOTE: The provided tensor must be on a device that supports execution.
   """
-  kv, sd = _gguf_parse(fn if isinstance(fn, Tensor) else Tensor(pathlib.Path(fn)))
+  kv, sd = _gguf_parse(fn if isinstance(fn, Tensor) else Tensor(pathlib.Path(fn)), devices, shard_policy)
   if kv.get('split.count', 1) <= 1: return kv, sd
   if isinstance(fn, Tensor): raise ValueError("multi-part GGUF requires a path argument (got Tensor)")
-  for pp in _gguf_split_paths(pathlib.Path(fn), kv)[1:]: sd.update(_gguf_parse(Tensor(pp))[1])
+  for pp in _gguf_split_paths(pathlib.Path(fn), kv)[1:]: sd.update(_gguf_parse(Tensor(pp), devices, shard_policy)[1])
   return kv, sd

--- a/tinygrad/llm/model.py
+++ b/tinygrad/llm/model.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 import functools, itertools, pathlib
 from dataclasses import dataclass, replace
-from tinygrad import Tensor, nn, UOp, TinyJit, getenv, function
+from tinygrad import Device, Tensor, nn, UOp, TinyJit, getenv, function
 from tinygrad.llm.gguf import gguf_load
 from tinygrad.uop.ops import resolve
+
+_TP_LAYOUT: dict[str, int|str] = {
+  "attn_q.weight":0, "attn_q_b.weight":0, "attn_k.weight":0, "attn_k.bias":0, "attn_v.weight":0, "attn_v.bias":0,
+  "attn_k_b.weight":0, "attn_v_b.weight":0, "attn_output.weight":1,
+  "ffn_gate.weight":0, "ffn_up.weight":0, "ffn_down.weight":1,
+  "ffn_gate_shexp.weight":"replicate", "ffn_up_shexp.weight":"replicate", "ffn_down_shexp.weight":"replicate",
+  "ffn_gate_exps.weight":1, "ffn_up_exps.weight":1, "ffn_down_exps.weight":2,
+  "attn_norm.weight":"replicate", "attn_q_a.weight":"replicate", "attn_q_a_norm.weight":"replicate",
+  "attn_kv_a_mqa.weight":"replicate", "attn_kv_a_norm.weight":"replicate",
+  "ffn_norm.weight":"replicate", "ffn_gate_inp.weight":"replicate", "exp_probs_b.bias":"replicate",
+}
+def _shard_policy(name:str) -> int|str|None: return _TP_LAYOUT.get(name.split(".", 2)[-1] if name.startswith("blk.") else name)
 
 @functools.cache
 def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0, device:str|None=None) -> Tensor:
@@ -304,6 +316,7 @@ class Transformer:
     self.output_norm = nn.RMSNorm(config.dim, config.norm_eps)
     self.output = nn.Linear(config.dim, config.vocab_size, bias=False)
     self.max_context = config.max_context
+    self.devices: tuple[str, ...]|None = None
     self.has_recurrent_block = any(isinstance(b, GatedDeltaNetBlock) for b in self.blk)
     self._cached_tokens: list[int] = []
     # we specialize the JIT for prefill and rollout
@@ -312,7 +325,9 @@ class Transformer:
 
   def forward(self, tokens:Tensor, start_pos:int|UOp, temperature:Tensor) -> Tensor:
     x = self.token_embd(tokens).float()                   # (B, T, D)
+    if self.devices is not None: x = x.to(self.devices)
     for block in self.blk: x = block(x, start_pos)
+    if self.devices is not None: x = x.to(self.devices[0])
     logits = self.output(self.output_norm(x))[:, -1, :]
     # Gumbel-max trick: argmax(logits/temp - log(-log(uniform))) is equivalent to sampling from softmax(logits/temp)
     return (logits / temperature.maximum(1e-12) - (Tensor.rand_like(logits).maximum(1e-12).log().neg()).log()).argmax(-1, keepdim=True)
@@ -322,9 +337,10 @@ class Transformer:
 
   @staticmethod
   def from_gguf(gguf:Tensor|str|pathlib.Path, max_context:int|None=None,
-                realize=bool(getenv("REALIZE", 0))) -> tuple[Transformer, dict]:
+                realize=bool(getenv("REALIZE", 0)), shard:int=1) -> tuple[Transformer, dict]:
     # TODO: remove the need for copy to default device
-    kv, state_dict = gguf_load(gguf.to(None).realize() if isinstance(gguf, Tensor) else gguf)
+    devices = tuple(Device.canonicalize(f"{Device.DEFAULT}:{i}") for i in range(shard)) if shard > 1 else None
+    kv, state_dict = gguf_load(gguf.to(None).realize() if isinstance(gguf, Tensor) else gguf, devices, shard_policy=_shard_policy)
 
     # all state items should be float16, not float32
     state_dict = {k:v.cast('float16') if getenv("HALF", 1) else v for k,v in state_dict.items()}
@@ -382,6 +398,10 @@ class Transformer:
       qkv_bias='blk.0.attn_q.bias' in state_dict,
       expert_bias=f"blk.{kv.get(f'{arch}.leading_dense_block_count', 0)}.exp_probs_b.bias" in state_dict)
     model = Transformer(config)
+    model.devices = devices
+    for k,v in nn.state.get_state_dict(model).items():
+      if (sd:=state_dict.get(k)) is not None and isinstance(sd.device, tuple) and not isinstance(v.device, tuple):
+        v.replace(Tensor.empty(*v.shape, device=sd.device[0]).shard(sd.device, axis=sd.uop.axis))
     nn.state.load_state_dict(model, state_dict, verbose=False, consume=True, realize=False)  # NOTE: rope_freqs.weight (32,) is unused
     # NOTE: without this contiguous, it unpacks the weights from the model every time. we shouldn't need this, but for now it's faster
     if realize:

--- a/tinygrad/schedule/allreduce.py
+++ b/tinygrad/schedule/allreduce.py
@@ -5,14 +5,13 @@ from tinygrad.uop.ops import UOp, Invalid
 # *** allreduce implementation ***
 def handle_allreduce(buf:UOp, red:UOp) -> UOp|None:
   if not isinstance(buf.device, tuple): return None
-  assert all_int(buf.shape), f"does not support symbolic shape {buf.shape}"
   ndev, shape, numel = len(buf.device), buf.shape, prod(buf.shape)
   op, device = red.arg
 
   # ring allreduce doesn't provide a benefit with only 2 nodes or where number of elements is less than 256k (empirically)
   # fallback to naive allreduce to save on kernel dispatch, chunking and reassembling chunks.
-  use_all2all = (ALL2ALL >= 2 or (ndev > 2 and numel > getenv("RING_ALLREDUCE_THRESHOLD", 256_000) and ALL2ALL >= 1))
-  use_ring = not use_all2all and (RING >= 2 or (ndev > 2 and numel > getenv("RING_ALLREDUCE_THRESHOLD", 256_000) and RING >= 1))
+  use_all2all = all_int(shape) and (ALL2ALL >= 2 or (ndev > 2 and numel > getenv("RING_ALLREDUCE_THRESHOLD", 256_000) and ALL2ALL >= 1))
+  use_ring = all_int(shape) and not use_all2all and (RING >= 2 or (ndev > 2 and numel > getenv("RING_ALLREDUCE_THRESHOLD", 256_000) and RING >= 1))
   if DEBUG >= 2: print(f"{'ALL2ALL' if use_all2all else 'RING' if use_ring else 'NAIVE'} ALLREDUCE {ndev}x{numel} | {buf.dtype}")
 
   # contiguous before we copy it
@@ -23,6 +22,7 @@ def handle_allreduce(buf:UOp, red:UOp) -> UOp|None:
     return functools.reduce(lambda x,y: x.alu(op, y), [buf.mselect(i).copy_to_device(device) for i in range(ndev)])
 
   # chunk data into ndev pieces
+  assert isinstance(numel, int)
   factor = next((f for f in [32, 16, 8, 4, 2] if numel % f == 0), 1)
   base, left = divmod(numel // factor,  ndev)
   chunks = list(itertools.pairwise(itertools.accumulate([(base + 1) * factor] * left + [base * factor] * (ndev - left), initial=0)))

--- a/tinygrad/schedule/multi.py
+++ b/tinygrad/schedule/multi.py
@@ -18,6 +18,15 @@ def mstack_early_shrink(ms:UOp, shrink:UOp):
       ret.append(apply_shrink(x, i).contiguous())
   return ms.replace(src=tuple(ret))
 
+def mstack_factor_op(ms:UOp):
+  s0 = ms.src[0]
+  if s0.op not in GroupOp.Elementwise and s0.op not in GroupOp.Movement: return None
+  if not all(s.op is s0.op and s.arg == s0.arg and s.dtype == s0.dtype and len(s.src) == len(s0.src) for s in ms.src[1:]): return None
+  all_kids = [[s.src[i] for s in ms.src] for i in range(len(s0.src))]
+  if not all(all_same(kids) or all(isinstance(k.device, str) for k in kids) for kids in all_kids): return None
+  new_srcs = tuple(kids[0] if all_same(kids) else UOp(Ops.MSTACK, kids[0].dtype, tuple(kids)) for kids in all_kids)
+  return s0.replace(src=new_srcs)
+
 replace_allreduce = PatternMatcher([
   # BROADCAST: explicitly expand broadcast copies and combine with MSTACK
   (UPat(Ops.COPY, name="c", src=(UPat(GroupOp.All-{Ops.CONST}, name="x"),)), lambda c,x:
@@ -27,6 +36,8 @@ replace_allreduce = PatternMatcher([
     x.mselect(0).copy_to_device(c.device) if isinstance(c.device, str) and isinstance(x.device, tuple) else None),
   # MSELECT on MSTACK is replaced with nothing
   (UPat(Ops.MSELECT, src=(UPat(Ops.MSTACK, name="mstack"),), name="ms"), lambda mstack, ms: mstack.src[ms.arg]),
+  # factor an op shared by every shard out of MSTACK: MSTACK(f(a),f(b)) -> f(MSTACK(a,b))
+  (UPat(Ops.MSTACK, name="ms"), mstack_factor_op),
   # move shrink before MSTACK
   (UPat(Ops.SHRINK, src=(UPat(Ops.MSTACK, name="ms"),), allow_any_len=True, name="shrink"), mstack_early_shrink),
   # move MSELECT before movement ops

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -639,9 +639,9 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
     if self.op is Ops.REDUCE: return None if src_axis is not None and src_axis in self.arg[1] else src_axis
     if self.op is Ops.RESHAPE:
       if src_axis is None: return None
-      arg_acc:list[sint] = list(itertools.accumulate(self.marg, operator.mul, initial=1))
+      arg_acc:list[sint] = [ssimplify(x) for x in itertools.accumulate(self.marg, operator.mul, initial=1)]
       # new_axis is the last one that preserves prod(prior to new_axis) and must not move items between shards
-      new_axis = len(arg_acc) - arg_acc[::-1].index(prod(self.src[0].shape[:src_axis])) - 1
+      new_axis = len(arg_acc) - arg_acc[::-1].index(ssimplify(prod(self.src[0].shape[:src_axis]))) - 1
       if self.shape[new_axis] % len(self.device) != 0: raise RuntimeError(f"reshape {self.src[0].shape} -> {self.shape} moved items between shards")
       return new_axis
     if self.op is Ops.PERMUTE: return self.marg.index(src_axis) if src_axis is not None else None


### PR DESCRIPTION
```
(.venv) (llm_shard_tp) ~/tinygrad$ echo "who are you" | JITBEAM=2 PYTHONPATH="." python3 tinygrad/llm/cli.py --model /raid/gguf/glm/GLM-5.2-UD-Q4_K_M-00001-of-00011.gguf --shard 4                                            
using model "Glm-5.2" with 458,843,089,920 bytes and 743,180,209,920 params        
>>> I am a language model developed by Z.ai, designed to assist with a wide range of questions and tasks. My purpose is to provide helpful, accurate, and thoughtful responses to your queries. Feel free to ask anything—I'm h
ere to help!                                                                                                   

(.venv) (llm_shard_tp) ~/tinygrad$ JITBEAM=2 PYTHONPATH="." python3 tinygrad/llm/cli.py --model /raid/gguf/glm/GLM-5.2-UD-Q4_K_M-00001-of-00011.gguf --shard 4 --benchmark
using model "Glm-5.2" with 458,843,089,920 bytes and 743,180,209,920 params
61924.96 ms,   0.02 tok/s,    0.96 GB/s, 59670/476254 MB  --  [gMASK][gMASK]
30319.04 ms,   0.03 tok/s,    1.67 GB/s, 50536/476254 MB  --  [gMASK][gMASK][gMASK]
22374.18 ms,   0.04 tok/s,    0.73 GB/s, 16224/476262 MB  --  [gMASK][gMASK][gMASK][gMASK]
 34.39 ms,  29.08 tok/s,  471.99 GB/s, 16231/476262 MB  --  [gMASK][gMASK][gMASK][gMASK][gMASK]
 33.63 ms,  29.74 tok/s,  482.90 GB/s, 16237/476262 MB  --  [gMASK][gMASK][gMASK][gMASK][gMASK][gMASK]
 33.57 ms,  29.79 tok/s,  483.97 GB/s, 16244/476262 MB  --  [gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK]
 33.41 ms,  29.93 tok/s,  486.44 GB/s, 16251/476262 MB  --  [gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK]
 33.80 ms,  29.58 tok/s,  480.96 GB/s, 16257/476262 MB  --  [gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK]
 33.98 ms,  29.43 tok/s,  478.56 GB/s, 16262/476262 MB  --  [gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK]
 34.00 ms,  29.42 tok/s,  478.48 GB/s, 16266/476262 MB  --  [gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK]
 33.82 ms,  29.57 tok/s,  481.10 GB/s, 16270/476262 MB  --  [gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK][gMASK]
[...]
(.venv) (llm_shard_tp) ~/tinygrad$ JITBEAM=2 PYTHONPATH=. python3 tinygrad/llm/cli.py   --model /raid/gguf/kimi/Kimi-K2.6-UD-Q4_K_XL-00001-of-00014.gguf   --shard 4 --benchmark 
using model "Kimi-K2.6" with 583,703,889,920 bytes and 1,026,408,232,448 params
52929.48 ms,   0.02 tok/s,    0.87 GB/s, 46162/599371 MB  --  [BOS] |
28117.37 ms,   0.04 tok/s,    1.35 GB/s, 37932/599371 MB  --  [BOS] | `
19617.35 ms,   0.05 tok/s,    0.76 GB/s, 14828/599381 MB  --  [BOS] | `em
 28.11 ms,  35.57 tok/s,  527.62 GB/s, 14833/599381 MB  --  [BOS] | `empp
 27.80 ms,  35.96 tok/s,  533.69 GB/s, 14839/599381 MB  --  [BOS] | `emppen
 27.86 ms,  35.89 tok/s,  532.73 GB/s, 14844/599381 MB  --  [BOS] | `emppen`
 27.76 ms,  36.03 tok/s,  535.02 GB/s, 14849/599381 MB  --  [BOS] | `emppen`='
 28.28 ms,  35.36 tok/s,  525.27 GB/s, 14854/599381 MB  --  [BOS] | `emppen`='001
 28.16 ms,  35.51 tok/s,  527.64 GB/s, 14858/599381 MB  --  [BOS] | `emppen`='001000
 28.00 ms,  35.72 tok/s,  530.81 GB/s, 14861/599381 MB  --  [BOS] | `emppen`='001000014
 27.99 ms,  35.72 tok/s,  531.03 GB/s, 14864/599381 MB  --  [BOS] | `emppen`='001000014',
 28.26 ms,  35.38 tok/s,  526.03 GB/s, 14868/599381 MB  --  [BOS] | `emppen`='001000014', `
 27.82 ms,  35.95 tok/s,  534.62 GB/s, 14871/599381 MB  --  [BOS] | `emppen`='001000014', `emp
