### PR TITLE
buffers and args supported in any input order on all backends

### DIFF
--- a/test/backend/test_arg_order.py
+++ b/test/backend/test_arg_order.py
@@ -1,0 +1,114 @@
+import unittest
+from tinygrad import Tensor, Device, UOp, TinyJit, Variable
+from tinygrad.dtype import dtypes, AddrSpace
+from tinygrad.uop.ops import KernelInfo
+from tinygrad.codegen import to_program
+
+def _alu(slot:int, name:str) -> UOp:
+  return UOp.param(slot, dtypes.int, (), name=name, addrspace=AddrSpace.ALU)
+
+def _buf(slot:int, n:int=1) -> UOp:
+  return UOp.param(slot, dtypes.int, (n,))
+
+def _launch(sink:UOp, bufs:list[Tensor], vals:tuple[int, ...]=()):
+  elf = to_program(sink, Device[Device.DEFAULT].renderer).to_elf()
+  Device[Device.DEFAULT].runtime(elf)(*[b.uop.buffer._buf for b in bufs], vals=vals)
+  Device[Device.DEFAULT].synchronize()
+  return elf
+
+def _abi(elf) -> list[tuple[int, bool, int]]:
+  return [(slot, is_buf, idx) for _, slot, _, _, is_buf, idx in elf.signature]
+
+class TestArgOrder(unittest.TestCase):
+  def test_scalar_first(self):
+    n, buf = _alu(0, "n"), _buf(1)
+    sink = buf[0].store(n).sink(arg=KernelInfo(name="scalar_first"), tag=1)
+    out = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out], (7,))
+    self.assertEqual(_abi(elf), [(0, False, 0), (1, True, 0)])
+    self.assertEqual(out.item(), 7)
+
+  def test_buf_first(self):
+    buf, n = _buf(0), _alu(1, "n")
+    sink = buf[0].store(n).sink(arg=KernelInfo(name="buf_first"), tag=1)
+    out = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out], (7,))
+    self.assertEqual(_abi(elf), [(0, True, 0), (1, False, 0)])
+    self.assertEqual(out.item(), 7)
+
+  def test_interleaved(self):
+    out_p, n, inp_p = _buf(0, 4), _alu(1, "n"), _buf(2, 4)
+    i = UOp.range(4, 0)
+    sink = out_p[i].store(inp_p[i] + n).end(i).sink(arg=KernelInfo(name="interleaved"), tag=1)
+    out = Tensor.zeros(4, dtype=dtypes.int).contiguous().realize()
+    inp = Tensor([1, 2, 3, 4], dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out, inp], (10,))
+    self.assertEqual(_abi(elf), [(0, True, 0), (1, False, 0), (2, True, 1)])
+    self.assertEqual(out.tolist(), [11, 12, 13, 14])
+
+  def test_two_scalars_around_buf(self):
+    a, buf, b = _alu(0, "a"), _buf(1), _alu(2, "b")
+    sink = buf[0].store(a + b).sink(arg=KernelInfo(name="two_scalars"), tag=1)
+    out = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out], (3, 4))
+    self.assertEqual(_abi(elf), [(0, False, 0), (1, True, 0), (2, False, 1)])
+    self.assertEqual(out.item(), 7)
+
+  def test_mixed4_scalar_first(self):
+    s0, o_p, s1, inp_p = _alu(0, "s0"), _buf(1, 4), _alu(2, "s1"), _buf(3, 4)
+    i = UOp.range(4, 0)
+    sink = o_p[i].store(inp_p[i] * s0 + s1).end(i).sink(arg=KernelInfo(name="mixed4"), tag=1)
+    out = Tensor.zeros(4, dtype=dtypes.int).contiguous().realize()
+    inp = Tensor([1, 2, 3, 4], dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out, inp], (2, 1))
+    self.assertEqual(_abi(elf), [(0, False, 0), (1, True, 0), (2, False, 1), (3, True, 1)])
+    self.assertEqual(out.tolist(), [3, 5, 7, 9])
+
+  def test_bufs_only(self):
+    dst_p, src_p = _buf(0, 4), _buf(1, 4)
+    i = UOp.range(4, 0)
+    sink = dst_p[i].store(src_p[i]).end(i).sink(arg=KernelInfo(name="bufs_only"), tag=1)
+    out = Tensor.zeros(4, dtype=dtypes.int).contiguous().realize()
+    inp = Tensor([9, 8, 7, 6], dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out, inp], ())
+    self.assertEqual(_abi(elf), [(0, True, 0), (1, True, 1)])
+    self.assertEqual(out.tolist(), [9, 8, 7, 6])
+
+  def test_two_scalars_then_buf(self):
+    a, b, buf = _alu(0, "a"), _alu(1, "b"), _buf(2)
+    sink = buf[0].store(a * b).sink(arg=KernelInfo(name="two_scalars_then_buf"), tag=1)
+    out = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out], (6, 7))
+    self.assertEqual(_abi(elf), [(0, False, 0), (1, False, 1), (2, True, 0)])
+    self.assertEqual(out.item(), 42)
+
+  def test_two_bufs_scalar_last(self):
+    o_p, inp_p, n = _buf(0, 4), _buf(1, 4), _alu(2, "n")
+    i = UOp.range(4, 0)
+    sink = o_p[i].store(inp_p[i] + n).end(i).sink(arg=KernelInfo(name="two_bufs_scalar_last"), tag=1)
+    out = Tensor.zeros(4, dtype=dtypes.int).contiguous().realize()
+    inp = Tensor([1, 2, 3, 4], dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out, inp], (5,))
+    self.assertEqual(_abi(elf), [(0, True, 0), (1, True, 1), (2, False, 0)])
+    self.assertEqual(out.tolist(), [6, 7, 8, 9])
+
+  def test_mixed4_buf_first(self):
+    o_p, s0, inp_p, s1 = _buf(0, 4), _alu(1, "s0"), _buf(2, 4), _alu(3, "s1")
+    i = UOp.range(4, 0)
+    sink = o_p[i].store(inp_p[i] * s0 + s1).end(i).sink(arg=KernelInfo(name="mixed4_buf_first"), tag=1)
+    out = Tensor.zeros(4, dtype=dtypes.int).contiguous().realize()
+    inp = Tensor([1, 2, 3, 4], dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out, inp], (2, 1))
+    self.assertEqual(_abi(elf), [(0, True, 0), (1, False, 0), (2, True, 1), (3, False, 1)])
+    self.assertEqual(out.tolist(), [3, 5, 7, 9])
+
+  def test_jit_vars_last(self):
+    n = Variable("n", 0, 100)
+    @TinyJit
+    def jit_addn(t, v): return (t + v).contiguous()
+    x = Tensor([1, 2, 3, 4], dtype=dtypes.int).contiguous().realize()
+    got = [jit_addn(x, n.bind(k)).tolist() for k in (3, 5, 7)]
+    self.assertEqual(got, [[4, 5, 6, 7], [6, 7, 8, 9], [8, 9, 10, 11]])
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, replace
 from collections import defaultdict
