### PR TITLE
support importing tinygrad from a zipapp

### DIFF
--- a/test/unit/test_zipimport.py
+++ b/test/unit/test_zipimport.py
@@ -1,0 +1,19 @@
+import pathlib, subprocess, sys, unittest, zipfile
+import tinygrad
+from tinygrad.device import Device
+from tinygrad.helpers import temp
+
+class TestZipImport(unittest.TestCase):
+  def test_import_from_zip(self):
+    pkg = pathlib.Path(tinygrad.__file__).parent
+    with zipfile.ZipFile(zippath:=temp("tinygrad_zipimport.zip"), "w") as zf:
+      for f in pkg.rglob("*.py"):
+        if "__pycache__" not in f.parts: zf.write(f, f.relative_to(pkg.parent).as_posix())
+    code = "import sys; sys.path.insert(0, sys.argv[1]); from tinygrad.device import Device; import tinygrad.runtime.autogen as autogen; " \
+           "autogen.libc; print(sorted(Device._devices))"
+    proc = subprocess.run([sys.executable, "-I", "-c", code, zippath], capture_output=True, text=True)
+    self.assertEqual(proc.returncode, 0, proc.stderr)
+    self.assertEqual(proc.stdout.strip(), str(sorted(Device._devices)))
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from collections import defaultdict
 from typing import Any, Generic, TypeVar, Iterator, Generator, Self, TYPE_CHECKING
-import importlib, inspect, functools, pathlib, os, contextlib, re, atexit, pickle, decimal
+import importlib.resources, inspect, functools, os, contextlib, re, atexit, pickle, decimal
 from tinygrad.helpers import LRU, getenv, diskcache_get, diskcache_put, DEBUG, GlobalCounters, PROFILE, temp, colored
 from tinygrad.helpers import Context, CCACHE, ALLOW_DEVICE_USAGE, MAX_BUFFER_SIZE, cpu_events, ProfileEvent, ProfilePointEvent, suppress_finalizing
 from tinygrad.helpers import select_by_name, select_first_inited, DEV, TracingKey, size_to_str, pluralize, Target, unwrap, round_up
@@ -14,7 +14,7 @@ if TYPE_CHECKING: from tinygrad.renderer import Renderer
 ALL_DEVICES = ["METAL", "AMD", "NV", "CUDA", "QCOM", "CL", "CPU", "DSP", "WEBGPU"]
 class _Device:
   def __init__(self) -> None:
-    self._devices = [x.stem[len("ops_"):].upper() for x in (pathlib.Path(__file__).parent/"runtime").iterdir() if x.stem.startswith("ops_")]
+    self._devices = [x.name[len("ops_"):-3].upper() for x in importlib.resources.files(__package__+".runtime").iterdir() if x.name.startswith("ops_")]
     self._opened_devices:set[str] = set()
   @functools.cache  # this class is a singleton, pylint: disable=method-cache-max-size-none
   def _canonicalize(self, device:str) -> str: return re.sub(r":0$", "", (d:=device.split(":", 1)[0].upper()) + device[len(d):])

--- a/tinygrad/runtime/autogen/__init__.py
+++ b/tinygrad/runtime/autogen/__init__.py
@@ -29,6 +29,10 @@ nv_lib_path = ("[f'/{pre}/cuda/targets/{tgt}/lib' for pre in ['opt', 'usr/local'
 
 def load(name, files, **kwargs):
   if not (f:=(root/(path:=kwargs.pop("path", __name__)).replace('.','/')/f"{name}.py")).exists() or getenv('REGEN'):
+    # the file can be missing but the module still importable (e.g. zipimport), try that before regenerating
+    if not getenv('REGEN'):
+      try: return importlib.import_module(f"{path}.{name.replace('/', '.')}")
+      except ImportError: pass
     files, kwargs['args'] = files() if callable(files) else files, args() if callable(args:=kwargs.get('args', [])) else args
     if (srcs:=kwargs.pop('srcs', None)):
       srcpath = (td:=tempfile.TemporaryDirectory(f"autogen-src-{name.replace('/','-')}")).name + "/"


### PR DESCRIPTION
I'm building [nammy](https://github.com/aisk/nammy), a small training library for NAM (Neural Amp Modeler) guitar tone models. I ship it to Windows users as a single-file zipapp, so they can double-click the .pyzw file, get a tkinter GUI, and train their tone model with tinygrad.

Two small places in tinygrad depend on the local filesystem and break inside a zip. `Device` lists the runtime directory to find backends, and `autogen.load()` sees the generated bindings as "missing" and tries to download headers and regenerate them. I work around both with build-time patches ([tools/build_standalone.py](https://github.com/aisk/nammy/blob/master/tools/build_standalone.py)), but others will likely hit this too — tinygrad is tiny, pure Python, and supports widely available backends like OpenCL, so it's a great fit for shipping small-model training inside an app. I'd like to fix it upstream instead.

This PR enumerates backends with `importlib.resources` (same result on a normal install, and it works from a zip), and makes `load()` try importing the module before regenerating. `REGEN=1` regenerates as before, and a genuinely missing file still falls through to generation. A regression test zips up tinygrad and imports `Device` plus an autogen module from the archive.

I used Claude Code to assist with writing the code, locating the problem, and writing the tests.
