### PR TITLE
buffers and args supported in any input order on all backends ci green 

### DIFF
--- a/test/backend/test_arg_order.py
+++ b/test/backend/test_arg_order.py
@@ -1,0 +1,114 @@
+import unittest
+from tinygrad import Tensor, Device, UOp, TinyJit, Variable
+from tinygrad.dtype import dtypes, AddrSpace
+from tinygrad.uop.ops import KernelInfo
+from tinygrad.codegen import to_program
+
+def _alu(slot:int, name:str) -> UOp:
+  return UOp.param(slot, dtypes.int, (), name=name, addrspace=AddrSpace.ALU)
+
+def _buf(slot:int, n:int=1) -> UOp:
+  return UOp.param(slot, dtypes.int, (n,))
+
+def _launch(sink:UOp, bufs:list[Tensor], vals:tuple[int, ...]=()):
+  elf = to_program(sink, Device[Device.DEFAULT].renderer).to_elf()
+  Device[Device.DEFAULT].runtime(elf)(*[b.uop.buffer._buf for b in bufs], vals=vals)
+  Device[Device.DEFAULT].synchronize()
+  return elf
+
+def _abi(elf) -> list[tuple[int, bool, int]]:
+  return [(slot, is_buf, idx) for _, slot, _, _, is_buf, idx in elf.signature]
+
+class TestArgOrder(unittest.TestCase):
+  def test_scalar_first(self):
+    n, buf = _alu(0, "n"), _buf(1)
+    sink = buf[0].store(n).sink(arg=KernelInfo(name="scalar_first"), tag=1)
+    out = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out], (7,))
+    self.assertEqual(_abi(elf), [(0, False, 0), (1, True, 0)])
+    self.assertEqual(out.item(), 7)
+
+  def test_buf_first(self):
+    buf, n = _buf(0), _alu(1, "n")
+    sink = buf[0].store(n).sink(arg=KernelInfo(name="buf_first"), tag=1)
+    out = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out], (7,))
+    self.assertEqual(_abi(elf), [(0, True, 0), (1, False, 0)])
+    self.assertEqual(out.item(), 7)
+
+  def test_interleaved(self):
+    out_p, n, inp_p = _buf(0, 4), _alu(1, "n"), _buf(2, 4)
+    i = UOp.range(4, 0)
+    sink = out_p[i].store(inp_p[i] + n).end(i).sink(arg=KernelInfo(name="interleaved"), tag=1)
+    out = Tensor.zeros(4, dtype=dtypes.int).contiguous().realize()
+    inp = Tensor([1, 2, 3, 4], dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out, inp], (10,))
+    self.assertEqual(_abi(elf), [(0, True, 0), (1, False, 0), (2, True, 1)])
+    self.assertEqual(out.tolist(), [11, 12, 13, 14])
+
+  def test_two_scalars_around_buf(self):
+    a, buf, b = _alu(0, "a"), _buf(1), _alu(2, "b")
+    sink = buf[0].store(a + b).sink(arg=KernelInfo(name="two_scalars"), tag=1)
+    out = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out], (3, 4))
+    self.assertEqual(_abi(elf), [(0, False, 0), (1, True, 0), (2, False, 1)])
+    self.assertEqual(out.item(), 7)
+
+  def test_mixed4_scalar_first(self):
+    s0, o_p, s1, inp_p = _alu(0, "s0"), _buf(1, 4), _alu(2, "s1"), _buf(3, 4)
+    i = UOp.range(4, 0)
+    sink = o_p[i].store(inp_p[i] * s0 + s1).end(i).sink(arg=KernelInfo(name="mixed4"), tag=1)
+    out = Tensor.zeros(4, dtype=dtypes.int).contiguous().realize()
+    inp = Tensor([1, 2, 3, 4], dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out, inp], (2, 1))
+    self.assertEqual(_abi(elf), [(0, False, 0), (1, True, 0), (2, False, 1), (3, True, 1)])
+    self.assertEqual(out.tolist(), [3, 5, 7, 9])
+
+  def test_bufs_only(self):
+    dst_p, src_p = _buf(0, 4), _buf(1, 4)
+    i = UOp.range(4, 0)
+    sink = dst_p[i].store(src_p[i]).end(i).sink(arg=KernelInfo(name="bufs_only"), tag=1)
+    out = Tensor.zeros(4, dtype=dtypes.int).contiguous().realize()
+    inp = Tensor([9, 8, 7, 6], dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out, inp], ())
+    self.assertEqual(_abi(elf), [(0, True, 0), (1, True, 1)])
+    self.assertEqual(out.tolist(), [9, 8, 7, 6])
+
+  def test_two_scalars_then_buf(self):
+    a, b, buf = _alu(0, "a"), _alu(1, "b"), _buf(2)
+    sink = buf[0].store(a * b).sink(arg=KernelInfo(name="two_scalars_then_buf"), tag=1)
+    out = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out], (6, 7))
+    self.assertEqual(_abi(elf), [(0, False, 0), (1, False, 1), (2, True, 0)])
+    self.assertEqual(out.item(), 42)
+
+  def test_two_bufs_scalar_last(self):
+    o_p, inp_p, n = _buf(0, 4), _buf(1, 4), _alu(2, "n")
+    i = UOp.range(4, 0)
+    sink = o_p[i].store(inp_p[i] + n).end(i).sink(arg=KernelInfo(name="two_bufs_scalar_last"), tag=1)
+    out = Tensor.zeros(4, dtype=dtypes.int).contiguous().realize()
+    inp = Tensor([1, 2, 3, 4], dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out, inp], (5,))
+    self.assertEqual(_abi(elf), [(0, True, 0), (1, True, 1), (2, False, 0)])
+    self.assertEqual(out.tolist(), [6, 7, 8, 9])
+
+  def test_mixed4_buf_first(self):
+    o_p, s0, inp_p, s1 = _buf(0, 4), _alu(1, "s0"), _buf(2, 4), _alu(3, "s1")
+    i = UOp.range(4, 0)
+    sink = o_p[i].store(inp_p[i] * s0 + s1).end(i).sink(arg=KernelInfo(name="mixed4_buf_first"), tag=1)
+    out = Tensor.zeros(4, dtype=dtypes.int).contiguous().realize()
+    inp = Tensor([1, 2, 3, 4], dtype=dtypes.int).contiguous().realize()
+    elf = _launch(sink, [out, inp], (2, 1))
+    self.assertEqual(_abi(elf), [(0, True, 0), (1, False, 0), (2, True, 1), (3, False, 1)])
+    self.assertEqual(out.tolist(), [3, 5, 7, 9])
+
+  def test_jit_vars_last(self):
+    n = Variable("n", 0, 100)
+    @TinyJit
+    def jit_addn(t, v): return (t + v).contiguous()
+    x = Tensor([1, 2, 3, 4], dtype=dtypes.int).contiguous().realize()
+    got = [jit_addn(x, n.bind(k)).tolist() for k in (3, 5, 7)]
+    self.assertEqual(got, [[4, 5, 6, 7], [6, 7, 8, 9], [8, 9, 10, 11]])
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -481,7 +481,11 @@ def do_to_program(ast:UOp, renderer:Renderer) -> UOp:
     # instruction selection
     if isinstance(renderer, ISARenderer):
       full_sink = graph_rewrite(full_sink, renderer.pre_isel_matcher, ctx=itertools.count(-1, -1), name="pre instruction selection", bottom_up=True)
