### PR TITLE
merge Ops.SPECIAL into Ops.PARAM

### DIFF
--- a/docs/abstractions4.py
+++ b/docs/abstractions4.py
@@ -65,7 +65,7 @@ def example_2_hip(a:Tensor, correct):
     from tinygrad.runtime.support.compiler_amd import HIPCCCompiler
     lib = HIPCCCompiler(Device[Device.DEFAULT].renderer.target.arch, []).compile_cached(code)
     # the sink specifies the GLOBAL and LOCAL sizes, along with the input buffers and name
-    sink = UOp.sink(UOp.special(GLOBALS, 'gidx0'), UOp.special(THREADS, 'lidx0'), out, buf,
+    sink = UOp.sink(UOp.hw_idx(GLOBALS, 'gidx0'), UOp.hw_idx(THREADS, 'lidx0'), out, buf,
                     arg=KernelInfo(name="hip_reduce_sum_kernel"))
     return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.LINEAR, src=(*sink.src, sink)), UOp(Ops.SOURCE, arg=code), UOp(Ops.BINARY, arg=lib)))
   eval_harness("HIP kernel", a, lambda x: Tensor.empty(GLOBALS).custom_kernel(x, fxn=hip_reduce_sum)[0].sum(), check=correct)
@@ -207,7 +207,7 @@ def example_5_custom_assembly(a:Tensor, correct):
 
     k.emit(s_sendmsg(simm16=3))  # DEALLOC_VGPRS
     k.emit(s_endpgm())
-    return k.finalize(UOp.sink(UOp.special(CU_COUNT, 'gidx0'), UOp.special(LANES, 'lidx0'), out, buf, arg=KernelInfo(name="asm_reduce")))
+    return k.finalize(UOp.sink(UOp.hw_idx(CU_COUNT, 'gidx0'), UOp.hw_idx(LANES, 'lidx0'), out, buf, arg=KernelInfo(name="asm_reduce")))
 
   out = Tensor.zeros(1,).contiguous().realize()
   eval_harness("RDNA3 assembly kernel", a, lambda x: out.custom_kernel(x, fxn=asm_sum)[0], check=correct)

--- a/extra/gemm/amd_asm_matmul.py
+++ b/extra/gemm/amd_asm_matmul.py
@@ -456,8 +456,8 @@ def test_matmul():
 
   dname:str = Device.DEFAULT
   def asm_kernel(A:UOp, B:UOp, C:UOp) -> UOp:
