### PR TITLE
Revert "do not assert index in mem coalesing (#16723)"

### DIFF
--- a/tinygrad/codegen/late/coalese.py
+++ b/tinygrad/codegen/late/coalese.py
@@ -64,7 +64,7 @@ def memory_coalesing(sink:UOp, ctx:Renderer) -> UOp:
     # TODO: this should handle images too, it's just memory coalesing
     if u.op in {Ops.LOAD, Ops.STORE} and not isinstance(u.src[0].src[0].dtype, ImageDType):
       assert len(u.src) == (2 if u.op is Ops.STORE else 1), "memory coalesing does not support gated loads/stores"
-      if u.src[0].op is not Ops.INDEX: continue
+      assert u.src[0].op is Ops.INDEX
       buf, idx_u = u.src[0].src
       if buf.addrspace == AddrSpace.REG: continue
       idx: Any = idx_u.src[1] if idx_u.op is Ops.WHERE and idx_u.src[2].arg is Invalid else idx_u


### PR DESCRIPTION
This reverts commit b99b9e187557a3eee7fa1f236e7f3a6c19125404.

Will keep it back to original code, the correct hcq2 impl (as of now with buf.shrink.bitcast.index(0).store) does not need this