### PR TITLE
ci: use llvm-20 in amd tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -552,7 +552,7 @@ jobs:
           key: ${{ matrix.backend }}-minimal
           deps: testing_unit
           amd: 'true'
-          llvm: ${{ matrix.backend == 'amdllvm' && 'true' }}
+          llvm: 'true'
       - name: Check Device.DEFAULT and print some source
         run: |
           python3 -c "from tinygrad import Device; assert Device.DEFAULT in ['AMD'], Device.DEFAULT"


### PR DESCRIPTION
LLVM 18 crashes on [`v_log_f16_e32_00ae007e`](https://github.com/tinygrad/tinygrad/actions/runs/29142154774/job/86517259345)

potentially related? https://github.com/llvm/llvm-project/issues/132013