### PR TITLE
fix Tensor.roll on zero-sized tensors

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -2162,6 +2162,8 @@ class TestOps(unittest.TestCase):
   def test_roll(self):
     helper_test_op([(2, 4)], lambda x: x.roll(1))
     helper_test_op([(2, 4)], lambda x: x.roll((1,)))
+    helper_test_op([(0,)], lambda x: x.roll(1, 0))
+    helper_test_op([(2, 0, 3)], lambda x: x.roll(1))
     self.helper_test_exception([(2, 4)], lambda x: x.roll((1, 2)), expected=RuntimeError)
     helper_test_op([(2, 4)], lambda x: x.roll(1, 0))
     helper_test_op([(2, 4)], lambda x: x.roll(-1, 0))

--- a/tinygrad/mixin/movement.py
+++ b/tinygrad/mixin/movement.py
@@ -540,6 +540,7 @@ class MovementMixin:
     if dims is None: return self.flatten().roll(shifts, 0).reshape(self.shape)
     dims, shifts = tuple(self._resolve_dim(d) for d in make_tuple(dims, 1)), make_tuple(shifts, 1)
     if len(dims) != len(shifts): raise RuntimeError(f"{len(dims)=} != {len(shifts)=}")
+    if 0 in self.shape: return self
     shrink_arg: list[tuple[sint, sint]|None] = [None] * self.ndim
     for d, s in zip(dims, shifts): shrink_arg[d] = (delta:=self.shape[d]-s%self.shape[d], delta+self.shape[d])
     return self.repeat(*tuple(2 if i in dims else 1 for i in range(self.ndim))).shrink(tuple(shrink_arg))


### PR DESCRIPTION
Fixes #17468.

Avoid the modulo-by-zero path when `Tensor.roll` receives a tensor containing
a zero-sized dimension. Such tensors have no elements to move, so returning the
input preserves the expected shape and matches both PyTorch and NumPy while
keeping the existing argument validation intact.

Regression coverage includes explicit-dimension and flattened `dims=None`
rolls on empty tensors.

Validation:

- `DEV=PYTHON FORWARD_ONLY=1 python -m pytest test/backend/test_ops.py -k test_roll -q -n12`
- `python -m ruff check .`
- `python -m mypy tinygrad/` under Ubuntu/WSL

AI disclosure: I used Codex to help discover and reproduce the bug, compare
behavior with PyTorch and NumPy, implement the fix and tests, and draft this PR.
I reviewed the resulting code and validation output.
