### PR TITLE
Add Tensor associative_scan

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1136,6 +1136,25 @@ class TestOps(unittest.TestCase):
     helper_test_op([(0,3)], lambda x: torch.cumsum(x, dim=0), lambda x: Tensor.cumsum(x, axis=0))
     helper_test_op([(2,3,0)], lambda x: torch.cumsum(x, dim=2), lambda x: Tensor.cumsum(x, axis=2))
 
+  def test_associative_scan_add(self):
+    helper_test_op([(3, 7)], lambda x: torch.cumsum(x, dim=1), lambda x: x.associative_scan(lambda a,b: a+b, axis=1))
+
+  def test_associative_scan_reverse_add(self):
+    helper_test_op([(7,)], lambda x: torch.flip(torch.cumsum(torch.flip(x, dims=(0,)), dim=0), dims=(0,)),
+                   lambda x: x.associative_scan(lambda a,b: a+b, axis=0, reverse=True))
+
+  def test_associative_scan_max(self):
+    helper_test_op([(5, 6)], lambda x: torch.cummax(x, dim=0).values,
+                   lambda x: x.associative_scan(lambda a,b: a.maximum(b), axis=0), forward_only=True)
+
+  def test_associative_scan_matmul(self):
+    vals = np.linspace(-1.0, 1.0, 20, dtype=np.float32).reshape(5, 2, 2)
+    expected, acc = [], vals[0]
+    for i in range(vals.shape[0]):
+      if i: acc = acc @ vals[i]
+      expected.append(acc.copy())
+    np.testing.assert_allclose(Tensor(vals).associative_scan(lambda a,b: a@b, axis=0).numpy(), np.stack(expected), atol=1e-6, rtol=1e-6)
+
   def test_small_cumprod(self):
     helper_test_op([(10)],lambda x: torch.cumprod(x, dim=0),lambda x: Tensor.cumprod(x, axis=0))
   @slow_test

--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1148,12 +1148,13 @@ class TestOps(unittest.TestCase):
                    lambda x: x.associative_scan(lambda a,b: a.maximum(b), axis=0), forward_only=True)
 
   def test_associative_scan_matmul(self):
-    vals = np.linspace(-1.0, 1.0, 20, dtype=np.float32).reshape(5, 2, 2)
-    expected, acc = [], vals[0]
-    for i in range(vals.shape[0]):
-      if i: acc = acc @ vals[i]
-      expected.append(acc.copy())
-    np.testing.assert_allclose(Tensor(vals).associative_scan(lambda a,b: a@b, axis=0).numpy(), np.stack(expected), atol=1e-6, rtol=1e-6)
+    def torch_scan(x):
+      expected, acc = [], x[0]
+      for i in range(x.shape[0]):
+        if i: acc = acc @ x[i]
+        expected.append(acc)
+      return torch.stack(expected)
+    helper_test_op([(5, 2, 2)], torch_scan, lambda x: x.associative_scan(lambda a,b: a@b, axis=0), forward_only=True)
 
   def test_small_cumprod(self):
     helper_test_op([(10)],lambda x: torch.cumprod(x, dim=0),lambda x: Tensor.cumprod(x, axis=0))

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -775,19 +775,23 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
       return x[tuple(idx)]
 
     def _interleave(even:Self, odd:Self, n:int) -> Self:
-      if odd.shape[axis] == 0: return even
-      paired = _slice(even, 0, odd.shape[axis]).stack(odd, dim=axis+1).flatten(axis, axis+1)
-      return paired if n%2 == 0 else paired.cat(_slice(even, odd.shape[axis], odd.shape[axis]+1), dim=axis)
+      odd_len = odd.shape[axis]
+      assert isinstance(odd_len, int)
+      if odd_len == 0: return even
+      paired = _slice(even, 0, odd_len).stack(odd, dim=axis+1).flatten(axis, axis+1)
+      return paired if n%2 == 0 else paired.cat(_slice(even, odd_len, odd_len+1), dim=axis)
 
     def _scan(x:Self) -> Self:
       n = x.shape[axis]
       assert isinstance(n, int), "associative_scan requires a static scan axis"
       if n <= 1: return x
       even, odd = _slice(x, 0, None, 2), _slice(x, 1, None, 2)
