### PR TITLE
fix asinh gradient at zero

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1813,6 +1813,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=-300, high=-297)
     helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=300, high=303)
     helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=-1e10, high=-1e9)
+    helper_test_op(None, lambda x: x.asinh(), grad_atol=1e-6, vals=[[-1.0, 0.0, 1.0]])
   def test_acosh(self):
     helper_test_op([(45,65)], lambda x: x.acosh(), grad_atol=1e-6)
     helper_test_op([(45,65)], lambda x: x.acosh(), grad_atol=1e-3, grad_rtol=1e-2, low=-300, high=-297)

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -870,7 +870,7 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).asinh().numpy())
     ```
     """
-    return self.sign() * (self.abs() + (self.square() + 1).sqrt()).log()
+    return (sg:=(self<0).where(-1.0, 1.0)) * (self*sg + (self.square() + 1).sqrt()).log()
 
   def acosh(self) -> Self:
     """


### PR DESCRIPTION
sign(0) is 0, so the sign(x)*log(abs(x)+...) form from #17749 differentiates to sign(x)^2 * f'(abs(x)) and the gradient at 0 comes out 0 instead of 1. Using the same signum for the abs keeps d|x|/dx at 1 there. Values are unchanged.

test_asinh builds its inputs with uniform, which never returns exactly 0, so the one point where that form changes character is the one it could not sample.