### PR TITLE
spec tests for movement ops before custom_kernel

### DIFF
--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -466,6 +466,7 @@ class TestCustomKernel(unittest.TestCase):
   def test_2d_shrink_input(self): self._test_mop_input(lambda x: x.reshape(4, 8)[:, 2:6], pre_kernel=True)
   def test_pad_input(self): self._test_mop_input(lambda x: x[:4].pad(((0, 4),)), pre_kernel=True)
   def test_flip_input(self): self._test_mop_input(lambda x: x.flip(0), pre_kernel=True)
+  def test_expand_input(self): self._test_mop_input(lambda x: x.reshape(16, 2)[:, :1].expand(16, 2), pre_kernel=True)
 
 class TestUnshardIndex(unittest.TestCase):
   """Regression tests for INDEX on UNSHARD (fragment) resolution in schedule/multi.py.

--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -433,7 +433,7 @@ class TestCustomKernel(unittest.TestCase):
     a = Tensor.custom_kernel(a.reshape(2, 2).T, fxn=custom_src_kernel)[0]
     self.assertEqual(a.tolist(), [[1, 2], [1, 3]])
 
-  def _test_mop_input(self, mop_fxn, pre_kernel=False):
+  def _test_mop_input(self, mop_fxn, max_kernels):
     # default: input is BUFFER
     x = mop_fxn(Tensor.arange(32).clone("CPU").realize())
     y = Tensor.custom_kernel(Tensor.empty_like(x), x, fxn=custom_add_one_kernel)[0]
@@ -441,7 +441,7 @@ class TestCustomKernel(unittest.TestCase):
     y.realize()
     kernel_count = GlobalCounters.kernel_count
     self.assertEqual(y.tolist(), x.add(1).tolist())
-    self.assertEqual(kernel_count, 1+int(pre_kernel))
+    self.assertLessEqual(kernel_count, max_kernels)
     # same test with @function, input is PARAM
     from tinygrad import function
     x0 = Tensor.arange(32).clone("CPU").realize()
@@ -454,19 +454,17 @@ class TestCustomKernel(unittest.TestCase):
     y = run(x0).realize()
     kernel_count = GlobalCounters.kernel_count
     self.assertEqual(y.tolist(), mop_fxn(x0).add(1).tolist())
-    self.assertEqual(kernel_count, 1+int(pre_kernel))
+    self.assertLessEqual(kernel_count, max_kernels)
 
-  def test_shrink_input(self): self._test_mop_input(lambda x: x[:4])
-  @unittest.expectedFailure
-  def test_double_permute_input(self): self._test_mop_input(lambda x: x.reshape(4, 8).T.T)
-  @unittest.expectedFailure
-  def test_reshape_input(self): self._test_mop_input(lambda x: x.reshape(16, 2))
-  def test_permute_input(self): self._test_mop_input(lambda x: x.reshape(4, 8).T, pre_kernel=True)
-  def test_offset_shrink_input(self): self._test_mop_input(lambda x: x[4:8])
-  def test_2d_shrink_input(self): self._test_mop_input(lambda x: x.reshape(4, 8)[:, 2:6], pre_kernel=True)
-  def test_pad_input(self): self._test_mop_input(lambda x: x[:4].pad(((0, 4),)), pre_kernel=True)
-  def test_flip_input(self): self._test_mop_input(lambda x: x.flip(0), pre_kernel=True)
-  def test_expand_input(self): self._test_mop_input(lambda x: x.reshape(16, 2)[:, :1].expand(16, 2), pre_kernel=True)
+  def test_shrink_input(self): self._test_mop_input(lambda x: x[:4], max_kernels=2)
+  def test_double_permute_input(self): self._test_mop_input(lambda x: x.reshape(4, 8).T.T, max_kernels=3)
+  def test_reshape_input(self): self._test_mop_input(lambda x: x.reshape(16, 2), max_kernels=2)
+  def test_permute_input(self): self._test_mop_input(lambda x: x.reshape(4, 8).T, max_kernels=3)
+  def test_offset_shrink_input(self): self._test_mop_input(lambda x: x[4:8], max_kernels=2)
+  def test_2d_shrink_input(self): self._test_mop_input(lambda x: x.reshape(4, 8)[:, 2:6], max_kernels=3)
+  def test_pad_input(self): self._test_mop_input(lambda x: x[:4].pad(((0, 4),)), max_kernels=2)
+  def test_flip_input(self): self._test_mop_input(lambda x: x.flip(0), max_kernels=2)
+  def test_expand_input(self): self._test_mop_input(lambda x: x.reshape(16, 2)[:, :1].expand(16, 2), max_kernels=3)
 
 class TestUnshardIndex(unittest.TestCase):
   """Regression tests for INDEX on UNSHARD (fragment) resolution in schedule/multi.py.

