### PR TITLE
fix(clang): use portable bfloat16 storage

### DIFF
--- a/test/backend/test_renderer_failures.py
+++ b/test/backend/test_renderer_failures.py
@@ -4,8 +4,8 @@ from tinygrad.device import Device, Buffer
 from tinygrad.dtype import dtypes, ConstType
 from tinygrad.engine.realize import run_linear
 from tinygrad.codegen import to_program
-from tinygrad.helpers import prod
-from tinygrad.renderer.cstyle import CStyleLanguage
+from tinygrad.helpers import prod, Target
+from tinygrad.renderer.cstyle import CStyleLanguage, ClangRenderer
 from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.renderer.wgsl import WGSLRenderer
 from test.helpers import check_schedule
@@ -50,6 +50,14 @@ class TestRendererFailures(unittest.TestCase):
     sink = UOp(Ops.SINK, src=(gated_alu_store,), arg=KernelInfo())
     ret = _test_uop_result([], sink, local_size=[4, 2, 1])[0]
     np.testing.assert_equal(ret, [0, 0, 0, 0, 0, 1, 1, 1])
+
+class TestClangRendererFailures(unittest.TestCase):
+  def test_bfloat16_uses_portable_storage(self):
+    linear = (Tensor.ones(4, dtype=dtypes.bfloat16) + Tensor.ones(4, dtype=dtypes.bfloat16)).schedule_linear()
+    src = to_program(linear.src[0].src[0], ClangRenderer(Target("CPU", "CLANG", "x86_64,native"))).src[2].arg
+    self.assertNotIn("__bf16", src)
+    self.assertIn("unsigned short", src)
+    self.assertIn("16256u", src)
 
 @unittest.skipIf(not isinstance(Device[Device.DEFAULT].renderer, CStyleLanguage), "uops are for cstyle")
 class TestCStyleFailures(unittest.TestCase):

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -267,7 +267,11 @@ class ClangRenderer(CStyleLanguage):
   # language options
   barrier = "__atomic_thread_fence(__ATOMIC_SEQ_CST);"
   buffer_suffix = " restrict"
-  type_map = {dtypes.bool:"_Bool", dtypes.half:"__fp16"}
+  type_map = {dtypes.bool:"_Bool", dtypes.half:"__fp16", dtypes.bfloat16:"unsigned short"}
+  string_rewrite = PatternMatcher([
+    (UPat.cvar("c").cast(dtypes.bfloat16),
+      lambda ctx,c: f"{(struct.unpack('I', struct.pack('f', float_to_bf16(c.val)))[0] >> 16)}u"),
+  ]) + base_rewrite
   code_for_op = {**({k:v for k,v in CStyleLanguage.code_for_op.items() if k not in [Ops.EXP2, Ops.SIN, Ops.LOG2, Ops.TRUNC, Ops.RECIPROCAL]}),
                  Ops.SQRT: lambda x,dtype: f"__builtin_sqrt({x})" if dtype == dtypes.float64 else f"__builtin_sqrtf({x})",
                  Ops.TRUNC: lambda x,dtype: f"__builtin_trunc({x})" if dtype == dtypes.float64 else f"__builtin_truncf({x})",


### PR DESCRIPTION
Fixes #6909

Clang kernels currently expose bfloat16 storage as native `__bf16`. Clang 22 rejects that type on an unsupported cross-target (`--target=wasm32-unknown-unknown`) with `__bf16 is not supported on this target`; older Clang/x86 combinations reported the same soft-promotion failure in the issue.

This maps Clang bfloat16 storage to `unsigned short` and renders bfloat16 constants as their 16-bit payload. Arithmetic is unchanged: the existing `create_non_native_float_pats` and `pm_manual_bf16_cast` rules still promote operations through float32, including the `BF16 << 16 -> F32` conversion.

The regression test generates a representative bfloat16 tensor kernel and checks that its source contains no `__bf16`, uses portable storage, and encodes `1.0` as `16256u` rather than numerically casting `1.0f` to an integer.

Tests:
- `DEV=CPU python -m pytest test/backend/test_renderer_failures.py -q -n12` (8 passed, 7 skipped)
- `DEV=CPU python -m pytest test/backend/test_dtype_alu.py::TestDTypeALU::test_emulated_bfloat16 -q -n12` (passed)
- `python -m mypy tinygrad/` (215 files, no issues)
- `python -m ruff check tinygrad/renderer/cstyle.py test/backend/test_renderer_failures.py`

Risk is limited to Clang bfloat16 source spelling and constant representation; load/store width remains 16-bit and arithmetic promotion is unchanged. This does not add native bfloat16 arithmetic or change other renderers. No speedup is claimed.

AI assistance disclosure: I used Hermes Agent (GPT-5.6) for issue/history investigation, test-first implementation, verification, and an independent review; I reviewed the final diff and PR text.