### PR TITLE
update dtype of rewrites [pr]

### DIFF
--- a/test/device/test_ocl.py
+++ b/test/device/test_ocl.py
@@ -4,7 +4,7 @@ from tinygrad import Device
 from tinygrad.device import Buffer, TinyELF
 from tinygrad.dtype import dtypes
 from tinygrad.helpers import Target
-from tinygrad.runtime.ops_cl import CLDevice, CLAllocator, CLCompiler
+from tinygrad.runtime.ops_cl import CLDevice, CLAllocator, CLCompiler, cl
 
 @unittest.skipUnless(Device.DEFAULT == "CL", "Runs only on OpenCL")
 class TestCLCompileCache(unittest.TestCase):
@@ -15,6 +15,14 @@ class TestCLCompileCache(unittest.TestCase):
     device.runtime(obj)
     with patch.object(CLCompiler, 'compile', side_effect=RuntimeError("compile should not be called on cache hit")):
       device.runtime(obj)
+
+  def test_wait_releases_event(self):
+    device = Device[Device.DEFAULT]
+    obj = TinyELF(b"__kernel void event_test() {}", "event_test", Target("CL"), ())
+    prg = device.runtime(obj)
+    with patch.object(cl, "clReleaseEvent", wraps=cl.clReleaseEvent) as release:
+      prg(wait=True)
+      release.assert_called_once()
 
 @unittest.skipUnless(Device.DEFAULT == "CL", "Runs only on OpenCL")
 class TestCLError(unittest.TestCase):

--- a/test/null/test_graph_rewrite.py
+++ b/test/null/test_graph_rewrite.py
@@ -322,6 +322,25 @@ class TestRecurse(unittest.TestCase):
     with self.assertRaises(RuntimeError):
       graph_rewrite(a, pm, bottom_up=True)
 
+# TODO: delete this class with _rebuild_dtype once the dtype field is removed — every rebuild
+# derives then, and the stored SHL form these tests pin becomes inexpressible
+class TestRebuildRederivesDtype(unittest.TestCase):
+  def test_rebuild_rederives_dtype(self):
+    # a rule may return an existing node of a different dtype; the rebuilt parent derives, never inherits
+    x = UOp.const(None, 1.0).cast(dtypes.float)
+    pm = PatternMatcher([(UPat(Ops.CAST, src=(UPat.cvar("c"),)), lambda c: c)])
+    self.assertIs(graph_rewrite(x+x, pm).dtype, dtypes.weakfloat)
+    self.assertIs(graph_rewrite(x+x, pm, walk=True).dtype, dtypes.weakfloat)
+
+  def test_rebuild_keeps_dtype_on_invalid_src(self):
+    # Invalid is dtype-agnostic poison: a src becoming Invalid never invalidates the stored dtype.
+    # the explicit dtype IS the subject: the renderer-lowered shift keeps src[0]'s dtype with a uint
+    # count, a stored form derivation cannot reproduce (re-deriving it over the poisoned src raises)
+    x = UOp.const(None, 5).cast(dtypes.int)
+    shl = UOp(Ops.SHL, dtypes.int, (x, UOp.const(None, 2).cast(dtypes.uint)))
+    out = graph_rewrite(shl, PatternMatcher([(UPat(Ops.CAST, dtype=dtypes.int), lambda: UOp.invalid())]))
+    self.assertIs(out.dtype, dtypes.int)
+
 def bidir_append(ctx, x, b): ctx.append((x.arg if x.op is Ops.CONST else "+", b))
 class TestBidirectional(unittest.TestCase):
   def test_simple(self):

--- a/test/null/test_graph_rewrite.py
+++ b/test/null/test_graph_rewrite.py
@@ -332,6 +332,13 @@ class TestRebuildRederivesDtype(unittest.TestCase):
     self.assertIs(graph_rewrite(x+x, pm).dtype, dtypes.weakfloat)
     self.assertIs(graph_rewrite(x+x, pm, walk=True).dtype, dtypes.weakfloat)
 
