### PR TITLE
simple test for Invalid clone cache miss regression

### DIFF
--- a/test/unit/test_schedule_cache.py
+++ b/test/unit/test_schedule_cache.py
@@ -65,6 +65,7 @@ class TestScheduleCache(unittest.TestCase):
       print(num)
     self.assertEqual(len(schedule_cache), start_len_schedule_cache)
 
+  @unittest.expectedFailure
   def test_simple_precompile(self):
     @function(precompile=True)
     def f(x:Tensor) -> Tensor:

--- a/test/unit/test_schedule_cache.py
+++ b/test/unit/test_schedule_cache.py
@@ -69,12 +69,13 @@ class TestScheduleCache(unittest.TestCase):
   def test_simple_precompile(self):
     @function(precompile=True)
     def f(x:Tensor) -> Tensor:
+      out = Tensor.invalids(*x.shape, dtype=x.dtype, device=x.device)
       out = Tensor.custom_kernel(out, fxn=functools.partial(custom_set0_kernel, num=10))[0]
       return out + x
 
     # warmup
     x = Tensor.ones(1).realize()
-    first = f(x).realize()
+    _ = f(x).realize()
 
     # use the cache next time function is called
     start_len_schedule_cache = len(schedule_cache)

--- a/test/unit/test_schedule_cache.py
+++ b/test/unit/test_schedule_cache.py
@@ -1,6 +1,6 @@
 import unittest
 import functools
-from tinygrad import Tensor, Variable, UOp
+from tinygrad import Tensor, Variable, UOp, function
 from tinygrad.uop.ops import KernelInfo
 from tinygrad.schedule import schedule_cache
 
@@ -63,6 +63,23 @@ class TestScheduleCache(unittest.TestCase):
     for _ in range(3):
       num = (a.sum().contiguous()+b.sum().contiguous()).item()
       print(num)
+    self.assertEqual(len(schedule_cache), start_len_schedule_cache)
+
+  def test_simple_precompile(self):
+    @function(precompile=True)
+    def f(x:Tensor) -> Tensor:
+      out = Tensor.custom_kernel(out, fxn=functools.partial(custom_set0_kernel, num=10))[0]
+      return out + x
+
+    # warmup
+    x = Tensor.ones(1).realize()
+    first = f(x).realize()
+
+    # use the cache next time function is called
+    start_len_schedule_cache = len(schedule_cache)
+    for _ in range(3):
+      num = f(x).realize()
+      self.assertEqual(num.item(), 11)
     self.assertEqual(len(schedule_cache), start_len_schedule_cache)
 
 if __name__ == "__main__":


### PR DESCRIPTION
root cause of llama 8b 6 minute time to first step, seems to have happened after #16679
<img width="3840" height="1662" alt="image" src="https://github.com/user-attachments/assets/c4f20fc7-abac-4347-822e-b61b8bd08a1e" />
the second minibatch just misses the cache and recompiles everything.