--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -433,7 +433,7 @@ class TestCustomKernel(unittest.TestCase):
     a = Tensor.custom_kernel(a.reshape(2, 2).T, fxn=custom_src_kernel)[0]
     self.assertEqual(a.tolist(), [[1, 2], [1, 3]])
 
-  def test_mop_input(self, mop_fxn=lambda x: x.reshape(16, 2), kcount:int=0):
+  def _test_mop_input(self, mop_fxn, pre_kernel=False):
     # default: input is BUFFER
     x = mop_fxn(Tensor.arange(32).clone("CPU").realize())
     y = Tensor.custom_kernel(Tensor.empty_like(x), x, fxn=custom_add_one_kernel)[0]
@@ -441,7 +441,7 @@ class TestCustomKernel(unittest.TestCase):
     y.realize()
     kernel_count = GlobalCounters.kernel_count
     self.assertEqual(y.tolist(), x.add(1).tolist())
-    self.assertEqual(kernel_count, 1+kcount)
+    self.assertEqual(kernel_count, 1+int(pre_kernel))
     # same test with @function, input is PARAM
     from tinygrad import function
     x0 = Tensor.arange(32).clone("CPU").realize()
@@ -454,20 +454,18 @@ class TestCustomKernel(unittest.TestCase):
     y = run(x0).realize()
     kernel_count = GlobalCounters.kernel_count
     self.assertEqual(y.tolist(), mop_fxn(x0).add(1).tolist())
-    # TODO: another +1 is because function copies the output
-    self.assertEqual(kernel_count, 1+kcount+1)
+    self.assertEqual(kernel_count, 1+int(pre_kernel))
 
-  def test_shrink_input(self): self.test_mop_input(lambda x: x[:4], kcount=0)
+  def test_shrink_input(self): self._test_mop_input(lambda x: x[:4])
   @unittest.expectedFailure
-  def test_double_permute_input(self): self.test_mop_input(lambda x: x.reshape(4, 8).T.T, kcount=0)
-  def test_permute_input(self): self.test_mop_input(lambda x: x.reshape(4, 8).T, kcount=1)
-  def test_offset_shrink_input(self): self.test_mop_input(lambda x: x[4:8], kcount=0)
-  def test_2d_shrink_input(self): self.test_mop_input(lambda x: x.reshape(4, 8)[:, 2:6], kcount=1)
+  def test_double_permute_input(self): self._test_mop_input(lambda x: x.reshape(4, 8).T.T)
   @unittest.expectedFailure
