### PR TITLE
Throw RuntimeError for unsupported NVIDIA arch

### DIFF
--- a/test/unit/test_nvdev_chip_name.py
+++ b/test/unit/test_nvdev_chip_name.py
@@ -1,0 +1,18 @@
+import unittest
+
+class TestNVChipPrefix(unittest.TestCase):
+  def test_known_architectures(self):
+    from tinygrad.runtime.support.nv.nvdev import nv_chip_prefix
+    self.assertEqual(nv_chip_prefix(0x17), "GA1")
+    self.assertEqual(nv_chip_prefix(0x19), "AD1")
+    self.assertEqual(nv_chip_prefix(0x1b), "GB2")
+
+  def test_unmapped_architecture_raises_clear_error(self):
+    from tinygrad.runtime.support.nv.nvdev import nv_chip_prefix
+    with self.assertRaises(RuntimeError) as ctx:
+      nv_chip_prefix(0x3f)
+    self.assertIn("0x3f", str(ctx.exception))
+    self.assertNotIsInstance(ctx.exception, KeyError)
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tinygrad/runtime/support/nv/nvdev.py
+++ b/tinygrad/runtime/support/nv/nvdev.py
@@ -9,6 +9,12 @@ from tinygrad.runtime.support.hcq import MMIOInterface
 
 NV_DEBUG = getenv("NV_DEBUG", 0)
 
+NV_CHIP_ARCHITECTURES = {0x17: "GA1", 0x19: "AD1", 0x1b: "GB2"}
+def nv_chip_prefix(architecture:int) -> str:
+  if architecture not in NV_CHIP_ARCHITECTURES:
+    raise RuntimeError(f"Unrecognized NVIDIA GPU architecture id {architecture:#x}. This GPU architecture is not supported by tinygrad.")
+  return NV_CHIP_ARCHITECTURES[architecture]
+
 class NVReg:
   def __init__(self, nvdev, base, off, fields=None): self.nvdev, self.base, self.off, self.fields = nvdev, base, off, fields
 
@@ -111,7 +117,7 @@ class NVDev:
     self.pci_dev.write_config_flush(pci.PCI_COMMAND, self.pci_dev.read_config(pci.PCI_COMMAND, 2) | pci.PCI_COMMAND_MASTER, 2)
     self.chip_id = self.reg("NV_PMC_BOOT_0").read()
     self.chip_details = self.reg("NV_PMC_BOOT_42").read_bitfields()
-    self.chip_name = {0x17: "GA1", 0x19: "AD1", 0x1b: "GB2"}[self.chip_details['architecture']] + f"{self.chip_details['implementation']:02d}"
+    self.chip_name = nv_chip_prefix(self.chip_details['architecture']) + f"{self.chip_details['implementation']:02d}"
     self.fw_name = {"GB2": "gb202", "AD1": "ad102", "GA1": "ga102"}[self.chip_name[:3]]
     self.mmu_ver, self.fmc_boot = (3, True) if self.chip_details['architecture'] >= 0x1a else (2, False)
 

--- a/tinygrad/runtime/support/nv/nvdev.py
+++ b/tinygrad/runtime/support/nv/nvdev.py
@@ -12,7 +12,7 @@ NV_DEBUG = getenv("NV_DEBUG", 0)
 NV_CHIP_ARCHITECTURES = {0x17: "GA1", 0x19: "AD1", 0x1b: "GB2"}
 def nv_chip_prefix(architecture:int) -> str:
   if architecture not in NV_CHIP_ARCHITECTURES:
-    raise RuntimeError(f"Unrecognized NVIDIA GPU architecture id {architecture:#x}. This GPU architecture is not supported by tinygrad.")
+    raise RuntimeError(f"Unrecognized NVIDIA GPU architecture id {architecture:#x}")
   return NV_CHIP_ARCHITECTURES[architecture]
 
 class NVReg:


### PR DESCRIPTION
Fix bare KeyError when an NVIDIA GPU reports an unrecognized architecture ID. Now raises a RuntimeError naming the unsupported architecture ID. Includes a unit test to check for regression. Claude was used to write this fix.