### PR TITLE
hcq: recover synchronously rejected program submissions

### DIFF
--- a/test/device/test_hcq.py
+++ b/test/device/test_hcq.py
@@ -1,9 +1,11 @@
 import unittest, ctypes, struct, os, random, numpy as np, time
+from unittest.mock import patch
 from tinygrad import Device, Tensor, dtypes
 from tinygrad.helpers import mv_address, DEBUG, DEV
 from test.helpers import slow, replace_opts
 from tinygrad.device import Buffer, BufferSpec
-from tinygrad.runtime.support.hcq import HCQCompiled, HCQBuffer
+import tinygrad.runtime.support.hcq as hcq
+from tinygrad.runtime.support.hcq import HCQCompiled, HCQBuffer, HCQProgram, HCQSubmissionRejected
 from tinygrad.runtime.autogen import libc
 from tinygrad.runtime.support.system import PCIIfaceBase
 from tinygrad.engine.realize import get_runtime
@@ -12,6 +14,119 @@ from tinygrad.codegen.opt import Opt, OptOps
 from tinygrad import Variable
 
 MOCKGPU = DEV.interface.startswith("MOCK")
+
+class TestHCQSubmissionRejection(unittest.TestCase):
+  class Signal:
+    timestamp = 0
+
+  class Queue:
+    def __init__(self, dev, error:BaseException|None, reserve_later:bool=False):
+      self.dev, self.error, self.reserve_later = dev, error, reserve_later
+      self.signal_values:list[int] = []
+      self.records_at_submit,self.submitted = -1,False
+
+    def wait(self, *args): return self
+    def memory_barrier(self): return self
+    def timestamp(self, *args): return self
+    def exec(self, *args): return self
+    def signal(self, signal, value):
+      self.signal_values.append(value)
+      return self
+    def submit(self, dev, var_vals=None):
+      self.records_at_submit = len(dev.sig_prof_records)
+      if self.reserve_later: dev.next_timeline()
+      if self.error is not None: raise self.error
+      self.submitted = True
+
+  class Device:
+    device = "FAKE"
+    next_timeline = HCQCompiled.next_timeline
+    submit_program_timeline = HCQCompiled.submit_program_timeline
+
+    def __init__(self, error:BaseException|None, reserve_later:bool=False):
+      self.timeline_signal, self.timeline_value = TestHCQSubmissionRejection.Signal(), 7
+      self.sig_prof_records,self.pending_wait_signals,self.created_signals,self.prof_exec_counter = [],[],[],0
+      self.error,self.error_state,self.reserve_later,self.last_queue = error,None,reserve_later,None
+
+    def new_signal(self):
+      self.created_signals.append(signal:=TestHCQSubmissionRejection.Signal())
+      return signal
+    def hw_compute_queue_t(self):
+      self.last_queue = TestHCQSubmissionRejection.Queue(self, self.error, self.reserve_later)
+      return self.last_queue
+    def synchronize(self, timeout=None):
+      if self.error_state is not None: raise self.error_state
+
+  class Program:
+    name, profile_key = "rejected", b"rejected"
+    def __init__(self, dev): self.dev,self.fill_count = dev,0
+    def fill_kernargs(self, bufs, vals):
+      self.fill_count += 1
+      return object()
+
+  def test_definite_rejection_rolls_back_timeline_and_profile(self):
+    dev = self.Device(HCQSubmissionRejected("definite rejection"))
+    sentinel = (object(), object(), "prior", "FAKE", None)
+    dev.sig_prof_records.append(sentinel)
+    with patch.object(hcq, "PROFILE", True), self.assertRaisesRegex(HCQSubmissionRejected, "definite rejection"):
+      HCQProgram.__call__(self.Program(dev))
+    self.assertEqual((dev.timeline_value, dev.prof_exec_counter, dev.sig_prof_records), (7, 1, [sentinel]))
+    self.assertEqual((dev.last_queue.signal_values, dev.last_queue.records_at_submit), ([7], 2))
+
+  def test_other_failures_do_not_rollback_unrelated_reservations(self):
+    ambiguous = self.Device(RuntimeError("ambiguous failure"))
+    program = self.Program(ambiguous)
+    with patch.object(hcq, "PROFILE", True), self.assertRaisesRegex(RuntimeError, "ambiguous failure"):
+      HCQProgram.__call__(program)
+    self.assertEqual((ambiguous.timeline_value, len(ambiguous.sig_prof_records), ambiguous.last_queue.records_at_submit,
+                      ambiguous.error_state), (8, 1, 1, ambiguous.error))
+    blocked = self.Queue(ambiguous, None)
+    with self.assertRaisesRegex(RuntimeError, "ambiguous failure"): ambiguous.submit_program_timeline(blocked)
+    self.assertEqual((ambiguous.timeline_value, blocked.signal_values), (8, []))
+    with self.assertRaisesRegex(RuntimeError, "ambiguous failure"): HCQProgram.__call__(program)
+    self.assertEqual(program.fill_count, 1)
+
+    non_lifo = self.Device(HCQSubmissionRejected("non-LIFO rejection"), reserve_later=True)
+    queue = self.Queue(non_lifo, non_lifo.error, reserve_later=True)
+    with self.assertRaisesRegex(HCQSubmissionRejected, "non-LIFO rejection"): non_lifo.submit_program_timeline(queue)
+    self.assertEqual((non_lifo.timeline_value, queue.signal_values), (9, [7]))
+    self.assertRegex(str(non_lifo.error_state), "non-latest timeline reservation")
+
+  def test_interrupted_submission_poison_blocks_future_work(self):
+    dev = self.Device(None)
+    queue = self.Queue(dev, KeyboardInterrupt())
+    with self.assertRaises(KeyboardInterrupt): dev.submit_program_timeline(queue)
+    self.assertEqual((dev.timeline_value, queue.signal_values, queue.submitted), (8, [7], False))
+    self.assertRegex(str(dev.error_state), "interrupted with unknown acceptance state: KeyboardInterrupt")
+
+    blocked = self.Queue(dev, None)
+    with self.assertRaisesRegex(RuntimeError, "interrupted with unknown acceptance state"): dev.submit_program_timeline(blocked)
+    self.assertEqual((dev.timeline_value, blocked.signal_values, blocked.submitted), (8, [], False))
+
+    interrupted_reservation = self.Device(None)
+    def interrupt_next_timeline():
+      interrupted_reservation.timeline_value += 1
+      raise KeyboardInterrupt
+    interrupted_reservation.next_timeline = interrupt_next_timeline
+    unmodified = self.Queue(interrupted_reservation, None)
+    with self.assertRaises(KeyboardInterrupt): interrupted_reservation.submit_program_timeline(unmodified)
+    self.assertEqual((interrupted_reservation.timeline_value, unmodified.signal_values, unmodified.submitted), (8, [], False))
+    self.assertRegex(str(interrupted_reservation.error_state), "interrupted with unknown acceptance state: KeyboardInterrupt")
+
+  def test_program_retains_unprofiled_wait_signals_after_unknown_completion(self):
+    for failure in (RuntimeError("submission acceptance unknown"), None):
+      with self.subTest(failure=failure):
+        dev = self.Device(failure)
+        if failure is None:
+          timeout_error = RuntimeError("wait timeout")
+          def fail_synchronize(timeout=None):
+            dev.error_state = timeout_error
+            raise timeout_error
+          dev.synchronize = fail_synchronize
+        message = "submission acceptance unknown" if failure is not None else "wait timeout"
+        with patch.object(hcq, "PROFILE", False), self.assertRaisesRegex(RuntimeError, message):
+          HCQProgram.__call__(self.Program(dev), wait=True)
+        self.assertEqual(dev.pending_wait_signals, dev.created_signals)
 
 @unittest.skipUnless(issubclass(type(Device[Device.DEFAULT]), HCQCompiled), "HCQ device required to run")
 class TestHCQ(unittest.TestCase):