+  def test_rebuild_keeps_dtype_on_ins(self):
+    # machine IR: a typed Ops.INS states its dtype at the producer (post-isel, outside spec_program) —
+    # a rebuild over rewritten srcs must keep it, never wipe it to void
+    ins = UOp(Ops.INS, dtypes.float, (UOp.const(None, 1.0).cast(dtypes.float),))
+    pm = PatternMatcher([(UPat(Ops.CAST, src=(UPat.cvar("c"),)), lambda c: c)])
+    self.assertIs(graph_rewrite(ins, pm).dtype, dtypes.float)
+
   def test_rebuild_keeps_dtype_on_invalid_src(self):
     # Invalid is dtype-agnostic poison: a src becoming Invalid never invalidates the stored dtype.
     # the explicit dtype IS the subject: the renderer-lowered shift keeps src[0]'s dtype with a uint

--- a/test/null/test_simplify_valid_idx.py
+++ b/test/null/test_simplify_valid_idx.py
@@ -1,10 +1,13 @@
 import unittest, itertools
+from unittest.mock import patch
 
-from tinygrad.codegen.late.coalesce import indexing_simplify
-from tinygrad.dtype import dtypes
+from tinygrad.codegen.decomp.dtype import pm_dtype_decomps
+from tinygrad.codegen.late.coalesce import indexing_simplify, image_valid_dims
+from tinygrad.dtype import dtypes, AddrSpace
+from tinygrad.helpers import Context, Target
+from tinygrad.renderer.cstyle import OpenCLRenderer
 from tinygrad.uop.ops import UOp, Ops, graph_rewrite
 from tinygrad.uop.symbolic import simplify_valid, sym, pm_move_where_on_load
-from tinygrad.helpers import Context
 from test.helpers import full_rewrite
 from test.null.test_uop_symbolic import check_uop_against_string
 
@@ -196,6 +199,26 @@ class TestValidIdxSimplification(unittest.TestCase):
       "(r0<((r1*4)+r2))")
 
 class TestImageSimplification(unittest.TestCase):
+  def test_osx_multirow_image_alignment(self):
+    with patch("tinygrad.codegen.late.coalesce.OSX", True):
+      dims = image_valid_dims(dtypes.half, 32*1088*4, "IMAGE_PITCH_ALIGNMENT=64")
+    self.assertNotIn((32, 1088), dims)
+    self.assertTrue(all(h == 1 or w % 256 == 0 for h,w in dims))
+
+  def test_half_image_param_decomposes_atomically(self):
+    # Image access is intentionally float even when its backing storage is half.
+    with Context(SPEC=1):
+      buf = UOp.param(0, dtypes.half, (1, 64, 4))
+      idx = buf.index(UOp.const(None, 0), UOp.const(None, 0), dtype=dtypes.float)
+      load = UOp(Ops.LOAD, dtypes.float, (idx,))
+      acc = UOp.param(1, dtypes.float, (), addrspace=AddrSpace.ALU)
+      ren = OpenCLRenderer(Target(device="CL", arch="IMAGE_PITCH_ALIGNMENT=64"))
+      out = graph_rewrite((acc+load).sink(), pm_dtype_decomps, ctx=(set(), ren))
+    param = next(u for u in out.toposort() if u.op is Ops.PARAM and u.arg.slot == 0)
+    image_idx, image_load, add = (next(u for u in out.toposort() if u.op is op) for op in (Ops.INDEX, Ops.LOAD, Ops.ADD))
+    self.assertEqual((param.dtype, param.arg.dtype), (dtypes.ushort, dtypes.ushort))
+    self.assertEqual((image_idx.dtype, image_load.dtype, add.dtype), (dtypes.float,)*3)
+
   def check(self, load, svalid, sidx0, sidx1):
     load = simplify_image_idx(load.sink()).src[0]
     off = load.src[0]

--- a/test/null/test_uop_symbolic.py
+++ b/test/null/test_uop_symbolic.py
@@ -1022,7 +1022,9 @@ class TestSymbolic(unittest.TestCase):
 
     # the vars are now scalar PARAMs
     pvar = {u.expr: u for u in rewritten_uop.toposort() if u.op is Ops.PARAM}
