### PR TITLE
avoid repeated parsing and toposort in _valid_priority [PR]

### DIFF
--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -347,7 +347,7 @@ def uop_given_valid(valid:UOp, uop:UOp, try_simplex=True) -> UOp:
 
 def _valid_priority(v: UOp, valids:list[UOp]) -> int:
   # we want valid that's in other valids' parents to be first, so it's more likely the other valids get simplified
-  return sum(-1 if (res:=parse_valid(v)) is not None and res[0] in other.toposort() else 0 for other in valids)
+  return 0 if (res:=parse_valid(v)) is None else sum(-1 for other in valids if (x:=res[0]) is other or x in other.backward_slice)
 
 def simplify_valid(valid:UOp) -> UOp|None:
   if valid.op_in_backward_slice_with_self(Ops.INDEX): return None  # this should only be for indexing, skip if there's a INDEX

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -347,7 +347,7 @@ def uop_given_valid(valid:UOp, uop:UOp, try_simplex=True) -> UOp:
 
 def _valid_priority(v: UOp, valids:list[UOp]) -> int:
   # we want valid that's in other valids' parents to be first, so it's more likely the other valids get simplified
-  return 0 if (res:=parse_valid(v)) is None else sum(-1 for other in valids if (x:=res[0]) is other or x in other.backward_slice)
+  return 0 if (res:=parse_valid(v)) is None else sum(-1 for other in valids if res[0] in other.backward_slice_with_self)
 
 def simplify_valid(valid:UOp) -> UOp|None:
   if valid.op_in_backward_slice_with_self(Ops.INDEX): return None  # this should only be for indexing, skip if there's a INDEX


### PR DESCRIPTION
`_valid_priority` currently calls `parse_valid(v)` and `other.toposort()` for every item in `valids`. This change parses `v` once and then checks `x is other` or membership in `other.backward_slice`. I opted to check `x is other` directly instead of using `backward_slice_with_self` to avoid a dictionary allocation.

Benchmark results:

|n|old ms|direct ms|with_self ms|direct speedup|with_self speedup|
|---:|---:|---:|---:|---:|---:|
|1|0.0022|0.0009|0.0011|2.32x|2.02x|
|2|0.0086|0.0018|0.0026|4.69x|3.38x|
|4|0.0434|0.0041|0.0079|10.60x|5.46x|
|8|0.2619|0.0107|0.0343|24.39x|7.63x|
|16|1.7126|0.0312|0.1783|54.83x|9.61x|
|32|12.3000|0.1012|1.0308|121.50x|11.93x|
|64|93.9261|0.3626|6.9884|259.03x|13.44x|

Code used to benchmark and to verify identical returns: https://gist.github.com/stylishvoid/659706b35e21c70b305bcf9a14633c37