### PR TITLE
fix full_like device leak in case buffer=False

### DIFF
--- a/tinygrad/mixin/creation.py
+++ b/tinygrad/mixin/creation.py
@@ -73,8 +73,7 @@ class CreationMixin(DTypeMixin, MovementMixin):
     print(Tensor.full((2, 3), False).numpy())
     ```
     """
-    # TODO: enable this check
-    # if not buffer: assert device is None, "buffer=False does not support device specification"
+    if not buffer: assert device is None, "buffer=False does not support device specification"
     from tinygrad.uop.ops import UOp
     new_shape = argfix(shape)
     dt = to_dtype(dtype) if dtype is not None else fill_value.dtype if isinstance(fill_value, UOp) else dtypes.from_py(fill_value)
@@ -98,7 +97,7 @@ class CreationMixin(DTypeMixin, MovementMixin):
     if isinstance(self.device, tuple):
       if device is not None: raise RuntimeError("cannot specify `device` on `*_like` of a multi device tensor")
       return self._multi_like(lambda shape, dev: type(self).full(shape, fill_value, dtype=dtype or self.dtype, device=dev, buffer=buffer))
-    return type(self).full(self.shape, fill_value, dtype=dtype or self.dtype, device=self.device if device is None else device, buffer=buffer)
+    return type(self).full(self.shape, fill_value, dtype=dtype or self.dtype, device=(self.device if device is None else device) if buffer else device, buffer=buffer)
 
   @classmethod
   def zeros(cls, *shape, **kwargs) -> Self:

--- a/tinygrad/mixin/creation.py
+++ b/tinygrad/mixin/creation.py
@@ -97,7 +97,9 @@ class CreationMixin(DTypeMixin, MovementMixin):
     if isinstance(self.device, tuple):
       if device is not None: raise RuntimeError("cannot specify `device` on `*_like` of a multi device tensor")
       return self._multi_like(lambda shape, dev: type(self).full(shape, fill_value, dtype=dtype or self.dtype, device=dev, buffer=buffer))
-    return type(self).full(self.shape, fill_value, dtype=dtype or self.dtype, device=(self.device if device is None else device) if buffer else device, buffer=buffer)
+    #`buffer=False` produces a device-less broadcast const, so don't inherit `self.device` in that case (None stays None, raising `full` assert)
+    device = (self.device if device is None else device) if buffer else device
+    return type(self).full(self.shape, fill_value, dtype=dtype or self.dtype, device=device, buffer=buffer)
 
   @classmethod
   def zeros(cls, *shape, **kwargs) -> Self:


### PR DESCRIPTION
following [this todo](https://github.com/tinygrad/tinygrad/blob/master/tinygrad/mixin/creation.py#L76),
we want to raise the assert when `buffer=False` and `device!=None` 
breaking case `device=None, buffer=False` in `full_like` which was setting `device = self.device`

now `buffer=True` in `full_like` will still assign `self.device`, otherwise we send the inputed user `device`
 