### PR TITLE
qcom: match cl for SP_CS_INSTR_SIZE

### DIFF
--- a/extra/qcom_gpu_driver/opencl_ioctl.py
+++ b/extra/qcom_gpu_driver/opencl_ioctl.py
@@ -4,7 +4,7 @@ from hexdump import hexdump
 from copy import deepcopy
 import pathlib, sys
 from tinygrad.helpers import to_mv, getenv
-from tinygrad.runtime.autogen import adreno
+from tinygrad.runtime.autogen import mesa
 sys.path.append(pathlib.Path(__file__).parent.parent.parent.as_posix())
 
 IOCTL = getenv("IOCTL", 0)
@@ -23,7 +23,7 @@ for child in xml.getroot():
 CAPTURED_STATE = {}
 
 REGS = {}
-for k, v in adreno.__dict__.items():
+for k, v in mesa.__dict__.items():
   if k.startswith("REG_") and isinstance(v, int) and v > 1024: REGS[v] = k
 
 from extra.qcom_gpu_driver import msm_kgsl
@@ -42,7 +42,7 @@ def get_struct(argp, stype):
 
 def format_struct(s):
   sdats = []
-  for field_name, *_ in s._real_fields_:
+  for field_name, *_ in s._fields_:
     if field_name in {"__pad", "PADDING_0"}: continue
     dat = getattr(s, field_name)
     if isinstance(dat, int): sdats.append(f"{field_name}:0x{dat:X}")
@@ -96,9 +96,9 @@ def parse_cmd_buf(dat):
         CAPTURED_STATE['LOAD_FRAGS'].append((state_block, state_type, num_unit, dst_off))
 
         if state_block == SB6_CS_SHADER:
-          from extra.disassemblers.adreno import disasm_raw
+          from tinygrad.runtime.support.compiler_mesa import disas_adreno
           if state_type == ST6_SHADER and IOCTL > 3:
-            disasm_raw(get_mem(((vals[2] << 32) | vals[1]), num_unit * 128))
+            disas_adreno(get_mem(((vals[2] << 32) | vals[1]), num_unit * 128))
           if state_type == ST6_CONSTANTS:
             x = get_mem(((vals[2] << 32) | vals[1]), num_unit*4)
             CAPTURED_STATE['constants'] = x[:]
@@ -142,7 +142,7 @@ def parse_cmd_buf(dat):
       vals = struct.unpack("I"*size, dat[ptr+4:ptr+4+4*size])
       if IOCTL > 0: print(f"{ptr:3X} -- typ 4: {size=:3d}, {reg_name}", hprint(vals))
       for vi,v in enumerate(vals): CAPTURED_STATE[offset+vi] = v
-      if offset == adreno.REG_A6XX_SP_CS_CONFIG:
+      if offset == mesa.REG_A6XX_SP_CS_CONFIG:
         val = vals[0]
         if IOCTL > 0:
           print(f"\tBINDLESS_TEX={(val >> 0) & 0b1}")
@@ -215,79 +215,3 @@ def install_hook(c_function, python_function):
 
 libc = ctypes.CDLL(ctypes.util.find_library("libc"))
 install_hook(libc.ioctl, ioctl)
