### PR TITLE
llama beam nan fix [pr]

### DIFF
--- a/test/opt/test_kernel_opts.py
+++ b/test/opt/test_kernel_opts.py
@@ -244,8 +244,15 @@ class TestKernelOpts(unittest.TestCase):
   def test_padto_group_full_unroll_sum(self):
     a = Tensor.ones(2, 28, 4096, dtype=dtypes.bfloat16).realize()
     out = ((a * 0.5).float().square()).sum(axis=(0, 2))
-    opts_to_apply = [Opt(OptOps.GROUPTOP, 1, 256), Opt(OptOps.PADTO, 3, 32), Opt(OptOps.UNROLL, 2, 0), Opt(OptOps.UPCAST, 0, 7)]
-    helper_linearizer_opt(out, [opts_to_apply], check_default_opt=False)
+    opts_to_apply = [Opt(OptOps.GROUPTOP, 1, 256), Opt(OptOps.PADTO, 3, 32)]
+    helper_linearizer_opt(out, [opts_to_apply+[Opt(OptOps.UNROLL, 2, 16), Opt(OptOps.UPCAST, 0, 7)]], check_default_opt=False)
+    out = ((a * 0.5).float().square()).sum(axis=(0, 2))
+    with self.assertRaises(KernelOptError):
+      helper_linearizer_opt(out, [opts_to_apply+[Opt(OptOps.UNROLL, 2, 0), Opt(OptOps.UPCAST, 0, 7)]], check_default_opt=False)
+    a = Tensor.ones(2, 28, 4352, dtype=dtypes.bfloat16).realize()
+    out = ((a * 0.5).float().square()).sum(axis=(0, 2))
+    with self.assertRaises(KernelOptError):
+      helper_linearizer_opt(out, [opts_to_apply+[Opt(OptOps.UNROLL, 2, 4), Opt(OptOps.UPCAST, 0, 7)]], check_default_opt=False)
 
   def test_padto_sum(self):
     N = 18

--- a/test/opt/test_kernel_opts.py
+++ b/test/opt/test_kernel_opts.py
@@ -247,7 +247,7 @@ class TestKernelOpts(unittest.TestCase):
     opts_to_apply = [Opt(OptOps.GROUPTOP, 1, 256), Opt(OptOps.PADTO, 3, 32), Opt(OptOps.UNROLL, 2, 0), Opt(OptOps.UPCAST, 0, 7)]
     with self.assertRaises(KernelOptError):
       helper_linearizer_opt(out(), [opts_to_apply], check_default_opt=False)
-    # this unroll can still since each reduction is either all Invalid or all data
+    # this unroll is okay since each reduction is either all Invalid or all data
     helper_linearizer_opt(out(), [[Opt(OptOps.GROUPTOP, 1, 256), Opt(OptOps.PADTO, 3, 32), Opt(OptOps.UNROLL, 2, 16), Opt(OptOps.UPCAST, 0, 7)]])
 
   def test_padto_sum(self):

--- a/test/opt/test_kernel_opts.py
+++ b/test/opt/test_kernel_opts.py
@@ -241,7 +241,6 @@ class TestKernelOpts(unittest.TestCase):
 
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_local, "test requires locals")
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")
-  @unittest.expectedFailure
   def test_padto_group_full_unroll_sum(self):
     a = Tensor.ones(2, 28, 4096, dtype=dtypes.bfloat16).realize()
     out = ((a * 0.5).float().square()).sum(axis=(0, 2))

--- a/test/opt/test_kernel_opts.py
+++ b/test/opt/test_kernel_opts.py
@@ -243,16 +243,12 @@ class TestKernelOpts(unittest.TestCase):
   @unittest.skipUnless(Device[Device.DEFAULT].renderer.has_shared, "test requires shared")
   def test_padto_group_full_unroll_sum(self):
     a = Tensor.ones(2, 28, 4096, dtype=dtypes.bfloat16).realize()
-    out = ((a * 0.5).float().square()).sum(axis=(0, 2))
-    opts_to_apply = [Opt(OptOps.GROUPTOP, 1, 256), Opt(OptOps.PADTO, 3, 32)]
-    helper_linearizer_opt(out, [opts_to_apply+[Opt(OptOps.UNROLL, 2, 16), Opt(OptOps.UPCAST, 0, 7)]], check_default_opt=False)
-    out = ((a * 0.5).float().square()).sum(axis=(0, 2))
+    def out(): return ((a.clone() * 0.5).float().square()).sum(axis=(0, 2))
+    opts_to_apply = [Opt(OptOps.GROUPTOP, 1, 256), Opt(OptOps.PADTO, 3, 32), Opt(OptOps.UNROLL, 2, 0), Opt(OptOps.UPCAST, 0, 7)]
     with self.assertRaises(KernelOptError):
