### PR TITLE
precompile_backward tests for sched_cache

### DIFF
--- a/test/unit/test_schedule_cache.py
+++ b/test/unit/test_schedule_cache.py
@@ -4,13 +4,13 @@ from tinygrad import Tensor, Variable, UOp, function
 from tinygrad.uop.ops import KernelInfo
 from tinygrad.schedule import schedule_cache
 
-def custom_set0_kernel(A:UOp, _B:UOp=None, num:int=0) -> UOp:
-  return A[0].set(num).sink(arg=KernelInfo(f"custom_set0_{num}"))
+def custom_add_kernel(A:UOp, B:UOp, num:int=0) -> UOp:
+  return A[0].set(B[0] + num).sink(arg=KernelInfo(f"custom_add_{num}"))
 
-def custom_set0_backward(grad_a:UOp, _) -> tuple[None, UOp]:
-  x = Tensor.invalids(*grad_a.shape, dtype=grad_output.dtype, device=grad_output.device)
-  x = Tensor.custom_kernel(x, fxn=functools.partial(custom_set0_kernel, num=0))[0]
-  return None, (x * Tensor(grad_a, device=grad_output.device)).uop
+def custom_add_backward(grad_output:UOp, _) -> tuple[None, UOp]:
+  grad = Tensor.invalids(*grad_output.shape, dtype=grad_output.dtype, device=grad_output.device)
+  grad = Tensor.custom_kernel(grad, Tensor(grad_output, device=grad_output.device), fxn=functools.partial(custom_add_kernel, num=0))[0]
+  return None, grad.uop
 
 class TestScheduleCache(unittest.TestCase):
   def test_bound_variable_reuses_cache(self):
@@ -30,27 +30,27 @@ class TestScheduleCache(unittest.TestCase):
 
   def test_custom_kernel(self):
     for i in range(4):
-      a = Tensor.empty(1)
-      a = Tensor.custom_kernel(a, fxn=functools.partial(custom_set0_kernel, num=i))[0]
+      a, b = Tensor.empty(1), Tensor.ones(1)
+      a = Tensor.custom_kernel(a, b, fxn=functools.partial(custom_add_kernel, num=i))[0]
       a.realize()
-      self.assertEqual(a.item(), i)
+      self.assertEqual(a.item(), i+1)
 
   def test_same_custom_function_reuses_cache(self):
     schedule_cache.clear()
-    fxn = functools.partial(custom_set0_kernel, num=10)
+    fxn = functools.partial(custom_add_kernel, num=10)
 
     # first run
-    a = Tensor.empty(1)
-    a = Tensor.custom_kernel(a, fxn=fxn)[0]
+    a, x = Tensor.empty(1), Tensor.ones(1)
+    a = Tensor.custom_kernel(a, x, fxn=fxn)[0]
     a.realize()
-    self.assertEqual(a.item(), 10)
+    self.assertEqual(a.item(), 11)
     cache_size_after_first = len(schedule_cache)
 
     # second run with same function should reuse cache
-    b = Tensor.empty(1)
-    b = Tensor.custom_kernel(b, fxn=fxn)[0]
+    b, x = Tensor.empty(1), Tensor.ones(1)
+    b = Tensor.custom_kernel(b, x, fxn=fxn)[0]
     b.realize()
-    self.assertEqual(b.item(), 10)
+    self.assertEqual(b.item(), 11)
     self.assertEqual(len(schedule_cache), cache_size_after_first)
 
   def test_simple(self):
@@ -75,24 +75,24 @@ class TestScheduleCache(unittest.TestCase):
     @function(precompile=True, precompile_backward=True)
     def f(x:Tensor) -> Tensor:
       out = Tensor.invalids(*x.shape, dtype=x.dtype, device=x.device)
-      out = Tensor.custom_kernel(out, x, fxn=functools.partial(custom_set0_kernel, num=10), grad_fxn=custom_set0_backward)[0]
-      return out + x
+      out = Tensor.custom_kernel(out, x, fxn=functools.partial(custom_add_kernel, num=10), grad_fxn=custom_add_backward)[0]
+      return out * x
 
     # warmup
     x = Tensor.ones(1).realize()
     out = f(x)
-    out.sum().backward()
+    out.backward(x)
     self.assertEqual(out.item(), 11)
-    self.assertEqual(x.grad.item(), 1)
+    self.assertEqual(x.grad.item(), 12)
 
     # use the cache next time function is called
     start_len_schedule_cache = len(schedule_cache)
     for _ in range(3):
       x = Tensor.ones(1).realize()
       out = f(x)
-      out.sum().backward()
+      out.backward(x)
       self.assertEqual(out.item(), 11)
-      self.assertEqual(x.grad.item(), 1)
+      self.assertEqual(x.grad.item(), 12)
     self.assertEqual(len(schedule_cache), start_len_schedule_cache)
 
 if __name__ == "__main__":

--- a/test/unit/test_schedule_cache.py
+++ b/test/unit/test_schedule_cache.py
@@ -4,8 +4,13 @@ from tinygrad import Tensor, Variable, UOp, function
 from tinygrad.uop.ops import KernelInfo
 from tinygrad.schedule import schedule_cache
 
-def custom_set0_kernel(A:UOp, num:int) -> UOp:
+def custom_set0_kernel(A:UOp, _B:UOp=None, num:int=0) -> UOp:
   return A[0].set(num).sink(arg=KernelInfo(f"custom_set0_{num}"))
