### PR TITLE
Schedule DISK tensor assignments lazily

### DIFF
--- a/examples/mlperf/dataloader.py
+++ b/examples/mlperf/dataloader.py
@@ -353,6 +353,7 @@ def load_retinanet_data(base_dir:Path, val:bool, queue_in:Queue, queue_out:Queue
   while (data:=queue_in.get()) is not None:
     idx, img, tgt = data
     img = image_load(base_dir, img["subset"], img["file_name"])
+    writes:list[Tensor] = []
 
     if val:
       img = resize(img)[0]
@@ -369,12 +370,11 @@ def load_retinanet_data(base_dir:Path, val:bool, queue_in:Queue, queue_out:Queue
       clipped_match_idxs = np.clip(match_idxs, 0, None)
       clipped_boxes, clipped_labels = tgt["boxes"][clipped_match_idxs], tgt["labels"][clipped_match_idxs]
 
-      boxes[idx].flatten().assign(clipped_boxes.tobytes())
-      labels[idx].flatten().assign(clipped_labels.tobytes())
-      matches[idx].flatten().assign(match_idxs.tobytes())
-      anchors[idx].flatten().assign(anchor.tobytes())
+      writes += [boxes[idx].flatten().assign(clipped_boxes.tobytes()), labels[idx].flatten().assign(clipped_labels.tobytes()),
+                 matches[idx].flatten().assign(match_idxs.tobytes()), anchors[idx].flatten().assign(anchor.tobytes())]
 
-    imgs[idx].flatten().assign(img.tobytes())
+    writes.append(imgs[idx].flatten().assign(img.tobytes()))
+    Tensor.realize(*writes)
 
     queue_out.put(idx)
   queue_out.put(None)

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -316,6 +316,14 @@ class TestDiskTensor(TempDirTestCase):
     dt.assign(Tensor.full((4,), 42, dtype=dtypes.int32)).realize()
     np.testing.assert_array_equal(dt.numpy(), [42, 42, 42, 42])
 
+  def test_assign_to_disk_is_lazy(self):
+    fn = pathlib.Path(self.tmp("dt_assign_lazy"))
+    dt = Tensor.empty(4, device=f"disk:{fn}", dtype=dtypes.int32)
+    dt.assign(42)
+    self.assertFalse(fn.exists())
+    dt.realize()
+    np.testing.assert_array_equal(dt.numpy(), [42, 42, 42, 42])
+
   def test_assign_slice_from_const(self):
     # slice assign from CONST to disk - tests size calculation when no RANGE ops
     dt = Tensor([0, 1, 2, 3], dtype=dtypes.int32).to(f"disk:{self.tmp('dt_slice_const')}")
@@ -323,11 +331,21 @@ class TestDiskTensor(TempDirTestCase):
     np.testing.assert_array_equal(dt.numpy(), [0, 99, 99, 3])
 
   def test_disk_to_disk_copy(self):
-    # disk-to-disk copy needs to go through CPU
     src = Tensor([1, 2, 3, 4], dtype=dtypes.int32).to(f"disk:{self.tmp('dt_d2d_src')}")
     dst = Tensor.empty(4, device=f"disk:{self.tmp('dt_d2d_dst')}", dtype=dtypes.int32)
-    dst.assign(src.to("CPU")).realize()
+    dst.assign(src).realize()
     np.testing.assert_array_equal(dst.numpy(), [1, 2, 3, 4])
+
+    sliced_dst = Tensor.empty(2, device=f"disk:{self.tmp('dt_d2d_sliced_dst')}", dtype=dtypes.int32)
+    sliced_dst.assign(src[1:3]).realize()
+    np.testing.assert_array_equal(sliced_dst.numpy(), [2, 3])
+    np.testing.assert_array_equal(src.numpy(), [1, 2, 3, 4])
+
+    pending_src = Tensor.empty(4, device=f"disk:{self.tmp('dt_d2d_pending_src')}", dtype=dtypes.int32).assign([1, 2, 3, 4])
+    pending_dst = Tensor.empty(2, device=f"disk:{self.tmp('dt_d2d_pending_dst')}", dtype=dtypes.int32)
+    pending_dst.assign(pending_src[1:3]).realize()
+    np.testing.assert_array_equal(pending_dst.numpy(), [2, 3])
+    np.testing.assert_array_equal(pending_src.numpy(), [1, 2, 3, 4])
 
   def test_assign_slice(self):
     def assign(x,s,y): x[s] = y

--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -82,7 +82,7 @@ def safe_save(tensors:dict[str, Tensor], fn:str, metadata:dict[str, Any]|None=No
   t = Tensor.empty(8+len(j)+offset, dtype=dtypes.uint8, device=f"disk:{fn}")
   t[0:8].bitcast(dtypes.int64).assign([len(j)])
   t[8:8+len(j)].assign(list(j.encode('utf-8')))
-  for k,v in safe_load(t).items(): v.assign(tensors[k])
+  for k,v in safe_load(t).items(): v.assign(tensors[k]).realize()
 
 # tinyfs
 

--- a/tinygrad/schedule/__init__.py
+++ b/tinygrad/schedule/__init__.py
@@ -142,9 +142,17 @@ def assert_all_same_devices(ast:UOp):
   devices = dedup([x.device for x in ast.toposort() if x.op is Ops.PARAM and x.device is not None])
   if len(devices) >= 2: raise RuntimeError(f"all buffers must be on the same device: {devices}")
 
-def copy_kernel_to_copy_uop(call:UOp, dst:UOp, src:UOp, r:UOp|None=None):
+def copy_kernel_to_copy_uop(call:UOp, dst:UOp, src:UOp, r:UOp|None=None,
+                            dst_offset:UOp|None=None, src_offset:UOp|None=None):
   if dst.device == src.device and not (isinstance(dst.device, str) and dst.device.startswith("DISK")): return None
-  return call.replace(src=(UOp(Ops.COPY, src=(src,), arg=dst.device),) + call.src[1:])
+  call_src, size = list(call.src), r.src[0] if r is not None else 1
+  if dst_offset is not None or (r is not None and dst.shape != src.shape):
+    start = dst_offset.val if dst_offset is not None else 0
+    call_src[dst.arg.slot+1] = call_src[dst.arg.slot+1].shrink(((start, start+size),))
+  if src_offset is not None:
+    start = src_offset.val
+    call_src[src.arg.slot+1] = call_src[src.arg.slot+1].shrink(((start, start+size),))
+  return call.replace(src=(UOp(Ops.COPY, src=(src,), arg=dst.device), *call_src[1:]))
 
 def simplify_copy_kernel(call:UOp, ast:UOp, dst:UOp, src:UOp):
   # NOTE: this is a codegen for SDMA devices
@@ -160,11 +168,23 @@ pm_copy_from_store = PatternMatcher([
   (UPat(Ops.CALL, src=(UPat(Ops.SINK, name="ast"), UPat.var("dst"), UPat.var("src")), name="call"), simplify_copy_kernel),
 
   # replace this with a copy if it's a copy
-  (UPat(Ops.CALL, src=(UPat(Ops.PARAM, name="dst").index(UPat(Ops.CONST, arg=0))
-                .store(UPat(Ops.PARAM, name="src").index(UPat(Ops.CONST, arg=0))).sink(),),
+  (UPat(Ops.CALL, src=(UPat(Ops.PARAM, name="dst").index(UPat(Ops.CONST, name="dst_offset"))
+                .store(UPat(Ops.PARAM, name="src").index(UPat(Ops.CONST, name="src_offset"))).sink(),),
                 name="call", allow_any_len=True), copy_kernel_to_copy_uop),
   (UPat(Ops.CALL, src=(UPat(Ops.PARAM, name="dst").index(UPat(Ops.RANGE, name="r"))
                 .store(UPat(Ops.PARAM, name="src").index(UPat(Ops.RANGE, name="r"))).end(UPat(Ops.RANGE, name="r")).sink(),),
+                name="call", allow_any_len=True), copy_kernel_to_copy_uop),
+  (UPat(Ops.CALL, src=(UPat(Ops.PARAM, name="dst").index(UPat(Ops.ADD, src=(UPat(Ops.RANGE, name="r"),
+                  UPat(Ops.CONST, name="dst_offset"))))
+                .store(UPat(Ops.PARAM, name="src").index(UPat(Ops.RANGE, name="r"))).end(UPat(Ops.RANGE, name="r")).sink(),),
+                name="call", allow_any_len=True), copy_kernel_to_copy_uop),
+  (UPat(Ops.CALL, src=(UPat(Ops.PARAM, name="dst").index(UPat(Ops.ADD, src=(UPat(Ops.RANGE, name="r"),
+                  UPat(Ops.CONST, name="dst_offset"))))
+                .store(UPat(Ops.PARAM, name="src").index(UPat(Ops.RANGE, name="r")).bitcast()).end(UPat(Ops.RANGE, name="r")).sink(),),
+                name="call", allow_any_len=True), copy_kernel_to_copy_uop),
+  (UPat(Ops.CALL, src=(UPat(Ops.PARAM, name="dst").index(UPat(Ops.RANGE, name="r"))
+                .store(UPat(Ops.PARAM, name="src").index(UPat(Ops.ADD, src=(UPat(Ops.RANGE, name="r"),
+                  UPat(Ops.CONST, name="src_offset"))))).end(UPat(Ops.RANGE, name="r")).sink(),),
                 name="call", allow_any_len=True), copy_kernel_to_copy_uop),
 
   # if it wasn't copy, it currently can't be cross device

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -33,10 +33,11 @@ def tag_uop(ctx:AllocCtx, x:UOp):
 def disk_like(u:UOp): return isinstance(u.device, str) and u.device.startswith(("DISK", "TINYFS"))
 
 def disk_copy_is_buffer(ctx:AllocCtx, u:UOp):
-  # copies to disk are replaced with the disk buffer
+  # copies to disk are replaced with an explicit write to the disk buffer
   if disk_like(u) and u.tag is None:
-    ctx.buffer_map[u] = u.empty_like()
-    return u.rtag(())
+    ctx.buffer_map[u] = buf = u.empty_like()
+    src = u.src[0] if u.src[0].has_buffer_identity(after_ok=True) else u.src[0].contiguous()
+    return buf.after(buf.store(src)).rtag(())
   # all copies from disk/numpy are realized into a real buffer
   from_creation = isinstance(u.src[0].device, str) and u.src[0].device.startswith(("NPY", "DISK", "PYTHON", "TINYFS"))
   if from_creation: return tag_uop(ctx, u)
@@ -46,7 +47,8 @@ add_tags = PatternMatcher([
   (UPat(Ops.COPY, name="u"), disk_copy_is_buffer),
   # no tag on copies that are assigned via STORE+AFTER — merge COPY tag into AFTER
   (UPat(Ops.AFTER, src=(UPat(), UPat(Ops.STORE, src=(UPat(name="dest"), UPat(Ops.COPY, name="c")))), name="a"),
-   lambda a,c,dest: a.replace(src=(a.src[0], a.src[1].replace(src=(dest, c.rtag(())))), tag=a.tag+c.tag) if a.tag and c.tag else None),
+   lambda a,c,dest: a.replace(src=(a.src[0], a.src[1].replace(src=(dest, c.rtag(())))), tag=a.tag+c.tag)
+   if a.tag and c.tag and not disk_like(dest) else None),
   (UPat((Ops.CONTIGUOUS, Ops.AFTER), name="x"), tag_uop),
   (UPat(GroupOp.All, name="x"), lambda ctx,x: tag_uop(ctx,x) if x in ctx.bases else None),
 ])
@@ -151,7 +153,8 @@ pm_early_transform_tensor_graph = PatternMatcher([
 
   # fold MOPS+BITCAST over BUFFER into SHRINK when movement ops collapse to contiguous range
   (UPat((Ops.COPY, Ops.CONTIGUOUS), src=(UPat(GroupOp.Movement|{Ops.BITCAST}, name="src"),), name="c"), contiguous_mops_to_view),
-  (UPat(Ops.STORE, src=(UPat(Ops.BITCAST, name="src"), UPat()), name="c", allow_any_len=True), contiguous_mops_to_view),
+  (UPat(Ops.STORE, src=(UPat(GroupOp.Movement|{Ops.BITCAST}, name="src"), UPat()), name="c", allow_any_len=True),
+   lambda ctx,c,src: contiguous_mops_to_view(ctx, c, src) if src.op is Ops.BITCAST or disk_like(src) else None),
 
   # remove contiguous on movement ops before a copy on disk
   (UPat(GroupOp.Movement-{Ops.SHRINK, Ops.RESHAPE}, name="x").f(Ops.CONTIGUOUS).f(Ops.COPY, name="copy"), lambda x,copy:
@@ -446,18 +449,30 @@ class Tensor(RandMixin):
       raise RuntimeError(f"assign device mismatch {self.device} != {x.device}")
     if isinstance(self.device, tuple) and x.uop.device is not None and self.uop.axis != x.uop.axis:
       raise RuntimeError(f"multi axis mismatch {self.uop.axis} != {x.uop.axis}")
-
-    # TODO: this is a hack for writing to DISK. remove with working assign
-    if is_disk:
+    if isinstance(self.device, str) and self.device.startswith("TINYFS"):
+      # TINYFS writes are RPCs that return content hashes, not schedulable stores.
       (b:=self._buffer()).copy_from(Buffer("PYTHON", b.size, b.dtype, opaque=x._data()))
       return self
+    xb = x.uop
+    while xb.op in GroupOp.Movement|{Ops.BITCAST, Ops.DETACH}: xb = xb.src[0]
+    if is_disk and xb.op is Ops.AFTER:
+      # snapshot pending source state before taking a DISK subbuffer, which would otherwise alias the source file
+      Tensor(xb).realize()
+      x = x.contiguous()
+    elif is_disk and not x.uop.has_buffer_identity(after_ok=True): x = x.clone("CPU") if x.uop.is_virtual else x.contiguous()
+    if is_disk:
+      base = self.uop
+      while base.op in GroupOp.Movement|{Ops.BITCAST}: base = base.src[0]
+      check_uop = self.uop.substitute({base:base.empty_like()}, walk=True) if base.op is Ops.COPY and disk_like(base) else self.uop
+      if check_uop.contiguous_view() is None: raise RuntimeError("non-contiguous view is not supported")
+
     # STORE+AFTER: STORE is the write effect (void), AFTER wraps the view for correct shape/ranging
     assign = self.uop.after(self.uop.store(x.uop))
     ib = self.uop
     while not ib.has_buffer_identity() and ib.op in GroupOp.Movement|{Ops.BITCAST, Ops.DETACH}: ib = ib.src[0]
-    if ib is not self.uop and ib.has_buffer_identity(after_ok=True):
+    if ib is not self.uop and (ib.has_buffer_identity(after_ok=True) or disk_like(ib)):
       # view assign: replace at the buffer-identity level (e.g. RESHAPE(BUFFER)) so @function's substitution catches it
-      _apply_map_to_tensors({ib: ib.after(assign)}, name="Embed View Assign")
+      _apply_map_to_tensors({ib: ib.after(assign.src[1] if disk_like(ib) else assign)}, name="Embed View Assign")
     else:
       # simple assign
       self.uop = assign


### PR DESCRIPTION
## Problem

`Tensor.assign` has a DISK-specific escape hatch that immediately calls `_buffer()` and copies bytes from `x._data()`. That makes assignment eager, bypasses the normal `STORE+AFTER` graph, and prevents multiple DISK writes from being scheduled together.

This is especially visible when assigning into a new DISK tensor: the backing file is created and populated during `assign(...)` rather than when the tensor is realized.

## Solution

Route DISK assignment through the normal lazy tensor graph and teach scheduling how to preserve the existing DISK behaviors:

- Represent copies to DISK as an explicit buffer write (`BUFFER.after(BUFFER.store(...))`) during callification.
- Keep DISK view assignments embedded at buffer identity so updates propagate to the owning tensor.
- Materialize virtual or computed cross-device sources before the DISK copy boundary.
- Recognize scalar and ranged stores with destination offsets as copies, passing a narrowed destination subbuffer to the COPY runtime.
- Preserve byte-contiguous bitcast views, including narrowing bitcasts used by serialized file formats.
- Reject non-contiguous DISK writes as before.
- Explicitly realize the accumulated writes at the end of `safe_save`, now that assignment is intentionally lazy.
- Retain the eager TINYFS path because TINYFS writes are RPCs that return content hashes rather than ordinary schedulable stores.

With this change, `assign(...)` itself no longer creates the DISK file; `realize()` or a read executes the scheduled writes.

## Coverage

Regression coverage now verifies:

- DISK assignment remains lazy until realization.
- Constant, scalar, slice, offset, and cross-device assignments.
- Direct DISK-to-DISK assignment, including sliced sources.
- Widening and narrowing bitcast views.
- Existing non-contiguous-write rejection.
- Safetensor writes across supported dtypes.
- Existing TINYFS round trips.

## Verification

```text
DEV=CPU python -m pytest -n12 -q \
  test/unit/test_disk_tensor.py::TestRawDiskBuffer::test_bitcasts_on_disk \
  test/unit/test_disk_tensor.py::TestDiskTensor \
  test/unit/test_disk_tensor.py::TestSafetensors::test_metadata \
  test/unit/test_disk_tensor.py::TestSafetensors::test_safe_save_only_copy \
  test/unit/test_disk_tensor.py::TestSafetensors::test_save_all_dtypes \
  test/unit/test_assign.py \
  test/unit/test_tinyfs.py
# 137 passed, 8 skipped, 1 xfailed

DEV=CPU python -m pytest -n12 -q \
  test/null/test_schedule.py \
  test/backend/test_schedule.py \
  test/backend/test_rangeify.py \
  -k 'not test_conv2d_half'
# 331 passed, 38 skipped, 6 xfailed

python -m pytest -q test/null/test_schedule.py::TestSchedule::test_conv2d_half
# 1 passed

python -m ruff check .
# All checks passed

python -m mypy tinygrad/
# Success: no issues found in 214 source files
```

Closes #10400
