### PR TITLE
usb: don't fail async transfers on signal interruption

### DIFF
--- a/tinygrad/runtime/support/usb.py
+++ b/tinygrad/runtime/support/usb.py
@@ -113,8 +113,10 @@ class USB3:
     return self._submit_async(0, libusb.LIBUSB_TRANSFER_TYPE_CONTROL, buf, timeout), memoryview(buf)[8:]
 
   def bulk_wait(self, tag:int):
-    """Block until the tagged transfer completes; raises if any async transfer failed."""
-    while tag in self._async_pending: checked(libusb.libusb_handle_events)(None)
+    """Block until the tagged transfer completes; raises if any async transfer failed. LIBUSB_ERROR_INTERRUPTED is retried."""
+    while tag in self._async_pending:
+      if (rc:=libusb.libusb_handle_events(None)) < 0 and rc != libusb.LIBUSB_ERROR_INTERRUPTED:
+        raise RuntimeError(f"libusb_handle_events: {ctypes.string_at(libusb.libusb_strerror(rc)).decode()}")
     if self._async_err: raise RuntimeError(f"async bulk OUT failed: status={self._async_err}")
 
   def bulk_read(self, length:int, timeout:int=1000) -> memoryview:


### PR DESCRIPTION
https://libusb.sourceforge.io/api-1.0/group__libusb__misc.html#ggab2323aa0f04bc22038e7e1740b2f29efa39c9284a18fb3277696d84d65f50dbea

LIBUSB_ERROR_INTERRUPTED  System call interrupted (perhaps due to signal) 

handled here too: 
https://github.com/google/gousb/pull/121/changes