### PR TITLE
Assign to slice only affects views

### DIFF
--- a/test/unit/test_assign.py
+++ b/test/unit/test_assign.py
@@ -1035,6 +1035,13 @@ class TestPartialAssignToSharedBuffer(unittest.TestCase):
     for v, s in zip(views, shapes):
       np.testing.assert_allclose(v.numpy(), np.ones(s))
 
+  def test_slice_assign_to_shared_buffer(self):
+    x = Tensor([1, 2], dtype=dtypes.int32).contiguous().realize()
+    reader = x + 10
+    x[:1].assign(Tensor([9], dtype=dtypes.int32))
+    Tensor.realize(reader, x)
+    np.testing.assert_equal(reader.numpy(), np.array([11, 12], dtype=np.int32))
+    np.testing.assert_equal(x.numpy(), np.array([9, 2], dtype=np.int32))
 
 class TestAfterCachePatterns(unittest.TestCase):
   def test_double_store_after(self):

--- a/test/unit/test_assign.py
+++ b/test/unit/test_assign.py
@@ -1040,8 +1040,16 @@ class TestPartialAssignToSharedBuffer(unittest.TestCase):
     reader = x + 10
     x[:1].assign(Tensor([9], dtype=dtypes.int32))
     Tensor.realize(reader, x)
-    np.testing.assert_equal(reader.numpy(), np.array([11, 12], dtype=np.int32))
-    np.testing.assert_equal(x.numpy(), np.array([9, 2], dtype=np.int32))
+    self.assertEqual(reader.tolist(), [11, 12])
+    self.assertEqual(x.tolist(), [9, 2])
+
+  def test_slice_assign_does_not_rewrite_view_wrapped_reader(self):
+    x = Tensor([1, 2], dtype=dtypes.int32).contiguous().realize()
+    reader = (x + 10).reshape(1, 2)
+    x[:1].assign(Tensor([9], dtype=dtypes.int32))
+    Tensor.realize(reader, x)
+    self.assertEqual(reader.tolist(), [[11, 12]])
+    self.assertEqual(x.tolist(), [9, 2])
 
 class TestAfterCachePatterns(unittest.TestCase):
   def test_double_store_after(self):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -16,11 +16,12 @@ from tinygrad.callify import transform_to_call
 # *** all in scope Tensors are here. this gets relevant UOps ***
 
 all_tensors: dict[weakref.ref[Tensor], None] = {}
-def _apply_map_to_tensors(applied_map:dict[UOp, UOp], name:str) -> None:
+def _apply_map_to_tensors(applied_map:dict[UOp, UOp], name:str, visitor:Callable[[UOp], bool]|None=None) -> None:
   with cpu_profile(TracingKey(name), "TINY"):
     # get tensors in scope
-    in_scope: dict[UOp, bool] = {}
-    def visitor(node: UOp) -> bool: return True if node in applied_map else any(in_scope.get(s, False) for s in node.src)
+    in_scope: dict[UOp, bool] = {node: True for node in applied_map}
+    if visitor is None:
+      def visitor(node: UOp) -> bool: return any(in_scope.get(s, False) for s in node.src)
     scope_tensors: list[Tensor] = [t for tref in list(all_tensors) if (t:=tref()) is not None and t.uop.topovisit(visitor, in_scope)]
 
     # get all Tensors and apply the map. always walk: replace exactly the nodes the map names, values are final
@@ -231,7 +232,9 @@ class Tensor(RandMixin):
       ib = self.uop
       while not ib.has_buffer_identity() and ib is not base: ib = ib.src[0]
       assigned_ib = ib.after(assign)
-      _apply_map_to_tensors({ib: assigned_ib}, name="Embed View Assign")
+      preserves_view = {Ops.PERMUTE, Ops.FLIP, Ops.RESHAPE, Ops.EXPAND, Ops.PAD, Ops.SHRINK, Ops.INDEX, Ops.STACK, Ops.BITCAST,
+                        Ops.RANGE, Ops.END, Ops.AFTER, Ops.GROUP, Ops.SINK}
+      _apply_map_to_tensors({ib: assigned_ib}, name="Embed View Assign", visitor=lambda node: node.op in preserves_view)
     else:
       # simple assign
       self.uop = assign

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -16,12 +16,11 @@ from tinygrad.callify import transform_to_call
 # *** all in scope Tensors are here. this gets relevant UOps ***
 
 all_tensors: dict[weakref.ref[Tensor], None] = {}
-def _apply_map_to_tensors(applied_map:dict[UOp, UOp], name:str, visitor:Callable[[UOp], bool]|None=None) -> None:
+def _apply_map_to_tensors(applied_map:dict[UOp, UOp], name:str, extra_filter:Callable[[UOp], bool]|None=None) -> None:
   with cpu_profile(TracingKey(name), "TINY"):
     # get tensors in scope
     in_scope: dict[UOp, bool] = {node: True for node in applied_map}
