### PR TITLE
tinygpu: map sysmem read+write for the GPU (device writes were dropped on Intel Macs)

### DIFF
--- a/extra/usbgpu/tbgpu/installer/Shared/server.c
+++ b/extra/usbgpu/tbgpu/installer/Shared/server.c
@@ -143,11 +143,12 @@ static int map_sysmem_fd(uint64_t size, int contiguous, response_t *resp, int *o
   if (ftruncate(fd, alloc_sz) < 0) goto fail;
   if ((ptr = mmap(NULL, alloc_sz, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0)) == MAP_FAILED) goto fail;
 
-  // PrepareDMA writes physical addresses to output buffer, copy to shared mem
-  uint8_t paddr_buf[8192] = {0};
-  size_t out_sz = sizeof(paddr_buf);
-  if (IOConnectCallStructMethod(g_conn, 3, ptr, alloc_sz, paddr_buf, &out_sz) != KERN_SUCCESS) goto fail;
-  memcpy(ptr, paddr_buf, out_sz);
+  // PrepareDMA: the buffer is passed as the (out-of-line) OUTPUT struct so the kernel wraps it in a device-writable descriptor
+  // (an input struct is mapped read-only for DMA and Intel's AppleVTD drops device writes into it). The dext writes the
+  // [paddr0, len0, ..., 0, 0] table to the head of the buffer itself. The small input struct carries request flags.
+  uint64_t flags = contiguous ? 1 : 0;
+  size_t out_sz = alloc_sz;
+  if (IOConnectCallStructMethod(g_conn, 3, &flags, sizeof(flags), ptr, &out_sz) != KERN_SUCCESS) goto fail;
 
   g_sysmem[idx] = (typeof(g_sysmem[idx])){.addr = (mach_vm_address_t)ptr, .size = alloc_sz, .shm_fd = fd};
   strncpy(g_sysmem[idx].shm_name, shm_name, sizeof(g_sysmem[idx].shm_name));

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.cpp
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.cpp
@@ -119,7 +119,7 @@ static kern_return_t WriteDMASegments(IOMemoryDescriptor* mem, IOAddressSegment*
 }
 
 kern_return_t TinyGPUDriver::SetupDMA(IOMemoryDescriptor* memory, uint64_t size, IODMACommand** outCmd,
-                                       IOAddressSegment* segments, uint32_t* segCount)
+                                       IOAddressSegment* segments, uint32_t* segCount, uint64_t* outFlags)
 {
 	IODMACommandSpecification dmaSpec = {.options = 0, .maxAddressBits = 40};
 	IODMACommand* dmaCmd = nullptr;
@@ -127,10 +127,13 @@ kern_return_t TinyGPUDriver::SetupDMA(IOMemoryDescriptor* memory, uint64_t size,
 	kern_return_t err = IODMACommand::Create(ivars->pci, kIODMACommandCreateNoOptions, &dmaSpec, &dmaCmd);
 	if (err) { os_log(OS_LOG_DEFAULT, "tinygpu: DMA create failed err=%d", err); return err; }
 
-	uint64_t flags = kIOMemoryDirectionInOut;
+	// flags is an OUTPUT: kIOMemoryDirectionOut = device may read, kIOMemoryDirectionIn = device may write. IOMMUs that honour the
+	// access bits (Intel AppleVTD) drop DMA the descriptor was not prepared for, so callers must check both bits are present.
+	uint64_t flags = 0;
 	err = dmaCmd->PrepareForDMA(kIODMACommandPrepareForDMANoOptions, memory, 0, size, &flags, segCount, segments);
 	if (err) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareForDMA failed err=%d", err); dmaCmd->release(); return err; }
 
+	if (outFlags) *outFlags = flags;
 	*outCmd = dmaCmd;
 	return 0;
 }
@@ -144,7 +147,8 @@ kern_return_t TinyGPUDriver::CreateDMA(size_t size, TinyGPUCreateDMAResp* dmaDes
 	IODMACommand* dmaCmd = nullptr;
 	IOAddressSegment segments[32];
 	uint32_t segCount = 32;
-	err = SetupDMA(sharedBuf, size, &dmaCmd, segments, &segCount);
+	uint64_t dmaFlags = 0;
+	err = SetupDMA(sharedBuf, size, &dmaCmd, segments, &segCount, &dmaFlags);
 	if (err) { sharedBuf->release(); return err; }
 
 	err = WriteDMASegments(sharedBuf, segments, segCount, IOVMPageSize, IOVMPageSize);
@@ -152,7 +156,7 @@ kern_return_t TinyGPUDriver::CreateDMA(size_t size, TinyGPUCreateDMAResp* dmaDes
 
 	dmaDesc->sharedBuf = sharedBuf;
 	dmaDesc->dmaCmd = dmaCmd;
-	os_log(OS_LOG_DEFAULT, "tinygpu: CreateDMA size=0x%zx segs=%u", size, segCount);
+	os_log(OS_LOG_DEFAULT, "tinygpu: CreateDMA size=0x%zx segs=%u flags=0x%llx", size, segCount, dmaFlags);
 	return 0;
 }
 

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.iig
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.iig
@@ -9,7 +9,7 @@
 
 struct TinyGPUCreateDMAResp
 {
-	IOBufferMemoryDescriptor* sharedBuf;
+	IOMemoryDescriptor* sharedBuf; // dext-owned buffer (CreateDMA) or the RW wrapper descriptor (PrepareDMA), released in Stop
 	IODMACommand* dmaCmd;
 };
 
@@ -29,7 +29,7 @@ public:
 	kern_return_t MapBar(uint32_t bar, IOMemoryDescriptor** memory) LOCALONLY;
 	kern_return_t CreateDMA(size_t size, TinyGPUCreateDMAResp* dmaDesc) LOCALONLY;
 	kern_return_t SetupDMA(IOMemoryDescriptor* memory, uint64_t size, IODMACommand** outCmd,
-	                       IOAddressSegment* segments, uint32_t* segCount) LOCALONLY;
+	                       IOAddressSegment* segments, uint32_t* segCount, uint64_t* outFlags) LOCALONLY;
 
 	kern_return_t CfgRead(uint32_t off, uint32_t size, uint32_t* val) LOCALONLY;
 	kern_return_t CfgWrite(uint32_t off, uint32_t size, uint32_t val) LOCALONLY;

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriverUserClient.cpp
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriverUserClient.cpp
@@ -86,6 +86,10 @@ kern_return_t TinyGPUDriverUserClient::Stop_Impl(IOService* in_provider)
 				d.dmaCmd->release();
 				d.dmaCmd = nullptr;
 			}
