### PR TITLE
tinygpu: return a sysmem view of the mapped size

### DIFF
--- a/tinygrad/runtime/support/system.py
+++ b/tinygrad/runtime/support/system.py
@@ -377,6 +377,7 @@ class RemotePCIDevice(PCIDevice):
     sock.sendall(struct.pack('<BIIQQQ', cmd, dev_id, bar, *(*args, 0, 0, 0)[:3]) + payload)
     if has_fd:
       msg, anc, _, _ = sock.recvmsg(17, socket.CMSG_LEN(4))
+      if not anc: raise RuntimeError(f"TinyGPU server refused {RemoteCmd(cmd).name} (no fd returned), check the tinygpu log")
       fd = struct.unpack('<i', anc[0][2][:4])[0]
     else: msg, fd = RemotePCIDevice._recvall(sock, 17), None
     if (resp:=struct.unpack('<BQQ', msg))[0] != 0:
@@ -444,4 +445,7 @@ class APLRemotePCIDevice(RemotePCIDevice):
 
     # paddrs are returned as (paddr, size) pairs until a (paddr=0, size=0) terminator in the beginning of the mapping.
     paddrs_raw = list(itertools.takewhile(lambda p: p[1] != 0, zip(memview.view(fmt='Q')[0::2], memview.view(fmt='Q')[1::2])))
-    return memview, [p + i for p, sz in paddrs_raw for i in range(0, sz, 0x1000)][:ceildiv(size, 0x1000)]
+    assert sum(sz for _, sz in paddrs_raw) >= size, f"TinyGPU dext returned a truncated scatter list for a {size:#x} byte sysmem alloc"
+    # the server allocates at least 16KB but only ceil(size/4K) pages are mapped on the GPU. return a view of the mapped size only:
+    # NVCommandQueue.bind derives command lengths from the view, and a larger view makes the GPU fetch past the mapping (4KB page hosts)
+    return memview.view(0, round_up(size, 0x1000)), [p + i for p, sz in paddrs_raw for i in range(0, sz, 0x1000)][:ceildiv(size, 0x1000)]


### PR DESCRIPTION
Part 3 of the split of #17767. Two small changes in `system.py`, +2 lines net.

`APLRemotePCIDevice.alloc_sysmem` returned a CPU view of the server's whole allocation (the TinyGPU server allocates at least 16 KB) while only `ceil(size/4K)` pages are mapped on the GPU. `NVCommandQueue.bind` takes the command length from that view, so on a 4 KB page host the GPFIFO entry claimed 16 KB of commands with only 4 KB mapped and the pushbuffer fetch ran off the mapping (`MMU_FAULT_QUEUED` on the first JIT graph). Apple Silicon has 16 KB pages so the rounding matches and it never showed. Return a view of the mapped size and assert the scatter list covers the request.

`_rpc` raised an `IndexError` when the server answered without an fd. Raise a clear `RuntimeError` instead.

Tested on an Intel Mac Pro with an RTX 3060 (with the dext PRs): `tinygrad.llm` with the default JIT graphs, `test_jit.py`, `test_graph.py`, `test_ops.py`.