-from typing import Any, Callable, Generic, TypeVar, Iterator, Generator, Self, TYPE_CHECKING
+from typing import Any, Callable, Generic, TypeVar, Iterable, Iterator, Generator, Self, TYPE_CHECKING
 import importlib, inspect, functools, pathlib, os, contextlib, re, atexit, pickle, decimal, subprocess, struct
 from tinygrad.helpers import LRU, getenv, diskcache_get, diskcache_put, DEBUG, GlobalCounters, PROFILE, temp, colored
 from tinygrad.helpers import Context, CCACHE, ALLOW_DEVICE_USAGE, MAX_BUFFER_SIZE, cpu_events, ProfileEvent, ProfilePointEvent, suppress_finalizing
@@ -325,14 +325,15 @@ class TinyELF:
   name: str
   target: Target
   # tuple of (name, slot, dtype, shape)
-  signature: tuple[tuple[str|None, int, DType, tuple], ...]
+  signature: tuple[tuple[str|None, int, DType, tuple, bool, int], ...]
   profile_key: bytes|None = None
 
   @staticmethod
-  def iter_sig(signature:tuple[tuple[str|None, int, DType, tuple], ...], offset:int=0) -> Generator[tuple[int, DType], None, None]:
-    for _,_,dt,_ in signature:
-      yield (offset:=round_up(offset, dt.itemsize)), dt
-      offset += dt.itemsize
+  def iter_sig(signature:Iterable[tuple[str|None, int, DType, tuple, bool, int]],
+               offset:int=0) -> Generator[tuple[int, DType, bool, int], None, None]:
+    for *_, dt, s, is_buf, idx in signature:
+      yield (offset:=round_up(offset, 8 if is_buf else dt.itemsize)), dt, is_buf, idx
+      offset += 8 if is_buf else dt.itemsize
 
 class Program(Generic[DeviceType]):
   def __init__(self, dev:DeviceType, obj:TinyELF): pass