-      full_sink = graph_rewrite(full_sink, renderer.isel_matcher, ctx=IselContext(full_sink), name="instruction selection", bottom_up=True)
+    param_order = list(dict.fromkeys(u for u in linearize(full_sink) if u.op is Ops.PARAM))
+    prog_info = replace(prog_info, params=tuple(param_order))
+    if isinstance(renderer, ISARenderer):
+      full_sink = graph_rewrite(full_sink, renderer.isel_matcher, ctx=IselContext(full_sink,param_order=param_order),
+                                name="instruction selection", bottom_up=True)
     prg = UOp(Ops.PROGRAM, src=(full_sink,), arg=prog_info)
   else: raise RuntimeError(f"can't call to_program on {ast.op}")
   if not isinstance(prg.arg, ProgramInfo): prg = prg.replace(arg=ProgramInfo.from_sink(prg.src[0], renderer.target))

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, replace
 from collections import defaultdict
-from typing import Any, Callable, Generic, TypeVar, Iterator, Generator, Self, TYPE_CHECKING
+from typing import Any, Callable, Generic, TypeVar, Iterable, Iterator, Generator, Self, TYPE_CHECKING
 import importlib, inspect, functools, pathlib, os, contextlib, re, atexit, pickle, decimal, subprocess, struct
 from tinygrad.helpers import LRU, getenv, diskcache_get, diskcache_put, DEBUG, GlobalCounters, PROFILE, temp, colored
 from tinygrad.helpers import Context, CCACHE, ALLOW_DEVICE_USAGE, MAX_BUFFER_SIZE, cpu_events, ProfileEvent, ProfilePointEvent, suppress_finalizing
@@ -326,14 +326,15 @@ class TinyELF:
   name: str
   target: Target
   # tuple of (name, slot, dtype, shape)
-  signature: tuple[tuple[str|None, int, DType, tuple], ...]
+  signature: tuple[tuple[str|None, int, DType, tuple, bool, int], ...]
   profile_key: bytes|None = None
 
   @staticmethod
-  def iter_sig(signature:tuple[tuple[str|None, int, DType, tuple], ...], offset:int=0) -> Generator[tuple[int, DType], None, None]:
-    for _,_,dt,_ in signature:
-      yield (offset:=round_up(offset, dt.itemsize)), dt
-      offset += dt.itemsize
+  def iter_sig(signature:Iterable[tuple[str|None, int, DType, tuple, bool, int]],
+               offset:int=0) -> Generator[tuple[int, DType, bool, int], None, None]:
+    for *_, dt, s, is_buf, idx in signature:
+      yield (offset:=round_up(offset, 8 if is_buf else dt.itemsize)), dt, is_buf, idx
+      offset += 8 if is_buf else dt.itemsize
 
 class Program(Generic[DeviceType]):
   def __init__(self, dev:DeviceType, obj:TinyELF): pass

--- a/tinygrad/renderer/isa/__init__.py
+++ b/tinygrad/renderer/isa/__init__.py
@@ -15,13 +15,13 @@ class Register:
   def __repr__(self): return self.name
 
 class IselContext:
-  def __init__(self, sink:UOp):
-    self.uses = consumer_map_from_toposort(sink.toposort())
+  def __init__(self, sink:UOp, param_order:list[UOp]|None=None):
+    ts = sink.toposort()
+    self.uses = consumer_map_from_toposort(ts)
     self.reg_n = itertools.count()
-    def arg_key(u:UOp):
-      if u.op is Ops.SPECIAL: return (2, u.arg)
-      return (0, u.arg.slot) if u.arg.addrspace is not None else (1, u.expr)
-    self.func_args = sorted([u for u in self.uses if u.op in {Ops.PARAM, Ops.SPECIAL}], key=arg_key)
+    src = param_order if param_order is not None else ts
+    self.func_args = [u for u in src if u in self.uses and u.op is Ops.PARAM]
+    self.func_args += sorted((u for u in self.uses if u.op is Ops.SPECIAL), key=lambda u: u.arg)
 
   def vreg(self, cons:tuple[Register, ...]|Register):
     return Register(f"v{next(self.reg_n)}", 0, _cons=cons if isinstance(cons, tuple) else (cons,))

--- a/tinygrad/runtime/graph/metal.py
+++ b/tinygrad/runtime/graph/metal.py
@@ -26,7 +26,7 @@ class MetalGraph(GraphRunner):
 
     self.var_bind_data = []
     if len(self.vars):
-      self.var_buf = self.dev.allocator.alloc(sum(dt.itemsize for r in self.runtimes for (_,_,dt,s) in unwrap(r).signature if s == ()))
+      self.var_buf = self.dev.allocator.alloc(sum(dt.itemsize for r in self.runtimes for *_, dt, _, is_buf, _ in unwrap(r).signature if not is_buf))
       self.var_buf_view, var_buf_offset = cast(MetalAllocator, self.dev.allocator)._as_buffer(self.var_buf), 0
 
     all_pipelines, all_resources = [], [self.var_buf.buf] if len(self.vars) else []
@@ -35,14 +35,15 @@ class MetalGraph(GraphRunner):
       icb_command = self.icb.indirectComputeCommandAtIndex(j).retained()
       icb_command.setComputePipelineState(runtime.pipeline_state)
       all_pipelines.append(runtime.pipeline_state)
-      for i, b in enumerate(bufs):
-        if not any(pos == i for pos, _ in replace):
-          icb_command.setKernelBuffer_offset_atIndex(b._buf.buf, b._buf.offset, i)
-          all_resources.append(b._buf.buf)
-      for nm,i,dt,_ in runtime.signature[len(bufs):]:
-        icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, i)
-        self.var_bind_data.append((nm, var_buf_offset, dt.fmt))
-        var_buf_offset += dt.itemsize
+      for nm, slot, dt, shape, is_buf, idx in runtime.signature:
+        if is_buf:
+          if not any(pos == idx for pos, _ in replace):
+            icb_command.setKernelBuffer_offset_atIndex(bufs[idx]._buf.buf, bufs[idx]._buf.offset, slot)
+            all_resources.append(bufs[idx]._buf.buf)
+        else:
+          icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, slot)
+          self.var_bind_data.append((nm, var_buf_offset, dt.fmt))
+          var_buf_offset += dt.itemsize
       global_size, local_size = ast.arg.launch_dims({v: 0 for v in self.vars})
       icb_command.concurrentDispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
       icb_command.setBarrier()
@@ -63,7 +64,8 @@ class MetalGraph(GraphRunner):
       computeCommand = self.icb.indirectComputeCommandAtIndex(j)
       for pos, iidx in self.uop_replace[j]:
         buf = cast(Buffer, input_uops[iidx].buffer)
-        computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, pos)
+        slot = next(slot for (_, slot, _, _, is_buf, idx) in unwrap(self.runtimes[j]).signature if is_buf and idx == pos)
+        computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, slot)
         updated_bufs.append(buf._buf.buf)
 
     all_resources = dedup(self.all_resources + updated_bufs)

--- a/tinygrad/runtime/ops_cl.py
+++ b/tinygrad/runtime/ops_cl.py
@@ -54,8 +54,9 @@ class CLProgram(Program['CLDevice']):
 
   def __call__(self, *bufs:cl.cl_mem, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]|None=None, vals:tuple[int, ...]=(),
                wait=False, **kw) -> float|None:
-    for i, (_, slot, dt, shape) in enumerate(self.signature):
-      b = bufs[slot] if slot < len(bufs) else getattr(ctypes, f"c_int{dt.bitsize}")(vals[slot-len(bufs)])
+    g = sorted({s for _,s,_,_,ib,_ in self.signature if ib})
+    for i, (_, slot, dt, shape, is_buf, idx) in enumerate(self.signature):
+      b = bufs[g.index(slot)] if is_buf else getattr(ctypes, f"c_int{dt.bitsize}")(vals[idx])
       if is_image_shape(shape):
         pitch = (round_up(shape[1], 256) if OSX else shape[1]) * 4 * dt.itemsize
         fmt = cl.cl_image_format(cl.CL_RGBA, {2:cl.CL_HALF_FLOAT, 4:cl.CL_FLOAT}[dt.itemsize])

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -156,13 +156,13 @@ class CPUProgram(Program['CPUDevice']):
                vals:tuple[int|None, ...]=(), wait:bool=False, timeout:int|None=None) -> float|None:
     st = time.perf_counter()
     if self.lvp:
-      lvp_args = bytearray(12 + (len(bufs) + len(vals)) * 8)
-      addr = mv_address(lvp_args)
-      struct.pack_into(f'<3I{len(bufs)}Q', lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2, *[b.va_addr for b in bufs])
-      for v,(off,dt) in zip(vals, TinyELF.iter_sig(self.signature[-len(vals):], len(bufs)*8)): struct.pack_into(f'<{dt.fmt}', lvp_args, 12+off, v)
+      addr = mv_address(lvp_args:=bytearray(12 + (len(bufs)+len(vals))*8))
+      struct.pack_into('<3I', lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2)
+      for o, dt, is_buf, idx in TinyELF.iter_sig(self.signature):
+        struct.pack_into('<Q' if is_buf else f'<{dt.fmt}', lvp_args, 12+o, bufs[idx].va_addr if is_buf else vals[idx])
       self.fxn(addr)
     else:
-      args = [*[cast(int, b.va_addr) for b in bufs], *cast(tuple[int, ...], vals)]
+      args = [cast(int,bufs[idx].va_addr if is_buf else vals[idx]) for *_,_,is_buf,idx in self.signature]
       assert len(args) <= MAX_ARGS, f"CPU programs support at most {MAX_ARGS} arguments, got {len(args)}"
       for tid in range(global_size[0]):
         if 'core_id' in self.runtimevars: args[self.runtimevars['core_id']] = tid

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -16,9 +16,12 @@ def check(status):
     raise RuntimeError(f"CUDA Error {status}, {error}")
 
 def encode_args(args, vals, signature) -> tuple[ctypes.Structure, ctypes.Array]:
-  fields = ([(f'f{i}', cuda.CUdeviceptr_v2, i*8) for i in range(len(args))] +
-            [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), off) for i,(off,dt) in enumerate(TinyELF.iter_sig(signature[len(args):], len(args)*8))])
-  c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
+  fields, ordered, end = [], [], 0
+  for o, dt, is_buf, idx in TinyELF.iter_sig(signature):
+    fields.append((f'f{idx}', cuda.CUdeviceptr_v2, o) if is_buf else (f'v{idx}', getattr(ctypes, f"c_int{dt.bitsize}"), o))
+    ordered.append(args[idx] if is_buf else vals[idx])
+    end = o + (8 if is_buf else dt.itemsize)
+  c_args = init_c_struct_t(end, tuple(fields))(*ordered)
   vargs = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), ctypes.cast(ctypes.byref(c_args), ctypes.c_void_p), ctypes.c_void_p(2),
                                 ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(c_args))), ctypes.c_void_p), ctypes.c_void_p(0))
   return c_args, vargs

--- a/tinygrad/runtime/ops_dsp.py
+++ b/tinygrad/runtime/ops_dsp.py
@@ -41,9 +41,9 @@ class DSPRenderer(ClangRenderer):
     msrc += [f'{self._render_dtype(b[1][0].dtype) if b[1][0].addrspace == AddrSpace.ALU else "int"} sz_or_val_{i} = '
              f'*({self._render_dtype(b[1][0].dtype) if b[1][0].addrspace == AddrSpace.ALU else "int"}*)((char*)pra[0].buf.pv+{i*8});'
              for i,b in enumerate(bufs)]
-    msrc += [f'int off{i} = ((int*)pra[1].buf.pv)[{i}];' for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
-    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{i+3}].dma.fd,0)+off{i};'
-             for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
+    gbufs = [i for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
+    msrc += [f'int off{i} = ((int*)pra[1].buf.pv)[{k}];' for k,i in enumerate(gbufs)]
+    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{k+3}].dma.fd,0)+off{i};' for k,i in enumerate(gbufs)]
     msrc += ["unsigned long long start = HAP_perf_get_time_us();"]
     fbufs = [(f'buf_{i}' if b[1][0].addrspace == AddrSpace.GLOBAL else f'sz_or_val_{i}') for i,b in enumerate(bufs)]
     msrc += [f"{function_name}({', '.join(fbufs)});"]
@@ -73,8 +73,8 @@ class DSPProgram(Program['DSPDevice']):
 
     pra, fds, attrs, _ = rpc_prep_args(ins=[var_vals_mv:=memoryview(bytearray((len(bufs)+len(vals))*8)), off_mv:=memoryview(bytearray(len(bufs)*4))],
                                        outs=[timer:=memoryview(bytearray(8)).cast('Q')], in_fds=[b.share_info.fd for b in bufs])
-    for i,b in enumerate(bufs): struct.pack_into('i', var_vals_mv, i*8, b.size)
-    for i,(v,(_,_,dt,_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
+    for i,(*_,dt,_,is_buf,idx) in enumerate(self.signature):
+      struct.pack_into('i' if is_buf else unwrap(dt.fmt), var_vals_mv, i*8, bufs[idx].size if is_buf else vals[idx])
     off_mv.cast('I')[:] = array.array('I', tuple(b.offset for b in bufs))
     self.dev.exec_lib(self.lib, rpc_sc(method=2, ins=2, outs=1, fds=len(bufs)), pra, fds, attrs)
     return timer[0] / 1e6
@@ -286,8 +286,8 @@ class MockDSPProgram(Program[DSPDevice]):
       dsp_lib.flush()
       os.chmod(dsp_lib.name, 0o0777)
       proc = subprocess.run(["qemu-hexagon-static", *(['-strace'] if DEBUG >= 5 else []), dsp_lib.name],
-        input=b''.join([bytes(to_mv(x.va_addr, x.size)) for x in bufs] +
-                       [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,_) in zip(vals, self.signature[len(bufs):])]),
+        input=b''.join(bytes(to_mv(bufs[idx].va_addr, bufs[idx].size)) if is_buf else struct.pack(unwrap(dt.fmt), vals[idx])
+              for *_,dt,_,is_buf,idx in self.signature),
         stdout=subprocess.PIPE, check=True)
     offset = 4
     for x in bufs:

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -37,11 +37,14 @@ class HIPProgram(Program[HIPDevice]):
   def __call__(self, *args, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(), wait=False, **kw):
     check(hip.hipSetDevice(self.dev.device_id))
     if not hasattr(self, "vargs"):
-      fields = ([(f'f{i}', hip.hipDeviceptr_t, i*8) for i in range(len(args))] +
-        [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), o) for i,(o,dt) in enumerate(TinyELF.iter_sig(self.signature[len(args):], len(args)*8))])
-      self.c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
+      fields, ordered, end = [], [], 0
+      for o, dt, is_buf, idx in TinyELF.iter_sig(self.signature):
+        fields.append((f'f{idx}', hip.hipDeviceptr_t, o) if is_buf else (f'v{idx}', getattr(ctypes, f"c_int{dt.bitsize}"), o))
+        ordered.append(args[idx] if is_buf else vals[idx])
+        end = o + (8 if is_buf else dt.itemsize)
+      self.c_args = init_c_struct_t(end, tuple(fields))(*ordered)
       self.vargs = (ctypes.c_void_p * 5)(1, ctypes.cast(ctypes.byref(self.c_args), ctypes.c_void_p), 2,
-                                         ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(self.c_args))), ctypes.c_void_p), 3)
+                                        ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(self.c_args))), ctypes.c_void_p), 3)
 
     for i in range(len(args)): self.c_args.__setattr__(f'f{i}', args[i])
     for i in range(len(vals)): self.c_args.__setattr__(f'v{i}', vals[i])

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -138,9 +138,9 @@ class MetalProgram(Program[MetalDevice]):
     command_buffer = self.dev.mtl_queue.commandBuffer().retained()
     encoder = command_buffer.computeCommandEncoder().retained()
     encoder.setComputePipelineState(self.pipeline_state)