-    self.assertEqual(rewritten_uop, (pvar['s']<2).where(pvar['a'].cast(dtypes.half), pvar['b'].cast(dtypes.half)))
+    # the comparison literal has committed to the PARAM width during lowering
+    c2 = UOp.const(None, 2).cast(dtypes.int).simplify()
+    self.assertEqual(rewritten_uop, (pvar['s']<c2).where(pvar['a'].cast(dtypes.half), pvar['b'].cast(dtypes.half)))
 
   def test_where_merge_branches(self):
     cond1 = Variable("s", 0, 10) < 6

--- a/test/null/test_viz.py
+++ b/test/null/test_viz.py
@@ -426,21 +426,21 @@ class TestVizIntegration(unittest.TestCase):
       def default_test(root): return graph_rewrite(root, sym)
       tracked_test = track_rewrites()(default_test)
       c = UOp.const(dtypes.int, 1)
-      default_test(c+1) # goes to the default group
+      default_test(c1:=c+1) # goes to the default group
       tracked_test(c)   # all rewrites after this go inside the second group.
-      default_test(c+2)
+      default_test(c2:=c+2)
     ls = viz.list_items()
     self.assertEqual(len(ls), 2)
     graph = next(viz.get_details(0, 0))["graph"]
-    self.assertEqual(list(graph), [id(c), id(c+1)])
+    self.assertEqual(list(graph), [id(c), id(c1.src[1]), id(c1)])
     self.assertTrue(graph[id(c)]["exclude"])
-    self.assertFalse(graph[id(c+1)]["exclude"])
+    self.assertFalse(graph[id(c1)]["exclude"])
     self.assertEqual(list(next(viz.get_details(1, 0))["graph"]), [id(c)])
     graph = next(viz.get_details(1, 1))["graph"]
-    self.assertEqual(list(graph), [id(c), id(c.const_like(2)), id(c+2)])
+    self.assertEqual(list(graph), [id(c), id(c2.src[1]), id(c2)])
     self.assertTrue(graph[id(c)]["exclude"])
-    self.assertTrue(graph[id(c.const_like(2))]["exclude"])
-    self.assertFalse(graph[id(c+2)]["exclude"])
+    self.assertTrue(graph[id(c2.src[1])]["exclude"])
+    self.assertFalse(graph[id(c2)]["exclude"])
 
   def test_recurse(self):
     with save_viz() as viz:

--- a/test/unit/test_dtype_weak.py
+++ b/test/unit/test_dtype_weak.py
@@ -3,7 +3,7 @@ import tempfile, unittest, math
 from tinygrad import Tensor, dtypes, TinyJit
 from tinygrad.helpers import Context
 from tinygrad.dtype import least_upper_float
-from tinygrad.uop.ops import UOp, Ops, dtype_from_uop
+from tinygrad.uop.ops import UOp, Ops, dtype_from_uop, graph_rewrite, pm_lower_index_dtype
 from tinygrad.uop.spec import spec_shared, type_verify
 from tinygrad.engine.jit import JitError
 
@@ -43,13 +43,27 @@ class TestWeakPromotion(unittest.TestCase):
     r = Tensor([2], dtype=dtypes.uint8, device="CPU").copysign(Tensor([1], dtype=dtypes.uint32, device="CPU"))
     self.assertEqual((r.dtype, r.tolist()), (dtypes.uint32, [2]))
 
-  def test_uop_scalar_const_unchanged(self):
-    for dtype, value in ((dtypes.weakint, 1), (dtypes.int32, 1), (dtypes.float32, 0.5)):
+  def test_uop_scalar_const_lifts_kind(self):
+    for dtype, value, out_dtype, const_dtype in ((dtypes.weakint, 1, dtypes.weakint, dtypes.weakint),
+      (dtypes.int32, 1, dtypes.int32, dtypes.weakint), (dtypes.int32, 0.5, dtypes.weakfloat, dtypes.weakfloat),
+      (dtypes.float32, 1, dtypes.float32, dtypes.weakfloat)):
       out = UOp.variable("x", 0.0 if dtype == dtypes.float32 else 0, 10.0 if dtype == dtypes.float32 else 10, dtype) + value