-    gidxs = [UOp.special(n, f"gidx{i}") for i,n in enumerate(grid)]
-    lidxs = [UOp.special(n, f"lidx{i}") for i,n in enumerate(local)]
+    gidxs = [UOp.hw_idx(n, f"gidx{i}") for i,n in enumerate(grid)]
+    lidxs = [UOp.hw_idx(n, f"lidx{i}") for i,n in enumerate(local)]
     lds_size = max(LDS_SIZE, 65536//getenv("LIMIT_OCC", 65536))
     lds = UOp.placeholder((lds_size,), dtypes.uint8, 0, AddrSpace.LOCAL)
     sink = UOp.sink(A.base, B.base, C.base, lds, *gidxs, *lidxs, arg=KernelInfo(name=colored("kernel", "cyan"),

--- a/extra/gemm/amd_matmul.py
+++ b/extra/gemm/amd_matmul.py
@@ -12,9 +12,9 @@ run_count = 5
 
 def make_matmul_kernel(name:str, src:str, local_size:int):
   def fxn(a:UOp, b:UOp, c:UOp) -> UOp:
-    threads = UOp.special(local_size, "lidx0")
-    wg_x = UOp.special(N//128, "gidx0")
-    wg_y = UOp.special(N//128, "gidx1")
+    threads = UOp.hw_idx(local_size, "lidx0")
+    wg_x = UOp.hw_idx(N//128, "gidx0")
+    wg_y = UOp.hw_idx(N//128, "gidx1")
     sink = UOp.sink(a.base, b.base, c.base, threads, wg_x, wg_y, arg=KernelInfo(name, estimates=Estimates(ops=2*N**3, mem=3*N*N*4)))
     lib = Device[Device.DEFAULT].compiler.compile_cached(src)
     return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.LINEAR, src=(*sink.src, sink)),

--- a/extra/gemm/amd_uop_matmul.py
+++ b/extra/gemm/amd_uop_matmul.py
@@ -38,8 +38,8 @@ def hand_spec_kernel3(c:UOp, a:UOp, b:UOp) -> UOp:
   # ---------------------------
   # block indices
   # ---------------------------
-  block_id_n = UOp.special(N // BLOCK_N, "gidx0")
-  block_id_m = UOp.special(M // BLOCK_M, "gidx1")
+  block_id_n = UOp.hw_idx(N // BLOCK_N, "gidx0")
+  block_id_m = UOp.hw_idx(M // BLOCK_M, "gidx1")
 
   # index the output with the globals
   c = c.reshape(M // BLOCK_M, BLOCK_M, N // BLOCK_N, BLOCK_N)[block_id_m, :, block_id_n, :]
@@ -55,7 +55,7 @@ def hand_spec_kernel3(c:UOp, a:UOp, b:UOp) -> UOp:
   # ---------------------------
   # GLOBAL -> LOCAL (A_local, B_local)
   # ---------------------------
-  tid = UOp.special(THREADS_PER_BLOCK, "lidx0")
+  tid = UOp.hw_idx(THREADS_PER_BLOCK, "lidx0")
 
   # A: read BM x BK tiles (permute on store into locals)
   BM_A_local_stride = (BLOCK_M + 4) if is_kernel5 else BLOCK_M

--- a/extra/gemm/cdna_asm_gemm.py
+++ b/extra/gemm/cdna_asm_gemm.py
@@ -2616,8 +2616,8 @@ def custom_asm_gemm(C:UOp, A:UOp, B:UOp, dname:str) -> UOp:
   batch, M, K = A.shape
   K2, N = B.shape[(1 if B.ndim == 3 else 0):]
   assert K == K2
-  lidx = UOp.special(WORKGROUP_SIZE, "lidx0")
-  gidx = UOp.special(NUM_WG, "gidx0")
+  lidx = UOp.hw_idx(WORKGROUP_SIZE, "lidx0")
+  gidx = UOp.hw_idx(NUM_WG, "gidx0")
   insts = build_kernel(batch, M, N, K, A.dtype.base)
   lds = UOp.placeholder((133_120,), dtypes.uint8, 0, AddrSpace.LOCAL)
   sink = UOp.sink(C.base, A.base, B.base, lds, lidx, gidx,
@@ -2635,8 +2635,8 @@ def custom_hk_fp8_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str, scale_mode:int
   N, K2 = B.shape[(1 if B.ndim == 3 else 0):]
   assert K == K2, f"{A.shape} {B.shape}"
   block_size = 256
-  threads = UOp.special(64 * 8, "lidx0")
-  workgroups = UOp.special((M // block_size) * (N // block_size), "gidx0")
+  threads = UOp.hw_idx(64 * 8, "lidx0")
+  workgroups = UOp.hw_idx((M // block_size) * (N // block_size), "gidx0")
   sink_inputs = (C.base, A.base, B.base) + tuple(s.base for s in scales) + (threads, workgroups)
   sink = UOp.sink(*sink_inputs,
                   arg=KernelInfo(f"hk_fp8_gemm_{M}_{N}_{K}", estimates=Estimates(ops=2*M*N*K, mem=(M*K+N*K)*A.dtype.itemsize+M*N*C.dtype.itemsize)))
@@ -2657,8 +2657,8 @@ def custom_hk_mxfp8_gemm(C:UOp, A:UOp, B:UOp, scale_A:UOp, scale_B:UOp, *extra:U
   N, K2 = B.shape[(1 if B.ndim == 3 else 0):]
   assert K == K2, f"{A.shape} {B.shape}"
   block_size = 256
-  threads = UOp.special(64 * 8, "lidx0")
-  workgroups = UOp.special((M // block_size) * (N // block_size), "gidx0")
+  threads = UOp.hw_idx(64 * 8, "lidx0")
+  workgroups = UOp.hw_idx((M // block_size) * (N // block_size), "gidx0")
   e_a = extra[0].base if len(extra) >= 1 else scale_A.base
   e_b = extra[1].base if len(extra) >= 2 else scale_B.base
   sink_inputs = (C.base, A.base, B.base, scale_A.base, scale_B.base, e_a, e_b, threads, workgroups)
@@ -2749,8 +2749,8 @@ def custom_hk_bf16_gemm(C:UOp, A:UOp, B:UOp, *args:UOp, dname:str) -> UOp:
   assert K == K2, f"{A.shape} {B.shape}"
   block_m, block_n, block_k, num_warps = 256, 256, 64, 8
   assert M % block_m == 0 and N % block_n == 0 and K % block_k == 0, f"invalid bf16 tile {(block_m, block_n, block_k)} for {(M, N, K)}"
-  threads = UOp.special(64 * num_warps, "lidx0")
-  workgroups = UOp.special((M // block_m) * (N // block_n), "gidx0")
+  threads = UOp.hw_idx(64 * num_warps, "lidx0")
+  workgroups = UOp.hw_idx((M // block_m) * (N // block_n), "gidx0")
   b_extra = args[0].base if len(args) >= 1 else B.base
   sink = UOp.sink(C.base, A.base, B.base, b_extra, threads, workgroups,
                   arg=KernelInfo(f"hk_bf16_gemm_{M}_{N}_{K}", estimates=Estimates(ops=2*M*N*K, mem=(M*K+N*K+M*N)*A.dtype.itemsize)))
@@ -2768,8 +2768,8 @@ def custom_hk_bf16_atb_gemm(C:UOp, A:UOp, B:UOp, dname:str) -> UOp:
   assert K == K2, f"{A.shape} {B.shape}"
   block_m, block_n, block_k, num_warps = 256, 256, 64, 8
   assert M % block_m == 0 and N % block_n == 0 and K % block_k == 0, f"invalid bf16 atb tile {(block_m, block_n, block_k)} for {(M, N, K)}"
-  threads = UOp.special(64 * num_warps, "lidx0")
-  workgroups = UOp.special((M // block_m) * (N // block_n), "gidx0")
+  threads = UOp.hw_idx(64 * num_warps, "lidx0")
+  workgroups = UOp.hw_idx((M // block_m) * (N // block_n), "gidx0")
   sink = UOp.sink(C.base, A.base, B.base, threads, workgroups,
                   arg=KernelInfo(f"hk_bf16_atb_gemm_{M}_{N}_{K}", estimates=Estimates(ops=2*M*N*K, mem=(M*K+N*K+M*N)*A.dtype.itemsize)))
   kittens_path = pathlib.Path(__file__).parent.parent/"thunder"/"amd"

--- a/extra/gemm/metal_uop_matmul.py
+++ b/extra/gemm/metal_uop_matmul.py
@@ -10,9 +10,9 @@ def mat_idx(buf, g0, g1, warp, u):
   return buf[g0, l[4]*4 + l[2]*2 + l[1], g1, l[3]*4 + l[0]*2 + u]
 
 def hand_spec_tc_cores():
-  gx = UOp.special(N // 8, "gidx0")
-  gy = UOp.special(N // 8, "gidx1")
-  warp = UOp.special(32, "lidx0")
+  gx = UOp.hw_idx(N // 8, "gidx0")
+  gy = UOp.hw_idx(N // 8, "gidx1")
+  warp = UOp.hw_idx(32, "lidx0")
 
   c = UOp.placeholder((N, N), dtypes.float, slot=0).reshape((N//8, 8, N//8, 8))
   a = UOp.placeholder((N, N), dtypes.float, slot=1).reshape((N//8, 8, N//8, 8))

--- a/extra/gemm/mi350x_uop_matmul.py
+++ b/extra/gemm/mi350x_uop_matmul.py
@@ -58,9 +58,9 @@ def custom_gemm(C:UOp, A:UOp, B:UOp) -> UOp:
   assert C.shape[1] == B.shape[1]
   assert A.shape[1] == B.shape[0]
 
-  gx, gy = UOp.special(M//BLOCK_M, "gidx0"), UOp.special(N//BLOCK_N, "gidx1")
-  warp = UOp.special(WARP_SIZE, "lidx0")
-  warpgroup = UOp.special(WARPGROUP_SIZE, "lidx1")
+  gx, gy = UOp.hw_idx(M//BLOCK_M, "gidx0"), UOp.hw_idx(N//BLOCK_N, "gidx1")
+  warp = UOp.hw_idx(WARP_SIZE, "lidx0")
+  warpgroup = UOp.hw_idx(WARPGROUP_SIZE, "lidx1")
 
   # generic copy logic (not good)
   def generic_copy(glbl, gargs, lcl, rng):

--- a/extra/gemm/mi350x_uop_matmul_2.py
+++ b/extra/gemm/mi350x_uop_matmul_2.py
@@ -68,7 +68,7 @@ def compute_on_locals(acc:UOp, Asl:UOp, Bsl:UOp, rng:int, afters:tuple[UOp, ...]
   return acc_store.end(M_inner_loop, N_inner_loop, K_inner_loop)
 
 def custom_gemm(C:UOp, A:UOp, B:UOp) -> UOp:
-  gx, gy = UOp.special(M//BLOCK_M, "gidx0"), UOp.special(N//BLOCK_N, "gidx1")
+  gx, gy = UOp.hw_idx(M//BLOCK_M, "gidx0"), UOp.hw_idx(N//BLOCK_N, "gidx1")
   K_outer_loop = UOp.range(K//BLOCK_K, 0, AxisType.REDUCE)
 
   # split out the globals into blocks
@@ -79,7 +79,7 @@ def custom_gemm(C:UOp, A:UOp, B:UOp) -> UOp:
   # ---------------------------
   # GLOBAL -> LOCAL (As, Bs)
   # ---------------------------
-  tid = UOp.special(TID_SIZE, "lidx0")
+  tid = UOp.hw_idx(TID_SIZE, "lidx0")
   warpgroup, warp = tid//WARP_SIZE, tid%WARP_SIZE
 
   A_view = A.reshape(-1, TID_SIZE, 8)

--- a/extra/gemm/rdna4_asm_matmul.py
+++ b/extra/gemm/rdna4_asm_matmul.py
@@ -217,8 +217,8 @@ def test_matmul():
 
   dname = Device.DEFAULT
   def asm_kernel(A, B, C):
-    gidxs = [UOp.special(n, f"gidx{i}") for i,n in enumerate(grid)]
-    lidxs = [UOp.special(THREADS, "lidx0")]
+    gidxs = [UOp.hw_idx(n, f"gidx{i}") for i,n in enumerate(grid)]
+    lidxs = [UOp.hw_idx(THREADS, "lidx0")]
     lds_size = max(LDS_SIZE, 65536//getenv("LIMIT_OCC",2))
     lds = UOp.placeholder((lds_size,), dtypes.uint8, 0, AddrSpace.LOCAL)
     sink = UOp.sink(A.base, B.base, C.base, lds, *gidxs, *lidxs,

--- a/extra/llama_kernels/cast_amax/__init__.py
+++ b/extra/llama_kernels/cast_amax/__init__.py
@@ -15,7 +15,7 @@ def _custom_fused_bwd_w13(grad_xw13_fp8:UOp, grad_amax_buf:UOp,
                           xw13:UOp, grad_x2:UOp, amax_state:UOp, grad_amax_state:UOp, dname:str) -> UOp:
   hidden = xw13.shape[2] // 2
   n_elems = xw13.shape[0] * xw13.shape[1] * hidden
-  threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
+  threads, workgroups = UOp.hw_idx(THREADS_PER_WG, "lidx0"), UOp.hw_idx(NUM_WG, "gidx0")
   mem = n_elems * 2 * 3 + n_elems * 2 + NUM_WG * 4 + 4
   sink = UOp.sink(grad_xw13_fp8.base, grad_amax_buf.base,
                   xw13.base, grad_x2.base, amax_state.base, grad_amax_state.base, threads, workgroups,
@@ -29,7 +29,7 @@ def _custom_fused_cast_amax_w13(fp8_out:UOp, amax_buf:UOp, xw13:UOp, amax_state:
   # NOTE: grad_amax_state is plumbed through as an unused fwd input so the bwd kernel can read it via kernel.src
   hidden = xw13.shape[2] // 2
   n_elems = xw13.shape[0] * xw13.shape[1] * hidden
-  threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
+  threads, workgroups = UOp.hw_idx(THREADS_PER_WG, "lidx0"), UOp.hw_idx(NUM_WG, "gidx0")
   mem = n_elems * 2 * 2 + n_elems + NUM_WG * 4
   sink = UOp.sink(fp8_out.base, amax_buf.base, xw13.base, amax_state.base, threads, workgroups,
                   arg=KernelInfo(f"fused_silu_mul_cast_amax_w13_{n_elems}", estimates=Estimates(ops=5*n_elems, mem=mem)))

--- a/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/__init__.py
+++ b/extra/llama_kernels/fused_rmsnorm_mul_quantize_fp8/__init__.py
@@ -13,7 +13,7 @@ def _custom_fwd(fp8_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax_buf:UOp,
                 x:UOp, weight:UOp, amax_state:UOp, dname:str, eps_val:float) -> UOp:
   MBS, SEQ, HIDDEN = x.shape
   n_elems = MBS * SEQ * HIDDEN
-  threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
+  threads, workgroups = UOp.hw_idx(THREADS_PER_WG, "lidx0"), UOp.hw_idx(NUM_WG, "gidx0")
   mem = n_elems * 2 + n_elems + MBS * SEQ * 4 + n_elems + HIDDEN * 2 + NUM_WG * 4 + 4
   sink = UOp.sink(fp8_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
                   x.base, weight.base, amax_state.base, threads, workgroups,
@@ -30,7 +30,7 @@ def _custom_fwd_add(fp8_out:UOp, h_out:UOp, x_normed_out:UOp, rrms_out:UOp, amax
                     x:UOp, residual:UOp, weight:UOp, amax_state:UOp, dname:str, eps_val:float) -> UOp:
   MBS, SEQ, HIDDEN = x.shape
   n_elems = MBS * SEQ * HIDDEN
-  threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
+  threads, workgroups = UOp.hw_idx(THREADS_PER_WG, "lidx0"), UOp.hw_idx(NUM_WG, "gidx0")
   mem = n_elems * 2 * 4 + MBS * SEQ * 4 + HIDDEN * 2 + NUM_WG * 4 + 4
   sink = UOp.sink(fp8_out.base, h_out.base, x_normed_out.base, rrms_out.base, amax_buf.base,
                   x.base, residual.base, weight.base, amax_state.base, threads, workgroups,
@@ -47,7 +47,7 @@ def _custom_bwd(grad_x:UOp, grad_weight_partial:UOp,
                 grad_fp8:UOp, x_normed:UOp, rrms:UOp, weight:UOp, amax_state:UOp, dname:str) -> UOp:
   MBS, SEQ, HIDDEN = x_normed.shape
   n_elems = MBS * SEQ * HIDDEN
-  threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(NUM_WG, "gidx0")
+  threads, workgroups = UOp.hw_idx(THREADS_PER_WG, "lidx0"), UOp.hw_idx(NUM_WG, "gidx0")
   mem = n_elems * 2 * 3 + NUM_WG * HIDDEN * 4 + MBS * SEQ * 4 + HIDDEN * 2 + 4
   sink = UOp.sink(grad_x.base, grad_weight_partial.base,
                   grad_fp8.base, x_normed.base, rrms.base, weight.base, amax_state.base, threads, workgroups,

--- a/extra/llama_kernels/transpose_quantize_mxfp8/__init__.py
+++ b/extra/llama_kernels/transpose_quantize_mxfp8/__init__.py
@@ -12,7 +12,7 @@ BLK = 32
 def _custom_transpose_quantize_mxfp8(q:UOp, e8:UOp, g:UOp, dname:str) -> UOp:
   M, N = g.shape
   num_wg = (M // BLK) * (N // TILE_N)
-  threads, workgroups = UOp.special(THREADS_PER_WG, "lidx0"), UOp.special(num_wg, "gidx0")
+  threads, workgroups = UOp.hw_idx(THREADS_PER_WG, "lidx0"), UOp.hw_idx(num_wg, "gidx0")
   mem = M * N * 2 + M * N + (M // BLK) * N   # read bf16, write fp8 + e8
   sink = UOp.sink(q.base, e8.base, g.base, threads, workgroups,
                   arg=KernelInfo(f"transpose_quantize_mxfp8_{M}_{N}", estimates=Estimates(ops=M*N, mem=mem)))

--- a/extra/mmapeak/mmapeak.py
+++ b/extra/mmapeak/mmapeak.py
@@ -33,8 +33,8 @@ def launchBenchmark(instruction, vgprIndices, dense=True, accum=False, **kwargs)
     inst = instruction(v[0:vgprIndices[0]], v[vgprIndices[1]:vgprIndices[2]], v[vgprIndices[3]:vgprIndices[4]], v[vgprIndices[5]])
   insts = repeat([inst for _ in range(INSTRUCTIONS_PER_LOOP)], n=INTERNAL_LOOP, counter_sreg=s[1])
   def fxn(A:UOp) -> UOp:
-    threads = UOp.special(WAVE_SIZE * NUM_WAVES, "lidx0")
-    gidx = UOp.special(NUM_WORKGROUPS, "gidx0")
+    threads = UOp.hw_idx(WAVE_SIZE * NUM_WAVES, "lidx0")
+    gidx = UOp.hw_idx(NUM_WORKGROUPS, "gidx0")
     FLOPs = FLOPS_PER_MATMUL * NUM_WAVES * NUM_WORKGROUPS * INTERNAL_LOOP * INSTRUCTIONS_PER_LOOP
     sink = UOp.sink(A.base, threads, gidx, arg=KernelInfo(inst.op.name.lower(), estimates=Estimates(ops=FLOPs, mem=0)))
     return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.LINEAR, src=tuple([UOp(Ops.INS, arg=x) for x in insts]))))

--- a/extra/thunder/amd/fa.py
+++ b/extra/thunder/amd/fa.py
@@ -94,8 +94,8 @@ def custom_fa_forward(o:UOp, l_vec:UOp, q:UOp, k:UOp, v:UOp, device:str, arch:st
   NUM_THREADS = 64 * NUM_WARPS
   gsz = (H, (math.ceil((N // Q_BLOCK_SIZE) / NUM_WARPS)), B)
   lsz = (NUM_THREADS, 1, 1)
-  threadIdx_x = UOp.special(lsz[0], "lidx0")
-  blockIdx_x, blockIdx_y, blockIdx_z = UOp.special(gsz[0], "gidx0"), UOp.special(gsz[1], "gidx1"), UOp.special(gsz[2], "gidx2")
+  threadIdx_x = UOp.hw_idx(lsz[0], "lidx0")
+  blockIdx_x, blockIdx_y, blockIdx_z = UOp.hw_idx(gsz[0], "gidx0"), UOp.hw_idx(gsz[1], "gidx1"), UOp.hw_idx(gsz[2], "gidx2")
 
   el = q.dtype.itemsize
   mem = (2*B*N*H*D + 2*B*N*H_KV*D) * el + B*H*N * l_vec.dtype.itemsize
@@ -124,8 +124,8 @@ def custom_fa_backward_pre(delta_vec:UOp, dq:UOp, o:UOp, do:UOp, device:str, arc
   NUM_THREADS = 64 * NUM_WARPS
   gsz = (B, H, N // (DOT_SLICE_QO * NUM_WARPS))
   lsz = (NUM_THREADS, 1, 1)
-  threadIdx_x = UOp.special(lsz[0], "lidx0")
-  blockIdx_x, blockIdx_y, blockIdx_z = UOp.special(gsz[0], "gidx0"), UOp.special(gsz[1], "gidx1"), UOp.special(gsz[2], "gidx2")
+  threadIdx_x = UOp.hw_idx(lsz[0], "lidx0")
+  blockIdx_x, blockIdx_y, blockIdx_z = UOp.hw_idx(gsz[0], "gidx0"), UOp.hw_idx(gsz[1], "gidx1"), UOp.hw_idx(gsz[2], "gidx2")
 
   el = o.dtype.itemsize
   mem = 3*B*H*N*D * el + B*H*N * delta_vec.dtype.itemsize
@@ -154,8 +154,8 @@ def custom_fa_backward(dq:UOp, dk:UOp, dv:UOp, do:UOp, q:UOp, k:UOp, v:UOp, l_ve
   NUM_THREADS = 64 * NUM_WARPS
   gsz = (H, N // BLOCK_SIZE_KV, B)
   lsz = (NUM_THREADS, 1, 1)
-  threadIdx_x = UOp.special(lsz[0], "lidx0")
-  blockIdx_x, blockIdx_y, blockIdx_z = UOp.special(gsz[0], "gidx0"), UOp.special(gsz[1], "gidx1"), UOp.special(gsz[2], "gidx2")
+  threadIdx_x = UOp.hw_idx(lsz[0], "lidx0")
+  blockIdx_x, blockIdx_y, blockIdx_z = UOp.hw_idx(gsz[0], "gidx0"), UOp.hw_idx(gsz[1], "gidx1"), UOp.hw_idx(gsz[2], "gidx2")
 
   el = q.dtype.itemsize
   mem = (3*B*H*N*D + 4*B*H_KV*N*D) * el + 2*B*H*N * l_vec.dtype.itemsize
@@ -184,8 +184,8 @@ def custom_fa_backward_post(dq_out:UOp, dq_in:UOp, device:str, arch:str, B:int, 
   NUM_THREADS = 64 * NUM_WARPS
   gsz = (B, H, N // (DOT_SLICE_QO * NUM_WARPS))
   lsz = (NUM_THREADS, 1, 1)
-  threadIdx_x = UOp.special(lsz[0], "lidx0")
-  blockIdx_x, blockIdx_y, blockIdx_z = UOp.special(gsz[0], "gidx0"), UOp.special(gsz[1], "gidx1"), UOp.special(gsz[2], "gidx2")
+  threadIdx_x = UOp.hw_idx(lsz[0], "lidx0")
+  blockIdx_x, blockIdx_y, blockIdx_z = UOp.hw_idx(gsz[0], "gidx0"), UOp.hw_idx(gsz[1], "gidx1"), UOp.hw_idx(gsz[2], "gidx2")
 
   el = dq_out.dtype.itemsize
   mem = 2*B*H*N*D * el

--- a/extra/thunder/tiny/tk/kernel.py
+++ b/extra/thunder/tiny/tk/kernel.py
@@ -20,10 +20,10 @@ class Kernel(AbstractContextManager):
   def __init__(self, name:str, grid_size:tuple[int, int, int], block_size:int):
     self.name = name
 
-    self.blockIdx_x = UOp.special(grid_size[0], "gidx0")
-    self.blockIdx_y = UOp.special(grid_size[1], "gidx1")
-    self.blockIdx_z = UOp.special(grid_size[2], "gidx2")
-    self.threadIdx_x = UOp.special(block_size, "lidx0")
+    self.blockIdx_x = UOp.hw_idx(grid_size[0], "gidx0")
+    self.blockIdx_y = UOp.hw_idx(grid_size[1], "gidx1")
+    self.blockIdx_z = UOp.hw_idx(grid_size[2], "gidx2")
+    self.threadIdx_x = UOp.hw_idx(block_size, "lidx0")
 
     self.range_stack: list[_tk_range] = []
     self.store_stack: list[tuple[UOp, UOp]] = []

--- a/test/amd/test_asm_kernel.py
+++ b/test/amd/test_asm_kernel.py
@@ -17,7 +17,7 @@ from extra.gemm.amd_asm_matmul import Kernel
 def custom_add_one(A:UOp) -> UOp:
   A = A.flatten()
   assert dtypes.is_float(A.dtype.base), f"buffer dtype must be float32, got {A.dtype}"
-  threads = UOp.special(A.numel(), "lidx0")
+  threads = UOp.hw_idx(A.numel(), "lidx0")
   insts = [
     s_load_b64(s[0:1], s[0:1], soffset=NULL),
     s_waitcnt_lgkmcnt(sdst=NULL, simm16=0),
@@ -35,7 +35,7 @@ def custom_add_one(A:UOp) -> UOp:
 def custom_add_var(A:UOp, B:UOp) -> UOp:
   A,B = A.flatten(), B.flatten()
   assert A.dtype.base == dtypes.uint32, f"buffer dtype must be uint32, got {A.dtype}"
-  threads = UOp.special(A.numel(), "lidx0")
+  threads = UOp.hw_idx(A.numel(), "lidx0")
   var = UOp.param(2, dtypes.weakint, vmin_vmax=(0, 10), name="var", addrspace=AddrSpace.ALU)
   insts = [
     s_load_b128(s[4:7], s[0:1]),
@@ -54,8 +54,8 @@ def custom_add_var(A:UOp, B:UOp) -> UOp:
 def custom_wave_sync(A:UOp, arch:str) -> UOp:
   # 4 waves across 1024 WG — enough to saturate a SIMD with many concurrent WGs
   # s_sleep yields the SIMD so waves from different WGs interleave, causing barrier packet reordering
-  threads = UOp.special(128, "lidx0")
-  wg = UOp.special(1024, "gidx0")
+  threads = UOp.hw_idx(128, "lidx0")
+  wg = UOp.hw_idx(1024, "gidx0")
   insts = []
   for _ in range(4):
     insts.append(s_sleep(4))
@@ -68,8 +68,8 @@ def custom_wave_sync(A:UOp, arch:str) -> UOp:
 def custom_lds_sync(A:UOp, arch:str) -> UOp:
   A = A.flatten()
   num_threads = A.shape[0]
-  threads = UOp.special(num_threads, "lidx0")
-  wg = UOp.special(1, "gidx0")
+  threads = UOp.hw_idx(num_threads, "lidx0")
+  wg = UOp.hw_idx(1, "gidx0")
   lds = UOp.placeholder((512,), dtypes.uint8, 0, AddrSpace.LOCAL)  # 128 * 4 bytes
   isa = r4 if arch == "rdna4" else r3
   wait_kmcnt = [isa.s_wait_kmcnt(simm16=0)] if arch == "rdna4" else [isa.s_waitcnt_lgkmcnt(sdst=NULL, simm16=0)]
@@ -101,8 +101,8 @@ def custom_lds_sync(A:UOp, arch:str) -> UOp:
 
 def custom_handwritten(A:UOp) -> UOp:
   A = A.flatten()
-  threads = UOp.special(128, "lidx0")
-  wg = UOp.special(1, "gidx0")
+  threads = UOp.hw_idx(128, "lidx0")
+  wg = UOp.hw_idx(1, "gidx0")
   lds = UOp.placeholder((512,), dtypes.uint8, 0, AddrSpace.LOCAL)  # 128 * 4 bytes
   pipes = {getenv("PIPE", "")} if getenv("PIPE", "") else {"SALU", "VALU", "TRANSCENDENTAL", "WMMA"}
   k = Kernel()
@@ -147,7 +147,7 @@ def custom_handwritten(A:UOp) -> UOp:
 
 def custom_data_deps(A:UOp) -> UOp:
   A = A.flatten()
-  threads = UOp.special(A.numel(), "lidx0")
+  threads = UOp.hw_idx(A.numel(), "lidx0")
   k = Kernel()
   k.emit(s_load_b64(s[0:1], s[0:1], soffset=NULL))
   k.emit(s_waitcnt_lgkmcnt(sdst=NULL, simm16=0))

--- a/test/backend/test_linearizer.py
+++ b/test/backend/test_linearizer.py
@@ -265,11 +265,11 @@ class TestLinearizer(unittest.TestCase):
     t = Tensor.ones(5, 6, 7).contiguous().realize().shrink(((0, 4), (0, 5), (0, 6)))
     ast = helper_linearizer_opt(t+1)
     uops = tuple(to_program(replace_opts(ast, []), renderer=Device[Device.DEFAULT].renderer).src[1].src)
-    idxs = dedup([uop for uop in uops if uop.op is Ops.SPECIAL])
-    idxs = sorted(idxs, key=lambda uop: uop.arg)
-    assert (idxs[0].arg, idxs[0].src[0].arg) == ('gidx0', 6), idxs[0]
-    assert (idxs[1].arg, idxs[1].src[0].arg) == ('gidx1', 5), idxs[1].arg
-    assert (idxs[2].arg, idxs[2].src[0].arg) == ('gidx2', 4), idxs[2].arg
+    idxs = dedup([uop for uop in uops if uop.is_hw_idx])
+    idxs = sorted(idxs, key=lambda uop: uop.arg.hw_dim)
+    assert (idxs[0].arg.hw_dim, idxs[0].src[0].arg) == ('gidx0', 6), idxs[0]
+    assert (idxs[1].arg.hw_dim, idxs[1].src[0].arg) == ('gidx1', 5), idxs[1].arg
+    assert (idxs[2].arg.hw_dim, idxs[2].src[0].arg) == ('gidx2', 4), idxs[2].arg
 
   def test_sum_collapse(self):
     t = Tensor([2]).reshape(1, 1).expand(256, 256).sum()
@@ -306,7 +306,7 @@ class TestLinearizer(unittest.TestCase):
       # ignore kernel optimized IF statements for now
       if if_op:=next((u for u in uops if u.op is Ops.IF), None):
         uops = uops[:uops.index(if_op)]
-      assert len(set([u.op for u in uops if u.op in {Ops.RANGE, Ops.SPECIAL}])) == 1, "has either specials or ranges, not both"
+      assert len(set(u.is_hw_idx for u in uops if u.op is Ops.RANGE or u.is_hw_idx)) <= 1, "has either hw_idx or ranges, not both"
       reg_stores = [u for u in uops if u.op is Ops.STORE and isinstance(dt:=u.src[0].dtype, PtrDType) and dt.addrspace == AddrSpace.REG]
       assert len(reg_stores) == 0, "STORE to reg should have been simplified"
       assert len([u for u in uops if u.op is Ops.MAX]) <= max_ops, "no unnecessary MAX ops"

--- a/test/backend/test_renderer_failures.py
+++ b/test/backend/test_renderer_failures.py
@@ -34,7 +34,7 @@ class TestRendererFailures(unittest.TestCase):
   @unittest.skipIf(not isinstance(Device[Device.DEFAULT].renderer, (PTXRenderer, PythonRenderer)), "test is for ptx or python renderer")
   def test_gated_store_with_alu(self):
     a = UOp.param(0, dtypes.int.ptr(4))
-    gate_alu = (lidx0:=UOp(Ops.SPECIAL, dtypes.int, (UOp.const(dtypes.int, 4),), 'lidx0')).ne(0)
+    gate_alu = (lidx0:=UOp.hw_idx(4, 'lidx0', dtypes.int)).ne(0)
     gated_alu_store = UOp(Ops.STORE, dtypes.void, (a.index(lidx0.valid(gate_alu), ptr=True), UOp.const(dtypes.int, 1)))
     sink = UOp(Ops.SINK, dtypes.void, (gated_alu_store,), arg=KernelInfo())
     ret = _test_uop_result([], sink, local_size=[4, 1, 1])[0]
@@ -43,8 +43,8 @@ class TestRendererFailures(unittest.TestCase):
   @unittest.skipIf(not isinstance(Device[Device.DEFAULT].renderer, (PTXRenderer, PythonRenderer)), "test is for ptx or python renderer")
   def test_gated_store_with_alu_2d(self):
     a = UOp.param(0, dtypes.int.ptr(8))
-    gate_alu_0 = (lidx0:=UOp(Ops.SPECIAL, dtypes.int, (UOp.const(dtypes.int, 4),), 'lidx0')).ne(0)
-    gate_alu_1 = (lidx1:=UOp(Ops.SPECIAL, dtypes.int, (UOp.const(dtypes.int, 2),), 'lidx1')).ne(0)
+    gate_alu_0 = (lidx0:=UOp.hw_idx(4, 'lidx0', dtypes.int)).ne(0)
+    gate_alu_1 = (lidx1:=UOp.hw_idx(2, 'lidx1', dtypes.int)).ne(0)
     gated_alu_store = UOp(Ops.STORE, dtypes.void, (a.index((lidx0+lidx1*4).valid(gate_alu_0&gate_alu_1), ptr=True), UOp.const(dtypes.int, 1)))
     sink = UOp(Ops.SINK, dtypes.void, (gated_alu_store,), arg=KernelInfo())
     ret = _test_uop_result([], sink, local_size=[4, 2, 1])[0]
@@ -88,7 +88,7 @@ class TestPTXFailures(unittest.TestCase):
   @unittest.skip("INDEX can only have a gate ALU parent, not an IF")
   def test_gated_store_with_if(self):
     a = UOp.param(0, dtypes.int.ptr())
-    gate_alu = (lidx0:=UOp(Ops.SPECIAL, dtypes.int, (UOp.const(dtypes.int, 4),), 'lidx0')).ne(0)
+    gate_alu = (lidx0:=UOp.hw_idx(4, 'lidx0', dtypes.int)).ne(0)
     val = UOp.const(dtypes.int, 1)
     if_uop = UOp(Ops.IF, dtypes.void, (gate_alu,))
     gated_alu_store = UOp(Ops.STORE, dtypes.void, (a.index(lidx0, if_uop), val))

--- a/test/null/test_gpudims.py
+++ b/test/null/test_gpudims.py
@@ -1,7 +1,7 @@
 import unittest, math
 import z3
 from tinygrad.codegen.gpudims import get_grouped_dims, add_gpudims
-from tinygrad.uop.ops import UOp, Ops, KernelInfo, AxisType
+from tinygrad.uop.ops import UOp, KernelInfo, AxisType
 from tinygrad.uop.validate import uops_to_z3
 from tinygrad.dtype import dtypes
 from tinygrad.renderer import Renderer
@@ -10,8 +10,8 @@ from tinygrad.helpers import flatten, dedup, Target
 class TestGroupedDims(unittest.TestCase):
   def _check_grouped_dims(self, prefix, dims, max_sizes, reverse, expected_sizes, assert_same_length=True):
     idxs = get_grouped_dims(prefix, dims, max_sizes, reverse)
-    loop_idxs = dedup(flatten([[y for y in x.toposort() if y.op is Ops.SPECIAL] for x in idxs]))
-    loop_idxs = sorted(loop_idxs, key=lambda uop: uop.arg)
+    loop_idxs = dedup(flatten([[y for y in x.toposort() if y.is_hw_idx] for x in idxs]))
+    loop_idxs = sorted(loop_idxs, key=lambda uop: uop.arg.hw_dim)
     sizes = [x.src[0].arg for x in loop_idxs]
     assert len(idxs) == len(dims), f"expected idxs to have same length as dims {len(dims)}, got {len(idxs)}"
     if assert_same_length:
@@ -22,19 +22,19 @@ class TestGroupedDims(unittest.TestCase):
   def _verify_indices_z3(self, idxs, dims):
     """Use z3 to prove bijectivity: bounds (0 <= flat < total) + injectivity (different inputs => different flat)."""
     total = math.prod(dims)
-    specials = sorted(dedup(flatten([[y for y in x.toposort() if y.op is Ops.SPECIAL] for x in idxs])), key=lambda u: u.arg)
-    # build flat index and primed flat (same expression with renamed SPECIALs)
+    specials = sorted(dedup(flatten([[y for y in x.toposort() if y.is_hw_idx] for x in idxs])), key=lambda u: u.arg.hw_dim)
+    # build flat index and primed flat (same expression with renamed hw_idx PARAMs)
     flat = UOp.const(dtypes.weakint, 0)
     for i, idx in enumerate(idxs):
       flat = flat + idx * int(math.prod(dims[i+1:]))
-    flat_p = flat.substitute({s: UOp(Ops.SPECIAL, s.dtype, s.src, s.arg+"_p") for s in specials})
+    flat_p = flat.substitute({s: UOp.hw_idx(s.src[0], s.arg.hw_dim+"_p", s.dtype) for s in specials})
     solver = z3.Solver()
     [z3_flat, z3_flat_p] = uops_to_z3(solver, flat, flat_p)
     # bounds
     self.assertEqual(solver.check(z3_flat < 0), z3.unsat, f"flat can be negative: {dims=}")
     self.assertEqual(solver.check(z3_flat >= total), z3.unsat, f"flat can be >= {total}: {dims=}")
     # injectivity: flat == flat' but inputs differ => unsat
-    inputs_differ = z3.Or(*[z3.Int(s.arg) != z3.Int(s.arg+"_p") for s in specials])
+    inputs_differ = z3.Or(*[z3.Int(s.arg.hw_dim) != z3.Int(s.arg.hw_dim+"_p") for s in specials])
     self.assertEqual(solver.check(z3.And(z3_flat == z3_flat_p, inputs_differ)), z3.unsat, f"not injective: {dims=}")
 
   def test_grouped_dims(self):
@@ -88,19 +88,19 @@ class TestGroupedDims(unittest.TestCase):
     with self.assertRaises(RuntimeError):
       get_grouped_dims("gidx", (2,3,4,5,6), (16,16,16))
 
-  def test_grouped_direct_dims_are_special(self):
+  def test_grouped_direct_dims_are_hw_idx(self):
     # when (2,3) are merged into 6, the unmerged dims (4,5) should map directly to SPECIAL ops (no div/mod)
     idxs = get_grouped_dims("gidx", (2,3,4,5), (16,16,16), False)
-    assert idxs[2].op is Ops.SPECIAL, f"expected SPECIAL for direct-mapped dim, got {idxs[2].op}"
-    assert idxs[3].op is Ops.SPECIAL, f"expected SPECIAL for direct-mapped dim, got {idxs[3].op}"
+    assert idxs[2].is_hw_idx, f"expected hw_idx PARAM for direct-mapped dim, got {idxs[2].op}"
+    assert idxs[3].is_hw_idx, f"expected hw_idx PARAM for direct-mapped dim, got {idxs[3].op}"
 
   def test_global_prod_max(self):
     g, l = UOp.range(256, 0, AxisType.GLOBAL), UOp.range(256, 1, AxisType.LOCAL)
     sink = UOp.param(0, dtypes.float.ptr()).index(g + l).store(UOp.const(dtypes.float, 1.0)).end(g, l).sink(arg=KernelInfo())
     class R(Renderer): global_max, local_max, global_prod_max = (256, 256, 256), (128, 128, 128), (128, 128, 128)
-    specials = [u for u in add_gpudims(R(Target()), sink).toposort() if u.op is Ops.SPECIAL]
-    self.assertGreater(len([s for s in specials if "lidx" in s.arg]), 1)
-    self.assertGreater(len([s for s in specials if "gidx" in s.arg]), 1)
+    specials = [u for u in add_gpudims(R(Target()), sink).toposort() if u.is_hw_idx]
+    self.assertGreater(len([s for s in specials if "lidx" in s.arg.hw_dim]), 1)
+    self.assertGreater(len([s for s in specials if "gidx" in s.arg.hw_dim]), 1)
 
   def test_max_sizes_none(self):
     self._check_grouped_dims("gidx", (2,3,4), None, False, [2,3,4])

--- a/test/null/test_graph_rewrite.py
+++ b/test/null/test_graph_rewrite.py
@@ -128,7 +128,7 @@ class TestModuloAndDivisionFolding(unittest.TestCase):
 
   def test_graph_rewrite_div_folding_bug(self):
     lhs = UOp(Ops.ADD, dtypes.int.vec(4), src=(
-      UOp(Ops.STACK, dtypes.int.vec(4), arg=None, src=(UOp(Ops.SPECIAL, dtypes.int, arg='lidx0', src=(UOp.const(dtypes.int, 32),)),)*4),
+      UOp(Ops.STACK, dtypes.int.vec(4), arg=None, src=(UOp.hw_idx(32, 'lidx0', dtypes.int),)*4),
       UOp.const(dtypes.int.vec(4), (0, 256, 512, 768))))
     rhs = UOp.const(dtypes.int.vec(4), 2)
     unopt = lhs<rhs

--- a/test/null/test_simplify_valid_idx.py
+++ b/test/null/test_simplify_valid_idx.py
@@ -23,7 +23,7 @@ def get_load_image_uop(image_shape:tuple[int, ...], valid:UOp, idx:tuple[UOp, UO
     UOp.param(0, dtypes.imagef(image_shape)).index(idx[1].valid(valid), idx[0].valid(valid), ptr=True),
   ))
 
-def Special(expr, nmax): return UOp(Ops.SPECIAL, dtypes.weakint, (UOp.const(dtypes.weakint, nmax),), expr)
+def HwIdx(expr, nmax): return UOp.hw_idx(nmax, expr)
 def Variable(expr, nmin, nmax): return UOp.variable(expr, nmin, nmax)
 def Range(n, nmax): return UOp.range(nmax, n)
 
@@ -35,8 +35,8 @@ class TestValidIdxSimplification(unittest.TestCase):
     check_uop_against_string(self, off.get_valid(), svalid)
 
   def test_cumsum(self):
-    gidx0 = Special("gidx0", 5)
-    lidx0 = Special("lidx0", 4)
+    gidx0 = HwIdx("gidx0", 5)
+    lidx0 = HwIdx("lidx0", 4)
     gate = (gidx0*4+lidx0<19).ne(True)
     idx = gidx0*4+lidx0-19
     load = get_gated_load_uop(gate, idx)
@@ -57,7 +57,7 @@ class TestValidIdxSimplification(unittest.TestCase):
       "((((r0*3)+r1)<8)&((((r2*3)+r3)%4)<2))")
 
   def test_simplify_within_valid2(self):
-    gidx0 = Special("gidx0", 56)
+    gidx0 = HwIdx("gidx0", 56)
     ridx0 = Range(0, 3)
     alu0 = gidx0+ridx0
     valid = (alu0 < 57) & (alu0 >= 1)
@@ -71,8 +71,8 @@ class TestValidIdxSimplification(unittest.TestCase):
     self.assertEqual(simplify_valid(v1&v0).render(), "(r0<1)")
 
   def test_valid_order_matters2(self):
-    gidx0 = Special("gidx0", 13)
-    gidx1 = Special("gidx1", 13)
+    gidx0 = HwIdx("gidx0", 13)
+    gidx1 = HwIdx("gidx1", 13)
     ridx0 = Range(0, 4)
     alu0 = (gidx1+(ridx0*13))
     v0 = (gidx0+11)%14<11
@@ -119,8 +119,8 @@ class TestValidIdxSimplification(unittest.TestCase):
     # from FUSE_ARANGE=1 python test/test_ops.py TestOps.test_scatter_add
     # can lead to OOB
     ridx2 = Range(2, 4)
-    lidx0 = Special("lidx0", 3)
-    gidx0 = Special("gidx0", 2)
+    lidx0 = HwIdx("lidx0", 3)
+    gidx0 = HwIdx("gidx0", 2)
     idx=(((lidx0+(gidx0*3))+(ridx2*5))+40)
     valid = (lidx0+(gidx0*3)) < 5
     val7 = get_gated_load_uop(valid, idx)
@@ -212,8 +212,8 @@ class TestImageSimplification(unittest.TestCase):
   def test_idx_gt_c(self):
     # (idx1 < c+1).ne(True) ? (..., idx1-1+c) : 0 can drop the valid
     # (idx1 < c+1).ne(True) -> idx > c
-    gidx0 = Special("gidx0", 32)
-    gidx1 = Special("gidx1", 32)
+    gidx0 = HwIdx("gidx0", 32)
+    gidx1 = HwIdx("gidx1", 32)
     shape = (10, 10, 4)
     load = get_load_image_uop(shape, (gidx1<1).ne(True), (gidx0, gidx1-1))
     self.check(load, None, "gidx0", "(gidx1+-1)")
@@ -231,8 +231,8 @@ class TestImageSimplification(unittest.TestCase):
 
   def test_idx_lt_bound(self):
     # (idx1 < image_bound) ? (..., idx1) : 0 can drop the valid
-    gidx0 = Special("gidx0", 32)
-    gidx1 = Special("gidx1", 32)
+    gidx0 = HwIdx("gidx0", 32)
+    gidx1 = HwIdx("gidx1", 32)
     load = get_load_image_uop((10, 10, 4), gidx1<10, (gidx0, gidx1))
     self.check(load, None, "gidx0", "gidx1")
 
@@ -246,8 +246,8 @@ class TestImageSimplification(unittest.TestCase):
 
   def test_generic_idx_lt_bound(self):
     # (idx1 < image_bound - c) ? (..., idx1 + c) : 0 can drop the valid
-    gidx0 = Special("gidx0", 32)
-    gidx1 = Special("gidx1", 32)
+    gidx0 = HwIdx("gidx0", 32)
+    gidx1 = HwIdx("gidx1", 32)
     shape = (10, 10, 4)
     load = get_load_image_uop(shape, (gidx1<8), (gidx0, gidx1+2))
     self.check(load, None, "gidx0", "(gidx1+2)")
@@ -256,8 +256,8 @@ class TestImageSimplification(unittest.TestCase):
     self.check(load, None, "gidx0", "(gidx1+5)")
 
   def test_valid_empty_set(self):
-    gidx0 = Special("gidx0", 32)
-    gidx1 = Special("gidx1", 32)
+    gidx0 = HwIdx("gidx0", 32)
+    gidx1 = HwIdx("gidx1", 32)
     shape = (32, 32, 4)
     idx = (gidx0%2, gidx1+2)
     # not empty
@@ -273,8 +273,8 @@ class TestImageSimplification(unittest.TestCase):
   def test_openpilot_conv1(self):
     # first conv in openpilot
     # kernel in tinygrad ae5d1407ee844a97a52ad3756835d38e7e2b9e1b https://gist.github.com/chenyuxyz/39c2d4e9a076b46731c67d345ff066b6
-    idx1 = Special("idx1", 32)
-    idx2 = Special("idx2", 64)
+    idx1 = HwIdx("idx1", 32)
+    idx2 = HwIdx("idx2", 64)
     # ridx0 = Variable("ridx0", 0, 5)
     # ridx1 = Variable("ridx1", 0, 2)
     # ridx2 = Variable("ridx2", 0, 2)
@@ -294,8 +294,8 @@ class TestImageSimplification(unittest.TestCase):
 
   def test_openpilot_conv2(self):
     # conv in test/external/external_test_valid_remove.py
-    idx1 = Special("idx1", 32)
-    idx2 = Special("idx2", 64)
+    idx1 = HwIdx("idx1", 32)
+    idx2 = HwIdx("idx2", 64)
     # ridx0 = Variable("ridx0", 0, 2)
     # ridx1 = Variable("ridx1", 0, 2)
     # ridx2 = Variable("ridx2", 0, 2)
@@ -315,9 +315,9 @@ class TestImageSimplification(unittest.TestCase):
 
   def test_openpilot_conv3(self):
     # in openpilot 0.9.7
-    idx0 = Special("idx0", 64)
-    idx1 = Special("idx1", 2)
-    idx2 = Special("idx2", 4)
+    idx0 = HwIdx("idx0", 64)
+    idx1 = HwIdx("idx1", 2)
+    idx2 = HwIdx("idx2", 4)
     ridx0 = Range(0, 7)
     ridx1 = Range(1, 7)
 
@@ -338,7 +338,7 @@ class TestImageSimplification(unittest.TestCase):
 
   def test_simplify1(self):
     # idx has the form (A % m, A // m + k) and valid has (c0 < A) and (A < c1)
-    gidx = Special("gidx", 512)
+    gidx = HwIdx("gidx", 512)
     valid = (gidx<488) & (gidx<480).ne(True)
     idx = ((gidx*3+18)%26, (gidx*3+18)//26-56)
     load = get_load_image_uop((1, 26, 4), valid, idx)
@@ -346,7 +346,7 @@ class TestImageSimplification(unittest.TestCase):
 
   def test_simplify2(self):
     # from DEV=CL DEBUG=4 FORWARD_ONLY=1 IMAGE=2 python3 test/test_ops.py TestOps.test_simple_padding_conv2d
-    lidx = Special("lidx", 4)
+    lidx = HwIdx("lidx", 4)
     valid = (lidx<3) & (lidx<1).ne(True)
     idx = ((lidx+1)%2, (lidx+1)//2-1)
     load = get_load_image_uop((1, 2, 4), valid, idx)
@@ -354,14 +354,14 @@ class TestImageSimplification(unittest.TestCase):
 
   def test_simplify3(self):
     # from openpilot
-    idx0 = Special("idx0", 265)
+    idx0 = HwIdx("idx0", 265)
     valid = (idx0<201).ne(True)
     idx = ((idx0+55)%64, (idx0+55)//64-4)
     load = get_load_image_uop((1, 64, 4), valid, idx)
     self.check(load, None, "(idx0+-201)", "0")
 
   def test_simplify4(self):
-    idx0 = Special("idx0", 512)
+    idx0 = HwIdx("idx0", 512)
     shape = (4, 64, 4)
     alu2 = ((idx0*4+1)%32)
     alu3 = ((idx0*4+2)%32)
@@ -385,8 +385,8 @@ class TestImageSimplification(unittest.TestCase):
   def test_simplify5(self):
     # openpilot 0.9.7, chunk replacement to simplify
     shape = (10, 384, 4)
-    idx0 = Special("idx0", 16)
-    idx1 = Special("idx1", 24)
+    idx0 = HwIdx("idx0", 16)
+    idx1 = HwIdx("idx1", 24)
     alu0 = idx0*4
     alu1 = (idx1*256)+alu0
     alu2 = idx1//3
@@ -400,8 +400,8 @@ class TestImageSimplification(unittest.TestCase):
   def test_simplify6(self):
     # from openpilot
     # the valid implies the numerator of the div/mod is positive and can be simplified with floordiv rules
-    idx1 = Special("idx1", 16)
-    idx2 = Special("idx2", 64)
+    idx1 = HwIdx("idx1", 16)
+    idx2 = HwIdx("idx2", 64)
     ridx3 = Range(3, 3)
     ridx4 = Range(4, 3)
     ridx5 = Range(5, 3)
@@ -414,9 +414,9 @@ class TestImageSimplification(unittest.TestCase):
   def test_simplify7(self):
     # DEBUG=2 ALLOWED_KERNEL_COUNT=123 ALLOWED_READ_IMAGE=1397 ALLOWED_GATED_READ_IMAGE=94 FLOAT16=1 CL=1 IMAGE=2 python examples/openpilot/compile3.py https://gitlab.com/commaai/openpilot-lfs.git/gitlab-lfs/objects/cf6376aa9a090f0da26c280ef69eabf9bbdd51d1faac9ed392919c3db69be916 # noqa: E501
     # kernel 143
-    gidx0 = Special("gidx0", 32)
-    lidx0 = Special("lidx0", 16)
-    lidx1 = Special("lidx1", 8)
+    gidx0 = HwIdx("gidx0", 32)
+    lidx0 = HwIdx("lidx0", 16)
+    lidx1 = HwIdx("lidx1", 8)
     r0 = Range(0, 7)
 
     # buf.render()='UOp(Ops.DEFINE_GLOBAL, dtypes.imageh((32, 1024, 4)), arg=1, src=())'
@@ -436,10 +436,10 @@ class TestImageSimplification(unittest.TestCase):
   def test_simplify8(self):
     # from openpilot compile3, kernel r_4_16_8_16_4_4_3_3n1
     # valid guarantees A >= 0, so divmod simplifies and gate is removed
-    gidx0 = Special("gidx0", 16)
-    gidx1 = Special("gidx1", 4)
-    lidx0 = Special("lidx0", 8)
-    lidx1 = Special("lidx1", 16)
+    gidx0 = HwIdx("gidx0", 16)
+    gidx1 = HwIdx("gidx1", 4)
+    lidx0 = HwIdx("lidx0", 8)
+    lidx1 = HwIdx("lidx1", 16)
     A = gidx0 + gidx1*8192 + lidx0*1024 + lidx1*64 - 1040
     valid = ((lidx1 < 1).ne(True)) & (((gidx1 + lidx0) < 1).ne(True))
     load = get_load_image_uop((32, 1024, 4), valid, (A % 1024, A // 1024))
@@ -448,9 +448,9 @@ class TestImageSimplification(unittest.TestCase):
   def test_simplify9(self):
     # from openpilot compile3, kernel r_32_16_8_4_4_7_7 (image 1x16384)
     # valid guarantees A1 >= 0 and A1 < 512, gate should be removable
-    gidx0 = Special("gidx0", 32)
-    lidx0 = Special("lidx0", 16)
-    lidx1 = Special("lidx1", 8)
+    gidx0 = HwIdx("gidx0", 32)
+    lidx0 = HwIdx("lidx0", 16)
+    lidx1 = HwIdx("lidx1", 8)
     r0 = Range(0, 7)
     A1 = lidx0*32 + r0*32 + lidx1*4 - 99
     valid = ((lidx1 < 1).ne(True)) & ((lidx0 + r0) < 3).ne(True) & ((lidx0 + r0) < 19)
@@ -466,10 +466,10 @@ class TestImageSimplification(unittest.TestCase):
   def test_simplify10(self):
     # from openpilot compile3, kernel r_16_8_4_4_4_4_7_7 (image 1x8192)
     # valid guarantees A1 >= 0 and A1 < 128, gate should be removable
-    gidx0 = Special("gidx0", 16)
-    lidx0 = Special("lidx0", 8)
-    lidx1 = Special("lidx1", 4)
-    lidx2 = Special("lidx2", 4)
+    gidx0 = HwIdx("gidx0", 16)
+    lidx0 = HwIdx("lidx0", 8)
+    lidx1 = HwIdx("lidx1", 4)
+    lidx2 = HwIdx("lidx2", 4)
     r0 = Range(0, 7)
     A1 = lidx0*16 + r0*16 + lidx1*4 - 51
     valid = ((lidx1 < 1).ne(True)) & ((lidx0 + r0) < 3).ne(True) & ((lidx0 + r0) < 11)
@@ -485,7 +485,7 @@ class TestImageSimplification(unittest.TestCase):
   def test_drop_non_monotonic_window(self):
     # two-sided window valid (645 <= gidx0 < 653) on a non-monotonic index (lane split via %4 and //4):
     # gidx0 outside the window pushes idx_x out of the (1, 48) image, so the gate is dropped
-    gidx0 = Special("gidx0", 1064)
+    gidx0 = HwIdx("gidx0", 1064)
     r12 = Range(12, 3)
     valid = ((gidx0 < 645).ne(True)) & (gidx0 < 653)
     idx = (r12*4 + (gidx0+3)%4 + (gidx0+3)//4*24 - 3888, UOp.const(dtypes.weakint, 0))

--- a/test/null/test_uop_graph.py
+++ b/test/null/test_uop_graph.py
@@ -540,7 +540,7 @@ class TestUOpGraph(unittest.TestCase):
   def test_fold_gated_load_local(self):
     glbl0 = UOp.param(0, dtypes.int.ptr(16))
     smem = UOp.placeholder((18,), dtypes.int, slot=0, addrspace=AddrSpace.LOCAL)
-    lidx = UOp.special(16, "lidx0", dtypes.int)
+    lidx = UOp.hw_idx(16, "lidx0", dtypes.int)
     st = smem.index(lidx, ptr=True).store(glbl0.index(lidx, ptr=True).load())
     barrier = st.barrier()
     ld0 = smem.after(barrier).index(UOp.invalid())

--- a/test/null/test_uop_symbolic.py
+++ b/test/null/test_uop_symbolic.py
@@ -9,7 +9,7 @@ from tinygrad.uop.symbolic import sym, commutative, pm_simplify_valid, pm_move_w
 from tinygrad.uop.validate import uops_to_z3
 
 def check_uop_against_string(self, v:UOp, s:str):
-  sym_vars = {v.render():v for v in v.toposort() if v.op in (Ops.RANGE, Ops.SPECIAL, Ops.PARAM)}
+  sym_vars = {v.render():v for v in v.toposort() if v.op in (Ops.RANGE, Ops.PARAM)}
   s_eval = eval(s, sym_vars)
   if isinstance(s_eval, int) and v.dtype==dtypes.weakint: s_eval = UOp.const(dtypes.weakint, s_eval)
   elif isinstance(s_eval, (bool, int, float)): s_eval = UOp.const(dtypes.from_py(s_eval), s_eval)

--- a/test/null/test_uop_vmin_vmax.py
+++ b/test/null/test_uop_vmin_vmax.py
@@ -75,7 +75,7 @@ class TestVminVmaxProperties(unittest.TestCase):
     self.assertEqual(uop.vmax, 8)
 
   def test_vmin_vmax_variable_inside_special(self):
-    uop = UOp(Ops.SPECIAL, dtypes.int, arg='gidx0', src=(UOp.variable('i', 1, 10, dtypes.int),))
+    uop = UOp.hw_idx(UOp.variable('i', 1, 10, dtypes.int), 'gidx0', dtypes.int)
     self.assertEqual(uop.vmin, 0)
     self.assertEqual(uop.vmax, 9)
 

--- a/test/null/test_uops.py
+++ b/test/null/test_uops.py
@@ -111,7 +111,7 @@ class TestExecALU(unittest.TestCase):
 class TestGatedStoreRewrite(unittest.TestCase):
   def test_tiny_gate_store(self):
     gmem = UOp.param(0, dtypes.float.ptr(8))
-    gidx0 = UOp(Ops.SPECIAL, dtypes.int, (UOp.const(dtypes.int, 4),), 'gidx0')
+    gidx0 = UOp.hw_idx(4, 'gidx0', dtypes.int)
     gate = gidx0<UOp.const(dtypes.int, 1)
     idx = UOp(Ops.INDEX, dtypes.float.ptr(8), (gmem, (gidx0 * UOp.const(dtypes.int, 2)).valid(gate)))
     val = UOp.const(dtypes.float, 42.0)
@@ -128,7 +128,7 @@ class TestGatedStoreRewrite(unittest.TestCase):
   def test_gate_some_stores(self):
     gmem0 = UOp.param(0, dtypes.float.ptr(8))
     gmem1 = UOp.param(1, dtypes.float.ptr(8))
-    gidx0 = UOp(Ops.SPECIAL, dtypes.int, (UOp.const(dtypes.int, 4),), 'gidx0')
+    gidx0 = UOp.hw_idx(4, 'gidx0', dtypes.int)
     idx = gidx0 * UOp.const(dtypes.int, 2)
     idx0 = UOp(Ops.INDEX, dtypes.float.ptr(8), (gmem0, idx.valid(gidx0<UOp.const(dtypes.int, 1))))
     idx1 = UOp(Ops.INDEX, dtypes.float.ptr(8), (gmem1, idx))
@@ -148,7 +148,7 @@ class TestGatedStoreRewrite(unittest.TestCase):
   def test_merge_ifs_alt(self):
     gmem0 = UOp.param(0, dtypes.float.ptr(8))
     gmem1 = UOp.param(1, dtypes.float.ptr(8))
-    gidx0 = UOp(Ops.SPECIAL, dtypes.int, (UOp.const(dtypes.int, 4),), 'gidx0')
+    gidx0 = UOp.hw_idx(4, 'gidx0', dtypes.int)
     idx = gidx0*UOp.const(dtypes.int, 2)
     gate = gidx0<UOp.const(dtypes.int, 1)
     idx0 = UOp(Ops.INDEX, dtypes.float.ptr(8), (gmem0, idx.valid(gate)))
@@ -282,7 +282,7 @@ class TestUOpMethod(unittest.TestCase):
     self.assertEqual(list(var_vals)[0], a.expr)
 
   def test_const_factor(self):
-    gidx0 = UOp(Ops.SPECIAL, dtypes.int, (UOp.const(dtypes.int, 8),), 'gidx0')
+    gidx0 = UOp.hw_idx(8, 'gidx0', dtypes.int)
     self.assertEqual(UOp.const(dtypes.int, 17).const_factor(), 17)
     self.assertEqual(gidx0.const_factor(), 1)
     self.assertEqual((gidx0*3).const_factor(), 3)

--- a/test/null/test_validate_oob.py
+++ b/test/null/test_validate_oob.py
@@ -135,7 +135,7 @@ class TestValidateOOB(unittest.TestCase):
     with Context(CHECK_OOB=1, SPEC=2):
       buf_bool = UOp.param(0, dtypes.bool.ptr(16))
       buf_int = UOp.param(1, dtypes.int.ptr(8))
-      gidx = UOp(Ops.SPECIAL, dtypes.weakint, (UOp.const(dtypes.weakint, 16),), "gidx0")
+      gidx = UOp.hw_idx(16, "gidx0")
       ld_bool = buf_bool.index(gidx, ptr=True).load()
       with self.assertRaises(RuntimeError):
         to_uops_list([buf_int.index(gidx.valid(ld_bool), ptr=True).load()])  # gidx 0..15, buf_int size 8
@@ -149,8 +149,8 @@ class TestValidateOOB(unittest.TestCase):
       sbuf = UOp.placeholder((8,), dtypes.uint, slot=0, addrspace=AddrSpace.LOCAL)
 
       # Define indices, valids and barrier
-      gidx = UOp(Ops.SPECIAL, dtypes.int, (UOp.const(dtypes.int, 416),), "gidx0")
-      lidx = UOp(Ops.SPECIAL, dtypes.int, (UOp.const(dtypes.int, 10),), "lidx0")
+      gidx = UOp.hw_idx(416, "gidx0", dtypes.int)
+      lidx = UOp.hw_idx(10, "lidx0", dtypes.int)
 
       gate = (gidx<400) & (lidx<8)
 

--- a/test/null/test_viz.py
+++ b/test/null/test_viz.py
@@ -823,8 +823,8 @@ class TestCfg(unittest.TestCase):
   def get_cfg(self, name:str, k:Kernel):
     insts = k.finalize()
     def fxn(out:UOp) -> UOp:
-      lidx = UOp.special(1, "lidx0")
-      gidx = UOp.special(1, "gidx0")
+      lidx = UOp.hw_idx(1, "lidx0")
+      gidx = UOp.hw_idx(1, "gidx0")
       sink = UOp.sink(out.base, lidx, gidx, arg=KernelInfo(name=name))
       return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.LINEAR, src=tuple([UOp(Ops.INS, arg=x) for x in insts]))))
     with save_viz() as viz:

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -39,7 +39,7 @@ pm_remove_vec_dtypes = PatternMatcher([
 ])+pm_clean_up_group_sink
 
 def do_number_param(ctx:list[int], x:UOp):
-  if x.arg.slot != -1: return None
+  if x.arg.slot != -1 or x.is_hw_idx: return None
   ctx[0] += 1
   return x.replace(arg=replace(x.arg, slot=ctx[0]-1))
 

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -148,7 +148,7 @@ def full_rewrite_to_sink(ast:UOp, ren:Renderer, optimize:bool=True) -> UOp:
   sink = graph_rewrite(sink, pm_add_control_flow, ctx=CFGContext(sink), name="add control flow", bottom_up=True)
 
   # put unnumbered variable PARAMs in slots
-  num_params = len([x for x in sink.toposort() if x.op is Ops.PARAM and x.arg.slot != -1])
+  num_params = len([x for x in sink.toposort() if x.op is Ops.PARAM and x.arg.slot >= 0])
   sink = graph_rewrite(sink, pm_number_params, ctx=[num_params], name="number params with -1", walk=True)
 
   if VIZ: graph_rewrite(sink, PatternMatcher([]), name="View Output AST")

--- a/tinygrad/codegen/gpudims.py
+++ b/tinygrad/codegen/gpudims.py
@@ -35,7 +35,7 @@ def get_grouped_dims(prefix, dims:tuple[sint, ...], max_sizes:tuple[int, ...]|No
     if len(limited) > len(max_sizes): raise RuntimeError(f"cannot limit dim {dims=}, {max_sizes=}")
     # try to split up dims: (a,) -> (b, c)
     if limited == dims: limited = _split_dims(dims, max_sizes)
-  raw_idxs = [UOp.special(s, f"{prefix}{i}") for i,s in enumerate(limited)]
+  raw_idxs = [UOp.hw_idx(s, f"{prefix}{i}") for i,s in enumerate(limited)]
   if len(limited) < len(dims):
     ret = []
     if (contraction:=get_contraction(dims, limited)) is None: raise RuntimeError(f"get_contraction should not be None {dims=} {limited=}")
@@ -58,7 +58,7 @@ def get_grouped_dims(prefix, dims:tuple[sint, ...], max_sizes:tuple[int, ...]|No
 def add_gpudims(ctx:Renderer, s:UOp):
   if s.arg is None: return None
   s_topo = list(s.toposort())
-  if any(x.op is Ops.SPECIAL for x in s_topo): return None
+  if any(x.is_hw_idx for x in s_topo): return None
 
   # get ranges
   all_ranges = {x.arg[0:-1]:x for x in s_topo if x.op is Ops.RANGE}
@@ -82,7 +82,7 @@ def add_gpudims(ctx:Renderer, s:UOp):
   else:
     # define indexes for GPU-like execution
     local_idxs = get_grouped_dims("lidx", local_shape, ctx.local_max)
-    hw_local = [_dim_max(u.src[0]) for u in local_idxs if u.op is Ops.SPECIAL]
+    hw_local = [_dim_max(u.src[0]) for u in local_idxs if u.is_hw_idx]
     global_max = ctx.global_max if ctx.global_prod_max is None else \
       tuple(min(gm, pm//l) for gm,pm,l in zip(ctx.global_max or ctx.global_prod_max, ctx.global_prod_max, hw_local+[1]*3))
     idxs = get_grouped_dims("gidx", global_shape, global_max, reverse=True) + local_idxs

--- a/tinygrad/codegen/late/linearizer.py
+++ b/tinygrad/codegen/late/linearizer.py
@@ -23,6 +23,7 @@ def linearize(sink:UOp) -> list[UOp]:
     extra = None
     match u.op:
       # the order and placement of these defines is important
+      case Ops.PARAM if u.is_hw_idx: priority = 0
       case Ops.PARAM: priority, extra = -20, u.arg.slot
       case Ops.BUFFER: priority = -17 if u.addrspace == AddrSpace.LOCAL else -18
       case Ops.LOAD: priority = -1    # place loads early

--- a/tinygrad/codegen/late/regalloc.py
+++ b/tinygrad/codegen/late/regalloc.py
@@ -133,5 +133,5 @@ def regalloc_rewrite(ctx:LinearScanRegallocContext, x:UOp):
   return nx, before + [nx] + after
 
 pm_regalloc_rewrite = PatternMatcher([
-  (UPat({Ops.INS, Ops.RANGE, Ops.END, Ops.BUFFER, Ops.PARAM, Ops.SPECIAL} | PSEUDO_OPS, name="x"), regalloc_rewrite),
+  (UPat({Ops.INS, Ops.RANGE, Ops.END, Ops.BUFFER, Ops.PARAM} | PSEUDO_OPS, name="x"), regalloc_rewrite),
 ])

--- a/tinygrad/codegen/opt/postrange.py
+++ b/tinygrad/codegen/opt/postrange.py
@@ -52,9 +52,9 @@ class Scheduler:
     if name_override is not None: name = name_override
     else:
       k_type = "r" if self.reduceop is not None else "E"
-      special_uops = sorted([x for x in self.ast.toposort() if x.op is Ops.SPECIAL], key=lambda x: x.arg)
-      special_ops = [colored(str(x.vmax+1), "blue" if x.arg[0] == "g" else "cyan") for x in special_uops]
-      name = k_type + colored('_', 'BLACK').join(['']+special_ops+[colored(x.src[0].render(), color) for x,color in zip(self.rngs, self.colors())])
+      hw_idx_uops = sorted([x for x in self.ast.toposort() if x.is_hw_idx], key=lambda x: x.arg.hw_dim)
+      hw_idx_ops = [colored(str(x.vmax+1), "blue" if x.arg.hw_dim[0] == "g" else "cyan") for x in hw_idx_uops]
+      name = k_type + colored('_', 'BLACK').join(['']+hw_idx_ops+[colored(x.src[0].render(), color) for x,color in zip(self.rngs, self.colors())])
       Scheduler.kernel_cnt[(function_name := to_function_name(name))] += 1
       num = f"n{Scheduler.kernel_cnt[function_name]-1}" if Scheduler.kernel_cnt[function_name] > 1 else ""
       name += colored(num, 'BLACK')

--- a/tinygrad/renderer/__init__.py
+++ b/tinygrad/renderer/__init__.py
@@ -40,11 +40,11 @@ class Estimates:
       if u.op is Ops.RANGE:
         mult_stack.append(mults)
         mults *= cast(sint, u.src[0].ssimplify())
-        # SPECIAL are already counted in mults
-        mults = mults.substitute({x:x.const_like(0) for x in mults.toposort() if x.op is Ops.SPECIAL}) if isinstance(mults, UOp) else mults
+        # hw index PARAMs are already counted in mults
+        mults = mults.substitute({x:x.const_like(0) for x in mults.toposort() if x.is_hw_idx}) if isinstance(mults, UOp) else mults
       elif u.op is Ops.END: mults = mult_stack.pop(-1)
-      elif u.op is Ops.SPECIAL: mults *= cast(sint, u.src[0].ssimplify()) # NOTE: we don't push to the mult_stack here, you can't end these
-      elif u.op is Ops.PARAM and u.arg.addrspace == AddrSpace.ALU and u.expr == 'core_id': mults *= int(u.vmax) + 1
+      elif u.is_hw_idx: mults *= cast(sint, u.src[0].ssimplify()) # NOTE: we don't push to the mult_stack here, you can't end these
+      elif u.op is Ops.PARAM and u.arg.addrspace == AddrSpace.ALU and not u.is_hw_idx and u.expr == 'core_id': mults *= int(u.vmax) + 1
       elif u.op is Ops.LOAD and u.src[0].addrspace != AddrSpace.REG:
         lds += u.max_numel() * u.dtype.scalar().itemsize * mults
       elif u.op is Ops.STORE and u.src[0].addrspace != AddrSpace.REG:
@@ -65,8 +65,8 @@ class Renderer:
   has_shared: bool = True
   has_aux: bool = False # additional program info, eg. image shapes
   # NOTE: these two should be in (x,y,z) order to match the max_sizes argument in get_grouped_dims
-  global_max: tuple[int, ...]|None = (0x8FFFFFFF,) * (3) # TODO: Ops.SPECIAL int32 indexes right now
-  local_max: tuple[int, ...]|None = (0x8FFFFFFF,) * (3) # TODO: Ops.SPECIAL int32 indexes right now
+  global_max: tuple[int, ...]|None = (0x8FFFFFFF,) * (3) # TODO: hw index PARAM int32 indexes right now
+  local_max: tuple[int, ...]|None = (0x8FFFFFFF,) * (3) # TODO: hw index PARAM int32 indexes right now
   global_prod_max: tuple[int, ...]|None = None
   shared_max: int = 32768
   tensor_cores: list[TensorCore] = []

--- a/tinygrad/renderer/amd/elf.py
+++ b/tinygrad/renderer/amd/elf.py
@@ -37,10 +37,11 @@ def assemble_linear(prg:UOp, lin:UOp, arch:str) -> bytes:
   # ** scan sink for metadata
   sink, n_bufs, n_vars, lds_size, gids = prg.src[0], 0, 0, 0, set()
   for u in sink.toposort():
-    if u.op is Ops.PARAM and u.addrspace is AddrSpace.ALU: n_vars += 1
+    if u.is_hw_idx:
+      if u.arg.hw_dim.startswith("gidx"): gids.add(int(u.arg.hw_dim[-1]))
+    elif u.op is Ops.PARAM and u.addrspace is AddrSpace.ALU: n_vars += 1
     elif u.op is Ops.PARAM: n_bufs += 1
     elif u.op is Ops.BUFFER and u.addrspace is AddrSpace.LOCAL: lds_size += u.ptrdtype.size * u.ptrdtype.base.itemsize
-    elif u.op is Ops.SPECIAL and u.arg.startswith("gidx"): gids.add(int(u.arg[-1]))
   code_bytes = b"".join(inst.to_bytes() for inst in insts)
   arch = next(v for k, v in _arch_map.items() if arch.startswith(k))
   is_cdna, is_rdna4 = arch == "cdna", arch == "rdna4"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -27,7 +27,8 @@ base_rewrite = PatternMatcher([
 
   # GPU stuff
   (UPat(Ops.BARRIER), lambda ctx: ctx.barrier),
-  (UPat(Ops.SPECIAL, name="x"), lambda ctx,x: f"{ctx.code_for_workitem[x.arg[0]](x.arg[-1])}; /* {(x.src[0]).render()} */"),
+  (UPat(Ops.PARAM, name="x"), lambda ctx,x: f"{ctx.code_for_workitem[x.arg.hw_dim[0]](x.arg.hw_dim[-1])}; /* {(x.src[0]).render()} */"
+   if x.is_hw_idx else None),
 
   # const
   (UPat(Ops.CONST, arg=math.inf, name="x"), lambda ctx, x: f"({ctx.render_cast(x, ctx.infinity)})"),
@@ -144,7 +145,7 @@ class CStyleLanguage(Renderer):
       tmp = "const sampler_t smp = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;\n"
     buftypes = [(name, self._render_dtype(u.dtype, sz=1, addrspace=u.addrspace, mutable=mutable)+self.buffer_suffix \
                  if u.addrspace == AddrSpace.GLOBAL else self.arg_int_prefix if u.dtype == dtypes.int else None) for name,(u,mutable) in bufs]
-    local_dims = [u.src[0] for u in uops if u.op is Ops.SPECIAL and u.arg[0] == "l"]
+    local_dims = [u.src[0] for u in uops if u.is_hw_idx and u.arg.hw_dim[0] == "l"]
     launch_bounds = prod([d.vmax for d in local_dims])
     prg = ''.join([f"{self.kernel_typedef.format(launch_bounds=launch_bounds)} {function_name}(",] +
     [', '.join([f'{t} {name}' for name,t in buftypes] + self.extra_args)] +
@@ -209,14 +210,14 @@ class CStyleLanguage(Renderer):
       if u.op is Ops.SINK:
         if u.arg is not None: name = u.arg.function_name
         continue
-      if u.op is Ops.PARAM:
+      if u.op is Ops.PARAM and not u.is_hw_idx:
         r[u] = f"data{u.arg.slot}_" + '_'.join([str(x) for x in u.shape])
         bufs[u] = (r[u], (u, u in writable_params))
         continue
 
       # naming
       prefix = None
-      if u.op is Ops.SPECIAL: r[u] = u.arg
+      if u.is_hw_idx: r[u] = u.arg.hw_dim
       elif u.op is Ops.RANGE: r[u] = f"{axis_letters[u.arg[-1]]}idx"+range_str(u)
       else:
         prefix = {Ops.WMMA: "wmma", Ops.CONST: "const", Ops.BUFFER: "buf", Ops.CAST: "cast", Ops.BITCAST: "cast", Ops.STACK: "cast",
@@ -234,7 +235,7 @@ class CStyleLanguage(Renderer):
         r[u] = l
       else:
         if u.op not in {Ops.RANGE, Ops.STORE, Ops.BUFFER} and u.dtype != dtypes.void:
-          l = f"{self.render_type(u)} {r[u]} = {l}" + (";" if u.op is not Ops.SPECIAL else "")
+          l = f"{self.render_type(u)} {r[u]} = {l}" + (";" if not u.is_hw_idx else "")
         kernel.append("  "*depth + l)
         if prefix: c[prefix] += 1  # if it was used, increment
       if u.op in {Ops.IF, Ops.RANGE}: depth += 1
@@ -328,7 +329,7 @@ class OpenCLRenderer(CStyleLanguage):
 
   def aux(self, uops:list[UOp]):
     arg_dtypes:list[list[tuple[int, DType]]] = []
-    for i,u in enumerate(u for u in uops if u.op is Ops.PARAM):
+    for i,u in enumerate(u for u in uops if u.op is Ops.PARAM and not u.is_hw_idx):
       while len(arg_dtypes) <= u.arg.slot: arg_dtypes.append([])
       arg_dtypes[u.arg.slot].append((i, u.dtype))
     return tuple(tuple(a) for a in arg_dtypes),
@@ -536,7 +537,7 @@ class HIPRenderer(CStyleLanguage):
     used_dtypes = uops_to_dtypes(uops)
     if any(u.op is Ops.CONST and not math.isfinite(u.arg) for u in uops):
       prefix += ["#define INFINITY (__builtin_inff())", "#define NAN (__builtin_nanf(\"\"))"]
-    if any(u.op is Ops.SPECIAL for u in uops):
+    if any(u.is_hw_idx for u in uops):
       prefix.append("typedef long unsigned int size_t;")
       ockl = [(f"__ockl_get_{name}", "unsigned int", "size_t", "const") for name in ["local_id", "group_id", "local_size"]]
     ocml_ops = {Ops.EXP2: ("exp2", "pure"), Ops.LOG2: ("log2", "pure"), Ops.SQRT: ("sqrt", "const"), Ops.SIN: ("sin", ""), Ops.TRUNC: ("trunc", "")}

--- a/tinygrad/renderer/isa/__init__.py
+++ b/tinygrad/renderer/isa/__init__.py
@@ -18,9 +18,9 @@ class IselContext:
     self.uses = consumer_map_from_toposort(sink.toposort())
     self.reg_n = itertools.count()
     def arg_key(u:UOp):
-      if u.op is Ops.SPECIAL: return (2, u.arg)
+      if u.is_hw_idx: return (2, u.arg.hw_dim)
       return (0, u.arg.slot) if u.arg.addrspace is not None else (1, u.expr)
-    self.func_args = sorted([u for u in self.uses if u.op in {Ops.PARAM, Ops.SPECIAL}], key=arg_key)
+    self.func_args = sorted([u for u in self.uses if u.op is Ops.PARAM], key=arg_key)
 
   def vreg(self, cons:tuple[Register, ...]|Register):
     return Register(f"v{next(self.reg_n)}", 0, _cons=cons if isinstance(cons, tuple) else (cons,))

--- a/tinygrad/renderer/isa/x86.py
+++ b/tinygrad/renderer/isa/x86.py
@@ -403,7 +403,7 @@ isel_matcher = PatternMatcher([
    x.replace(src=(x.ins(X86Ops.RET, src=x.src + tuple(def_reg(dtypes.uint64 if r in GPR else dtypes.float64.vec(2), r) for r in CALLEE_SAVED)),)) \
     if not x.src or x.src[0].arg is not X86Ops.RET else None),
   # function abi constraints
-  (UPat((Ops.PARAM, Ops.SPECIAL), name="x"), abi),
+  (UPat(Ops.PARAM, name="x"), abi),
   # constants that can't be immediates, move them to registers
   (UPat.cvar("x", dtypes.int64s), lambda x: x.ins(X86Ops.MOVABS, src=(imm(x.dtype, x.arg),)) if not x.tag else None),
   (UPat.cvar("x", dtypes.ints+(dtypes.bool,)), lambda x: x.ins(X86Ops.MOVi, src=(imm(x.dtype, x.arg),)) if not x.tag else None),

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -146,7 +146,7 @@ class LLVMRenderer(Renderer):
       if u.op is Ops.SINK:
         if u.arg is not None: name = u.arg.function_name
         continue
-      if u.op is Ops.PARAM:
+      if u.op is Ops.PARAM and not u.is_hw_idx:
         r[u] = f"%data{u.arg.slot}"
         args.append((r[u], u))
       elif u.op is Ops.BUFFER:
@@ -206,7 +206,7 @@ class AMDLLVMRenderer(LLVMRenderer):
   abi = "amdgpu_kernel"
   code_for_op = {**LLVMRenderer.code_for_op, **{op: lambda: None for op in llvm_intrinsics}}
   string_rewrite = PatternMatcher([
-    (UPat(Ops.SPECIAL, name="x"), lambda ctx, x: f"  {ctx[x]} = " + f"{ code_for_workitem[x.arg[0]](x.arg[-1])}; "),
+    (UPat(Ops.PARAM, name="x"), lambda ctx, x: f"  {ctx[x]} = {code_for_workitem[x.arg.hw_dim[0]](x.arg.hw_dim[-1])};" if x.is_hw_idx else None),
     (UPat(tuple(llvm_intrinsics), name="x"),
     lambda ctx, x: f"  {ctx[x]} = call {ldt(x.dtype)} @llvm.{llvm_intrinsics[x.op]}.{ldt(x.dtype.scalar())}({ldt(x.src[0].dtype)} {ctx[x.src[0]]})"),
     (UPat(Ops.BARRIER), lambda ctx: barrier),
@@ -243,7 +243,7 @@ exit: %packed = phi i32 [%packed_bf8, %do_bf8], [%packed_fp8, %do_fp8]\n  %trunc
     return "\n".join((k:=self._render_kernel(uops, prefix))[0] + (k[1], self._render_footer(uops)))
   def _render_footer(self, uops: list[UOp]) -> str:
     # TODO: this is copied from cstyle
-    local_dims = [u.src[0] for u in uops if u.op is Ops.SPECIAL and u.arg[0] == "l"]
+    local_dims = [u.src[0] for u in uops if u.is_hw_idx and u.arg.hw_dim[0] == "l"]
     requiredMaxThreadsPerBlock = prod([d.vmax for d in local_dims])
     attributes = ["alwaysinline", "nounwind", '"no-builtins"',
                   f'"amdgpu-flat-work-group-size"="1,{requiredMaxThreadsPerBlock}"', '"no-trapping-math"="true"']

--- a/tinygrad/renderer/nir.py
+++ b/tinygrad/renderer/nir.py
@@ -145,8 +145,9 @@ class NIRRenderer(Renderer):
 
   def_rewrite = PatternMatcher([
     (UPat(Ops.CONST, name="x"), lambda ctx,x: nimm(ctx.b, x.arg, x.dtype)),
+    (UPat(Ops.PARAM, name="x"), lambda ctx,x: nchannel(ctx.b, {'g':ngid, 'l':nlid, 'i': nid}[x.arg.hw_dim[0]](ctx.b), int(x.arg.hw_dim[-1]))
+     if x.is_hw_idx else None),
     (UPat(Ops.PARAM, name="x"), lambda ctx,x: ctx.param(ctx.b, x, x.dtype.itemsize if x.addrspace is AddrSpace.ALU else 8)),
-    (UPat(Ops.SPECIAL, name="x"), lambda ctx,x: nchannel(ctx.b, {'g':ngid, 'l':nlid, 'i': nid}[x.arg[0]](ctx.b), int(x.arg[-1]))),
     (UPat(Ops.STORE, src=(UPat((Ops.INDEX, Ops.SHRINK), src=(UPat.var("buf"),UPat.var("off")), allow_any_len=True), UPat.var("val"))),
      lambda ctx,buf,off,val: nstore(ctx.b, buf.addrspace, nidx(ctx.b, ctx.r[buf], ctx.r[off], buf.addrspace, buf.dtype.itemsize), ctx.r[val])),
     (UPat(Ops.LOAD, src=(UPat((Ops.INDEX, Ops.SHRINK), src=(UPat.var("buf"), UPat.var("off")), allow_any_len=True), UPat.var("alt"),
@@ -180,12 +181,13 @@ class NIRRenderer(Renderer):
   def param(self, b:mesa.nir_builder, x, sz:int) -> mesa.nir_def: raise NotImplementedError("needs param")
   def prerender(self, uops:list[UOp]):
     self.b = mesa.nir_builder_init_simple_shader(mesa.MESA_SHADER_COMPUTE, mesa.nir_shader_compiler_options.from_buffer_copy(self.nir_options), None)
-    self.b.shader.contents.info.workgroup_size_variable = any([u.op == Ops.SPECIAL and u.arg[0] == 'i' for u in uops])
+    self.b.shader.contents.info.workgroup_size_variable = any([u.is_hw_idx and u.arg.hw_dim[0] == 'i' for u in uops])
   def postrender(self, uops:list[UOp]): pass
 
   def render(self, uops:list[UOp]):
     self.prerender(uops)
-    for u in [u for u in uops if u.op is Ops.SPECIAL and u.arg[0] == "l"]: self.b.shader.contents.info.workgroup_size[int(u.arg[-1])] = u.src[0].arg
+    for u in [u for u in uops if u.is_hw_idx and u.arg.hw_dim[0] == "l"]:
+      self.b.shader.contents.info.workgroup_size[int(u.arg.hw_dim[-1])] = u.src[0].arg
     self.r: dict[UOp, Any] = {}
     self.param_idx, ranges = 0, []
 

--- a/tinygrad/renderer/ptx.py
+++ b/tinygrad/renderer/ptx.py
@@ -81,7 +81,9 @@ def modifier(a: DType, b: DType): return '.rzi' if dtypes.is_int(a) and dtypes.i
 string_rewrite = PatternMatcher([
   (UPat.cvar("x", dtypes.bool), lambda ctx, x: f"setp.ne.s16 {ctx.r[x]}, {render_val(x.arg, x.dtype)}, 0;"),
   (UPat.cvar("x"), lambda ctx, x: f"mov.b{ctx.types[x.dtype][1:]} {ctx.r[x]}, {render_val(x.arg, x.dtype)};"),
-  (UPat(Ops.SPECIAL, name="x"), lambda ctx,x: f"mov.u32 %{x.arg}, %{'ctaid' if x.arg[0] == 'g' else 'tid'}.{chr(120+int(x.arg[-1]))};"),
+  (UPat(Ops.PARAM, name="x"), lambda ctx,x:
+   f"mov.u32 %{x.arg.hw_dim}, %{'ctaid' if x.arg.hw_dim[0] == 'g' else 'tid'}.{chr(120+int(x.arg.hw_dim[-1]))};"
+   if x.is_hw_idx else None),
   (UPat(Ops.PARAM, name="x"), lambda ctx, x:
    f"ld.param.{ctx.types[dtypes.ulong] if x.addrspace is AddrSpace.GLOBAL else ctx.mem_types[x.dtype]} {ctx.r[x]}, [data{x.arg.slot}+0];"),
   # address computation: addr = buf + idx*itemsize
@@ -159,7 +161,7 @@ class PTXRenderer(Renderer):
   def render_kernel(self, kernel, function_name, bufs, regs, uops) -> str:
     def fmt(line): return line if line[0]=="$" else "\t" + line.replace(" ", "\t" if len(line.split(" ")[0]) > 7 else "\t\t", 1)
     kernel = '\n'.join(map(fmt, [f".reg .{reg.split('_')[-2]} %{reg}<{cnt}>;" for reg,cnt in regs] + kernel + ["ret;"]))
-    local_dims = [u.src[0] for u in uops if u.op is Ops.SPECIAL and u.arg[0] == "l"]
+    local_dims = [u.src[0] for u in uops if u.is_hw_idx and u.arg.hw_dim[0] == "l"]
     launch_bounds = prod([d.vmax for d in local_dims])
     params = ',\n\t'.join([f".param .{'u64' if u.addrspace is AddrSpace.GLOBAL else self.types[u.dtype]} {name}" for name,u in bufs])
     return f"{self.kernel_prefix.format(launch_bounds=launch_bounds)} {function_name} (\n\t{params}\n)\n.maxntid {launch_bounds}\n{{\n{kernel}\n}}"
@@ -198,7 +200,7 @@ class PTXRenderer(Renderer):
         # on REG, INDEX/SHRINK pick the register (must be CONST) and LOAD is a noop
         r[u] = r[u.src[0]] if u.op is Ops.LOAD else r[u.src[0]][u.src[1].arg]
         continue
-      if u.op is Ops.SPECIAL: r[u] = "%" + u.arg
+      if u.is_hw_idx: r[u] = "%" + u.arg.hw_dim
       elif u.op is Ops.LOAD:
         r[u] = [ssa('val', dtype=self.types[u.dtype.scalar()]) for _ in range(u.max_numel())] if u.max_numel() > 1 else ssa('val', u)
       elif u.op is Ops.PARAM: bufs.append((f"data{u.arg.slot}", u))
@@ -208,9 +210,12 @@ class PTXRenderer(Renderer):
                        [ssa("wmma_in", dtype="b32") for _ in range(0, len(r[u.src[1]]), 4 // u.src[0].dtype.scalar().itemsize)],
                        [ssa("wmma_acc", dtype="b32") for _ in range(0, len(r[u.src[2]]), 4 // u.dtype.scalar().itemsize)]]
         r[u] = [ssa("wmma", dtype=self.types[u.dtype.scalar()]) for _ in range(u.max_numel())]
-      prefix, dtype = {Ops.CAST: ("cast", None), Ops.BITCAST: ("cast", None), Ops.END: ("pred", "pred"), Ops.RANGE: ("ridx", None),
+      prefix, dtype = {
+        Ops.CAST: ("cast", None), Ops.BITCAST: ("cast", None), Ops.END: ("pred", "pred"), Ops.RANGE: ("ridx", None),
         Ops.CONST: ("const", None), Ops.BUFFER: ("local", "u64"), Ops.INDEX: ("bidx", "u64"), Ops.SHRINK: ("bidx", "u64"),
-        Ops.PARAM: ("dat", "u64" if u.addrspace is AddrSpace.GLOBAL else None), **{op: ("alu", None) for op in GroupOp.ALU}}.get(u.op, (None, None))
+        Ops.PARAM: ("dat", "u64" if u.addrspace is AddrSpace.GLOBAL else None) if not u.is_hw_idx else (None, None),
+        **{op: ("alu", None) for op in GroupOp.ALU}
+      }.get(u.op, (None, None))
       if prefix: r[u] = ssa(prefix, u, dtype)
 
       l: str|list[str]|None = string_rewrite.rewrite(u, ctx=self)
@@ -218,7 +223,7 @@ class PTXRenderer(Renderer):
         raise RuntimeError(f"failed to render {u.op} with {u.dtype} srcs {[x.dtype for x in u.src]}")
       kernel.extend([l] if isinstance(l, str) else l)
 
-      if u.op is Ops.SPECIAL: kernel = [f".reg .u32 %{u.arg};"] + kernel
+      if u.is_hw_idx: kernel = [f".reg .u32 %{u.arg.hw_dim};"] + kernel
     return self.render_kernel(kernel, name, bufs, c.items(), uops)
 
   def supported_dtypes(self): return {d for d in super().supported_dtypes()

--- a/tinygrad/renderer/wgsl.py
+++ b/tinygrad/renderer/wgsl.py
@@ -99,7 +99,9 @@ class WGSLRenderer(CStyleLanguage):
   def render_load(self, x:str, u:UOp) -> str: return f"atomicLoad(&{x})" if is_packed(u) else x
   def buf_map(self, u:UOp) -> str: return "atomic<u32>" if is_packed(u) else self.type_map[u.dtype.base]
   def render_kernel(self, function_name:str, kernel:list[str], bufs:list[tuple[str,tuple[UOp,bool]]], uops:list[UOp], prefix=None) -> str:
-    local_size = [u.src[0].ssimplify() for u in sorted([u for u in uops if u.op is Ops.SPECIAL and u.arg[0] == 'l'], key=lambda u: u.arg)]
+    local_size = [u.src[0].ssimplify() for u in sorted(
+      [u for u in uops if u.is_hw_idx and u.arg.hw_dim[0] == 'l'],
+      key=lambda u: u.arg.hw_dim)]
     if not local_size: local_size = [1]
     bind_it = iter(range(len(bufs)))
     external_local_bufs = [line.lstrip() for line in kernel if "var<workgroup>" in line]

--- a/tinygrad/renderer/wgsl.py
+++ b/tinygrad/renderer/wgsl.py
@@ -99,9 +99,7 @@ class WGSLRenderer(CStyleLanguage):
   def render_load(self, x:str, u:UOp) -> str: return f"atomicLoad(&{x})" if is_packed(u) else x
   def buf_map(self, u:UOp) -> str: return "atomic<u32>" if is_packed(u) else self.type_map[u.dtype.base]
   def render_kernel(self, function_name:str, kernel:list[str], bufs:list[tuple[str,tuple[UOp,bool]]], uops:list[UOp], prefix=None) -> str:
-    local_size = [u.src[0].ssimplify() for u in sorted(
-      [u for u in uops if u.is_hw_idx and u.arg.hw_dim[0] == 'l'],
-      key=lambda u: u.arg.hw_dim)]
+    local_size = [u.src[0].ssimplify() for u in sorted([u for u in uops if u.is_hw_idx and u.arg.hw_dim[0] == 'l'],key=lambda u: u.arg.hw_dim)]
     if not local_size: local_size = [1]
     bind_it = iter(range(len(bufs)))
     external_local_bufs = [line.lstrip() for line in kernel if "var<workgroup>" in line]

--- a/tinygrad/runtime/ops_python.py
+++ b/tinygrad/runtime/ops_python.py
@@ -85,6 +85,9 @@ class PythonProgram:
           i += 1
           continue
         if u.op is Ops.AFTER: values[u] = src_values[0]
+        elif u.is_hw_idx:
+          if u.arg.hw_dim[0] == 'g': values[u] = [idxs[2-int(u.arg.hw_dim[-1])]] * warp_size
+          elif u.arg.hw_dim[0] == 'l': values[u] = [x[2-int(u.arg.hw_dim[-1])] for x in warp]
         elif u.op is Ops.PARAM and u.addrspace is AddrSpace.ALU: values[u] = [pvals.pop(0)] * warp_size
         elif u.op in {Ops.PARAM, Ops.BUFFER}:
           storage_fmt = storage_fmt_for_dtype(u.dtype.base.scalar())
@@ -96,9 +99,6 @@ class PythonProgram:
           else:
             buf = memoryview(bytearray(u.max_numel()*u.dtype.itemsize)) if u.op is not Ops.PARAM else pbufs.pop(0)
             values[u] = [buf.cast(storage_fmt)] * warp_size
-        elif u.op is Ops.SPECIAL:
-          if u.arg[0] == 'g': values[u] = [idxs[2-int(u.arg[-1])]] * warp_size
-          elif u.arg[0] == 'l': values[u] = [x[2-int(u.arg[-1])] for x in warp]
         elif u.op is Ops.CONST: values[u] = [u.arg] * warp_size
         elif u.op in {Ops.INDEX, Ops.SHRINK}:
           ret:list = []

--- a/tinygrad/uop/__init__.py
+++ b/tinygrad/uop/__init__.py
@@ -11,13 +11,10 @@ class FastEnum(IntEnum):
 
 # the order of these Ops controls the order of the toposort
 class Ops(FastEnum):
-  # ** 1 -- defines/special **
+  # ** 1 -- defines **
 
   # BIND pairs a symbolic PARAM with a concrete value
   BIND = auto()
-
-  # this is a RANGE for GPU dimensions, similar to symbolic shapes but not exactly
-  SPECIAL = auto()
 
   # BUFFER allocates global/local/register storage depending on its addrspace
   BUFFER = auto()
@@ -121,7 +118,7 @@ class GroupOp:
 
   Defines = {Ops.PARAM, Ops.BUFFER}
 
-  Irreducible = {Ops.CONST, Ops.SPECIAL, Ops.RANGE, Ops.PARAM}
+  Irreducible = {Ops.CONST, Ops.RANGE, Ops.PARAM}
   Movement = {Ops.RESHAPE, Ops.EXPAND, Ops.PERMUTE, Ops.PAD, Ops.SHRINK, Ops.FLIP}
 
   # BinaryOps that can be flipped

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -27,7 +27,7 @@ class ParamArg:
   addrspace: AddrSpace|None = AddrSpace.GLOBAL
   axis: int|None = None
   device: str|tuple[str, ...]|None = None
-  hw_dim: str|None = None # hardware indices are represented as PARAMs with hw_dim set
+  hw_dim: str|None = None
   def __repr__(self):
     fields = (("vmin_vmax", None), ("name", None), ("addrspace", AddrSpace.GLOBAL), ("axis", None), ("device", None), ("hw_dim", None))
     args = [repr(self.slot)] + [f"{k}={v!r}" for k,default in fields if (v:=getattr(self, k)) != default]
@@ -214,7 +214,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
 
   @functools.cached_property
   def tuplize(self:UOp) -> tuple:
-    return (self.op.value, repr(self.arg), self.dtype,)+tuple([x.tuplize for x in self.src])
+    return (self.op.value, self.arg, self.dtype,)+tuple([x.tuplize for x in self.src])
 
   @property
   def ptrdtype(self) -> PtrDType:
@@ -568,7 +568,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
   @staticmethod
   def hw_idx(end:sint, name:str, dtype=dtypes.weakint):
     return UOp(Ops.PARAM, dtype=dtype, src=(sint_to_uop(end, dtype),),
-               arg=ParamArg(slot=-1, addrspace=AddrSpace.ALU, hw_dim=name))
+               arg=ParamArg(slot=-2, addrspace=AddrSpace.ALU, hw_dim=name))
   def _rop(self, op:Ops, axis:tuple[int, ...]):
     axis = tuple(sorted([x for x in axis if resolve(self.shape[x] != 1)]))
     return UOp(Ops.REDUCE, self.dtype, (self,), (op, axis)) if len(axis) else self

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -27,8 +27,9 @@ class ParamArg:
   addrspace: AddrSpace|None = AddrSpace.GLOBAL
   axis: int|None = None
   device: str|tuple[str, ...]|None = None
+  hw_dim: str|None = None # hardware indices are represented as PARAMs with hw_dim set
   def __repr__(self):
-    fields = (("vmin_vmax", None), ("name", None), ("addrspace", AddrSpace.GLOBAL), ("axis", None), ("device", None))
+    fields = (("vmin_vmax", None), ("name", None), ("addrspace", AddrSpace.GLOBAL), ("axis", None), ("device", None), ("hw_dim", None))
     args = [repr(self.slot)] + [f"{k}={v!r}" for k,default in fields if (v:=getattr(self, k)) != default]
     return f"ParamArg({', '.join(args)})"
 axis_letters = {AxisType.GLOBAL: "g", AxisType.THREAD: "t", AxisType.LOCAL: "l", AxisType.WARP: "w", AxisType.LOOP: "L", AxisType.UPCAST: "u",
@@ -213,7 +214,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
 
   @functools.cached_property
   def tuplize(self:UOp) -> tuple:
-    return (self.op.value, self.arg, self.dtype,)+tuple([x.tuplize for x in self.src])
+    return (self.op.value, repr(self.arg), self.dtype,)+tuple([x.tuplize for x in self.src])
 
   @property
   def ptrdtype(self) -> PtrDType:
@@ -277,7 +278,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
 
       # some ops init the shape
       case Ops.GETADDR: return ()
-      case Ops.BIND | Ops.RANGE | Ops.SPECIAL: return ()
+      case Ops.BIND | Ops.RANGE: return ()
       case Ops.BINARY: return (len(self.arg),)
       case Ops.BUFFER:
         if len(self.src): return self.src[0].as_shape
@@ -292,6 +293,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
         # STAGE adds the existing shape to the front, opposite of INDEX
         return tuple([int(r.vmax+1) for r in self.src[1:]])+self.src[0].shape
       case Ops.PARAM:
+        if self.is_hw_idx: return ()
         if isinstance(self.dtype, ImageDType): return self.dtype.shape
         if isinstance(self.dtype, PtrDType): return (self.ptrdtype.size,)
         return self.src[0].as_shape if len(self.src) >= 1 else None
@@ -564,7 +566,9 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
   def range(end:sint, axis_id, axis_type=AxisType.LOOP, *arg, dtype=dtypes.weakint, src=(), **kwargs):
     return UOp(Ops.RANGE, dtype=dtype, src=(sint_to_uop(end, dtype),)+src, arg=(axis_id, axis_type)+arg, **kwargs)
   @staticmethod
-  def special(end:sint, name:str, dtype=dtypes.weakint): return UOp(Ops.SPECIAL, dtype=dtype, src=(sint_to_uop(end, dtype),), arg=name)
+  def hw_idx(end:sint, name:str, dtype=dtypes.weakint):
+    return UOp(Ops.PARAM, dtype=dtype, src=(sint_to_uop(end, dtype),),
+               arg=ParamArg(slot=-1, addrspace=AddrSpace.ALU, hw_dim=name))
   def _rop(self, op:Ops, axis:tuple[int, ...]):
     axis = tuple(sorted([x for x in axis if resolve(self.shape[x] != 1)]))
     return UOp(Ops.REDUCE, self.dtype, (self,), (op, axis)) if len(axis) else self
@@ -784,7 +788,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
   def addrspace(self) -> AddrSpace|None:
     if self.op is Ops.PARAM: return self.arg.addrspace
     if self.op is Ops.BUFFER: return self.arg.addrspace
-    if self.op in {Ops.SPECIAL, Ops.RANGE}: return AddrSpace.ALU
+    if self.op is Ops.RANGE: return AddrSpace.ALU
     if self.op is Ops.LOAD: return AddrSpace.ALU # LOAD brings things into the ALU
     if self.op in {Ops.INDEX, Ops.CAST, Ops.AFTER, Ops.REDUCE, Ops.GEP, Ops.STORE, Ops.MSTACK, Ops.MSELECT}:
       return self.src[0].addrspace
@@ -794,6 +798,8 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
       if not len(ad) or not all_same(ad): return None
       return ad[0]
     return None
+  @property
+  def is_hw_idx(self) -> bool: return self.op is Ops.PARAM and self.arg.hw_dim is not None
   @property
   def buf_uop(self) -> UOp:
     if self.op in {Ops.BUFFER, Ops.PARAM}: return self
@@ -912,7 +918,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
   @property
   def val(self) -> int: return self.unbind()[1]
   def variables(self) -> list[Variable]:
-    return sorted({x for x in self.backward_slice_with_self if x.op is Ops.PARAM and x.arg.addrspace is AddrSpace.ALU},
+    return sorted({x for x in self.backward_slice_with_self if x.op is Ops.PARAM and x.arg.addrspace is AddrSpace.ALU and not x.is_hw_idx},
                   key=lambda v: v.expr)
 
   # *** uop symbolic stuff ***
@@ -1000,7 +1006,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
     if self.op is Ops.WHERE and dtypes.is_int(self.dtype): return min(self.src[1].vmin, self.src[2].vmin), max(self.src[1].vmax, self.src[2].vmax)
     # NOTE: returned UOp is assumed to be CONST
     if self.op is Ops.PARAM and self.arg.vmin_vmax is not None: return self.arg.vmin_vmax
-    if self.op in (Ops.RANGE, Ops.SPECIAL): return 0, (self.src[0]-1).vmax
+    if self.op is Ops.RANGE or self.is_hw_idx: return 0, (self.src[0]-1).vmax
     if self.op is Ops.BIND: return self.src[0]._min_max # ignore the bound value
     if self.op in {Ops.UNROLL, Ops.STACK}: return min(x.vmin for x in self.src), max(x.vmax for x in self.src)
     if self.op is Ops.CONST and self.arg is not Invalid: return self.arg, self.arg
@@ -1014,7 +1020,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
   def _sym_fxn(self):
     from tinygrad.uop.render import _render_with_splits, renderer_infer
     sself = self.simplify()
-    varnames = tuple(dedup(x.expr for x in sself.toposort() if x.op is Ops.PARAM and x.arg.addrspace == AddrSpace.ALU))
+    varnames = tuple(dedup(x.expr for x in sself.toposort() if x.op is Ops.PARAM and x.arg.addrspace == AddrSpace.ALU and not x.is_hw_idx))
     # TODO: sanitize varnames, or don't use naked eval while staying fast
     ret = _render_with_splits(list(sself.toposort()), renderer_infer, {sself})
     lines = [f"  {k}={v}" for k,v in ret.items() if k != "ast"] + [f"  return {ret['ast']}"]
@@ -1133,15 +1139,15 @@ class ProgramInfo:
     global_size: list[int] = [1, 1, 1]
     local_size: list[int]|None = [1, 1, 1]
     for u in sink.toposort():
-      if u.op is Ops.PARAM and u.addrspace == AddrSpace.ALU: _vars.append(u)
-      if u.op is Ops.PARAM and u.addrspace != AddrSpace.ALU: _globals.append(u.arg.slot)
+      if u.op is Ops.PARAM and u.addrspace == AddrSpace.ALU and not u.is_hw_idx: _vars.append(u)
+      if u.op is Ops.PARAM and u.addrspace != AddrSpace.ALU and not u.is_hw_idx: _globals.append(u.arg.slot)
       if u.op in (Ops.STORE, Ops.LOAD):
         if (idx:=u.src[0]).op in (Ops.INDEX, Ops.SHRINK) or (u.src[0].op is Ops.CAST and (idx:=u.src[0].src[0]).op is Ops.INDEX):
           if (buf:=idx.src[0].buf_uop).op is Ops.PARAM: (outs if u.op is Ops.STORE else ins).append(buf.arg.slot)
-      if u.op is Ops.SPECIAL:
-        if u.arg[0] == 'i': local_size = None
-        special_size = local_size if u.arg[0] == 'l' else global_size
-        if special_size is not None: special_size[int(u.arg[-1])] = cast(int, u.src[0].ssimplify())
+      if u.is_hw_idx:
+        if u.arg.hw_dim[0] == 'i': local_size = None
+        hw_idx_size = local_size if u.arg.hw_dim[0] == 'l' else global_size
+        if hw_idx_size is not None: hw_idx_size[int(u.arg.hw_dim[-1])] = cast(int, u.src[0].ssimplify())
       if u.op is Ops.PARAM and u in _vars and u.expr == 'core_id': global_size[0] = int(u.vmax) + 1
     return ProgramInfo(sink.arg.name if isinstance(sink.arg, KernelInfo) else "test", tuple(global_size),
                        tuple(local_size) if local_size is not None else None, tuple(sorted(dedup(_vars), key=lambda v: v.arg.slot)),
@@ -1659,11 +1665,11 @@ pm_lower_index_dtype = PatternMatcher([
   (UPat(Ops.RANGE, src=(UPat.var("end").cast(dtypes.weakint)), name="r"), lambda r,end: r.replace(dtype=end.dtype, src=(end,)).cast(dtypes.weakint)),
   (UPat(Ops.STACK, src=UPat().cast(dtypes.weakint), name="v"),
     lambda v: v.replace(dtype=(dt:=select_dtype(v)), src=tuple(s.src[0].cast(dt.scalar()) for s in v.src)).cast(dtypes.weakint)),
-  # special can only be int32
-  (UPat(Ops.SPECIAL, src=(UPat.var("var").cast(dtypes.weakint),), name="u"),
-    lambda u,var: u.replace(dtype=dtypes.int, src=(var,)).cast(dtypes.weakint)),
+  # hw_idx PARAMs can only be int32
+  (UPat(Ops.PARAM, src=(UPat.var("var").cast(dtypes.weakint),), name="u"),
+    lambda u,var: u.replace(dtype=dtypes.int, src=(var,)).cast(dtypes.weakint) if u.is_hw_idx else None),
   (UPat(Ops.PARAM, dtype=dtypes.weakint, name="u"),
-    lambda u: u.replace(dtype=dtypes.int).cast(dtypes.weakint) if u.addrspace == AddrSpace.ALU else None),
+    lambda u: u.replace(dtype=dtypes.int).cast(dtypes.weakint) if u.addrspace == AddrSpace.ALU and not u.is_hw_idx else None),
   (UPat(Ops.BIND, src=(UPat.var("var").cast(dtypes.weakint), UPat.cvar("val").cast(dtypes.weakint))),
     lambda var,val: var.bind(val).cast(dtypes.weakint)),
   # remove hanging casts

--- a/tinygrad/uop/render.py
+++ b/tinygrad/uop/render.py
@@ -32,8 +32,8 @@ def strip_binary_parens(x:UOp, left:str, right:str, code_for_op) -> str:
     precedence.get(x.src[1].op,99)<precedence[x.op] else right)
 
 renderer = PatternMatcher([
+  (UPat(Ops.PARAM, name="x"), lambda x: x.arg.hw_dim if x.is_hw_idx else None),
   (UPat(Ops.PARAM, name="x"), lambda x: x.arg.name if x.arg.name is not None else f"p{x.arg.slot}"),
-  (UPat((Ops.SPECIAL), name="x"), lambda x: x.arg),
   (UPat(Ops.RANGE, name="x"), lambda x: f"r{range_str(x)}"),
   (UPat(Ops.CONST, name="x"), lambda x: str(x.arg)),
   (UPat(Ops.UNROLL, name="x"), lambda ctx,x,u: f"UNROLL({ctx[x.src[0]]}, {u.arg})"),
@@ -78,7 +78,8 @@ sugar = {Ops.SINK, Ops.END, Ops.STORE, Ops.LOAD, Ops.SQRT, Ops.INDEX, Ops.REDUCE
 pm_pyrender_extra = PatternMatcher([
   (UPat(Ops.CONST, src=(), name="x"), lambda x: f"UOp.const({x.dtype}, {x.arg})"),
   (UPat((Ops.CAST, Ops.BITCAST), name="x"), lambda ctx,x: f"{ctx[x.src[0]]}.{x.op.name.lower()}({x.dtype})"),
-  (UPat(Ops.SPECIAL, src=(UPat(Ops.CONST),), name="x"), lambda x: f"UOp.special({x.src[0].arg}, {repr(x.arg)}, dtype={x.dtype})"),
+  (UPat(Ops.PARAM, src=(UPat(Ops.CONST),), name="x"),
+    lambda x: f"UOp.hw_idx({x.src[0].arg}, {repr(x.arg.hw_dim)}, dtype={x.dtype})" if x.is_hw_idx else None),
   (UPat(Ops.BUFFER, src=(UPat(),), name="x"), lambda x:
     f"UOp.new_buffer({repr(x.arg.device)}, {x.max_numel()}, {x.dtype}, {x.arg.slot})"
     if isinstance(x.arg, ParamArg) and x.addrspace is AddrSpace.GLOBAL else None),
@@ -134,7 +135,7 @@ def pyrender(ast:UOp) -> str:
 
   cmap = consumer_map_from_toposort(lst)
   not_rendered = {Ops.CONST, Ops.DEVICE}
-  always_rendered = {Ops.PARAM, Ops.LOAD, Ops.SPECIAL, Ops.RANGE, Ops.CONTIGUOUS, Ops.STACK,
+  always_rendered = {Ops.PARAM, Ops.LOAD, Ops.RANGE, Ops.CONTIGUOUS, Ops.STACK,
                      Ops.BUFFER, Ops.COPY, Ops.CALL, Ops.FUNCTION, Ops.WHERE, Ops.END}
 
   to_render: set[UOp] = {ast}

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -25,7 +25,7 @@ def validate_index(uidx:UOp, gate:UOp|None=None):
   # WEBGPU has a BITCAST in the index, PTX casts pointer to long
   # VECTORIZE/GEP can't be properly modeled in z3 since it doesn't support vectors
   # don't descend into PARAM shape metadata; only the PARAM value participates in index arithmetic
-  for x in idx.toposort(gate=lambda x: x.op is not Ops.PARAM) | gate.toposort(gate=lambda x: x.op is not Ops.PARAM):
+  for x in idx.toposort(gate=lambda x: x.op is not Ops.PARAM or x.is_hw_idx) | gate.toposort(gate=lambda x: x.op is not Ops.PARAM or x.is_hw_idx):
     if x.op in {Ops.BITCAST, Ops.STACK, Ops.GEP} or (x.op is Ops.CAST and isinstance(x.src[0].dtype, PtrDType)): return True
 
   # if all is good and CHECK_OOB=1, validate with z3

--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -78,7 +78,9 @@ spec_shared = PatternMatcher([
   (UPat(Ops.END, src=(UPat(),), allow_any_len=True, name="x"), lambda x: all(u.op is Ops.RANGE for u in x.src[1:])),
 
   # PARAM
-  (UPat(Ops.PARAM, name="x"), lambda x: isinstance(x.arg, ParamArg)),
+  (UPat(Ops.PARAM, src=(UPat.var("x", (dtypes.weakint, dtypes.int32)),), name="s"),
+   lambda s,x: (s.dtype == x.dtype and isinstance(s.arg.hw_dim, str)) if s.is_hw_idx else None),
+  (UPat(Ops.PARAM, name="x"), lambda x: isinstance(x.arg, ParamArg) and not x.is_hw_idx),
   (UPat(Ops.BUFFER, src=(UPat(),), name="x"), lambda x:
    isinstance(x.arg, ParamArg) and x.addrspace in (AddrSpace.REG, AddrSpace.LOCAL)),
 
@@ -96,8 +98,6 @@ spec_shared = PatternMatcher([
   # BARRIER (on any length). TODO: this should only be in spec_program
   (UPat(Ops.BARRIER, dtypes.void), lambda: True),
 
-  # SPECIAL. TODO: this should only be in spec_program
-  (UPat(Ops.SPECIAL, src=(UPat.var("x", (dtypes.weakint, dtypes.int32)),), name="s"), lambda s,x: s.dtype == x.dtype and isinstance(s.arg, str)),
 
   # assembly instruction
   (UPat(Ops.INS), lambda: True),
@@ -224,7 +224,7 @@ spec_full = PatternMatcher([
 
   (UPat(Ops.CALL, src=(UPat((Ops.SLICE,)),), allow_any_len=True), lambda: True),
 
-  # codegen may end ranges after gpudims has replaced RANGE with SPECIAL.
+  # codegen may end ranges after gpudims has replaced RANGE with PARAM.
   (UPat(Ops.END, src=(UPat(), UPat()), allow_any_len=True), lambda: True),
 
   # allow any AFTER

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -267,7 +267,7 @@ symbolic = symbolic_simple+commutative+PatternMatcher([
   ((UPat.var("y")+UPat.var("c").where(UPat.var("t"), UPat.var("f"))) + UPat.var("c").where(UPat.var("tt"), UPat.var("ff")), \
    lambda y,c,t,tt,f,ff: y+c.where(t+tt, f+ff) if t.op == tt.op == Ops.CONST or f.op == ff.op == Ops.CONST else None),
   # ALU/variable min==max -> CONST
-  (UPat({Ops.CMPLT, Ops.CMPNE, Ops.FLOORDIV, Ops.FLOORMOD, Ops.PARAM, Ops.BIND, Ops.SPECIAL}, name="x"),
+  (UPat({Ops.CMPLT, Ops.CMPNE, Ops.FLOORDIV, Ops.FLOORMOD, Ops.PARAM, Ops.BIND}, name="x"),
    lambda x: x.const_like(x.vmin) if x.vmin == x.vmax else None),
   (UPat(Ops.RANGE, src=(UPat(Ops.CONST,)), name="x"), lambda x: x.const_like(x.vmin) if x.vmin == x.vmax else None),
   # max folding

--- a/tinygrad/uop/validate.py
+++ b/tinygrad/uop/validate.py
@@ -53,6 +53,7 @@ z3_renderer = PatternMatcher([
 ])
 
 def uops_to_z3(solver:z3.Solver, *uops: UOp) -> list[z3.ExprRef]:
+  # gate on upstream AFTER/BUFFER as a replacement for PtrDType, but keep INDEX as an unknown LOAD
   lst = list(UOp.sink(*uops).toposort(gate=lambda x: x.op not in {Ops.AFTER, Ops.BUFFER} and
                                       (x.dtype.scalar() in dtypes.ints+(dtypes.bool, dtypes.weakint) or x.op is Ops.SINK)))[:-1]
   z3map: dict[UOp, z3.ExprRef] = {}

--- a/tinygrad/uop/validate.py
+++ b/tinygrad/uop/validate.py
@@ -27,8 +27,9 @@ def create_bounded(name:str, vmin:int, vmax:int, z3ctx:z3.Context) -> tuple[z3.A
 z3_renderer = PatternMatcher([
   (UPat.var("cond").where(UPat.var("x"), UPat.const(dtypes.weakint, Invalid)), lambda x,cond,ctx: (ctx[1][x], ctx[1][cond])),
   # variables
-  (UPat(Ops.SPECIAL, name="x"), lambda x,ctx: create_bounded(x.arg, 0, ctx[1][x.src[0]]-1, ctx[0])),
-  (UPat(Ops.PARAM, name="x"), lambda x,ctx: create_bounded(x.arg.name, x.vmin, x.vmax, ctx[0])),
+  (UPat(Ops.PARAM, name="x"), lambda x,ctx:
+   create_bounded(x.arg.hw_dim, 0, ctx[1][x.src[0]]-1, ctx[0]) if x.is_hw_idx else None),
+  (UPat(Ops.PARAM, name="x"), lambda x,ctx: create_bounded(x.arg.name, x.vmin, x.vmax, ctx[0]) if not x.is_hw_idx else None),
   (UPat(Ops.RANGE, name="x"), lambda x,ctx: create_bounded(x.render(simplify=False), 0, ctx[1][x.src[0]]-1, ctx[0])),
   # loads are variables bounded by the min/max of the dtype. non-pointer INDEX is also a LOAD
   (UPat((Ops.LOAD, Ops.INDEX), dtypes.ints+(dtypes.weakint,), name="x"), lambda x,ctx:
@@ -51,8 +52,7 @@ z3_renderer = PatternMatcher([
 ])
 
 def uops_to_z3(solver:z3.Solver, *uops: UOp) -> list[z3.ExprRef]:
-  # gate on upstream AFTER/BUFFER as a replacement for PtrDType, but keep INDEX as an unknown LOAD
-  lst = list(UOp.sink(*uops).toposort(gate=lambda x: x.op not in {Ops.AFTER, Ops.BUFFER} and \
+  lst = list(UOp.sink(*uops).toposort(gate=lambda x: x.op not in {Ops.AFTER, Ops.BUFFER} and
                                       (x.dtype.scalar() in dtypes.ints+(dtypes.bool, dtypes.weakint) or x.op is Ops.SINK)))[:-1]
   z3map: dict[UOp, z3.ExprRef] = {}
   for u in lst:

--- a/tinygrad/uop/validate.py
+++ b/tinygrad/uop/validate.py
@@ -27,8 +27,7 @@ def create_bounded(name:str, vmin:int, vmax:int, z3ctx:z3.Context) -> tuple[z3.A
 z3_renderer = PatternMatcher([
   (UPat.var("cond").where(UPat.var("x"), UPat.const(dtypes.weakint, Invalid)), lambda x,cond,ctx: (ctx[1][x], ctx[1][cond])),
   # variables
-  (UPat(Ops.PARAM, name="x"), lambda x,ctx:
-   create_bounded(x.arg.hw_dim, 0, ctx[1][x.src[0]]-1, ctx[0]) if x.is_hw_idx else None),
+  (UPat(Ops.PARAM, name="x"), lambda x,ctx: create_bounded(x.arg.hw_dim, 0, ctx[1][x.src[0]]-1, ctx[0]) if x.is_hw_idx else None),
   (UPat(Ops.PARAM, name="x"), lambda x,ctx: create_bounded(x.arg.name, x.vmin, x.vmax, ctx[0]) if not x.is_hw_idx else None),
   (UPat(Ops.RANGE, name="x"), lambda x,ctx: create_bounded(x.render(simplify=False), 0, ctx[1][x.src[0]]-1, ctx[0])),
   # loads are variables bounded by the min/max of the dtype. non-pointer INDEX is also a LOAD
@@ -48,6 +47,8 @@ z3_renderer = PatternMatcher([
   (UPat(Ops.CAST, dtypes.ints+(dtypes.weakint,),src=(UPat.var("x", dtypes.bool),)), lambda x,ctx: (z3.If(ctx[1][x], 1, 0), None)),
   (UPat(Ops.CAST, dtypes.ints+(dtypes.weakint,), src=(UPat.var("x", dtypes.ints+(dtypes.weakint,)),)), lambda x,ctx: (ctx[1][x], None)),
   (UPat(Ops.CAST, dtypes.bool, name="x"), lambda x,ctx: (ctx[1][x.src[0]]!=0, None)),
+  # BITCAST between int types is a no-op in Z3's integer model (Z3 has no concept of bit reinterpretation)
+  (UPat(Ops.BITCAST, dtypes.ints+(dtypes.weakint,), src=(UPat.var("x", dtypes.ints+(dtypes.weakint,)),)), lambda x,ctx: (ctx[1][x], None)),
   (UPat(GroupOp.ALU, name="x"), lambda x,ctx: (z3_alu[x.op](*(ctx[1][s] for s in x.src)), None)),
 ])
 

--- a/tinygrad/uop/validate.py
+++ b/tinygrad/uop/validate.py
@@ -27,8 +27,8 @@ def create_bounded(name:str, vmin:int, vmax:int, z3ctx:z3.Context) -> tuple[z3.A
 z3_renderer = PatternMatcher([
   (UPat.var("cond").where(UPat.var("x"), UPat.const(dtypes.weakint, Invalid)), lambda x,cond,ctx: (ctx[1][x], ctx[1][cond])),
   # variables
-  (UPat(Ops.PARAM, name="x"), lambda x,ctx: create_bounded(x.arg.hw_dim, 0, ctx[1][x.src[0]]-1, ctx[0]) if x.is_hw_idx else None),
-  (UPat(Ops.PARAM, name="x"), lambda x,ctx: create_bounded(x.arg.name, x.vmin, x.vmax, ctx[0]) if not x.is_hw_idx else None),
+  (UPat(Ops.PARAM, name="x"), lambda x,ctx: create_bounded(x.arg.hw_dim, 0, ctx[1][x.src[0]]-1, ctx[0])
+    if x.is_hw_idx else create_bounded(x.arg.name, x.vmin, x.vmax, ctx[0])),
   (UPat(Ops.RANGE, name="x"), lambda x,ctx: create_bounded(x.render(simplify=False), 0, ctx[1][x.src[0]]-1, ctx[0])),
   # loads are variables bounded by the min/max of the dtype. non-pointer INDEX is also a LOAD
   (UPat((Ops.LOAD, Ops.INDEX), dtypes.ints+(dtypes.weakint,), name="x"), lambda x,ctx:
@@ -47,8 +47,6 @@ z3_renderer = PatternMatcher([
   (UPat(Ops.CAST, dtypes.ints+(dtypes.weakint,),src=(UPat.var("x", dtypes.bool),)), lambda x,ctx: (z3.If(ctx[1][x], 1, 0), None)),
   (UPat(Ops.CAST, dtypes.ints+(dtypes.weakint,), src=(UPat.var("x", dtypes.ints+(dtypes.weakint,)),)), lambda x,ctx: (ctx[1][x], None)),
   (UPat(Ops.CAST, dtypes.bool, name="x"), lambda x,ctx: (ctx[1][x.src[0]]!=0, None)),
-  # BITCAST between int types is a no-op in Z3's integer model (Z3 has no concept of bit reinterpretation)
-  (UPat(Ops.BITCAST, dtypes.ints+(dtypes.weakint,), src=(UPat.var("x", dtypes.ints+(dtypes.weakint,)),)), lambda x,ctx: (ctx[1][x], None)),
   (UPat(GroupOp.ALU, name="x"), lambda x,ctx: (z3_alu[x.op](*(ctx[1][s] for s in x.src)), None)),
 ])
 

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -47,7 +47,7 @@ from tinygrad.dtype import dtypes, AddrSpace
 
 uops_colors = {Ops.LOAD: "#ffc0c0", Ops.STORE: "#87CEEB", Ops.CONST: "#e0e0e0", Ops.REDUCE: "#FF5B5B",
                Ops.SHAPED_WMMA: "#FF5B5B",
-               Ops.RANGE: "#c8a0e0", Ops.BARRIER: "#ff8080", Ops.IF: "#c8b0c0", Ops.SPECIAL: "#c0c0ff",
+               Ops.RANGE: "#c8a0e0", Ops.BARRIER: "#ff8080", Ops.IF: "#c8b0c0",
                Ops.INDEX: "#D8F9E4", Ops.STACK: "#D8F9E4",
                Ops.WMMA: "#efefc0", Ops.MULTI: "#f6ccff", Ops.INS: "#eec4ff",
                **{x:"#D8F9E4" for x in GroupOp.Movement}, **{x:"#ffffc0" for x in GroupOp.ALU}, Ops.THREEFRY:"#ffff80",
@@ -151,7 +151,7 @@ def uop_to_json(data:VizData, x:UOp) -> dict[int, dict]:
       if u.op in {Ops.INDEX, Ops.STAGE}:
         if len(u.toposort()) < 30: label += f"\n{u.render()}"
         ranges: list[UOp] = []
-        for us in u.src[1:]: ranges += [s for s in us.toposort() if s.op in {Ops.RANGE, Ops.SPECIAL}]
+        for us in u.src[1:]: ranges += [s for s in us.toposort() if s.op is Ops.RANGE or s.is_hw_idx]
         if ranges: label += "\n"+' '.join([f"{s.render()}={s.vmax+1}" for s in ranges])
       if u.op in {Ops.END, Ops.REDUCE} and len(trngs:=list(UOp.sink(*u.src[range_start[u.op]:]).ranges)):
         label += "\n"+' '.join([f"{range_str(s, color=True)}({s.vmax+1})" for s in trngs])
@@ -166,7 +166,8 @@ def uop_to_json(data:VizData, x:UOp) -> dict[int, dict]:
       label = "\n".join(lines[:30]) + "\n..."
     addrspace_color:str|None = None
     with soft_err(): addrspace_color = addrspace_colors.get(u.addrspace, None) if u.addrspace is not None else None
-    graph[id(u)] = {"label":label, "src":[(i,id(x)) for i,x in enumerate(u.src)], "exclude":u in excluded, "color":uops_colors.get(u.op, "#ffffff"),
+    graph[id(u)] = {"label":label, "src":[(i,id(x)) for i,x in enumerate(u.src)], "exclude":u in excluded,
+                    "color":"#c0c0ff" if u.is_hw_idx else uops_colors.get(u.op, "#ffffff"),
                     "ref":ref, "tag":repr(u.tag) if u.tag is not None else None, "addrspace":addrspace_color}
   return graph
 


### PR DESCRIPTION
Remove Ops.SPECIAL and fold hardware indices into Ops.PARAM via UOp.hw_idx() / is_hw_idx.

Mostly a mechanical migration across renderers, tests, kernel helpers, codegen, and viz, with the supporting constructor/check updates needed to keep hardware indices distinct from ordinary params.

Big diff, but most of it is just replacing constructor calls and Ops.SPECIAL checks.

Other changes
- nir.py, ops_python.py: check is_hw_idx before the general PARAM handler, since hw_idx params also have addrspace=ALU.
- elf.py: skip hw_idx params before the user-variable counter so they aren't treated as ordinary parameters.
- Preserve the previous SPECIAL coloring for hw_idx nodes in viz.