-      helper_linearizer_opt(out, [opts_to_apply+[Opt(OptOps.UNROLL, 2, 0), Opt(OptOps.UPCAST, 0, 7)]], check_default_opt=False)
-    a = Tensor.ones(2, 28, 4352, dtype=dtypes.bfloat16).realize()
-    out = ((a * 0.5).float().square()).sum(axis=(0, 2))
-    with self.assertRaises(KernelOptError):
-      helper_linearizer_opt(out, [opts_to_apply+[Opt(OptOps.UNROLL, 2, 4), Opt(OptOps.UPCAST, 0, 7)]], check_default_opt=False)
+      helper_linearizer_opt(out(), [opts_to_apply], check_default_opt=False)
+    # this unroll can still since each reduction is either all Invalid or all data
+    helper_linearizer_opt(out(), [[Opt(OptOps.GROUPTOP, 1, 256), Opt(OptOps.PADTO, 3, 32), Opt(OptOps.UNROLL, 2, 16), Opt(OptOps.UPCAST, 0, 7)]])
 
   def test_padto_sum(self):
     N = 18

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -56,9 +56,8 @@ def expand_reduce(r:UOp):
       for i,s in enumerate(u.shape):
         if s > 1: new_axes.append(i)
   if len(new_axes) == 0: return None
-  x = r.src[0]
-  # replace Invalid with the identity element
-  if x.op is Ops.WHERE and x.src[2].is_invalid: x = x.src[0].where(x.src[1], x.const_like(identity_element(r.arg[0], r.dtype)))
+  assert r.arg[1] == 0
+  if (x:=r.src[0]).op is Ops.WHERE and x.src[2].is_invalid: x = x.src[0].where(x.src[1], x.const_like(identity_element(r.arg[0], r.dtype)))
   # permute so new_axes come to front, then reduce
   perm = tuple(new_axes) + tuple(i for i in range(len(r.src[0].shape)) if i not in new_axes)
   out_shape = tuple([1 if i in new_axes else s for i,s in enumerate(r.src[0].shape)])

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -57,6 +57,7 @@ def expand_reduce(r:UOp):
         if s > 1: new_axes.append(i)
   if len(new_axes) == 0: return None
   x = r.src[0]
+  # replace Invalid with the identity element
   if x.op is Ops.WHERE and x.src[2].is_invalid: x = x.src[0].where(x.src[1], x.const_like(identity_element(r.arg[0], r.dtype)))
   # permute so new_axes come to front, then reduce
   perm = tuple(new_axes) + tuple(i for i in range(len(r.src[0].shape)) if i not in new_axes)

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -56,11 +56,12 @@ def expand_reduce(r:UOp):
       for i,s in enumerate(u.shape):
         if s > 1: new_axes.append(i)
   if len(new_axes) == 0: return None
-  assert r.arg[1] == 0
+  x = r.src[0]
+  if x.op is Ops.WHERE and x.src[2].is_invalid: x = x.src[0].where(x.src[1], x.const_like(identity_element(r.arg[0], r.dtype)))
   # permute so new_axes come to front, then reduce
   perm = tuple(new_axes) + tuple(i for i in range(len(r.src[0].shape)) if i not in new_axes)
   out_shape = tuple([1 if i in new_axes else s for i,s in enumerate(r.src[0].shape)])
-  return r.src[0].permute(perm).reduce(*range_srcs, arg=(r.arg[0], len(new_axes))).reshape(out_shape)
+  return x.permute(perm).reduce(*range_srcs, arg=(r.arg[0], len(new_axes))).reshape(out_shape)
 
 def contract_axis(ctx:dict[int, int], u:UOp, arg):
   permute_tail = [ctx[rn] for rn,_ in arg]

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -57,11 +57,10 @@ def expand_reduce(r:UOp):
         if s > 1: new_axes.append(i)
   if len(new_axes) == 0: return None
   assert r.arg[1] == 0
-  if (x:=r.src[0]).op is Ops.WHERE and x.src[2].is_invalid: x = x.src[0].where(x.src[1], x.const_like(identity_element(r.arg[0], r.dtype)))
   # permute so new_axes come to front, then reduce
   perm = tuple(new_axes) + tuple(i for i in range(len(r.src[0].shape)) if i not in new_axes)
   out_shape = tuple([1 if i in new_axes else s for i,s in enumerate(r.src[0].shape)])
-  return x.permute(perm).reduce(*range_srcs, arg=(r.arg[0], len(new_axes))).reshape(out_shape)
+  return r.src[0].permute(perm).reduce(*range_srcs, arg=(r.arg[0], len(new_axes))).reshape(out_shape)
 
 def contract_axis(ctx:dict[int, int], u:UOp, arg):
   permute_tail = [ctx[rn] for rn,_ in arg]

--- a/tinygrad/codegen/opt/postrange.py
+++ b/tinygrad/codegen/opt/postrange.py
@@ -17,7 +17,7 @@ class Scheduler:
     self.ast, self.ren = ast, ren
     self.dont_use_locals = self.ast.arg.dont_use_locals if self.ast.arg is not None else False
     self.applied_opts = list(self.ast.arg.applied_opts) if self.ast.arg is not None else []
