### PR TITLE
[pr] support buffers and args in any order

### DIFF
--- a/test/amd/hw/helpers.py
+++ b/test/amd/hw/helpers.py
@@ -170,9 +170,11 @@ def run_program_emu(instructions: list, n_lanes: int = 1) -> WaveState:
 
 def run_program_hw(instructions: list, n_lanes: int = 1) -> WaveState:
   """Run instructions on real AMD hardware via HIPCompiler and the AMD runtime."""
+  from tinygrad import dtypes
   from tinygrad.device import Device, TinyELF
   from tinygrad.runtime.support.compiler_amd import HIPCompiler
   from tinygrad.helpers import Target, flat_mv
+  from tinygrad.uop.ops import ParamArg
 
   dev = Device["AMD"]
   compiler = HIPCompiler(dev.arch)  # type: ignore[attr-defined]
@@ -222,7 +224,7 @@ amdhsa.kernels:
 """
 
   lib = compiler.compile(asm_src)
-  prg = dev.runtime(TinyELF(lib, "test", Target("AMD", arch=dev.arch), ()))
+  prg = dev.runtime(TinyELF(lib, "test", Target("AMD", arch=dev.arch), ((ParamArg(0, dtypes.uint8), ()),)))
 
   buf_sz = _out_bytes(n_lanes)
   out_gpu = dev.allocator.alloc(buf_sz)

--- a/test/amd/hw/test_dpp.py
+++ b/test/amd/hw/test_dpp.py
@@ -37,8 +37,10 @@ def _run_wave64_emu(instructions: list, out_reg: int = 1) -> list[int]:
   return list(out_buf)
 
 def _run_wave64_hw(instructions: list, out_reg: int = 1) -> list[int]:
+  from tinygrad import dtypes
   from tinygrad.device import Device, TinyELF
   from tinygrad.runtime.support.compiler_amd import HIPCompiler
+  from tinygrad.uop.ops import ParamArg
 
   dev = Device["AMD"]
   compiler = HIPCompiler(dev.arch)  # type: ignore[attr-defined]
@@ -83,7 +85,7 @@ amdhsa.kernels:
 .end_amdgpu_metadata
 """
   lib = compiler.compile(asm_src)
-  prg = dev.runtime(TinyELF(lib, "test", Target("AMD", arch=dev.arch), ()))
+  prg = dev.runtime(TinyELF(lib, "test", Target("AMD", arch=dev.arch), ((ParamArg(0, dtypes.uint8), ()),)))
   out_gpu = dev.allocator.alloc(WAVE64 * 4)
   prg(out_gpu, global_size=(1, 1, 1), local_size=(WAVE64, 1, 1), wait=True)
   out = bytearray(WAVE64 * 4)

--- a/test/amd/hw/test_rdna4_permlane_var.py
+++ b/test/amd/hw/test_rdna4_permlane_var.py
@@ -36,8 +36,10 @@ def _run_emu(instructions: list, out_reg: int = 2) -> list[int]:
   return list(out_buf)
 
 def _run_hw(instructions: list, out_reg: int = 2) -> list[int]:
+  from tinygrad import dtypes
   from tinygrad.device import Device, TinyELF
   from tinygrad.runtime.support.compiler_amd import HIPCompiler
+  from tinygrad.uop.ops import ParamArg
 
   dev = Device['AMD']
   if not dev.arch.startswith('gfx12'): raise unittest.SkipTest('requires RDNA4 hardware')