+
+def custom_set0_backward(grad_output:UOp, _) -> tuple[None, UOp]:
+  zero = Tensor.invalids(*grad_output.shape, dtype=grad_output.dtype, device=grad_output.device)
+  zero = Tensor.custom_kernel(zero, fxn=functools.partial(custom_set0_kernel, num=0))[0]
+  return None, (zero * Tensor(grad_output, device=grad_output.device)).uop
 
 class TestScheduleCache(unittest.TestCase):
   def test_bound_variable_reuses_cache(self):
@@ -65,23 +70,28 @@ class TestScheduleCache(unittest.TestCase):
       print(num)
     self.assertEqual(len(schedule_cache), start_len_schedule_cache)
 
-  @unittest.expectedFailure
   def test_simple_precompile(self):
-    @function(precompile=True)
+    @function(precompile=True, precompile_backward=True)
     def f(x:Tensor) -> Tensor:
       out = Tensor.invalids(*x.shape, dtype=x.dtype, device=x.device)
-      out = Tensor.custom_kernel(out, fxn=functools.partial(custom_set0_kernel, num=10))[0]
+      out = Tensor.custom_kernel(out, x, fxn=functools.partial(custom_set0_kernel, num=10), grad_fxn=custom_set0_backward)[0]
       return out + x
 
     # warmup
     x = Tensor.ones(1).realize()
-    _ = f(x).realize()
+    out = f(x)
+    out.sum().backward()
+    self.assertEqual(out.item(), 11)
+    self.assertEqual(x.grad.item(), 1)
 
     # use the cache next time function is called
     start_len_schedule_cache = len(schedule_cache)
     for _ in range(3):
-      num = f(x).realize()
-      self.assertEqual(num.item(), 11)
+      x = Tensor.ones(1).realize()
+      out = f(x)
+      out.sum().backward()
+      self.assertEqual(out.item(), 11)
+      self.assertEqual(x.grad.item(), 1)
     self.assertEqual(len(schedule_cache), start_len_schedule_cache)
 
 if __name__ == "__main__":

--- a/test/unit/test_schedule_cache.py
+++ b/test/unit/test_schedule_cache.py
@@ -76,14 +76,14 @@ class TestScheduleCache(unittest.TestCase):
     def f(x:Tensor) -> Tensor:
       out = Tensor.invalids(*x.shape, dtype=x.dtype, device=x.device)
       out = Tensor.custom_kernel(out, x, fxn=functools.partial(custom_add_kernel, num=10), grad_fxn=custom_add_backward)[0]
-      return out * x
+      return out + x
 
     # warmup
     x = Tensor.ones(1).realize()
     out = f(x)
     out.backward(x)
-    self.assertEqual(out.item(), 11)
-    self.assertEqual(x.grad.item(), 12)
+    self.assertEqual(out.item(), 12)
+    self.assertEqual(x.grad.item(), 2)
 
     # use the cache next time function is called
     start_len_schedule_cache = len(schedule_cache)
@@ -91,8 +91,8 @@ class TestScheduleCache(unittest.TestCase):
       x = Tensor.ones(1).realize()
       out = f(x)
       out.backward(x)
-      self.assertEqual(out.item(), 11)
-      self.assertEqual(x.grad.item(), 12)
+      self.assertEqual(out.item(), 12)
+      self.assertEqual(x.grad.item(), 2)
     self.assertEqual(len(schedule_cache), start_len_schedule_cache)
 
 if __name__ == "__main__":

--- a/test/unit/test_schedule_cache.py
+++ b/test/unit/test_schedule_cache.py
@@ -7,10 +7,10 @@ from tinygrad.schedule import schedule_cache
 def custom_set0_kernel(A:UOp, _B:UOp=None, num:int=0) -> UOp:
   return A[0].set(num).sink(arg=KernelInfo(f"custom_set0_{num}"))
 
-def custom_set0_backward(grad_output:UOp, _) -> tuple[None, UOp]:
-  zero = Tensor.invalids(*grad_output.shape, dtype=grad_output.dtype, device=grad_output.device)
-  zero = Tensor.custom_kernel(zero, fxn=functools.partial(custom_set0_kernel, num=0))[0]
-  return None, (zero * Tensor(grad_output, device=grad_output.device)).uop
+def custom_set0_backward(grad_a:UOp, _) -> tuple[None, UOp]:
+  x = Tensor.invalids(*grad_a.shape, dtype=grad_output.dtype, device=grad_output.device)
+  x = Tensor.custom_kernel(x, fxn=functools.partial(custom_set0_kernel, num=0))[0]
+  return None, (x * Tensor(grad_a, device=grad_output.device)).uop
 
 class TestScheduleCache(unittest.TestCase):
   def test_bound_variable_reuses_cache(self):
@@ -70,6 +70,7 @@ class TestScheduleCache(unittest.TestCase):
       print(num)
     self.assertEqual(len(schedule_cache), start_len_schedule_cache)
 
+  @unittest.expectedFailure
   def test_simple_precompile(self):
     @function(precompile=True, precompile_backward=True)
     def f(x:Tensor) -> Tensor:


### PR DESCRIPTION
Fixing this speeds up time to first llama 8b step by 2.8x, wasn't tested in CI and it regressed recently.
Missed precompile_backward, so even #17542 is incomplete though it fixes forward.