### PR TITLE
support Metal atomics in embedding backward

### DIFF
--- a/test/backend/test_arange.py
+++ b/test/backend/test_arange.py
@@ -1,10 +1,12 @@
-import unittest
+import unittest, platform
 import numpy as np
 from tinygrad import Tensor, GlobalCounters, dtypes, nn, Device, Variable
 from tinygrad.helpers import Context, getenv, DEV
 from tinygrad.engine.realize import run_linear, estimate_uop, compile_linear
 from tinygrad.renderer.ptx import PTXRenderer
 from test.helpers import needs_second_gpu
+
+METAL3 = Device.DEFAULT == "METAL" and int(platform.mac_ver()[0].split('.')[0]) >= 13
 
 class TestArange(unittest.TestCase):
   def _get_flops(self, tensor, desired):
@@ -164,7 +166,7 @@ class TestIndexing(unittest.TestCase):
   def test_llama_embedding_opt(self): self.test_llama_embedding(0, 1_736_704_000)
 
   # NOTE: call doesn't work with SPEC=2
-  @unittest.skipIf(Device.DEFAULT not in ("CPU", "AMD"), "atomics only on AMD/CPU")
+  @unittest.skipIf(Device.DEFAULT not in ("CPU", "AMD") and not METAL3, "atomics only on AMD/CPU/Metal 3")
   @Context(USE_ATOMICS=1, SPEC=1)
   def test_llama_8b_embedding_backward(self):
     from tinygrad.renderer.cstyle import CStyleLanguage
@@ -188,7 +190,7 @@ class TestIndexing(unittest.TestCase):
     for i in idx.flatten().numpy(): expected_grad[i] += 2
     np.testing.assert_allclose(emb.weight.grad.numpy(), expected_grad, rtol=1e-5, atol=1e-5)
 
-  @unittest.skipIf(Device.DEFAULT not in ("CPU", "AMD"), "atomics only on AMD/CPU")
+  @unittest.skipIf(Device.DEFAULT not in ("CPU", "AMD") and not METAL3, "atomics only on AMD/CPU/Metal 3")
   @Context(USE_ATOMICS=1, SPEC=1)
   def test_embedding_backward_padded_embed(self):
     from tinygrad.renderer.cstyle import CStyleLanguage

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -358,6 +358,7 @@ def _embedding_bwd(grad_emb:UOp, call:UOp) -> tuple:
     # atomic scatter-add: grad_weight[token_id, j] += grad_emb_flat[i, j]
     if device in ("CPU", "NULL"): atomic_arg = "__atomic_fetch_add({0}, {1}, __ATOMIC_RELAXED);"
     elif device == "AMD": atomic_arg = "__hip_atomic_fetch_add({0}, {1}, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);"
+    elif device == "METAL": atomic_arg = "atomic_fetch_add_explicit((device atomic_float*){0}, {1}, memory_order_relaxed);"
     else: raise NotImplementedError(f"no atomics for device {device}")
     atomic = UOp(Ops.CUSTOM, src=(grad_weight.index(local_token_id, j_idx), grad_val), arg = atomic_arg)
     return atomic.end(i, j_outer, j_inner).sink(arg=KernelInfo(name="embedding_bwd", opts_to_apply=()))


### PR DESCRIPTION
Adds Metal 3's `atomic_float` spelling to the existing `USE_ATOMICS`
embedding backward and enables its two existing correctness tests on Metal.
This makes the sparse backward usable on Apple Silicon without changing the
default path.

Apple M4, full weight-gradient schedule, GPU-event medians
(`USE_ATOMICS=0 -> 1`, 10 warmups, 120 samples):

- `V=1000, D=128, idx=(4, 256)`: 1.06 ms -> 0.10 ms
- `V=32000, D=256, idx=(4, 64)`: 6.29 ms -> 0.62 ms

The `V=16, D=16, idx=(1, 1)` microcase is slower:
0.016 ms -> 0.021 ms. The path remains opt-in.

Requires Metal 3/macOS 13+.

Tested with the Metal backend tests (19 passed, 4 skipped), ruff, and mypy.

AI disclosure: I did use Codex to investigate, implement, benchmark, and test this change :). Plz don't ban me bro I come in peace. 