-      pairs = fn(_slice(even, 0, odd.shape[axis]), odd)
+      even_len, odd_len = even.shape[axis], odd.shape[axis]
+      assert isinstance(even_len, int) and isinstance(odd_len, int)
+      pairs = fn(_slice(even, 0, odd_len), odd)
       scanned_pairs = _scan(pairs)
       even_out = _slice(even, 0, 1)
-      if even.shape[axis] > 1: even_out = even_out.cat(fn(_slice(scanned_pairs, 0, even.shape[axis]-1), _slice(even, 1, None)), dim=axis)
+      if even_len > 1: even_out = even_out.cat(fn(_slice(scanned_pairs, 0, even_len-1), _slice(even, 1, None)), dim=axis)
       return _interleave(even_out, scanned_pairs, n)
 
     return _scan(self)

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -758,6 +758,40 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     pooled = self.transpose(axis,-1)._pad_constant(pads, identity_element(op, self.dtype))._pool((self.shape[axis],))
     return getattr(pooled, {Ops.ADD: "sum", Ops.MAX: "max", Ops.MUL: "prod"}[op])(-1).transpose(axis, -1)
 
+  def associative_scan(self, fn:Callable[[Self, Self], Self], axis:int=0, reverse:bool=False) -> Self:
+    """
+    Computes a parallel prefix scan along `axis` using an associative binary function.
+
+    `fn` must take two tensors with matching shapes and return a tensor with the same
+    shape. For example, `lambda a,b: a+b` gives the same result as `cumsum`.
+    """
+    axis = self._resolve_dim(axis)
+    if self.ndim == 0 or 0 in self.shape: return self
+    if reverse: return self.flip(axis).associative_scan(fn, axis).flip(axis)
+
+    def _slice(x:Self, start:int, stop:int|None=None, step:int=1) -> Self:
+      idx = [slice(None)] * x.ndim
+      idx[axis] = slice(start, stop, step)
+      return x[tuple(idx)]
+
+    def _interleave(even:Self, odd:Self, n:int) -> Self:
+      if odd.shape[axis] == 0: return even
+      paired = _slice(even, 0, odd.shape[axis]).stack(odd, dim=axis+1).flatten(axis, axis+1)
+      return paired if n%2 == 0 else paired.cat(_slice(even, odd.shape[axis], odd.shape[axis]+1), dim=axis)
+
+    def _scan(x:Self) -> Self:
+      n = x.shape[axis]
+      assert isinstance(n, int), "associative_scan requires a static scan axis"
+      if n <= 1: return x
+      even, odd = _slice(x, 0, None, 2), _slice(x, 1, None, 2)
+      pairs = fn(_slice(even, 0, odd.shape[axis]), odd)
+      scanned_pairs = _scan(pairs)
+      even_out = _slice(even, 0, 1)
+      if even.shape[axis] > 1: even_out = even_out.cat(fn(_slice(scanned_pairs, 0, even.shape[axis]-1), _slice(even, 1, None)), dim=axis)
+      return _interleave(even_out, scanned_pairs, n)
+
+    return _scan(self)
+
   def _split_cumalu(self, axis:int, op:Ops) -> Self:
     axis = self._resolve_dim(axis)
     if self.ndim == 0 or 0 in self.shape: return self.cast(self.sum().dtype) if op is Ops.ADD else self


### PR DESCRIPTION
Refs #3039

This adds an initial Tensor-level associative prefix scan API:

- `Tensor.associative_scan(fn, axis=0, reverse=False)` for associative binary tensor functions.
- Divide-and-conquer scan over the requested static axis.
- Support for odd lengths and reverse scans.
- Regression coverage against cumsum, reverse cumsum, cummax values, and non-commutative matrix prefix products.

This is intentionally implemented at the Tensor composition layer first rather than introducing a new UOp/IR primitive, so the semantics can be reviewed before lowering work.

Validation run locally:

- `git diff --check`
- `python -m py_compile tinygrad/mixin/op.py test/backend/test_ops.py`
- Direct tinygrad + NumPy checks for add, reverse add, max, and matrix product associative scans.

Not run locally:

- `test/backend/test_ops.py` through unittest/pytest, because this local Python environment does not have torch installed.