### PR TITLE
(perf): reduce simplify_merge_adjacent unnecessary graph rewrites and use greedy recursion

### DIFF
--- a/test/opt/test_merge_adjacent_scaling.py
+++ b/test/opt/test_merge_adjacent_scaling.py
@@ -1,0 +1,53 @@
+import unittest
+import numpy as np
+import tinygrad.codegen.simplify as simp
+from tinygrad import Tensor, Device
+from tinygrad.codegen import full_rewrite_to_sink
+from tinygrad.helpers import Context
+from tinygrad.uop.ops import Ops, graph_rewrite, tracked_ctxs
+
+def count_check_merge(n:int) -> int:
+  # compile an n-axis reduce kernel with match stats on, counting check_merge rewrites (each is a full graph walk)
+  linear = Tensor.empty(*([2]*n)).sum().schedule_linear()
+  asts = [u.src[0] for u in linear.toposort() if u.op is Ops.CALL and u.src[0].op is Ops.SINK]
+  assert len(asts) == 1
+  with Context(TRACK_MATCH_STATS=2):
+    tracked_ctxs.clear()
+    full_rewrite_to_sink(asts[0], Device[Device.DEFAULT].renderer)
+  return sum(tr.name.startswith("check_merge") for ctx in tracked_ctxs for tr in ctx)
+
+def merged_reduce_ranges(*shape):
+  # apply just the "simplify ranges" pass (full_rewrite_to_sink eliminates the REDUCE entirely in later passes)
+  linear = Tensor.empty(*shape).sum().schedule_linear()
+  ast = [u.src[0] for u in linear.toposort() if u.op is Ops.CALL and u.src[0].op is Ops.SINK][0]
+  out = graph_rewrite(ast, simp.pm_flatten_range+simp.pm_simplify_ranges, ctx={}, name="simplify ranges")
+  reds = [u for u in out.toposort() if u.op is Ops.REDUCE]
+  assert len(reds) == 1
+  return reds[0].ended_ranges
+
+class TestMergeAdjacentScaling(unittest.TestCase):
+  # on b53cd35cf every ordered pair of ranges was rewritten: 70 check_merge rewrites for n=8.
+  # with greedy restart per merge, each merge is accepted on its first try: n-1 rewrites.
+  # (repeat compiles of related graphs in one process can do less work due to rewrite caches, so these are upper bounds)
+  # measured with TRACK_MATCH_STATS=2 (the same data VIZ shows), base -> this branch:
+  #   check_merge rewrites:  70 -> 7 (n=8),  310 -> 15 (n=16)
+  #   full_rewrite_to_sink: 16.4ms -> 7.7ms (n=8),  172.5ms -> 17.2ms (n=20, 10x)
+  def test_check_merge_rewrites(self):
+    self.assertLessEqual(count_check_merge(8), 7)
+
+  def test_check_merge_rewrites_large(self):
+    self.assertLessEqual(count_check_merge(16), 15)
+
+  # greedy merging collapses all 4 adjacent same-type ranges into one range of size 2*3*4*5
+  def test_greedy_merge_outcome(self):
+    ranges = merged_reduce_ranges(2,3,4,5)
+    self.assertEqual(len(ranges), 1)
+    self.assertEqual(ranges[0].src[0].arg, 120)
+
+  # the merged range must index correctly (the //s1, %s1 substitution): sum of 0..119
+  @unittest.skipIf(Device.DEFAULT == "NULL", "no copyout on NULL")
+  def test_merge_preserves_numerics(self):
+    self.assertEqual(Tensor(np.arange(120, dtype=np.int32).reshape(2,3,4,5)).sum().item(), 7140)
+
+if __name__ == '__main__':
+  unittest.main(verbosity=2)

--- a/test/opt/test_merge_adjacent_scaling.py
+++ b/test/opt/test_merge_adjacent_scaling.py
@@ -7,7 +7,7 @@ from tinygrad.helpers import Context
 from tinygrad.uop.ops import Ops, graph_rewrite, tracked_ctxs
 
 def count_check_merge(n:int) -> int:
-  # compile an n-axis reduce kernel with match stats on, counting check_merge rewrites (each is a full graph walk)
+  # compile an n-axis reduce kernel, counting check_merge rewrites (each is a full graph walk)
   linear = Tensor.empty(*([2]*n)).sum().schedule_linear()
   asts = [u.src[0] for u in linear.toposort() if u.op is Ops.CALL and u.src[0].op is Ops.SINK]
   assert len(asts) == 1
@@ -17,7 +17,7 @@ def count_check_merge(n:int) -> int:
   return sum(tr.name.startswith("check_merge") for ctx in tracked_ctxs for tr in ctx)
 
 def merged_reduce_ranges(*shape):
-  # apply just the "simplify ranges" pass (full_rewrite_to_sink eliminates the REDUCE entirely in later passes)
+  # apply just the "simplify ranges" pass
   linear = Tensor.empty(*shape).sum().schedule_linear()
   ast = [u.src[0] for u in linear.toposort() if u.op is Ops.CALL and u.src[0].op is Ops.SINK][0]
   out = graph_rewrite(ast, simp.pm_flatten_range+simp.pm_simplify_ranges, ctx={}, name="simplify ranges")
