### PR TITLE
llm: use packed expert weights for decode

### DIFF
--- a/test/unit/test_gguf.py
+++ b/test/unit/test_gguf.py
@@ -1,7 +1,7 @@
 import os, struct, unittest, tempfile, pathlib, sys
 from tinygrad import dtypes, Tensor, fetch, Device
 from tinygrad.helpers import disable_gc
-from tinygrad.llm.gguf import _ggml_iq_grid, ggml_data_to_tensor, gguf_load
+from tinygrad.llm.gguf import _ggml_iq_grid, ggml_data_to_tensor, gguf_load, GGMLQuantizedTensor
 from tinygrad.runtime.autogen import ggml_common as _ggml
 import numpy as np
 from gguf import GGUFReader, GGUFValueType, GGMLQuantizationType, GGML_QUANT_SIZES, dequantize, quantize
@@ -245,6 +245,32 @@ class TestGGUFGEMV(unittest.TestCase):
   def test_gguf_gemv_mxfp4(self): self._test_gguf_gemv(GGMLQuantizationType.MXFP4)
   @unittest.skipUnless(dtypes.bfloat16 in supported_dtypes, "Backend must support bfloat16")
   def test_gguf_gemv_bf16(self): self._test_gguf_gemv(GGMLQuantizationType.BF16)
