### PR TITLE
Turing (TU10x) FWSEC structs

### DIFF
--- a/extra/nv_gpu_driver/vbios.h
+++ b/extra/nv_gpu_driver/vbios.h
@@ -191,6 +191,53 @@ typedef struct {
 #define FALCON_UCODE_DESC_V3_44_FMT     "9d1w2b2w"
 #define BCRT30_RSA3K_SIG_SIZE 384
 
+typedef struct {
+    FALCON_UCODE_DESC_HEADER Hdr;
+    unsigned int StoredSize;
+    unsigned int UncompressedSize;
+    unsigned int VirtualEntry;
+    unsigned int InterfaceOffset;
+    unsigned int IMEMPhysBase;
+    unsigned int IMEMLoadSize;
+    unsigned int IMEMVirtBase;
+    unsigned int IMEMSecBase;
+    unsigned int IMEMSecSize;
+    unsigned int DMEMOffset;
+    unsigned int DMEMPhysBase;
+    unsigned int DMEMLoadSize;
+    unsigned int AltIMEMLoadSize;
+    unsigned int AltDMEMLoadSize;
+} FALCON_UCODE_DESC_V2;
+
+#define FALCON_UCODE_DESC_V2_SIZE_60    60
+
+typedef struct {
+    NvU32 blStartTag;
+    NvU32 blDmemDescLoadOff;
+    NvU32 blCodeOffset;
+    NvU32 blCodeSize;
+    NvU32 blDataOffset;
+    NvU32 blDataSize;
+} __attribute__((packed)) RM_FLCN_BL_DESC;
+
+typedef struct {
+    NvU32 reserved[4];
+    NvU32 signature[4];
+    NvU32 ctxDma;
+    NvU32 codeDmaBaseLo;
+    NvU32 codeDmaBaseHi;
+    NvU32 nonSecureCodeOff;
+    NvU32 nonSecureCodeSize;
+    NvU32 secureCodeOff;
+    NvU32 secureCodeSize;
+    NvU32 codeEntryPoint;
+    NvU32 dataDmaBaseLo;
+    NvU32 dataDmaBaseHi;
+    NvU32 dataSize;
+    NvU32 argc;
+    NvU32 argv;
+} __attribute__((packed)) RM_FLCN_BL_DMEM_DESC;
+
 typedef struct
 {
     NvU32 version;

--- a/test/null/test_nv_fwsec.py
+++ b/test/null/test_nv_fwsec.py
@@ -1,0 +1,39 @@
+import ctypes, unittest
+from tinygrad.runtime.autogen import nv
+
+class TestNVFwsecBootloaderStructs(unittest.TestCase):
+  def test_falcon_ucode_desc_v2_layout(self):
+    self.assertEqual(ctypes.sizeof(nv.FALCON_UCODE_DESC_V2), 60)
+    d = nv.FALCON_UCODE_DESC_V2(Hdr=nv.FALCON_UCODE_DESC_HEADER(vDesc=0x0203ff02), StoredSize=1, UncompressedSize=2, VirtualEntry=3,
+      InterfaceOffset=4, IMEMPhysBase=5, IMEMLoadSize=6, IMEMVirtBase=7, IMEMSecBase=8, IMEMSecSize=9, DMEMOffset=10, DMEMPhysBase=11,
+      DMEMLoadSize=12, AltIMEMLoadSize=13, AltDMEMLoadSize=14)
+    assert int.from_bytes(d, 'little') == int.from_bytes(
+      b''.join(v.to_bytes(4, 'little') for v in [0x0203ff02,1,2,3,4,5,6,7,8,9,10,11,12,13,14]), 'little')
+    assert d.Hdr.vDesc == 0x0203ff02 and d.IMEMSecBase == 8 and d.AltDMEMLoadSize == 14
+
+  def test_rm_flcn_bl_desc_layout(self):
+    self.assertEqual(ctypes.sizeof(nv.RM_FLCN_BL_DESC), 24)
+    d = nv.RM_FLCN_BL_DESC(blStartTag=0x11, blDmemDescLoadOff=0x22, blCodeOffset=0x33, blCodeSize=0x44, blDataOffset=0x55, blDataSize=0x66)
+    assert int.from_bytes(d, 'little') == int.from_bytes(
+      b''.join(v.to_bytes(4, 'little') for v in [0x11,0x22,0x33,0x44,0x55,0x66]), 'little')
+
+  def test_rm_flcn_bl_dmem_desc_layout(self):
+    self.assertEqual(ctypes.sizeof(nv.RM_FLCN_BL_DMEM_DESC), 84)
+    d = nv.RM_FLCN_BL_DMEM_DESC(ctxDma=4, codeDmaBaseLo=0xaabbccdd, codeDmaBaseHi=0x1, nonSecureCodeOff=0x100, nonSecureCodeSize=0x200,
+      secureCodeOff=0x300, secureCodeSize=0x400, codeEntryPoint=0, dataDmaBaseLo=0xeeff0011, dataDmaBaseHi=0x2, dataSize=0x500,
+      argc=0, argv=0)
+    b = bytes(d)
+    assert b[0:32] == b'\x00' * 32
+    assert int.from_bytes(b[32:36], 'little') == 4                # ctxDma
+    assert int.from_bytes(b[36:40], 'little') == 0xaabbccdd        # codeDmaBaseLo
+    assert int.from_bytes(b[40:44], 'little') == 0x1               # codeDmaBaseHi
+    assert int.from_bytes(b[44:48], 'little') == 0x100             # nonSecureCodeOff
+    assert int.from_bytes(b[48:52], 'little') == 0x200             # nonSecureCodeSize
+    assert int.from_bytes(b[52:56], 'little') == 0x300             # secureCodeOff
+    assert int.from_bytes(b[56:60], 'little') == 0x400             # secureCodeSize
+    assert int.from_bytes(b[64:68], 'little') == 0xeeff0011        # dataDmaBaseLo
+    assert int.from_bytes(b[68:72], 'little') == 0x2               # dataDmaBaseHi
+    assert int.from_bytes(b[72:76], 'little') == 0x500             # dataSize
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tinygrad/runtime/autogen/nv.py
+++ b/tinygrad/runtime/autogen/nv.py
@@ -4601,6 +4601,54 @@ class FALCON_UCODE_DESC_V3(c.Struct):
   Reserved: int
 FALCON_UCODE_DESC_V3.register_fields([('Hdr', FALCON_UCODE_DESC_HEADER, 0), ('StoredSize', ctypes.c_uint32, 4), ('PKCDataOffset', ctypes.c_uint32, 8), ('InterfaceOffset', ctypes.c_uint32, 12), ('IMEMPhysBase', ctypes.c_uint32, 16), ('IMEMLoadSize', ctypes.c_uint32, 20), ('IMEMVirtBase', ctypes.c_uint32, 24), ('DMEMPhysBase', ctypes.c_uint32, 28), ('DMEMLoadSize', ctypes.c_uint32, 32), ('EngineIdMask', ctypes.c_uint16, 36), ('UcodeId', ctypes.c_ubyte, 38), ('SignatureCount', ctypes.c_ubyte, 39), ('SignatureVersions', ctypes.c_uint16, 40), ('Reserved', ctypes.c_uint16, 42)])
 @c.record
+class FALCON_UCODE_DESC_V2(c.Struct):
+  SIZE = 60
+  Hdr: FALCON_UCODE_DESC_HEADER
+  StoredSize: int
+  UncompressedSize: int
+  VirtualEntry: int
+  InterfaceOffset: int
+  IMEMPhysBase: int
+  IMEMLoadSize: int
+  IMEMVirtBase: int
+  IMEMSecBase: int
+  IMEMSecSize: int
+  DMEMOffset: int
+  DMEMPhysBase: int
+  DMEMLoadSize: int
+  AltIMEMLoadSize: int
+  AltDMEMLoadSize: int
+FALCON_UCODE_DESC_V2.register_fields([('Hdr', FALCON_UCODE_DESC_HEADER, 0), ('StoredSize', ctypes.c_uint32, 4), ('UncompressedSize', ctypes.c_uint32, 8), ('VirtualEntry', ctypes.c_uint32, 12), ('InterfaceOffset', ctypes.c_uint32, 16), ('IMEMPhysBase', ctypes.c_uint32, 20), ('IMEMLoadSize', ctypes.c_uint32, 24), ('IMEMVirtBase', ctypes.c_uint32, 28), ('IMEMSecBase', ctypes.c_uint32, 32), ('IMEMSecSize', ctypes.c_uint32, 36), ('DMEMOffset', ctypes.c_uint32, 40), ('DMEMPhysBase', ctypes.c_uint32, 44), ('DMEMLoadSize', ctypes.c_uint32, 48), ('AltIMEMLoadSize', ctypes.c_uint32, 52), ('AltDMEMLoadSize', ctypes.c_uint32, 56)])
+@c.record
+class RM_FLCN_BL_DESC(c.Struct):
+  SIZE = 24
+  blStartTag: int
+  blDmemDescLoadOff: int
+  blCodeOffset: int
+  blCodeSize: int
+  blDataOffset: int
+  blDataSize: int
+RM_FLCN_BL_DESC.register_fields([('blStartTag', NvU32, 0), ('blDmemDescLoadOff', NvU32, 4), ('blCodeOffset', NvU32, 8), ('blCodeSize', NvU32, 12), ('blDataOffset', NvU32, 16), ('blDataSize', NvU32, 20)])
+@c.record
+class RM_FLCN_BL_DMEM_DESC(c.Struct):
+  SIZE = 84
+  reserved: c.Array[ctypes.c_uint32, Literal[4]]
+  signature: c.Array[ctypes.c_uint32, Literal[4]]
+  ctxDma: int
+  codeDmaBaseLo: int
+  codeDmaBaseHi: int
+  nonSecureCodeOff: int
+  nonSecureCodeSize: int
+  secureCodeOff: int
+  secureCodeSize: int
+  codeEntryPoint: int
+  dataDmaBaseLo: int
+  dataDmaBaseHi: int
+  dataSize: int
+  argc: int
+  argv: int
+RM_FLCN_BL_DMEM_DESC.register_fields([('reserved', c.Array[NvU32, Literal[4]], 0), ('signature', c.Array[NvU32, Literal[4]], 16), ('ctxDma', NvU32, 32), ('codeDmaBaseLo', NvU32, 36), ('codeDmaBaseHi', NvU32, 40), ('nonSecureCodeOff', NvU32, 44), ('nonSecureCodeSize', NvU32, 48), ('secureCodeOff', NvU32, 52), ('secureCodeSize', NvU32, 56), ('codeEntryPoint', NvU32, 60), ('dataDmaBaseLo', NvU32, 64), ('dataDmaBaseHi', NvU32, 68), ('dataSize', NvU32, 72), ('argc', NvU32, 76), ('argv', NvU32, 80)])
+@c.record
 class FWSECLIC_READ_VBIOS_DESC(c.Struct):
   SIZE = 24
   version: int
@@ -4893,6 +4941,7 @@ FALCON_UCODE_DESC_HEADER_FORMAT = "1d"
 FALCON_UCODE_DESC_V3_SIZE_44 = 44
 FALCON_UCODE_DESC_V3_44_FMT = "9d1w2b2w"
 BCRT30_RSA3K_SIG_SIZE = 384
+FALCON_UCODE_DESC_V2_SIZE_60 = 60
 FWSECLIC_READ_VBIOS_STRUCT_FLAGS = (2)
 FWSECLIC_FRTS_REGION_MEDIA_FB = (2)
 FWSECLIC_FRTS_REGION_SIZE_1MB_IN_4K = (0x100)


### PR DESCRIPTION
These are the FWSEC structs required for the Turing (TU10x) bootloader. This was taken from nouveau and is something required to get support working for Turing cards (in the upcoming PRs). AI was used to make this and was verified by me. 