-  def test_pad_input(self): self.test_mop_input(lambda x: x[:4].pad(((0, 4),)), kcount=1)
-  @unittest.expectedFailure
-  def test_flip_input(self): self.test_mop_input(lambda x: x.flip(0), kcount=1)
-  def test_expand_input(self): self.test_mop_input(lambda x: x.reshape(16, 2)[:, :1].expand(16, 2), kcount=1)
+  def test_reshape_input(self): self._test_mop_input(lambda x: x.reshape(16, 2))
+  def test_permute_input(self): self._test_mop_input(lambda x: x.reshape(4, 8).T, pre_kernel=True)
+  def test_offset_shrink_input(self): self._test_mop_input(lambda x: x[4:8])
+  def test_2d_shrink_input(self): self._test_mop_input(lambda x: x.reshape(4, 8)[:, 2:6], pre_kernel=True)
+  def test_pad_input(self): self._test_mop_input(lambda x: x[:4].pad(((0, 4),)), pre_kernel=True)
+  def test_flip_input(self): self._test_mop_input(lambda x: x.flip(0), pre_kernel=True)
 
 class TestUnshardIndex(unittest.TestCase):
   """Regression tests for INDEX on UNSHARD (fragment) resolution in schedule/multi.py.

--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -434,7 +434,7 @@ class TestCustomKernel(unittest.TestCase):
     self.assertEqual(a.tolist(), [[1, 2], [1, 3]])
 
   def test_mop_input(self, mop_fxn=lambda x: x.reshape(16, 2), kcount:int=0):
-    # raw: mop outside, input is a realized BUFFER
+    # default: input is BUFFER
     x = mop_fxn(Tensor.arange(32).clone("CPU").realize())
     y = Tensor.custom_kernel(Tensor.empty_like(x), x, fxn=custom_add_one_kernel)[0]
     GlobalCounters.reset()
@@ -442,7 +442,7 @@ class TestCustomKernel(unittest.TestCase):
     kernel_count = GlobalCounters.kernel_count
     self.assertEqual(y.tolist(), x.add(1).tolist())
     self.assertEqual(kernel_count, 1+kcount)
-    # same test wrapped in @function like the trainer (mop inside, input is a PARAM)
+    # same test with @function, input is PARAM
     from tinygrad import function
     x0 = Tensor.arange(32).clone("CPU").realize()
     @function(precompile=True)
@@ -454,7 +454,8 @@ class TestCustomKernel(unittest.TestCase):
     y = run(x0).realize()
     kernel_count = GlobalCounters.kernel_count
     self.assertEqual(y.tolist(), mop_fxn(x0).add(1).tolist())
-    self.assertEqual(kernel_count, 1+kcount)
+    # TODO: another +1 is because function copies the output
+    self.assertEqual(kernel_count, 1+kcount+1)
 
   # becomes a SLICE when the device supports it
   def test_shrink_input(self): self.test_mop_input(lambda x: x[:4], kcount=0)

--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -433,6 +433,40 @@ class TestCustomKernel(unittest.TestCase):
     a = Tensor.custom_kernel(a.reshape(2, 2).T, fxn=custom_src_kernel)[0]
     self.assertEqual(a.tolist(), [[1, 2], [1, 3]])
 
+  def test_mop_input(self, mop_fxn=lambda x: x.reshape(16, 2), kcount:int=0):
+    # raw: mop outside, input is a realized BUFFER
+    x = mop_fxn(Tensor.arange(32).clone("CPU").realize())
+    y = Tensor.custom_kernel(Tensor.empty_like(x), x, fxn=custom_add_one_kernel)[0]
+    GlobalCounters.reset()
+    y.realize()
+    kernel_count = GlobalCounters.kernel_count
+    self.assertEqual(y.tolist(), x.add(1).tolist())
+    self.assertEqual(kernel_count, 1+kcount)
+    # same test wrapped in @function like the trainer (mop inside, input is a PARAM)
+    from tinygrad import function
+    x0 = Tensor.arange(32).clone("CPU").realize()
+    @function(precompile=True)
+    def run(a:Tensor) -> Tensor:
+      xv = mop_fxn(a)
+      y = Tensor.invalids(*xv.shape, dtype=xv.dtype, device=a.device)
+      return Tensor.custom_kernel(y, xv, fxn=custom_add_one_kernel)[0]
+    GlobalCounters.reset()
+    y = run(x0).realize()
+    kernel_count = GlobalCounters.kernel_count
+    self.assertEqual(y.tolist(), mop_fxn(x0).add(1).tolist())
+    self.assertEqual(kernel_count, 1+kcount)
+
+  # becomes a SLICE when the device supports it
+  def test_shrink_input(self): self.test_mop_input(lambda x: x[:4], kcount=0)
+  def test_double_permute_input(self): self.test_mop_input(lambda x: x.reshape(4, 8).T.T, kcount=0)
+  # must materialize the movement op before CALL
+  def test_permute_input(self): self.test_mop_input(lambda x: x.reshape(4, 8).T, kcount=1)
+  def test_offset_shrink_input(self): self.test_mop_input(lambda x: x[4:8], kcount=0)
+  def test_2d_shrink_input(self): self.test_mop_input(lambda x: x.reshape(4, 8)[:, 2:6], kcount=1)
+  def test_pad_input(self): self.test_mop_input(lambda x: x[:4].pad(((0, 4),)), kcount=1)
+  def test_flip_input(self): self.test_mop_input(lambda x: x.flip(0), kcount=1)
+  def test_expand_input(self): self.test_mop_input(lambda x: x.reshape(16, 2)[:, :1].expand(16, 2), kcount=1)
+
 class TestUnshardIndex(unittest.TestCase):
   """Regression tests for INDEX on UNSHARD (fragment) resolution in schedule/multi.py.
 

--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -459,12 +459,15 @@ class TestCustomKernel(unittest.TestCase):
 
   # becomes a SLICE when the device supports it
   def test_shrink_input(self): self.test_mop_input(lambda x: x[:4], kcount=0)
+  @unittest.expectedFailure
   def test_double_permute_input(self): self.test_mop_input(lambda x: x.reshape(4, 8).T.T, kcount=0)
   # must materialize the movement op before CALL
   def test_permute_input(self): self.test_mop_input(lambda x: x.reshape(4, 8).T, kcount=1)
   def test_offset_shrink_input(self): self.test_mop_input(lambda x: x[4:8], kcount=0)
   def test_2d_shrink_input(self): self.test_mop_input(lambda x: x.reshape(4, 8)[:, 2:6], kcount=1)
+  @unittest.expectedFailure
   def test_pad_input(self): self.test_mop_input(lambda x: x[:4].pad(((0, 4),)), kcount=1)
