### PR TITLE
preserve typed ranges through reshape

### DIFF
--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -55,7 +55,7 @@ def flip_contract_kernel(dest:UOp, src:UOp):
   return store.end(i, j).sink(arg=KernelInfo(name=f"flip_contract_{dest.numel()}", opts_to_apply=()))
 
 def slice_sum_kernel(dest:UOp, src:UOp):
-  G = UOp.range(src.shape[0], 0)
+  G = UOp.range(src.shape[0], 0, dtype=dtypes.int)
   slice_src = src[G, :]
   reg = UOp.placeholder((1,), dest.dtype, 0, addrspace=AddrSpace.REG)
   reg = reg.after(G)[0].set(0)

--- a/tinygrad/schedule/indexing.py
+++ b/tinygrad/schedule/indexing.py
@@ -171,7 +171,7 @@ def apply_movement_op(op:Ops, in_shape:tuple[sint,...], arg:tuple, rngs:tuple[UO
         symbolic+pm_simplify_valid, name="pad")) for r,sh,(off,sz) in zip(rngs, in_shape, arg))
     case Ops.RESHAPE:
       sink = UOp.sink(*rngs).simplify() # NOTE: this applies any commutative flips to the rngs early
-      sub_array = {r:UOp.range(r.src[0], i, AxisType.PLACEHOLDER) for i,r in enumerate(sink.ranges)}
+      sub_array = {r:r.replace(src=r.src[:1], arg=(i, AxisType.PLACEHOLDER)) for i,r in enumerate(sink.ranges)}
       rngs = _apply_reshape(in_shape, arg, sink.substitute(sub_array)).substitute({v:k for k,v in sub_array.items()}).src
     case _: raise RuntimeError(f"{op} is not a MovementOp")
   return rngs


### PR DESCRIPTION
An explicitly typed custom-kernel range can survive reshape indexing as
`AxisType.PLACEHOLDER` after #17257 because the temporary range no longer
matches the original dtype.

Preserve the original range while changing only its temporary axis identity.
The existing slice-sum custom-kernel test now covers this path.

Checks:
- `DEV=CPU ... pytest -n12 test/backend/test_custom_kernel.py` (40 passed)
- `DEV=METAL ... pytest -n12 test/backend/test_custom_kernel.py` (40 passed)
- relevant rangeify/indexing/tiny tests (65 passed)
- Ruff and mypy

AI disclosure: I used Codex to reduce the failure and test the patch. I reviewed
the two-line diff and ran the checks above.