@@ -84,7 +86,7 @@ amdhsa.kernels:
 .end_amdgpu_metadata
 """
   lib = compiler.compile(asm_src)
-  prg = dev.runtime(TinyELF(lib, "test", Target("AMD", arch=dev.arch), ()))
+  prg = dev.runtime(TinyELF(lib, "test", Target("AMD", arch=dev.arch), ((ParamArg(0, dtypes.uint8), ()),)))
   out_gpu = dev.allocator.alloc(LANES * 4)
   prg(out_gpu, global_size=(1, 1, 1), local_size=(LANES, 1, 1), wait=True)
   out = bytearray(LANES * 4)

--- a/test/backend/test_arg_order.py
+++ b/test/backend/test_arg_order.py
@@ -1,0 +1,125 @@
+import itertools, pickle, struct, unittest
+from tinygrad import Device, UOp, dtypes
+from tinygrad.device import Buffer, TinyELF
+from tinygrad.dtype import AddrSpace
+from tinygrad.engine.realize import compile_linear, run_linear
+from tinygrad.helpers import Context, Target
+from tinygrad.uop.ops import KernelInfo, Ops, ParamArg, ProgramInfo
+
+def _read_int(buf:Buffer) -> int: return struct.unpack("i", buf.as_memoryview())[0]
+
+def _run(sink:UOp, bufs:list[Buffer], vals:dict[str, int]):
+  run_linear(UOp(Ops.LINEAR, src=(sink.call(*(UOp.from_buffer(x) for x in bufs)),)), var_vals=vals, update_stats=False)
+
+class TestArgOrder(unittest.TestCase):
+  def test_two_buffers_two_scalars_all_orders(self):
+    roles = ("out", "inp", "a", "b")
+    for perm in itertools.permutations(roles):
+      with self.subTest(order=perm):
+        params = {role:UOp.param(slot, dtypes.int, () if role in ("a", "b") else (1,),
+                                 name=role if role in ("a", "b") else None,
+                                 addrspace=AddrSpace.ALU if role in ("a", "b") else AddrSpace.GLOBAL)
+                  for slot,role in enumerate(perm)}
+        sink = params["out"][0].store(params["inp"][0].load() + params["a"]*11 + params["b"]*101).sink(arg=KernelInfo("arg_order"))
+        info, buf_roles = ProgramInfo.from_sink(sink), [role for role in perm if role in ("out", "inp")]
+        self.assertEqual((info.globals, info.outs, info.ins), ((0, 1), (buf_roles.index("out"),), (buf_roles.index("inp"),)))
+        out, inp = Buffer(Device.DEFAULT, 1, dtypes.int, initial_value=bytes(4)), \
+                   Buffer(Device.DEFAULT, 1, dtypes.int, initial_value=struct.pack("i", 5))
+        _run(sink, [out if role == "out" else inp for role in perm if role in ("out", "inp")], {"a":2, "b":3})
+        self.assertEqual(_read_int(out), 330)
+
+  def test_repeated_launch(self):
+    scalar_spec = [("a", dtypes.int, 11), ("b", dtypes.int, 101)]
+    spec = scalar_spec[:1] + [("out", dtypes.int, 0)] + scalar_spec[1:] + [("inp", dtypes.int, 0)]
+    params = {name:UOp.param(slot, dt, (1,) if name in ("out", "inp") else (), name=None if name in ("out", "inp") else name,
+                             addrspace=AddrSpace.GLOBAL if name in ("out", "inp") else AddrSpace.ALU)
+              for slot,(name,dt,_) in enumerate(spec)}
+    val = params["inp"][0].load()
+    for name,_,weight in scalar_spec: val += params[name].cast(dtypes.int)*weight
+    sink = params["out"][0].store(val).sink(arg=KernelInfo("arg_dtypes"))
+    cases = [(5, {name:i+1 for i,(name,_,_) in enumerate(scalar_spec)}),
+             (7, {name:len(scalar_spec)-i for i,(name,_,_) in enumerate(scalar_spec)})]
+    for inp_val, vals in cases:
+      out = Buffer(Device.DEFAULT, 1, dtypes.int, initial_value=bytes(4))
+      inp = Buffer(Device.DEFAULT, 1, dtypes.int, initial_value=struct.pack("i", inp_val))
+      _run(sink, [out, inp], vals)
+      self.assertEqual(_read_int(out), inp_val + sum(vals[name]*weight for name,_,weight in scalar_spec))
+
+  def test_mixed_scalar_widths(self):
+    if not all(dt in Device[Device.DEFAULT].renderer.supported_dtypes() for dt in (dtypes.int8, dtypes.int16, dtypes.int32, dtypes.int64)):
+      self.skipTest("requires 8/16/32/64-bit integer support")
+    spec = (("a", dtypes.int8), ("out", dtypes.int64), ("b", dtypes.int16), ("inp", dtypes.int64),
+            ("c", dtypes.int32), ("d", dtypes.int64))
+    params = {name:UOp.param(slot, dt, (1,) if name in ("out", "inp") else (), name=None if name in ("out", "inp") else name,
+                             addrspace=AddrSpace.GLOBAL if name in ("out", "inp") else AddrSpace.ALU)
+              for slot,(name,dt) in enumerate(spec)}
+    value = params["inp"][0].load()
+    for name in ("a", "b", "c", "d"): value += params[name].cast(dtypes.int64)
+    sink = params["out"][0].store(value).sink(arg=KernelInfo("arg_widths"))
+    vals = {"a":-3, "b":2000, "c":-100000, "d":2**35}
+    out = Buffer(Device.DEFAULT, 1, dtypes.int64, initial_value=bytes(8))
+    inp = Buffer(Device.DEFAULT, 1, dtypes.int64, initial_value=struct.pack("q", 17))
+    _run(sink, [out, inp], vals)
+    self.assertEqual(struct.unpack("q", out.as_memoryview())[0], 17 + sum(vals.values()))
+
+  @unittest.skipUnless(Device.DEFAULT == "CL", "requires OpenCL images")
+  def test_image_buffer_interleaving(self):
+    a = UOp.param(0, dtypes.int, (), name="a", addrspace=AddrSpace.ALU)
+    out = UOp.param(1, dtypes.float, (32,))
+    inp = UOp.param(2, dtypes.float, (1,))
+    b = UOp.param(3, dtypes.int, (), name="b", addrspace=AddrSpace.ALU)
+    image = UOp.param(4, dtypes.float, (32,))
+    value = inp[0].load() + a.cast(dtypes.float) + b.cast(dtypes.float)
+    sink = UOp.sink(*(out.index(i).store(image.index(i).load() + value) for i in range(4)), arg=KernelInfo("arg_order_image"))
+    out_buf = Buffer(Device.DEFAULT, 32, dtypes.float, initial_value=bytes(128))
+    inp_buf = Buffer(Device.DEFAULT, 1, dtypes.float, initial_value=struct.pack("f", 4.0))
+    image_buf = Buffer(Device.DEFAULT, 32, dtypes.float, initial_value=struct.pack("4f", 1.0, 2.0, 3.0, 4.0) + bytes(112))
+    with Context(IMAGE=1): _run(sink, [out_buf, inp_buf, image_buf], {"a":2, "b":3})
+    self.assertEqual(struct.unpack("4f", out_buf.as_memoryview()[:16]), (10.0, 11.0, 12.0, 13.0))
+
+  def test_graph(self):
+    if Device[Device.DEFAULT].graph is None: self.skipTest("graph support required")
+    a, inp, mid = UOp.param(0, dtypes.int, (), name="a", addrspace=AddrSpace.ALU), UOp.param(1, dtypes.int, (1,)), \
+                  UOp.param(2, dtypes.int, (1,))
+    first = mid[0].store(inp[0].load() + a).sink(arg=KernelInfo("arg_order_graph_first"))
+    second_inp, b, out = UOp.param(0, dtypes.int, (1,)), UOp.param(1, dtypes.int, (), name="b", addrspace=AddrSpace.ALU), \
+                         UOp.param(2, dtypes.int, (1,))
+    second = out[0].store(second_inp[0].load() + b).sink(arg=KernelInfo("arg_order_graph_second"))
+    inputs = tuple(UOp.param(i, dtypes.int, (1,), device=Device.DEFAULT) for i in range(3))
+    first_call, second_call = first.call(*inputs[:2]), second.call(inputs[1], inputs[2])
+    def make_inputs(inp_value:int):
+      bufs = (Buffer(Device.DEFAULT, 1, dtypes.int, initial_value=struct.pack("i", inp_value)).ensure_allocated(),
+              Buffer(Device.DEFAULT, 1, dtypes.int, initial_value=bytes(4)).ensure_allocated(),
+              Buffer(Device.DEFAULT, 1, dtypes.int, initial_value=bytes(4)).ensure_allocated())
+      return bufs, tuple(UOp.from_buffer(buf) for buf in bufs)
+    _, initial_inputs = make_inputs(5)
+    graph = Device[Device.DEFAULT].graph(
+      UOp(Ops.CUSTOM_FUNCTION, src=(compile_linear(UOp(Ops.LINEAR, src=(first_call, second_call))),), arg="graph"), initial_inputs)
+    for inp_value, vals in ((5, {"a":2, "b":3}), (7, {"a":4, "b":1})):
+      bufs, input_uops = make_inputs(inp_value)
+      graph(input_uops, vals, wait=True)
+      self.assertEqual(_read_int(bufs[2]), inp_value + vals["a"] + vals["b"])
+
+  def test_signature_layout_and_pickle(self):
+    signature = ((ParamArg(0, dtypes.int8, name="i8", addrspace=AddrSpace.ALU), ()),
+                 (ParamArg(1, dtypes.float), (2, 2, 4)),
+                 (ParamArg(2, dtypes.int16, name="i16", addrspace=AddrSpace.ALU), ()),
+                 (ParamArg(3, dtypes.int), ()),
+                 (ParamArg(4, dtypes.int32, name="i32", addrspace=AddrSpace.ALU), ()),
+                 (ParamArg(5, dtypes.int64, name="i64", addrspace=AddrSpace.ALU), ()))
+    elf = TinyELF(b"", "layout", Target(), signature)
+    self.assertEqual([(off, arg.addrspace, shape, idx) for off,arg,shape,idx in TinyELF.iter_sig(elf.signature)],
+                     [(0, AddrSpace.ALU, (), 0), (8, AddrSpace.GLOBAL, (2, 2, 4), 0), (16, AddrSpace.ALU, (), 1),
+                      (24, AddrSpace.GLOBAL, (), 1), (32, AddrSpace.ALU, (), 2), (40, AddrSpace.ALU, (), 3)])
+    self.assertEqual(pickle.loads(pickle.dumps(elf)), elf)
+
+  def test_manual_program_signature(self):
+    out = UOp.param(0, dtypes.int, (1,))
+    val = UOp.param(1, dtypes.int, (), name="val", addrspace=AddrSpace.ALU)
+    inp = UOp.param(2, dtypes.int, (1,))
+    sink = out[0].store(inp[0].load() + val).sink(arg=KernelInfo("manual_signature"))
+    prg = UOp(Ops.PROGRAM, src=(sink, UOp(Ops.LINEAR), UOp(Ops.SOURCE, arg=""), UOp(Ops.BINARY, arg=b"")), arg=ProgramInfo.from_sink(sink))
+    self.assertEqual([(arg.slot, arg.name, arg.addrspace) for arg,_ in prg.to_elf().signature],
+                     [(0, None, AddrSpace.GLOBAL), (1, "val", AddrSpace.ALU), (2, None, AddrSpace.GLOBAL)])
+
+if __name__ == "__main__": unittest.main()

--- a/test/external/external_test_am_fault_recovery.py
+++ b/test/external/external_test_am_fault_recovery.py
@@ -17,8 +17,10 @@ def _run(code:str, timeout:float=15.0) -> subprocess.CompletedProcess:
 
 def _run_asm(asm_src:str) -> subprocess.CompletedProcess:
   return _run('from tinygrad.device import Device, TinyELF; from tinygrad.helpers import Target; '
-              'from tinygrad.runtime.support.compiler_amd import HIPCompiler; dev = Device["AMD"]; '
-              f'dev.runtime(TinyELF(HIPCompiler(dev.arch).compile("""{asm_src}"""), "test", Target("AMD", arch=dev.arch), ()))('
+              'from tinygrad.runtime.support.compiler_amd import HIPCompiler; from tinygrad.uop.ops import ParamArg; from tinygrad import dtypes; '
+              'dev = Device["AMD"]; '
+              f'dev.runtime(TinyELF(HIPCompiler(dev.arch).compile("""{asm_src}"""), "test", Target("AMD", arch=dev.arch), '
+              '((ParamArg(0, dtypes.uint8), ()),)))('
               'dev.allocator.alloc(64), global_size=(1,1,1), local_size=(1,1,1), wait=True)')
 
 def _verify_recovery() -> subprocess.CompletedProcess:

--- a/tinygrad/codegen/opt/postrange.py
+++ b/tinygrad/codegen/opt/postrange.py
@@ -4,7 +4,7 @@ from typing import cast
 from tinygrad.uop.ops import Ops, UOp, KernelInfo, graph_rewrite, AxisType, ssimplify, remove_all_tags
 from tinygrad.uop.ops import axis_letters, axis_colors, axis_to_pos
 from tinygrad.device import Buffer
-from tinygrad.dtype import dtypes, Invalid
+from tinygrad.dtype import dtypes, AddrSpace, Invalid
 from tinygrad.helpers import colored, getenv, DEBUG, NOOPT, argsort, round_up, prod, merge_dicts, get_single_element, flatten
 from tinygrad.helpers import ALLOW_TF32, count, Context
 from tinygrad.codegen.opt import Opt, OptOps, KernelOptError, check
@@ -328,7 +328,8 @@ class Scheduler:
   def group_for_reduces(self) -> int: return len(self.axes_of(AxisType.GROUP_REDUCE))
 
 def args_from_ast(ast:UOp, dname:str) -> tuple[list[Buffer], dict[str, int]]:
-  glbls = sorted([x for x in ast.backward_slice if x.op is Ops.PARAM and x.arg.slot >= 0], key=lambda x: x.arg.slot)
+  glbls = sorted([x for x in ast.backward_slice if x.op is Ops.PARAM and x.arg.slot >= 0 and x.addrspace is not AddrSpace.ALU],
+                 key=lambda x: x.arg.slot)
   return [Buffer(dname, x.max_numel(), x.dtype) for x in glbls], {k.expr:int(k.vmax+k.vmin)//2 for k in ast.variables()}
 
 def apply_opts(ast:UOp, ren:Renderer, beam:int=0) -> UOp:

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -6,8 +6,10 @@ import importlib, inspect, functools, pathlib, os, contextlib, re, atexit, pickl
 from tinygrad.helpers import LRU, getenv, diskcache_get, diskcache_put, DEBUG, GlobalCounters, PROFILE, temp, colored
 from tinygrad.helpers import Context, CCACHE, ALLOW_DEVICE_USAGE, MAX_BUFFER_SIZE, cpu_events, ProfileEvent, ProfilePointEvent, suppress_finalizing
 from tinygrad.helpers import select_by_name, select_first_inited, DEV, TracingKey, size_to_str, pluralize, Target, unwrap, round_up
-from tinygrad.dtype import DType, _to_np_dtype
-if TYPE_CHECKING: from tinygrad.renderer import Renderer
+from tinygrad.dtype import DType, AddrSpace, _to_np_dtype
+if TYPE_CHECKING:
+  from tinygrad.renderer import Renderer
+  from tinygrad.uop.ops import ParamArg
 
 # **************** Device ****************
 
@@ -325,15 +327,17 @@ class TinyELF:
   lib: bytes
   name: str
   target: Target
-  # tuple of (name, slot, dtype, shape)
-  signature: tuple[tuple[str|None, int, DType, tuple], ...]
+  signature: tuple[tuple[ParamArg, tuple], ...]
   profile_key: bytes|None = None
 
   @staticmethod
-  def iter_sig(signature:tuple[tuple[str|None, int, DType, tuple], ...], offset:int=0) -> Generator[tuple[int, DType], None, None]:
-    for _,_,dt,_ in signature:
-      yield (offset:=round_up(offset, dt.itemsize)), dt
-      offset += dt.itemsize
+  def iter_sig(signature:tuple[tuple[ParamArg, tuple], ...], offset:int=0) -> Generator[tuple[int, ParamArg, tuple, int], None, None]:
+    buf_idx = val_idx = 0
+    for arg, shape in signature:
+      if arg.addrspace is AddrSpace.ALU: idx, val_idx, size = val_idx, val_idx+1, arg.dtype.itemsize
+      else: idx, buf_idx, size = buf_idx, buf_idx+1, 8
+      yield (offset:=round_up(offset, size)), arg, shape, idx
+      offset += size
 
 class Program(Generic[DeviceType]):
   def __init__(self, dev:DeviceType, obj:TinyELF): pass

--- a/tinygrad/runtime/graph/metal.py
+++ b/tinygrad/runtime/graph/metal.py
@@ -2,6 +2,7 @@ from typing import Any, cast
 import ctypes, decimal, struct
 from tinygrad.helpers import dedup, getenv, unwrap, PROFILE
 from tinygrad.device import Buffer, Device, ProfileGraphEntry, ProfileGraphEvent
+from tinygrad.dtype import AddrSpace
 from tinygrad.uop.ops import UOp, Ops
 from tinygrad.engine.jit import GraphRunner, GraphException
 from tinygrad.runtime.ops_metal import MetalDevice, MetalAllocator, wait_check, to_ns_str
@@ -26,7 +27,8 @@ class MetalGraph(GraphRunner):
 
     self.var_bind_data = []
     if len(self.vars):
-      self.var_buf = self.dev.allocator.alloc(sum(dt.itemsize for r in self.runtimes for (_,_,dt,s) in unwrap(r).signature if s == ()))
+      self.var_buf = self.dev.allocator.alloc(sum(arg.dtype.itemsize for r in self.runtimes for arg,_ in unwrap(r).signature
+                                                if arg.addrspace is AddrSpace.ALU))
       self.var_buf_view, var_buf_offset = cast(MetalAllocator, self.dev.allocator)._as_buffer(self.var_buf), 0
 
     all_pipelines, all_resources = [], [self.var_buf.buf] if len(self.vars) else []
@@ -35,14 +37,16 @@ class MetalGraph(GraphRunner):
       icb_command = self.icb.indirectComputeCommandAtIndex(j).retained()
       icb_command.setComputePipelineState(runtime.pipeline_state)
       all_pipelines.append(runtime.pipeline_state)
+      bind_idxs = [i for i,(arg,_) in enumerate(runtime.signature) if arg.addrspace is not AddrSpace.ALU]
       for i, b in enumerate(bufs):
         if not any(pos == i for pos, _ in replace):
-          icb_command.setKernelBuffer_offset_atIndex(b._buf.buf, b._buf.offset, i)
+          icb_command.setKernelBuffer_offset_atIndex(b._buf.buf, b._buf.offset, bind_idxs[i])
           all_resources.append(b._buf.buf)
-      for nm,i,dt,_ in runtime.signature[len(bufs):]:
+      for i,(arg,_) in enumerate(runtime.signature):
+        if arg.addrspace is not AddrSpace.ALU: continue
         icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, i)
-        self.var_bind_data.append((nm, var_buf_offset, dt.fmt))
-        var_buf_offset += dt.itemsize
+        self.var_bind_data.append((unwrap(arg.name), var_buf_offset, arg.dtype.fmt))
+        var_buf_offset += arg.dtype.itemsize
       global_size, local_size = ast.arg.launch_dims({v: 0 for v in self.vars})
       icb_command.concurrentDispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
       icb_command.setBarrier()
@@ -61,9 +65,11 @@ class MetalGraph(GraphRunner):
     updated_bufs = []
     for j in self.updatable:
       computeCommand = self.icb.indirectComputeCommandAtIndex(j)
+      runtime = unwrap(self.runtimes[j])
+      bind_idxs = [i for i,(arg,_) in enumerate(runtime.signature) if arg.addrspace is not AddrSpace.ALU]
       for pos, iidx in self.uop_replace[j]:
         buf = cast(Buffer, input_uops[iidx].buffer)
-        computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, pos)
+        computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, bind_idxs[pos])
         updated_bufs.append(buf._buf.buf)
 
     all_resources = dedup(self.all_resources + updated_bufs)

--- a/tinygrad/runtime/ops_cl.py
+++ b/tinygrad/runtime/ops_cl.py
@@ -6,6 +6,7 @@ from tinygrad.runtime.support import c
 from tinygrad.helpers import to_char_p_p, from_mv, OSX, DEBUG, mv_address, suppress_finalizing, unwrap, round_up, is_image_shape
 from tinygrad.renderer.cstyle import OpenCLRenderer
 from tinygrad.device import BufferSpec, LRUAllocator, Compiled, Compiler, CompileError, TinyELF, Program
+from tinygrad.dtype import AddrSpace
 
 CC_CB = c.CFUNCTYPE[None, [c.POINTER[ctypes.c_char], c.POINTER[None], cl.size_t, c.POINTER[None]]]
 BP_CB = c.CFUNCTYPE[None, [cl.cl_program, c.POINTER[None]]]
@@ -54,11 +55,11 @@ class CLProgram(Program['CLDevice']):
 
   def __call__(self, *bufs:cl.cl_mem, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]|None=None, vals:tuple[int, ...]=(),
                wait=False, **kw) -> float|None:
-    for i, (_, slot, dt, shape) in enumerate(self.signature):
-      b = bufs[slot] if slot < len(bufs) else getattr(ctypes, f"c_int{dt.bitsize}")(vals[slot-len(bufs)])
+    for i, (_, arg, shape, idx) in enumerate(TinyELF.iter_sig(self.signature)):
+      b = bufs[idx] if arg.addrspace is not AddrSpace.ALU else getattr(ctypes, f"c_int{arg.dtype.bitsize}")(vals[idx])
       if is_image_shape(shape):
-        pitch = (round_up(shape[1], 256) if OSX else shape[1]) * 4 * dt.itemsize
-        fmt = cl.cl_image_format(cl.CL_RGBA, {2:cl.CL_HALF_FLOAT, 4:cl.CL_FLOAT}[dt.itemsize])
+        pitch = (round_up(shape[1], 256) if OSX else shape[1]) * 4 * arg.dtype.itemsize
+        fmt = cl.cl_image_format(cl.CL_RGBA, {2:cl.CL_HALF_FLOAT, 4:cl.CL_FLOAT}[arg.dtype.itemsize])
         desc = cl.cl_image_desc(cl.CL_MEM_OBJECT_IMAGE2D, shape[1], shape[0], image_row_pitch=pitch, buffer=b)
         img = checked(cl.clCreateImage(self.dev.context, cl.CL_MEM_READ_WRITE, fmt, desc, None, status:=ctypes.c_int32()), status)
         check(cl.clSetKernelArg(self.kernel, i, ctypes.sizeof(img), ctypes.byref(img)))

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -65,10 +65,14 @@ def cpu_cmd(devs:tuple[str, ...], prog, *args:UOp) -> UOp:
   return UOp(Ops.INS, dtypes.void, words + (UOp.const(0, dtypes.uint64),) * (CMD_SIZE - len(words)), arg="cmd")
 
 def cpu_exec(ctx:tuple[str, ...], call:UOp, prg:UOp) -> UOp:
-  args = [get_call_arg_uops(call)[i].getaddr(ctx) for i in prg.arg.globals] + [v.cast(dtypes.uint64) for v in get_call_var_uops(call, prg)]
-  if (core:=prg.arg.runtimevars.get('core_id')) is None: return cpu_cmd(ctx, prg, *args)
+  bufs = [get_call_arg_uops(call)[i].getaddr(ctx) for i in prg.arg.globals]
+  vals = [v.cast(dtypes.uint64) for v in get_call_var_uops(call, prg)]
+  sig = list(TinyELF.iter_sig(prg.to_elf().signature))
+  args = [bufs[idx] if arg.addrspace is not AddrSpace.ALU else vals[idx] for _,arg,_,idx in sig]
+  if (core_idx:=prg.arg.runtimevars.get('core_id')) is None: return cpu_cmd(ctx, prg, *args)
+  core = next(i for i,(_,arg,_,idx) in enumerate(sig) if arg.addrspace is AddrSpace.ALU and idx == core_idx)
 
-  la = [cpu_cmd(ctx,prg,*args[:(cid:=(len(prg.arg.globals)+core))],UOp.const(t, dtypes.uint64),*args[cid+1:]) for t in range(prg.arg.global_size[0])]
+  la = [cpu_cmd(ctx,prg,*args[:core],UOp.const(t, dtypes.uint64),*args[core+1:]) for t in range(prg.arg.global_size[0])]
   return UOp(Ops.LINEAR, dtypes.void, tuple(la))
 
 pm_cpu_opsel = PatternMatcher([
@@ -118,7 +122,7 @@ class CPUProgram(Program['CPUDevice']):
 
   def __init__(self, dev:CPUDevice, obj:TinyELF):
     self.dev, self.name, self.signature = dev, obj.name, obj.signature
-    self.runtimevars = {name:slot for name,slot,*_ in obj.signature if name == 'core_id'}
+    self.runtimevars = {arg.name:i for i,(arg,_) in enumerate(obj.signature) if arg.name == 'core_id'}
     self.lvp = obj.target.renderer == "LVP"
 
     if sys.platform == "win32": # mypy doesn't understand when WIN is used here
@@ -158,11 +162,14 @@ class CPUProgram(Program['CPUDevice']):
     if self.lvp:
       lvp_args = bytearray(12 + (len(bufs) + len(vals)) * 8)
       addr = mv_address(lvp_args)
-      struct.pack_into(f'<3I{len(bufs)}Q', lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2, *[b.va_addr for b in bufs])
-      for v,(off,dt) in zip(vals, TinyELF.iter_sig(self.signature[-len(vals):], len(bufs)*8)): struct.pack_into(f'<{dt.fmt}', lvp_args, 12+off, v)
+      struct.pack_into('<3I', lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2)
+      for off,arg,_,idx in TinyELF.iter_sig(self.signature):
+        struct.pack_into('<Q' if arg.addrspace is not AddrSpace.ALU else f'<{arg.dtype.fmt}', lvp_args, 12+off,
+                         bufs[idx].va_addr if arg.addrspace is not AddrSpace.ALU else vals[idx])
       self.fxn(addr)
     else:
-      args = [*[cast(int, b.va_addr) for b in bufs], *cast(tuple[int, ...], vals)]
+      args = [cast(int, bufs[idx].va_addr) if arg.addrspace is not AddrSpace.ALU else cast(int, vals[idx])
+              for _,arg,_,idx in TinyELF.iter_sig(self.signature)]
       assert len(args) <= MAX_ARGS, f"CPU programs support at most {MAX_ARGS} arguments, got {len(args)}"
       for tid in range(global_size[0]):
         if 'core_id' in self.runtimevars: args[self.runtimevars['core_id']] = tid

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import ctypes
 from tinygrad.helpers import DEBUG, DEV, getenv, mv_address, suppress_finalizing
 from tinygrad.device import Compiled, BufferSpec, LRUAllocator, Program, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.renderer.cstyle import CUDARenderer, NVCCRenderer
 from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.runtime.autogen import cuda
@@ -16,9 +17,13 @@ def check(status):
     raise RuntimeError(f"CUDA Error {status}, {error}")
 
 def encode_args(args, vals, signature) -> tuple[ctypes.Structure, ctypes.Array]:
-  fields = ([(f'f{i}', cuda.CUdeviceptr_v2, i*8) for i in range(len(args))] +
-            [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), off) for i,(off,dt) in enumerate(TinyELF.iter_sig(signature[len(args):], len(args)*8))])
-  c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
+  fields, ordered, end = [], [], 0
+  for off, arg, _, idx in TinyELF.iter_sig(signature):
+    is_buf = arg.addrspace is not AddrSpace.ALU
+    fields.append((f'f{idx}', cuda.CUdeviceptr_v2, off) if is_buf else (f'v{idx}', getattr(ctypes, f"c_int{arg.dtype.bitsize}"), off))
+    ordered.append(args[idx] if is_buf else vals[idx])
+    end = off + (8 if is_buf else arg.dtype.itemsize)
+  c_args = init_c_struct_t(end, tuple(fields))(*ordered)
   vargs = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), ctypes.cast(ctypes.byref(c_args), ctypes.c_void_p), ctypes.c_void_p(2),
                                 ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(c_args))), ctypes.c_void_p), ctypes.c_void_p(0))
   return c_args, vargs

--- a/tinygrad/runtime/ops_dsp.py
+++ b/tinygrad/runtime/ops_dsp.py
@@ -41,9 +41,9 @@ class DSPRenderer(ClangRenderer):
     msrc += [f'{self._render_dtype(b[1][0].dtype) if b[1][0].addrspace == AddrSpace.ALU else "int"} sz_or_val_{i} = '
              f'*({self._render_dtype(b[1][0].dtype) if b[1][0].addrspace == AddrSpace.ALU else "int"}*)((char*)pra[0].buf.pv+{i*8});'
              for i,b in enumerate(bufs)]
-    msrc += [f'int off{i} = ((int*)pra[1].buf.pv)[{i}];' for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
-    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{i+3}].dma.fd,0)+off{i};'
-             for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
+    global_params = [(i,b) for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
+    msrc += [f'int off{i} = ((int*)pra[1].buf.pv)[{j}];' for j,(i,_) in enumerate(global_params)]
+    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{j+3}].dma.fd,0)+off{i};' for j,(i,_) in enumerate(global_params)]
     msrc += ["unsigned long long start = HAP_perf_get_time_us();"]
     fbufs = [(f'buf_{i}' if b[1][0].addrspace == AddrSpace.GLOBAL else f'sz_or_val_{i}') for i,b in enumerate(bufs)]
     msrc += [f"{function_name}({', '.join(fbufs)});"]
@@ -73,8 +73,9 @@ class DSPProgram(Program['DSPDevice']):
 
     pra, fds, attrs, _ = rpc_prep_args(ins=[var_vals_mv:=memoryview(bytearray((len(bufs)+len(vals))*8)), off_mv:=memoryview(bytearray(len(bufs)*4))],
                                        outs=[timer:=memoryview(bytearray(8)).cast('Q')], in_fds=[b.share_info.fd for b in bufs])
-    for i,b in enumerate(bufs): struct.pack_into('i', var_vals_mv, i*8, b.size)
-    for i,(v,(_,_,dt,_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
+    for i,(_,arg,_,idx) in enumerate(TinyELF.iter_sig(self.signature)):
+      struct.pack_into('i' if arg.addrspace is not AddrSpace.ALU else unwrap(arg.dtype.fmt), var_vals_mv, i*8,
+                       bufs[idx].size if arg.addrspace is not AddrSpace.ALU else vals[idx])
     off_mv.cast('I')[:] = array.array('I', tuple(b.offset for b in bufs))
     self.dev.exec_lib(self.lib, rpc_sc(method=2, ins=2, outs=1, fds=len(bufs)), pra, fds, attrs)
     return timer[0] / 1e6
@@ -286,8 +287,8 @@ class MockDSPProgram(Program[DSPDevice]):
       dsp_lib.flush()
       os.chmod(dsp_lib.name, 0o0777)
       proc = subprocess.run(["qemu-hexagon-static", *(['-strace'] if DEBUG >= 5 else []), dsp_lib.name],
-        input=b''.join([bytes(to_mv(x.va_addr, x.size)) for x in bufs] +
-                       [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,_) in zip(vals, self.signature[len(bufs):])]),
+        input=b''.join(bytes(to_mv(bufs[idx].va_addr, bufs[idx].size)) if arg.addrspace is not AddrSpace.ALU else
+                       struct.pack(unwrap(arg.dtype.fmt), vals[idx]) for _,arg,_,idx in TinyELF.iter_sig(self.signature)),
         stdout=subprocess.PIPE, check=True)
     offset = 4
     for x in bufs:

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -1,6 +1,7 @@
 import ctypes
 from tinygrad.helpers import mv_address, getenv, suppress_finalizing
 from tinygrad.device import Compiled, LRUAllocator, BufferSpec, Program, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.runtime.autogen import hip
 from tinygrad.renderer.cstyle import HIPRenderer
 from tinygrad.runtime.support.c import init_c_var, init_c_struct_t
@@ -37,9 +38,13 @@ class HIPProgram(Program[HIPDevice]):
   def __call__(self, *args, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(), wait=False, **kw):
     check(hip.hipSetDevice(self.dev.device_id))
     if not hasattr(self, "vargs"):
-      fields = ([(f'f{i}', hip.hipDeviceptr_t, i*8) for i in range(len(args))] +
-        [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), o) for i,(o,dt) in enumerate(TinyELF.iter_sig(self.signature[len(args):], len(args)*8))])
-      self.c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
+      fields, ordered, end = [], [], 0
+      for off, arg, _, idx in TinyELF.iter_sig(self.signature):
+        is_buf = arg.addrspace is not AddrSpace.ALU
+        fields.append((f'f{idx}', hip.hipDeviceptr_t, off) if is_buf else (f'v{idx}', getattr(ctypes, f"c_int{arg.dtype.bitsize}"), off))
+        ordered.append(args[idx] if is_buf else vals[idx])
+        end = off + (8 if is_buf else arg.dtype.itemsize)
+      self.c_args = init_c_struct_t(end, tuple(fields))(*ordered)
       self.vargs = (ctypes.c_void_p * 5)(1, ctypes.cast(ctypes.byref(self.c_args), ctypes.c_void_p), 2,
                                          ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(self.c_args))), ctypes.c_void_p), 3)
 

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -2,6 +2,7 @@ import subprocess, pathlib, struct, ctypes, tempfile, functools, decimal, platfo
 from tinygrad.helpers import prod, to_mv, round_up, cache_dir, PROFILE, ProfileRangeEvent, cpu_profile, unwrap, suppress_finalizing
 import tinygrad.runtime.support.objc as objc
 from tinygrad.device import Compiled, Compiler, CompileError, Program, TinyELF, LRUAllocator, ProfileDeviceEvent
+from tinygrad.dtype import AddrSpace
 from tinygrad.renderer.cstyle import MetalRenderer
 from tinygrad.runtime.autogen import metal
 from tinygrad.runtime.support.c import DLL
@@ -138,9 +139,9 @@ class MetalProgram(Program[MetalDevice]):
     command_buffer = self.dev.mtl_queue.commandBuffer().retained()
     encoder = command_buffer.computeCommandEncoder().retained()
     encoder.setComputePipelineState(self.pipeline_state)
-    for i,a in enumerate(bufs): encoder.setBuffer_offset_atIndex(a.buf, a.offset, i)
-    for a,(_,i,dt,_) in zip(vals, self.signature[len(bufs):]):
-      encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(a)), dt.itemsize, i)
+    for i,(_,arg,_,idx) in enumerate(TinyELF.iter_sig(self.signature)):
+      if arg.addrspace is not AddrSpace.ALU: encoder.setBuffer_offset_atIndex(bufs[idx].buf, bufs[idx].offset, i)
+      else: encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{arg.dtype.bitsize}")(vals[idx])), arg.dtype.itemsize, i)
     encoder.dispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
     encoder.endEncoding()
     command_buffer.setLabel(to_ns_str(self.name)) # TODO: is this always needed?

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -3,10 +3,12 @@ import os, ctypes, contextlib, re, functools, mmap, struct, array, sys, weakref
 assert sys.platform != 'win32'
 from typing import cast
 from dataclasses import dataclass
-from tinygrad.runtime.support.hcq import HCQCompiled, HCQAllocator, HCQBuffer, HWQueue, CLikeArgsState, HCQProgram, HCQSignal, BumpAllocator
+from tinygrad.runtime.support.hcq import HCQCompiled, HCQAllocator, HCQBuffer, HWQueue, HCQArgsState, CLikeArgsState, HCQProgram
+from tinygrad.runtime.support.hcq import HCQSignal, BumpAllocator
 from tinygrad.runtime.support.hcq import MMIOInterface, FileIOInterface, hcq_filter_visible_devices, hcq_profile
 from tinygrad.uop.ops import sint
 from tinygrad.device import Compiled, BufferSpec, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.helpers import getenv, mv_address, round_up, data64, data64_le, prod, OSX, hi32, lo32, PROFILE, ContextVar, VIZ, ProfileEvent
 from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.renderer.cstyle import CUDARenderer, NVCCRenderer
@@ -240,10 +242,15 @@ class NVVideoQueue(NVCommandQueue):
 
 class NVArgsState(CLikeArgsState):
   def __init__(self, buf:HCQBuffer, prg:NVProgram, bufs:tuple[HCQBuffer, ...], vals:tuple[int, ...]=()):
-    if (is_mock:=isinstance(prg.dev.iface, MOCKIface)): prg.cbuf_0[80:82] = [len(bufs), len(vals)]
-    super().__init__(buf, prg, bufs, vals=() if is_mock else vals, prefix=prg.cbuf_0 or None)
-    # mock expects all vars to be 64 bit
-    if is_mock and vals: self.bind_sints_to_buf(*vals, buf=self.buf, fmt='q', offset=len(prg.cbuf_0)*4 + len(bufs)*8)
+    if not isinstance(prg.dev.iface, MOCKIface):
+      super().__init__(buf, prg, bufs, vals=vals, prefix=prg.cbuf_0 or None)
+      return
+    HCQArgsState.__init__(self, buf, prg, bufs, vals=vals)
+    prg.cbuf_0[80:82] = [len(bufs), len(vals)]
+    if prg.cbuf_0: self.buf.cpu_view().view(size=len(prg.cbuf_0)*4, fmt='I')[:] = array.array('I', prg.cbuf_0)
+    # mock expects every parameter to be 64 bit, but still in kernel ABI order
+    args = [bufs[idx].va_addr if arg.addrspace is not AddrSpace.ALU else vals[idx] for _,arg,_,idx in TinyELF.iter_sig(prg.signature)]
+    if args: self.bind_sints_to_buf(*args, buf=self.buf, fmt='q', offset=len(prg.cbuf_0)*4)
 
 class NVProgram(HCQProgram['NVDevice']):
   def __init__(self, dev:NVDevice, obj:TinyELF):

--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -202,8 +202,10 @@ class QCOMArgsState(HCQArgsState):
     super().__init__(buf, prg, bufs, vals=vals)
     ctypes.memset(int(self.buf.va_addr), 0, prg.kernargs_alloc_size)
 
-    ubos = [bufs[slot] for _,slot,_,shape in prg.signature if slot < len(bufs) and not is_image_shape(shape)]
-    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape in prg.signature if slot < len(bufs) and is_image_shape(shape)]
+    params = list(TinyELF.iter_sig(prg.signature))
+    uavs = [(arg.dtype,shape,bufs[idx]) for _,arg,shape,idx in params if arg.addrspace is not AddrSpace.ALU and is_image_shape(shape)]
+    packed = [(arg,shape,idx) for _,arg,shape,idx in params if arg.addrspace is AddrSpace.ALU or not is_image_shape(shape)]
+    packed_sig = tuple((arg,shape) for arg,shape,_ in packed)
     # NIR can reorder images to different texture slots
     ibos, texs = uavs[:prg.ibo_cnt], [uavs[prg.ibo_cnt + (prg.tex_to_image[i] if prg.NIR else i)] for i in range(prg.tex_cnt)]
     for cnst_val,cnst_off,cnst_sz in prg.consts_info:
@@ -211,13 +213,13 @@ class QCOMArgsState(HCQArgsState):
 
     if prg.samp_cnt > 0: to_mv(int(self.buf.va_addr) + prg.samp_off, len(prg.samplers) * 4).cast('I')[:] = array.array('I', prg.samplers)
     if prg.NIR:
-      self.bind_sints_to_buf(*[b.va_addr for b in ubos], buf=self.buf, fmt='Q', offset=prg.buf_off)
-      for v,(o,dt) in zip(vals, TinyELF.iter_sig(prg.signature[len(bufs):], len(ubos)*8)):
-        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_off + o)
+      for (o,arg,_,_), (_,_,idx) in zip(TinyELF.iter_sig(packed_sig), packed):
+        self.bind_sints_to_buf(bufs[idx].va_addr if arg.addrspace is not AddrSpace.ALU else vals[idx], buf=self.buf,
+                               fmt='Q' if arg.addrspace is not AddrSpace.ALU else arg.dtype.fmt, offset=prg.buf_off + o)
     else:
-      for i, b in enumerate(ubos): self.bind_sints_to_buf(b.va_addr, buf=self.buf, fmt='Q', offset=prg.buf_offs[i])
-      for i,(v,(_,_,dt,_)) in enumerate(zip(vals, prg.signature[len(bufs):])):
-        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_offs[i+len(ubos)])
+      for i,(arg,_,idx) in enumerate(packed):
+        self.bind_sints_to_buf(bufs[idx].va_addr if arg.addrspace is not AddrSpace.ALU else vals[idx], buf=self.buf,
+                               fmt='Q' if arg.addrspace is not AddrSpace.ALU else arg.dtype.fmt, offset=prg.buf_offs[i])
 
     def _tex(b, ibo=False):
       imgdt, shape, buf = b

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -1,5 +1,6 @@
 import functools, struct
 from tinygrad.device import Compiled, Allocator, BufferSpec, Program, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.renderer.wgsl import WGSLRenderer
 from tinygrad.helpers import round_up, suppress_finalizing, getenv, to_mv
 from tinygrad.runtime.autogen import webgpu
@@ -51,7 +52,7 @@ QueueOnSubmittedWorkDone = synchronous(webgpu.enum_WGPUQueueWorkDoneStatus)(webg
 
 class WebGPUProgram(Program['WebGpuDevice']):
   def __init__(self, dev:'WebGpuDevice', obj:TinyELF):
-    self.dev, self.name = dev, to_wgpu_str(obj.name)
+    self.dev, self.name, self.signature = dev, to_wgpu_str(obj.name), obj.signature
 
     # Creating shader module
     shader = webgpu.WGPUShaderModuleWGSLDescriptor(code=to_wgpu_str(obj.lib.decode()),
@@ -74,8 +75,10 @@ class WebGPUProgram(Program['WebGpuDevice']):
     def bgl_entry(n:int, ty:str):
       return webgpu.WGPUBindGroupLayoutEntry(binding=n, visibility=webgpu.WGPUShaderStage_Compute,
                                              buffer=webgpu.WGPUBufferBindingLayout(type=getattr(webgpu, f'WGPUBufferBindingType_{ty}')))
-    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(bufs)+len(vals)))(
-      bgl_entry(0, 'Uniform'), *(bgl_entry(i+1, 'Uniform' if i >= len(bufs) else 'Storage') for i in range(len(bufs)+len(vals))))
+    params = list(TinyELF.iter_sig(self.signature))
+    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(params)))(
+      bgl_entry(0, 'Uniform'), *(bgl_entry(i+1, 'Uniform' if arg.addrspace is AddrSpace.ALU else 'Storage')
+                                  for i,(_,arg,_,_) in enumerate(params)))
 
     webgpu.wgpuDevicePushErrorScope(self.dev.device_res, webgpu.WGPUErrorFilter_Validation)
     bind_layout = webgpu.wgpuDeviceCreateBindGroupLayout(self.dev.device_res,
@@ -94,7 +97,8 @@ class WebGPUProgram(Program['WebGpuDevice']):
     def bg_entry(n:int, x:webgpu.WGPUBuffer|int|float):
       buf = x if isinstance(x, webgpu.WGPUBuffer) else self.dev.create_uniform(x)
       return webgpu.WGPUBindGroupEntry(binding=n, buffer=buf, offset=0, size=webgpu.wgpuBufferGetSize(buf))
-    bindings = (webgpu.WGPUBindGroupEntry * (1+len(bufs)+len(vals)))(bg_entry(0, float('inf')), *(bg_entry(i+1, x) for i,x in enumerate(bufs+vals)))
+    xs = [vals[idx] if arg.addrspace is AddrSpace.ALU else bufs[idx] for _,arg,_,idx in params]
+    bindings = (webgpu.WGPUBindGroupEntry * (1+len(params)))(bg_entry(0, float('inf')), *(bg_entry(i+1, x) for i,x in enumerate(xs)))
 
     bind_group_desc = webgpu.WGPUBindGroupDescriptor(layout=bind_layout, entryCount=len(bindings), entries=bindings)
     webgpu.wgpuDevicePushErrorScope(self.dev.device_res, webgpu.WGPUErrorFilter_Validation)

--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -6,6 +6,7 @@ except ImportError: fcntl = None #type:ignore[assignment]
 from tinygrad.helpers import DEV, PROFILE, getenv, to_mv, from_mv, cpu_profile, ProfileRangeEvent, unwrap
 from tinygrad.helpers import suppress_finalizing, pluralize, TracingKey
 from tinygrad.device import Device, BufferSpec, Compiled, LRUAllocator, ProfileDeviceEvent, ProfileProgramEvent, Program, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.uop.ops import sym_infer, sint, UOp
 from tinygrad.runtime.autogen import libc
 from tinygrad.runtime.support.memory import BumpAllocator
@@ -326,10 +327,13 @@ class CLikeArgsState(HCQArgsState[ProgramType]):
 
     if prefix is not None: self.buf.cpu_view().view(size=len(prefix) * 4, fmt='I')[:] = array.array('I', prefix)
 
-    self.bind_sints_to_buf(*[b.va_addr for b in bufs], buf=self.buf, fmt='Q', offset=len(prefix or []) * 4)
-    for v,(val_offset,dt) in zip(vals, TinyELF.iter_sig(prg.signature[-len(vals):], len(bufs) * 8)):
-      assert v is not None
-      self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=len(prefix or []) * 4 + val_offset)
+    base = len(prefix or []) * 4
+    for offset,arg,_,idx in TinyELF.iter_sig(prg.signature):
+      if arg.addrspace is not AddrSpace.ALU: self.bind_sints_to_buf(bufs[idx].va_addr, buf=self.buf, fmt='Q', offset=base+offset)
+      else:
+        val = vals[idx]
+        assert val is not None
+        self.bind_sints_to_buf(val, buf=self.buf, fmt=arg.dtype.fmt, offset=base+offset)
 
 class HCQProgram(Program[HCQDeviceType]):
   def __init__(self, args_state_t:Type[HCQArgsState], dev:HCQDeviceType, obj:TinyELF, kernargs_alloc_size:int, base:int|None=None):

--- a/tinygrad/runtime/support/hcq2.py
+++ b/tinygrad/runtime/support/hcq2.py
@@ -4,11 +4,11 @@ import struct, functools, time, collections, itertools, decimal, statistics
 from dataclasses import replace, dataclass
 from tinygrad.helpers import suppress_finalizing, dedup, pluralize, JIT_BATCH_SIZE, unwrap, PROFILE
 from tinygrad.helpers import to_tuple, round_up, partition, panic, ContextVar, perf_counter_us, Context
-from tinygrad.device import Device, Buffer, BufferSpec, Compiled, LRUAllocator, MultiBuffer, DepsTracker
+from tinygrad.device import Device, Buffer, BufferSpec, Compiled, LRUAllocator, MultiBuffer, DepsTracker, TinyELF
 from tinygrad.device import ProfileDeviceEvent, ProfileGraphEntry, ProfileGraphEvent
 from tinygrad.uop.ops import Ops, sint, UOp, UPat, PatternMatcher, KernelInfo, graph_rewrite, rewrite_group, GroupOp
 from tinygrad.uop.symbolic import symbolic
-from tinygrad.dtype import dtypes, truncate, DType
+from tinygrad.dtype import dtypes, truncate, DType, AddrSpace
 from tinygrad.runtime.support.hcq import MMIOInterface, HCQBuffer
 from tinygrad.runtime.support.memory import BumpAllocator
 from tinygrad.renderer import Renderer, Estimates
@@ -85,8 +85,10 @@ def make_call(name:str, body:UOp, info:HCQInfo) -> UOp: return UOp.custom_functi
 def encode_kernargs_clike(call:UOp, prg:UOp, devs:str|tuple[str, ...]) -> UOp:
   data, info = prg.arg
   buf = UOp.placeholder((data.kernargs_alloc_size // 4,), dtypes.uint32, next(UOp.unique_num), device=devs).rtag("kernargs")
-  words = [get_call_arg_uops(call)[gi].getaddr(devs) for gi in info.globals] + list(info.vars)
-  return buf.after(*make_patches(buf, list(zip(itertools.accumulate((w.dtype.itemsize for w in words), initial=0), words))))
+  bufs = [get_call_arg_uops(call)[gi].getaddr(devs) for gi in info.globals]
+  words = [(off, bufs[idx] if arg.addrspace is not AddrSpace.ALU else info.vars[idx])
+           for off,arg,_,idx in TinyELF.iter_sig(data.signature)]
+  return buf.after(*make_patches(buf, words))
 
 def make_buf(devs, slot:int=0, tag:str="signal") -> UOp: return UOp.placeholder((1,), dtypes.uint64, slot, device=devs, volatile=True, tag=tag)
 

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1195,8 +1195,9 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
 
   def to_elf(self) -> TinyELF:
     assert self.op is Ops.PROGRAM and isinstance(self.arg, ProgramInfo), "to_elf should only be called on a PROGRAM ast"
-    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape)
-                for u in tuple(filter(lambda u: u.op is Ops.PARAM and u.addrspace != AddrSpace.ALU, self.src[1].src)) + self.arg.vars)
+    params = tuple(u for u in self.src[1].src if u.op is Ops.PARAM)
+    if not params: params = tuple(sorted((u for u in self.src[0].toposort() if u.op is Ops.PARAM), key=lambda u: u.arg.slot))
+    sig = tuple((replace(u.arg, dtype=u.dtype), u._shape) for u in params)
     return TinyELF(self.src[3].arg, self.arg.function_name, self.arg.target, sig, self.key)
 
 @dataclass(frozen=True)
@@ -1256,9 +1257,12 @@ class ProgramInfo:
         special_size = local_size if u.arg[0] == 'l' else global_size
         if special_size is not None: special_size[int(u.arg[-1])] = cast(int, u.src[0].ssimplify())
       if u.op is Ops.PARAM and u in _vars and u.expr == 'core_id': global_size[0] = int(u.vmax) + 1
+    _vars, _globals = sorted(dedup(_vars), key=lambda v: v.arg.slot), sorted(dedup(_globals))
+    var_slots = tuple(v.arg.slot for v in _vars if v.arg.slot >= 0)
+    def buf_slot(slot:int) -> int: return slot - sum(v < slot for v in var_slots)
     return ProgramInfo(sink.arg.name if isinstance(sink.arg, KernelInfo) else "test", tuple(global_size),
-                       tuple(local_size) if local_size is not None else None, tuple(sorted(dedup(_vars), key=lambda v: v.arg.slot)),
-                       tuple(sorted(dedup(_globals))), tuple(sorted(dedup(outs))), tuple(sorted(dedup(ins))), target)
+                       tuple(local_size) if local_size is not None else None, tuple(_vars), tuple(buf_slot(x) for x in _globals),
+                       tuple(buf_slot(x) for x in sorted(dedup(outs))), tuple(buf_slot(x) for x in sorted(dedup(ins))), target)
 
 @dataclass(frozen=True)
 class CallInfo:


### PR DESCRIPTION
Kernel signatures now preserve buffer and scalar parameters in ABI order while runtime buffer and value lists remain dense. This removes the buffers-first assumption across compiled backends, graphs, and image arguments.

Adds regressions for every two-buffer/two-scalar permutation, mixed scalar widths, repeated launches, images, graph rebinding, signature layout/pickle, and manual PROGRAM signatures.

Validated with CPU, OpenCL, WebGPU, DSP, CUDA, AMD/NV mock matrices, process replay with `ASSERT_DIFF=1`, ruff, and mypy.

AI was used to assist implementation and testing; I reviewed every line and validated the results.
