### PR TITLE
hotfix: don't run usbgpu benchmark on tinyc5

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -501,7 +501,7 @@ jobs:
 
   testcommausbgpubenchmark:
     name: UsbGPU Benchmark (comma)
-    runs-on: [self-hosted, Linux, comma4]
+    runs-on: [self-hosted, Linux, ci-tinyc6]
     timeout-minutes: 20
     defaults:
       run:


### PR DESCRIPTION
it can still run dsp benchmark, but aux usb seems to have issues