--- a/tinygrad/runtime/graph/metal.py
+++ b/tinygrad/runtime/graph/metal.py
@@ -26,7 +26,7 @@ class MetalGraph(GraphRunner):
 
     self.var_bind_data = []
     if len(self.vars):
-      self.var_buf = self.dev.allocator.alloc(sum(dt.itemsize for r in self.runtimes for (_,_,dt,s) in unwrap(r).signature if s == ()))
+      self.var_buf = self.dev.allocator.alloc(sum(dt.itemsize for r in self.runtimes for *_, dt, _, is_buf, _ in unwrap(r).signature if not is_buf))
       self.var_buf_view, var_buf_offset = cast(MetalAllocator, self.dev.allocator)._as_buffer(self.var_buf), 0
 
     all_pipelines, all_resources = [], [self.var_buf.buf] if len(self.vars) else []
@@ -35,14 +35,15 @@ class MetalGraph(GraphRunner):
       icb_command = self.icb.indirectComputeCommandAtIndex(j).retained()
       icb_command.setComputePipelineState(runtime.pipeline_state)
       all_pipelines.append(runtime.pipeline_state)
-      for i, b in enumerate(bufs):
-        if not any(pos == i for pos, _ in replace):
-          icb_command.setKernelBuffer_offset_atIndex(b._buf.buf, b._buf.offset, i)
-          all_resources.append(b._buf.buf)
-      for nm,i,dt,_ in runtime.signature[len(bufs):]:
-        icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, i)
-        self.var_bind_data.append((nm, var_buf_offset, dt.fmt))
-        var_buf_offset += dt.itemsize
+      for nm, slot, dt, shape, is_buf, idx in runtime.signature:
+        if is_buf:
+          if not any(pos == idx for pos, _ in replace):
+            icb_command.setKernelBuffer_offset_atIndex(bufs[idx]._buf.buf, bufs[idx]._buf.offset, slot)
+            all_resources.append(bufs[idx]._buf.buf)
+        else:
+          icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, slot)
+          self.var_bind_data.append((nm, var_buf_offset, dt.fmt))
+          var_buf_offset += dt.itemsize
       global_size, local_size = ast.arg.launch_dims({v: 0 for v in self.vars})
       icb_command.concurrentDispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
       icb_command.setBarrier()
@@ -63,7 +64,8 @@ class MetalGraph(GraphRunner):
       computeCommand = self.icb.indirectComputeCommandAtIndex(j)
       for pos, iidx in self.uop_replace[j]:
         buf = cast(Buffer, input_uops[iidx].buffer)
-        computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, pos)
+        slot = next(slot for (_, slot, _, _, is_buf, idx) in unwrap(self.runtimes[j]).signature if is_buf and idx == pos)
+        computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, slot)
         updated_bufs.append(buf._buf.buf)
 
     all_resources = dedup(self.all_resources + updated_bufs)

--- a/tinygrad/runtime/ops_cl.py
+++ b/tinygrad/runtime/ops_cl.py
@@ -54,8 +54,8 @@ class CLProgram(Program['CLDevice']):
 
   def __call__(self, *bufs:cl.cl_mem, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]|None=None, vals:tuple[int, ...]=(),
                wait=False, **kw) -> float|None:
