### PR TITLE
llm: support PrismML Q2 GGUF formats

### DIFF
--- a/test/unit/test_gguf.py
+++ b/test/unit/test_gguf.py
@@ -1,7 +1,8 @@
 import os, struct, unittest, tempfile, pathlib, sys
 from tinygrad import dtypes, Tensor, fetch, Device
-from tinygrad.helpers import disable_gc
+from tinygrad.helpers import disable_gc, round_up
 from tinygrad.llm.gguf import _ggml_iq_grid, ggml_data_to_tensor, gguf_load
+from tinygrad.llm.model import Transformer
 from tinygrad.runtime.autogen import ggml_common as _ggml
 import numpy as np
 from gguf import GGUFReader, GGUFValueType, GGMLQuantizationType, GGML_QUANT_SIZES, dequantize, quantize
@@ -106,10 +107,32 @@ class TestGGUF(unittest.TestCase):
 
   def test_dequantization_q1_0(self):
     # Q1_0: 2 bytes fp16 scale + 16 bytes (128 1-bit values)
-    block = np.frombuffer(np.float16(2.0).tobytes() + np.packbits(np.random.choice([0, 1], size=128)).tobytes(), dtype=np.uint8).copy()
+    block = np.frombuffer(np.float16(2.0).tobytes() + bytes(range(16)), dtype=np.uint8).copy()
     expected = np.float16(2.0) * (np.unpackbits(block[2:], bitorder="little").astype(np.int8) * 2 - 1)
     # TODO: replace 41 with GGMLQuantizationType.Q1_0.value on next gguf-py release
     np.testing.assert_equal(ggml_data_to_tensor(Tensor(block), 128, 41).numpy().flatten(), expected)
+
+  @staticmethod
+  def _q2_blocks(block_size, scales):
+    codes = np.arange(block_size, dtype=np.uint8) % 4
+    packed = (codes.reshape(-1, 4) * np.array([1, 4, 16, 64], dtype=np.uint8)).sum(1, dtype=np.uint8)
+    blocks = [np.frombuffer(np.float16(scale).tobytes() + packed.tobytes(), dtype=np.uint8) for scale in scales]
+    expected = np.concatenate([(codes.astype(np.int8) - 1) * scale for scale in scales]).astype(np.float32)
+    return np.concatenate(blocks), expected
+
+  def test_dequantization_q2_0(self):
+    for qtype, block_size in ((42, 64), (142, 128)):
+      with self.subTest(qtype=qtype):
+        blocks, expected = self._q2_blocks(block_size, (0.5, 2.0))
+        np.testing.assert_equal(ggml_data_to_tensor(Tensor(blocks), expected.size, qtype).numpy().flatten(), expected)
+
+  def test_q2_invalid_block_count(self):
+    with self.assertRaisesRegex(ValueError, "multiple of 64 elements"):
+      ggml_data_to_tensor(Tensor.empty(18, dtype=dtypes.uint8), 65, 42)
+    with self.assertRaisesRegex(ValueError, "multiple of 128 elements"):
+      ggml_data_to_tensor(Tensor.empty(34, dtype=dtypes.uint8), 64, 142)
+    with self.assertRaisesRegex(ValueError, "requires 18 bytes, got 17"):
+      ggml_data_to_tensor(Tensor.empty(17, dtype=dtypes.uint8), 64, 42)
 
   def test_expected_failure_unknown_type(self):
     with self.assertRaises(ValueError):
@@ -118,25 +141,87 @@ class TestGGUF(unittest.TestCase):
   @staticmethod
   def _build_gguf(tensors, kvs):
     # [header] [kv_data] [tensor_infos] [padding] [tensor_data_blob]
-    buf = bytearray()
+    buf, data_blob = bytearray(), bytearray()
+    alignment = next((v for k, v in kvs if k == "general.alignment"), 32)
+    infos = []
+    for name, dims, qtype, data in tensors:
+      data_off = round_up(len(data_blob), alignment)
+      data_blob += b"\x00" * (data_off - len(data_blob)) + data
+      infos.append((name, dims, qtype, data_off))
+    data_blob += b"\x00" * (round_up(len(data_blob), alignment) - len(data_blob))
     # Header: magic "GGUF" + version=3 + n_tensors + n_kv
     buf += struct.pack("<4siqq", b"GGUF", 3, len(tensors), len(kvs))
     # KV entries: [key_len: uint64][key bytes][type: int32][value]
     for k, v in kvs:
       kb = k.encode()
