### PR TITLE
llama: correct fused qkv shape assert

### DIFF
--- a/extra/thunder/amd/fa.py
+++ b/extra/thunder/amd/fa.py
@@ -94,7 +94,7 @@ def fused_qkv_rope(xqkv:Tensor, freqs_cis:Tensor, n_heads:int, n_kv_heads:int, h
   B_local = B // num_devices if is_dp else B
   H_local = n_heads // num_devices if is_mp else n_heads
   H_KV_local = n_kv_heads // num_devices if is_mp else n_kv_heads
-  assert (B_local, N, H_local, H_KV_local, head_dim) == (2, 8192, 32, 8, 128)
+  assert H_local % H_KV_local == 0 and head_dim % 2 == 0 and head_dim <= 512
   single_device = xqkv.device[0] if isinstance(xqkv.device, tuple) else xqkv.device
   arch = Device[single_device].renderer.target.arch
   axis = 0 if is_dp else 2 if is_mp else None


### PR DESCRIPTION
fixes running training in master. sadly we can't test this in CI because FA / GEMM kernels require hipcc.
Tested locally with `time FAKEDATA=1 PYTHONPATH=. NULL_ALLOW_COPYOUT=1 DEV=NULL:HIP:gfx950 JITBEAM=0 NOOPT=1 examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/dev_run.sh`.