-    if visitor is None:
-      def visitor(node: UOp) -> bool: return any(in_scope.get(s, False) for s in node.src)
+    def visitor(node: UOp) -> bool: return any(in_scope.get(s, False) for s in node.src) and (extra_filter is None or extra_filter(node))
     scope_tensors: list[Tensor] = [t for tref in list(all_tensors) if (t:=tref()) is not None and t.uop.topovisit(visitor, in_scope)]
 
     # get all Tensors and apply the map. always walk: replace exactly the nodes the map names, values are final
@@ -234,7 +233,7 @@ class Tensor(RandMixin):
       assigned_ib = ib.after(assign)
       preserves_view = {Ops.PERMUTE, Ops.FLIP, Ops.RESHAPE, Ops.EXPAND, Ops.PAD, Ops.SHRINK, Ops.INDEX, Ops.STACK, Ops.BITCAST,
                         Ops.RANGE, Ops.END, Ops.AFTER, Ops.GROUP, Ops.SINK, Ops.DETACH}
-      _apply_map_to_tensors({ib: assigned_ib}, name="Embed View Assign", visitor=lambda node: node.op in preserves_view)
+      _apply_map_to_tensors({ib: assigned_ib}, name="Embed View Assign", extra_filter=lambda node: node.op in preserves_view)
     else:
       # simple assign
       self.uop = assign

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -233,7 +233,7 @@ class Tensor(RandMixin):
       while not ib.has_buffer_identity() and ib is not base: ib = ib.src[0]
       assigned_ib = ib.after(assign)
       preserves_view = {Ops.PERMUTE, Ops.FLIP, Ops.RESHAPE, Ops.EXPAND, Ops.PAD, Ops.SHRINK, Ops.INDEX, Ops.STACK, Ops.BITCAST,
-                        Ops.RANGE, Ops.END, Ops.AFTER, Ops.GROUP, Ops.SINK}
+                        Ops.RANGE, Ops.END, Ops.AFTER, Ops.GROUP, Ops.SINK, Ops.DETACH}
       _apply_map_to_tensors({ib: assigned_ib}, name="Embed View Assign", visitor=lambda node: node.op in preserves_view)
     else:
       # simple assign

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -16,11 +16,11 @@ from tinygrad.callify import transform_to_call
 # *** all in scope Tensors are here. this gets relevant UOps ***
 
 all_tensors: dict[weakref.ref[Tensor], None] = {}
-def _apply_map_to_tensors(applied_map:dict[UOp, UOp], name:str, extra_filter:Callable[[UOp], bool]|None=None) -> None:
+def _apply_map_to_tensors(applied_map:dict[UOp, UOp], name:str, extra_filter:Callable[[UOp], bool]=lambda node: True) -> None:
   with cpu_profile(TracingKey(name), "TINY"):
     # get tensors in scope
     in_scope: dict[UOp, bool] = {node: True for node in applied_map}
-    def visitor(node: UOp) -> bool: return any(in_scope.get(s, False) for s in node.src) and (extra_filter is None or extra_filter(node))
+    def visitor(node: UOp) -> bool: return any(in_scope.get(s, False) for s in node.src) and extra_filter(node)
     scope_tensors: list[Tensor] = [t for tref in list(all_tensors) if (t:=tref()) is not None and t.uop.topovisit(visitor, in_scope)]
 
     # get all Tensors and apply the map. always walk: replace exactly the nodes the map names, values are final


### PR DESCRIPTION
Fixes issue #17074 where assignment to a view incorrectly affected a tensor created before the assignment. The issue is illustrated in the computation graph below. In the example, the addition is defined before the assignment, but the computation graph places the addition after the assignment. 
<img width="939" height="281" alt="image" src="https://github.com/user-attachments/assets/96f0b3c8-1ab0-4c29-9534-400c67bb5403" />

The addition should not depend on the slice assignment, but instead only depend on the shared buffer. 
<img width="779" height="427" alt="image" src="https://github.com/user-attachments/assets/451fa6a7-e378-4f12-962b-6380dad81309" />

The underlying issue was that the assignment substituted all occurrences of the buffer with a graph that included the slice assignment. As a result, the tensor that depended on the buffer value before the assignment ended up using the updated value instead. 

The substitution should only be performed for views of the buffer. The implementation performs a topovisit from each tensor sink to determine the tensors affected by the assignment. I changed the logic to only consider paths of view-preserving operations, instead of all children of the buffer. 

The code changes were done without AI. 