-      if isinstance(v, str): buf += struct.pack("<Q", len(kb)) + kb + struct.pack("<i", 8) + struct.pack("<Q", len(v)) + v.encode()
-      else: buf += struct.pack("<Q", len(kb)) + kb + struct.pack("<i", 4) + struct.pack("<I", v)
-    data_off = 0
+      buf += struct.pack("<Q", len(kb)) + kb
+      if isinstance(v, str): buf += struct.pack("<iQ", 8, len(v)) + v.encode()
+      elif isinstance(v, float): buf += struct.pack("<if", 6, v)
+      elif isinstance(v, list):
+        buf += struct.pack("<iiQ", 9, 8, len(v))
+        for x in v: buf += struct.pack("<Q", len(x)) + x.encode()
+      else: buf += struct.pack("<iI", 4, v)
     # Tensor infos: [name_len][name][ndims][dims reversed][qtype][offset_into_data_blob]
-    for name, dims, qtype, data in tensors:
+    for name, dims, qtype, data_off in infos:
       nb = name.encode()
       buf += struct.pack("<Q", len(nb)) + nb + struct.pack("<I", len(dims))
       for d in reversed(dims): buf += struct.pack("<Q", d)
-      buf += struct.pack("<i", qtype) + struct.pack("<Q", data_off)
-      data_off += len(data)
-    buf += b"\x00" * ((32 - len(buf) % 32) % 32)
-    for _, _, _, data in tensors: buf += data
+      buf += struct.pack("<iQ", qtype, data_off)
+    buf += b"\x00" * (round_up(len(buf), alignment) - len(buf)) + data_blob
     return bytes(buf)