-    for i, (_, slot, dt, shape) in enumerate(self.signature):
-      b = bufs[slot] if slot < len(bufs) else getattr(ctypes, f"c_int{dt.bitsize}")(vals[slot-len(bufs)])
+    for i, (_, _, dt, shape, is_buf, idx) in enumerate(self.signature):
+      b = bufs[idx] if is_buf else getattr(ctypes, f"c_int{dt.bitsize}")(vals[idx])
       if is_image_shape(shape):
         pitch = (round_up(shape[1], 256) if OSX else shape[1]) * 4 * dt.itemsize
         fmt = cl.cl_image_format(cl.CL_RGBA, {2:cl.CL_HALF_FLOAT, 4:cl.CL_FLOAT}[dt.itemsize])

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -156,17 +156,17 @@ class CPUProgram(Program['CPUDevice']):
                vals:tuple[int|None, ...]=(), wait:bool=False, timeout:int|None=None) -> float|None:
     st = time.perf_counter()
     if self.lvp:
-      lvp_args = bytearray(12 + (len(bufs) + len(vals)) * 8)
-      addr = mv_address(lvp_args)
-      struct.pack_into(f'<3I{len(bufs)}Q', lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2, *[b.va_addr for b in bufs])
-      for v,(off,dt) in zip(vals, TinyELF.iter_sig(self.signature[-len(vals):], len(bufs)*8)): struct.pack_into(f'<{dt.fmt}', lvp_args, 12+off, v)
+      addr = mv_address(lvp_args:=bytearray(12 + (len(bufs)+len(vals))*8))
+      struct.pack_into('<3I', lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2)
+      for o, dt, is_buf, idx in TinyELF.iter_sig(self.signature):
+        struct.pack_into('<Q' if is_buf else f'<{dt.fmt}', lvp_args, 12+o, bufs[idx].va_addr if is_buf else vals[idx])
       self.fxn(addr)
     else:
-      args = [*[cast(int, b.va_addr) for b in bufs], *cast(tuple[int, ...], vals)]
+      args = [cast(int,bufs[idx].va_addr if is_buf else vals[idx]) for *_,_,is_buf,idx in self.signature]
       assert len(args) <= MAX_ARGS, f"CPU programs support at most {MAX_ARGS} arguments, got {len(args)}"
       for tid in range(global_size[0]):
         if 'core_id' in self.runtimevars: args[self.runtimevars['core_id']] = tid
-        self.fxn(*[ctypes.c_uint64(x) for x in args])
+        self.fxn(*[ctypes.c_uint64(cast(int,x)) for x in args])
     return time.perf_counter() - st if wait else None
 
   @suppress_finalizing

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -16,9 +16,12 @@ def check(status):
     raise RuntimeError(f"CUDA Error {status}, {error}")
 
 def encode_args(args, vals, signature) -> tuple[ctypes.Structure, ctypes.Array]:
-  fields = ([(f'f{i}', cuda.CUdeviceptr_v2, i*8) for i in range(len(args))] +
-            [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), off) for i,(off,dt) in enumerate(TinyELF.iter_sig(signature[len(args):], len(args)*8))])
-  c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
+  fields, ordered, end = [], [], 0
+  for o, dt, is_buf, idx in TinyELF.iter_sig(signature):
+    fields.append((f'f{idx}', cuda.CUdeviceptr_v2, o) if is_buf else (f'v{idx}', getattr(ctypes, f"c_int{dt.bitsize}"), o))
+    ordered.append(args[idx] if is_buf else vals[idx])
+    end = o + (8 if is_buf else dt.itemsize)
+  c_args = init_c_struct_t(end, tuple(fields))(*ordered)
   vargs = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), ctypes.cast(ctypes.byref(c_args), ctypes.c_void_p), ctypes.c_void_p(2),
                                 ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(c_args))), ctypes.c_void_p), ctypes.c_void_p(0))
   return c_args, vargs

--- a/tinygrad/runtime/ops_dsp.py
+++ b/tinygrad/runtime/ops_dsp.py
@@ -41,9 +41,9 @@ class DSPRenderer(ClangRenderer):
     msrc += [f'{self._render_dtype(b[1][0].dtype) if b[1][0].addrspace == AddrSpace.ALU else "int"} sz_or_val_{i} = '
              f'*({self._render_dtype(b[1][0].dtype) if b[1][0].addrspace == AddrSpace.ALU else "int"}*)((char*)pra[0].buf.pv+{i*8});'
              for i,b in enumerate(bufs)]
