### PR TITLE
derivative of logsumexp is independent of max

### DIFF
--- a/test/null/test_schedule.py
+++ b/test/null/test_schedule.py
@@ -1472,6 +1472,18 @@ class TestSchedule(unittest.TestCase):
     x.softmax().sum().backward()
     run_linear(*check_schedule(x.grad, 4))
 
+  def test_logsumexp_backward(self):
+    Tensor.manual_seed(0)
+    x = Tensor.randn(4, 12, 64, 64).realize()
+    x.logsumexp(-1).sum().backward()
+    run_linear(*check_schedule(x.grad, 3))
+
+  def test_logcumsumexp_backward(self):
+    Tensor.manual_seed(0)
+    x = Tensor.randn(4, 512).realize()
+    x.logcumsumexp(-1).sum().backward()
+    run_linear(*check_schedule(x.grad, 3))
+
   def test_scaled_dot_product_attention_fusion(self):
     x, y, z, m = (Tensor.empty(32, 8, 16, 16) for _ in range(4))
     out = Tensor.scaled_dot_product_attention(x, y, z, attn_mask=m)

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -658,7 +658,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     print(t.logsumexp(axis=1).numpy())
     ```
     """
-    m = self.max(axis=axis, keepdim=True)
+    m = self.max(axis=axis, keepdim=True).detach()
     return (self - m).exp().sum(axis=axis, keepdim=keepdim).log() + (m if keepdim else m.squeeze(axis))
 
   def _softmax(self, axis, dtype:DTypeLike|None=None) -> tuple[Self, Self, Self]:
@@ -841,7 +841,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     x = self.transpose(axis, -1)
     last_dim_size = x.shape[-1]
     x_unsqueezed = x.unsqueeze(-2).expand((None,)*(self.ndim-1)+(last_dim_size, None))
-    x_cummax, _ = x.cummax(-1)
+    x_cummax = x.cummax(-1)[0].detach()
     mask = type(self).ones(last_dim_size, last_dim_size, buffer=False).tril()
     ret = mask.where(x_unsqueezed - x_cummax.unsqueeze(-1), self.dtype.min).exp().sum(-1).log() + x_cummax
     return ret.transpose(-1, axis)


### PR DESCRIPTION
same as #7009 but for logsumexp and logcumsumexp: detach the subtracted max, whose gradient contribution cancels exactly. two fewer kernels per backward. schedule regression tests added mirroring test_softmax_backward (5 -> 3 kernels, fail on master).

fwd+bwd, hot, 10 reps, NVIDIA A100-SXM4-40GB, CUDA backend:

| case | kernels | ms |
|------|---------|-----|
| logsumexp (4,12,64,64) ax=-1 | 5 -> 3 | 8.45 -> 6.48 |
| logsumexp (8192,8192) ax=-1 | 5 -> 3 | 7.96 -> 6.08 |
| logsumexp (32,512,50257) ax=-1 | 9 -> 5 | 113.19 -> 79.87 |
| logcumsumexp (64,512) ax=-1 | 5 -> 3 | 26.12 -> 22.80 |
| logcumsumexp (8,2048) ax=-1 | 10 -> 4 | 42.03 -> 30.07 |

gradients unchanged: test_ops compares vs torch at grad_atol=1e-7, also checked tied maxima and -inf masked rows.