### PR TITLE
fix Tensor.roll on zero-sized tensors

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -2164,6 +2164,10 @@ class TestOps(unittest.TestCase):
   def test_roll(self):
     helper_test_op([(2, 4)], lambda x: x.roll(1))
     helper_test_op([(2, 4)], lambda x: x.roll((1,)))
+    helper_test_op([(0,)], lambda x: x.roll(1, 0))
+    helper_test_op([(2, 0, 3)], lambda x: x.roll(1, 0))
+    helper_test_op([(2, 0, 3)], lambda x: x.roll(1, 1))
+    helper_test_op([(2, 0, 3)], lambda x: x.roll(1))
     self.helper_test_exception([(2, 4)], lambda x: x.roll((1, 2)), expected=RuntimeError)
     helper_test_op([(2, 4)], lambda x: x.roll(1, 0))
     helper_test_op([(2, 4)], lambda x: x.roll(-1, 0))

--- a/tinygrad/mixin/movement.py
+++ b/tinygrad/mixin/movement.py
@@ -550,6 +550,7 @@ class MovementMixin:
     if dims is None: return self.flatten().roll(shifts, 0).reshape(self.shape)
     dims, shifts = tuple(self._resolve_dim(d) for d in make_tuple(dims, 1)), make_tuple(shifts, 1)
     if len(dims) != len(shifts): raise RuntimeError(f"{len(dims)=} != {len(shifts)=}")
+    if 0 in self.shape: return self
     shrink_arg: list[tuple[sint, sint]|None] = [None] * self.ndim
     for d, s in zip(dims, shifts): shrink_arg[d] = (delta:=self.shape[d]-s%self.shape[d], delta+self.shape[d])
     return self.repeat(*tuple(2 if i in dims else 1 for i in range(self.ndim))).shrink(tuple(shrink_arg))


### PR DESCRIPTION
Fixes #17468

`Tensor.roll` calculates the shift with modulo by the selected dimension size. A zero-sized dimension therefore raised `ZeroDivisionError`, including when `dims=None` flattened an empty tensor.

After the existing dimension and shift validation, this returns the tensor unchanged when its shape contains a zero. An empty tensor has no elements to rearrange, so this preserves its shape and matches PyTorch and NumPy behavior. Regression cases cover `(0,)` and `(2, 0, 3)` with rolls along an empty dimension, a non-empty dimension, and the flattened tensor.

This should be merged because it restores valid empty-tensor behavior with a one-line core fix and focused regression coverage.

Validation:

- `DEV=CPU .venv/bin/python -m pytest test/backend/test_ops.py -k test_roll -q -n 4` (`1 passed`)
- `.venv/bin/python -m ruff check tinygrad/mixin/movement.py test/backend/test_ops.py`
- `.venv/bin/python -m mypy tinygrad/`
- `.venv/bin/python -m compileall -q tinygrad/mixin/movement.py test/backend/test_ops.py`

AI disclosure: I used an AI coding assistant to investigate, implement, validate, and prepare this PR. I reviewed the code and test results.
