### PR TITLE
Default hlb_cifar10 to half precision when supported

### DIFF
--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -145,6 +145,8 @@ hyp = {
 }
 
 def train_cifar():
+  if not getenv("DEFAULT_FLOAT", "") and dtypes.half in Device[Device.DEFAULT].renderer.supported_dtypes():
+    dtypes.default_float = dtypes.half
 
   def set_seed(seed):
     Tensor.manual_seed(seed)


### PR DESCRIPTION
## What changed

`examples/hlb_cifar10.py` now defaults to `dtypes.half` inside `train_cifar()` when the active backend supports half precision and `DEFAULT_FLOAT` was not explicitly set.

This keeps imports side-effect-free and preserves the existing override path, e.g. `DEFAULT_FLOAT=float` still runs the old float32 path.

## Why

The training hyperparameters already include FP16 loss scaling, and the example benefits materially from half precision on backends that support it.

Local METAL measurements with `BS=512`, no eval, after JIT warmup:

- Before/default float32: steady-state roughly 2.1s/step, ~2.95 GB used
- After/default half: steady-state roughly 1.2-1.4s/step, ~1.56 GB used

This is a small step toward the hlb_cifar speed target, not a claim that the full `<10s` bounty is solved.

## Validation

- `PYTHONPATH=. .venv/bin/python -m py_compile examples/hlb_cifar10.py`
- Import check confirms importing `examples.hlb_cifar10` does not mutate `dtypes.default_float`
- `PYTHONPATH=. STEPS=3 EVAL_STEPS=999999 BS=512 .venv/bin/python examples/hlb_cifar10.py`
- `PYTHONPATH=. DEFAULT_FLOAT=float STEPS=2 EVAL_STEPS=999999 BS=512 .venv/bin/python examples/hlb_cifar10.py`