--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -55,6 +55,9 @@ class FileIOInterface:
   @staticmethod
   def eventfd(initval, flags=None): return FileIOInterface(fd=os.eventfd(initval, flags))  # type: ignore[attr-defined]
 
+class HCQSubmissionRejected(RuntimeError):
+  """The backend guarantees that no command was accepted and none can later retire the reserved timeline."""
+
 if DEV.interface.startswith("MOCK"): from test.mockgpu.mockgpu import MockFileIOInterface as FileIOInterface  # noqa: F401 # pylint: disable=unused-import
 
 # **************** for HCQ Compatible Devices ****************
@@ -234,6 +237,7 @@ class HWQueue(Generic[SignalType, HCQDeviceType, ProgramType, ArgsStateType]):
       dev: The device to submit the queue to
     """
 
+    if dev.error_state is not None: raise dev.error_state
     if var_vals is not None: self._apply_var_vals(var_vals)
     self._submit(dev)
     return self
@@ -300,18 +304,20 @@ def hcq_profile(dev:HCQCompiled, enabled, desc, queue_type:Callable[[], HWQueue]
   st, en = (dev.new_signal(), dev.new_signal()) if enabled else (None, None)
   assert queue is not None or queue_type is not None, "Either queue or queue_type must be provided"
 
+  body_completed = False
   if enabled and queue is not None: queue.timestamp(st)
   elif enabled and queue_type is not None:
     queue_type().wait(dev.timeline_signal, dev.timeline_value - 1).timestamp(st).signal(dev.timeline_signal, dev.next_timeline()).submit(dev)
 
-  try: yield (st, en)
+  try:
+    yield (st, en)
+    body_completed = True
   finally:
-    if enabled and queue is not None: queue.timestamp(en)
+    if enabled and queue is not None and body_completed: queue.timestamp(en)
     elif enabled and queue_type is not None:
       queue_type().wait(dev.timeline_signal, dev.timeline_value - 1).timestamp(en).signal(dev.timeline_signal, dev.next_timeline()).submit(dev)
-
-    if enabled and PROFILE: dev.sig_prof_records.append((unwrap(st), unwrap(en), desc, f"{dev.device}:{dev_suff}" if dev_suff else dev.device,
-                                                         profile_key))
+    if enabled and PROFILE and (queue_type is not None or body_completed):
+      dev.sig_prof_records.append((unwrap(st), unwrap(en), desc, f"{dev.device}:{dev_suff}" if dev_suff else dev.device, profile_key))
 
 class HCQArgsState(Generic[ProgramType]):
   def __init__(self, buf:HCQBuffer, prg:ProgramType, bufs:tuple[HCQBuffer, ...], vals:tuple[sint|None, ...]=()):
@@ -371,14 +377,39 @@ class HCQProgram(Program[HCQDeviceType]):
       Execution time of the kernel if 'wait' is True, otherwise None.
     """
 