-    msrc += [f'int off{i} = ((int*)pra[1].buf.pv)[{i}];' for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
-    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{i+3}].dma.fd,0)+off{i};'
-             for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
+    gbufs = [i for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
+    msrc += [f'int off{i} = ((int*)pra[1].buf.pv)[{k}];' for k,i in enumerate(gbufs)]
+    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{k+3}].dma.fd,0)+off{i};' for k,i in enumerate(gbufs)]
     msrc += ["unsigned long long start = HAP_perf_get_time_us();"]
     fbufs = [(f'buf_{i}' if b[1][0].addrspace == AddrSpace.GLOBAL else f'sz_or_val_{i}') for i,b in enumerate(bufs)]
     msrc += [f"{function_name}({', '.join(fbufs)});"]
@@ -73,8 +73,8 @@ class DSPProgram(Program['DSPDevice']):
 
     pra, fds, attrs, _ = rpc_prep_args(ins=[var_vals_mv:=memoryview(bytearray((len(bufs)+len(vals))*8)), off_mv:=memoryview(bytearray(len(bufs)*4))],
                                        outs=[timer:=memoryview(bytearray(8)).cast('Q')], in_fds=[b.share_info.fd for b in bufs])
-    for i,b in enumerate(bufs): struct.pack_into('i', var_vals_mv, i*8, b.size)
-    for i,(v,(_,_,dt,_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
+    for i,(*_,dt,_,is_buf,idx) in enumerate(self.signature):
+      struct.pack_into('i' if is_buf else unwrap(dt.fmt), var_vals_mv, i*8, bufs[idx].size if is_buf else vals[idx])
     off_mv.cast('I')[:] = array.array('I', tuple(b.offset for b in bufs))
     self.dev.exec_lib(self.lib, rpc_sc(method=2, ins=2, outs=1, fds=len(bufs)), pra, fds, attrs)
     return timer[0] / 1e6
@@ -286,8 +286,8 @@ class MockDSPProgram(Program[DSPDevice]):
       dsp_lib.flush()
       os.chmod(dsp_lib.name, 0o0777)
       proc = subprocess.run(["qemu-hexagon-static", *(['-strace'] if DEBUG >= 5 else []), dsp_lib.name],
-        input=b''.join([bytes(to_mv(x.va_addr, x.size)) for x in bufs] +
-                       [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,_) in zip(vals, self.signature[len(bufs):])]),
+        input=b''.join(bytes(to_mv(bufs[idx].va_addr, bufs[idx].size)) if is_buf else struct.pack(unwrap(dt.fmt), vals[idx])
+              for *_,dt,_,is_buf,idx in self.signature),
         stdout=subprocess.PIPE, check=True)
     offset = 4
     for x in bufs:

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -37,11 +37,14 @@ class HIPProgram(Program[HIPDevice]):
   def __call__(self, *args, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(), wait=False, **kw):
     check(hip.hipSetDevice(self.dev.device_id))
     if not hasattr(self, "vargs"):
-      fields = ([(f'f{i}', hip.hipDeviceptr_t, i*8) for i in range(len(args))] +
-        [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), o) for i,(o,dt) in enumerate(TinyELF.iter_sig(self.signature[len(args):], len(args)*8))])
-      self.c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
+      fields, ordered, end = [], [], 0
+      for o, dt, is_buf, idx in TinyELF.iter_sig(self.signature):
+        fields.append((f'f{idx}', hip.hipDeviceptr_t, o) if is_buf else (f'v{idx}', getattr(ctypes, f"c_int{dt.bitsize}"), o))
+        ordered.append(args[idx] if is_buf else vals[idx])
+        end = o + (8 if is_buf else dt.itemsize)
+      self.c_args = init_c_struct_t(end, tuple(fields))(*ordered)
       self.vargs = (ctypes.c_void_p * 5)(1, ctypes.cast(ctypes.byref(self.c_args), ctypes.c_void_p), 2,
-                                         ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(self.c_args))), ctypes.c_void_p), 3)
+                                        ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(self.c_args))), ctypes.c_void_p), 3)
 
     for i in range(len(args)): self.c_args.__setattr__(f'f{i}', args[i])
     for i in range(len(vals)): self.c_args.__setattr__(f'v{i}', vals[i])

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -138,9 +138,9 @@ class MetalProgram(Program[MetalDevice]):
     command_buffer = self.dev.mtl_queue.commandBuffer().retained()
     encoder = command_buffer.computeCommandEncoder().retained()
     encoder.setComputePipelineState(self.pipeline_state)
