### PR TITLE
pytest: use timeout_method signal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,6 @@ norecursedirs = [
   ".git",
 ]
 timeout = 300
-timeout_method = "signal" # thread does not show traceback with pytest-xdist
 timeout_func_only = true
 testpaths = ["test"]
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ norecursedirs = [
   ".git",
 ]
 timeout = 300
-timeout_method = "thread"
+timeout_method = "signal" # thread does not show traceback with pytest-xdist
 timeout_func_only = true
 testpaths = ["test"]
 filterwarnings = [


### PR DESCRIPTION
should actually print tracebacks when timeouts occur