### PR TITLE
fix asinh precision loss on negative inputs

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1807,9 +1807,9 @@ class TestOps(unittest.TestCase):
       helper_test_op([()], lambda x: torch.nn.functional.hardtanh(x, -val, val), lambda x: x.hardtanh(-val, val), grad_atol=1e-6)
   def test_asinh(self):
     helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6)
-    # TODO: this one has larger tol?
-    helper_test_op([(45,65)], lambda x: x.asinh(), atol=1e-2, rtol=2e-2, grad_rtol=2e-2, low=-300, high=-297)
+    helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=-300, high=-297)
     helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=300, high=303)
+    helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=-1e10, high=-1e9)
   def test_acosh(self):
     helper_test_op([(45,65)], lambda x: x.acosh(), grad_atol=1e-6)
     helper_test_op([(45,65)], lambda x: x.acosh(), grad_atol=1e-3, grad_rtol=1e-2, low=-300, high=-297)

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -870,7 +870,7 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).asinh().numpy())
     ```
     """
-    return (self + (self.square() + 1).sqrt()).log()
+    return self.sign() * (self.abs() + (self.square() + 1).sqrt()).log()
 
   def acosh(self) -> Self:
     """


### PR DESCRIPTION
asinh is log(x + (x*x+1).sqrt()) and for negative x those two terms cancel. At -1e3 the answer is already off by 0.024, and by -1e4 the subtraction is exactly zero so asinh returns -inf. It's odd, so pull the sign out and the cancellation goes away.

That is what the TODO over the atol=1e-2 case in test_asinh was about; -300..-297 goes back to the default tolerances now. Gradients past -1e4 stop being nan. x*x still overflows above sqrt(FLT_MAX), on both signs.