-    for i,a in enumerate(bufs): encoder.setBuffer_offset_atIndex(a.buf, a.offset, i)
-    for a,(_,i,dt,_) in zip(vals, self.signature[len(bufs):]):
-      encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(a)), dt.itemsize, i)
+    for _, slot, dt, _, is_buf, idx in self.signature:
+      if is_buf: encoder.setBuffer_offset_atIndex(bufs[idx].buf, bufs[idx].offset, slot)
+      else: encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(vals[idx])), dt.itemsize, slot)
     encoder.dispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
     encoder.endEncoding()
     command_buffer.setLabel(to_ns_str(self.name)) # TODO: is this always needed?

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -3,8 +3,8 @@ import os, ctypes, contextlib, re, functools, mmap, struct, array, sys, weakref
 assert sys.platform != 'win32'
 from typing import cast
 from dataclasses import dataclass
-from tinygrad.runtime.support.hcq import HCQCompiled, HCQAllocator, HCQBuffer, HWQueue, CLikeArgsState, HCQProgram, HCQSignal, BumpAllocator
-from tinygrad.runtime.support.hcq import MMIOInterface, FileIOInterface, hcq_filter_visible_devices, hcq_profile
+from tinygrad.runtime.support.hcq import HCQCompiled, HCQAllocator, HCQBuffer, HWQueue, CLikeArgsState, HCQArgsState, HCQProgram, HCQSignal
+from tinygrad.runtime.support.hcq import MMIOInterface, FileIOInterface, hcq_filter_visible_devices, hcq_profile, BumpAllocator
 from tinygrad.uop.ops import sint
 from tinygrad.device import Compiled, BufferSpec, TinyELF
 from tinygrad.helpers import getenv, mv_address, round_up, data64, data64_le, prod, OSX, hi32, lo32, PROFILE, ContextVar, VIZ, ProfileEvent
@@ -240,10 +240,17 @@ class NVVideoQueue(NVCommandQueue):
 
 class NVArgsState(CLikeArgsState):
   def __init__(self, buf:HCQBuffer, prg:NVProgram, bufs:tuple[HCQBuffer, ...], vals:tuple[int, ...]=()):
-    if (is_mock:=isinstance(prg.dev.iface, MOCKIface)): prg.cbuf_0[80:82] = [len(bufs), len(vals)]
-    super().__init__(buf, prg, bufs, vals=() if is_mock else vals, prefix=prg.cbuf_0 or None)
-    # mock expects all vars to be 64 bit
-    if is_mock and vals: self.bind_sints_to_buf(*vals, buf=self.buf, fmt='q', offset=len(prg.cbuf_0)*4 + len(bufs)*8)
+    if not isinstance(prg.dev.iface, MOCKIface):
+      super().__init__(buf, prg, bufs, vals=vals, prefix=prg.cbuf_0 or None)
+      return
+    prg.cbuf_0[80:82] = [sum(is_buf for *_,_,is_buf,_ in prg.signature),
+                        sum(not is_buf for *_,_,is_buf,_ in prg.signature)]
+    HCQArgsState.__init__(self, buf, prg, bufs, vals=vals)
+    self.buf.cpu_view().view(size=len(prg.cbuf_0)*4, fmt='I')[:] = array.array('I', prg.cbuf_0)
+    # mock expects every arg as a 64-bit word: addresses unsigned, vals signed
+    for i,(*_,_,is_buf,idx) in enumerate(prg.signature):
+      self.bind_sints_to_buf(bufs[idx].va_addr if is_buf else vals[idx], buf=self.buf, fmt='Q' if is_buf else 'q',
+                            offset=len(prg.cbuf_0)*4 + i*8)
 
 class NVProgram(HCQProgram['NVDevice']):
   def __init__(self, dev:NVDevice, obj:TinyELF):