+    if self.dev.error_state is not None: raise self.dev.error_state
     kernargs = self.fill_kernargs(bufs, vals)
     q = unwrap(self.dev.hw_compute_queue_t)().wait(self.dev.timeline_signal, self.dev.timeline_value - 1).memory_barrier()
 
     self.dev.prof_exec_counter += 1
-    with hcq_profile(self.dev, queue=q, desc=self.name, enabled=wait or PROFILE, profile_key=self.profile_key) as (sig_st, sig_en):
-      q.exec(self, kernargs, global_size, local_size)
+    sig_st = sig_en = None
+    signals_retained = False
 
-    q.signal(self.dev.timeline_signal, self.dev.next_timeline()).submit(self.dev)
+    def retain_unprofiled_wait_signals():
+      nonlocal signals_retained
+      if wait and not PROFILE and not signals_retained:
+        self.dev.pending_wait_signals.extend((cast(HCQSignal, sig_st), cast(HCQSignal, sig_en)))
+        signals_retained = True
+    def release_unprofiled_wait_signals():
+      nonlocal signals_retained
+      if not signals_retained: return
+      for signal in (sig_st, sig_en):
+        if (index:=next((i for i,pending in enumerate(self.dev.pending_wait_signals) if pending is signal), None)) is not None:
+          self.dev.pending_wait_signals.pop(index)
+      signals_retained = False
+
+    try:
+      with hcq_profile(self.dev, queue=q, desc=self.name, enabled=wait or PROFILE, profile_key=self.profile_key) as (sig_st, sig_en):
+        q.exec(self, kernargs, global_size, local_size)
+      retain_unprofiled_wait_signals()
+      self.dev.submit_program_timeline(q)
+    except HCQSubmissionRejected:
+      release_unprofiled_wait_signals()
+      for index,record in enumerate(self.dev.sig_prof_records):
+        if record[0] is sig_st and record[1] is sig_en:
+          self.dev.sig_prof_records.pop(index)
+          break
+      raise
 
     if wait: self.dev.synchronize(timeout=timeout)
     return (float(sig_en.timestamp - sig_st.timestamp) / 1e6) if wait else None