-
-def before_launch():
-  global CAPTURED_STATE
-  CAPTURED_STATE.clear()
-def collect_last_launch_state():
-  global CAPTURED_STATE
-  return deepcopy(CAPTURED_STATE)
-def compare_launch_state(state, good_state):
-  cmp = [
-    (adreno.REG_A6XX_SP_CS_CONFIG, adreno.A6XX_SP_CS_CONFIG_NTEX__MASK),
-    (adreno.REG_A6XX_SP_CS_CONFIG, adreno.A6XX_SP_CS_CONFIG_NSAMP__MASK),
-    (adreno.REG_A6XX_SP_CS_CONFIG, adreno.A6XX_SP_CS_CONFIG_NIBO__MASK),
-    (adreno.REG_A6XX_SP_CS_CONFIG, adreno.A6XX_SP_CS_CONFIG_ENABLED),
-    (adreno.REG_A6XX_SP_CS_CONFIG, adreno.A6XX_SP_CS_CONFIG_BINDLESS_TEX),
-    (adreno.REG_A6XX_SP_CS_CONFIG, adreno.A6XX_SP_CS_CONFIG_BINDLESS_SAMP),
-    (adreno.REG_A6XX_SP_CS_CONFIG, adreno.A6XX_SP_CS_CONFIG_BINDLESS_IBO),
-    (adreno.REG_A6XX_SP_CS_CONFIG, adreno.A6XX_SP_CS_CONFIG_BINDLESS_UBO),
-
-    (adreno.REG_A6XX_SP_CS_CTRL_REG0, adreno.A6XX_SP_CS_CTRL_REG0_HALFREGFOOTPRINT__MASK),
-    (adreno.REG_A6XX_SP_CS_CTRL_REG0, adreno.A6XX_SP_CS_CTRL_REG0_FULLREGFOOTPRINT__MASK),
-    (adreno.REG_A6XX_SP_CS_CTRL_REG0, adreno.A6XX_SP_CS_CTRL_REG0_BRANCHSTACK__MASK),
-    (adreno.REG_A6XX_SP_CS_CTRL_REG0, adreno.A6XX_SP_CS_CTRL_REG0_FULLREGFOOTPRINT__MASK),
-    (adreno.REG_A6XX_SP_CS_CTRL_REG0, adreno.A6XX_SP_CS_CTRL_REG0_THREADMODE__MASK),
-    (adreno.REG_A6XX_SP_CS_CTRL_REG0, adreno.A6XX_SP_CS_CTRL_REG0_EARLYPREAMBLE),
-    (adreno.REG_A6XX_SP_CS_CTRL_REG0, adreno.A6XX_SP_CS_CTRL_REG0_MERGEDREGS),
-
-    (adreno.REG_A6XX_SP_CS_PVT_MEM_PARAM, adreno.A6XX_SP_CS_PVT_MEM_PARAM_MEMSIZEPERITEM__MASK),
-    (adreno.REG_A6XX_SP_CS_PVT_MEM_PARAM, adreno.A6XX_SP_CS_PVT_MEM_PARAM_HWSTACKSIZEPERTHREAD__MASK),
-
-    (adreno.REG_A6XX_SP_CS_UNKNOWN_A9B1, adreno.A6XX_SP_CS_UNKNOWN_A9B1_UNK5),
-    (adreno.REG_A6XX_SP_CS_UNKNOWN_A9B1, adreno.A6XX_SP_CS_UNKNOWN_A9B1_UNK6),
-
-    (adreno.REG_A6XX_SP_CS_BRANCH_COND, 0xffffffff),
-
-    (adreno.REG_A6XX_HLSQ_CS_NDRANGE_0, adreno.A6XX_HLSQ_CS_NDRANGE_0_KERNELDIM__MASK),
-    (adreno.REG_A6XX_HLSQ_CS_NDRANGE_0, adreno.A6XX_HLSQ_CS_NDRANGE_0_LOCALSIZEX__MASK),
-    (adreno.REG_A6XX_HLSQ_CS_NDRANGE_0, adreno.A6XX_HLSQ_CS_NDRANGE_0_LOCALSIZEY__MASK),
-    (adreno.REG_A6XX_HLSQ_CS_NDRANGE_0, adreno.A6XX_HLSQ_CS_NDRANGE_0_LOCALSIZEZ__MASK),
-
-    (adreno.REG_A6XX_HLSQ_CS_NDRANGE_1, 0xffffffff),
-    (adreno.REG_A6XX_HLSQ_CS_NDRANGE_2, 0xffffffff),
-    (adreno.REG_A6XX_HLSQ_CS_NDRANGE_3, 0xffffffff),
-    (adreno.REG_A6XX_HLSQ_CS_NDRANGE_4, 0xffffffff),
-    (adreno.REG_A6XX_HLSQ_CS_NDRANGE_5, 0xffffffff),
-    (adreno.REG_A6XX_HLSQ_CS_NDRANGE_6, 0xffffffff),
-
-    (adreno.REG_A6XX_HLSQ_CS_CNTL_0, 0xffffffff),
-    (adreno.REG_A6XX_HLSQ_CS_CNTL_1, 0xffffffff),
-    (adreno.REG_A6XX_HLSQ_CS_KERNEL_GROUP_X, 0xffffffff),
-    (adreno.REG_A6XX_HLSQ_CS_KERNEL_GROUP_Y, 0xffffffff),
-    (adreno.REG_A6XX_HLSQ_CS_KERNEL_GROUP_Z, 0xffffffff),
-  ]
-
-  for x,m in cmp:
-    print(f"Field {REGS[x]}, mask: 0x{m:X} cmp: {state.get(x, 0) & m} vs {good_state.get(x, 0) & m}")
-    if state.get(x, 0) & m != good_state.get(x, 0) & m:
-      return False, f"Field {REGS[x]}, mask: 0x{m:X} mismatch: {state.get(x, 0) & m} vs {good_state.get(x, 0) & m}"
-
-  for n in ['descriptors', 'ibos']:
-    if n not in good_state: continue
-    mv1, mv2 = state.get(n), good_state.get(n)
-
-    if len(mv1) != len(mv2): return False, f"{n}: len mismatch {len(mv1)} != {len(mv2)}"
-    mv1 = memoryview(bytearray(mv1)).cast('I')
-    mv2 = memoryview(bytearray(mv2)).cast('I')
-    for i in range(len(mv2)):
-      if i % 8 == 5 or i % 8 == 4: continue # addresses
-      if mv1[i]!=mv2[i]: return False, f"{n}: content mismatch {i} {mv1[i]} {mv2[i]}"
-
-  for n in ['samplers']:
-    if n not in good_state: continue
-    mv1, mv2 = state.get(n), good_state.get(n)
-    if len(mv1) != len(mv2): return False, f"{n}: len mismatch {len(mv1)} != {len(mv2)}"
-    if any(mv1[i]!=mv2[i] for i in range(len(mv1))): return False, f"{n}: content mismatch"
-
-  return True, "PASS"

