### PR TITLE
fix contiguous_view_offset for scalar index

### DIFF
--- a/test/backend/test_schedule.py
+++ b/test/backend/test_schedule.py
@@ -166,6 +166,12 @@ class TestSchedule(unittest.TestCase):
     self.assertEqual(t.device, dev)
     np.testing.assert_equal(t[:64].numpy(), np.arange(64).cumsum())
 
+  def test_copy_multi_scalar(self):
+    devs = ("CPU:0", "CPU:1")
+    x = Tensor.ones(2, device="CPU").realize().shard(devs, axis=0)
+    out = (x.sum()*2).reshape(1).to("CPU").realize()
+    np.testing.assert_equal(out.numpy(), [4.])
+
 class TestLimitBufs(unittest.TestCase):
   @unittest.skipIf(DEV.interface.startswith("MOCK") and Device.DEFAULT == "NV", "crashes in ocelot")
   def test_limit_bufs_with_var(self):

--- a/test/backend/test_schedule.py
+++ b/test/backend/test_schedule.py
@@ -168,8 +168,9 @@ class TestSchedule(unittest.TestCase):
 
   def test_copy_multi_scalar(self):
     devs = ("CPU:0", "CPU:1")
-    x = Tensor.ones(2, device="CPU").realize().shard(devs, axis=0)
-    out = (x.sum()*2).reshape(1).to("CPU").realize()
+    x = Tensor.ones(2, device="CPU").shard(devs, axis=0).realize()
+    out = (x.sum()*2).reshape(1).to("CPU")
+    run_linear(*check_schedule(out, 5))
     np.testing.assert_equal(out.numpy(), [4.])
 
 class TestLimitBufs(unittest.TestCase):

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -811,6 +811,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
     numel = self.numel()
     out = graph_rewrite(self.flatten().index(UOp.range(numel, 0)), pm_mops+symbolic, name="contiguous_view_offset")
     if out.op is not Ops.INDEX: return None
+    if len(out.src) == 1: return 0 if resolve(numel == 1, False) else None
     if out.src[1].op is Ops.CONST and resolve(numel == 1, False):
       if not isinstance(out.src[1].arg, int): return None  # masked/padded regions produce InvalidType
       return out.src[1].arg


### PR DESCRIPTION
it would fail with a tuple index error for a ()-shaped INDEX:
<img width="3836" height="970" alt="image" src="https://github.com/user-attachments/assets/afa38da6-2d2f-47bf-8f90-e2c8f7d37fd4" />
long standing bug in contiguous_view_offset, #16766 exposed it and llama started failing: `BENCHMARK=3 LLAMA_LAYERS=2 SPEC=0 NOOPT=1 PYTHONPATH=. NULL_ALLOW_COPYOUT=1 DEV=NULL:HIP:gfx950 JITBEAM=0 examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/profile.sh`