+
+class TestGGUFPackedMatvec(unittest.TestCase):
+  def _packed(self, shape:tuple[int, ...], qtype:GGMLQuantizationType) -> tuple[GGMLQuantizedTensor, Tensor]:
+    block_size, type_size = GGML_QUANT_SIZES[qtype]
+    rng = np.random.default_rng(42)
+    raw = rng.integers(0, 256, size=np.prod(shape) // block_size * type_size, dtype=np.uint8).reshape(-1, type_size)
+    raw[:, :4] = (rng.standard_normal((raw.shape[0], 2)) * 0.01).astype(np.float16).view(np.uint8).reshape(-1, 4)
+    raw_tensor = Tensor(raw.flatten())
+    return GGMLQuantizedTensor(raw_tensor, shape, qtype.value), ggml_data_to_tensor(raw_tensor, int(np.prod(shape)), qtype.value).reshape(shape)
+
+  def _test_matrix(self, qtype:GGMLQuantizationType):
+    packed, weight = self._packed((3, 512), qtype)
+    x = Tensor(np.random.default_rng(1).standard_normal((2, 512)).astype(np.float32))
+    np.testing.assert_allclose(packed.matvec(x).numpy(), (x @ weight.T).numpy(), atol=1e-3, rtol=1e-4)
+
+  def _test_selected(self, qtype:GGMLQuantizationType):
+    packed, weight = self._packed((4, 3, 512), qtype)
+    rows = Tensor([[[3, 1], [0, 3]]])
+    x = Tensor(np.random.default_rng(1).standard_normal((1, 2, 2, 512)).astype(np.float32))
+    expected = (x.unsqueeze(-2) @ weight[rows].transpose(-1, -2)).squeeze(-2)
+    np.testing.assert_allclose(packed.matvec(x, rows).numpy(), expected.numpy(), atol=1e-3, rtol=1e-4)
+
+  def test_matrix_q4_k(self): self._test_matrix(GGMLQuantizationType.Q4_K)
+  def test_matrix_q5_k(self): self._test_matrix(GGMLQuantizationType.Q5_K)
+  def test_selected_q4_k(self): self._test_selected(GGMLQuantizationType.Q4_K)
+  def test_selected_q5_k(self): self._test_selected(GGMLQuantizationType.Q5_K)
 
 class TestGGUFGC(unittest.TestCase):
   def test_gguf_load_no_tensor_leak(self):

--- a/test/unit/test_gguf.py
+++ b/test/unit/test_gguf.py
@@ -225,6 +225,10 @@ class TestGGUFGEMV(unittest.TestCase):
     buf += q_data.tobytes()
 
     _, tensors = gguf_load(Tensor(np.frombuffer(buf, dtype=np.uint8)).to(None))
+    if qtype in (GGMLQuantizationType.Q4_K, GGMLQuantizationType.Q5_K):
+      _, packed_tensors = gguf_load(Tensor(np.frombuffer(buf, dtype=np.uint8)).to(None), preserve_quantized=lambda name, typ: name == "weight")
+      self.assertIsInstance(packed_tensors["weight"], GGMLQuantizedTensor)
+      np.testing.assert_equal(packed_tensors["weight"].dequantized().numpy(), tensors["weight"].numpy())
 
     x = rng.standard_normal(cols).astype(np.float32)
     with np.errstate(all='ignore'):

--- a/test/unit/test_llm_moe.py
+++ b/test/unit/test_llm_moe.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 from dataclasses import replace
 from tinygrad import Tensor
-from tinygrad.llm.model import TransformerBlock, TransformerConfig
+from tinygrad.llm.model import ExpertWeights, TransformerBlock, TransformerConfig
 
 def _moe_config(dim=8, hidden=16, n_heads=2, num_experts=4, num_experts_per_tok=2):
   return TransformerConfig(
@@ -12,6 +12,20 @@ def _moe_config(dim=8, hidden=16, n_heads=2, num_experts=4, num_experts_per_tok=
     num_experts=num_experts, num_experts_per_tok=num_experts_per_tok)
 
 class TestMoEFeedForward(unittest.TestCase):
+  def test_packed_expert_decode_only_dispatch(self):
+    class PackedWeight:
+      calls = 0
+      def matvec(self, x:Tensor, rows:Tensor) -> Tensor:
+        self.calls += 1
+        return Tensor.zeros(*x.shape[:-1], 3)
+
+    expert = ExpertWeights(num_experts=4, in_features=8, out_features=3)
+    expert.packed_weight = packed = PackedWeight()
+    expert(Tensor([[[0, 1]]]), Tensor.zeros(1, 1, 1, 8)).realize()
+    self.assertEqual(packed.calls, 1)
+    expert(Tensor([[[0, 1], [2, 3]]]), Tensor.zeros(1, 2, 1, 8)).realize()
+    self.assertEqual(packed.calls, 1)
+
   def test_moe_feed_forward(self):
     dim, hidden, n_heads = 8, 16, 2
     num_experts, k = 4, 2

--- a/tinygrad/llm/gguf.py
+++ b/tinygrad/llm/gguf.py
@@ -181,7 +181,12 @@ readers: dict[int, Callable[[io.BufferedIOBase], Any]] = { 8: read_str, 9: read_
     [ (0,"c",1), (1,"b",1), (2,"H",2), (3,"h",2), (4,"I",4), (5,"i",4), (6,"f",4), (7,"?",1), (10,"Q",8), (11,"q",8), (12,"d",8) ] } }
 read_uint32, read_int32, read_uint64, read_int64 = readers[4], readers[5], readers[10], readers[11]
 
-def _gguf_parse(tensor: Tensor) -> tuple[dict, dict[str, Tensor]]:
+def _ggml_nbytes(n:int, ggml_type:int) -> int:
+  if (dtype := _GGML_NATIVE.get(ggml_type)) is not None: return n * dtype.itemsize
+  block_elems, block_bytes = _GGML_QUANT[ggml_type]
+  return n // block_elems * block_bytes
+
+def _gguf_parse(tensor: Tensor, preserve_quantized:Callable[[str, int], bool]|None=None) -> tuple[dict, dict[str, Tensor|GGMLQuantizedTensor]]:
   # TODO: remove the need for copy to default device
   tensor = tensor.to(None).realize()
   r = io.BufferedReader(TensorIO(tensor), 1_000_000)
@@ -197,7 +202,12 @@ def _gguf_parse(tensor: Tensor) -> tuple[dict, dict[str, Tensor]]:
   alignment, pos = kv_data.get("general.alignment", 32), r.tell()
   data_start = round_up(pos, alignment)
 
-  state_dict = {name: ggml_data_to_tensor(tensor[data_start + off:], prod(dims), typ).reshape(*reversed(dims)) for name, dims, typ, off in t_infos}
+  state_dict:dict[str, Tensor|GGMLQuantizedTensor] = {}
+  for name, dims, typ, off in t_infos:
+    shape, n = tuple(reversed(dims)), prod(dims)
+    raw = tensor[data_start + off:data_start + off + _ggml_nbytes(n, typ)]
+    state_dict[name] = GGMLQuantizedTensor(raw, shape, typ) if preserve_quantized is not None and preserve_quantized(name, typ) else \
+      ggml_data_to_tensor(raw, n, typ).reshape(shape)
   return kv_data, state_dict
 
 def _gguf_split_paths(path: pathlib.Path, kv: dict) -> list[pathlib.Path]:
@@ -206,7 +216,8 @@ def _gguf_split_paths(path: pathlib.Path, kv: dict) -> list[pathlib.Path]:
   if not (m := re.match(r"^(.*)-00001-of-\d{5}\.gguf$", str(path))): raise ValueError(f"first split path must end with -00001-of-NNNNN.gguf: {path}")
   return [pathlib.Path(f"{m.group(1)}-{i:05d}-of-{total:05d}.gguf") for i in range(1, total+1)]
 
-def gguf_load(fn: Tensor|str|pathlib.Path) -> tuple[dict, dict[str, Tensor]]:
+def gguf_load(fn: Tensor|str|pathlib.Path, preserve_quantized:Callable[[str, int], bool]|None=None) -> \
+    tuple[dict, dict[str, Tensor|GGMLQuantizedTensor]]:
   """
   Loads a .gguf file, returning the `kv_data` and `state_dict`. Multi-part splits are auto-merged when loaded by path.
 
@@ -221,8 +232,8 @@ def gguf_load(fn: Tensor|str|pathlib.Path) -> tuple[dict, dict[str, Tensor]]:
 
   NOTE: The provided tensor must be on a device that supports execution.
   """
-  kv, sd = _gguf_parse(fn if isinstance(fn, Tensor) else Tensor(pathlib.Path(fn)))
+  kv, sd = _gguf_parse(fn if isinstance(fn, Tensor) else Tensor(pathlib.Path(fn)), preserve_quantized)
   if kv.get('split.count', 1) <= 1: return kv, sd
   if isinstance(fn, Tensor): raise ValueError("multi-part GGUF requires a path argument (got Tensor)")
-  for pp in _gguf_split_paths(pathlib.Path(fn), kv)[1:]: sd.update(_gguf_parse(Tensor(pp))[1])
+  for pp in _gguf_split_paths(pathlib.Path(fn), kv)[1:]: sd.update(_gguf_parse(Tensor(pp), preserve_quantized)[1])
   return kv, sd

--- a/tinygrad/llm/gguf.py
+++ b/tinygrad/llm/gguf.py
@@ -1,10 +1,12 @@
 import functools, io, pathlib, re, struct
-from typing import Any, Callable
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Self
 
 from tinygrad.tensor import Tensor
-from tinygrad.dtype import dtypes
+from tinygrad.dtype import dtypes, DType, DTypeLike, to_dtype
 from tinygrad.helpers import prod, round_up
 from tinygrad.nn.state import TensorIO
+from tinygrad.uop.ops import UOp, Ops, KernelInfo, AxisType
 
 # ggml packs each iq grid entry as N bytes (N=4 for uint32 grids, N=8 for uint64 grids) in a single word. See ggml-common.h.
 @functools.lru_cache(None)
@@ -19,6 +21,56 @@ _GGML_NATIVE = {0: dtypes.float32, 1: dtypes.float16, 24: dtypes.int8, 25: dtype
 # quant types {ggml_type: (number of elements, number of bytes)}
 _GGML_QUANT = {2:(32,18), 3:(32,20), 6:(32,22), 7:(32,24), 8:(32,34),
                12:(256,144), 13:(256,176), 14:(256,210), 18:(256,98), 21:(256,110), 22:(256,82), 23:(256,136), 39:(32,17), 41:(128,18)}
+
+def _ggml_qk_matvec(out:UOp, x:UOp, raw:UOp, rows:UOp, ggml_type:int) -> UOp:
+  routes, outputs, K = out.shape[0], out.shape[1], x.shape[1]
+  _, block_bytes = _GGML_QUANT[ggml_type]
+  row_bytes = K // 256 * block_bytes
+  route, output = UOp.range(routes, 0, AxisType.GLOBAL), UOp.range(outputs, 1, AxisType.GLOBAL)
+  k = UOp.range(K, 2, AxisType.REDUCE)
+  block, within = k.cast(dtypes.int64) // 256, k.cast(dtypes.int64) % 256
+  group, lane = within // 32, within % 32
+  base = (rows[route].cast(dtypes.int64) * outputs + output.cast(dtypes.int64)) * row_bytes + block * block_bytes
+  def fp16(offset:int) -> UOp:
+    bits = raw[base + offset].cast(dtypes.uint16).bitwise_or(raw[base + offset + 1].cast(dtypes.uint16).lshift(8))
+    return bits.bitcast(dtypes.float16).cast(dtypes.float)
+  scale_group = group % 4
+  scale_lo, min_lo = raw[base + 4 + scale_group].bitwise_and(63), raw[base + 8 + scale_group].bitwise_and(63)
+  scale_hi = raw[base + 12 + scale_group].bitwise_and(15).bitwise_or(raw[base + 4 + scale_group].rshift(6).lshift(4))
+  min_hi = raw[base + 12 + scale_group].rshift(4).bitwise_or(raw[base + 8 + scale_group].rshift(6).lshift(4))
+  scale, min_scale = (group < 4).where(scale_lo, scale_hi), (group < 4).where(min_lo, min_hi)
+  qs_offset = 48 if ggml_type == 13 else 16
+  qbyte = raw[base + qs_offset + (group // 2) * 32 + lane]
+  quant = (group % 2).eq(0).where(qbyte.bitwise_and(15), qbyte.rshift(4)).cast(dtypes.float)
+  if ggml_type == 13: quant = quant + raw[base + 16 + lane].rshift(group).bitwise_and(1).cast(dtypes.float) * 16
+  weight = fp16(0) * scale.cast(dtypes.float) * quant - fp16(2) * min_scale.cast(dtypes.float)
+  value = (x[route, k].cast(dtypes.float) * weight).reduce(k, arg=Ops.ADD)
+  return out[route, output].store(value.cast(out.dtype)).end(route, output).sink(
+    arg=KernelInfo(name=f"ggml_q{4 if ggml_type == 12 else 5}_k_matvec_{routes}_{outputs}_{K}", opts_to_apply=()))
+
+@dataclass(frozen=True, slots=True)
+class GGMLQuantizedTensor:
+  raw:Tensor
+  shape:tuple[int, ...]
+  ggml_type:int
+  dtype:DType = dtypes.float32
+
+  def cast(self, dtype:DTypeLike) -> Self: return replace(self, dtype=to_dtype(dtype))
+
+  def dequantized(self) -> Tensor:
+    return ggml_data_to_tensor(self.raw, prod(self.shape), self.ggml_type).reshape(self.shape).cast(self.dtype)
+
+  def matvec(self, x:Tensor, rows:Tensor|None=None) -> Tensor:
+    assert self.ggml_type in (12, 13), f"packed matvec only supports Q4_K and Q5_K, got {self.ggml_type}"
+    assert len(self.shape) in (2, 3) and self.shape[-1] == x.shape[-1] and self.shape[-1] % 256 == 0
+    leading, outputs, K = x.shape[:-1], self.shape[-2], self.shape[-1]
+    if rows is None: rows = Tensor.zeros(*leading, dtype=dtypes.int32, device=x.device)
+    assert rows.shape == leading and self.raw.device == x.device
+    routes = prod(leading)
+    out = Tensor.empty(routes, outputs, dtype=self.dtype, device=x.device)
+    ret = Tensor.custom_kernel(out, x.reshape(routes, K), self.raw.reshape(-1), rows.reshape(routes),
+                               fxn=functools.partial(_ggml_qk_matvec, ggml_type=self.ggml_type))[0]
+    return ret.reshape(*leading, outputs)
 
 def ggml_data_to_tensor(t: Tensor, n: int, ggml_type: int) -> Tensor:
   """

--- a/tinygrad/llm/model.py
+++ b/tinygrad/llm/model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import functools, itertools, pathlib
 from dataclasses import dataclass, replace
 from tinygrad import Tensor, nn, UOp, TinyJit, getenv, function
-from tinygrad.llm.gguf import gguf_load
+from tinygrad.llm.gguf import gguf_load, GGMLQuantizedTensor
 from tinygrad.uop.ops import resolve
 
 @functools.cache
@@ -17,6 +17,8 @@ class ExpertWeights:
     self.weight = Tensor.zeros(num_experts, out_features, in_features)
   def __call__(self, sel:Tensor, x:Tensor) -> Tensor:
     # sel: (B, T, k), x: (B, T, 1, in) or (B, T, k, in) -> output: (B, T, k, out)
+    if x.shape[1] == 1 and hasattr(self, "packed_weight"):
+      return self.packed_weight.matvec(x.expand(*sel.shape, x.shape[-1]), sel)
     return (x.unsqueeze(-2) @ self.weight[sel].transpose(-1, -2)).contiguous().squeeze(-2)
 
 def apply_rope(x:Tensor, freqs_cis:Tensor) -> Tensor:
@@ -324,10 +326,13 @@ class Transformer:
   def from_gguf(gguf:Tensor|str|pathlib.Path, max_context:int|None=None,
                 realize=bool(getenv("REALIZE", 0))) -> tuple[Transformer, dict]:
     # TODO: remove the need for copy to default device
-    kv, state_dict = gguf_load(gguf.to(None).realize() if isinstance(gguf, Tensor) else gguf)
+    kv, state_dict = gguf_load(gguf.to(None).realize() if isinstance(gguf, Tensor) else gguf,
+      preserve_quantized=lambda name, typ: typ in (12, 13) and ".ffn_" in name and "_exps.weight" in name)
 
     # all state items should be float16, not float32
-    state_dict = {k:v.cast('float16') if getenv("HALF", 1) else v for k,v in state_dict.items()}
+    packed_state = {k:v for k,v in state_dict.items() if isinstance(v, GGMLQuantizedTensor)}
+    state_dict = {k:(v.dequantized() if isinstance(v, GGMLQuantizedTensor) else v).cast('float16') if getenv("HALF", 1) else
+                  (v.dequantized() if isinstance(v, GGMLQuantizedTensor) else v) for k,v in state_dict.items()}
 
     # some models like Llama 3.2 don't have an output.weight, they just tie to the token_embd.weight
     if 'output.weight' not in state_dict: state_dict['output.weight'] = state_dict['token_embd.weight']
@@ -383,6 +388,9 @@ class Transformer:
       expert_bias=f"blk.{kv.get(f'{arch}.leading_dense_block_count', 0)}.exp_probs_b.bias" in state_dict)
     model = Transformer(config)
     nn.state.load_state_dict(model, state_dict, verbose=False, consume=True, realize=False)  # NOTE: rope_freqs.weight (32,) is unused
+    for name, packed in packed_state.items():
+      _, block_idx, expert_name, _ = name.split(".")
+      getattr(model.blk[int(block_idx)], expert_name).packed_weight = packed.cast('float16') if getenv("HALF", 1) else packed
     # NOTE: without this contiguous, it unpacks the weights from the model every time. we shouldn't need this, but for now it's faster
     if realize:
       for s in (params:=nn.state.get_parameters(model)): s.replace(s.contiguous())


### PR DESCRIPTION
Stacked on #17169.

Preserves Q4_K/Q5_K MoE expert weights in packed GGUF form and dispatches the packed matvec only for the T=1 autoregressive decode path. Batched prefill continues through the existing selected-weight matmul path.

The dense lazy weight remains the normal state-dict parameter, so existing loading, prefill, and serialization behavior are preserved.

Validation:
- `uv run --extra linting ruff check .`
- `uv run --extra testing_unit pytest -q test/unit/test_gguf.py test/unit/test_llm_moe.py` (50 passed)
- AMD GPU targeted packed/MoE tests (5 passed)

Known draft blocker:
- A separate GLM-5.2 TP4 benchmark composition is numerically correct on a finite nonzero routed-MoE layer fixture, but direct-packed is slower there: 4.638 ms versus 2.696 ms for selected-first.
- Full 515-token TP4 requests currently hit an AMD MMU fault during the long prefill/rollout transition, so there is no valid end-to-end throughput result yet.
- A short-context full-model TP4 decode smoke is stable at 1.396 tok/s over 12 post-capture tokens. These TP changes are not part of this PR.