--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -154,13 +154,15 @@ class QCOMComputeQueue(HWQueue):
                                                              state_block=mesa.SB6_CS_SHADER, num_unit=1024 // 4),
              *data64_le(args_state.buf.va_addr))
     self.cmd(mesa.CP_LOAD_STATE6_FRAG, qreg.cp_load_state6_0(state_type=mesa.ST_SHADER, state_src=mesa.SS6_INDIRECT,
-                                                             state_block=mesa.SB6_CS_SHADER, num_unit=round_up(prg.image_size, 128) // 128),
+                                                             state_block=mesa.SB6_CS_SHADER, num_unit=ceildiv(prg.image_size, 128)),
              *data64_le(prg.lib_gpu.va_addr))
 
     self.reg(mesa.REG_A6XX_SP_REG_PROG_ID_0, 0xfcfcfcfc, 0xfcfcfcfc, 0xfcfcfcfc, 0xfc, qreg.a6xx_sp_cs_const_config(constlen=1024 // 4, enabled=True))
 
     self.reg(mesa.REG_A6XX_SP_CS_PVT_MEM_STACK_OFFSET, qreg.a6xx_sp_cs_pvt_mem_stack_offset(prg.hw_stack_offset))
-    self.reg(mesa.REG_A6XX_SP_CS_INSTR_SIZE, qreg.a6xx_sp_cs_instr_size(prg.image_size // 4))
+    # image_size is in bytes, but INSTR_SIZE is measured in units of instruction groups (16 instructions, 8 bytes each)
+    # https://elixir.bootlin.com/mesa/mesa-26.1.5/source/src/freedreno/ir3/ir3_shader.h#L719-L723
+    self.reg(mesa.REG_A6XX_SP_CS_INSTR_SIZE, qreg.a6xx_sp_cs_instr_size(ceildiv(prg.image_size, 128)))
 
     if prg.samp_cnt > 0:
       self.cmd(mesa.CP_LOAD_STATE6_FRAG, qreg.cp_load_state6_0(state_type=mesa.ST_SHADER, state_src=mesa.SS6_INDIRECT,


### PR DESCRIPTION
Match freedreno: https://elixir.bootlin.com/mesa/mesa-26.1.5/source/src/freedreno/ir3/ir3_shader.h#L719-L723

And QCOM CL:
```
$ IOCTL=4 DEV=CL python3 test/test_tiny.py TestTiny.test_plus
...
 C0 -- typ 7: size=  3, opcode=0x34 CP_LOAD_STATE6_FRAG (0xb60000,0xffba8000,7)
num_unit=2 state_block=13 state_src=2 state_type=0 dst_off=0
0000 [56d80800_20020000] (sy)(nop3) shl.b r0.x, r0.x, 2
0001 [20154103_00000000] (rpt1)mov.s32s32 r0.w, r0.x
0002 [20154001_00000000] mov.s32s32 r0.y, r0.x
0003 [00000000_00000000] nop
0004 [42100000_00031054] add.u r0.x, c21.x, r0.w
0005 [42100002_00041058] add.u r0.z, c22.x, r1.x
0006 [46f00003_201f0003] shr.b r0.w, r0.w, 31
0007 [46f00005_201f0004] shr.b r1.y, r1.x, 31
0008 [42900006_10540000] cmps.u.lt r1.z, r0.x, c21.x
0009 [42900007_10580002] cmps.u.lt r1.w, r0.z, c22.x
0010 [42100004_00011050] add.u r1.x, c20.x, r0.y
0011 [46f00008_201f0001] shr.b r2.x, r0.y, 31
0012 [67818001_40061055] sad.s32 r0.y, c21.y, (neg)r0.w, r1.z
0013 [67828003_40071059] sad.s32 r0.w, c22.y, (neg)r1.y, r1.w
0014 [42980805_10500004] (nop3) cmps.u.lt r1.y, r1.x, c20.x
0015 [67840005_40051051] sad.s32 r1.y, c20.y, (neg)r2.x, r1.y
0016 [c0020000_01800001] ldg.f32 r0.x, g[r0.x], 1
0017 [00000000_00000000] nop
0018 [c0020001_01808001] ldg.f32 r0.y, g[r0.z], 1
0019 [50100000_00010000] (sy)add.f r0.x, r0.x, r0.y
0020 [00000500_00000000] (rpt5)nop
0021 [c0c20900_01800000] stg.f32 g[r1.x], r0.x, 1
0022 [03000000_00000000] end
0023 [00000000_00000000] nop
0024 [00000000_00000000] nop
0025 [00000000_00000000] nop
0026 [00000000_00000000] nop
0027 [00000000_00000000] nop
0028 [00000000_00000000] nop
0029 [00000000_00000000] nop
0030 [00000000_00000000] nop
0031 [00000000_00000000] nop
...
100 -- typ 4: size=  1, REG_A6XX_SP_CS_INSTR_SIZE (2)
```
But on master:
```
$ IOCTL=4 DEV=QCOM python3 test/test_tiny.py TestTiny.test_plus
...
 FC -- typ 7: size=  3, opcode=0x34 CP_LOAD_STATE6_FRAG (0xb60000,0xf9ff9000,7)
num_unit=2 state_block=13 state_src=2 state_type=0 dst_off=0
0000 [56d80800_20020000] (sy)(nop3) shl.b r0.x, r0.x, 2
0001 [20154103_00000000] (rpt1)mov.s32s32 r0.w, r0.x
0002 [20154001_00000000] mov.s32s32 r0.y, r0.x
0003 [00000000_00000000] nop
0004 [42100000_00031054] add.u r0.x, c21.x, r0.w
0005 [42100002_00041058] add.u r0.z, c22.x, r1.x
0006 [46f00003_201f0003] shr.b r0.w, r0.w, 31
0007 [46f00005_201f0004] shr.b r1.y, r1.x, 31
0008 [42900006_10540000] cmps.u.lt r1.z, r0.x, c21.x
0009 [42900007_10580002] cmps.u.lt r1.w, r0.z, c22.x
0010 [42100004_00011050] add.u r1.x, c20.x, r0.y
0011 [46f00008_201f0001] shr.b r2.x, r0.y, 31
0012 [67818001_40061055] sad.s32 r0.y, c21.y, (neg)r0.w, r1.z
0013 [67828003_40071059] sad.s32 r0.w, c22.y, (neg)r1.y, r1.w
0014 [42980805_10500004] (nop3) cmps.u.lt r1.y, r1.x, c20.x
0015 [67840005_40051051] sad.s32 r1.y, c20.y, (neg)r2.x, r1.y
0016 [c0020000_01800001] ldg.f32 r0.x, g[r0.x], 1
0017 [00000000_00000000] nop
0018 [c0020001_01808001] ldg.f32 r0.y, g[r0.z], 1
0019 [50100000_00010000] (sy)add.f r0.x, r0.x, r0.y
0020 [00000500_00000000] (rpt5)nop
0021 [c0c20900_01800000] stg.f32 g[r1.x], r0.x, 1
0022 [03000000_00000000] end
0023 [00000000_00000000] nop
0024 [00000000_00000000] nop
0025 [00000000_00000000] nop
0026 [00000000_00000000] nop
0027 [00000000_00000000] nop
0028 [00000000_00000000] nop
0029 [00000000_00000000] nop
0030 [00000000_00000000] nop
0031 [00000000_00000000] nop
...
12C -- typ 4: size=  1, REG_A6XX_SP_CS_INSTR_SIZE (0x2e)
```