### PR TITLE
fix prod gradients at zero

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1535,6 +1535,8 @@ class TestOps(unittest.TestCase):
 
   def test_prod(self):
     helper_test_op(None, lambda x: x.prod(), vals=[[1.0, 2.0, 3.0]])
+    helper_test_op(None, lambda x: x.prod(), vals=[[0.0, 2.0, 3.0]])
+    helper_test_op(None, lambda x: x.prod(), vals=[[0.0, 0.0, 3.0]])
     with Context(NOOPT=1): helper_test_op(None, lambda x: x.prod(), vals=[[1.0, 2.0, 3.0]])
     helper_test_op([(3,4,5,6)], lambda x: x.prod(dim=3), lambda x: x.prod(axis=3))
     helper_test_op([(3,4,5,6)], lambda x: x.prod(dim=1), lambda x: x.prod(axis=1))

--- a/tinygrad/mixin/gradient.py
+++ b/tinygrad/mixin/gradient.py
@@ -7,7 +7,13 @@ from tinygrad.dtype import sum_acc_dtype
 def reduce_gradient(ctx:UOp, ret:UOp, op:Ops):
   if op == Ops.ADD: return (ctx._broadcast_to(ret.src[0].shape),)
   if op == Ops.MAX: return (((mask:=ret.src[0].eq(ret).cast(ctx.dtype))/mask._rop(Ops.ADD, tuple(range(ret.arg[1])))) * ctx,)
-  if op == Ops.MUL: return (ctx * ret / ret.src[0],)
+  if op == Ops.MUL:
+    x, axes = ret.src[0], tuple(range(ret.arg[1]))
+    is_zero = x.eq(0)
+    safe_x = is_zero.where(1, x)
+    zero_count = is_zero.cast(sum_acc_dtype(is_zero.dtype))._rop(Ops.ADD, axes)
+    zero_grad = (is_zero & zero_count.eq(1)).where(safe_x._rop(Ops.MUL, axes), 0)
+    return (ctx * zero_count.eq(0).where(ret / safe_x, zero_grad),)
 
 def _compact_params(body:UOp, all_args:tuple[UOp, ...]) -> tuple[UOp, tuple[UOp, ...]]:
   """Remove unused PARAMs from body and return compacted (body, args)."""


### PR DESCRIPTION
I was curious about using Lean/TorchLean to formalize a few tinygrad ops, and this popped out as a small mismatch in `prod` backward.

Right now `prod` backward uses `ret / x`, which works for nonzero inputs but gives `nan` at the zero coordinate:

```python
x = Tensor([0., 2., 3.])
x.prod().gradient(x)[0]
# current: [nan, 0, 0]
# expected: [6, 0, 0]
```

This patch counts zeros across the reduced axes. With no zeros, it keeps the existing `ret / x` path. With one zero, only that input receives the product of the nonzero entries. With multiple zeros, the gradient is zero.

I added focused regression coverage for scalar `prod` with one and multiple zeros.

I used some AI assistance while preparing/checking this patch. I also have a small Lean/TorchLean formalization of the finite-product derivative case if that would be useful.