### PR TITLE
llama3: load the gguf lazily

### DIFF
--- a/examples/llama3.py
+++ b/examples/llama3.py
@@ -243,7 +243,7 @@ def build_transformer(model_path: Path, model_size="8B", quantize=None, scale_dt
           else: v.shard_(device, axis=None)
 
       # replace weights in model
-      load_state_dict(model, weights, strict=False, consume=True)
+      load_state_dict(model, weights, strict=False, consume=True, realize=False)
   return model
 
 # default settings

--- a/test/backend/test_nn.py
+++ b/test/backend/test_nn.py
@@ -476,6 +476,31 @@ class TestNN(unittest.TestCase):
     np.testing.assert_allclose(layer.weight.numpy(), state_dict['weight'].numpy())
     np.testing.assert_allclose(layer.bias.numpy(), state_dict['bias'].numpy())
 
+  def test_load_state_dict_realize_false(self):
+    # gguf expands a small quantized buffer into a big float one, realize=False keeps that lazy
+    layer = Linear(3, 5, bias=False)
+    src = Tensor.full((5, 3), 2, dtype=dtypes.uint8).contiguous().realize()
+    load_state_dict(layer, {'weight': src.float() * 0.5}, realize=False)
+    self.assertFalse(layer.weight.uop.is_realized)
+    np.testing.assert_allclose(layer.weight.numpy(), np.ones((5, 3)))
+
+  def test_load_state_dict_realize_true(self):
+    layer = Linear(3, 5, bias=False)
+    src = Tensor.full((5, 3), 2, dtype=dtypes.uint8).contiguous().realize()
+    load_state_dict(layer, {'weight': src.float() * 0.5})
+    self.assertTrue(layer.weight.uop.is_realized)
+    np.testing.assert_allclose(layer.weight.numpy(), np.ones((5, 3)))
+
+  def test_load_state_dict_realize_false_allocates_nothing(self):
+    layer = Linear(1024, 1024, bias=False)
+    src = Tensor.full((1024, 1024), 2, dtype=dtypes.uint8).contiguous().realize()
+    state_dict = {'weight': src.float() * 0.5}
+    mem = GlobalCounters.mem_used
+    load_state_dict(layer, state_dict, realize=False)
+    self.assertEqual(GlobalCounters.mem_used, mem)
+    load_state_dict(layer, state_dict)
+    self.assertEqual(GlobalCounters.mem_used, mem + 1024*1024*4)
+
   #https://github.com/pytorch/pytorch/blob/d38164a545b4a4e4e0cf73ce67173f70574890b6/torch/nn/modules/module.py#L2425
   def test_load_conv_num_batches_tracked(self):
     layer = BatchNorm(sz=1, track_running_stats=False)


### PR DESCRIPTION
`examples/llama3.py` is the last gguf loader taking `load_state_dict`'s eager default. `tinygrad/llm/model.py:412` already passes `realize=False`, and `Transformer.from_gguf` has defaulted `realize` to `getenv("REALIZE", 0)` since #15144. This makes the example match the library.

With `realize=True` every weight is materialised at load, and `ggml_data_to_tensor` dequantises Q6_K to fp32 on the way. Left lazy, the dequant fuses into the consuming matmul and what stays resident is the quantized blocks.

Llama-3.2-1B-Instruct Q6_K, `--benchmark`, `DEV=CPU`, 20 tokens, 3 runs each:

|  | eager (now) | lazy (this PR) |
|---|---:|---:|
| peak RSS | 6.28 GiB | 2.08 GiB |
| RSS after load, steady | 6.28 GiB | 1.70 GiB |
| `GlobalCounters.mem_used` | 5.11 GiB | 1.46 GiB |
| `loaded weights in` | 2505 ms, 4.94 GB | 15 ms, 0.00 GB |
| ms/token, mean of 57 | 188.6 | 409.9 |

3.0x less memory for 2.2x the time per token. Generated text is character-identical at the same seed.

Peak RSS is `VmHWM`. Lazy's 2.08 GiB is a transient during the whole-file copy to the default device and settles at 1.70 GiB; eager's 6.28 GiB is steady state.

`realize` had no test coverage, so this adds three: that `realize=False` leaves the parameter lazy, that the default still materialises it, and that the lazy load allocates nothing.

`test/backend/test_nn.py` passes with `RUN_SLOW=1` apart from `test_embedding_one_kernel_fused_noopt`, which fails the same way on clean master.
