### PR TITLE
benchmarks: mac usbgpu nvrtc test

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -452,10 +452,8 @@ jobs:
       run: PYTHONPATH=. sh extra/setup_tinygpu_osx.sh
     - name: UsbGPU (USB4/TB) boot time
       run: PYTHONPATH=. DEBUG=3 DEV=PCI+NV:NAK time python3.11 test/test_tiny.py TestTiny.test_plus
-    - name: UsbGPU (USB4/TB) tiny tests (NAK)
+    - name: UsbGPU (USB4/TB) tiny tests
       run: PYTHONPATH=. DEV=PCI+NV:NAK python3.11 test/test_tiny.py
-    - name: UsbGPU (USB4/TB) tiny tests (NVRTC)
-      run: PYTHONPATH=. DEV=PCI+NV:CUDA python3.11 test/test_tiny.py
 
   testcommalatest:
     name: comma Benchmark (0.11.2)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -452,8 +452,10 @@ jobs:
       run: PYTHONPATH=. sh extra/setup_tinygpu_osx.sh
     - name: UsbGPU (USB4/TB) boot time
       run: PYTHONPATH=. DEBUG=3 DEV=PCI+NV:NAK time python3.11 test/test_tiny.py TestTiny.test_plus
-    - name: UsbGPU (USB4/TB) tiny tests
+    - name: UsbGPU (USB4/TB) tiny tests (NAK)
       run: PYTHONPATH=. DEV=PCI+NV:NAK python3.11 test/test_tiny.py
+    - name: UsbGPU (USB4/TB) tiny tests (NVRTC)
+      run: PYTHONPATH=. DEV=PCI+NV:CUDA python3.11 test/test_tiny.py
 
   testcommalatest:
     name: comma Benchmark (0.11.2)

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -144,6 +144,33 @@ jobs:
     - name: Run process replay tests
       uses: ./.github/actions/process-replay
 
+  testmacoscompile:
+    strategy:
+      fail-fast: false
+      matrix:
+        dev:
+          - 'NULL:CUDA:sm_120'
+    name: Compile-only (DEV=${{ matrix.dev }}, macos)
+    runs-on: macos-26
+    timeout-minutes: 15
+    env:
+      NULL_ALLOW_COPYOUT: 1
+      DEV: ${{ matrix.dev }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Setup Environment
+        uses: ./.github/actions/setup-tinygrad
+        with:
+          key: compile-${{ matrix.backend }}
+          deps: "testing_unit"
+      - name: Run test_ops
+        shell: bash
+        run: |
+          python -c "from tinygrad import Device; assert Device.DEFAULT == 'NULL'"
+          DEBUG=4 python3 test/backend/test_ops.py TestOps.test_add
+          python -m pytest -n=auto test/backend/test_ops.py --durations=20
+
 # ****** Windows Tests ******
 
   testwindows:


### PR DESCRIPTION
should really be `MOCK+NV:CUDA` in the macos matrix, but cuda 12 doesn't work with ocelot