+			if (d.sharedBuf) {
+				d.sharedBuf->release();
+				d.sharedBuf = nullptr;
+			}
 		}
 		ivars->dmaCount = 0;
 		IOSafeDeleteNULL(ivars->dmas, TinyGPUCreateDMAResp, ivars->dmaCap);
@@ -130,34 +134,53 @@ kern_return_t TinyGPUDriverUserClient::ExternalMethod(uint64_t selector, IOUserC
 		os_log(OS_LOG_DEFAULT, "tinygpu: reset");
 		return ivars->provider->ResetDevice();
 	} else if (selector == TinyGPURPC::PrepareDMA) {
-		// both input and output buffers must be >= 4097 bytes for IOMemoryDescriptor
-		if (!args->structureInputDescriptor || !args->structureOutputDescriptor) {
-			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA requires buffers >= 4097 bytes");
+		// The DMA buffer is the caller's (out-of-line, >= 4097 bytes) OUTPUT struct; the inband INPUT struct carries flags.
+		//
+		// The kernel wraps an ool input struct in a kIODirectionOut descriptor and an ool output struct in a kIODirectionIn one. A
+		// kIODirectionOut descriptor is prepared read-only for DMA, and IOMMUs that honour the access bits (Intel AppleVTD) silently
+		// drop every device write into it, which is how GSP-RM ended up unable to post its RPC queue on an Intel Mac Pro. Wrapping the
+		// output descriptor in an InOut multi-descriptor makes IODMACommand map it read+write (IOMemoryDescriptor::dmaMap).
+		if (!args->structureOutputDescriptor) {
+			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA requires an ool output buffer >= 4097 bytes");
 			return kIOReturnBadArgument;
 		}
 		if (ivars->ensureDMACap(ivars->dmaCount + 1)) return kIOReturnNoMemory;
 
 		uint64_t size = 0;
-		args->structureInputDescriptor->GetLength(&size);
+		args->structureOutputDescriptor->GetLength(&size);
+
+		IOMemoryDescriptor* dmaMem = nullptr;
+		IOMemoryDescriptor* sources[1] = { args->structureOutputDescriptor };
+		err = IOMemoryDescriptor::CreateWithMemoryDescriptors(kIOMemoryDirectionInOut, 1, sources, &dmaMem);
+		if (err || !dmaMem) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA wrapper failed err=%d", err); return err ?: kIOReturnError; }
 
 		IODMACommand* dmaCmd = nullptr;
 		IOAddressSegment segments[32];
 		uint32_t segCount = 32;
-		err = ivars->provider->SetupDMA(args->structureInputDescriptor, size, &dmaCmd, segments, &segCount);
-		if (err) return err;
+		uint64_t dmaFlags = 0;
+		err = ivars->provider->SetupDMA(dmaMem, size, &dmaCmd, segments, &segCount, &dmaFlags);
+		if (err) { dmaMem->release(); return err; }
+		if ((dmaFlags & kIOMemoryDirectionInOut) != kIOMemoryDirectionInOut) {
+			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA mapping is not read+write (flags=0x%llx), refusing", dmaFlags);
+			dmaCmd->CompleteDMA(kIODMACommandCompleteDMANoOptions); dmaCmd->release(); dmaMem->release();
+			return kIOReturnNotWritable;
+		}
 
-		// write physical addresses to output: [addr0, len0, addr1, len1, ..., 0, 0]
+		// The [addr, len, ..., 0, 0] table goes to the head of the buffer itself (the app reads it from the shared mapping).
 		IOMemoryMap* outMap = nullptr;
 		err = args->structureOutputDescriptor->CreateMapping(0, 0, 0, 0, 0, &outMap);
-		if (err || !outMap) { os_log(OS_LOG_DEFAULT, "tinygpu: output map failed err=%d", err); dmaCmd->release(); return err; }
-
+		if (err || !outMap) {
+			os_log(OS_LOG_DEFAULT, "tinygpu: output map failed err=%d", err);
+			dmaCmd->CompleteDMA(kIODMACommandCompleteDMANoOptions); dmaCmd->release(); dmaMem->release();
+			return err ?: kIOReturnError;
+		}
 		uint64_t* out = (uint64_t*)outMap->GetAddress();
 		for (uint32_t i = 0; i < segCount; i++) { out[i * 2] = segments[i].address; out[i * 2 + 1] = segments[i].length; }
 		out[segCount * 2] = 0; out[segCount * 2 + 1] = 0;
 		outMap->release();
 
-		os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA size=%llu segs=%u", size, segCount);
-		ivars->dmas[ivars->dmaCount++] = {nullptr, dmaCmd};
+		os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA size=%llu segs=%u flags=0x%llx", size, segCount, dmaFlags);
+		ivars->dmas[ivars->dmaCount++] = {dmaMem, dmaCmd}; // keep the wrapper alive as long as the DMA command that references it
 		return kIOReturnSuccess;
 	}
 


### PR DESCRIPTION
Part 1 of the split of #17767 (closed to be resubmitted in smaller parts). Fixes #17763, same first device write failure as #16097.

## Problem

`Shared/server.c` passed the shared memory buffer as the input struct of `IOConnectCallStructMethod`. The kernel wraps an out of line input struct in a `kIODirectionOut` descriptor, `PrepareForDMA` prepares that read only for DMA (xnu `IOMemoryDescriptor.cpp`, `wireVirtual`), and AppleVTD writes read only IOMMU page table entries. The GPU can read host memory (the booter succeeds) but every GPU write into host memory is dropped, so GSP-RM cannot post its RPC status queue and parks itself (`MAILBOX0 = 0x80000000`, `LIBOS_INTERRUPT_PROCESSOR_SUSPENDED` in OpenRM). The `flags` returned by `PrepareForDMA` say so (only `kIOMemoryDirectionOut`) but were discarded. Apple Silicon DART does not enforce the bit, so it never showed there.

## Change

* `server.c`: the buffer is passed as the output struct (`kIODirectionIn`), a small input struct carries flags for later use, the 8 KB `paddr_buf` copy is gone because the dext writes the `[paddr, len]...(0,0)` table to the head of the buffer.
* dext: wrap the output descriptor in an InOut multi descriptor (`IOMemoryDescriptor::CreateWithMemoryDescriptors`) so `IODMACommand` maps it read plus write, refuse a mapping whose returned flags are not read plus write, log the flags. `SetupDMA` returns the flags. The wrapper is kept alive with the DMA command and released in `Stop`.

Single `PrepareForDMA` call and the 32 segment array as before. Segment windowing is a separate PR.

## Tested

Mac Pro 2019 (Intel, VT-d on), macOS 15.6.1, RTX 3060 in an internal PCIe slot, dev build via `install_nosip.sh`. Dext log shows `flags=0x3` for every buffer. With this and the `alloc_sysmem` view fix (separate PR): `test/test_tiny.py`, `test/backend/test_jit.py`, `test_graph.py`, `test_llama_kernels.py` pass, `test_ops.py` 415 passed with 3 torch 2.2 reference artifacts, `tinygrad.llm` runs Llama 3.2 1B and 3B including the warm path (PCI reset through the dext).

Not tested on Apple Silicon. It should be a no op there (DART already allowed device writes) but I cannot run it.
