### PR TITLE
fix n^2 schedule of assign chains [pr]

### DIFF
--- a/test/backend/test_schedule.py
+++ b/test/backend/test_schedule.py
@@ -211,6 +211,20 @@ class TestLimitBufs(unittest.TestCase):
     t1, t2 = min(sched_time(400) for _ in range(3)), min(sched_time(1600) for _ in range(3))
     self.assertLess(t2/t1, 8, f"{t1*1e3:.1f}ms -> {t2*1e3:.1f}ms")
 
+class TestAssignScaling(unittest.TestCase):
+  def test_assign_chain_linear_scaling(self):
+    def sched_time(n):
+      with Context(TRACK_MATCH_STATS=0, DEBUG=0):
+        x = Tensor.zeros(16).contiguous().realize()
+        for _ in range(n): x = x.assign(x + 1)
+        with Context(SCACHE=0):
+          st = time.perf_counter()
+          x.schedule_linear()
+          return time.perf_counter() - st
+    sched_time(200)
+    t1, t2 = min(sched_time(200) for _ in range(3)), min(sched_time(1600) for _ in range(3))
+    self.assertLess(t2/t1, 20, f"{t1*1e3:.1f}ms -> {t2*1e3:.1f}ms")
+
 class TestSwizzle(unittest.TestCase):
   def test_swizzle_simple(self):
     Tensor.manual_seed(0)

--- a/tinygrad/schedule/indexing.py
+++ b/tinygrad/schedule/indexing.py
@@ -17,17 +17,20 @@ def realize_srcs(ctx:dict[UOp, None], rb:UOp) -> None:
   for s in rb.src:
     if s.base.op not in ALWAYS_CONTIGUOUS: ctx[s] = None
 
+# which nodes of src read base in this kernel? doesn't walk below AFTER/CONTIGUOUS (other kernels)
+def base_reads(src:UOp, base:UOp) -> dict[UOp, bool]:
+  reaches: dict[UOp, bool] = {}
+  for s in src.toposort(gate=lambda s: s.op not in {Ops.AFTER, Ops.CONTIGUOUS}):
+    reaches[s] = any(c is base or reaches.get(c) for c in s.src)
+  return reaches
+
 def realize_store_after_src(ctx:dict[UOp, None], dest:UOp, src:UOp):
   # don't realize COPY/SLICE when they are the direct source of STORE+AFTER — the target buffer is the output
   if src.op in {Ops.COPY, Ops.SLICE} and src in ctx \
      and not dest.op_in_backward_slice_with_self(Ops.SHRINK, Ops.PERMUTE, Ops.FLIP, Ops.PAD):
     del ctx[src]