-      self.assertEqual((out.dtype, out.src[1].dtype), (dtype, dtype))
+      self.assertEqual((out.dtype, out.src[1].op, out.src[1].dtype), (out_dtype, Ops.CONST, const_dtype))
+    x, c = UOp.variable("x", 0, 10, dtypes.int8), UOp.const(None, 1)
+    self.assertIs((x+c).src[1], c)
+    self.assertIs((c+x).src[0], c)
 
-  @unittest.expectedFailure  # TODO: a weak const defers to its consumer (JAX): these dtypes change once python scalars are weak consts
-  def test_changed_rows(self):
+  def test_store_leaf_demands_destination_dtype(self):
+    dst = UOp.param(0, dtypes.bfloat16, (1,)).index(0)
+    store = dst.store(UOp.const(None, 5.0))
+    out = graph_rewrite(store, pm_lower_index_dtype, ctx=({}, False))
+    self.assertEqual(out.src[1].dtype, dtypes.bfloat16)
+
+  def test_post_decomp_fallback_unifies_operand_widths(self):
+    out = graph_rewrite(UOp.const(None, True).where(4503599627370495, 0), pm_lower_index_dtype, ctx=({}, True))
+    self.assertEqual((out.dtype, out.src[1].dtype, out.src[2].dtype), (dtypes.long, dtypes.long, dtypes.long))
+
+  def test_weak_scalar_rows(self):
     t_i8, t_f16, t_bf16 = Tensor([1], dtype=dtypes.int8), Tensor([1], dtype=dtypes.float16), Tensor([1], dtype=dtypes.bfloat16)
     t_bool, t_u16 = Tensor([True]), Tensor([1], dtype=dtypes.uint16)
     self.assertEqual((t_i8 + 0.5).dtype, dtypes.weakfloat)
@@ -58,8 +72,8 @@ class TestWeakPromotion(unittest.TestCase):
     self.assertEqual(((t_bool + 1) + t_i8).dtype, dtypes.int8)
     self.assertEqual(((t_bool + 1) + t_u16).dtype, dtypes.uint16)
     self.assertEqual((Tensor(3) + t_i8).dtype, dtypes.int8)
-    # zeros/ones are full with a python fill value, so they are weak too (jnp.zeros pins float32; deliberate divergence)
-    self.assertEqual((Tensor.zeros(3) + t_f16).dtype, dtypes.float16)
+    # unbuffered zeros/ones are full with a Python fill value, so they are weak (buffered creation commits storage)
+    self.assertEqual((Tensor.zeros(3, buffer=False) + t_f16).dtype, dtypes.float16)
 
   def test_unchanged_rows(self):
     t_i8, t_f16, t_f32 = Tensor([1], dtype=dtypes.int8), Tensor([1], dtype=dtypes.float16), Tensor([1], dtype=dtypes.float32)

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -347,7 +347,7 @@ def full_rewrite_to_sink(ast:UOp, ren:Renderer, optimize:bool=True) -> UOp:
 
   # lower index dtype
   # NOTE: we need indexing_simplify to remove the cast to long using the Invalid
-  sink = graph_rewrite(sink, pm_lower_index_dtype+indexing_simplify, ctx={}, name="lower all index dtypes")
+  sink = graph_rewrite(sink, pm_lower_index_dtype+indexing_simplify, ctx=({}, False), name="lower all index dtypes")
 
   # final symbolic before decomp
   sink = graph_rewrite(sink, symbolic, name="final symbolic")
@@ -373,6 +373,7 @@ def full_rewrite_to_sink(ast:UOp, ren:Renderer, optimize:bool=True) -> UOp:
   extra_matcher = ren.extra_matcher if ren.extra_matcher is not None else PatternMatcher([])
   pm_final_rewrite = pm_decomp+extra_matcher+pm_split_ends
   sink = graph_rewrite(sink, pm_final_rewrite+pm_remove_invalid, ctx=ren, name="final rewrite")
+  sink = graph_rewrite(sink, pm_lower_index_dtype, ctx=({}, True), name="lower post-decomp weak consts")
 
   # add implicit barriers (stores/loads through LOCAL memory ordered by AFTER or across loop iterations need workgroup barriers)
   sink = graph_rewrite(sink, pm_implicit_barriers, name="add implicit barriers")

