### PR TITLE
llm: dequantize only selected MoE experts

### DIFF
--- a/test/unit/test_gguf.py
+++ b/test/unit/test_gguf.py
@@ -1,7 +1,7 @@
 import os, struct, unittest, tempfile, pathlib, sys
 from tinygrad import dtypes, Tensor, fetch, Device
 from tinygrad.helpers import disable_gc
-from tinygrad.llm.gguf import _ggml_iq_grid, ggml_data_to_tensor, gguf_load
+from tinygrad.llm.gguf import _ggml_iq_grid, get_ggml_quantization, ggml_data_to_tensor, gguf_load
 from tinygrad.runtime.autogen import ggml_common as _ggml
 import numpy as np
 from gguf import GGUFReader, GGUFValueType, GGMLQuantizationType, GGML_QUANT_SIZES, dequantize, quantize
@@ -137,6 +137,16 @@ class TestGGUF(unittest.TestCase):
     buf += b"\x00" * ((32 - len(buf) % 32) % 32)
     for _, _, _, data in tensors: buf += data
     return bytes(buf)
+
+  def test_quantized_metadata(self):
+    qtype = GGMLQuantizationType.IQ3_XXS
+    block_size, type_size = GGML_QUANT_SIZES[qtype]
+    raw = np.zeros(type_size, dtype=np.uint8)
+    buf = self._build_gguf([("weight", (block_size,), qtype.value, raw.tobytes())], [])
+    _, tensors = gguf_load(Tensor(np.frombuffer(buf, dtype=np.uint8)).to(None))
+    packed, ggml_type = get_ggml_quantization(tensors["weight"]) or (None, None)
+    self.assertEqual(ggml_type, qtype.value)
+    np.testing.assert_equal(packed.numpy(), raw)
 
   def test_multi_part_load(self):
     with tempfile.TemporaryDirectory() as d:

--- a/test/unit/test_llm_moe.py
+++ b/test/unit/test_llm_moe.py
@@ -1,8 +1,11 @@
 import unittest
 import numpy as np
 from dataclasses import replace
