### PR TITLE
Jit order independent inputs

### DIFF
--- a/test/backend/test_jit.py
+++ b/test/backend/test_jit.py
@@ -17,7 +17,6 @@ class TestJit(unittest.TestCase):
     _simple_test(add)
 
   def test_jit_arg_order_pos_kwargs(self):
-    # capture positional, replay as kwargs
     @TinyJit
     def sub(first, second): return (first - second).realize()
     a, b = Tensor.randn(10, 10, device=Device.DEFAULT).realize(), Tensor.randn(10, 10, device=Device.DEFAULT).realize()
@@ -27,7 +26,6 @@ class TestJit(unittest.TestCase):
     assert_jit_cache_len(sub, 1)
 
   def test_jit_arg_order_kwargs_pos(self):
-    # capture as kwargs, replay positionally
     @TinyJit
     def sub(first, second): return (first - second).realize()
     a, b = Tensor.randn(10, 10, device=Device.DEFAULT).realize(), Tensor.randn(10, 10, device=Device.DEFAULT).realize()
@@ -43,6 +41,15 @@ class TestJit(unittest.TestCase):
     sub(first=a, second=b)
     sub(first=a, second=b)
     np.testing.assert_allclose(sub(first=b, second=a).numpy(), b.numpy()-a.numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(sub, 1)
+
+  def test_jit_arg_swap_pos(self):
+    @TinyJit
+    def sub(first, second): return (first - second).realize()
+    a, b = Tensor.randn(10, 10, device=Device.DEFAULT).realize(), Tensor.randn(10, 10, device=Device.DEFAULT).realize()
+    sub(a, b)
+    sub(a, b)
+    np.testing.assert_allclose(sub(b, a).numpy(), b.numpy()-a.numpy(), atol=1e-4, rtol=1e-5)
     assert_jit_cache_len(sub, 1)
 
   def test_jit_raw_buffer_input(self):

--- a/test/backend/test_jit.py
+++ b/test/backend/test_jit.py
@@ -5,25 +5,19 @@ import numpy as np
 from test.helpers import assert_jit_cache_len, call_is_graph, not_support_multi_device, needs_second_gpu, KernelCountException
 from test.unit.test_jit import _simple_test
 from tinygrad import Tensor, Variable, TinyJit, Device, dtypes, UOp
+from tinygrad.device import Buffer
 from tinygrad.engine.jit import graph_class
 from tinygrad.helpers import JIT, DEV, GlobalCounters
 from tinygrad.uop.ops import Ops
 from tinygrad.renderer.isa.x86 import X86Renderer
+
+def _mkbuf(v): return Buffer(Device.DEFAULT, 3, dtypes.float32, initial_value=np.full(3, v, dtype=np.float32).tobytes())
 
 class TestJit(unittest.TestCase):
   def test_simple_jit(self):
     @TinyJit
     def add(a, b): return (a+b).realize()
     _simple_test(add)
-
-  def test_jit_arg_order_pos_kwargs(self):
-    @TinyJit
-    def sub(first, second): return (first - second).realize()
-    a, b = Tensor.randn(10, 10, device=Device.DEFAULT).realize(), Tensor.randn(10, 10, device=Device.DEFAULT).realize()
-    sub(a, b)
-    sub(a, b)
-    np.testing.assert_allclose(sub(first=a, second=b).numpy(), a.numpy()-b.numpy(), atol=1e-4, rtol=1e-5)
-    assert_jit_cache_len(sub, 1)
 
   def test_jit_arg_order_kwargs_pos(self):
     @TinyJit
@@ -52,13 +46,63 @@ class TestJit(unittest.TestCase):
     np.testing.assert_allclose(sub(b, a).numpy(), b.numpy()-a.numpy(), atol=1e-4, rtol=1e-5)
     assert_jit_cache_len(sub, 1)
 
+  def test_jit_arg_order_mixed(self):
+    @TinyJit
+    def f(x, y, z): return (x - y + z).realize()
+    a, b, c = (Tensor.randn(10, 10, device=Device.DEFAULT).realize() for _ in range(3))
+    f(a, b, c)
+    f(a, b, c)
+    np.testing.assert_allclose(f(a, c, z=b).numpy(), (a-c+b).numpy(), atol=1e-4, rtol=1e-5)
+    np.testing.assert_allclose(f(c, y=b, z=a).numpy(), (c-b+a).numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(f, 1)
+
+  def test_jit_raw_buffer_mixed_order(self):
+    @TinyJit
+    def f(buf, first, second):
+      return (Tensor(UOp.from_buffer(buf), device=buf.device) + first - second).realize()
+    a, b = Tensor.randn(3, device=Device.DEFAULT).realize(), Tensor.randn(3, device=Device.DEFAULT).realize()
+    b1, b2 = _mkbuf(10.0), _mkbuf(20.0)
+    f(b1, a, b)
+    f(b1, a, b)
+    np.testing.assert_allclose(f(b2, b, a).numpy(), (Tensor(UOp.from_buffer(b2), device=b2.device) + b - a).numpy(), atol=1e-4, rtol=1e-5)
+    np.testing.assert_allclose(f(b2, b, second=a).numpy(), (Tensor(UOp.from_buffer(b2), device=b2.device) + b - a).numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(f, 1)
+
   def test_jit_raw_buffer_input(self):
     @TinyJit
     def f(b): return (Tensor(UOp.from_buffer(b), device=b.device) * 2).realize()
-    from tinygrad.device import Buffer
     for i in range(4):
       buf = Buffer(Device.DEFAULT, 3, dtypes.float32, initial_value=np.array([i+1]*3, dtype=np.float32).tobytes())
       np.testing.assert_allclose(f(buf).numpy(), [2*(i+1)]*3, atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(f, 1)
+
+  def test_jit_raw_buffer_nested_list(self):
+    @TinyJit
+    def f(items):
+      return (Tensor(UOp.from_buffer(items[0]), device=items[0].device) * 2).realize()
+    for i, v in enumerate([1.0, 5.0, 9.0]):
+      np.testing.assert_allclose(f([_mkbuf(v)]).numpy(), [v*2]*3, atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(f, 1)
+
+  def test_jit_raw_buffer_nested_multiple(self):
+    @TinyJit
+    def f(items):
+      t0 = Tensor(UOp.from_buffer(items[0]), device=items[0].device)
+      t1 = Tensor(UOp.from_buffer(items[1]), device=items[1].device)
+      return (t0 + t1).realize()
+    for a, b in [(1.0, 2.0), (5.0, 6.0), (9.0, 10.0)]:
+      np.testing.assert_allclose(f([_mkbuf(a), _mkbuf(b)]).numpy(), [a+b]*3, atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(f, 1)
+
+  def test_jit_raw_buffer_middle_slot(self):
+    @TinyJit
+    def f(x, buf, y):
+      return (Tensor(UOp.from_buffer(buf), device=buf.device) + x - y).realize()
+    a, c = Tensor.randn(3, device=Device.DEFAULT).realize(), Tensor.randn(3, device=Device.DEFAULT).realize()
+    b1, b2 = _mkbuf(10.0), _mkbuf(20.0)
+    f(a, b1, c)
+    f(a, b1, c)
+    np.testing.assert_allclose(f(a, b2, c).numpy(), (Tensor(UOp.from_buffer(b2), device=b2.device) + a - c).numpy(), atol=1e-4, rtol=1e-5)
     assert_jit_cache_len(f, 1)
 
   @unittest.skipUnless(Device.DEFAULT == "CPU", "core_id is a CPU runtimevar")

--- a/test/backend/test_jit.py
+++ b/test/backend/test_jit.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from test.helpers import assert_jit_cache_len, call_is_graph, not_support_multi_device, needs_second_gpu, KernelCountException
 from test.unit.test_jit import _simple_test
-from tinygrad import Tensor, Variable, TinyJit, Device, dtypes
+from tinygrad import Tensor, Variable, TinyJit, Device, dtypes, UOp
 from tinygrad.engine.jit import graph_class
 from tinygrad.helpers import JIT, DEV, GlobalCounters
 from tinygrad.uop.ops import Ops
@@ -15,6 +15,44 @@ class TestJit(unittest.TestCase):
     @TinyJit
     def add(a, b): return (a+b).realize()
     _simple_test(add)
+
+  def test_jit_arg_order_pos_kwargs(self):
+    # capture positional, replay as kwargs
+    @TinyJit
+    def sub(first, second): return (first - second).realize()
+    a, b = Tensor.randn(10, 10, device=Device.DEFAULT).realize(), Tensor.randn(10, 10, device=Device.DEFAULT).realize()
+    sub(a, b)
+    sub(a, b)
+    np.testing.assert_allclose(sub(first=a, second=b).numpy(), a.numpy()-b.numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(sub, 1)
+
+  def test_jit_arg_order_kwargs_pos(self):
+    # capture as kwargs, replay positionally
+    @TinyJit
+    def sub(first, second): return (first - second).realize()
+    a, b = Tensor.randn(10, 10, device=Device.DEFAULT).realize(), Tensor.randn(10, 10, device=Device.DEFAULT).realize()
+    sub(first=a, second=b)
+    sub(first=a, second=b)
+    np.testing.assert_allclose(sub(a, b).numpy(), a.numpy()-b.numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(sub, 1)
+
+  def test_jit_arg_swap_kwargs(self):
+    @TinyJit
+    def sub(first, second): return (first - second).realize()
+    a, b = Tensor.randn(10, 10, device=Device.DEFAULT).realize(), Tensor.randn(10, 10, device=Device.DEFAULT).realize()
+    sub(first=a, second=b)
+    sub(first=a, second=b)
+    np.testing.assert_allclose(sub(first=b, second=a).numpy(), b.numpy()-a.numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(sub, 1)
+
+  def test_jit_raw_buffer_input(self):
+    @TinyJit
+    def f(b): return (Tensor(UOp.from_buffer(b), device=b.device) * 2).realize()
+    from tinygrad.device import Buffer
+    for i in range(4):
+      buf = Buffer(Device.DEFAULT, 3, dtypes.float32, initial_value=np.array([i+1]*3, dtype=np.float32).tobytes())
+      np.testing.assert_allclose(f(buf).numpy(), [2*(i+1)]*3, atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(f, 1)
 
   @unittest.skipUnless(Device.DEFAULT == "CPU", "core_id is a CPU runtimevar")
   def test_hcq_core_id_runtimevar_merge(self):

--- a/test/unit/test_jit.py
+++ b/test/unit/test_jit.py
@@ -141,52 +141,7 @@ class TestJit(unittest.TestCase):
       np.testing.assert_allclose(c.numpy(), a.numpy()+b.numpy(), atol=1e-4, rtol=1e-5)
     assert_jit_cache_len(add_kwargs, 1)
 
-  def test_jit_pos_then_kwargs(self):
-    # capture with positional args, then replay with keyword args (same conceptual order)
-    @TinyJit
-    def sub(first, second): return (first - second).realize()
-    a, b = Tensor.randn(10, 10).realize(), Tensor.randn(10, 10).realize()
-    sub(a, b)
-    sub(a, b)  # capture, names=[0, 1]
-    out = sub(first=a, second=b)
-    np.testing.assert_allclose(out.numpy(), a.numpy()-b.numpy(), atol=1e-4, rtol=1e-5)
-    assert_jit_cache_len(sub, 1)
-
-  def test_jit_kwargs_then_pos(self):
-    # capture: keyword args, then replay with positional args
-    @TinyJit
-    def sub(first, second): return (first - second).realize()
-    a, b = Tensor.randn(10, 10).realize(), Tensor.randn(10, 10).realize()
-    sub(first=a, second=b)
-    sub(first=a, second=b)  # capture, names=['first', 'second']
-    out = sub(a, b)
-    np.testing.assert_allclose(out.numpy(), a.numpy()-b.numpy(), atol=1e-4, rtol=1e-5)
-    assert_jit_cache_len(sub, 1)
-
-  def test_jit_swapped_kwargs(self):
-    # swapped keyword values must map to the right slots, not raise
-    @TinyJit
-    def sub(first, second): return (first - second).realize()
-    a, b = Tensor.randn(10, 10).realize(), Tensor.randn(10, 10).realize()
-    sub(first=a, second=b)
-    sub(first=a, second=b)  # capture
-    out = sub(first=b, second=a)
-    np.testing.assert_allclose(out.numpy(), b.numpy()-a.numpy(), atol=1e-4, rtol=1e-5)
-    assert_jit_cache_len(sub, 1)
-
-  def test_jit_swapped_pos(self):
-    # swapped positional values must map to the right slots
-    @TinyJit
-    def sub(first, second): return (first - second).realize()
-    a, b = Tensor.randn(10, 10).realize(), Tensor.randn(10, 10).realize()
-    sub(a, b)
-    sub(a, b)  # capture
-    out = sub(b, a)
-    np.testing.assert_allclose(out.numpy(), b.numpy()-a.numpy(), atol=1e-4, rtol=1e-5)
-    assert_jit_cache_len(sub, 1)
-
   def test_jit_raw_buffer_input(self):
-    # a raw Buffer must be usable as a JIT input (not silently dropped / stale)
     @TinyJit
     def f(b):
       return (Tensor(UOp.from_buffer(b), device=b.device) * 2).realize()

--- a/test/unit/test_jit.py
+++ b/test/unit/test_jit.py
@@ -141,6 +141,15 @@ class TestJit(unittest.TestCase):
       np.testing.assert_allclose(c.numpy(), a.numpy()+b.numpy(), atol=1e-4, rtol=1e-5)
     assert_jit_cache_len(add_kwargs, 1)
 
+  def test_jit_arg_order_pos_kwargs(self):
+    @TinyJit
+    def sub(first, second): return (first - second).realize()
+    a, b = Tensor.randn(10, 10).realize(), Tensor.randn(10, 10).realize()
+    sub(a, b)
+    sub(a, b)
+    np.testing.assert_allclose(sub(first=a, second=b).numpy(), a.numpy()-b.numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(sub, 1)
+
   def test_jit_raw_buffer_input(self):
     @TinyJit
     def f(b):

--- a/test/unit/test_jit.py
+++ b/test/unit/test_jit.py
@@ -1,6 +1,7 @@
 import unittest, numpy as np
 from test.helpers import assert_jit_cache_len
-from tinygrad import Tensor, TinyJit, Context, UOp, dtypes
+from tinygrad import Tensor, TinyJit, Context, UOp, dtypes, Device
+from tinygrad.device import Buffer
 from tinygrad.engine.jit import JitError
 
 def _simple_test(add, extract=lambda x: x, N=10):
@@ -139,6 +140,60 @@ class TestJit(unittest.TestCase):
       c = add_kwargs(first=a, second=b)
       np.testing.assert_allclose(c.numpy(), a.numpy()+b.numpy(), atol=1e-4, rtol=1e-5)
     assert_jit_cache_len(add_kwargs, 1)
+
+  def test_jit_pos_then_kwargs(self):
+    # capture with positional args, then replay with keyword args (same conceptual order)
+    @TinyJit
+    def sub(first, second): return (first - second).realize()
+    a, b = Tensor.randn(10, 10).realize(), Tensor.randn(10, 10).realize()
+    sub(a, b)
+    sub(a, b)  # capture, names=[0, 1]
+    out = sub(first=a, second=b)
+    np.testing.assert_allclose(out.numpy(), a.numpy()-b.numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(sub, 1)
+
+  def test_jit_kwargs_then_pos(self):
+    # capture: keyword args, then replay with positional args
+    @TinyJit
+    def sub(first, second): return (first - second).realize()
+    a, b = Tensor.randn(10, 10).realize(), Tensor.randn(10, 10).realize()
+    sub(first=a, second=b)
+    sub(first=a, second=b)  # capture, names=['first', 'second']
+    out = sub(a, b)
+    np.testing.assert_allclose(out.numpy(), a.numpy()-b.numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(sub, 1)
+
+  def test_jit_swapped_kwargs(self):
+    # swapped keyword values must map to the right slots, not raise
+    @TinyJit
+    def sub(first, second): return (first - second).realize()
+    a, b = Tensor.randn(10, 10).realize(), Tensor.randn(10, 10).realize()
+    sub(first=a, second=b)
+    sub(first=a, second=b)  # capture
+    out = sub(first=b, second=a)
+    np.testing.assert_allclose(out.numpy(), b.numpy()-a.numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(sub, 1)
+
+  def test_jit_swapped_pos(self):
+    # swapped positional values must map to the right slots
+    @TinyJit
+    def sub(first, second): return (first - second).realize()
+    a, b = Tensor.randn(10, 10).realize(), Tensor.randn(10, 10).realize()
+    sub(a, b)
+    sub(a, b)  # capture
+    out = sub(b, a)
+    np.testing.assert_allclose(out.numpy(), b.numpy()-a.numpy(), atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(sub, 1)
+
+  def test_jit_raw_buffer_input(self):
+    # a raw Buffer must be usable as a JIT input (not silently dropped / stale)
+    @TinyJit
+    def f(b):
+      return (Tensor(UOp.from_buffer(b), device=b.device) * 2).realize()
+    for i in range(4):
+      buf = Buffer(Device.DEFAULT, 3, dtypes.float32, initial_value=np.array([i+1]*3, dtype=np.float32).tobytes())
+      np.testing.assert_allclose(f(buf).numpy(), [2*(i+1)]*3, atol=1e-4, rtol=1e-5)
+    assert_jit_cache_len(f, 1)
 
   def test_array_jit(self):
     @TinyJit

--- a/test/unit/test_jit_footguns.py
+++ b/test/unit/test_jit_footguns.py
@@ -260,16 +260,16 @@ class TestJitFootguns(unittest.TestCase):
     result = f(Tensor([3]), True)  # passing True but False branch runs
     self.assertEqual(result.item(), 6)  # should be 9!
 
-  def test_positional_kwargs_cannot_mix(self):
-    """Must use same calling convention after capture."""
+  def test_positional_kwargs_can_mix(self):
+    """Calling convention can change after capture."""
     @TinyJit
     def f(a, b): return (a + b).realize()
 
     f(Tensor([1]), Tensor([2]))  # warmup with positional
     f(Tensor([1]), Tensor([2]))  # capture with positional
 
-    with self.assertRaises(JitError):
-      f(a=Tensor([3]), b=Tensor([4]))  # kwargs fail
+    result = f(a=Tensor([3]), b=Tensor([4]))  # kwargs on replay
+    self.assertEqual(result.item(), 7)
 
   def test_class_method_shared_across_instances(self):
     """JIT on instance methods is shared at class level."""

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -199,8 +199,7 @@ class CapturedJit(Generic[ReturnType]):
 
 def _prepare_jit_inputs(args, kwargs):
   input_tensors: list[tuple[int|str, Tensor]] = [(name,t) for name,t in list(enumerate(args))+sorted(kwargs.items()) if t.__class__ is Tensor]
-  names = [name for name,_ in input_tensors]
-  tensors = [t for _,t in input_tensors]
+  names, tensors = [name for name,_ in input_tensors], [t for _,t in input_tensors]
   # extract tensors and raw Buffers from containers (shallow, not recursive to avoid grabbing model weights)
   for x in args + tuple(kwargs.values()):
     it = x if isinstance(x, (tuple,list)) else x.values() if isinstance(x, dict) else []

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -163,13 +163,12 @@ ReturnType = TypeVar('ReturnType')
 class CapturedJit(Generic[ReturnType]):
   ret: Any  # includes the Tensors or any other returned object
   _linear: UOp
-  expected_names: list[int|str]
   expected_input_info: list[tuple[UOp, tuple[Variable, ...], DType, str]]  # (view, variables, dtype, device) per input
 
   @functools.cached_property
   def linear(self) -> UOp: return link_linear(self._linear)
 
-  def __reduce__(self): return self.__class__, (self.ret, self._linear, self.expected_names, self.expected_input_info)
+  def __reduce__(self): return self.__class__, (self.ret, self._linear, self.expected_input_info)
 
   @functools.cached_property
   def _written_uops(self) -> set[UOp]:
@@ -199,11 +198,12 @@ class CapturedJit(Generic[ReturnType]):
 
 def _prepare_jit_inputs(args, kwargs):
   input_tensors: list[tuple[int|str, Tensor]] = [(name,t) for name,t in list(enumerate(args))+sorted(kwargs.items()) if t.__class__ is Tensor]
-  names, tensors = [name for name,_ in input_tensors], [t for _,t in input_tensors]
+  tensors = [t for _,t in input_tensors]
   # extract tensors from containers (shallow, not recursive to avoid grabbing model weights)
   for x in args + tuple(kwargs.values()):
     it = x if isinstance(x, (tuple,list)) else x.values() if isinstance(x, dict) else []
     tensors += [t for t in it if t.__class__ is Tensor and not any(t is y for y in tensors)]
+  tensors += [Tensor(u, device=u.device) for u in [UOp.from_buffer(x) for x in args+tuple(kwargs.values()) if isinstance(x, Buffer)]] #coverage for buffers
   def get_input_uops() -> list[UOp]: return flatten([[t.uop.src[0]] if t.uop.op is Ops.UNSHARD else [t.uop] for t in tensors])
   if any(u.is_virtual for u in get_input_uops()): raise JitError("JIT inputs must be real buffers; use .clone()")
   if len(unrealized_tensors := [x for x in tensors if not x.uop.is_realized]): Tensor.realize(*unrealized_tensors)
@@ -215,7 +215,7 @@ def _prepare_jit_inputs(args, kwargs):
   _var_vals = merge_dicts([x[1] for x in inputs] + [dict(v.unbind() for v in (args + tuple(kwargs.values())) if isinstance(v, UOp))])
   var_vals = {k.expr:v for k,v in _var_vals.items()}
   expected_input_info = [(x[0], tuple(sorted(x[1].keys(), key=lambda v: v.expr)), x[2], x[3]) for x in inputs]
-  return input_buf_uops, var_vals, names, expected_input_info
+  return input_buf_uops, var_vals, expected_input_info
 
 class _TinyJit(Generic[ReturnType]):
   def __init__(self, fxn:Callable[..., ReturnType]|None, captured:CapturedJit|None=None, prune=False):
@@ -240,7 +240,7 @@ class _TinyJit(Generic[ReturnType]):
 
   @disable_gc()
   def __call__(self, *args, **kwargs) -> ReturnType:
-    input_buf_uops, var_vals, names, expected_input_info = _prepare_jit_inputs(args, kwargs)
+    input_buf_uops, var_vals, expected_input_info = _prepare_jit_inputs(args, kwargs)
     if not JIT or self.cnt == 0:
       # jit ignore
       assert self.fxn is not None
@@ -277,12 +277,11 @@ class _TinyJit(Generic[ReturnType]):
       # drop the pre-planning graph: it keeps the whole capture-time working set allocated (big_linear) or referenced (held_bufs).
       # the planned linear only uses the arena/held buffers, so the intermediates must be freed before linking and first exec
       del big_linear, held_bufs
-      self.captured = CapturedJit(ret, linear, names, expected_input_info)
+      self.captured = CapturedJit(ret, linear, expected_input_info)
       ret = self.captured(input_buf_uops, var_vals)
     elif self.cnt >= 2:
       # jit exec
       assert self.captured is not None
-      if self.captured.expected_names != names: raise JitError(f"args mismatch in JIT: {self.captured.expected_names=} != {names}")
       if self.captured.expected_input_info != expected_input_info:
         raise JitError(f"args mismatch in JIT: {self.captured.expected_input_info=} != {expected_input_info=}")
       ret = self.captured(input_buf_uops, var_vals)

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -163,12 +163,13 @@ ReturnType = TypeVar('ReturnType')
 class CapturedJit(Generic[ReturnType]):
   ret: Any  # includes the Tensors or any other returned object
   _linear: UOp
+  expected_names: list[int|str]
   expected_input_info: list[tuple[UOp, tuple[Variable, ...], DType, str]]  # (view, variables, dtype, device) per input
 
   @functools.cached_property
   def linear(self) -> UOp: return link_linear(self._linear)
 
-  def __reduce__(self): return self.__class__, (self.ret, self._linear, self.expected_input_info)
+  def __reduce__(self): return self.__class__, (self.ret, self._linear, self.expected_names, self.expected_input_info)
 
   @functools.cached_property
   def _written_uops(self) -> set[UOp]:
@@ -198,6 +199,7 @@ class CapturedJit(Generic[ReturnType]):
 
 def _prepare_jit_inputs(args, kwargs):
   input_tensors: list[tuple[int|str, Tensor]] = [(name,t) for name,t in list(enumerate(args))+sorted(kwargs.items()) if t.__class__ is Tensor]
+  names = [name for name,_ in input_tensors]
   tensors = [t for _,t in input_tensors]
   # extract tensors and raw Buffers from containers (shallow, not recursive to avoid grabbing model weights)
   for x in args + tuple(kwargs.values()):
@@ -216,7 +218,7 @@ def _prepare_jit_inputs(args, kwargs):
   _var_vals = merge_dicts([x[1] for x in inputs] + [dict(v.unbind() for v in (args + tuple(kwargs.values())) if isinstance(v, UOp))])
   var_vals = {k.expr:v for k,v in _var_vals.items()}
   expected_input_info = [(x[0], tuple(sorted(x[1].keys(), key=lambda v: v.expr)), x[2], x[3]) for x in inputs]
-  return input_buf_uops, var_vals, expected_input_info
+  return input_buf_uops, var_vals, names, expected_input_info
 
 class _TinyJit(Generic[ReturnType]):
   def __init__(self, fxn:Callable[..., ReturnType]|None, captured:CapturedJit|None=None, prune=False):
@@ -241,7 +243,7 @@ class _TinyJit(Generic[ReturnType]):
 
   @disable_gc()
   def __call__(self, *args, **kwargs) -> ReturnType:
-    input_buf_uops, var_vals, expected_input_info = _prepare_jit_inputs(args, kwargs)
+    input_buf_uops, var_vals, names, expected_input_info = _prepare_jit_inputs(args, kwargs)
     if not JIT or self.cnt == 0:
       # jit ignore
       assert self.fxn is not None
@@ -278,7 +280,7 @@ class _TinyJit(Generic[ReturnType]):
       # drop the pre-planning graph: it keeps the whole capture-time working set allocated (big_linear) or referenced (held_bufs).
       # the planned linear only uses the arena/held buffers, so the intermediates must be freed before linking and first exec
       del big_linear, held_bufs
-      self.captured = CapturedJit(ret, linear, expected_input_info)
+      self.captured = CapturedJit(ret, linear, names, expected_input_info)
       ret = self.captured(input_buf_uops, var_vals)
     elif self.cnt >= 2:
       # jit exec

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -213,7 +213,7 @@ def _prepare_jit_inputs(args, kwargs):
   # collect buffer UOps (including MultiBuffer)
   input_buf_uops: list[UOp] = [u.base for u in input_uops if u.base.realized is not None]
   if len(set(input_buf_uops)) != len(input_buf_uops): raise JitError("duplicate inputs to JIT")
-  inputs = [(*(u.substitute({u.base:UOp(Ops.NOOP, u.base.dtype)}, extra_pm=mop_cleanup).unbind_all()), u.dtype, u.device) for u in input_uops]
+  inputs = [(*(u.substitute({u.base:UOp(Ops.NOOP)}, extra_pm=mop_cleanup).unbind_all()), u.dtype, u.device) for u in input_uops]
   _var_vals = merge_dicts([x[1] for x in inputs] + [dict(v.unbind() for v in (args + tuple(kwargs.values())) if isinstance(v, UOp))])
   var_vals = {k.expr:v for k,v in _var_vals.items()}
   expected_input_info = [(x[0], tuple(sorted(x[1].keys(), key=lambda v: v.expr)), x[2], x[3]) for x in inputs]

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -199,11 +199,12 @@ class CapturedJit(Generic[ReturnType]):
 def _prepare_jit_inputs(args, kwargs):
   input_tensors: list[tuple[int|str, Tensor]] = [(name,t) for name,t in list(enumerate(args))+sorted(kwargs.items()) if t.__class__ is Tensor]
   tensors = [t for _,t in input_tensors]
-  # extract tensors from containers (shallow, not recursive to avoid grabbing model weights)
+  # extract tensors and raw Buffers from containers (shallow, not recursive to avoid grabbing model weights)
   for x in args + tuple(kwargs.values()):
     it = x if isinstance(x, (tuple,list)) else x.values() if isinstance(x, dict) else []
     tensors += [t for t in it if t.__class__ is Tensor and not any(t is y for y in tensors)]
-  tensors += [Tensor(u, device=u.device) for u in [UOp.from_buffer(x) for x in args+tuple(kwargs.values()) if isinstance(x, Buffer)]] #coverage for buffers
+    tensors += [Tensor(UOp.from_buffer(b), device=b.device) for b in it if isinstance(b, Buffer)]
+  tensors += [Tensor(UOp.from_buffer(x), device=x.device) for x in args + tuple(kwargs.values()) if isinstance(x, Buffer)]
   def get_input_uops() -> list[UOp]: return flatten([[t.uop.src[0]] if t.uop.op is Ops.UNSHARD else [t.uop] for t in tensors])
   if any(u.is_virtual for u in get_input_uops()): raise JitError("JIT inputs must be real buffers; use .clone()")
   if len(unrealized_tensors := [x for x in tensors if not x.uop.is_realized]): Tensor.realize(*unrealized_tensors)

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -199,7 +199,8 @@ class CapturedJit(Generic[ReturnType]):
 
 def _prepare_jit_inputs(args, kwargs):
   input_tensors: list[tuple[int|str, Tensor]] = [(name,t) for name,t in list(enumerate(args))+sorted(kwargs.items()) if t.__class__ is Tensor]
-  names, tensors = [name for name,_ in input_tensors], [t for _,t in input_tensors]
+  names = [name for name,_ in input_tensors]
+  tensors = [t for _,t in input_tensors]
   # extract tensors and raw Buffers from containers (shallow, not recursive to avoid grabbing model weights)
   for x in args + tuple(kwargs.values()):
     it = x if isinstance(x, (tuple,list)) else x.values() if isinstance(x, dict) else []
@@ -213,7 +214,7 @@ def _prepare_jit_inputs(args, kwargs):
   # collect buffer UOps (including MultiBuffer)
   input_buf_uops: list[UOp] = [u.base for u in input_uops if u.base.realized is not None]
   if len(set(input_buf_uops)) != len(input_buf_uops): raise JitError("duplicate inputs to JIT")
-  inputs = [(*(u.substitute({u.base:UOp(Ops.NOOP)}, extra_pm=mop_cleanup).unbind_all()), u.dtype, u.device) for u in input_uops]
+  inputs = [(*(u.substitute({u.base:UOp(Ops.NOOP, u.base.dtype)}, extra_pm=mop_cleanup).unbind_all()), u.dtype, u.device) for u in input_uops]
   _var_vals = merge_dicts([x[1] for x in inputs] + [dict(v.unbind() for v in (args + tuple(kwargs.values())) if isinstance(v, UOp))])
   var_vals = {k.expr:v for k,v in _var_vals.items()}
   expected_input_info = [(x[0], tuple(sorted(x[1].keys(), key=lambda v: v.expr)), x[2], x[3]) for x in inputs]


### PR DESCRIPTION
Collect raw tinygrad.device.Buffer objects as JIT inputs (top-level and nested in containers) alongside Tensors, and drop the expected_names check so positional and keyword args are interchangeable across capture and replay. Backends already bind by slot, so all inherit the fix.

Tests in test/unit (smoke) and test/backend (matrix): pos<->kwargs, swap, mixed, raw buffers (top-level, middle-slot, nested). Footgun test updated to assert convention mixing.