-    for i,a in enumerate(bufs): encoder.setBuffer_offset_atIndex(a.buf, a.offset, i)
-    for a,(_,i,dt,_) in zip(vals, self.signature[len(bufs):]):
-      encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(a)), dt.itemsize, i)
+    for _, slot, dt, _, is_buf, idx in self.signature:
+      if is_buf: encoder.setBuffer_offset_atIndex(bufs[idx].buf, bufs[idx].offset, slot)
+      else: encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(vals[idx])), dt.itemsize, slot)
     encoder.dispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
     encoder.endEncoding()
     command_buffer.setLabel(to_ns_str(self.name)) # TODO: is this always needed?

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -3,8 +3,8 @@ import os, ctypes, contextlib, re, functools, mmap, struct, array, sys, weakref
 assert sys.platform != 'win32'
 from typing import cast
 from dataclasses import dataclass
-from tinygrad.runtime.support.hcq import HCQCompiled, HCQAllocator, HCQBuffer, HWQueue, CLikeArgsState, HCQProgram, HCQSignal, BumpAllocator
-from tinygrad.runtime.support.hcq import MMIOInterface, FileIOInterface, hcq_filter_visible_devices, hcq_profile
+from tinygrad.runtime.support.hcq import HCQCompiled, HCQAllocator, HCQBuffer, HWQueue, CLikeArgsState, HCQArgsState, HCQProgram, HCQSignal
+from tinygrad.runtime.support.hcq import MMIOInterface, FileIOInterface, hcq_filter_visible_devices, hcq_profile, BumpAllocator
 from tinygrad.uop.ops import sint
 from tinygrad.device import Compiled, BufferSpec, TinyELF
 from tinygrad.helpers import getenv, mv_address, round_up, data64, data64_le, prod, OSX, hi32, lo32, PROFILE, ContextVar, VIZ, ProfileEvent
@@ -240,10 +240,17 @@ class NVVideoQueue(NVCommandQueue):
 
 class NVArgsState(CLikeArgsState):
   def __init__(self, buf:HCQBuffer, prg:NVProgram, bufs:tuple[HCQBuffer, ...], vals:tuple[int, ...]=()):
-    if (is_mock:=isinstance(prg.dev.iface, MOCKIface)): prg.cbuf_0[80:82] = [len(bufs), len(vals)]
-    super().__init__(buf, prg, bufs, vals=() if is_mock else vals, prefix=prg.cbuf_0 or None)
-    # mock expects all vars to be 64 bit
-    if is_mock and vals: self.bind_sints_to_buf(*vals, buf=self.buf, fmt='q', offset=len(prg.cbuf_0)*4 + len(bufs)*8)
+    if not isinstance(prg.dev.iface, MOCKIface):
+      super().__init__(buf, prg, bufs, vals=vals, prefix=prg.cbuf_0 or None)
+      return
+    prg.cbuf_0[80:82] = [sum(is_buf for *_,_,is_buf,_ in prg.signature),
+                        sum(not is_buf for *_,_,is_buf,_ in prg.signature)]
+    HCQArgsState.__init__(self, buf, prg, bufs, vals=vals)
+    self.buf.cpu_view().view(size=len(prg.cbuf_0)*4, fmt='I')[:] = array.array('I', prg.cbuf_0)
+    # mock expects every arg as a 64-bit word: addresses unsigned, vals signed
+    for i,(*_,_,is_buf,idx) in enumerate(prg.signature):
+      self.bind_sints_to_buf(bufs[idx].va_addr if is_buf else vals[idx], buf=self.buf, fmt='Q' if is_buf else 'q',
+                            offset=len(prg.cbuf_0)*4 + i*8)
 
 class NVProgram(HCQProgram['NVDevice']):
   def __init__(self, dev:NVDevice, obj:TinyELF):

--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -202,22 +202,20 @@ class QCOMArgsState(HCQArgsState):
     super().__init__(buf, prg, bufs, vals=vals)
     ctypes.memset(int(self.buf.va_addr), 0, prg.kernargs_alloc_size)
 
-    ubos = [bufs[slot] for _,slot,_,shape in prg.signature if slot < len(bufs) and not is_image_shape(shape)]
-    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape in prg.signature if slot < len(bufs) and is_image_shape(shape)]
+    uavs = [(dt, s, bufs[idx]) for *_, dt, s, is_buf, idx in prg.signature if is_buf and is_image_shape(s)]
     # NIR can reorder images to different texture slots
     ibos, texs = uavs[:prg.ibo_cnt], [uavs[prg.ibo_cnt + (prg.tex_to_image[i] if prg.NIR else i)] for i in range(prg.tex_cnt)]
     for cnst_val,cnst_off,cnst_sz in prg.consts_info:
       to_mv(cast(int, self.buf.va_addr) + cnst_off, cnst_sz)[:] = cnst_val.to_bytes(cnst_sz, byteorder='little')
 
     if prg.samp_cnt > 0: to_mv(int(self.buf.va_addr) + prg.samp_off, len(prg.samplers) * 4).cast('I')[:] = array.array('I', prg.samplers)
+    non_img = [x for x in prg.signature if not is_image_shape(x[3])]
     if prg.NIR:
-      self.bind_sints_to_buf(*[b.va_addr for b in ubos], buf=self.buf, fmt='Q', offset=prg.buf_off)
-      for v,(o,dt) in zip(vals, TinyELF.iter_sig(prg.signature[len(bufs):], len(ubos)*8)):
-        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_off + o)
+      for o,dt,is_buf,idx in TinyELF.iter_sig(non_img):
+        self.bind_sints_to_buf(bufs[idx].va_addr if is_buf else vals[idx], buf=self.buf, fmt='Q' if is_buf else dt.fmt, offset=prg.buf_off+o)
     else:
-      for i, b in enumerate(ubos): self.bind_sints_to_buf(b.va_addr, buf=self.buf, fmt='Q', offset=prg.buf_offs[i])
-      for i,(v,(_,_,dt,_)) in enumerate(zip(vals, prg.signature[len(bufs):])):
-        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_offs[i+len(ubos)])
+      for i, (*_, dt, s, is_buf, idx) in enumerate(non_img):
+        self.bind_sints_to_buf(bufs[idx].va_addr if is_buf else vals[idx], buf=self.buf, fmt='Q' if is_buf else dt.fmt, offset=prg.buf_offs[i])
 
     def _tex(b, ibo=False):
       imgdt, shape, buf = b

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -51,7 +51,7 @@ QueueOnSubmittedWorkDone = synchronous(webgpu.enum_WGPUQueueWorkDoneStatus)(webg
 
 class WebGPUProgram(Program['WebGpuDevice']):
   def __init__(self, dev:'WebGpuDevice', obj:TinyELF):
-    self.dev, self.name = dev, to_wgpu_str(obj.name)
+    self.dev, self.name, self.signature = dev, to_wgpu_str(obj.name), obj.signature
 
     # Creating shader module
     shader = webgpu.WGPUShaderModuleWGSLDescriptor(code=to_wgpu_str(obj.lib.decode()),
@@ -74,8 +74,9 @@ class WebGPUProgram(Program['WebGpuDevice']):
     def bgl_entry(n:int, ty:str):
       return webgpu.WGPUBindGroupLayoutEntry(binding=n, visibility=webgpu.WGPUShaderStage_Compute,
                                              buffer=webgpu.WGPUBufferBindingLayout(type=getattr(webgpu, f'WGPUBufferBindingType_{ty}')))
-    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(bufs)+len(vals)))(
-      bgl_entry(0, 'Uniform'), *(bgl_entry(i+1, 'Uniform' if i >= len(bufs) else 'Storage') for i in range(len(bufs)+len(vals))))
+    xs = [bufs[idx] if is_buf else vals[idx] for *_,_,is_buf,idx in self.signature]
+    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(xs)))(bgl_entry(0, 'Uniform'),
+            *(bgl_entry(i+1, 'Storage' if is_buf else 'Uniform') for i,(*_,_,is_buf,_) in enumerate(self.signature)))
 
     webgpu.wgpuDevicePushErrorScope(self.dev.device_res, webgpu.WGPUErrorFilter_Validation)
     bind_layout = webgpu.wgpuDeviceCreateBindGroupLayout(self.dev.device_res,
@@ -94,7 +95,7 @@ class WebGPUProgram(Program['WebGpuDevice']):
     def bg_entry(n:int, x:webgpu.WGPUBuffer|int|float):
       buf = x if isinstance(x, webgpu.WGPUBuffer) else self.dev.create_uniform(x)
       return webgpu.WGPUBindGroupEntry(binding=n, buffer=buf, offset=0, size=webgpu.wgpuBufferGetSize(buf))
-    bindings = (webgpu.WGPUBindGroupEntry * (1+len(bufs)+len(vals)))(bg_entry(0, float('inf')), *(bg_entry(i+1, x) for i,x in enumerate(bufs+vals)))
+    bindings = (webgpu.WGPUBindGroupEntry * (1+len(xs)))(bg_entry(0, float('inf')), *(bg_entry(i+1, x) for i,x in enumerate(xs)))
 
     bind_group_desc = webgpu.WGPUBindGroupDescriptor(layout=bind_layout, entryCount=len(bindings), entries=bindings)
     webgpu.wgpuDevicePushErrorScope(self.dev.device_res, webgpu.WGPUErrorFilter_Validation)

--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -326,10 +326,12 @@ class CLikeArgsState(HCQArgsState[ProgramType]):
 
     if prefix is not None: self.buf.cpu_view().view(size=len(prefix) * 4, fmt='I')[:] = array.array('I', prefix)
 
-    self.bind_sints_to_buf(*[b.va_addr for b in bufs], buf=self.buf, fmt='Q', offset=len(prefix or []) * 4)
-    for v,(val_offset,dt) in zip(vals, TinyELF.iter_sig(prg.signature[-len(vals):], len(bufs) * 8)):
-      assert v is not None
-      self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=len(prefix or []) * 4 + val_offset)
+    for o,dt,is_buf,idx in TinyELF.iter_sig(prg.signature):
+      if is_buf: self.bind_sints_to_buf(bufs[idx].va_addr, buf=self.buf, fmt='Q', offset=len(prefix or [])*4+o)
+      else:
+        v = vals[idx]
+        assert v is not None
+        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=len(prefix or [])*4+o)
 
 class HCQProgram(Program[HCQDeviceType]):
   def __init__(self, args_state_t:Type[HCQArgsState], dev:HCQDeviceType, obj:TinyELF, kernargs_alloc_size:int, base:int|None=None):

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1195,8 +1195,10 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
 
   def to_elf(self) -> TinyELF:
     assert self.op is Ops.PROGRAM and isinstance(self.arg, ProgramInfo), "to_elf should only be called on a PROGRAM ast"
-    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape)
-                for u in tuple(filter(lambda u: u.op is Ops.PARAM and u.addrspace != AddrSpace.ALU, self.src[1].src)) + self.arg.vars)
+    bc, vc = itertools.count(), itertools.count()
+    params = self.arg.params or [u for u in self.src[1].src if u.op is Ops.PARAM] or [u for u in self.src[0].src if u.op is Ops.PARAM]
+    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape, (is_buf:=u.addrspace!=AddrSpace.ALU), next(bc if is_buf else vc))
+            for u in params if u.op is Ops.PARAM)
     return TinyELF(self.src[3].arg, self.arg.function_name, self.arg.target, sig, self.key)
 
 @dataclass(frozen=True)
@@ -1221,6 +1223,7 @@ class ProgramInfo:
   outs: tuple[int, ...] = ()
   ins: tuple[int, ...] = ()
   target: Target = Target()
+  params: tuple[UOp, ...] = ()
 
   @property
   def function_name(self): return to_function_name(self.name)


### PR DESCRIPTION
Buffers and args supported in any input order on all backends 
The buffers and args were piled in a strict order for the backends to be able to distinguish them, added _is_buf and the index inside the signature tuple then modified the backends accordingly not sure of the scope of the bounty and if realize layer should as well be touched, either way i think another pr should be better for this
CI green in my actions




### Explanations line by line or so by ME no LLM:
### uop/ops.py: 
adding `is_buf` and `idx` to the the signature 
`params = self.arg.params or [u for u in self.src[1].src if u.op is Ops.PARAM] or [u for u in self.src[0].src if u.op is Ops.PARAM]`
`params` for 1- IselContext or 2- regular path 3- custom kernels
example with a metal kernel
```
#include <metal_stdlib>
using namespace metal;
kernel void scalar_first(constant int& data0_, device int* data1_1, uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  *(data1_1+0) = data0_;
}
constant int& data0_: no buffer 
device int* data1_1: buffer
```
this is what we want to be supported, the buffers not necessary coming first
why would the buffers come first? Because the backends in ops_*.py used that order to gate the buffers
So now instead of gating on position we’re gating directly with the information in the tuple (is_buf) then we have directly the index inside the signature accessible since this what the backends want sometimes, it saves lines

we have to take care of 9 backends we will walk through each of them:
### `ops_cuda.py`
**BEFORE**   
```
fields = ([(f'f{i}', cuda.CUdeviceptr_v2, i*8) for i in range(len(args))] +
            [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), off) for i,(off,dt) in enumerate(TinyELF.iter_sig(signature[len(args):], len(args)*8))])
  c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
vargs = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), ctypes.cast(ctypes.byref(c_args), ctypes.c_void_p), ctypes.c_void_p(2),
                                ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(c_args))), ctypes.c_void_p), ctypes.c_void_p(0))

```
**AFTER**
```
  fields, ordered, end = [], [], 0
  for o, dt, is_buf, idx in TinyELF.iter_sig(signature):
    fields.append((f'f{idx}', cuda.CUdeviceptr_v2, o) if is_buf else (f'v{idx}', getattr(ctypes, f"c_int{dt.bitsize}"), o))
    ordered.append(args[idx] if is_buf else vals[idx])
    end = o + (8 if is_buf else dt.itemsize)
  c_args = init_c_struct_t(end, tuple(fields))(*ordered)
vargs = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), ctypes.cast(ctypes.byref(c_args), ctypes.c_void_p), ctypes.c_void_p(2),
                                ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(c_args))), ctypes.c_void_p), ctypes.c_void_p(0))

```
We’re constructing `v_args` that we will pass to the cuda function later

