### PR TITLE
add generic parallel associative scan

### DIFF
--- a/test/test_associative_scan.py
+++ b/test/test_associative_scan.py
@@ -1,0 +1,53 @@
+import unittest
+import numpy as np
+
+from tinygrad import Tensor, associative_scan
+
+
+class TestAssociativeScan(unittest.TestCase):
+  def test_add_1d(self):
+    x = Tensor([1, 2, 3, 4, 5])
+    np.testing.assert_equal(associative_scan(lambda a,b: a+b, x).numpy(), [1, 3, 6, 10, 15])
+
+  def test_add_axis_1(self):
+    x = Tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
+    expected = np.cumsum(np.array([[1, 2, 3, 4], [5, 6, 7, 8]]), axis=1)
+    np.testing.assert_equal(associative_scan(lambda a,b: a+b, x, axis=1).numpy(), expected)
+
+  def test_max(self):
+    x = Tensor([3, 1, 4, 2, 8, 5])
+    expected = np.maximum.accumulate(np.array([3, 1, 4, 2, 8, 5]))
+    np.testing.assert_equal(associative_scan(lambda a,b: a.maximum(b), x).numpy(), expected)
+
+  def test_mul(self):
+    x = Tensor([1, 2, 3, 4])
+    np.testing.assert_equal(associative_scan(lambda a,b: a*b, x).numpy(), [1, 2, 6, 24])
+
+  def test_reverse(self):
+    x = Tensor([1, 2, 3, 4])
+    np.testing.assert_equal(associative_scan(lambda a,b: a+b, x, reverse=True).numpy(), [10, 9, 7, 4])
+
+  def test_negative_axis(self):
+    x = Tensor([[1, 2, 3], [4, 5, 6]])
+    expected = np.cumsum(np.array([[1, 2, 3], [4, 5, 6]]), axis=-1)
+    np.testing.assert_equal(associative_scan(lambda a,b: a+b, x, axis=-1).numpy(), expected)
+
+  def test_noncommutative_matrix_product(self):
+    values = np.array([
+      [[1, 2], [0, 1]],
+      [[2, 0], [1, 3]],
+      [[1, 1], [2, 1]],
+    ], dtype=np.float32)
+
+    forward = np.empty_like(values)
+    forward[0] = values[0]
+    for i in range(1, len(values)): forward[i] = forward[i-1] @ values[i]
+    np.testing.assert_allclose(associative_scan(lambda a,b: a@b, Tensor(values)).numpy(), forward)
+
+    reverse = np.empty_like(values)
+    reverse[-1] = values[-1]
+    for i in range(len(values)-2, -1, -1): reverse[i] = values[i] @ reverse[i+1]
+    np.testing.assert_allclose(associative_scan(lambda a,b: a@b, Tensor(values), reverse=True).numpy(), reverse)
+
+
+if __name__ == "__main__": unittest.main()

--- a/tinygrad/__init__.py
+++ b/tinygrad/__init__.py
@@ -3,6 +3,7 @@ if int(os.getenv("TYPED", "0")):
   from typeguard import install_import_hook
   install_import_hook(__name__)
 from tinygrad.tensor import Tensor                                    # noqa: F401
+from tinygrad.ops_scan import associative_scan                        # noqa: F401
 from tinygrad.engine.jit import TinyJit                               # noqa: F401
 from tinygrad.function import function                                # noqa: F401
 from tinygrad.uop.ops import UOp

--- a/tinygrad/ops_scan.py
+++ b/tinygrad/ops_scan.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+from typing import Callable
+
+from tinygrad.tensor import Tensor
+
+
+def _slice_axis(x:Tensor, axis:int, start:int|None=None, stop:int|None=None, step:int|None=None) -> Tensor:
+  idx = [slice(None)] * x.ndim
+  idx[axis] = slice(start, stop, step)
+  return x[tuple(idx)]
+
+
+def associative_scan(fn:Callable[[Tensor, Tensor], Tensor], elems:Tensor, axis:int=0, reverse:bool=False) -> Tensor:
+  """Inclusive parallel associative scan over ``elems``.
+
+  ``fn`` must be associative and operate on tensors with matching shapes. The
+  implementation uses a divide-and-conquer recursion with O(log N) dependency
+  depth, similar to JAX ``lax.associative_scan``.
+
+  Args:
+    fn: associative binary function, e.g. ``lambda a, b: a + b``.
+    elems: tensor supporting slicing, ``cat``, ``stack`` and ``flip``.
+    axis: axis to scan over.
+    reverse: scan from right to left while preserving operand order.
+  """
+  if not callable(fn): raise TypeError("fn must be callable")
+  if elems.ndim == 0: raise ValueError("associative_scan requires at least one dimension")
+  axis = axis if axis >= 0 else axis + elems.ndim
+  if axis < 0 or axis >= elems.ndim: raise IndexError(f"axis {axis} out of range for ndim {elems.ndim}")
+  n = elems.shape[axis]
+  if not isinstance(n, int): raise ValueError("associative_scan currently requires a concrete scan dimension")
+  if n == 0: return elems
+
+  x = elems.flip((axis,)) if reverse else elems
+  combine:Callable[[Tensor, Tensor], Tensor] = (lambda a,b: fn(b,a)) if reverse else fn
+
+  def scan(cur:Tensor) -> Tensor:
+    length = cur.shape[axis]
+    if not isinstance(length, int): raise ValueError("associative_scan currently requires a concrete scan dimension")
+    if length < 2: return cur
+
+    left = _slice_axis(cur, axis, 0, length-1, 2)
+    right = _slice_axis(cur, axis, 1, length, 2)
+    odd_prefix = scan(combine(left, right))
+
+    first = _slice_axis(cur, axis, 0, 1)
+    if length > 2:
+      even_src = _slice_axis(cur, axis, 2, length, 2)
+      even_src_len = (length-1) // 2
+      prior = _slice_axis(odd_prefix, axis, 0, even_src_len)
+      even_tail = combine(prior, even_src)
+      even_prefix = first.cat(even_tail, dim=axis)
+    else:
+      even_prefix = first
+
+    pairs = length // 2
+    ev = _slice_axis(even_prefix, axis, 0, pairs)
+    od = _slice_axis(odd_prefix, axis, 0, pairs)
+    interleaved = ev.stack(od, dim=axis+1).flatten(axis, axis+1)
+    if length % 2:
+      interleaved = interleaved.cat(_slice_axis(even_prefix, axis, pairs, pairs+1), dim=axis)
+    return interleaved
+
+  out = scan(x)
+  return out.flip((axis,)) if reverse else out


### PR DESCRIPTION
Refs #3039

## Summary

Adds a public inclusive `associative_scan(fn, elems, axis=0, reverse=False)` using a divide-and-conquer parallel-prefix algorithm with logarithmic dependency depth.

## What is included

- public import as `tinygrad.associative_scan`;
- arbitrary and negative scan axes;
- forward and reverse scans with operand order preserved for noncommutative associative functions;
- odd and even sequence lengths;
- concrete-shape validation for the recursive scan dimension;
- NumPy-backed correctness tests for addition, multiplication, maximum, non-leading/negative axes, reverse scans, and batched matrix products.

## Files

- `tinygrad/ops_scan.py` — implementation;
- `tinygrad/__init__.py` — public export;
- `test/test_associative_scan.py` — correctness coverage.

## Validation

The branch is based directly on the current `tinygrad/master`, is zero commits behind, and contains one focused commit. The earlier pylint, pre-commit, ruff, mypy, and `TYPED=1` failures were resolved; GitHub Actions restarted after the final noncommutative-order test and squash.

This remains a draft only while the final matrix runs.