### PR TITLE
tinygpu: raise the server sysmem allocation cap

### DIFF
--- a/extra/usbgpu/tbgpu/installer/Shared/server.c
+++ b/extra/usbgpu/tbgpu/installer/Shared/server.c
@@ -39,7 +39,7 @@ typedef struct { uint8_t status; uint64_t resp0, resp1; } __attribute__((packed)
 
 #define BULK_BUF_SIZE (64 << 20)
 #define MAX_BARS 6
-#define MAX_SYSMEM 128
+#define MAX_SYSMEM 8192
 
 static uint8_t g_bulk_buf[BULK_BUF_SIZE];
 static io_connect_t g_conn = IO_OBJECT_NULL;


### PR DESCRIPTION
Part 4 of the split of #17767, one line.

Sysmem allocations are never freed for the life of the TinyGPU server and the table of 128 was exhausted by `test/backend/test_graph.py` (every JIT graph allocates a bound pushbuffer and signals), which then failed in `alloc_sysmem`. Entries are 64 bytes, so 8192 costs about half a megabyte of static memory. A free command in the protocol would be the proper fix, this keeps test suites and long sessions working meanwhile.
