### PR TITLE
lvp: skip test_masked_select

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -3335,6 +3335,7 @@ class TestOps(unittest.TestCase):
   @unittest.skipIf((DEV.interface.startswith("MOCK") or Device.DEFAULT == "PYTHON"), "very slow on MOCKGPU because reduce does not fold")
   @unittest.skipIf(Device.DEFAULT == "WEBGPU", "webgpu runtime issue")
   @unittest.skipIf(Device.DEFAULT == "QCOM", "QCOM fails with: Resource deadlock avoided")
+  @unittest.skipIf(Device.DEFAULT == "CPU" and DEV.renderer == "LVP", "extremely slow with LVP")
   def test_masked_select(self):
     helper_test_op([(32, 10)], lambda x: x.masked_select(x>0.5), lambda x: x.masked_select(x>0.5), forward_only=True)
     helper_test_op([(32, 10)], lambda x: x.masked_select(torch.tensor(True)), lambda x: x.masked_select(Tensor(True)), forward_only=True)


### PR DESCRIPTION
`test_masked_select` is [extremely slow on LVP](https://github.com/tinygrad/tinygrad/actions/runs/29935237611/job/88974995203#step:6:48), triggers timeouts after #17133