-from tinygrad import Tensor
-from tinygrad.llm.model import ExpertGating, TransformerBlock, TransformerConfig
+from types import SimpleNamespace
+from unittest.mock import patch
+from tinygrad import dtypes, GlobalCounters, Tensor, UOp
+from tinygrad.llm.gguf import ggml_data_to_tensor
+from tinygrad.llm.model import _attach_quantized_experts, ExpertGating, ExpertWeights, TransformerBlock, TransformerConfig
 
 def _moe_config(dim=8, hidden=16, n_heads=2, num_experts=4, num_experts_per_tok=2):
   return TransformerConfig(
@@ -10,6 +13,15 @@ def _moe_config(dim=8, hidden=16, n_heads=2, num_experts=4, num_experts_per_tok=
     norm_eps=1e-5, vocab_size=100, head_dim=dim//n_heads, rope_theta=10000,
     rope_dim=dim//n_heads, v_head_dim=dim//n_heads, max_context=16,
     num_experts=num_experts, num_experts_per_tok=num_experts_per_tok)
+
+def _q8_expert_layer(num_experts=4, dim=32):
+  raw = np.empty((num_experts, dim, 34), dtype=np.uint8)
+  raw[:, :, :2] = np.frombuffer(np.float16(1).tobytes(), dtype=np.uint8)
+  for expert in range(num_experts): raw[expert, :, 2:] = expert + 1
+  packed = Tensor(raw.flatten()).realize()
+  layer = ExpertWeights(num_experts, dim, dim)
+  layer.set_quantized(ggml_data_to_tensor(packed, num_experts * dim * dim, 8).reshape(num_experts, dim, dim), packed, 8)
+  return layer
 
 class TestMoEFeedForward(unittest.TestCase):
   def test_moe_feed_forward(self):
@@ -32,6 +44,46 @@ class TestMoEFeedForward(unittest.TestCase):
     # expected moe_output ≈ avg(silu(1), silu(3))
     expected = (Tensor([1.0]).silu().item() + Tensor([3.0]).silu().item()) / 2
     np.testing.assert_allclose(out.numpy()[0, 0, 0], expected, rtol=1e-2)
+
+  def test_quantized_expert_selection(self):
+    dim = 32
+    out = _q8_expert_layer()(Tensor([[[1, 3]]]), Tensor.ones(1, 1, 1, dim)).numpy()
+    expected = np.array([2, 4], dtype=np.float32).reshape(1, 1, 2, 1).repeat(dim, axis=-1) * dim
+    np.testing.assert_allclose(out, expected)
+
+  def test_quantized_expert_selection_symbolic_prefill(self):
+    dim, layer = 32, _q8_expert_layer()
+    sel_np = np.array([[[1, 3], [0, 2]]], dtype=np.int32)
+    toks = UOp.variable("toks", 1, 4).bind(2)
+    with patch("tinygrad.llm.model.ggml_data_to_tensor", wraps=ggml_data_to_tensor) as dequant:
+      out = layer(Tensor(sel_np)[:, :toks], Tensor.ones(1, 2, 1, dim)[:, :toks])[:, :2].numpy()
+    self.assertEqual(dequant.call_args.args[1], layer.num_experts * dim * dim)
+    expected = (sel_np + 1)[..., None].repeat(dim, axis=-1) * dim
+    np.testing.assert_allclose(out, expected)
+
+  def test_attach_quantized_experts_skips_unsupported_blocks(self):
+    expert = ExpertWeights(2, 32, 32)
+    blocks = [SimpleNamespace(ffn_gate_exps=expert)]
+    weight, packed = Tensor.zeros(2, 32, 32), Tensor.zeros(2 * 32 * 34, dtype=dtypes.uint8)
+    state_dict = {"blk.0.ffn_gate_exps.weight":weight, "blk.1.ffn_gate_exps.weight":weight, "blk.0.fake_exps.weight":weight}
+    with patch("tinygrad.llm.model.get_ggml_quantization", return_value=(packed, 8)):
+      packed_weights = _attach_quantized_experts(blocks, state_dict)
+    self.assertEqual(packed_weights, {"blk.0.ffn_gate_exps.weight"})
+    self.assertIs(state_dict["blk.0.ffn_gate_exps.weight"], expert.weight)
+    self.assertIs(state_dict["blk.1.ffn_gate_exps.weight"], weight)
+    self.assertIs(state_dict["blk.0.fake_exps.weight"], weight)
+
+  def test_iq3_xxs_expert_selection_ops(self):
+    num_experts, dim = 64, 256
+    packed = Tensor.zeros(num_experts * dim * dim // 256 * 98, dtype=dtypes.uint8).contiguous().realize()
+    layer = ExpertWeights(num_experts, dim, dim)
+    layer.set_quantized(ggml_data_to_tensor(packed, num_experts * dim * dim, 18).reshape(num_experts, dim, dim), packed, 18)
+    sel, x = Tensor([[[0, 63]]]).realize(), Tensor.ones(1, 1, 1, dim).realize()
+
+    GlobalCounters.reset()
+    out = layer(sel, x).realize()
+    self.assertLess(GlobalCounters.global_ops, 5_000_000)
+    np.testing.assert_equal(out.numpy(), 0)
 
   def test_moe_feed_forward_batched(self):
     dim, hidden, n_heads = 8, 16, 2

--- a/tinygrad/llm/gguf.py
+++ b/tinygrad/llm/gguf.py
@@ -1,7 +1,8 @@
-import functools, io, pathlib, re, struct
+import functools, io, pathlib, re, struct, weakref
 from typing import Any, Callable
 
 from tinygrad.tensor import Tensor
+from tinygrad.uop.ops import UOp
 from tinygrad.dtype import dtypes
 from tinygrad.helpers import prod, round_up
 from tinygrad.nn.state import TensorIO
@@ -19,6 +20,13 @@ _GGML_NATIVE = {0: dtypes.float32, 1: dtypes.float16, 24: dtypes.int8, 25: dtype
 # quant types {ggml_type: (number of elements, number of bytes)}
 _GGML_QUANT = {2:(32,18), 3:(32,20), 6:(32,22), 7:(32,24), 8:(32,34),
                12:(256,144), 13:(256,176), 14:(256,210), 18:(256,98), 21:(256,110), 22:(256,82), 23:(256,136), 39:(32,17), 41:(128,18)}
+
+_quantized_tensors: weakref.WeakKeyDictionary[UOp, tuple[UOp, int]] = weakref.WeakKeyDictionary()
+
+def get_ggml_quantization(tensor:Tensor) -> tuple[Tensor, int]|None:
+  if (meta:=_quantized_tensors.get(tensor.uop)) is None: return None
+  packed, ggml_type = meta
+  return Tensor(packed), ggml_type
 
 def ggml_data_to_tensor(t: Tensor, n: int, ggml_type: int) -> Tensor:
   """
@@ -145,7 +153,14 @@ def _gguf_parse(tensor: Tensor) -> tuple[dict, dict[str, Tensor]]:
   alignment, pos = kv_data.get("general.alignment", 32), r.tell()
   data_start = round_up(pos, alignment)
 
-  state_dict = {name: ggml_data_to_tensor(tensor[data_start + off:], prod(dims), typ).reshape(*reversed(dims)) for name, dims, typ, off in t_infos}
+  state_dict = {}
+  for name, dims, typ, off in t_infos:
+    n, shape = prod(dims), tuple(reversed(dims))
+    decoded = ggml_data_to_tensor(data:=tensor[data_start + off:], n, typ).reshape(*shape)
+    if typ in _GGML_QUANT:
+      block_size, type_size = _GGML_QUANT[typ]
+      _quantized_tensors[decoded.uop] = (data[:n//block_size*type_size].uop, typ)
+    state_dict[name] = decoded
   return kv_data, state_dict
 
 def _gguf_split_paths(path: pathlib.Path, kv: dict) -> list[pathlib.Path]:

--- a/tinygrad/llm/model.py
+++ b/tinygrad/llm/model.py
@@ -3,7 +3,8 @@ import enum, functools, itertools, pathlib
 from dataclasses import dataclass, replace
 from tinygrad import Tensor, nn, UOp, TinyJit, getenv, function, dtypes
 from tinygrad.nn import Linear
-from tinygrad.llm.gguf import gguf_load
+from tinygrad.llm.gguf import _GGML_QUANT, get_ggml_quantization, ggml_data_to_tensor, gguf_load
+from tinygrad.helpers import all_int
 from tinygrad.uop.ops import resolve
 
 class ExpertGating(enum.IntEnum):
@@ -21,10 +22,40 @@ def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0, device:str|
 class ExpertWeights:
   """Like Linear but with num_experts dimension. Weight shape: (num_experts, out_features, in_features)."""
   def __init__(self, num_experts:int, in_features:int, out_features:int):
+    self.num_experts, self.in_features, self.out_features = num_experts, in_features, out_features
     self.weight = Tensor.zeros(num_experts, out_features, in_features)
+    self.ggml_type:int|None = None
+  def set_quantized(self, weight:Tensor, packed:Tensor, ggml_type:int):
+    assert weight.shape == (self.num_experts, self.out_features, self.in_features)
+    assert self.out_features * self.in_features % _GGML_QUANT[ggml_type][0] == 0
+    self.weight, self.ggml_type = packed.flatten(), ggml_type
   def __call__(self, sel:Tensor, x:Tensor) -> Tensor:
     # sel: (B, T, k), x: (B, T, 1, in) or (B, T, k, in) -> output: (B, T, k, out)
-    return (x.unsqueeze(-2) @ self.weight[sel].transpose(-1, -2)).contiguous().squeeze(-2)
+    if self.ggml_type is None: weight = self.weight[sel]
+    elif all_int(sel.shape) or resolve(sel.shape[1] == 1):
+      packed = self.weight.reshape(self.num_experts, -1)[sel].flatten()
+      weight = ggml_data_to_tensor(packed, int(sel.numel()) * self.out_features * self.in_features, self.ggml_type).reshape(
+        *sel.shape, self.out_features, self.in_features)
+      if getenv("HALF", 1): weight = weight.cast('float16')
+    else:
+      weight = ggml_data_to_tensor(self.weight, self.num_experts * self.out_features * self.in_features, self.ggml_type).reshape(
+        self.num_experts, self.out_features, self.in_features)
+      if getenv("HALF", 1): weight = weight.cast('float16')
+      weight = weight[sel]
+    return (x.unsqueeze(-2) @ weight.transpose(-1, -2)).contiguous().squeeze(-2)
+
+def _attach_quantized_experts(blocks, state_dict:dict[str, Tensor]) -> set[str]:
+  packed_weights:set[str] = set()
+  for name, weight in state_dict.items():
+    parts = name.split('.')
+    if len(parts) != 4 or parts[0] != "blk" or parts[3] != "weight": continue
+    block_idx = int(parts[1])
+    if not 0 <= block_idx < len(blocks): continue
+    expert_weights = getattr(blocks[block_idx], parts[2], None)
+    if isinstance(expert_weights, ExpertWeights) and (quantization:=get_ggml_quantization(weight)) is not None:
+      expert_weights.set_quantized(weight, *quantization)
+      state_dict[name], packed_weights = expert_weights.weight, packed_weights | {name}
+  return packed_weights
 
 def apply_rope(x:Tensor, freqs_cis:Tensor) -> Tensor:
   assert x.shape[-1] % 2 == 0
@@ -372,9 +403,6 @@ class Transformer:
     # TODO: remove the need for copy to default device
     kv, state_dict = gguf_load(gguf.to(None).realize() if isinstance(gguf, Tensor) else gguf)
 
-    # all state items should be float16, not float32
-    state_dict = {k:v.cast('float16') if getenv("HALF", 1) else v for k,v in state_dict.items()}
-
     # some models like Llama 3.2 don't have an output.weight, they just tie to the token_embd.weight
     if 'output.weight' not in state_dict: state_dict['output.weight'] = state_dict['token_embd.weight']
 
@@ -443,6 +471,8 @@ class Transformer:
       qkv_bias='blk.0.attn_q.bias' in state_dict,
       expert_bias=f"blk.{kv.get(f'{arch}.leading_dense_block_count', 0)}.exp_probs_b.bias" in state_dict)
     model = Transformer(config)
+    packed_weights = _attach_quantized_experts(model.blk, state_dict)
+    state_dict = {k:v if k in packed_weights else v.cast('float16') if getenv("HALF", 1) else v for k,v in state_dict.items()}
     nn.state.load_state_dict(model, state_dict, verbose=False, consume=True, realize=False)  # NOTE: rope_freqs.weight (32,) is unused
     # NOTE: without this contiguous, it unpacks the weights from the model every time. we shouldn't need this, but for now it's faster
     if realize:


### PR DESCRIPTION
Fixes #17316

IQ3_XXS expert tensors were dequantized as a complete `(experts, out, in)` tensor before `ExpertWeights` selected the routed experts. Decode therefore expanded and read every expert even though only the top-k routes contributed to the output.

This preserves each GGUF tensor's packed storage metadata and attaches packed expert buffers to `ExpertWeights`. Static and single-token decode select packed expert slices before dequantization. Symbolic multi-token prefill keeps the previous full-tensor path, and packed attachment ignores truncated MTP blocks or unsupported expert-like state entries.

This should be merged because it removes the all-expert decode dequantization reported in #17316 while preserving output tokens and existing prefill behavior.

### Lambda H100 benchmark

Hardware: Lambda Cloud NVIDIA H100 80 GB HBM3, CUDA backend, driver 570.148.08  
Base: `0c5307b4f3c1ec301bae064120df2e27a7b0eb88`

```sh
REALIZE=0 DEV=CUDA python -m tinygrad.llm \
  -m Qwen3.6-35B-A3B-UD-IQ3_XXS.gguf \
  --max_context 256 --warmup --benchmark 10
```

Median of the final 9 steady-state samples:

| | ms/token | tok/s | reported MB/token | model memory |
|---|---:|---:|---:|---:|
| master | 222.23 | 4.50 | 83,525 | 14,937 MB |
| patched | 161.49 | 6.19 | 3,412 | 13,302 MB |

The patch reduced reported per-token traffic by **24.48x** and improved decode throughput by **1.38x**. All 10 generated token prefixes were identical. Lambda instances were terminated after collecting the logs.

### Validation

- `DEV=CPU python -m pytest test/null/test_attention.py test/unit/test_attention.py test/unit/test_gguf.py test/unit/test_llm_mla.py test/unit/test_llm_moe.py test/unit/test_llm_server.py -q -n 4` (`80 passed`)
- `python -m ruff check .`
- `python -m mypy tinygrad/`
- Synthetic IQ3_XXS expert test: 64-expert work fell from 34.9M ops to 2.69M ops with top-2 routing.

AI disclosure: I used an AI coding assistant to investigate, implement, validate, benchmark, and prepare this PR. I reviewed the code and all test and benchmark results.
