### PR TITLE
qcom: use program instruction length

### DIFF
--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -160,7 +160,7 @@ class QCOMComputeQueue(HWQueue):
     self.reg(mesa.REG_A6XX_SP_REG_PROG_ID_0, 0xfcfcfcfc, 0xfcfcfcfc, 0xfcfcfcfc, 0xfc, qreg.a6xx_sp_cs_const_config(constlen=1024 // 4, enabled=True))
 
     self.reg(mesa.REG_A6XX_SP_CS_PVT_MEM_STACK_OFFSET, qreg.a6xx_sp_cs_pvt_mem_stack_offset(prg.hw_stack_offset))
-    self.reg(mesa.REG_A6XX_SP_CS_INSTR_SIZE, qreg.a6xx_sp_cs_instr_size(prg.image_size // 4))
+    self.reg(mesa.REG_A6XX_SP_CS_INSTR_SIZE, qreg.a6xx_sp_cs_instr_size(prg.instrlen))
 
     if prg.samp_cnt > 0:
       self.cmd(mesa.CP_LOAD_STATE6_FRAG, qreg.cp_load_state6_0(state_type=mesa.ST_SHADER, state_src=mesa.SS6_INDIRECT,
@@ -236,6 +236,7 @@ class QCOMProgram(HCQProgram['QCOMDevice']):
       from tinygrad.runtime.support.compiler_mesa import IR3Compiler
       v, cs, imm_vals, self.image = IR3Compiler.unpack_lib(obj.lib)
       self.prg_offset, self.brnchstck, self.image_size, self.pvtmem, self.shmem = 0, v.branchstack, v.info.size, v.pvtmem_size, v.shared_size
+      self.instrlen = v.instrlen
       self.wgsz = alloc.offset_vec4 * 4 + 8 if (alloc:=cs.allocs.consts[mesa.IR3_CONST_ALLOC_DRIVER_PARAMS]).size_vec4 else 0xfc
 
       self.wgid, self.lid = v.cs.work_group_id, v.cs.local_invocation_id # register ids
@@ -252,7 +253,9 @@ class QCOMProgram(HCQProgram['QCOMDevice']):
 
       self.tex_off, self.ibo_off, self.samp_off = 2048, 2048 + 0x40 * self.tex_cnt, 2048 + 0x40 * (self.tex_cnt + self.ibo_cnt)
       self.fregs, self.hregs = v.info.max_reg + 1, v.info.max_half_reg + 1
-    else: self._parse_lib(obj.lib)
+    else:
+      self._parse_lib(obj.lib)
+      self.instrlen = round_up(self.image_size, 128) // 128
 
     self.lib_gpu: HCQBuffer = self.dev.allocator.alloc(self.image_size, buf_spec:=BufferSpec(cpu_access=True, nolru=True))
     to_mv(self.lib_gpu.va_addr, self.image_size)[:] = self.image


### PR DESCRIPTION
While bringing up [QCOM over MSM DRM](https://github.com/tinygrad/tinygrad/pull/17224), `driving_vision` hit repeatable SP translation faults followed by hangcheck recovery.

<details>
<summary>dmesg</summary>

```text
[  227.810610] *** gpu fault: ttbr0=0000000143f93000 iova=0000000107e24000 dir=READ type=TRANSLATION source=UCHE (0,0,0,1)
[  227.843786] *** gpu fault: ttbr0=0000000143f93000 iova=0000000107e24040 dir=READ type=TRANSLATION source=UCHE (0,0,0,1)
[  227.907785] adreno 5000000.gpu: [drm:a6xx_irq] *ERROR* gpu fault ring 0 fence 69cc status 00800005 rb 1b60/1b9f ib1 0000000100474628/0000 ib2 000000010564C900/0000
[  227.922678] msm_dpu ae01000.display-controller: [drm:recover_worker] *ERROR* 6.3.0.2: hangcheck recover!
[  227.932305] msm_dpu ae01000.display-controller: [drm:recover_worker] *ERROR* 6.3.0.2: offending task: python3 (python3 /data/openpilot/tinygrad_repo/examples/openpilot/compile3.py /data/openpilot/selfdrive/modeld/models/driving_vision.onnx /data/openpilot/selfdrive/modeld/models/driving_vision_tinygrad.pkl)
[  227.959760] revision: 630 (6.3.0.2)
[  227.963293] rb 0: fence:    27080/27084
[  227.967181] rptr:     6831
[  227.969931] rb wptr:  7071
[  227.972674] adreno 5000000.gpu: [drm:a6xx_recover] CP_SCRATCH_REG0: 0
[  227.979191] adreno 5000000.gpu: [drm:a6xx_recover] CP_SCRATCH_REG1: 0
[  227.985697] adreno 5000000.gpu: [drm:a6xx_recover] CP_SCRATCH_REG2: 27079
[  227.992550] adreno 5000000.gpu: [drm:a6xx_recover] CP_SCRATCH_REG3: 0
[  227.999051] adreno 5000000.gpu: [drm:a6xx_recover] CP_SCRATCH_REG4: 0
[  228.005561] adreno 5000000.gpu: [drm:a6xx_recover] CP_SCRATCH_REG5: 0
[  228.012069] adreno 5000000.gpu: [drm:a6xx_recover] CP_SCRATCH_REG6: 0
[  228.018579] adreno 5000000.gpu: [drm:a6xx_recover] CP_SCRATCH_REG7: 1
```

</details>

<details>
<summary>compile3.py</summary>

```text
Traceback (most recent call last):
  File "/data/openpilot/tinygrad_repo/examples/openpilot/compile3.py", line 145, in <module>
    inputs, outputs = compile(onnx_file)
                      ^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad_repo/examples/openpilot/compile3.py", line 37, in compile
    ret = run_onnx_jit(**inputs).numpy()
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/jit.py", line 251, in __call__
    if len(params:=get_parameters(ret)): Tensor.realize(*params)
                                         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/tensor.py", line 540, in _wrapper
    ret = fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/tensor.py", line 194, in realize
    run_linear(*Tensor.linear_with_vars(*to_realize), update_stats=do_update_stats)
  File "/data/openpilot/tinygrad/engine/realize.py", line 279, in run_linear
    for call in linear.src: pm_exec.rewrite(call, ctx)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/uop/ops.py", line 1444, in rewrite
    if (ret:=match(uop, ctx)) is not None and ret is not uop: return ret
             ^^^^^^^^^^^^^^^
  File "<string>", line 3, in compiled_match
  File "/data/openpilot/tinygrad/engine/realize.py", line 170, in exec_copy
    elif hasattr(dest.allocator, '_as_buffer'): src.allocator._copyout(dest.as_memoryview(force_zero_copy=True), src._buf)
                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 200, in as_memoryview
    if not no_sync: self.allocator.dev.synchronize()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 440, in synchronize
    raise e
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 436, in synchronize
    try: self.timeline_signal.wait(self.timeline_value - 1, timeout=timeout if timeout is not None and self.can_recover else None)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 296, in wait
    if not_passed and self.value < value: raise RuntimeError(f"Wait timeout: {timeout} ms! (the signal is not set to {value}, but {self.value})")
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Wait timeout: 30000 ms! (the signal is not set to 8626, but 8625)
Traceback (most recent call last):
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 339, in _fini
    def _fini(dev, buf, spec): dev.allocator.free(buf, buf.size, spec)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 272, in free
    else: super().free(opaque, size, options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 236, in free
    self._free(opaque, options if options is not None else self.default_buffer_spec)
  File "/data/openpilot/tinygrad/helpers.py", line 127, in wrapper
    try: return func(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 567, in _free
    for dev in buf.mapped_devs: dev.synchronize()
                                ^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad_repo/examples/openpilot/compile3.py", line 145, in <module>
    inputs, outputs = compile(onnx_file)
                      ^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad_repo/examples/openpilot/compile3.py", line 37, in compile
    ret = run_onnx_jit(**inputs).numpy()
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/jit.py", line 251, in __call__
    if len(params:=get_parameters(ret)): Tensor.realize(*params)
                                         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/tensor.py", line 540, in _wrapper
    ret = fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/tensor.py", line 194, in realize
    run_linear(*Tensor.linear_with_vars(*to_realize), update_stats=do_update_stats)
  File "/data/openpilot/tinygrad/engine/realize.py", line 279, in run_linear
    for call in linear.src: pm_exec.rewrite(call, ctx)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/uop/ops.py", line 1444, in rewrite
    if (ret:=match(uop, ctx)) is not None and ret is not uop: return ret
             ^^^^^^^^^^^^^^^
  File "<string>", line 3, in compiled_match
  File "/data/openpilot/tinygrad/engine/realize.py", line 170, in exec_copy
    elif hasattr(dest.allocator, '_as_buffer'): src.allocator._copyout(dest.as_memoryview(force_zero_copy=True), src._buf)
                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 200, in as_memoryview
    if not no_sync: self.allocator.dev.synchronize()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 440, in synchronize
    raise e
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 436, in synchronize
    try: self.timeline_signal.wait(self.timeline_value - 1, timeout=timeout if timeout is not None and self.can_recover else None)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 296, in wait
    if not_passed and self.value < value: raise RuntimeError(f"Wait timeout: {timeout} ms! (the signal is not set to {value}, but {self.value})")
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Wait timeout: 30000 ms! (the signal is not set to 8626, but 8625)
Traceback (most recent call last):
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 339, in _fini
    def _fini(dev, buf, spec): dev.allocator.free(buf, buf.size, spec)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 272, in free
    else: super().free(opaque, size, options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 236, in free
    self._free(opaque, options if options is not None else self.default_buffer_spec)
  File "/data/openpilot/tinygrad/helpers.py", line 127, in wrapper
    try: return func(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 567, in _free
    for dev in buf.mapped_devs: dev.synchronize()
                                ^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 339, in _fini
    def _fini(dev, buf, spec): dev.allocator.free(buf, buf.size, spec)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 272, in free
    else: super().free(opaque, size, options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 236, in free
    self._free(opaque, options if options is not None else self.default_buffer_spec)
  File "/data/openpilot/tinygrad/helpers.py", line 127, in wrapper
    try: return func(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 567, in _free
    for dev in buf.mapped_devs: dev.synchronize()
                                ^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad_repo/examples/openpilot/compile3.py", line 145, in <module>
    inputs, outputs = compile(onnx_file)
                      ^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad_repo/examples/openpilot/compile3.py", line 37, in compile
    ret = run_onnx_jit(**inputs).numpy()
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/jit.py", line 251, in __call__
    if len(params:=get_parameters(ret)): Tensor.realize(*params)
                                         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/tensor.py", line 540, in _wrapper
    ret = fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/tensor.py", line 194, in realize
    run_linear(*Tensor.linear_with_vars(*to_realize), update_stats=do_update_stats)
  File "/data/openpilot/tinygrad/engine/realize.py", line 279, in run_linear
    for call in linear.src: pm_exec.rewrite(call, ctx)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/uop/ops.py", line 1444, in rewrite
    if (ret:=match(uop, ctx)) is not None and ret is not uop: return ret
             ^^^^^^^^^^^^^^^
  File "<string>", line 3, in compiled_match
  File "/data/openpilot/tinygrad/engine/realize.py", line 170, in exec_copy
    elif hasattr(dest.allocator, '_as_buffer'): src.allocator._copyout(dest.as_memoryview(force_zero_copy=True), src._buf)
                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 200, in as_memoryview
    if not no_sync: self.allocator.dev.synchronize()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 440, in synchronize
    raise e
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 436, in synchronize
    try: self.timeline_signal.wait(self.timeline_value - 1, timeout=timeout if timeout is not None and self.can_recover else None)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 296, in wait
    if not_passed and self.value < value: raise RuntimeError(f"Wait timeout: {timeout} ms! (the signal is not set to {value}, but {self.value})")
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Wait timeout: 30000 ms! (the signal is not set to 8626, but 8625)
Traceback (most recent call last):
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 339, in _fini
    def _fini(dev, buf, spec): dev.allocator.free(buf, buf.size, spec)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 272, in free
    else: super().free(opaque, size, options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 236, in free
    self._free(opaque, options if options is not None else self.default_buffer_spec)
  File "/data/openpilot/tinygrad/helpers.py", line 127, in wrapper
    try: return func(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 567, in _free
    for dev in buf.mapped_devs: dev.synchronize()
                                ^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 339, in _fini
    def _fini(dev, buf, spec): dev.allocator.free(buf, buf.size, spec)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 272, in free
    else: super().free(opaque, size, options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 236, in free
    self._free(opaque, options if options is not None else self.default_buffer_spec)
  File "/data/openpilot/tinygrad/helpers.py", line 127, in wrapper
    try: return func(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 567, in _free
    for dev in buf.mapped_devs: dev.synchronize()
                                ^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 339, in _fini
    def _fini(dev, buf, spec): dev.allocator.free(buf, buf.size, spec)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 272, in free
    else: super().free(opaque, size, options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 236, in free
    self._free(opaque, options if options is not None else self.default_buffer_spec)
  File "/data/openpilot/tinygrad/helpers.py", line 127, in wrapper
    try: return func(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 567, in _free
    for dev in buf.mapped_devs: dev.synchronize()
                                ^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad_repo/examples/openpilot/compile3.py", line 145, in <module>
    inputs, outputs = compile(onnx_file)
                      ^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad_repo/examples/openpilot/compile3.py", line 37, in compile
    ret = run_onnx_jit(**inputs).numpy()
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/jit.py", line 251, in __call__
    if len(params:=get_parameters(ret)): Tensor.realize(*params)
                                         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/tensor.py", line 540, in _wrapper
    ret = fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/tensor.py", line 194, in realize
    run_linear(*Tensor.linear_with_vars(*to_realize), update_stats=do_update_stats)
  File "/data/openpilot/tinygrad/engine/realize.py", line 279, in run_linear
    for call in linear.src: pm_exec.rewrite(call, ctx)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/uop/ops.py", line 1444, in rewrite
    if (ret:=match(uop, ctx)) is not None and ret is not uop: return ret
             ^^^^^^^^^^^^^^^
  File "<string>", line 3, in compiled_match
  File "/data/openpilot/tinygrad/engine/realize.py", line 170, in exec_copy
    elif hasattr(dest.allocator, '_as_buffer'): src.allocator._copyout(dest.as_memoryview(force_zero_copy=True), src._buf)
                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 200, in as_memoryview
    if not no_sync: self.allocator.dev.synchronize()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 440, in synchronize
    raise e
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 436, in synchronize
    try: self.timeline_signal.wait(self.timeline_value - 1, timeout=timeout if timeout is not None and self.can_recover else None)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 296, in wait
    if not_passed and self.value < value: raise RuntimeError(f"Wait timeout: {timeout} ms! (the signal is not set to {value}, but {self.value})")
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Wait timeout: 30000 ms! (the signal is not set to 8626, but 8625)
Traceback (most recent call last):
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 339, in _fini
    def _fini(dev, buf, spec): dev.allocator.free(buf, buf.size, spec)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 272, in free
    else: super().free(opaque, size, options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 236, in free
    self._free(opaque, options if options is not None else self.default_buffer_spec)
  File "/data/openpilot/tinygrad/helpers.py", line 127, in wrapper
    try: return func(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 567, in _free
    for dev in buf.mapped_devs: dev.synchronize()
                                ^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 339, in _fini
    def _fini(dev, buf, spec): dev.allocator.free(buf, buf.size, spec)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 272, in free
    else: super().free(opaque, size, options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 236, in free
    self._free(opaque, options if options is not None else self.default_buffer_spec)
  File "/data/openpilot/tinygrad/helpers.py", line 127, in wrapper
    try: return func(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 567, in _free
    for dev in buf.mapped_devs: dev.synchronize()
                                ^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 339, in _fini
    def _fini(dev, buf, spec): dev.allocator.free(buf, buf.size, spec)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 272, in free
    else: super().free(opaque, size, options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 236, in free
    self._free(opaque, options if options is not None else self.default_buffer_spec)
  File "/data/openpilot/tinygrad/helpers.py", line 127, in wrapper
    try: return func(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 567, in _free
    for dev in buf.mapped_devs: dev.synchronize()
                                ^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 339, in _fini
    def _fini(dev, buf, spec): dev.allocator.free(buf, buf.size, spec)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 272, in free
    else: super().free(opaque, size, options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 236, in free
    self._free(opaque, options if options is not None else self.default_buffer_spec)
  File "/data/openpilot/tinygrad/helpers.py", line 127, in wrapper
    try: return func(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 567, in _free
    for dev in buf.mapped_devs: dev.synchronize()
                                ^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad_repo/examples/openpilot/compile3.py", line 145, in <module>
    inputs, outputs = compile(onnx_file)
                      ^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad_repo/examples/openpilot/compile3.py", line 37, in compile
    ret = run_onnx_jit(**inputs).numpy()
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/jit.py", line 251, in __call__
    if len(params:=get_parameters(ret)): Tensor.realize(*params)
                                         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/tensor.py", line 540, in _wrapper
    ret = fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/uv/python/cpython-3.12.13-linux-aarch64-gnu/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/tensor.py", line 194, in realize
    run_linear(*Tensor.linear_with_vars(*to_realize), update_stats=do_update_stats)
  File "/data/openpilot/tinygrad/engine/realize.py", line 279, in run_linear
    for call in linear.src: pm_exec.rewrite(call, ctx)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/uop/ops.py", line 1444, in rewrite
    if (ret:=match(uop, ctx)) is not None and ret is not uop: return ret
             ^^^^^^^^^^^^^^^
  File "<string>", line 3, in compiled_match
  File "/data/openpilot/tinygrad/engine/realize.py", line 170, in exec_copy
    elif hasattr(dest.allocator, '_as_buffer'): src.allocator._copyout(dest.as_memoryview(force_zero_copy=True), src._buf)
                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/device.py", line 200, in as_memoryview
    if not no_sync: self.allocator.dev.synchronize()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 429, in synchronize
    if self.error_state is not None: raise self.error_state
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/engine/realize.py", line 97, in try_exec
    return runtime(*[bufs[i].get_buf(device) for i in prg.arg.globals], global_size=new_gs, local_size=(*local_size,),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/ops_qcom.py", line 297, in __call__
    return super().__call__(*bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 380, in __call__
    if wait: self.dev.synchronize(timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 440, in synchronize
    raise e
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 436, in synchronize
    try: self.timeline_signal.wait(self.timeline_value - 1, timeout=timeout if timeout is not None and self.can_recover else None)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/openpilot/tinygrad/runtime/support/hcq.py", line 296, in wait
    if not_passed and self.value < value: raise RuntimeError(f"Wait timeout: {timeout} ms! (the signal is not set to {value}, but {self.value})")
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Wait timeout: 30000 ms! (the signal is not set to 8626, but 8625)
QCOM synchronization failed before finalizing: Wait timeout: 30000 ms! (the signal is not set to 8626, but 8625)
```

</details>

`A6XX_SP_CS_INSTR_SIZE` is expressed in instruction-group units. On A6xx, one group is 16 IR3 instructions, with each instruction being 2 dwords, so one instrlen unit represents 128 bytes of instructions.

AI use: Partly Codex