### PR TITLE
(tinygpu) make sysmem DMA mappings writable for the GPU on Intel Macs

### DIFF
--- a/extra/usbgpu/tbgpu/installer/Shared/server.c
+++ b/extra/usbgpu/tbgpu/installer/Shared/server.c
@@ -39,7 +39,7 @@ typedef struct { uint8_t status; uint64_t resp0, resp1; } __attribute__((packed)
 
 #define BULK_BUF_SIZE (64 << 20)
 #define MAX_BARS 6
-#define MAX_SYSMEM 128
+#define MAX_SYSMEM 8192  // sysmem allocations are never freed for the life of the server, 128 was hit by test_graph
 
 static uint8_t g_bulk_buf[BULK_BUF_SIZE];
 static io_connect_t g_conn = IO_OBJECT_NULL;
@@ -143,11 +143,12 @@ static int map_sysmem_fd(uint64_t size, int contiguous, response_t *resp, int *o
   if (ftruncate(fd, alloc_sz) < 0) goto fail;
   if ((ptr = mmap(NULL, alloc_sz, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0)) == MAP_FAILED) goto fail;
 
-  // PrepareDMA writes physical addresses to output buffer, copy to shared mem
-  uint8_t paddr_buf[8192] = {0};
-  size_t out_sz = sizeof(paddr_buf);
-  if (IOConnectCallStructMethod(g_conn, 3, ptr, alloc_sz, paddr_buf, &out_sz) != KERN_SUCCESS) goto fail;
-  memcpy(ptr, paddr_buf, out_sz);
+  // PrepareDMA: the buffer is passed as the (out-of-line) OUTPUT struct so the kernel wraps it in a device-writable descriptor
+  // (an input struct is mapped read-only for DMA and Intel's AppleVTD drops device writes into it). The dext writes the
+  // [paddr0, len0, ..., 0, 0] table to the head of the buffer itself. The small input struct carries request flags.
+  uint64_t flags = contiguous ? 1 : 0;
+  size_t out_sz = alloc_sz;
+  if (IOConnectCallStructMethod(g_conn, 3, &flags, sizeof(flags), ptr, &out_sz) != KERN_SUCCESS) goto fail;
 
   g_sysmem[idx] = (typeof(g_sysmem[idx])){.addr = (mach_vm_address_t)ptr, .size = alloc_sz, .shm_fd = fd};
   strncpy(g_sysmem[idx].shm_name, shm_name, sizeof(g_sysmem[idx].shm_name));

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.cpp
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.cpp
@@ -118,8 +118,8 @@ static kern_return_t WriteDMASegments(IOMemoryDescriptor* mem, IOAddressSegment*
 	return 0;
 }
 
-kern_return_t TinyGPUDriver::SetupDMA(IOMemoryDescriptor* memory, uint64_t size, IODMACommand** outCmd,
-                                       IOAddressSegment* segments, uint32_t* segCount)
+kern_return_t TinyGPUDriver::SetupDMA(IOMemoryDescriptor* memory, uint64_t offset, uint64_t size, IODMACommand** outCmd,
+                                       IOAddressSegment* segments, uint32_t* segCount, uint64_t* outFlags)
 {
 	IODMACommandSpecification dmaSpec = {.options = 0, .maxAddressBits = 40};
 	IODMACommand* dmaCmd = nullptr;
@@ -127,10 +127,13 @@ kern_return_t TinyGPUDriver::SetupDMA(IOMemoryDescriptor* memory, uint64_t size,
 	kern_return_t err = IODMACommand::Create(ivars->pci, kIODMACommandCreateNoOptions, &dmaSpec, &dmaCmd);
 	if (err) { os_log(OS_LOG_DEFAULT, "tinygpu: DMA create failed err=%d", err); return err; }
 
-	uint64_t flags = kIOMemoryDirectionInOut;
-	err = dmaCmd->PrepareForDMA(kIODMACommandPrepareForDMANoOptions, memory, 0, size, &flags, segCount, segments);
+	// flags is an OUTPUT: kIOMemoryDirectionOut = device may read, kIOMemoryDirectionIn = device may write. IOMMUs that honour the
+	// access bits (Intel AppleVTD) drop DMA the descriptor was not prepared for, so callers must check both bits are present.
+	uint64_t flags = 0;
+	err = dmaCmd->PrepareForDMA(kIODMACommandPrepareForDMANoOptions, memory, offset, size, &flags, segCount, segments);
 	if (err) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareForDMA failed err=%d", err); dmaCmd->release(); return err; }
 
+	if (outFlags) *outFlags = flags;
 	*outCmd = dmaCmd;
 	return 0;
 }
@@ -144,7 +147,8 @@ kern_return_t TinyGPUDriver::CreateDMA(size_t size, TinyGPUCreateDMAResp* dmaDes
 	IODMACommand* dmaCmd = nullptr;
 	IOAddressSegment segments[32];
 	uint32_t segCount = 32;
-	err = SetupDMA(sharedBuf, size, &dmaCmd, segments, &segCount);
+	uint64_t dmaFlags = 0;
+	err = SetupDMA(sharedBuf, 0, size, &dmaCmd, segments, &segCount, &dmaFlags);
 	if (err) { sharedBuf->release(); return err; }
 
 	err = WriteDMASegments(sharedBuf, segments, segCount, IOVMPageSize, IOVMPageSize);
@@ -152,7 +156,7 @@ kern_return_t TinyGPUDriver::CreateDMA(size_t size, TinyGPUCreateDMAResp* dmaDes
 
 	dmaDesc->sharedBuf = sharedBuf;
 	dmaDesc->dmaCmd = dmaCmd;
-	os_log(OS_LOG_DEFAULT, "tinygpu: CreateDMA size=0x%zx segs=%u", size, segCount);
+	os_log(OS_LOG_DEFAULT, "tinygpu: CreateDMA size=0x%zx segs=%u flags=0x%llx", size, segCount, dmaFlags);
 	return 0;
 }
 

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.iig
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.iig
@@ -9,7 +9,7 @@
 
 struct TinyGPUCreateDMAResp
 {
-	IOBufferMemoryDescriptor* sharedBuf;
+	IOMemoryDescriptor* sharedBuf; // dext-owned buffer (CreateDMA) or the RW wrapper descriptor (PrepareDMA), released in Stop
 	IODMACommand* dmaCmd;
 };
 
@@ -28,8 +28,8 @@ public:
 
 	kern_return_t MapBar(uint32_t bar, IOMemoryDescriptor** memory) LOCALONLY;
 	kern_return_t CreateDMA(size_t size, TinyGPUCreateDMAResp* dmaDesc) LOCALONLY;
-	kern_return_t SetupDMA(IOMemoryDescriptor* memory, uint64_t size, IODMACommand** outCmd,
-	                       IOAddressSegment* segments, uint32_t* segCount) LOCALONLY;
+	kern_return_t SetupDMA(IOMemoryDescriptor* memory, uint64_t offset, uint64_t size, IODMACommand** outCmd,
+	                       IOAddressSegment* segments, uint32_t* segCount, uint64_t* outFlags) LOCALONLY;
 
 	kern_return_t CfgRead(uint32_t off, uint32_t size, uint32_t* val) LOCALONLY;
 	kern_return_t CfgWrite(uint32_t off, uint32_t size, uint32_t val) LOCALONLY;

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriverUserClient.cpp
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriverUserClient.cpp
@@ -86,6 +86,10 @@ kern_return_t TinyGPUDriverUserClient::Stop_Impl(IOService* in_provider)
 				d.dmaCmd->release();
 				d.dmaCmd = nullptr;
 			}
+			if (d.sharedBuf) {
+				d.sharedBuf->release();
+				d.sharedBuf = nullptr;
+			}
 		}
 		ivars->dmaCount = 0;
 		IOSafeDeleteNULL(ivars->dmas, TinyGPUCreateDMAResp, ivars->dmaCap);
@@ -130,34 +134,80 @@ kern_return_t TinyGPUDriverUserClient::ExternalMethod(uint64_t selector, IOUserC
 		os_log(OS_LOG_DEFAULT, "tinygpu: reset");
 		return ivars->provider->ResetDevice();
 	} else if (selector == TinyGPURPC::PrepareDMA) {
-		// both input and output buffers must be >= 4097 bytes for IOMemoryDescriptor
-		if (!args->structureInputDescriptor || !args->structureOutputDescriptor) {
-			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA requires buffers >= 4097 bytes");
+		// The DMA buffer is the caller's (out-of-line, >= 4097 bytes) OUTPUT struct; the inband INPUT struct carries flags.
+		//
+		// Why the output side: the kernel wraps an ool input struct in a kIODirectionOut (read-only-for-DMA) descriptor and an ool output
+		// struct in a kIODirectionIn one. IOMMUs that honour the access bits (Intel AppleVTD) silently drop every device write into a
+		// buffer prepared from an input descriptor, which is how GSP-RM ended up unable to post its RPC queue on an Intel Mac Pro.
+		// Wrapping the output descriptor in a multi-descriptor makes IODMACommand map it read+write (IOMemoryDescriptor::dmaMap), which
+		// is the only route DriverKit gives a dext to make app-owned memory device-writable.
+		if (!args->structureOutputDescriptor) {
+			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA requires an ool output buffer >= 4097 bytes");
 			return kIOReturnBadArgument;
 		}
-		if (ivars->ensureDMACap(ivars->dmaCount + 1)) return kIOReturnNoMemory;
+		uint64_t reqFlags = 0;
+		if (args->structureInput && args->structureInput->getLength() >= sizeof(uint64_t))
+			reqFlags = *(const uint64_t*)args->structureInput->getBytesNoCopy();
+		if (reqFlags & 1) os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA contiguous requested; not possible for app-owned memory, ignoring");
 
 		uint64_t size = 0;
-		args->structureInputDescriptor->GetLength(&size);
+		args->structureOutputDescriptor->GetLength(&size);
 
-		IODMACommand* dmaCmd = nullptr;
-		IOAddressSegment segments[32];
-		uint32_t segCount = 32;
-		err = ivars->provider->SetupDMA(args->structureInputDescriptor, size, &dmaCmd, segments, &segCount);
-		if (err) return err;
+		IOMemoryDescriptor* dmaMem = nullptr;
+		IOMemoryDescriptor* sources[1] = { args->structureOutputDescriptor };
+		err = IOMemoryDescriptor::CreateWithMemoryDescriptors(kIOMemoryDirectionInOut, 1, sources, &dmaMem);
+		if (err || !dmaMem) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA wrapper failed err=%d", err); return err ?: kIOReturnError; }
 
-		// write physical addresses to output: [addr0, len0, addr1, len1, ..., 0, 0]
+		// The [addr, len, ..., 0, 0] table goes to the head of the buffer itself (the app reads it from the shared mapping).
 		IOMemoryMap* outMap = nullptr;
 		err = args->structureOutputDescriptor->CreateMapping(0, 0, 0, 0, 0, &outMap);
-		if (err || !outMap) { os_log(OS_LOG_DEFAULT, "tinygpu: output map failed err=%d", err); dmaCmd->release(); return err; }
-
+		if (err || !outMap) { os_log(OS_LOG_DEFAULT, "tinygpu: output map failed err=%d", err); dmaMem->release(); return err ?: kIOReturnError; }
 		uint64_t* out = (uint64_t*)outMap->GetAddress();
-		for (uint32_t i = 0; i < segCount; i++) { out[i * 2] = segments[i].address; out[i * 2 + 1] = segments[i].length; }
-		out[segCount * 2] = 0; out[segCount * 2 + 1] = 0;
-		outMap->release();
+		const uint64_t maxEntries = size / 16 - 1; // leave room for the terminator
 
-		os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA size=%llu segs=%u", size, segCount);
-		ivars->dmas[ivars->dmaCount++] = {nullptr, dmaCmd};
+		// DriverKit's PrepareForDMA returns at most 32 segments per call, so map the buffer in windows (one IODMACommand each) and
+		// fail instead of truncating. With an IOMMU the whole buffer is normally one segment; without one it is 4 KB pages.
+		uint64_t done = 0, total = 0, dmaFlags = 0;
+		const size_t firstCmd = ivars->dmaCount;
+		size_t windows = 0;
+		while (done < size) {
+			if (ivars->ensureDMACap(ivars->dmaCount + 1)) { err = kIOReturnNoMemory; break; }
+			IODMACommand* dmaCmd = nullptr;
+			IOAddressSegment segments[32];
+			uint32_t segCount = 32;
+			err = ivars->provider->SetupDMA(dmaMem, done, size - done, &dmaCmd, segments, &segCount, &dmaFlags);
+			if (err) break;
+			ivars->dmas[ivars->dmaCount++] = {nullptr, dmaCmd};
+			windows++;
+			if (segCount == 0) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareForDMA returned no segments at off=%llu", done); err = kIOReturnNoSpace; break; }
+			for (uint32_t i = 0; i < segCount; i++) {
+				if (total >= maxEntries) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA segment table does not fit in the buffer"); err = kIOReturnNoSpace; break; }
+				out[total * 2] = segments[i].address; out[total * 2 + 1] = segments[i].length;
+				total++; done += segments[i].length;
+			}
+			if (err) break;
+		}
+		if (!err && (dmaFlags & kIOMemoryDirectionInOut) != kIOMemoryDirectionInOut) {
+			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA mapping is not read+write (flags=0x%llx), refusing", dmaFlags);
+			err = kIOReturnNotWritable;
+		}
+		if (err) {
+			for (size_t i = firstCmd; i < ivars->dmaCount; i++) {
+				ivars->dmas[i].dmaCmd->CompleteDMA(kIODMACommandCompleteDMANoOptions);
+				ivars->dmas[i].dmaCmd->release();
+				ivars->dmas[i] = {nullptr, nullptr};
+			}
+			ivars->dmaCount = firstCmd;
+			outMap->release();
+			dmaMem->release();
+			return err;
+		}
+		out[total * 2] = 0; out[total * 2 + 1] = 0;
+		outMap->release();
+		// keep the wrapper alive as long as the DMA commands that reference it
+		ivars->dmas[firstCmd].sharedBuf = dmaMem;
+
+		os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA size=%llu segs=%llu windows=%zu flags=0x%llx", size, total, windows, dmaFlags);
 		return kIOReturnSuccess;
 	}
 

--- a/tinygrad/runtime/support/system.py
+++ b/tinygrad/runtime/support/system.py
@@ -375,6 +375,7 @@ class RemotePCIDevice(PCIDevice):
     sock.sendall(struct.pack('<BIIQQQ', cmd, dev_id, bar, *(*args, 0, 0, 0)[:3]) + payload)
     if has_fd:
       msg, anc, _, _ = sock.recvmsg(17, socket.CMSG_LEN(4))
+      if not anc: raise RuntimeError(f"TinyGPU server refused {RemoteCmd(cmd).name} (no fd returned), check the tinygpu log")
       fd = struct.unpack('<i', anc[0][2][:4])[0]
     else: msg, fd = RemotePCIDevice._recvall(sock, 17), None
     if (resp:=struct.unpack('<BQQ', msg))[0] != 0:
@@ -442,4 +443,7 @@ class APLRemotePCIDevice(RemotePCIDevice):
 
     # paddrs are returned as (paddr, size) pairs until a (paddr=0, size=0) terminator in the beginning of the mapping.
     paddrs_raw = list(itertools.takewhile(lambda p: p[1] != 0, zip(memview.view(fmt='Q')[0::2], memview.view(fmt='Q')[1::2])))
-    return memview, [p + i for p, sz in paddrs_raw for i in range(0, sz, 0x1000)][:ceildiv(size, 0x1000)]
+    assert sum(sz for _, sz in paddrs_raw) >= size, f"TinyGPU dext returned a truncated scatter list for a {size:#x} byte sysmem alloc"
+    # the server allocates at least 16KB but only ceil(size/4K) pages are mapped on the GPU. return a view of the mapped size only:
+    # NVCommandQueue.bind derives command lengths from the view, and a larger view makes the GPU fetch past the mapping (4KB page hosts)
+    return memview.view(0, round_up(size, 0x1000)), [p + i for p, sz in paddrs_raw for i in range(0, sz, 0x1000)][:ceildiv(size, 0x1000)]


### PR DESCRIPTION
# tinygpu: make sysmem DMA mappings writable for the GPU on Intel Macs

Fixes #17763 (NV backend on an Intel Mac Pro 2019 with an RTX 3060 in an internal PCIe slot). The same first write failure is in #16097.

## Root cause

`Shared/server.c` passed the shared memory buffer as the input struct of `IOConnectCallStructMethod`. The kernel wraps an out of line input struct in a `kIODirectionOut` descriptor, `IODMACommand::PrepareForDMA` wires that with read only DMA access, and AppleVTD writes read only IOMMU page table entries. The GPU can read host memory (the booter succeeds) but every GPU write into host memory is dropped, so GSP-RM cannot post its libos logs or the RPC status queue header and parks itself (`MAILBOX0 = 0x80000000`, which OpenRM defines as `LIBOS_INTERRUPT_PROCESSOR_SUSPENDED`). The `flags` value returned by `PrepareForDMA` says so directly (only `kIOMemoryDirectionOut`) but was discarded. Apple Silicon DART does not enforce the bit, so nothing was visible there.

## Changes

* dext: the buffer is now the output struct (`kIODirectionIn`), wrapped in an InOut multi descriptor so `IODMACommand` maps it read plus write. Map in windows of at most 32 segments (the DriverKit `PrepareForDMA` limit) instead of silently truncating, refuse a mapping whose returned flags are not read plus write, log the flags. The `[paddr, len]` table is written to the head of the buffer, so the 8 KB copy in the app is gone. `SetupDMA` takes an offset and returns the flags.
* `server.c`: shm passed as output struct, flags as a small input struct, `MAX_SYSMEM` 128 to 8192 (sysmem allocations are never freed for the life of the server, `test_graph` exhausted 128).
* `system.py`: `alloc_sysmem` returned a CPU view of the server's whole allocation (16 KB minimum) while only `ceil(size / 4K)` pages are mapped on the GPU. `NVCommandQueue.bind` takes the command length from the view, so on 4 KB page hosts the GPU fetched past the mapping (MMU fault on the first JIT graph). Return a view of the mapped size. Clear error when the server refuses an allocation instead of an `IndexError`.

## Tested

Mac Pro 2019, macOS 15.6.1, VT-d on, RTX 3060 (GA106) in Slot 3, dev build via `install_nosip.sh`. Dext log shows `PrepareDMA ... windows=1 flags=0x3` for every buffer.

* `test/test_tiny.py`, `test/backend/test_jit.py`, `test_graph.py`, `test_llama_kernels.py` pass.
* `test/backend/test_ops.py`: 415 passed, 3 failed, all three from the torch 2.2.2 reference (last torch with Intel Mac wheels): `cummax` and `cummin` expect an `IndexError` old torch does not raise, `scaled_dot_product_attention_gqa` uses `enable_gqa`.
* `python -m tinygrad.llm` runs Llama 3.2 1B (18.9 tok/s) and 3B, including the warm path (PCI reset through the dext).

## Not tested

* Apple Silicon. The change should be a no op there (DART already allowed device writes with the old path) but I do not have the equipment to test it.
* Hosts without an IOMMU (`dart=0`), where the multi window path is exercised. With an IOMMU every buffer is one segment.