+  @unittest.expectedFailure
   def test_flip_input(self): self.test_mop_input(lambda x: x.flip(0), kcount=1)
   def test_expand_input(self): self.test_mop_input(lambda x: x.reshape(16, 2)[:, :1].expand(16, 2), kcount=1)
 

--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -433,7 +433,8 @@ class TestCustomKernel(unittest.TestCase):
     a = Tensor.custom_kernel(a.reshape(2, 2).T, fxn=custom_src_kernel)[0]
     self.assertEqual(a.tolist(), [[1, 2], [1, 3]])
 
-  def _test_mop_input(self, mop_fxn, max_kernels):
+class TestCustomKernelInput(unittest.TestCase):
+  def _test_mop(self, mop_fxn, max_kernels):
     # default: input is BUFFER
     x = mop_fxn(Tensor.arange(32).clone("CPU").realize())
     y = Tensor.custom_kernel(Tensor.empty_like(x), x, fxn=custom_add_one_kernel)[0]
@@ -456,15 +457,15 @@ class TestCustomKernel(unittest.TestCase):
     self.assertEqual(y.tolist(), mop_fxn(x0).add(1).tolist())
     self.assertLessEqual(kernel_count, max_kernels)
 
-  def test_shrink_input(self): self._test_mop_input(lambda x: x[:4], max_kernels=2)
-  def test_double_permute_input(self): self._test_mop_input(lambda x: x.reshape(4, 8).T.T, max_kernels=3)
-  def test_reshape_input(self): self._test_mop_input(lambda x: x.reshape(16, 2), max_kernels=2)
-  def test_permute_input(self): self._test_mop_input(lambda x: x.reshape(4, 8).T, max_kernels=3)
-  def test_offset_shrink_input(self): self._test_mop_input(lambda x: x[4:8], max_kernels=2)
-  def test_2d_shrink_input(self): self._test_mop_input(lambda x: x.reshape(4, 8)[:, 2:6], max_kernels=3)
-  def test_pad_input(self): self._test_mop_input(lambda x: x[:4].pad(((0, 4),)), max_kernels=2)
-  def test_flip_input(self): self._test_mop_input(lambda x: x.flip(0), max_kernels=2)
-  def test_expand_input(self): self._test_mop_input(lambda x: x.reshape(16, 2)[:, :1].expand(16, 2), max_kernels=3)
+  def test_reshape(self): self._test_mop(lambda x: x.reshape(16, 2), max_kernels=2)
+  def test_permute(self): self._test_mop(lambda x: x.reshape(4, 8).T, max_kernels=3)
+  def test_double_permute(self): self._test_mop(lambda x: x.reshape(4, 8).T.T, max_kernels=3)
+  def test_shrink(self): self._test_mop(lambda x: x[:4], max_kernels=2)
+  def test_pad(self): self._test_mop(lambda x: x[:4].pad(((0, 4),)), max_kernels=2)
+  def test_flip(self): self._test_mop(lambda x: x.flip(0), max_kernels=2)
+  def test_offset_shrink(self): self._test_mop(lambda x: x[4:8], max_kernels=2)
+  def test_2d_shrink(self): self._test_mop(lambda x: x.reshape(4, 8)[:, 2:6], max_kernels=3)
+  def test_expand(self): self._test_mop(lambda x: x.reshape(16, 2)[:, :1].expand(16, 2), max_kernels=3)
 
 class TestUnshardIndex(unittest.TestCase):
   """Regression tests for INDEX on UNSHARD (fragment) resolution in schedule/multi.py.

--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -457,11 +457,9 @@ class TestCustomKernel(unittest.TestCase):
     # TODO: another +1 is because function copies the output
     self.assertEqual(kernel_count, 1+kcount+1)
 
-  # becomes a SLICE when the device supports it
   def test_shrink_input(self): self.test_mop_input(lambda x: x[:4], kcount=0)
   @unittest.expectedFailure
   def test_double_permute_input(self): self.test_mop_input(lambda x: x.reshape(4, 8).T.T, kcount=0)
-  # must materialize the movement op before CALL
   def test_permute_input(self): self.test_mop_input(lambda x: x.reshape(4, 8).T, kcount=1)
   def test_offset_shrink_input(self): self.test_mop_input(lambda x: x[4:8], kcount=0)
   def test_2d_shrink_input(self): self.test_mop_input(lambda x: x.reshape(4, 8)[:, 2:6], kcount=1)


### PR DESCRIPTION
spec comes from getting a taxonomy of llama's E copy kernels in master.
removing pure copy contiguous works already when it's not wrapped around `@function`. 