### PR TITLE
failing test for unbound _device_num err in BEAM

### DIFF
--- a/test/backend/test_multitensor.py
+++ b/test/backend/test_multitensor.py
@@ -76,6 +76,7 @@ class TestMultiTensor(unittest.TestCase):
     run_linear(linear)
     self.assertEqual(len(set(names)), 1, "function was relinearized")
 
+  @unittest.expectedFailure
   def test_shard_beam(self):
     cpu_2 = ("CPU:1", "CPU:2")
     src = Tensor.ones(16).shard(cpu_2, 0).realize()

--- a/test/backend/test_multitensor.py
+++ b/test/backend/test_multitensor.py
@@ -76,6 +76,12 @@ class TestMultiTensor(unittest.TestCase):
     run_linear(linear)
     self.assertEqual(len(set(names)), 1, "function was relinearized")
 
+  def test_shard_beam(self):
+    src = Tensor.ones(16).shard(devices_2, 0).realize()
+    pad = src.to(devices_2[::-1]).schedule_linear().src[0]
+    with Context(BEAM=1, IGNORE_BEAM_CACHE=1): prg = compile_linear(UOp(Ops.LINEAR, src=(pad,))).src[0].src[0]
+    self.assertNotEqual(prg.src[0].arg.applied_opts, ())
+
   def test_shard_same_device(self):
     X = Tensor.ones(256).contiguous().realize()
     X.shard_((d1, X.device), 0)

--- a/test/backend/test_multitensor.py
+++ b/test/backend/test_multitensor.py
@@ -77,8 +77,9 @@ class TestMultiTensor(unittest.TestCase):
     self.assertEqual(len(set(names)), 1, "function was relinearized")
 
   def test_shard_beam(self):
-    src = Tensor.ones(16).shard(devices_2, 0).realize()
-    pad = src.to(devices_2[::-1]).schedule_linear().src[0]
+    cpu_2 = ("CPU:1", "CPU:2")
+    src = Tensor.ones(16).shard(cpu_2, 0).realize()
+    pad = src.to(cpu_2[::-1]).schedule_linear().src[0]
     with Context(BEAM=1, IGNORE_BEAM_CACHE=1): prg = compile_linear(UOp(Ops.LINEAR, src=(pad,))).src[0].src[0]
     self.assertNotEqual(prg.src[0].arg.applied_opts, ())
 


### PR DESCRIPTION
ast.variables no longer returns _device_num, so BEAM runtime errors:
<img width="1512" height="639" alt="Screenshot 2026-07-31 at 7 21 26 PM" src="https://github.com/user-attachments/assets/94dfe6ec-9218-434f-a2cd-c93686024537" />
This shows up as a 13% regression in llama 8b step time, since some kernels silently no longer use BEAM.