### PR TITLE
scalar ALU index fix + llm: preserve_thinking

### DIFF
--- a/test/backend/test_wait_loop.py
+++ b/test/backend/test_wait_loop.py
@@ -81,6 +81,20 @@ def loop_in_loop_kernel(C:UOp) -> UOp:
 
   return C[0].store(i[0].load()).sink(arg=KernelInfo(name="loop_in_loop", opts_to_apply=()))
 
+def scalar_alu_index_kernel(out: UOp) -> UOp:
+  val = UOp.param(1, dtypes.int, (1,), vmin_vmax=(0, 100), addrspace=AddrSpace.ALU, name="val")
+  idx = UOp(Ops.INDEX, dtypes.int, (val, UOp.const(0, dtypes.int)))
+  return out[0].store(idx + 1).sink(arg=KernelInfo(name="scalar_alu_index"))
+
+class TestScalarALUIndex(unittest.TestCase):
+  def test_scalar_alu_index(self):
+    # regression: indexing a scalar (1,)-shaped ALU param must render the variable
+    # directly, not as data.x (which is a compile error on a scalar int)
+    out = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize()
+    result = Tensor.custom_kernel(out, fxn=scalar_alu_index_kernel)[0]
+    run_linear(result.schedule_linear(), var_vals={"val": 42})
+    self.assertEqual(result.item(), 43)
+
 class TestWaitLoop(unittest.TestCase):
   def test_wait_loop(self):
     c = Tensor.empty(1, dtype=dtypes.int)

--- a/test/null/test_llm_server.py
+++ b/test/null/test_llm_server.py
@@ -124,11 +124,11 @@ class TestLLMServer(unittest.TestCase):
     self.assertTrue(any(args[0].startswith("total:") and args[1] == "red" for args, _ in color.call_args_list))
 
   def test_stream_disconnect_closes_source(self):
-    from tinygrad.viz.serve import HTTPRequestHandler
+    from tinygrad.llm.serve import Handler
     source, handler = Mock(), Mock()
     source.__iter__ = Mock(return_value=iter([{}]))
     handler.wfile.write.side_effect = BrokenPipeError
-    HTTPRequestHandler.stream_json(handler, source)
+    Handler.stream_json(handler, source)
     source.close.assert_called_once()
 
   def test_non_streaming(self):

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -150,6 +150,9 @@ devectorizer2 = mop_cleanup+pm_mops+PatternMatcher([
   (UPat(GroupOp.Elementwise|{Ops.LOAD,Ops.STORE}, name="b"), do_devectorize),
   # INDEX without src is nothing (TODO: this should be in mop_cleanup)
   (UPat(Ops.INDEX, src=(UPat.var('x'),)), lambda x: x),
+  # INDEX of a scalar ALU param is the param itself
+  (UPat(Ops.INDEX, src=(UPat(Ops.PARAM, name="v"),), allow_any_len=True),
+   lambda v: v if v.addrspace == AddrSpace.ALU and v.max_numel() == 1 else None),
   # unpack WMMA
   (UPat(Ops.WMMA, name="u"), do_stack_wmma),
   # stacked INDEX is many INDEX

--- a/tinygrad/llm/cli.py
+++ b/tinygrad/llm/cli.py
@@ -113,7 +113,7 @@ class FallbackTemplate:
     if self.tok.preset == 'glm4': return ""
     if self.tok.preset == 'tekken': return "[/INST]"
     return self.tok.decode([self.tok.eos_id])
-  def render(self, messages:list[dict], tools=None, add_generation_prompt:bool=True) -> str:
+  def render(self, messages:list[dict], tools=None, add_generation_prompt:bool=True, preserve_thinking:bool=False) -> str:
     out = self.tok.decode([] if self.tok.bos_id is None else [self.tok.bos_id]) + ("<sop>" if self.tok.preset == 'glm4' else "")
     for msg in messages:
       out += self.role(msg["role"])

--- a/tinygrad/llm/serve.py
+++ b/tinygrad/llm/serve.py
@@ -128,7 +128,7 @@ class Handler(HTTPRequestHandler):
     if self.path == "/v1/chat/completions":
       # render and tokenize
       normalize_messages(body["messages"])
-      rendered = self.server.template.render(messages=body["messages"], tools=body.get("tools"), add_generation_prompt=True)
+      rendered = self.server.template.render(messages=body["messages"], tools=body.get("tools"), add_generation_prompt=True, preserve_thinking=True)
       ids: list[int] = self.server.tok.encode(rendered)
       stderr_log(f"prep:{(time.perf_counter()-request_st)*1e3:5.0f} ms  {colored('--', 'BLACK')}  ")
       if len(ids) >= self.server.model.max_context:

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -162,7 +162,6 @@ class CStyleLanguage(Renderer):
 
   def render_index(self, x:UOp, buf:UOp, idx:UOp):
     if buf.addrspace == AddrSpace.ALU:
-      if buf.max_numel() == 1: return self[buf]
       # this is lane access in C
       if idx.op is not Ops.CONST: return f"({self[buf]})[{self[idx]}]"
       return self[buf]+(f"[{idx.val}]" if buf.max_numel() > self.gep_arr_threshold else f".{'xyzwabcd'[idx.val]}")

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -162,6 +162,7 @@ class CStyleLanguage(Renderer):
 
   def render_index(self, x:UOp, buf:UOp, idx:UOp):
     if buf.addrspace == AddrSpace.ALU:
+      if buf.max_numel() == 1: return self[buf]
       # this is lane access in C
       if idx.op is not Ops.CONST: return f"({self[buf]})[{self[idx]}]"
       return self[buf]+(f"[{idx.val}]" if buf.max_numel() > self.gep_arr_threshold else f".{'xyzwabcd'[idx.val]}")


### PR DESCRIPTION
…dler import

- cstyle.py: return scalar directly when ALU buffer has 1 element
- cli.py: add preserve_thinking param to FallbackTemplate.render
- serve.py: pass preserve_thinking=True when rendering chat completions
- test_llm_server.py: fix import to use Handler from llm.serve