### PR TITLE
CUDA: disable CUDA graphs on pre-11.0 drivers

### DIFF
--- a/test/mockgpu/cuda/cuda.py
+++ b/test/mockgpu/cuda/cuda.py
@@ -140,6 +140,10 @@ def cuDeviceComputeCapability(major, minor, dev: int) -> int:
   minor._obj.value = 5
   return orig_cuda.CUDA_SUCCESS
 
+def cuDriverGetVersion(version) -> int:
+  version._obj.value = 12000
+  return orig_cuda.CUDA_SUCCESS
+
 def cuDeviceCanAccessPeer(canAccessPeer, dev: int, peerDev: int) -> int:
   canAccessPeer._obj.value = 1  # Always allow peer access in simulation
   return orig_cuda.CUDA_SUCCESS

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -103,6 +103,7 @@ class CUDADevice(Compiled):
     self.cu_device = init_c_var(cuda.CUdevice, lambda x: check(cuda.cuDeviceGet(ctypes.byref(x), device_id)))
     self.context = init_c_var(cuda.CUcontext, lambda x: check(cuda.cuCtxCreate_v2(ctypes.byref(x), 0, self.cu_device)))
     check(cuda.cuDeviceComputeCapability(ctypes.byref(major := ctypes.c_int()), ctypes.byref(minor := ctypes.c_int()), device_id))
+    check(cuda.cuDriverGetVersion(ctypes.byref(driver_version := ctypes.c_int())))
 
     for dev in CUDADevice.devices:
       check(cuda.cuDeviceCanAccessPeer(ctypes.byref(val := ctypes.c_int()), self.cu_device, dev.cu_device))
@@ -117,8 +118,9 @@ class CUDADevice(Compiled):
     CUDADevice.devices.append(self)
 
     from tinygrad.runtime.graph.cuda import CUDAGraph
+    # cuGraphInstantiate_v2 (used by CUDAGraph) needs a CUDA 11.0+ driver; disable graphs on older drivers.
     super().__init__(device, CUDAAllocator(self), [CUDARenderer, PTXRenderer, NVCCRenderer], functools.partial(CUDAProgram, self),
-                     None if MOCKGPU else CUDAGraph, arch=f"sm_{major.value}{minor.value}")
+                     None if (MOCKGPU or driver_version.value < 11000) else CUDAGraph, arch=f"sm_{major.value}{minor.value}")
 
   def count(self) -> int: return init_c_var(ctypes.c_int, lambda x: check(cuda.cuDeviceGetCount(ctypes.byref(x)))).value
 


### PR DESCRIPTION
After making tinygrad work on a Jetson Nano with CUDA 10.2 (Maxwell sm_53) and Python 3.11 (see https://github.com/tinygrad/tinygrad/pull/16809) I now try to run a tiny benchmark `tg_bench.py`:

```python
# tg_bench.py
import time
from tinygrad import Tensor, Device, TinyJit
from tinygrad.nn import Conv2d, Linear
class Pilot:
    def __init__(self):
        self.c1,self.c2,self.c3 = Conv2d(3,16,5,2), Conv2d(16,32,5,2), Conv2d(32,32,3,2)
        self.fc = Linear(32,2)
    def __call__(self,x):
        x=self.c1(x).relu(); x=self.c2(x).relu(); x=self.c3(x).relu()
        return self.fc(x.mean(axis=(2,3)))
net=Pilot(); x=Tensor.rand(1,3,120,160)
@TinyJit
def run(x): return net(x).realize()
for _ in range(8): run(x); Device[Device.DEFAULT].synchronize()
N=200; t=time.perf_counter()
for _ in range(N): run(x)
Device[Device.DEFAULT].synchronize()
dt=time.perf_counter()-t
print(f"{Device.DEFAULT} (TinyJit): {N/dt:.1f} inf/s, {1000*dt/N:.2f} ms each")
```

I run it like this:

```
export CUDA_PATH=/usr/local/cuda
export PATH=/usr/local/cuda/bin:$PATH
export LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/tegra:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
DEV=CUDA ~/tg/bin/python ~/tg_bench.py
```

but I get the error:

```
    func = self._FuncPtr((name_or_ordinal, self))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: /usr/lib/aarch64-linux-gnu/tegra/libcuda.so: undefined symbol: cuGraphInstantiate_v2
```

CUDAGraph instantiates via cuGraphInstantiate_v2, which only exists in CUDA 11.0+ drivers. On older drivers (like our CUDA 10.2 on the Jetson Nano) loading that symbol raises `undefined symbol: cuGraphInstantiate_v2` as soon as TinyJit tries to capture a graph.

## Fix

Read the driver version with `cuDriverGetVersion` and only enable `CUDAGraph` when the driver is 11.0 or newer. On older drivers the device falls back to graph-less JIT, so `TinyJit` still caches and replays kernels (it just does not batch them into a hardware graph).

To make the tests work I also had to override `cuDriverGetVersion` in the mock (returns `12000`, `CUDA_SUCCESS`), exactly mirroring how `cuDeviceComputeCapability` is mocked.

The only remaining [CI failure](https://github.com/tinygrad/tinygrad/actions/runs/28476095216/job/84401868557?pr=16810#step:6:79) on `Linux (DEV=CPU:LLVM)` looks a flake unrelated to this PR.

```
FAILED test/backend/test_ops.py::TestOps::test_small_cummin - worker 'gw0' crashed while running 'test/backend/test_ops.py::TestOps::test_small_cummin'
```

## AI disclosure

Claude was used to write the fix, a human verified the fix and wrote this PR text.