@@ -26,10 +26,9 @@ def merged_reduce_ranges(*shape):
   return reds[0].ended_ranges
 
 class TestMergeAdjacentScaling(unittest.TestCase):
-  # on b53cd35cf every ordered pair of ranges was rewritten: 70 check_merge rewrites for n=8.
-  # with greedy restart per merge, each merge is accepted on its first try: n-1 rewrites.
-  # (repeat compiles of related graphs in one process can do less work due to rewrite caches, so these are upper bounds)
-  # measured with TRACK_MATCH_STATS=2 (the same data VIZ shows), base -> this branch:
+  # on b53cd35cf every ordered pair of ranges was rewritten: 70 check_merge rewrites for n=8
+  # with greedy restart per merge, each merge is accepted on its first try: n-1 rewrites
+  # measured with TRACK_MATCH_STATS=2, base -> this branch:
   #   check_merge rewrites:  70 -> 7 (n=8),  310 -> 15 (n=16)
   #   full_rewrite_to_sink: 16.4ms -> 7.7ms (n=8),  172.5ms -> 17.2ms (n=20, 10x)
   def test_check_merge_rewrites(self):
@@ -44,7 +43,7 @@ class TestMergeAdjacentScaling(unittest.TestCase):
     self.assertEqual(len(ranges), 1)
     self.assertEqual(ranges[0].src[0].arg, 120)
 
-  # the merged range must index correctly (the //s1, %s1 substitution): sum of 0..119
+  # the merged range must index correctly (the //s1, %s1 substitution)
   @unittest.skipIf(Device.DEFAULT == "NULL", "no copyout on NULL")
   def test_merge_preserves_numerics(self):
     self.assertEqual(Tensor(np.arange(120, dtype=np.int32).reshape(2,3,4,5)).sum().item(), 7140)

--- a/tinygrad/codegen/simplify.py
+++ b/tinygrad/codegen/simplify.py
@@ -20,21 +20,22 @@ pm_flatten_range = PatternMatcher([
 def count_divmod(x:UOp) -> int: return sum(u.op in {Ops.FLOORDIV, Ops.FLOORMOD} for u in x.backward_slice)
 def simplify_merge_adjacent(u:UOp) -> UOp|None:
   reduce_ranges = [x.ranges for x in u.backward_slice_with_self if x.op is Ops.REDUCE]
+  cur_divmods = count_divmod(u)
   # on END we only want to merge adjacent ranges, on REDUCE we want to try all combinations
   for r0, r1 in (zip(u.ended_ranges, u.ended_ranges[1:]) if u.op is Ops.END else itertools.permutations(u.ended_ranges, 2)):
     # check same type
-    if r0.arg[-1] == r1.arg[-1]:
-      # check if the ranges to merge are in the same reduces
-      if all((r0 in rngs) == (r1 in rngs) for rngs in reduce_ranges):
-        s0, s1 = r0.src[0], r1.src[0]
-        # do the merge
-        new_range = r0.replace(src=(s0*s1,))
-        nidx = graph_rewrite(u, _substitute+symbolic+pm_flatten_range, ctx={r0:new_range//s1, r1:new_range%s1},
-                             name=f"check_merge_{r0.arg[0]}_{r1.arg[0]}")
+    if r0.arg[-1] != r1.arg[-1]: continue
+    # check if the ranges to merge are in the same reduces
+    if not all((r0 in rngs) == (r1 in rngs) for rngs in reduce_ranges): continue
+    s0, s1 = r0.src[0], r1.src[0]
+    # do the merge
+    new_range = r0.replace(src=(s0*s1,))
+    nidx = graph_rewrite(u, _substitute+symbolic+pm_flatten_range, ctx={r0:new_range//s1, r1:new_range%s1},
+                         name=f"check_merge_{r0.arg[0]}_{r1.arg[0]}")
 
-        # check if it simplifies
-        if count_divmod(nidx) <= count_divmod(u):
-          u = nidx
+    # check if it simplifies
+    # greedy: take the first simplifying merge, the recursion restarts the scan on the new graph
+    if count_divmod(nidx) <= cur_divmods: return simplify_merge_adjacent(nidx)
   return u
 
 def mark_gated(ctx, idx):


### PR DESCRIPTION
Old code was recomputing `graph_rewrite` plus two FULL graph `backward_slice` walks, even when `u` hasn't changed. `count_divmod(nidx) <= count_divmod(u)`. It also kept iterating after merge, `for r0, r1 in permutations`, when those are already gone. Reduce with 20 ranges paid 380 rewrites and 760 graph walks in one pass!

To solve:
1. Recompute `count_divmod` only when a merge is accepted (already half the walks gone).
2. Greedy recursion: instead of trying every merge, take first merge and stop iterating stale pair lists, re-enter the function on the new graph. Recursion depth is bounded because every accepted merge strictly reduces the range count by one (two ranges become one). 
3. Simplify code using early `continue`

Time complexity drops O(n^2) to O(n)
 - `check_merge` rewrites:  70 -> 7 (n=8),  310 -> 15 (n=16)
 -  `full_rewrite_to_sink`: 16.4ms -> 7.7ms (n=8),  172.5ms -> 17.2ms (n=20, 10x better)


tests are for merge correctness and verifying the new linear behavior