### PR TITLE
don't apply float-half-float optimization outside image loads

### DIFF
--- a/test/backend/test_dtype.py
+++ b/test/backend/test_dtype.py
@@ -229,10 +229,10 @@ class TestFloatDType(TestDType):
     _test_op(lambda: Tensor([-0.9, -0.3, 1.2], dtype=dtypes.float32).cast(dtypes.uint32), dtypes.uint32,
              [0, 0, 1])
 
-  @unittest.skipUnless(dtypes.half in supported_dtypes, f"no float16 on {Device.DEFAULT}")
-  @unittest.skipIf(Device.DEFAULT == "CL" and getenv("RUSTICL_ENABLE", "") == "llvmpipe",
+  @unittest.skipIf(dtypes.half in supported_dtypes and Device.DEFAULT == "CL" and getenv("RUSTICL_ENABLE", "") == "llvmpipe",
                    "rusticl/llvmpipe does not round standalone float16 casts")
-  @unittest.skipIf(sys.platform == "linux" and Device.DEFAULT == "WEBGPU", "Linux WebGPU does not round standalone float16 casts")
+  @unittest.skipIf(dtypes.half in supported_dtypes and sys.platform == "linux" and Device.DEFAULT == "WEBGPU",
+                   "Linux WebGPU does not round standalone float16 casts")
   def test_float_half_float_preserves_rounding(self):
     values = np.array([1.0003, -2.0007, 123.456], dtype=np.float32)
     got = Tensor(values).cast(dtypes.float16).cast(dtypes.float32).numpy()

--- a/test/backend/test_dtype.py
+++ b/test/backend/test_dtype.py
@@ -229,6 +229,12 @@ class TestFloatDType(TestDType):
     _test_op(lambda: Tensor([-0.9, -0.3, 1.2], dtype=dtypes.float32).cast(dtypes.uint32), dtypes.uint32,
              [0, 0, 1])
 
+  def test_float_half_float_preserves_rounding(self):
+    values = np.array([1.0003, -2.0007, 123.456], dtype=np.float32)
+    got = Tensor(values).cast(dtypes.float16).cast(dtypes.float32).numpy()
+    expected = values.astype(np.float16).astype(np.float32)
+    np.testing.assert_array_equal(got, expected)
+
 @unittest.skipUnless(dtypes.double in supported_dtypes, f"no double on {Device.DEFAULT}")
 class TestDoubleDType(TestDType):
   DTYPE = dtypes.double

--- a/test/backend/test_dtype.py
+++ b/test/backend/test_dtype.py
@@ -1,4 +1,4 @@
-import contextlib, unittest, math
+import contextlib, unittest, math, sys
 import numpy as np
 import torch
 from typing import Any, List
@@ -229,6 +229,10 @@ class TestFloatDType(TestDType):
     _test_op(lambda: Tensor([-0.9, -0.3, 1.2], dtype=dtypes.float32).cast(dtypes.uint32), dtypes.uint32,
              [0, 0, 1])
 
+  @unittest.skipUnless(dtypes.half in supported_dtypes, f"no float16 on {Device.DEFAULT}")
+  @unittest.skipIf(Device.DEFAULT == "CL" and getenv("RUSTICL_ENABLE", "") == "llvmpipe",
+                   "rusticl/llvmpipe does not round standalone float16 casts")
+  @unittest.skipIf(sys.platform == "linux" and Device.DEFAULT == "WEBGPU", "Linux WebGPU does not round standalone float16 casts")
   def test_float_half_float_preserves_rounding(self):
     values = np.array([1.0003, -2.0007, 123.456], dtype=np.float32)
     got = Tensor(values).cast(dtypes.float16).cast(dtypes.float32).numpy()

--- a/tinygrad/codegen/decomp/dtype.py
+++ b/tinygrad/codegen/decomp/dtype.py
@@ -114,6 +114,9 @@ def f2f_clamp(val:UOp, dt:DType, sat=True) -> UOp:
   # FIXME: CMPLT of nan is undefined
   return val.ne(val).where(val, (val < -mx).where(-sat, (mx < val).where(sat, val)))
 
+def f2f_round(val:UOp, dt:DType) -> UOp:
+  return shl(rne(val.bitcast(f2f_dt[val.dtype]), (s:=dtypes.finfo(val.dtype)[1] - dtypes.finfo(dt)[1])), s).bitcast(val.dtype)
+
 def f2f_load(x: UOp, fr:DType, to:DType) -> UOp:
   if (n:=x.max_numel()) == 1: return f2f(x.replace(dtype=f2f_dt[fr]), fr, to)
   return UOp(Ops.STACK, src=tuple(f2f(x.replace(dtype=f2f_dt[fr], src=(reindex(x.src[0], i, 1),)), fr, to) for i in range(n)))
@@ -161,7 +164,7 @@ pm_float_decomp = PatternMatcher([
   (UPat(Ops.BITCAST, src=(UPat.var("x"),), name="bc"), lambda ctx,bc,x:
    f2f(x.bitcast(f2f_dt[ctx[0]]), ctx[0], ctx[1]) if bc.dtype == ctx[0] else None),
   (UPat(Ops.CAST, dtypes.floats, src=(UPat.var("val"),), name="x"), lambda ctx,x,val:
-   f2f_clamp(val.cast(ctx[1]), ctx[0]) if x.dtype == ctx[0] else None),
+   f2f_round(f2f_clamp(val.cast(ctx[1]), ctx[0]), ctx[0]) if x.dtype == ctx[0] else None),
   (UPat(GroupOp.All-{Ops.BITCAST}, dtypes.floats, name="x"), lambda ctx,x:
    x.replace(dtype=ctx[1], src=tuple(s.cast(ctx[1]) if s.dtype == ctx[0] else s for s in x.src))
    if x.dtype == ctx[0] else None),

--- a/tinygrad/codegen/late/coalesce.py
+++ b/tinygrad/codegen/late/coalesce.py
@@ -94,8 +94,9 @@ pm_simplify_add_image = PatternMatcher([
   # image load/store is always float
   (UPat(Ops.INDEX, dtype=dtypes.float, name="x").load(dtype=dtypes.half), lambda x: x.load().cast(dtypes.half)),
   (UPat(Ops.INDEX, dtype=dtypes.float, name="x").store(UPat(name="d", dtype=dtypes.half)), lambda x,d: x.store(d.cast(dtypes.float))),
-  (UPat(Ops.INDEX, dtype=dtypes.float, name="x").load().cast(dtypes.half).cast(dtypes.float),
-   lambda x: x.load() if x.src[0].dtype == dtypes.half and is_image_shape(x.src[0]._shape) else None),
+  (UPat.any(UPat(Ops.LOAD, dtype=dtypes.float, name="x"),
+            UPat(Ops.INDEX, dtype=dtypes.float, src=(UPat(Ops.LOAD), UPat()), name="x")).cast(dtypes.half).cast(dtypes.float),
+   lambda x: x if (buf:=x.buf_uop).dtype == dtypes.half and is_image_shape(buf._shape) else None),
 ])
 
 def memory_coalescing(sink:UOp, ctx:Renderer) -> UOp:

--- a/tinygrad/codegen/late/coalesce.py
+++ b/tinygrad/codegen/late/coalesce.py
@@ -94,7 +94,8 @@ pm_simplify_add_image = PatternMatcher([
   # image load/store is always float
   (UPat(Ops.INDEX, dtype=dtypes.float, name="x").load(dtype=dtypes.half), lambda x: x.load().cast(dtypes.half)),
   (UPat(Ops.INDEX, dtype=dtypes.float, name="x").store(UPat(name="d", dtype=dtypes.half)), lambda x,d: x.store(d.cast(dtypes.float))),
-  (UPat.var("x", dtype=dtypes.float).cast(dtypes.half).cast(dtypes.float), lambda x: x),
+  (UPat(Ops.INDEX, dtype=dtypes.float, name="x").load().cast(dtypes.half).cast(dtypes.float),
+   lambda x: x.load() if x.src[0].dtype == dtypes.half and is_image_shape(x.src[0]._shape) else None),
 ])
 
 def memory_coalescing(sink:UOp, ctx:Renderer) -> UOp:


### PR DESCRIPTION
fixes #17208

in this PR I made the optimization conditional on the buffer having half storage and being image-shaped and being a load operation