### PR TITLE
usb: wait for PCIe link after power on

### DIFF
--- a/tinygrad/runtime/support/usb.py
+++ b/tinygrad/runtime/support/usb.py
@@ -90,10 +90,11 @@ class CustomASM24Controller:
   def __init__(self, usb:USB3):
     self.usb = usb
 
-    # Custom firmware now boots with PCIe off. Power it on before probing the link.
-    ltssm = self.read(0xB450, 1)[0]
-    if ltssm != 0x78: self.set_pcie_power(True)
-    ltssm = self.read(0xB450, 1)[0]
+    # Custom firmware now boots with PCIe off. Power it on before probing the link with a 5s grace period.
+    if (ltssm:=self.read(0xB450, 1)[0]) != 0x78:
+      self.set_pcie_power(True)
+      grace_period = time.monotonic() + 5.
+      while time.monotonic() < grace_period and (ltssm:=self.read(0xB450, 1)[0]) != 0x78: time.sleep(0.1)
     if ltssm != 0x78: raise RuntimeError(f"PCIe link not up (LTSSM=0x{ltssm:02X}), custom firmware not ready")
 
   def set_pcie_power(self, enabled:bool, timeout:int=10000): self.usb.control_write(0xF3, value=int(enabled), timeout=timeout)


### PR DESCRIPTION
Accounts for delay between the bridge accepting the PCIe power-on command (F3) and downstream GPU completing PCIe link training (LTSSM=0x78).
This happens during cold GPU initialization: the bridge can return from F3 while LTSSM is still 0x00 or 0x01, then reach 0x78 shortly afterward.