We want to fill the args inside this (https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXEC.html#group__CUDA__EXEC_1gb8f3dc3031b40da29d5f9a7139e52e15)

`cuLaunchKernel ( CUfunction f, unsigned int  gridDimX, unsigned int  gridDimY, unsigned int  gridDimZ, unsigned int  blockDimX, unsigned int  blockDimY, unsigned int  blockDimZ, unsigned int  sharedMemBytes, CUstream hStream, void** kernelParams, void** extra )
`
tinygrad places the args via `void** extra` (ops_cuda.py: 72), `c_args` will be copied into kernel param space, `v_args` is informations about `c_args`
for instance when running (generated by a LLM comments by me, env OCELOT_PATH="$PWD/libgpuocelot.dylib"  on M4)
```
def _run(name, sink, bufs, vals):
  prg = to_program(sink, Device[Device.DEFAULT].renderer)
  print(f"\n===== {name} =====")
  print(prg.src[2].arg)
  Device[Device.DEFAULT].runtime(prg.to_elf())(*[b.uop.buffer._buf for b in bufs], vals=vals)
  Device[Device.DEFAULT].synchronize()

# scalar first: void k(int n, int* buf)
n = UOp.param(0, dtypes.int, (), name="n", addrspace=AddrSpace.ALU) # <- this is the scalar, slot 0
buf = UOp.param(1, dtypes.int, (1,)) # <- this is the buffer, slot 1
sink = buf[0].store(n).sink(arg=KernelInfo(name="scalar_first"), tag=1)
out = Tensor.zeros(1, dtype=dtypes.int).contiguous().realize()
_run("scalar_first", sink, [out], (7,))
if out.item() != 7: failed.append(f"scalar_first got {out.item()}")

```
Kernel ptx
```
===== scalar_first =====
.version VERSION
.target TARGET
.address_size 64
.visible .entry scalar_first (
	.param .s32 data0, <- our n
	.param .u64 data1 <- our buf[0]
)
.maxntid 1
{
	.reg		.s32 %dat_s32_<1>;
	.reg		.s32 %cast_s32_<2>;
	.reg		.u64 %dat_u64_<1>;
	.reg		.u64 %bidx_u64_<1>;
	ld.param.s32	%dat_s32_0, [data0+0];
	mov.b32		%cast_s32_0, 1;
	ld.param.u64	%dat_u64_0, [data1+0];
	mov.b32		%cast_s32_1, 0;
	cvt.s64.s32	%bidx_u64_0, %cast_s32_1;
	mad.lo.s64	%bidx_u64_0, %bidx_u64_0, 4, %dat_u64_0;
	st.global.s32	[%bidx_u64_0+0], %dat_s32_0;
	ret;
}

```
**BEFORE**:
`zsh: segmentation fault  PYTHONPATH=. OCELOT_PATH="$PWD/libgpuocelot.dylib" DEV=MOCK+CUDA:PTX python3` 
—> SEGFAULT because `encode_args` sets pointers (`data1`) then ints (`data0`) into `c_args`, `cuLaunchKernel` receives that, PTX generates the above code, thus mismatch
**AFTER** —> CLEAN

### `ops_hip.py:`
Similar to CUDA 

### `ops_cl.py:`
**BEFORE**
```
    for i, (_, slot, dt, shape) in enumerate(self.signature):
      b = bufs[slot] if slot < len(bufs) else getattr(ctypes, f"c_int{dt.bitsize}")(vals[slot-len(bufs)])

```
**AFTER**
```
    for i, (_, _, dt, shape, is_buf, idx) in enumerate(self.signature):
      b = bufs[idx] if is_buf else getattr(ctypes, f"c_int{dt.bitsize}")(vals[idx])

```
we’re directly walking through the signature and know if we have a buffer or not + the index 

Kernel
```
===== scalar_first =====
__kernel void scalar_first(const int data0_, __global int* data1_1) {
  *(data1_1+0) = data0_;
}

```
**BEFORE** -> `RuntimeError: OpenCL Error -51: CL_INVALID_ARG_SIZE`
**AFTER** -> CLEAN

### **ops_cpu.py:**
**LVP BRANCH**
**BEFORE**
```
      lvp_args = bytearray(12 + (len(bufs) + len(vals)) * 8)
      addr = mv_address(lvp_args)
      struct.pack_into(f'<3I{len(bufs)}Q', lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2, *[b.va_addr for b in bufs])
      for v,(off,dt) in zip(vals, TinyELF.iter_sig(self.signature[-len(vals):], len(bufs)*8)): struct.pack_into(f'<{dt.fmt}', lvp_args, 12+off, v)
```
**AFTER**       
```
addr = mv_address(lvp_args:=bytearray(12 + (len(bufs)+len(vals))*8))
      struct.pack_into('<3I', lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2)
      for o, dt, is_buf, idx in TinyELF.iter_sig(self.signature):
        struct.pack_into('<Q' if is_buf else f'<{dt.fmt}', lvp_args, 12+o, bufs[idx].va_addr if is_buf else vals[idx])

```
no `self.signature[-len(vals):]` needed we use `is_buf`, can be in any order

CLANG BRANCH
**BEFORE**
`args = [*[cast(int, b.va_addr) for b in bufs], *cast(tuple[int, ...], vals)]
`
**AFTER** 
`args = [cast(int,bufs[idx].va_addr if is_buf else vals[idx]) for *_,_,is_buf,idx in self.signature]
`
We then call `self.fxn` which is whatever callable that’s pointed by `self.addr`, for the lvp path it takes a pointer to `lvp_args` that we fill inside `pack_into`, clang iterates over the `args`

now here this is a bit trickier bc on the linux x86 path isel would kinda re-sort params into buffers first so had to stop `IselContext` from sorting here

**BEFORE**
```
class IselContext:
 def __init__(self, sink:UOp):
    self.uses = consumer_map_from_toposort(sink.toposort())
    self.reg_n = itertools.count()
    def arg_key(u:UOp):
      if u.op is Ops.SPECIAL: return (2, u.arg)
      return (0, u.arg.slot) if u.arg.addrspace is not None else (1, u.expr)
    self.func_args = sorted([u for u in self.uses if u.op in {Ops.PARAM, Ops.SPECIAL}], key=arg_key)
```
**AFTER**
```
class IselContext:
  def __init__(self, sink:UOp, param_order:list[UOp]|None=None):
    ts = sink.toposort()
    self.uses = consumer_map_from_toposort(ts)
    self.reg_n = itertools.count()
    src = param_order if param_order is not None else ts
    self.func_args = [u for u in src if u in self.uses and u.op is Ops.PARAM]
    self.func_args += sorted((u for u in self.uses if u.op is Ops.SPECIAL), key=lambda u: u.arg)
```

Kernel (clang)
```
===== scalar_first =====

void scalar_first(const int data0_, int* restrict data1_1) {
  *(data1_1+0) = data0_;
}
```
**BEFORE** -> SEGFAULT -> lvp_args / args got pointers then int
**AFTER** -> CLEAN

### `ops_dsp.py`
**BEFORE**:
```
    msrc += [f'int off{i} = ((int*) pra[1] .buf.pv)[{i}];' for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{i+3}].dma.fd,0)+off{i};'
             for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
```
**AFTER**:
```
    gbufs = [i for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
    msrc += [f'int off{i} = ((int*)pra[1].buf.pv)[{k}];' for k,i in enumerate(gbufs)]
    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{k+3}].dma.fd,0)+off{i};' for k,i in enumerate(gbufs)]
```
here we modify the index

here `bufs` used to be pointers first then scalar so with `i` here `for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL` we directly knew this the slot of the buffer, now it’s not the case anymore `i` will be the prototype slot but not the i’th pointer so we have to enumerate on the pointer (`gbufs`) to get which pointer it is (`k`) at which slot (`i`)

**BEFORE**
```
  for i,b in enumerate(bufs): struct.pack_into('i', var_vals_mv, i*8, b.size)
  for i,(v,(_,_,dt,_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
```
**AFTER**
```
for i,(*_,dt,_,is_buf,idx) in enumerate(self.signature):
  struct.pack_into('i' if is_buf else unwrap(dt.fmt), var_vals_mv, i*8, bufs[idx].size if is_buf else vals[idx])
```
we directly get which one is a buffer via is_buf, at which index idx

**BEFORE**
```
    input=b''.join([bytes(to_mv(x.va_addr, x.size)) for x in bufs] +
             [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,_) in zip(vals, self.signature[len(bufs):])]),
```
**AFTER**
```
    input=b''.join(bytes(to_mv(bufs[idx].va_addr, bufs[idx].size)) if is_buf else struct.pack(unwrap(dt.fmt), vals[idx])
        for *_,dt,_,is_buf,idx in self.signature),
```
we directly get which one is a buffer via `is_buf`, at which index `idx`

Kernel

**BEFORE**	
```
int HAP_power_set(void*, void*);
typedef union { struct { void *pv; unsigned int len; } buf; struct { int fd; unsigned int offset; } dma; } remote_arg;
void* HAP_mmap(void *addr, int len, int prot, int flags, int fd, long offset);
int HAP_munmap(void *addr, int len);
unsigned long long HAP_perf_get_time_us(void);
__attribute__((noinline)) void scalar_first(const int data0_, int* restrict __attribute__((align_value(128))) data1_1) {
  *(data1_1+0) = data0_;
}
int entry(unsigned long long handle, unsigned int sc, remote_arg* pra) {
struct dcvs_v2_req req = {.type=7, .dcvs_enable=0, .set_latency=1, .latency=100, .set_dcvs_params=1, .target_corner = 6 /* TURBO */};
HAP_power_set((void*)handle, (void*)&req);
if ((sc>>24) != 2) return 0;
int sz_or_val_0 = *(int*)((char*)pra[0].buf.pv+0);
int sz_or_val_1 = *(int*)((char*)pra[0].buf.pv+8);
int off1 = ((int*)pra[1].buf.pv)[1]; <- wrong
void *buf_1 = HAP_mmap(0,sz_or_val_1,3,0,pra[4].dma.fd,0)+off1; <- wrong
unsigned long long start = HAP_perf_get_time_us();
scalar_first(sz_or_val_0, buf_1);
*(unsigned long long *)(pra[2]. buf .pv) = HAP_perf_get_time_us() - start;
HAP_munmap(buf_1, sz_or_val_1);
return 0; }
```
**AFTER**
```
int HAP_power_set(void*, void*);
typedef union { struct { void *pv; unsigned int len; } buf; struct { int fd; unsigned int offset; } dma; } remote_arg;
void* HAP_mmap(void *addr, int len, int prot, int flags, int fd, long offset);
int HAP_munmap(void *addr, int len);
unsigned long long HAP_perf_get_time_us(void);
__attribute__((noinline)) void scalar_first(const int data0_, int* restrict __attribute__((align_value(128))) data1_1) {
  *(data1_1+0) = data0_;
}
int entry(unsigned long long handle, unsigned int sc, remote_arg* pra) {
struct dcvs_v2_req req = {.type=7, .dcvs_enable=0, .set_latency=1, .latency=100, .set_dcvs_params=1, .target_corner = 6 /* TURBO */};
HAP_power_set((void*)handle, (void*)&req);
if ((sc>>24) != 2) return 0;
int sz_or_val_0 = *(int*)((char*)pra[0].buf.pv+0);
int sz_or_val_1 = *(int*)((char*)pra[0].buf.pv+8);
int off1 = ((int*)pra[1].buf.pv)[0]; <- ok 
void *buf_1 = HAP_mmap(0,sz_or_val_1,3,0,pra[3].dma.fd,0)+off1; <- ok
unsigned long long start = HAP_perf_get_time_us();
scalar_first(sz_or_val_0, buf_1);
*(unsigned long long *)(pra[2].buf.pv) = HAP_perf_get_time_us() - start;
HAP_munmap(buf_1, sz_or_val_1);
return 0; }
```
### `ops_metal.py`
**BEFORE**
```
    for i,a in enumerate(bufs): encoder.setBuffer_offset_atIndex(a.buf, a.offset, i)
    for a,(_,i,dt,_) in zip(vals, self.signature[len(bufs):]):
      encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(a)), dt.itemsize, i)
```
**AFTER**
```
    for _, slot, dt, _, is_buf, idx in self.signature:
      if is_buf: encoder.setBuffer_offset_atIndex(bufs[idx].buf, bufs[idx].offset, slot)
      else: encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(vals[idx])), dt.itemsize, slot)
```
we directly get which one is a buffer via is_buf, at which index idx

**BEFORE**
```
      for i, b in enumerate(bufs):
        if not any(pos == i for pos, _ in replace):
          icb_command.setKernelBuffer_offset_atIndex(b._buf.buf, b._buf.offset, i)
          all_resources.append(b._buf.buf)
      for nm,i,dt,_ in runtime.signature[len(bufs):]:
        icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, i)
        self.var_bind_data.append((nm, var_buf_offset, dt.fmt))
        var_buf_offset += dt.itemsize
```
**AFTER**
```
      for nm, slot, dt, shape, is_buf, idx in runtime.signature:
        if is_buf:
          if not any(pos == idx for pos, _ in replace):
            icb_command.setKernelBuffer_offset_atIndex(bufs[idx]._buf.buf, bufs[idx]._buf.offset, slot)
            all_resources.append(bufs[idx]._buf.buf)
        else:
          icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, slot)
          self.var_bind_data.append((nm, var_buf_offset, dt.fmt))
          var_buf_offset += dt.itemsize
```
we’re using the new signature

**BEFORE**
``` 
computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, pos)
```
**AFTER**
```
        slot = next(slot for (_, slot, _, _, is_buf, idx) in unwrap(self.runtimes[j]).signature if is_buf and idx == pos)
        computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, slot)
```

### `ops_nv.py`
**BEFORE**     
```
if (is_mock:=isinstance(prg.dev.iface, MOCKIface)): prg.cbuf_0[80:82] = [len(bufs), len(vals)]
    super().__init__(buf, prg, bufs, vals=() if is_mock else vals, prefix=prg.cbuf_0 or None)
    # mock expects all vars to be 64 bit
    if is_mock and vals: self.bind_sints_to_buf(*vals, buf=self.buf, fmt='q', offset=len(prg.cbuf_0)*4 + len(bufs)*8)
```
**AFTER**
```
    if not isinstance(prg.dev.iface, MOCKIface):
      super().__init__(buf, prg, bufs, vals=vals, prefix=prg.cbuf_0 or None)
      return
    prg.cbuf_0[80:82] = [sum(is_buf for *_,_,is_buf,_ in prg.signature),
                        sum(not is_buf for *_,_,is_buf,_ in prg.signature)]
    HCQArgsState.__init__(self, buf, prg, bufs, vals=vals)
    self.buf.cpu_view().view(size=len(prg.cbuf_0)*4, fmt='I')[:] = array.array('I', prg.cbuf_0)
    # mock expects every arg as a 64-bit word: addresses unsigned, vals signed
    for i,(*_,_,is_buf,idx) in enumerate(prg.signature):
      self.bind_sints_to_buf(bufs[idx].va_addr if is_buf else vals[idx], buf=self.buf, fmt='Q' if is_buf else 'q',
                            offset=len(prg.cbuf_0)*4 + i*8)
```
`CLikeArgState.__init__` does
```
    for o,dt,is_buf,idx in TinyELF.iter_sig(prg.signature):
      if is_buf: self.bind_sints_to_buf(bufs[idx].va_addr, buf=self.buf, fmt='Q', offset=len(prefix or [])*4+o)
      else:
        v = vals[idx]
        assert v is not None
        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=len(prefix or [])*4+o)
```
here we skip `CLikeArgState.__init__` because the new `iter_sig` uses `dt.fmt` which would be wrong here bc the mock does
nvgpu.pu:93-95     
```
args = to_mv(args_addr, args_cnt*8).cast('Q')
    vals = to_mv(args_addr + args_cnt*8, vals_cnt*8).cast('Q') 
```
so the fake gpu expects only 8 bytes words and we would feed him 8 / 4 bytes without that skip
and we also have to match the offset accordingly and always 8 not o which can be 8 or 4 per `iter_sig`

Kernel 
```
.version VERSION
.target TARGET
.address_size 64
.visible .entry scalar_first (
	.param .s32 data0,
	.param .u64 data1
)
.maxntid 1
{
	.reg		.s32 %dat_s32_<1>;
	.reg		.s32 %cast_s32_<2>;
	.reg		.u64 %dat_u64_<1>;
	.reg		.u64 %bidx_u64_<1>;
	ld.param.s32	%dat_s32_0, [data0+0];
	mov.b32		%cast_s32_0, 1;
	ld.param.u64	%dat_u64_0, [data1+0];
	mov.b32		%cast_s32_1, 0;
	cvt.s64.s32	%bidx_u64_0, %cast_s32_1;
	mad.lo.s64	%bidx_u64_0, %bidx_u64_0, 4, %dat_u64_0;
	st.global.s32	[%bidx_u64_0+0], %dat_s32_0;
	ret;
}
```
**BEFORE** -> `segmentation fault  PYTHONPATH=. OCELOT_PATH="$PWD/libgpuocelot.dylib" DEV=MOCK+NV:PTX`
**AFTER** -> CLEAN

### `ops_qcom.py`
**BEFORE**
```
    ubos = [bufs[slot] for _,slot,_,shape in prg.signature if slot < len(bufs) and not is_image_shape(shape)]
    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape in prg.signature if slot < len(bufs) and is_image_shape(shape)]
```
**AFTER**
```   
uavs = [(dt, s, bufs[idx]) for *_, dt, s, is_buf, idx in prg.signature if is_buf and is_image_shape(s)]
```
we directly get `uvas` thks to `is_buf` and `idx`

**BEFORE**
```
      self.bind_sints_to_buf(*[b.va_addr for b in ubos], buf=self.buf, fmt='Q', offset=prg.buf_off)
      for v,(o,dt) in zip(vals, TinyELF.iter_sig(prg.signature[len(bufs):], len(ubos)*8)):
        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_off + o)
    else:
      for i, b in enumerate(ubos): self.bind_sints_to_buf(b.va_addr, buf=self.buf, fmt='Q', offset=prg.buf_offs[i])
      for i,(v,(_,_,dt,_)) in enumerate(zip(vals, prg.signature[len(bufs):])):
        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_offs[i+len(ubos)])
```
**AFTER**
```
      for o,dt,is_buf,idx in TinyELF.iter_sig(non_img):
        self.bind_sints_to_buf(bufs[idx].va_addr if is_buf else vals[idx], buf=self.buf, fmt='Q' if is_buf else dt.fmt, offset=prg.buf_off+o)
    else:
      for i, (*_, dt, s, is_buf, idx) in enumerate(non_img):
        self.bind_sints_to_buf(bufs[idx].va_addr if is_buf else vals[idx], buf=self.buf, fmt='Q' if is_buf else dt.fmt, offset=prg.buf_offs[i])
```
we directly get which one is a buffer via `is_buf`, at which index `idx` and via only the `uavs` list

So here’s the kernel but nothing to say about it and I can’t run there’s a bounty abt that I was looking at before this 
```
===== scalar_first =====
__kernel void scalar_first(const int data0_, __global int* data1_1) {
  *(data1_1+0) = data0_;
}
```
### `ops_cpu.py`
**BEFORE**
```    
self.dev, self.name = dev, to_wgpu_str(obj.name)
```
**AFTER**
```  
self.dev, self.name, self.signature = dev, to_wgpu_str(obj.name), obj.signature
```
we add the signature so we can:

**BEFORE**
```
    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(bufs)+len(vals)))(
      bgl_entry(0, 'Uniform'), *(bgl_entry(i+1, 'Uniform' if i >= len(bufs) else 'Storage') for i in range(len(bufs)+len(vals))))
```
**AFTER**
```
    xs = [bufs[idx] if is_buf else vals[idx] for *_,_,is_buf,idx in self.signature]
    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(xs)))(bgl_entry(0, 'Uniform'),
            *(bgl_entry(i+1, 'Storage' if is_buf else 'Uniform') for i,(*_,_,is_buf,_) in enumerate(self.signature)))
```
seperate buffers from args with it

**BEFORE**
```   
 bindings = (webgpu.WGPUBindGroupEntry * (1+len(bufs)+len(vals)))(bg_entry(0, float('inf')), *(bg_entry(i+1, x) for i,x in enumerate(bufs+vals)))
```
**AFTER**
```    
bindings = (webgpu.WGPUBindGroupEntry * (1+len(xs)))(bg_entry(0, float('inf')), *(bg_entry(i+1, x) for i,x in enumerate(xs)))
```
we reuse `xs`

Kernel
```
fn nan() -> f32 { let bits = 0xffffffffu; return bitcast<f32>(bits); }
@group(0) @binding(0)
var<uniform> INFINITY : f32;
@group(0) @binding(1)var<uniform>data0_:i32;
@group(0) @binding(2)var<storage,read_write>data1_1:array<i32>;
@compute @workgroup_size(1) fn scalar_first(@builtin(workgroup_id) gindex: vec3<u32>,@builtin(local_invocation_id) lindex: vec3<u32>) {
  data1_1[0] = data0_;
}
```
**BEFORE**
```
RuntimeError: [WGPUCreatePipelineAsyncStatus_ValidationError]The buffer type in the shader (BufferBindingType::Storage) is not compatible with the type in the layout (BufferBindingType::Uniform).
 - While validating that the entry-point's declaration for @group(0) @binding(2) matches [BindGroupLayout (unlabeled)]
 - While validating the entry-point's compatibility for group 0 with [BindGroupLayout (unlabeled)]
 - While validating compute stage ([ShaderModule (unlabeled)], entryPoint: "scalar_first").
```
**AFTER**: CLEAN
