### PR TITLE
CUDA: use virtual compute_XX arch for nvrtc when emitting PTX

### DIFF
--- a/tinygrad/runtime/support/compiler_cuda.py
+++ b/tinygrad/runtime/support/compiler_cuda.py
@@ -43,7 +43,9 @@ def cuda_disassemble(lib:bytes, arch:str, ptx=False):
 
 class NVRTCCompiler(Compiler):
   def __init__(self, arch:str, ptx=True, cache_key:str="cuda"):
-    self.ptx, self.arch, self.compile_options = ptx, arch, [f'--gpu-architecture={arch}']
+    # nvrtc < 11.0 only accepts virtual `compute_XX` for --gpu-architecture; it is also the
+    # correct target when emitting PTX. Real `sm_XX` is only needed (and only valid) for CUBIN.
+    self.ptx, self.arch, self.compile_options = ptx, arch, [f'--gpu-architecture={arch.replace("sm_", "compute_") if ptx else arch}']
     self.compile_options += [f"-I{CUDA_PATH}/include"] if CUDA_PATH else ["-I/usr/local/cuda/include", "-I/usr/include", "-I/opt/cuda/include"]
     nvrtc_check(nvrtc.nvrtcVersion((nvrtcMajor := ctypes.c_int()), (nvrtcMinor := ctypes.c_int())))
     if (nvrtcMajor.value, nvrtcMinor.value) >= (12, 4): self.compile_options.append("--minimal")


### PR DESCRIPTION
I'm trying to install tinygrad on a Jetson Nano with CUDA 10.2 (Maxwell `sm_53`) and Python 3.11.

A first attempt with 
```
export PATH=/usr/local/cuda/bin:$PATH
export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
DEV=CUDA ~/tg/bin/python -c "from tinygrad import Tensor,Device; print(\"dev\",Device.DEFAULT); print((Tensor([1.,2.,3.])+1).tolist())"
```
failed with:

```
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/uop/ops.py", line 1322, in rewrite
    if (ret:=match(uop, ctx)) is not None and ret is not uop: return ret
             ^^^^^^^^^^^^^^^
  File "<string>", line 3, in compiled_match
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/engine/realize.py", line 226, in <lambda>
    call.replace(src=(to_program(ast, Device[call.device if isinstance(call.device, str) else call.device[0]].renderer), *call.src[1:]))),
                                      ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/device.py", line 26, in __getitem__
    return self.__get_canonicalized_item(ix)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/device.py", line 31, in __get_canonicalized_item
    ret = [cls for cname, cls in inspect.getmembers(importlib.import_module(f'{base}.runtime.ops_{x}')) \
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/runtime/ops_cuda.py", line 102, in __init__
    check(cuda.cuInit(0))
          ^^^^^^^^^^^^^^
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/runtime/support/c.py", line 133, in wrapper
    if cfunc is None: (cfunc:=getattr(self, fn.__name__)).argtypes, cfunc.restype = argtypes, restype
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/runtime/support/c.py", line 139, in __getattr__
    if self.nm not in self._loaded_: raise AttributeError(f"failed to load library {self.nm}: {self.emsg}")
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: failed to load library cuda: try setting CUDA_PATH?
```
Tinygrad selected the CUDA device but couldn't load the CUDA driver library (`libcuda.so`) for cuInit. On Jetson Nano the driver lib isn't in the toolkit's lib64 but in the Tegra driver path.

A second attemtp with
```
export CUDA_PATH=/usr/local/cuda
export PATH=/usr/local/cuda/bin:$PATH
export LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/tegra:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
DEV=CUDA ~/tg/bin/python -c "from tinygrad import Tensor,Device; print(\"dev\",Device.DEFAULT); print((Tensor([1.,2.,3.])+1).tolist())" 
```
now fails with 

```
    if (ret:=match(uop, ctx)) is not None and ret is not uop: return ret
             ^^^^^^^^^^^^^^^
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/uop/ops.py", line 1296, in lazy_compile
    return entry[1](uop, ctx)
           ^^^^^^^^^^^^^^^^^^
  File "<string>", line 3, in compiled_match
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/codegen/__init__.py", line 162, in do_compile
    lib = ctx.compiler.compile_cached(source.arg)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/device.py", line 282, in compile_cached
    lib = self.compile(src)
          ^^^^^^^^^^^^^^^^^
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/runtime/support/compiler_cuda.py", line 53, in compile
    nvrtc_check(nvrtc.nvrtcCompileProgram(prog, len(self.compile_options), to_char_p_p([o.encode() for o in self.compile_options])), prog)
  File "/home/jeroen/tg/lib/python3.11/site-packages/tinygrad/runtime/support/compiler_cuda.py", line 17, in nvrtc_check
    raise CompileError(f"Nvrtc Error {status}, {ctypes.string_at(nvrtc.nvrtcGetErrorString(status)).decode()}\n{err_log}")
tinygrad.device.CompileError: Nvrtc Error 5, NVRTC_ERROR_INVALID_OPTION
nvrtc: error: invalid value for --gpu-architecture (-arch)
```

The driver loads now and the device is detected but the failure has moved to the nvrtc compile step.

`NVRTCCompiler` builds `--gpu-architecture={arch}` with `arch = "sm_{major}{minor}"`. The `sm_XX` value was only accepted by nvrtc starting in CUDA 11.0. Older nvrtc accepts only the virtual `compute_XX`.

## Fix

When the compiler emits PTX (the default CUDA path, `ptx=True`), target the virtual `compute_XX` arch. This is version-portable and is the correct target anyway, since PTX is a virtual-ISA artifact that the driver JIT-compiles for the real GPU at module load. The real `sm_XX` is kept for the CUBIN path (`ptx=False`), which already requires nvrtc >= 11.

Also see follow-up PR https://github.com/tinygrad/tinygrad/pull/16810

## AI disclosure

Claude was used to write the fix, a human verified the fix and wrote this PR text.