### PR TITLE
fall back to BAR1 size when vram scratch register returns 0

### DIFF
--- a/tinygrad/runtime/support/nv/nvdev.py
+++ b/tinygrad/runtime/support/nv/nvdev.py
@@ -130,10 +130,10 @@ class NVDev:
 
     vram_size_reg = self.reg("NV_PGC6_AON_SECURE_SCRATCH_GROUP_42").read()
     self.vram, self.mmio = self.pci_dev.map_bar(1), self.pci_dev.map_bar(0, fmt='I')
-    if vram_size_reg:
-      self.vram_size = vram_size_reg << 20
-    else:
+    if vram_size_reg in (0, 0xbadf5108):
       self.vram_size = self.vram.nbytes
+    else:
+      self.vram_size = vram_size_reg << 20
       if DEBUG >= 1: print(f"nv {self.devfmt}: WARNING: VRAM scratch reg is 0, using BAR1 size {self.vram_size // (1024 * 1024)} MB", flush=True)
     self.large_bar = self.vram.nbytes >= self.vram_size
 

--- a/tinygrad/runtime/support/nv/nvdev.py
+++ b/tinygrad/runtime/support/nv/nvdev.py
@@ -128,9 +128,13 @@ class NVDev:
     self.pte_t, self.pde_t, self.dual_pde_t = [self.__dict__[name] for name in [f'NV_MMU_VER{self.mmu_ver}_PTE', f'NV_MMU_VER{self.mmu_ver}_PDE',
                                                                                 f'NV_MMU_VER{self.mmu_ver}_DUAL_PDE']]
 
-    self.vram_size = self.reg("NV_PGC6_AON_SECURE_SCRATCH_GROUP_42").read() << 20
-
+    vram_size_reg = self.reg("NV_PGC6_AON_SECURE_SCRATCH_GROUP_42").read()
     self.vram, self.mmio = self.pci_dev.map_bar(1), self.pci_dev.map_bar(0, fmt='I')
+    if vram_size_reg:
+      self.vram_size = vram_size_reg << 20
+    else:
+      self.vram_size = self.vram.nbytes
+      if DEBUG >= 1: print(f"nv {self.devfmt}: WARNING: VRAM scratch reg is 0, using BAR1 size {self.vram_size // (1024 * 1024)} MB", flush=True)
     self.large_bar = self.vram.nbytes >= self.vram_size
 
     # UVM depth   HW level                            VA bits


### PR DESCRIPTION
On some GPU configurations (reproduced on RTX 4080 Mobile / AD104 via VFIO passthrough) the scratch register NV_PGC6_AON_SECURE_SCRATCH_GROUP_42 may read as 0, causing vram_size to be set to 0 and subsequent failures.

Fix: read the register first, then map BARs. If the register is non-zero (the common case), use it as before. If it is 0, fall back to the BAR1 memory-map size which reflects the actual VRAM amount reported by PCI config space.

This is a defensive fix with zero performance impact on hardware where the register works correctly.