--- a/tinygrad/codegen/decomp/dtype.py
+++ b/tinygrad/codegen/decomp/dtype.py
@@ -1,6 +1,6 @@
 from dataclasses import replace
 from tinygrad.dtype import dtypes, DType, truncate
-from tinygrad.helpers import flatten, DEBUG, EMULATED_DTYPES, Context, SPEC
+from tinygrad.helpers import flatten, DEBUG, EMULATED_DTYPES, Context, SPEC, is_image_shape
 from tinygrad.uop import GroupOp
 from tinygrad.uop.ops import UOp, UPat, Ops, PatternMatcher, graph_rewrite, ParamArg
 from tinygrad.renderer import Renderer
@@ -163,6 +163,9 @@ pm_long_decomp = PatternMatcher([
 
 # float decomposition patterns - ctx is (fr, to) tuple
 pm_float_decomp = PatternMatcher([
+  (UPat(Ops.PARAM, name="buf").index(UPat(), UPat(), dtype=dtypes.float, name="x"), lambda ctx,buf,x:
+   x.replace(src=(buf.replace(dtype=f2f_dt[ctx[0]], arg=replace(buf.arg, dtype=f2f_dt[ctx[0]]), tag=ctx[0]), *x.src[1:]))
+   if buf.dtype == ctx[0] and is_image_shape(buf._shape) else None),
   (UPat((*GroupOp.Defines, Ops.INDEX, Ops.SHRINK), name="x"), lambda ctx,x:
    x.replace(dtype=f2f_dt[ctx[0]], arg=replace(x.arg, dtype=f2f_dt[ctx[0]]) if isinstance(x.arg, ParamArg) else x.arg, tag=ctx[0])
    if x.dtype == ctx[0] and (x.op is not Ops.INDEX or x.src[0].op not in {Ops.LOAD, Ops.STACK}) else None),

--- a/tinygrad/codegen/late/coalesce.py
+++ b/tinygrad/codegen/late/coalesce.py
@@ -61,11 +61,13 @@ indexing_simplify = PatternMatcher([
 # get list of (height, width) that do not require pitch padding
 def image_valid_dims(base:DType, size:int, arch:str) -> list[tuple[int,int]]:
   if (ALIGN:=next((int(p.split('=')[1]) for p in arch.split(',') if p.startswith("IMAGE_PITCH_ALIGNMENT=")), 0)) == 0: return []
+  ROW_ALIGN = 256 if OSX else ALIGN
   MAXW, pxls = 16384, size // 4
   if base not in (dtypes.half, dtypes.float) or size > 4*MAXW*MAXW: return []
   # height=1 images just need to abide by alignment requirements in bytes, not pixels!
-  if size % (ALIGN * 4) != 0: return [] if (base.itemsize * size) % (64 if OSX else ALIGN) != 0 or pxls > MAXW else [(1, pxls)]
-  return [(pxls//ALIGN//k, ALIGN*k) for k in range(ceildiv(pxls//ALIGN, MAXW), min(pxls//ALIGN, MAXW//ALIGN)+1) if (pxls//ALIGN)%k == 0]
+  if size % (ROW_ALIGN * 4) != 0: return [] if (base.itemsize * size) % (64 if OSX else ALIGN) != 0 or pxls > MAXW else [(1, pxls)]
+  return [(pxls//ROW_ALIGN//k, ROW_ALIGN*k) for k in
+          range(ceildiv(pxls//ROW_ALIGN, MAXW), min(pxls//ROW_ALIGN, MAXW//ROW_ALIGN)+1) if (pxls//ROW_ALIGN)%k == 0]
 
 def transform_to_image(ctx, buf:UOp, x:UOp) -> UOp|None:
   shapes, ren = ctx

--- a/tinygrad/codegen/late/gater.py
+++ b/tinygrad/codegen/late/gater.py
@@ -10,7 +10,7 @@ pm_move_gates_from_index = PatternMatcher([
   # for image idx (must be first)
   (UPat.var("buf").index(UPat.var("gate").where(UPat.var("idx_y"), UPat(arg=Invalid)),
                          UPat.var("gate").where(UPat.var("idx_x"), UPat(arg=Invalid))).load(name="l"),
-   lambda buf,gate,idx_y,idx_x,l: buf.index(idx_y, idx_x, dtype=dtypes.float).load(l.vconst_like(0), gate)),
+   lambda buf,gate,idx_y,idx_x,l: (idx:=buf.index(idx_y, idx_x, dtype=dtypes.float)).load(idx.vconst_like(0), gate)),
   (UPat.var("buf").index(UPat.var("gate").where(UPat.var("idx_y"), UPat(arg=Invalid)),
                          UPat.var("gate").where(UPat.var("idx_x"), UPat(arg=Invalid))).store(UPat.var("data")),
    lambda buf,gate,idx_y,idx_x,data: buf.index(idx_y, idx_x, dtype=dtypes.float).store(data, gate)),

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -66,6 +66,7 @@ class DType(metaclass=DTypeMetaClass):
   def __repr__(self): return f"dtypes.{INVERSE_DTYPES_DICT[self.name]}"
   def __lt__(self, o:DType): return (self.priority, self.bitsize, self.name, self.fmt) < (o.priority, o.bitsize, o.name, o.fmt)
   def scalar(self) -> DType: return self
+  def weak(self) -> DType: return dtypes.weakfloat if dtypes.is_float(self) else dtypes.weakint if dtypes.is_int(self) else self
   @functools.cached_property
   def min(self):
     if dtypes.is_int(self): return 0 if dtypes.is_unsigned(self) else -2**(self.bitsize-1)

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -21,7 +21,11 @@ class ElementwiseMixin(CreationMixin):
   def _broadcasted(self, y: 'Self|ConstType|UOp', reverse: bool = False) -> tuple[Self, Self]:
     y = self.ufix(y)
     x, y = (self, y) if not reverse else (y, self)
-    return x.cast(out_dtype := least_upper_dtype(x.dtype, y.dtype)), y.cast(out_dtype)
+    out_dtype = least_upper_dtype(x.dtype, y.dtype)
+    weak_out_dtype = out_dtype.weak()
+    # Weak constant operands keep only the lub's kind; other operands cast to the lub.
+    return (x.cast(weak_out_dtype if x.dtype in dtypes.weaks and x._uop.base.op is Ops.CONST else out_dtype),
+            y.cast(weak_out_dtype if y.dtype in dtypes.weaks and y._uop.base.op is Ops.CONST else out_dtype))
 
   def _binop(self, op: Ops, x: Self | ConstType, reverse: bool) -> Self:
     lhs, rhs = self._broadcasted(x, reverse)

--- a/tinygrad/runtime/ops_cl.py
+++ b/tinygrad/runtime/ops_cl.py
@@ -69,10 +69,12 @@ class CLProgram(Program['CLDevice']):
                                     (ctypes.c_size_t * len(local_size))(*local_size) if local_size else None, 0, None, event))
     if wait:
       assert event is not None
-      check(cl.clWaitForEvents(1, event))
-      check(cl.clGetEventProfilingInfo(event, cl.CL_PROFILING_COMMAND_START, 8, ctypes.byref(start := ctypes.c_uint64()), None))
-      check(cl.clGetEventProfilingInfo(event, cl.CL_PROFILING_COMMAND_END, 8, ctypes.byref(end := ctypes.c_uint64()), None))
-      return float(end.value-start.value) * OSX_TIMING_RATIO * 1e-9
+      try:
+        check(cl.clWaitForEvents(1, event))
+        check(cl.clGetEventProfilingInfo(event, cl.CL_PROFILING_COMMAND_START, 8, ctypes.byref(start := ctypes.c_uint64()), None))
+        check(cl.clGetEventProfilingInfo(event, cl.CL_PROFILING_COMMAND_END, 8, ctypes.byref(end := ctypes.c_uint64()), None))
+        return float(end.value-start.value) * OSX_TIMING_RATIO * 1e-9
+      finally: check(cl.clReleaseEvent(event))
     return None
 
 class CLAllocator(LRUAllocator['CLDevice']):

--- a/tinygrad/runtime/ops_null.py
+++ b/tinygrad/runtime/ops_null.py
@@ -1,4 +1,4 @@
-import inspect, math
+import inspect
 from tinygrad.device import Compiled, Allocator, ProfileGraphEntry, ProfileGraphEvent, Program, TinyELF
 from tinygrad.engine.jit import MultiGraphRunner
 from tinygrad.renderer import Renderer, cstyle, nir, ptx, llvmir, wgsl
@@ -41,7 +41,7 @@ class NullGraph(MultiGraphRunner):
         descs.append((device, runtime.name if runtime is not None else f"{bufs[1].device} -> {bufs[0].device}", count:=event_count.get(device, 0)))
         event_count[device] = count+1
       # pack events evenly per device
-      dur, sigs, ents = max(1, math.ceil((perf_counter_us()-st)/max(event_count.values()))), [], []
+      dur, sigs, ents = 1, [], []  # synthetic 1us per event: NULL profiles are deterministic, never host-load-dependent
       for i,(device,name,count) in enumerate(descs):
         sigs += [st+count*dur, st+(count+1)*dur]
         ents.append(ProfileGraphEntry(device, name, 2*i, 2*i+1))

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1659,7 +1659,7 @@ class RewriteContext:
       else:
         # rebuild node with rewritten srcs
         new_src = tuple(self.replace.get(x, x) for x in n.src)
-        new_n = UOp(n.op, n.dtype, new_src, n.arg, n.tag) if new_src != n.src else n
+        new_n = UOp(n.op, _rebuild_dtype(n, new_src), new_src, n.arg, n.tag) if new_src != n.src else n
         # top-down: try pm on rebuilt node, use result as-is (no re-traversal)
         if self.pm is not None and (rewritten:=self.pm_rewrite(new_n)) is not None: new_n = rewritten
         self.replace[n] = new_n
@@ -1718,7 +1718,7 @@ class RewriteContext:
               continue
           else:
             # if srcs changed from rewrites, construct a new UOp with the new srcs
-            new_src_n = UOp(new_n.op, new_n.dtype, new_src, new_n.arg, new_n.tag)
+            new_src_n = UOp(new_n.op, _rebuild_dtype(new_n, new_src), new_src, new_n.arg, new_n.tag)
           # trigger a rewrite of new_src_n, then after that rewrite is done, link it back to n
           stack.append((n, 2, new_src_n))
           stack.append((new_src_n, 0, new_src_n))
@@ -1737,6 +1737,11 @@ class RewriteContext:
 def graph_rewrite(sink:UOp, pm:PatternMatcher, ctx=None, bottom_up=False, name=None, bpm=None, walk=False, enter_calls=False) -> UOp:
   rewrite_ctx = RewriteContext(pm if not bottom_up else None, pm if bottom_up else bpm, ctx, enter_calls)
   return rewrite_ctx.walk_rewrite(sink) if walk else rewrite_ctx.unified_rewrite(sink)
+
+def _rebuild_dtype(n:UOp, new_src:tuple[UOp,...]) -> DType:
+  # TODO: delete this once the dtype field is removed, every rebuild will re-derive
+  if all(a.dtype is b.dtype or b.base.arg is Invalid for a,b in zip(n.src, new_src)): return n.dtype
+  return dtype_from_uop(n.op, new_src, n.arg) or n.dtype
 
 def sint_to_uop(x:sint, dtype=dtypes.weakint) -> UOp: return UOp.const(dtype, x)
 def to_max_shape(shape:tuple[sint, ...]) -> tuple[int, ...]: return tuple(int(x.vmax) if isinstance(x, UOp) else x for x in shape)

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -125,7 +125,8 @@ def dtype_from_uop(op:Ops, src:tuple[UOp,...], arg:Any) -> DType|None:
       # a CALL of an opaque body is void, a CALL of an address can return a value
       return dtypes.void if src[0].dtype is dtypes.void else None
     case Ops.CUSTOM | Ops.CUSTOMI | Ops.INS | Ops.PYLITERAL:
-      return dtypes.void
+      # machine/opaque IR: the node's dtype is stated by its producer, derivation has no claim (a rebuild keeps it)
+      return None
     case Ops.NOOP:
       # NOOP can be void or carry any dtype (e.g. x.f(Ops.NOOP) or substitute base with NOOP)
       return None

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -587,7 +587,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
     return UOp.const(dtype or self.dtype, b).broadcast(self.max_numel())
   def ufix(self, x):
     if isinstance(x, UOp): return x
-    return UOp.const(least_upper_dtype(self.dtype, dtypes.from_py(x)), x)
+    return UOp.const(least_upper_dtype(self.dtype, dtypes.from_py(x)).weak(), x)
   def broadcast(self, count:int):
     if count == 1: return self
     return UOp(Ops.STACK, src=(self,)*count)
@@ -1768,20 +1768,30 @@ pm_lower_weak = PatternMatcher([
   (UPat(Ops.PARAM, dtype=dtypes.weakint, name="u"),
     lambda u: u.replace(dtype=None, arg=replace(u.arg, dtype=select_dtype(u))).cast(dtypes.weakint) if u.addrspace == AddrSpace.ALU else None),
 ])
-def lower_weak_srcs(ctx:dict[UOp, UOp]|None, u:UOp) -> UOp|None:
-  if ctx is None: ctx = {}
+def lower_weak_srcs(ctx:tuple[dict[UOp, UOp], bool]|None, u:UOp) -> UOp|None:
+  cache, fallback = ctx if ctx is not None else ({}, False)
+  if (u.dtype in dtypes.weaks and not fallback) or not any(s.dtype in dtypes.weaks for s in u.src): return None
   def lower(s:UOp) -> UOp:
-    if (r:=ctx.get(s)) is None:
+    if (r:=cache.get(s)) is None:
       r = graph_rewrite(s, pm_lower_weak)
       # the consumer absorbs the cast on its own edge
-      ctx[s] = r = r.src[0] if r.op is Ops.CAST and r.dtype in dtypes.weaks else r
+      cache[s] = r = r.src[0] if r.op is Ops.CAST and r.dtype in dtypes.weaks else r
     return r
+  operand_lub = u.op in GroupOp.Binary|{Ops.WHERE}
+  demand = u.src[0].dtype.scalar() if u.op is Ops.STORE else least_upper_dtype(*(s.dtype for s in u.src)) if operand_lub else None
+  if fallback and demand in dtypes.weaks:
+    demand = least_upper_dtype(*(select_dtype(s) if s.op is Ops.CONST and s.dtype in dtypes.weaks else strong_dtype(s.dtype)
+                                 for s in u.src))
+  if (fallback or demand is not None and demand not in dtypes.weaks) and \
+     any(s.op is Ops.CONST and s.dtype in dtypes.weaks for s in u.src):
+    src = tuple(UOp.const(demand if demand is not None else select_dtype(s), s.arg)
+                if s.op is Ops.CONST and s.dtype in dtypes.weaks else s for s in u.src)
+    u = u.replace(dtype=None, src=src)
   # a comparison demands a common operand width: lower it whole so the Binary rule unifies its operands
   ret = lower(u) if u.op in GroupOp.Comparison else u.replace(src=tuple(lower(s) if s.dtype in dtypes.weaks else s for s in u.src))
-  return None if ret is u else ret
+  return ret
 pm_lower_index_dtype = PatternMatcher([
-  (UPat(GroupOp.All, name="u"),
-   lambda ctx,u: lower_weak_srcs(ctx, u) if u.dtype not in dtypes.weaks and any(s.dtype in dtypes.weaks for s in u.src) else None),
+  (UPat(GroupOp.All, name="u"), lower_weak_srcs),
   # a valid index into an n-element buffer lives in [0,n): a gated long index narrows when n-1 fits int32 (out-of-gate wraps, discarded)
   # TODO: more generic
   (UPat((Ops.INDEX, Ops.SHRINK), src=(UPat.var("buf"), UPat.var("gate").where(UPat.var("idx", dtypes.long), UPat(Ops.CONST, arg=Invalid))),


### PR DESCRIPTION
temporarily before dtypes are inferred. with weak CONST, it's possible to have a rewrite that returns in a different dtype