+
+  def test_q2_legacy_g128_layout_inference(self):
+    large, large_expected = self._q2_blocks(128, [0.5] * 16)
+    small, small_expected = self._q2_blocks(128, [2.0])
+    blob = self._build_gguf([
+      ("large", (1, 2048), 42, large.tobytes()), ("small", (1, 128), 42, small.tobytes()),
+      ("tail", (1,), 0, np.array([1.0], dtype=np.float32).tobytes())], [])
+    _, tensors = gguf_load(Tensor(np.frombuffer(blob, dtype=np.uint8)))
+    np.testing.assert_equal(tensors["large"].numpy().flatten(), large_expected)
+    np.testing.assert_equal(tensors["small"].numpy().flatten(), small_expected)
+    pq2 = self._build_gguf([("pq2", (1, 128), 142, small.tobytes())], [])
+    np.testing.assert_equal(gguf_load(Tensor(np.frombuffer(pq2, dtype=np.uint8)))[1]["pq2"].numpy().flatten(), small_expected)
+
+  def test_q2_ambiguous_and_malformed_layouts(self):
+    q2, _ = self._q2_blocks(128, [1.0])
+    ambiguous = self._build_gguf([
+      ("q2", (1, 128), 42, q2.tobytes()), ("tail", (1,), 0, np.array([1.0], dtype=np.float32).tobytes())], [])
+    with self.assertRaisesRegex(ValueError, "type 42 has an ambiguous block layout"): gguf_load(Tensor(np.frombuffer(ambiguous, dtype=np.uint8)))
+    malformed = self._build_gguf([("q2", (1, 64), 142, q2[:18].tobytes())], [])
+    with self.assertRaisesRegex(ValueError, "type 142 tensor 'q2' has an invalid block layout"):
+      gguf_load(Tensor(np.frombuffer(malformed, dtype=np.uint8)))
+    bad_offset = bytearray(self._build_gguf([("x", (1,), 0, np.array([1.0], dtype=np.float32).tobytes())], []))
+    struct.pack_into("<Q", bad_offset, 49, 1)
+    with self.assertRaisesRegex(ValueError, "Invalid GGUF tensor offsets"): gguf_load(Tensor(np.frombuffer(bad_offset, dtype=np.uint8)))
+    bad_alignment = self._build_gguf([("x", (1,), 0, np.array([1.0], dtype=np.float32).tobytes())], [("general.alignment", 3)])
+    with self.assertRaisesRegex(ValueError, "Invalid GGUF alignment 3"): gguf_load(Tensor(np.frombuffer(bad_alignment, dtype=np.uint8)))
+
+  def test_prismml_qwen3_generation(self):
+    dim, hidden_dim, vocab_size = 128, 128, 16
+    def f16(shape, fill=0): return np.full(shape, fill, dtype=np.float16).tobytes()
+    tensors = [("token_embd.weight", (vocab_size, dim), 1, f16((vocab_size, dim))),
+      ("output_norm.weight", (dim,), 1, f16((dim,), 1)),
+      ("blk.0.attn_norm.weight", (dim,), 1, f16((dim,), 1)), ("blk.0.ffn_norm.weight", (dim,), 1, f16((dim,), 1)),
+      ("blk.0.attn_q.weight", (dim, dim), 1, f16((dim, dim))), ("blk.0.attn_k.weight", (dim, dim), 1, f16((dim, dim))),
+      ("blk.0.attn_v.weight", (dim, dim), 1, f16((dim, dim))), ("blk.0.attn_output.weight", (dim, dim), 1, f16((dim, dim))),
+      ("blk.0.ffn_gate.weight", (hidden_dim, dim), 1, f16((hidden_dim, dim))),
+      ("blk.0.ffn_up.weight", (hidden_dim, dim), 1, f16((hidden_dim, dim))),
+      ("blk.0.ffn_down.weight", (dim, hidden_dim), 1, f16((dim, hidden_dim)))]
+    kvs = [("general.architecture", "qwen3"), ("qwen3.context_length", 4), ("qwen3.block_count", 1),
+      ("qwen3.embedding_length", dim), ("qwen3.feed_forward_length", hidden_dim), ("qwen3.attention.head_count", 4),
+      ("qwen3.attention.head_count_kv", 4), ("qwen3.attention.layer_norm_rms_epsilon", 1e-5),
+      ("qwen3.rope.freq_base", 10000.0), ("tokenizer.ggml.tokens", [str(x) for x in range(vocab_size)])]
+    for label, qtype, block_size in (("binary", 41, 128), ("ternary", 42, 64)):
+      with self.subTest(label=label):
+        n = vocab_size * dim
+        if qtype == 41: quant = (np.float16(1).tobytes() + bytes([0xAA] * 16)) * (n // block_size)
+        else: quant = self._q2_blocks(block_size, [1.0] * (n // block_size))[0].tobytes()
+        blob = self._build_gguf(tensors + [("output.weight", (vocab_size, dim), qtype, quant)], kvs)
+        model, _ = Transformer.from_gguf(Tensor(np.frombuffer(blob, dtype=np.uint8)), max_context=4)
+        self.assertFalse(model.output.weight.uop.is_realized)
+        token = next(model.generate([0], chunk_size=1))
+        self.assertIsInstance(token, int)
+        self.assertIn(token, range(vocab_size))
 
   def test_multi_part_load(self):
     with tempfile.TemporaryDirectory() as d:

--- a/tinygrad/llm/gguf.py
+++ b/tinygrad/llm/gguf.py
@@ -18,7 +18,8 @@ _GGML_NATIVE = {0: dtypes.float32, 1: dtypes.float16, 24: dtypes.int8, 25: dtype
 
 # quant types {ggml_type: (number of elements, number of bytes)}
 _GGML_QUANT = {2:(32,18), 3:(32,20), 6:(32,22), 7:(32,24), 8:(32,34),
-               12:(256,144), 13:(256,176), 14:(256,210), 18:(256,98), 21:(256,110), 22:(256,82), 23:(256,136), 39:(32,17), 41:(128,18)}
+               12:(256,144), 13:(256,176), 14:(256,210), 18:(256,98), 21:(256,110), 22:(256,82), 23:(256,136), 39:(32,17),
+               41:(128,18), 42:(64,18), 142:(128,34)}
 
 def ggml_data_to_tensor(t: Tensor, n: int, ggml_type: int) -> Tensor:
   """
@@ -28,7 +29,8 @@ def ggml_data_to_tensor(t: Tensor, n: int, ggml_type: int) -> Tensor:
   int16 (id: 25), int32 (id: 26), int64 (id: 27), float64 (id: 28), bfloat16 (id: 30)
   Supported quantized types: Q4_0 (id: 2), Q4_1 (id: 3), Q5_0 (id: 6),
   Q5_1 (id: 7), Q8_0 (id: 8), Q4_K (id: 12), Q5_K (id: 13),
-  Q6_K (id: 14), IQ3_XXS (id: 18), IQ3_S (id: 21), IQ2_S (id: 22), IQ4_XS (id: 23), MXFP4 (id: 39), Q1_0 (id: 41)
+  Q6_K (id: 14), IQ3_XXS (id: 18), IQ3_S (id: 21), IQ2_S (id: 22), IQ4_XS (id: 23), MXFP4 (id: 39),
+  Q1_0 (id: 41), Q2_0 g64 (id: 42), Q2_0 g128 (id: 142)
   """
   # https://github.com/ggerganov/ggml/blob/323951f1bdcdfbd5b5ff3a9a7c3770e63b1a560e/include/ggml.h#L356
 
@@ -42,7 +44,10 @@ def ggml_data_to_tensor(t: Tensor, n: int, ggml_type: int) -> Tensor:
 
   if (nelements_nbytes := _GGML_QUANT.get(ggml_type)) is not None:
     from tinygrad.runtime.autogen import ggml_common as _ggml
-    blocks = t[:(n//nelements_nbytes[0])*nelements_nbytes[1]].reshape((-1, nelements_nbytes[1])).contiguous()
+    if n % nelements_nbytes[0]: raise ValueError(f"GGML type '{ggml_type}' requires a multiple of {nelements_nbytes[0]} elements, got {n}")
+    nbytes = (n//nelements_nbytes[0]) * nelements_nbytes[1]
+    if t.numel() < nbytes: raise ValueError(f"GGML type '{ggml_type}' requires {nbytes} bytes, got {t.numel()}")
+    blocks = t[:nbytes].reshape((-1, nelements_nbytes[1])).contiguous()
     if ggml_type == 2: return (q_to_uint8(blocks[:,2:], 4).bitcast(dtypes.int8) - 8) * blocks[:,:2].bitcast(dtypes.float16).cast(dtypes.float32)
     if ggml_type == 3:
       d, m = (blocks[:,s:s+2].bitcast(dtypes.float16).cast(dtypes.float32) for s in [ 0, 2 ])
@@ -116,6 +121,10 @@ def ggml_data_to_tensor(t: Tensor, n: int, ggml_type: int) -> Tensor:
       d = blocks[:,:2].bitcast(dtypes.float16)
       bits = q_to_uint8(blocks[:,2:], 1).reshape(-1, 8, 16).transpose(-1, -2).flatten(-2).bitcast(dtypes.int8)
       return d * (bits * 2 - 1)
+    if ggml_type in (42, 142):
+      d = blocks[:,:2].bitcast(dtypes.float16)
+      q = q_to_uint8(blocks[:,2:], 2).reshape(-1, 4, nelements_nbytes[1]-2).transpose(-1, -2).flatten(-2).bitcast(dtypes.int8)
+      return d * (q - 1)
   raise ValueError(f"GGML type '{ggml_type}' is not supported!")
 
 def _read_unpack(fmt: str, n: int, r:io.BufferedIOBase): return struct.unpack(fmt, r.read(n))[0]
@@ -129,7 +138,7 @@ readers: dict[int, Callable[[io.BufferedIOBase], Any]] = { 8: read_str, 9: read_
     [ (0,"c",1), (1,"b",1), (2,"H",2), (3,"h",2), (4,"I",4), (5,"i",4), (6,"f",4), (7,"?",1), (10,"Q",8), (11,"q",8), (12,"d",8) ] } }
 read_uint32, read_int32, read_uint64, read_int64 = readers[4], readers[5], readers[10], readers[11]
 
-def _gguf_parse(tensor: Tensor) -> tuple[dict, dict[str, Tensor]]:
+def _gguf_parse(tensor: Tensor, q2_type:int|None=None) -> tuple[dict, dict[str, Tensor], int|None]:
   # TODO: remove the need for copy to default device
   tensor = tensor.to(None).realize()
   r = io.BufferedReader(TensorIO(tensor), 1_000_000)
@@ -143,10 +152,32 @@ def _gguf_parse(tensor: Tensor) -> tuple[dict, dict[str, Tensor]]:
 
   t_infos = [ (read_str(r), tuple(read_uint64(r) for _ in range(read_uint32(r))), read_int32(r), read_uint64(r)) for _ in range(n_tensors) ]
   alignment, pos = kv_data.get("general.alignment", 32), r.tell()
+  if alignment <= 0 or alignment & (alignment-1): raise ValueError(f"Invalid GGUF alignment {alignment}")
   data_start = round_up(pos, alignment)
 
+  ordered, data_size = sorted(t_infos, key=lambda x:x[3]), tensor.numel()-data_start
+  if data_size < 0 or any(off % alignment or off >= data_size for _, _, _, off in ordered) \
+     or any(a[3] >= b[3] for a, b in zip(ordered, ordered[1:])): raise ValueError("Invalid GGUF tensor offsets")
+  spans = {info[3]: ((ordered[i+1][3] if i+1 < len(ordered) else data_size) - info[3], i+1 == len(ordered))
+           for i, info in enumerate(ordered)}
+  def matches_layout(dims:tuple[int, ...], off:int, block_size:int, type_size:int) -> bool:
+    if not dims or dims[0] % block_size: return False
+    span, is_last = spans[off]
+    nbytes = prod(dims) // block_size * type_size
+    return span in ({nbytes, round_up(nbytes, alignment)} if is_last else {round_up(nbytes, alignment)})
+  for name, dims, typ, off in t_infos:
+    if typ in (41, 142) and not matches_layout(dims, off, *_GGML_QUANT[typ]):
+      raise ValueError(f"GGML type {typ} tensor {name!r} has an invalid block layout")
+  if any(typ == 42 for _, _, typ, _ in t_infos):
+    layouts = {qtype for qtype in (42, 142) if all(typ != 42 or matches_layout(dims, off, *_GGML_QUANT[qtype])
+               for _, dims, typ, off in t_infos)}
+    if q2_type is not None: layouts &= {q2_type}
+    if len(layouts) != 1: raise ValueError(f"GGML type 42 has an {'ambiguous' if layouts else 'invalid'} block layout")
+    q2_type = layouts.pop()
+    t_infos = [(name, dims, q2_type if typ == 42 else typ, off) for name, dims, typ, off in t_infos]
+
   state_dict = {name: ggml_data_to_tensor(tensor[data_start + off:], prod(dims), typ).reshape(*reversed(dims)) for name, dims, typ, off in t_infos}
-  return kv_data, state_dict
+  return kv_data, state_dict, q2_type
 
 def _gguf_split_paths(path: pathlib.Path, kv: dict) -> list[pathlib.Path]:
   if (total := kv.get('split.count', 1)) <= 1: return [path]
@@ -169,8 +200,10 @@ def gguf_load(fn: Tensor|str|pathlib.Path) -> tuple[dict, dict[str, Tensor]]:
 
   NOTE: The provided tensor must be on a device that supports execution.
   """
-  kv, sd = _gguf_parse(fn if isinstance(fn, Tensor) else Tensor(pathlib.Path(fn)))
+  kv, sd, q2_type = _gguf_parse(fn if isinstance(fn, Tensor) else Tensor(pathlib.Path(fn)))
   if kv.get('split.count', 1) <= 1: return kv, sd
   if isinstance(fn, Tensor): raise ValueError("multi-part GGUF requires a path argument (got Tensor)")
-  for pp in _gguf_split_paths(pathlib.Path(fn), kv)[1:]: sd.update(_gguf_parse(Tensor(pp))[1])
+  for pp in _gguf_split_paths(pathlib.Path(fn), kv)[1:]:
+    _, part_sd, q2_type = _gguf_parse(Tensor(pp), q2_type)
+    sd.update(part_sd)
   return kv, sd


### PR DESCRIPTION
Fixes #17609

PrismML's published ternary GGUFs use three Q2 encodings: standard type 42 g64, legacy type 42 g128, and type 142 g128. Tinygrad currently rejects all of them because type 42 and type 142 are absent from the quantization table.

This adds the Q2 decoder for the standard g64 and g128 block layouts. Because legacy g128 reused type 42, the loader compares aligned tensor spans across the file and accepts type 42 only when one layout is uniquely identified. Ambiguous, malformed, mixed, misaligned, or inconsistent multipart layouts fail explicitly instead of being silently decoded with the wrong block size. Existing Q1 g128 files receive the same block-layout validation.

This should be merged because it enables the current binary and ternary PrismML Bonsai GGUF families through the existing Qwen3/Qwen3.5 model paths, while failing closed around the historical type-ID collision. Dequantization stays lazy and does not create a persistent full-precision weight copy.

### Validation

- `DEV=CPU python -m pytest test/null/test_attention.py test/null/test_llm_server.py test/null/test_llm_tokenizer.py test/unit/test_attention.py test/unit/test_gguf.py test/unit/test_llm_mla.py test/unit/test_llm_moe.py test/unit/test_llm_server.py -q -n 4` (`112 passed`, plus 4 parameterized subtests)
- `python -m ruff check .`
- `python -m mypy tinygrad/`
- Exact block tests cover Q1 g128, Q2 g64/type 42, and Q2 g128/type 142, including code `3 -> 2*scale`.
- Synthetic Qwen3 GGUFs generate one token with both binary Q1 and ternary Q2 output weights while asserting the quantized weight graph remains unrealized before inference.
- HTTP-range headers from the four 1.7B releases were checked against the loader without downloading model payloads: Q1 g128, legacy type-42 g128, type-42 g64, and type-142 g128 all parsed 310 tensors successfully. The two type-42 files each had 197 quantized tensors and produced a unique file-wide layout classification.

AI disclosure: I used an AI coding assistant to research the published PrismML formats, inspect tinygrad's loader, implement and test the change, review edge cases, and prepare this PR. I reviewed the code and all validation results.
