### PR TITLE
simplify more same device copies

### DIFF
--- a/test/unit/test_allreduce.py
+++ b/test/unit/test_allreduce.py
@@ -33,8 +33,8 @@ class TestRingAllReduce(unittest.TestCase):
       # N*(N-1) copies for input and output
       copy_count = N*(N-1)*2
       if len(copies) != copy_count: raise KernelCountException(copy_count, len(copies))
-      # N*N shrinks becoming contigs, N ALU, N extra contig, reassembly (cat), and mul
-      sink_count = (N*N)+(N)+(N)+(1)+(1)
+      # N*(N-1) remote shrinks becoming contigs, N ALU, N extra contig, reassembly (cat), and mul
+      sink_count = (N*(N-1))+(N)+(N)+(1)+(1)
       if len(sinks) != sink_count: raise KernelCountException(sink_count, len(sinks))
       # correctness
       run_linear(linear, var_vals)

--- a/test/unit/test_allreduce.py
+++ b/test/unit/test_allreduce.py
@@ -33,7 +33,7 @@ class TestRingAllReduce(unittest.TestCase):
       # N*(N-1) copies for input and output
       copy_count = N*(N-1)*2
       if len(copies) != copy_count: raise KernelCountException(copy_count, len(copies))
-      # N*(N-1) remote shrinks becoming contigs, N ALU, N extra contig, reassembly (cat), and mul
+      # N*(N-1) shrinks from other devices becoming contigs, N ALU, N extra contig, reassembly (cat), and mul
       sink_count = (N*(N-1))+(N)+(N)+(1)+(1)
       if len(sinks) != sink_count: raise KernelCountException(sink_count, len(sinks))
       # correctness

--- a/tinygrad/schedule/multi.py
+++ b/tinygrad/schedule/multi.py
@@ -15,7 +15,8 @@ def mstack_early_shrink(ms:UOp, shrink:UOp):
   ret:list[UOp] = []
   for i, x in enumerate(ms.src):
     if x.op is Ops.COPY:
-      ret.append(_apply_shrink(shrink.marg, x.src[0], i).copy_to_device(x.device))
+      src = _apply_shrink(shrink.marg, x.src[0], i)
+      ret.append(src.contiguous() if src.device == x.device else src.copy_to_device(x.device))
     else:
       ret.append(_apply_shrink(shrink.marg, x, i).contiguous())
   return ms.replace(src=tuple(ret))

--- a/tinygrad/schedule/prepare.py
+++ b/tinygrad/schedule/prepare.py
@@ -139,12 +139,12 @@ earliest_rewrites = mop_cleanup+PatternMatcher([
 
   # ** copy rules **
 
+  # copy to same device is a no-op
+  (UPat(Ops.COPY, src=(UPat.var("x"),), name="copy"), lambda x,copy: x if x.device == copy.device else None),
+
   # COPY transfers a contiguous range, so materialize a source that's resized (shrink/pad/expand) or reordered (permute/flip)
   (UPat(Ops.COPY, src=(UPat(GroupOp.Movement, name="r"),), name="c"),
    lambda c,r: c.replace(src=(r.contiguous(),)) if resolve(r.numel() != r.base.numel(), False) or r.contiguous_view_offset() is None else None),
-
-  # copy to same device is a no-op
-  (UPat(Ops.COPY, src=(UPat.var("x"),), name="copy"), lambda x,copy: x if x.device == copy.device else None),
 
   # copy on reshape is reshape on copy
   (UPat(Ops.COPY, src=(UPat(Ops.RESHAPE, name="shp"),), name="cpy"), lambda shp,cpy: shp.src[0].copy_to_device(cpy.device).reshape(shp.shape)),


### PR DESCRIPTION
-4 kernels in the allreduce, no sub buffer support as SDMA input yet, this SHRINK just gets fused with the later E kernel
```diff
- void E_28_4(... data1_112, data2_112, data3_112, data4_112)
+ void E_28_4(... data1_400, data2_112, data3_112, data4_112)

- val0 = *(data1_112 + alu0)
+ val0 = *(data1_400 + alu0)
```