-  # WAR hazard (TestAssign.test_assign_double_diamond_reduce) dont walk below AFTER/CONTIGUOUS (other kernels)
-  base = dest.base
-  reaches: dict[UOp, bool] = {}
-  for s in src.toposort(gate=lambda s: s.op not in {Ops.AFTER, Ops.CONTIGUOUS}):
-    reaches[s] = any(c is base or reaches.get(c) for c in s.src)
-  if src is base or reaches.get(src): ctx[src] = None
+  # WAR hazard (TestAssign.test_assign_double_diamond_reduce)
+  if src is (base:=dest.base) or base_reads(src, base).get(src): ctx[src] = None
 
 pm_generate_realize_map = PatternMatcher([
   # always realize

--- a/tinygrad/schedule/indexing.py
+++ b/tinygrad/schedule/indexing.py
@@ -22,8 +22,11 @@ def realize_store_after_src(ctx:dict[UOp, None], dest:UOp, src:UOp):
   if src.op in {Ops.COPY, Ops.SLICE} and src in ctx \
      and not dest.op_in_backward_slice_with_self(Ops.SHRINK, Ops.PERMUTE, Ops.FLIP, Ops.PAD):
     del ctx[src]
-  # you don't usually have to do this for assign unless there's a WAR hazard like TestAssign.test_assign_double_diamond_reduce
-  if dest.base in src.backward_slice_with_self: ctx[src] = None
+  # WAR hazard (TestAssign.test_assign_double_diamond_reduce) dont walk below AFTER/CONTIGUOUS (other kernels)
+  base, reaches = dest.base, {}
+  for s in src.toposort(gate=lambda s: s.op not in {Ops.AFTER, Ops.CONTIGUOUS}):
+    reaches[s] = any(c is base or reaches.get(c) for c in s.src)
+  if src is base or reaches.get(src): ctx[src] = None
 
 pm_generate_realize_map = PatternMatcher([
   # always realize

--- a/tinygrad/schedule/indexing.py
+++ b/tinygrad/schedule/indexing.py
@@ -23,7 +23,8 @@ def realize_store_after_src(ctx:dict[UOp, None], dest:UOp, src:UOp):
      and not dest.op_in_backward_slice_with_self(Ops.SHRINK, Ops.PERMUTE, Ops.FLIP, Ops.PAD):
     del ctx[src]
   # WAR hazard (TestAssign.test_assign_double_diamond_reduce) dont walk below AFTER/CONTIGUOUS (other kernels)
-  base, reaches = dest.base, {}
+  base = dest.base
+  reaches: dict[UOp, bool] = {}
   for s in src.toposort(gate=lambda s: s.op not in {Ops.AFTER, Ops.CONTIGUOUS}):
     reaches[s] = any(c is base or reaches.get(c) for c in s.src)
   if src is base or reaches.get(src): ctx[src] = None

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -10,7 +10,7 @@ from tinygrad.helpers import prod, all_same, getenv, dedup, all_int, DEBUG, SPLI
 from tinygrad.helpers import PCONTIG, FLOAT16, OPENPILOT_HACKS, argsort, partition, get_single_element
 from tinygrad.codegen.simplify import pm_flatten_range, pm_reduce_simplify
 from tinygrad.codegen.opt import Opt
-from tinygrad.schedule.indexing import run_rangeify, BufferizeOpts, IndexingContext, apply_movement_op
+from tinygrad.schedule.indexing import run_rangeify, BufferizeOpts, IndexingContext, apply_movement_op, base_reads
 from tinygrad.schedule.multi import multi_pm
 from tinygrad.schedule.allreduce import create_allreduce_function
 
@@ -60,17 +60,11 @@ pm_mops = PatternMatcher([
 # 0. do some cleanup rewrites, mostly copied from the old stuff
 
 def fix_store_hazard(target:UOp, src:UOp):
-  base = target.base
-  reaches_base: dict[UOp, bool] = {}
-  shrink_unsafe: bool|None = None
-  # don't walk below AFTER (prior kernel)
-  for s in src.toposort(gate=lambda s: s.op not in {Ops.CONTIGUOUS, Ops.AFTER}):
-    reaches_base[s] = reaches = any(c is base or reaches_base.get(c) for c in s.src)
-    if not reaches: continue
-    # PERMUTE and FLIP reorder indices SHRINK can have overlapping regions when dest is also shrunk
-    if s.op is Ops.SHRINK and shrink_unsafe is None: shrink_unsafe = target.op_in_backward_slice_with_self(Ops.SHRINK)
-    if s.op in {Ops.PERMUTE, Ops.FLIP} or (s.op is Ops.SHRINK and s is not target and shrink_unsafe):
-      return target.store(src.contiguous())
+  hazards = [s for s,r in base_reads(src, target.base).items() if r and not (s.op is Ops.SHRINK and s is target)]
+  # PERMUTE and FLIP reorder indices, SHRINK can have overlapping regions when dest is also shrunk
+  if any(s.op in {Ops.PERMUTE, Ops.FLIP} for s in hazards) or \
+     (any(s.op is Ops.SHRINK for s in hazards) and target.op_in_backward_slice_with_self(Ops.SHRINK)):
+    return target.store(src.contiguous())
 
 def split_reduceop(reduce:UOp, x:UOp):
   if prod(reduce.shape) == 0: return None

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -60,13 +60,17 @@ pm_mops = PatternMatcher([
 # 0. do some cleanup rewrites, mostly copied from the old stuff
 
 def fix_store_hazard(target:UOp, src:UOp):
-  if (base:=target.base) not in src.backward_slice_with_self: return None
-  # PERMUTE and FLIP reorder indices, SHRINK can have overlapping regions when dest is also shrunk
-  unsafe = {Ops.PERMUTE, Ops.FLIP} | ({Ops.SHRINK} if target.op_in_backward_slice_with_self(Ops.SHRINK) else set())
+  base = target.base
   reaches_base: dict[UOp, bool] = {}
-  for s in src.toposort(gate=lambda s: s.op is not Ops.CONTIGUOUS):
-    reaches_base[s] = s is base or any(reaches_base.get(c) for c in s.src)
-    if reaches_base[s] and s.op in unsafe and not (s is target and s.op is Ops.SHRINK): return target.store(src.contiguous())
+  shrink_unsafe: bool|None = None
+  # don't walk below AFTER (prior kernel)
+  for s in src.toposort(gate=lambda s: s.op not in {Ops.CONTIGUOUS, Ops.AFTER}):
+    reaches_base[s] = reaches = any(c is base or reaches_base.get(c) for c in s.src)
+    if not reaches: continue
+    # PERMUTE and FLIP reorder indices SHRINK can have overlapping regions when dest is also shrunk
+    if s.op is Ops.SHRINK and shrink_unsafe is None: shrink_unsafe = target.op_in_backward_slice_with_self(Ops.SHRINK)
+    if s.op in {Ops.PERMUTE, Ops.FLIP} or (s.op is Ops.SHRINK and s is not target and shrink_unsafe):
+      return target.store(src.contiguous())
 
 def split_reduceop(reduce:UOp, x:UOp):
   if prod(reduce.shape) == 0: return None

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -832,12 +832,15 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
       if not len(ad) or not all_same(ad): return None
       return ad[0]
     return None
+  # never returns self so safe to cache
+  @functools.cached_property
+  def _after_buf_uop(self) -> UOp: return self.src[0].buf_uop.base
   @property
   def buf_uop(self) -> UOp:
     if self.op in {Ops.BUFFER, Ops.PARAM}: return self
     if self.op is Ops.MSELECT: return self.src[0].buf_uop.mselect(self.arg)
     if self.op is Ops.MSTACK: return UOp(Ops.MSTACK, src=tuple(x.buf_uop for x in self.src))
-    if self.base.op is Ops.AFTER: return self.base.src[0].buf_uop.base
+    if (base:=self.base).op is Ops.AFTER: return base._after_buf_uop
     s = self
     while len(s.src) and s.op not in {Ops.BUFFER, Ops.PARAM, Ops.STAGE, Ops.MSTACK}: s = s.src[0]
     return s


### PR DESCRIPTION
gate STORE history walks at AFTER and cache AFTER buf_uop
n chained assigns: 871ms->302ms (n=400), 59.6s->4.6s (n=3200)

benchmark code https://gist.github.com/jk20342/6b1a5fc0618c03fb4ddc17a2314b6a5f