### PR TITLE
Reduce gguf mem usage

### DIFF
--- a/test/unit/test_gguf.py
+++ b/test/unit/test_gguf.py
@@ -154,6 +154,14 @@ class TestGGUF(unittest.TestCase):
       with self.assertRaises(FileNotFoundError):
         gguf_load(d / "test-00001-of-00002.gguf")
 
+  def test_disk_backed_payload(self):
+    with tempfile.TemporaryDirectory() as d:
+      fd = pathlib.Path(d) / "test.gguf"
+      a = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+      fd.write_bytes(self._build_gguf([("weight", (4,), 0, a.tobytes())], []))
+      _, tensors = gguf_load(Tensor(fd))
+      np.testing.assert_equal(tensors["weight"].numpy(), a)
+
   def _test_dequantization(self, qtype: GGMLQuantizationType):
     block_size, type_size = GGML_QUANT_SIZES[qtype]
     n_el, n_bytes = ggml_test_block_count * block_size, ggml_test_block_count * type_size

--- a/tinygrad/llm/gguf.py
+++ b/tinygrad/llm/gguf.py
@@ -33,7 +33,7 @@ def ggml_data_to_tensor(t: Tensor, n: int, ggml_type: int) -> Tensor:
   # https://github.com/ggerganov/ggml/blob/323951f1bdcdfbd5b5ff3a9a7c3770e63b1a560e/include/ggml.h#L356
 
   if (dtype := _GGML_NATIVE.get(ggml_type)) is not None:
-    return t[:dtype.itemsize * n].contiguous().bitcast(dtype)
+    return t[:dtype.itemsize * n].to(None).contiguous().bitcast(dtype)
 
   def q_to_uint8(t: Tensor, b: int) -> Tensor:
     # TODO: rewrite with arange?
@@ -42,7 +42,7 @@ def ggml_data_to_tensor(t: Tensor, n: int, ggml_type: int) -> Tensor:
 
   if (nelements_nbytes := _GGML_QUANT.get(ggml_type)) is not None:
     from tinygrad.runtime.autogen import ggml_common as _ggml
-    blocks = t[:(n//nelements_nbytes[0])*nelements_nbytes[1]].reshape((-1, nelements_nbytes[1])).contiguous()
+    blocks = t[:(n//nelements_nbytes[0])*nelements_nbytes[1]].to(None).reshape((-1, nelements_nbytes[1])).contiguous()
     if ggml_type == 2: return (q_to_uint8(blocks[:,2:], 4).bitcast(dtypes.int8) - 8) * blocks[:,:2].bitcast(dtypes.float16).cast(dtypes.float32)
     if ggml_type == 3:
       d, m = (blocks[:,s:s+2].bitcast(dtypes.float16).cast(dtypes.float32) for s in [ 0, 2 ])
@@ -130,8 +130,6 @@ readers: dict[int, Callable[[io.BufferedIOBase], Any]] = { 8: read_str, 9: read_
 read_uint32, read_int32, read_uint64, read_int64 = readers[4], readers[5], readers[10], readers[11]
 
 def _gguf_parse(tensor: Tensor) -> tuple[dict, dict[str, Tensor]]:
-  # TODO: remove the need for copy to default device
-  tensor = tensor.to(None).realize()
   r = io.BufferedReader(TensorIO(tensor), 1_000_000)
   magic, version, n_tensors, n_kv = r.read(4), read_int32(r), read_int64(r), read_int64(r)
   if magic != b"GGUF" or version not in [2, 3]: raise ValueError("Invalid GGUF format!")

--- a/tinygrad/llm/model.py
+++ b/tinygrad/llm/model.py
@@ -335,8 +335,7 @@ class Transformer:
   @staticmethod
   def from_gguf(gguf:Tensor|str|pathlib.Path, max_context:int|None=None,
                 realize=bool(getenv("REALIZE", 0))) -> tuple[Transformer, dict]:
-    # TODO: remove the need for copy to default device
-    kv, state_dict = gguf_load(gguf.to(None).realize() if isinstance(gguf, Tensor) else gguf)
+    kv, state_dict = gguf_load(gguf)
 
     # all state items should be float16, not float32
     state_dict = {k:v.cast('float16') if getenv("HALF", 1) else v for k,v in state_dict.items()}


### PR DESCRIPTION
Addresses this todo:

```
def _gguf_parse(tensor: Tensor) -> tuple[dict, dict[str, Tensor]]:
  # TODO: remove the need for copy to default device
  tensor = tensor.to(None).realize()
```

Instead of loading the entire gguf at once, it eagerly loads the header and lazily loads the rest chuck by chunk.

I tested this with this script:
```
from tinygrad import Tensor, fetch
from tinygrad.helpers import GlobalCounters
from tinygrad.llm.gguf import gguf_load

src = Tensor(fetch("https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories15M-q4_0.gguf?download=True"))

print(dict(GlobalCounters.mem_used_per_device))
kv, state = gguf_load(src)
print(dict(GlobalCounters.mem_used_per_device))
```

Current output of this script on `master`:
```
uv run temp.py
{}
{'CUDA': 19077344, 'PYTHON': 0}
```

Output on this branch:
```
uv run temp.py
{}
{'PYTHON': 0}
```

I also added a test to make sure the disk backed gguf loading worked as expected since I simplified this line:
```
gguf_load(gguf.to(None).realize() if isinstance(gguf, Tensor) else gguf)
```