--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -202,22 +202,20 @@ class QCOMArgsState(HCQArgsState):
     super().__init__(buf, prg, bufs, vals=vals)
     ctypes.memset(int(self.buf.va_addr), 0, prg.kernargs_alloc_size)
 
-    ubos = [bufs[slot] for _,slot,_,shape in prg.signature if slot < len(bufs) and not is_image_shape(shape)]
-    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape in prg.signature if slot < len(bufs) and is_image_shape(shape)]
+    uavs = [(dt, s, bufs[idx]) for *_, dt, s, is_buf, idx in prg.signature if is_buf and is_image_shape(s)]
     # NIR can reorder images to different texture slots
     ibos, texs = uavs[:prg.ibo_cnt], [uavs[prg.ibo_cnt + (prg.tex_to_image[i] if prg.NIR else i)] for i in range(prg.tex_cnt)]
     for cnst_val,cnst_off,cnst_sz in prg.consts_info:
       to_mv(cast(int, self.buf.va_addr) + cnst_off, cnst_sz)[:] = cnst_val.to_bytes(cnst_sz, byteorder='little')
 
     if prg.samp_cnt > 0: to_mv(int(self.buf.va_addr) + prg.samp_off, len(prg.samplers) * 4).cast('I')[:] = array.array('I', prg.samplers)
+    non_img = [x for x in prg.signature if not is_image_shape(x[3])]
     if prg.NIR:
-      self.bind_sints_to_buf(*[b.va_addr for b in ubos], buf=self.buf, fmt='Q', offset=prg.buf_off)
-      for v,(o,dt) in zip(vals, TinyELF.iter_sig(prg.signature[len(bufs):], len(ubos)*8)):
-        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_off + o)
+      for o,dt,is_buf,idx in TinyELF.iter_sig(non_img):
+        self.bind_sints_to_buf(bufs[idx].va_addr if is_buf else vals[idx], buf=self.buf, fmt='Q' if is_buf else dt.fmt, offset=prg.buf_off+o)
     else:
-      for i, b in enumerate(ubos): self.bind_sints_to_buf(b.va_addr, buf=self.buf, fmt='Q', offset=prg.buf_offs[i])
-      for i,(v,(_,_,dt,_)) in enumerate(zip(vals, prg.signature[len(bufs):])):
-        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_offs[i+len(ubos)])
+      for i, (*_, dt, s, is_buf, idx) in enumerate(non_img):
+        self.bind_sints_to_buf(bufs[idx].va_addr if is_buf else vals[idx], buf=self.buf, fmt='Q' if is_buf else dt.fmt, offset=prg.buf_offs[i])
 
     def _tex(b, ibo=False):
       imgdt, shape, buf = b

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -51,7 +51,7 @@ QueueOnSubmittedWorkDone = synchronous(webgpu.enum_WGPUQueueWorkDoneStatus)(webg
 
 class WebGPUProgram(Program['WebGpuDevice']):
   def __init__(self, dev:'WebGpuDevice', obj:TinyELF):
-    self.dev, self.name = dev, to_wgpu_str(obj.name)
+    self.dev, self.name, self.signature = dev, to_wgpu_str(obj.name), obj.signature
 
     # Creating shader module
     shader = webgpu.WGPUShaderModuleWGSLDescriptor(code=to_wgpu_str(obj.lib.decode()),
@@ -74,8 +74,9 @@ class WebGPUProgram(Program['WebGpuDevice']):
     def bgl_entry(n:int, ty:str):
       return webgpu.WGPUBindGroupLayoutEntry(binding=n, visibility=webgpu.WGPUShaderStage_Compute,
                                              buffer=webgpu.WGPUBufferBindingLayout(type=getattr(webgpu, f'WGPUBufferBindingType_{ty}')))
-    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(bufs)+len(vals)))(
-      bgl_entry(0, 'Uniform'), *(bgl_entry(i+1, 'Uniform' if i >= len(bufs) else 'Storage') for i in range(len(bufs)+len(vals))))
+    xs = [bufs[idx] if is_buf else vals[idx] for *_,_,is_buf,idx in self.signature]
+    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(xs)))(bgl_entry(0, 'Uniform'),
+            *(bgl_entry(i+1, 'Storage' if is_buf else 'Uniform') for i,(*_,_,is_buf,_) in enumerate(self.signature)))
 
     webgpu.wgpuDevicePushErrorScope(self.dev.device_res, webgpu.WGPUErrorFilter_Validation)
     bind_layout = webgpu.wgpuDeviceCreateBindGroupLayout(self.dev.device_res,
@@ -94,7 +95,7 @@ class WebGPUProgram(Program['WebGpuDevice']):
     def bg_entry(n:int, x:webgpu.WGPUBuffer|int|float):
       buf = x if isinstance(x, webgpu.WGPUBuffer) else self.dev.create_uniform(x)
       return webgpu.WGPUBindGroupEntry(binding=n, buffer=buf, offset=0, size=webgpu.wgpuBufferGetSize(buf))
-    bindings = (webgpu.WGPUBindGroupEntry * (1+len(bufs)+len(vals)))(bg_entry(0, float('inf')), *(bg_entry(i+1, x) for i,x in enumerate(bufs+vals)))
+    bindings = (webgpu.WGPUBindGroupEntry * (1+len(xs)))(bg_entry(0, float('inf')), *(bg_entry(i+1, x) for i,x in enumerate(xs)))
 
     bind_group_desc = webgpu.WGPUBindGroupDescriptor(layout=bind_layout, entryCount=len(bindings), entries=bindings)
     webgpu.wgpuDevicePushErrorScope(self.dev.device_res, webgpu.WGPUErrorFilter_Validation)

--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -326,10 +326,12 @@ class CLikeArgsState(HCQArgsState[ProgramType]):
 
     if prefix is not None: self.buf.cpu_view().view(size=len(prefix) * 4, fmt='I')[:] = array.array('I', prefix)
 
-    self.bind_sints_to_buf(*[b.va_addr for b in bufs], buf=self.buf, fmt='Q', offset=len(prefix or []) * 4)
-    for v,(val_offset,dt) in zip(vals, TinyELF.iter_sig(prg.signature[-len(vals):], len(bufs) * 8)):
-      assert v is not None
-      self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=len(prefix or []) * 4 + val_offset)
+    for o,dt,is_buf,idx in TinyELF.iter_sig(prg.signature):
+      if is_buf: self.bind_sints_to_buf(bufs[idx].va_addr, buf=self.buf, fmt='Q', offset=len(prefix or [])*4+o)
+      else:
+        v = vals[idx]
+        assert v is not None
+        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=len(prefix or [])*4+o)
 
 class HCQProgram(Program[HCQDeviceType]):
   def __init__(self, args_state_t:Type[HCQArgsState], dev:HCQDeviceType, obj:TinyELF, kernargs_alloc_size:int, base:int|None=None):

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1196,8 +1196,9 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
 
   def to_elf(self) -> TinyELF:
     assert self.op is Ops.PROGRAM and isinstance(self.arg, ProgramInfo), "to_elf should only be called on a PROGRAM ast"
-    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape)
-                for u in tuple(filter(lambda u: u.op is Ops.PARAM and u.addrspace != AddrSpace.ALU, self.src[1].src)) + self.arg.vars)
+    bc, vc = itertools.count(), itertools.count()
+    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape, (is_buf:=u.addrspace!=AddrSpace.ALU), next(bc if is_buf else vc))
+            for u in self.src[1].src if u.op is Ops.PARAM)
     return TinyELF(self.src[3].arg, self.arg.function_name, self.arg.target, sig, self.key)
 
 @dataclass(frozen=True)


### PR DESCRIPTION
params were passed in a strict order for the backends to be able to later distinguish the buffers and the args, added `_is_buf` and `idx` in the signature tuple then modified the backends accordingly
i dont know if the scope of the bounty include the realize layer as well, either way i think it should be another pr if this one lands