### PR TITLE
add Tensor.trace(), matching torch.trace()

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -621,6 +621,7 @@ tiny_backend = {**{k:wrap_out(v) for k,v in tiny_backend_out.items()}, **{
   "aten.argmin": Tensor.argmin,
   "aten.asinh": Tensor.asinh,
   "aten.mul": Tensor.mul,
+  "aten.trace": Tensor.trace,
   "aten.atanh": Tensor.atanh,
   "aten.fill_.Tensor": lambda self, value: self.const_like(value.reshape(()).item()),
   "aten.flip": Tensor.flip,

--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -2143,6 +2143,13 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3,5)], lambda x: x.diagonal(offset=2))  # offset on rectangular
     self.helper_test_exception([(3,3)], lambda x: x.diagonal(dim1=0, dim2=0), expected=RuntimeError)
 
+  def test_trace(self):
+    helper_test_op([(5,5)], lambda x: x.trace())
+    helper_test_op([(3,4)], lambda x: x.trace())  # rectangular
+    helper_test_op([(4,3)], lambda x: x.trace())  # rectangular (other way)
+    self.helper_test_exception([(5,)], lambda x: x.trace(), expected=RuntimeError)  # 1-D
+    self.helper_test_exception([(2,3,4)], lambda x: x.trace(), expected=RuntimeError)  # 3-D
+
   def test_roll(self):
     helper_test_op([(2, 4)], lambda x: x.roll(1))
     helper_test_op([(2, 4)], lambda x: x.roll((1,)))

--- a/tinygrad/mixin/reduce.py
+++ b/tinygrad/mixin/reduce.py
@@ -43,6 +43,23 @@ class ReduceMixin(DTypeMixin, MovementMixin):
     ret = self.cast(sum_acc_dtype(self.dtype) if dtype is None else to_dtype(dtype))._reduce(Ops.ADD, axis, keepdim)
     return ret.cast(self.dtype) if dtype is None and self.dtype in (dtypes.float16, dtypes.bfloat16, *dtypes.fp8s) else ret
 
+  def trace(self) -> Self:
+    """
+    Returns the sum of the elements of the main diagonal of a 2-D tensor.
+
+    Equivalent to `self.diagonal().sum()`.
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor.arange(9).reshape(3, 3)
+    print(t.numpy())
+    ```
+    ```python exec="true" source="above" session="tensor" result="python"
+    print(t.trace().numpy())
+    ```
+    """
+    if self.ndim != 2: raise RuntimeError(f"expect input to be 2-D, getting {self.ndim}-D")
+    return self.diagonal().sum()
+
   def prod(self, axis:int|Sequence[int]|None=None, keepdim=False, dtype:DTypeLike|None=None) -> Self:
     """
     Returns the product of the elements of the tensor along the specified axis or axes.


### PR DESCRIPTION
Adds `Tensor.trace()`, matching `torch.trace()` — sum of the main diagonal of a 2D tensor. Implemented as `self.diagonal().sum()` with a 2D-only shape check raising `RuntimeError`, matching torch's behavior.

Tested against `numpy.trace`/`torch.trace` for square and rectangular matrices, plus 1D/3D error cases. Forward and gradient paths verified locally on OpenCL (Intel iGPU).