@@ -405,6 +436,8 @@ class HCQCompiled(Compiled, Generic[SignalType]):
 
     self.timeline_value:int = 1
     self.sig_prof_records:list[tuple[HCQSignal, HCQSignal, str|TracingKey, str, bytes|None]] = []
+    # Keep unprofiled wait timestamps alive until synchronization proves the submission can no longer reference them.
+    self.pending_wait_signals:list[HCQSignal] = []
     self.prof_exec_counter:int = 0
     self.prof_prg_counter = itertools.count(0)
 
@@ -438,6 +471,7 @@ class HCQCompiled(Compiled, Generic[SignalType]):
       if hasattr(self, 'on_device_hang'): self.on_device_hang()
       raise e
 
+    self.pending_wait_signals = []
     if self.timeline_value > (1 << 31): self._wrap_timeline_signal()
     if PROFILE:
       Compiled.profile_events += [ProfileRangeEvent(dev, name, st.timestamp, en.timestamp, pk) for st,en,name,dev,pk in self.sig_prof_records]
@@ -446,6 +480,29 @@ class HCQCompiled(Compiled, Generic[SignalType]):
   def next_timeline(self):
     self.timeline_value += 1
     return self.timeline_value - 1
+
+  def submit_program_timeline(self, queue:HWQueue, var_vals:dict[str, int]|None=None):
+    # Program submissions may be synchronously rejected by a backend before any command can retire. Copy and graph
+    # queues have different reservation lifetimes and intentionally keep their existing submission paths.
+    if self.error_state is not None: raise self.error_state
+    target = None
+    try:
+      target = self.next_timeline()
+      return queue.signal(self.timeline_signal, target).submit(self, var_vals)
+    except HCQSubmissionRejected:
+      if target is None:
+        self.error_state = RuntimeError("timeline reservation failed with unknown state")
+        raise self.error_state
+      if self.timeline_value == target + 1: self.timeline_value = target
+      else: self.error_state = RuntimeError("definite submission rejection could not recover a non-latest timeline reservation")
+      raise
+    except Exception as error:
+      if self.error_state is None: self.error_state = error
+      raise
+    except BaseException as error:
+      if self.error_state is None:
+        self.error_state = RuntimeError(f"timeline submission was interrupted with unknown acceptance state: {type(error).__name__}")
+      raise
 
   def new_signal(self, **kwargs) -> SignalType:
     assert self.signal_t is not None, "Device does not support signals"


### PR DESCRIPTION
A program submission reserves its HCQ timeline value before the queue is submitted. A synchronous backend can reject the queue before accepting any command; today that leaves the reserved value behind, so later work can wait on a timeline value that will never retire.

This adds an explicit `HCQSubmissionRejected` contract for the case where the backend guarantees that nothing was accepted. Direct program submissions roll back only their latest reservation. Ordinary exceptions, interruptions, and non-LIFO rejection remain fail-closed by poisoning the device rather than reusing a timeline whose state is uncertain.

Unprofiled wait-timestamp signals remain alive until successful synchronization when acceptance is unknown, while profile state is removed after a definite rejection. Copy, graph, and profile-finalization queues keep their existing reservation flow.

Why merge this: it makes synchronous pre-acceptance rejection recoverable without weakening HCQ behavior for ambiguous failures. The follow-up QCOM mock uses this contract when virtual KGSL rejects a command before retirement.

Validation on Python 3.11/macOS:

- `python -m pytest -n12 test/device/test_hcq.py::TestHCQSubmissionRejection` — 4 passed, 2 subtests passed.
- configured Ruff and mypy — passed.
- `python -m pre_commit run --all-files` — all configured hooks passed.

AI disclosure: I used OpenAI Codex for implementation, tests, adversarial review, and drafting. Also reviewed all the lines.
