### PR TITLE
don't enter CALL body in assign fixups

### DIFF
--- a/test/external/external_test_schedule_scaling.py
+++ b/test/external/external_test_schedule_scaling.py
@@ -1,5 +1,5 @@
 import unittest, time
-from tinygrad import Tensor
+from tinygrad import Tensor, Context
 
 class TestScheduleScaling(unittest.TestCase):
   """Test that .schedule() scales linearly with graph size (no O(n^2) behavior)."""
@@ -129,6 +129,22 @@ class TestScheduleScaling(unittest.TestCase):
       parts = [Tensor.empty(4, 256) + i for i in range(n)]
       return parts[0].cat(*parts[1:])
     self._assert_linear(concat_chain)
+
+  @Context(DEV="NULL:HIP:gfx1100")
+  def test_custom_call_assign_scaling(self):
+    from tinygrad.uop.ops import UOp, Ops, KernelInfo
+    from tinygrad.runtime.autogen.amd.rdna3.ins import s_nop
+    call_id = 0
+    def custom_call_assign(n):
+      nonlocal call_id
+      call_id += 1
+      def custom_asm(out):
+        return UOp(Ops.PROGRAM, src=(UOp.sink(out.base, arg=KernelInfo(f"call_{call_id}")),
+          UOp(Ops.LINEAR, src=tuple(UOp(Ops.INS, arg=s_nop(i)) for i in range(n*8)))))
+      out = Tensor.custom_kernel(Tensor.empty(1), fxn=custom_asm)[0]
+      dsts = [Tensor.empty(1).assign(out+i) for i in range(n)]
+      return dsts[0].cat(*dsts[1:])
+    self._assert_linear(custom_call_assign, n_small=50, n_large=500)
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/external/external_test_schedule_scaling.py
+++ b/test/external/external_test_schedule_scaling.py
@@ -1,4 +1,4 @@
-import unittest, time
+import unittest, time, itertools
 from tinygrad import Tensor, Context
 
 class TestScheduleScaling(unittest.TestCase):
@@ -134,13 +134,11 @@ class TestScheduleScaling(unittest.TestCase):
   def test_custom_call_assign_scaling(self):
     from tinygrad.uop.ops import UOp, Ops, KernelInfo
     from tinygrad.runtime.autogen.amd.rdna3.ins import s_nop
-    call_id = 0
+    call_id = itertools.count(0)
     def custom_call_assign(n):
-      nonlocal call_id
-      call_id += 1
       def custom_asm(out):
-        return UOp(Ops.PROGRAM, src=(UOp.sink(out.base, arg=KernelInfo(f"call_{call_id}")),
-          UOp(Ops.LINEAR, src=tuple(UOp(Ops.INS, arg=s_nop(i)) for i in range(n*8)))))
+        return UOp(Ops.PROGRAM, src=(UOp.sink(out, arg=KernelInfo(f"call_{next(call_id)}")),
+                                     UOp(Ops.LINEAR, src=tuple(UOp(Ops.INS, arg=s_nop(i)) for i in range(n*8)))))
       out = Tensor.custom_kernel(Tensor.empty(1), fxn=custom_asm)[0]
       dsts = [Tensor.empty(1).assign(out+i) for i in range(n)]
       return dsts[0].cat(*dsts[1:])

--- a/test/external/external_test_schedule_scaling.py
+++ b/test/external/external_test_schedule_scaling.py
@@ -131,18 +131,17 @@ class TestScheduleScaling(unittest.TestCase):
     self._assert_linear(concat_chain)
 
   @Context(DEV="NULL:HIP:gfx1100")
-  def test_custom_call_assign_scaling(self):
+  def test_custom_kernel_assign_scaling(self):
     from tinygrad.uop.ops import UOp, Ops, KernelInfo
     from tinygrad.runtime.autogen.amd.rdna3.ins import s_nop
-    call_id = itertools.count(0)
-    def custom_call_assign(n):
+    count = itertools.count(0)
+    def custom_kernel_assign(n):
       def custom_asm(out):
-        return UOp(Ops.PROGRAM, src=(UOp.sink(out, arg=KernelInfo(f"call_{next(call_id)}")),
+        return UOp(Ops.PROGRAM, src=(UOp.sink(out, arg=KernelInfo(f"fxn_{next(count)}")),
                                      UOp(Ops.LINEAR, src=tuple(UOp(Ops.INS, arg=s_nop(i)) for i in range(n*8)))))
-      out = Tensor.custom_kernel(Tensor.empty(1), fxn=custom_asm)[0]
-      dsts = [Tensor.empty(1).assign(out+i) for i in range(n)]
-      return dsts[0].cat(*dsts[1:])
-    self._assert_linear(custom_call_assign, n_small=50, n_large=500)
+      call = Tensor.custom_kernel(Tensor.empty(1), fxn=custom_asm)[0]
+      return Tensor.cat(*[Tensor.empty(1).assign(call+i) for i in range(n)])
+    self._assert_linear(custom_kernel_assign, n_small=50, n_large=500)
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/tinygrad/schedule/indexing.py
+++ b/tinygrad/schedule/indexing.py
@@ -35,7 +35,7 @@ def realize_srcs(ctx:IndexingContext, rb:UOp) -> None:
 
 def realize_store_after_src(ctx:IndexingContext, dest:UOp, src:UOp):
   # you don't usually have to do this for assign unless there's a WAR hazard like TestAssign.test_assign_double_diamond_reduce
-  if dest.base in src.backward_slice_with_self: ctx.realize_map[src] = None
+  if dest.base in src.toposort(enter_calls=False): ctx.realize_map[src] = None
 
 def realize_custom_kernel_srcs(ctx:IndexingContext, c:UOp) -> None:
   for s in c.src[1:]:

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -60,7 +60,7 @@ pm_mops = PatternMatcher([
 # 0. do some cleanup rewrites, mostly copied from the old stuff
 
 def fix_store_hazard(target:UOp, src:UOp):
-  if (base:=target.base) not in src.backward_slice_with_self: return None
+  if (base:=target.base) not in src.toposort(enter_calls=False): return None
   # PERMUTE and FLIP reorder indices, SHRINK can have overlapping regions when dest is also shrunk
   unsafe = {Ops.PERMUTE, Ops.FLIP} | ({Ops.SHRINK} if target.op_in_backward_slice_with_self(Ops.SHRINK) else set())
   reaches_base: dict[UOp, bool] = {}


### PR DESCRIPTION
30% faster llama 8b time to first step, because it was traversing the CALL body of mxfp4 asm GEMM with all the Ops.INS
This needs proper testing before I merge, also aware that tests that assert absolute time for O(n^2) behavior are the worst with flakiness.
<img width="3840" height="1182" alt="image" src="https://github.com/user-attachments/assets/1581d85f-f197-49dc-a7e1-91923ca1405b" />
