### PR TITLE
test permuted input in custom Ops.PROGRAM test

### DIFF
--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -421,19 +421,16 @@ class TestCustomKernel(unittest.TestCase):
 
   @Context(DEV="CPU")
   def test_simple_from_source(self):
-    a = Tensor([0., 1., 2.]).realize()
-
+    a = Tensor.arange(4).clone().realize()
     src = "void test_src(float* restrict a) { a[0] = 1.0; }"
     # TODO: it currently requires a compiler for Ops.BINARY
     from tinygrad.device import Device
     binary = Device[a.device].renderer.compiler.compile(src)
     def custom_src_kernel(A:UOp) -> UOp:
       sink = UOp.sink(A, arg=KernelInfo(name="test_src"))
-      return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.LINEAR, src=tuple(sink.toposort())),
-                                   UOp(Ops.SOURCE, arg=src), UOp(Ops.BINARY, arg=binary)))
-
-    a = Tensor.custom_kernel(a, fxn=custom_src_kernel)[0]
-    self.assertEqual(a.tolist(), [1., 1., 2.])
+      return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.LINEAR, src=tuple(sink.toposort())), UOp(Ops.SOURCE, arg=src), UOp(Ops.BINARY, arg=binary)))
+    a = Tensor.custom_kernel(a.reshape(2, 2).T, fxn=custom_src_kernel)[0]
+    self.assertEqual(a.tolist(), [[0, 2], [1, 3]])
 
 class TestUOpReduce(unittest.TestCase):
   def test_uop_sum(self):

--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -422,7 +422,7 @@ class TestCustomKernel(unittest.TestCase):
   @Context(DEV="CPU")
   def test_simple_from_source(self):
     a = Tensor.arange(4).clone().realize()
-    src = "void test_src(float* restrict a) { a[0] = 1.0; }"
+    src = "void test_src(int* restrict a) { a[0] = 1; }"
     # TODO: it currently requires a compiler for Ops.BINARY
     from tinygrad.device import Device
     binary = Device[a.device].renderer.compiler.compile(src)
@@ -430,7 +430,7 @@ class TestCustomKernel(unittest.TestCase):
       sink = UOp.sink(A, arg=KernelInfo(name="test_src"))
       return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.LINEAR, src=tuple(sink.toposort())), UOp(Ops.SOURCE, arg=src), UOp(Ops.BINARY, arg=binary)))
     a = Tensor.custom_kernel(a.reshape(2, 2).T, fxn=custom_src_kernel)[0]
-    self.assertEqual(a.tolist(), [[0, 2], [1, 3]])
+    self.assertEqual(a.tolist(), [[1, 2], [1, 3]])
 
 class TestUOpReduce(unittest.TestCase):
   def test_uop_sum(self):


### PR DESCRIPTION
had bugs in custom_kernel contiguous removal that showed up as device hang:
<img width="1280" height="129" alt="Screenshot 2026-07-29 at 3 17 41 PM" src="https://github.com/user-attachments/assets/d35d331d-baa0-4379-96d8-4e8039d19200" />
now it tests this in CI.