### PR TITLE
scheduler: cap reduction refusion cost

### DIFF
--- a/test/null/test_schedule.py
+++ b/test/null/test_schedule.py
@@ -1838,6 +1838,15 @@ class TestUOpBecome(unittest.TestCase):
     assert b.uop.base is a.uop.base
 
 class TestFusionOp(unittest.TestCase):
+  def test_conv_backward_gradient_norm_fusion(self):
+    weights = [Tensor.empty(c, ic, 4, 4) for ic, c in ((1, 16), (16, 32), (32, 64))]
+    for weight in weights: weight.requires_grad = True
+    hidden = Tensor.empty(256, 1, 13, 13)
+    for weight in weights: hidden = hidden.conv2d(weight, stride=2, padding=1).relu()
+    hidden.sum().backward()
+    gradient_norm = sum((weight.grad * weight.grad).sum() for weight in weights).sqrt()
+    check_schedule(gradient_norm, 10)
+
   def test_recursive_add(self):
     st = time.perf_counter()
     a = Tensor([1,2,3,4])

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -285,7 +285,16 @@ def remove_bufferize(src:UOp, buf:UOp, idx:UOp):
   # this is the ranges replaced
   # NOTE: if buf src is a const, we don't replace it. if idx is Invalid (dead load), don't replace it either
   replaced = {k:v for k,v in zip(buf.src[1:], idx.src[1:]) if k.op is not Ops.CONST and not (v.op is Ops.CONST and v.val is Invalid)}
-  return src.substitute(replaced, extra_pm=pm_gate_substitute)
+  ret = src.substitute(replaced, extra_pm=pm_gate_substitute)
+  # avoid duplicating large computations inside consumer reduction loops, while preserving loop-invariant fusion.
+  # materialization is only worthwhile when the saved ALU work also exceeds the buffer's element count.
+  fused_topo = ret.toposort(gate=lambda x: x.op not in {Ops.AFTER, Ops.STORE, Ops.MSTACK} and not
+                            (x.op is Ops.STAGE and x.arg.addrspace == AddrSpace.GLOBAL))
+  fused_cost, max_cost = 0, max(getenv("FUSE_REDUCE_MAX_OPS", 2**18), buf.max_numel())
+  for u in fused_topo:
+    if u.op in GroupOp.ALU: fused_cost += prod(int(r.src[0].vmax) for r in u.ranges if r.arg[-1] is AxisType.REDUCE)
+    if fused_cost > max_cost: return None
+  return ret
 
 def remove_noop_bufferize(idx,b2):
   if idx.src[1:] != b2.src[1:]: return None


### PR DESCRIPTION
The conv-backward gradient norm in #16228 also trips the Metal watchdog on an M1 Pro. remove_bufferize was inlining producer graphs under consumer REDUCE axes without accounting for repeated work, collapsing the graph into a 220M-op kernel.

This change estimates refusion cost by summing, for each ALU node, only the REDUCE extents that node actually depends on. It keeps an intermediate buffer when that cost exceeds both FUSE_REDUCE_MAX_OPS, which defaults to 2**18, and the buffer element count. This preserves loop-invariant fusion and avoids materializing giant expanded buffers when recomputation is cheaper.

The regression uses the original three-layer conv-backward shapes with empty inputs. It now schedules 10 compute kernels instead of the over-fused 7.

Validation:
- original Metal repro completed 3/3 runs with the same value and a 23-kernel schedule
- Metal 2**31 index-overflow regression passes, including with CHECK_OOB=1
- full NULL schedule suite: 278 tests pass, including 8 skips and 6 expected failures
- rangeify: 29 passed, 7 skipped
- symbolic shape suites: 88 passed
- allreduce and LLM suites: 20 passed
- GPT-2 remains at the 168-kernel baseline
- ruff and mypy pass

Fixes #16228