-    self.pad_bound: dict[int, int] = {}  # gcd of padding boundaries in units of each range
+    self.pad_bound:dict[int, int] = {}
     self.opt_range = count(start=max([x.arg[0] for x in self.rngs], default=0)+1)
 
   @property

--- a/tinygrad/codegen/opt/postrange.py
+++ b/tinygrad/codegen/opt/postrange.py
@@ -17,6 +17,7 @@ class Scheduler:
     self.ast, self.ren = ast, ren
     self.dont_use_locals = self.ast.arg.dont_use_locals if self.ast.arg is not None else False
     self.applied_opts = list(self.ast.arg.applied_opts) if self.ast.arg is not None else []
+    self.pad_bound: dict[int, int] = {}  # gcd of padding boundaries in units of each range
     self.opt_range = count(start=max([x.arg[0] for x in self.rngs], default=0)+1)
 
   @property
@@ -45,6 +46,7 @@ class Scheduler:
     ret = Scheduler(self.ast, self.ren)
     ret.dont_use_locals = self.dont_use_locals
     ret.applied_opts = self.applied_opts[:]
+    ret.pad_bound = self.pad_bound.copy()
     if hasattr(self, 'tensor_core'): ret.tensor_core = self.tensor_core
     return ret
 
@@ -99,6 +101,11 @@ class Scheduler:
     replaced_rng = rng.replace(src=(old_sz,))
     sub_axis = (new_rng * old_sz + replaced_rng) if top else (replaced_rng * amount + new_rng)
     self.ast = self.ast.substitute({rng:sub_axis}, name=f"shift {rng.arg[:-1]} {amount} {str(new_type).split('.')[1].lower()}")
+    if (bound:=self.pad_bound.get(rng.arg[0])) is not None:
+      if top: self.pad_bound[new_rng.arg[0]] = bound//int(old_sz) if bound%int(old_sz) == 0 else 1
+      else:
+        self.pad_bound[rng.arg[0]] = bound//amount if bound%amount == 0 else 1
+        self.pad_bound[new_rng.arg[0]] = bound
     return replaced_rng, new_rng
 
   def ranges_of(self, *axis_type:AxisType) -> list[UOp]: return [r for r in self.rngs if r.arg[-1] in axis_type]
@@ -159,6 +166,7 @@ class Scheduler:
       if opt.op is OptOps.UNROLL:
         check(amt <= 32, "don't unroll more than 32")
         check(rng.arg[-1] in {AxisType.GROUP_REDUCE, AxisType.REDUCE}, "unroll is for GROUP_REDUCE/REDUCE")
+        if (bound:=self.pad_bound.get(rng.arg[0])) is not None: check(bound % amt == 0, "cannot unroll across padding")
       if opt.op is OptOps.UPCAST:
         check((self.ren is not None and self.ren.target.device == "DSP") or amt <= 16, "don't upcast more than 16")
         check(rng.arg[-1] in {AxisType.GLOBAL, AxisType.LOCAL, AxisType.WEAK}, f"upcast is for GLOBAL/LOCAL/LOOP, not {rng.arg[-1]}")
@@ -191,6 +199,8 @@ class Scheduler:
       check(rng.arg[-1] is not AxisType.THREAD, "cannot pad thread")
       new_sz = round_up(int(rng.vmax+1), cast(int, opt.arg))
       check(rng.vmax+1 > new_sz//4, "pad adds more than quadruple the work")
+      if new_sz > rng.vmax+1 and rng.arg[-1] in {AxisType.GROUP_REDUCE, AxisType.REDUCE}:
+        self.pad_bound[rng.arg[0]] = math.gcd(self.pad_bound.get(rng.arg[0], 0), int(rng.vmax+1))
       replaced_rng = UOp.range(new_sz, *rng.arg, dtype=rng.dtype)
       replaces = {rng:replaced_rng}
       valid = replaced_rng < rng.vmax+1


### PR DESCRIPTION
llama BEAM found a PADTO + UNROLL that I think is incorrect.

Before new codegen https://github.com/tinygrad/tinygrad/commit/c7e7687bd36e05fec2350f78d3cae022df8973d5, it failed in the old devectorizer, current master gives `nan`, this branch raises KernelOptError.

The nan kernel had PADTO 16 -> 32, UNROLL 32. So REDUCE lowers to: `val0+...+val15+Invalid+...+Invalid`. Per symbolic.py rules, Invalid poisons the entire ALU:
```c
for (int Ridx0 = 0; Ridx0 < 2; Ridx0++) {}
*(buf2+...) = *(buf0+...); // stores nan
```

This diff still allows for valid OptOps like PADTO 16 -> 32, UNROLL 16. [0..15] is all data and [16..31] is all Invalid:
```c
for (int Ridx1 = 0; Ridx1 < 2; Ridx1++) {
  if (Ridx1 < 1) buf0[...] += val0 + ... + val15;
}
```

Data never gets mixed with Invalid because of UNROLL.