### PR TITLE
add _device_num back to ast.variables (kimi)

### DIFF
--- a/test/backend/test_multitensor.py
+++ b/test/backend/test_multitensor.py
@@ -76,7 +76,6 @@ class TestMultiTensor(unittest.TestCase):
     run_linear(linear)
     self.assertEqual(len(set(names)), 1, "function was relinearized")
 
-  @unittest.expectedFailure
   def test_shard_beam(self):
     cpu_2 = ("CPU:1", "CPU:2")
     src = Tensor.ones(16).shard(cpu_2, 0).realize()

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -991,8 +991,9 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
   @property
   def val(self) -> int: return self.unbind()[1]
   def variables(self) -> list[Variable]:
-    return sorted({x for x in self.backward_slice_with_self if x.op is Ops.PARAM and x.arg.addrspace is AddrSpace.ALU},
-                  key=lambda v: v.expr)
+    return sorted({x if x.op is Ops.PARAM else UOp.variable("_device_num", 0, x.vmax, dtype=x.dtype)
+                   for x in self.backward_slice_with_self if (x.op is Ops.RANGE and x.arg[-1] is AxisType.DEVICE) or x.op is Ops.PARAM
+                   and x.arg.addrspace is AddrSpace.ALU}, key=lambda v: v.expr)
 
   # *** uop symbolic stuff ***
 


### PR DESCRIPTION
https://opncd.ai/share/bXocCCcf, it first wanted to change search.py, but I think it should be in ops.py, since pm_device_to_var is already treating this RANGE like a Variable.

Both solutions seem to be leaking AxisType.DEVICE implementation details elsewhere.
llama 8b regression should be fixed after this.