### PR TITLE
amd: use current ASM2464PD USB VID

### DIFF
--- a/test/unit/test_amd_usb.py
+++ b/test/unit/test_amd_usb.py
@@ -1,0 +1,19 @@
+import pytest
+
+from tinygrad.runtime import ops_amd
+
+
+def test_usb_iface_discovers_current_vid(monkeypatch):
+  calls = []
+
+  def list_devices(vid, pid):
+    calls.append((vid, pid))
+    return [(object(), "current")]
+
+  monkeypatch.setattr(ops_amd.USB3, "list_devices", staticmethod(list_devices))
+  monkeypatch.setattr(ops_amd, "hcq_filter_visible_devices", lambda visible, _prefix: visible)
+
+  with pytest.raises(RuntimeError, match=r"AMD:1 does not exist \(1 device available\)"):
+    ops_amd.USBIface(None, 1)
+
+  assert calls == [(0x3801, 0x0001)]

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -910,7 +910,7 @@ class PCIIface(PCIIfaceBase):
 
 class USBIface(PCIIface):
   def __init__(self, dev, dev_id): # pylint: disable=super-init-not-called
-    if dev_id >= len(visible:=hcq_filter_visible_devices(USB3.list_devices(0xADD1, 0x0001), "AMD")):
+    if dev_id >= len(visible:=hcq_filter_visible_devices(USB3.list_devices(0x3801, 0x0001), "AMD")):
       raise RuntimeError(f"AMD:{dev_id} does not exist ({pluralize('device', len(visible))} available)")
     self.dev, self.pci_dev, self.vram_bar, self.count = dev, USBPCIDevice("AM", *visible[dev_id]), 0, len(visible)
     self.dev_impl = AMDev(self.pci_dev)


### PR DESCRIPTION
The ASM2464PD firmware changed its USB VID from `0xADD1` to `0x3801` in tinygrad/asm2464pd-firmware#76, but the AMD USB interface still searched for the old VID.

Use `0x3801:0x0001` for device discovery and add a unit test for it.

Tested with:

- `python3 -m pytest test/unit/test_amd_usb.py -q`
- `ruff check tinygrad/runtime/ops_amd.py test/unit/test_amd_usb.py`
- `DEBUG=2 PYTHONPATH=. DEV=USB+AMD python3 test/test_tiny.py TestTiny.test_plus` on an Arch Linux host with a `3801:0001` ASM2464PD device
