### PR TITLE
tinygpu: map sysmem in windows instead of truncating at 32 segments

### DIFF
--- a/extra/usbgpu/tbgpu/installer/Shared/server.c
+++ b/extra/usbgpu/tbgpu/installer/Shared/server.c
@@ -143,11 +143,12 @@ static int map_sysmem_fd(uint64_t size, int contiguous, response_t *resp, int *o
   if (ftruncate(fd, alloc_sz) < 0) goto fail;
   if ((ptr = mmap(NULL, alloc_sz, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0)) == MAP_FAILED) goto fail;
 
-  // PrepareDMA writes physical addresses to output buffer, copy to shared mem
-  uint8_t paddr_buf[8192] = {0};
-  size_t out_sz = sizeof(paddr_buf);
-  if (IOConnectCallStructMethod(g_conn, 3, ptr, alloc_sz, paddr_buf, &out_sz) != KERN_SUCCESS) goto fail;
-  memcpy(ptr, paddr_buf, out_sz);
+  // PrepareDMA: the buffer is passed as the (out-of-line) OUTPUT struct so the kernel wraps it in a device-writable descriptor
+  // (an input struct is mapped read-only for DMA and Intel's AppleVTD drops device writes into it). The dext writes the
+  // [paddr0, len0, ..., 0, 0] table to the head of the buffer itself. The small input struct carries request flags.
+  uint64_t flags = contiguous ? 1 : 0;
+  size_t out_sz = alloc_sz;
+  if (IOConnectCallStructMethod(g_conn, 3, &flags, sizeof(flags), ptr, &out_sz) != KERN_SUCCESS) goto fail;
 
   g_sysmem[idx] = (typeof(g_sysmem[idx])){.addr = (mach_vm_address_t)ptr, .size = alloc_sz, .shm_fd = fd};
   strncpy(g_sysmem[idx].shm_name, shm_name, sizeof(g_sysmem[idx].shm_name));

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.cpp
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.cpp
@@ -118,7 +118,7 @@ static kern_return_t WriteDMASegments(IOMemoryDescriptor* mem, IOAddressSegment*
 	return 0;
 }
 
-kern_return_t TinyGPUDriver::SetupDMA(IOMemoryDescriptor* memory, uint64_t size, IODMACommand** outCmd,
+kern_return_t TinyGPUDriver::SetupDMA(IOMemoryDescriptor* memory, uint64_t offset, uint64_t size, IODMACommand** outCmd,
                                        IOAddressSegment* segments, uint32_t* segCount, uint64_t* outFlags)
 {
 	IODMACommandSpecification dmaSpec = {.options = 0, .maxAddressBits = 40};
@@ -130,7 +130,7 @@ kern_return_t TinyGPUDriver::SetupDMA(IOMemoryDescriptor* memory, uint64_t size,
 	// flags is an OUTPUT: kIOMemoryDirectionOut = device may read, kIOMemoryDirectionIn = device may write. IOMMUs that honour the
 	// access bits (Intel AppleVTD) drop DMA the descriptor was not prepared for, so callers must check both bits are present.
 	uint64_t flags = 0;
-	err = dmaCmd->PrepareForDMA(kIODMACommandPrepareForDMANoOptions, memory, 0, size, &flags, segCount, segments);
+	err = dmaCmd->PrepareForDMA(kIODMACommandPrepareForDMANoOptions, memory, offset, size, &flags, segCount, segments);
 	if (err) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareForDMA failed err=%d", err); dmaCmd->release(); return err; }
 
 	if (outFlags) *outFlags = flags;
@@ -148,7 +148,7 @@ kern_return_t TinyGPUDriver::CreateDMA(size_t size, TinyGPUCreateDMAResp* dmaDes
 	IOAddressSegment segments[32];
 	uint32_t segCount = 32;
 	uint64_t dmaFlags = 0;
-	err = SetupDMA(sharedBuf, size, &dmaCmd, segments, &segCount, &dmaFlags);
+	err = SetupDMA(sharedBuf, 0, size, &dmaCmd, segments, &segCount, &dmaFlags);
 	if (err) { sharedBuf->release(); return err; }
 
 	err = WriteDMASegments(sharedBuf, segments, segCount, IOVMPageSize, IOVMPageSize);

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.cpp
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.cpp
@@ -119,7 +119,7 @@ static kern_return_t WriteDMASegments(IOMemoryDescriptor* mem, IOAddressSegment*
 }
 
 kern_return_t TinyGPUDriver::SetupDMA(IOMemoryDescriptor* memory, uint64_t size, IODMACommand** outCmd,
-                                       IOAddressSegment* segments, uint32_t* segCount)
+                                       IOAddressSegment* segments, uint32_t* segCount, uint64_t* outFlags)
 {
 	IODMACommandSpecification dmaSpec = {.options = 0, .maxAddressBits = 40};
 	IODMACommand* dmaCmd = nullptr;
@@ -127,10 +127,13 @@ kern_return_t TinyGPUDriver::SetupDMA(IOMemoryDescriptor* memory, uint64_t size,
 	kern_return_t err = IODMACommand::Create(ivars->pci, kIODMACommandCreateNoOptions, &dmaSpec, &dmaCmd);
 	if (err) { os_log(OS_LOG_DEFAULT, "tinygpu: DMA create failed err=%d", err); return err; }
 
-	uint64_t flags = kIOMemoryDirectionInOut;
+	// flags is an OUTPUT: kIOMemoryDirectionOut = device may read, kIOMemoryDirectionIn = device may write. IOMMUs that honour the
+	// access bits (Intel AppleVTD) drop DMA the descriptor was not prepared for, so callers must check both bits are present.
+	uint64_t flags = 0;
 	err = dmaCmd->PrepareForDMA(kIODMACommandPrepareForDMANoOptions, memory, 0, size, &flags, segCount, segments);
 	if (err) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareForDMA failed err=%d", err); dmaCmd->release(); return err; }
 
+	if (outFlags) *outFlags = flags;
 	*outCmd = dmaCmd;
 	return 0;
 }
@@ -144,7 +147,8 @@ kern_return_t TinyGPUDriver::CreateDMA(size_t size, TinyGPUCreateDMAResp* dmaDes
 	IODMACommand* dmaCmd = nullptr;
 	IOAddressSegment segments[32];
 	uint32_t segCount = 32;
-	err = SetupDMA(sharedBuf, size, &dmaCmd, segments, &segCount);
+	uint64_t dmaFlags = 0;
+	err = SetupDMA(sharedBuf, size, &dmaCmd, segments, &segCount, &dmaFlags);
 	if (err) { sharedBuf->release(); return err; }
 
 	err = WriteDMASegments(sharedBuf, segments, segCount, IOVMPageSize, IOVMPageSize);
@@ -152,7 +156,7 @@ kern_return_t TinyGPUDriver::CreateDMA(size_t size, TinyGPUCreateDMAResp* dmaDes
 
 	dmaDesc->sharedBuf = sharedBuf;
 	dmaDesc->dmaCmd = dmaCmd;
-	os_log(OS_LOG_DEFAULT, "tinygpu: CreateDMA size=0x%zx segs=%u", size, segCount);
+	os_log(OS_LOG_DEFAULT, "tinygpu: CreateDMA size=0x%zx segs=%u flags=0x%llx", size, segCount, dmaFlags);
 	return 0;
 }
 

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.iig
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.iig
@@ -9,7 +9,7 @@
 
 struct TinyGPUCreateDMAResp
 {
-	IOBufferMemoryDescriptor* sharedBuf;
+	IOMemoryDescriptor* sharedBuf; // dext-owned buffer (CreateDMA) or the RW wrapper descriptor (PrepareDMA), released in Stop
 	IODMACommand* dmaCmd;
 };
 
@@ -29,7 +29,7 @@ public:
 	kern_return_t MapBar(uint32_t bar, IOMemoryDescriptor** memory) LOCALONLY;
 	kern_return_t CreateDMA(size_t size, TinyGPUCreateDMAResp* dmaDesc) LOCALONLY;
 	kern_return_t SetupDMA(IOMemoryDescriptor* memory, uint64_t size, IODMACommand** outCmd,
-	                       IOAddressSegment* segments, uint32_t* segCount) LOCALONLY;
+	                       IOAddressSegment* segments, uint32_t* segCount, uint64_t* outFlags) LOCALONLY;
 
 	kern_return_t CfgRead(uint32_t off, uint32_t size, uint32_t* val) LOCALONLY;
 	kern_return_t CfgWrite(uint32_t off, uint32_t size, uint32_t val) LOCALONLY;

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.iig
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriver.iig
@@ -28,7 +28,7 @@ public:
 
 	kern_return_t MapBar(uint32_t bar, IOMemoryDescriptor** memory) LOCALONLY;
 	kern_return_t CreateDMA(size_t size, TinyGPUCreateDMAResp* dmaDesc) LOCALONLY;
-	kern_return_t SetupDMA(IOMemoryDescriptor* memory, uint64_t size, IODMACommand** outCmd,
+	kern_return_t SetupDMA(IOMemoryDescriptor* memory, uint64_t offset, uint64_t size, IODMACommand** outCmd,
 	                       IOAddressSegment* segments, uint32_t* segCount, uint64_t* outFlags) LOCALONLY;
 
 	kern_return_t CfgRead(uint32_t off, uint32_t size, uint32_t* val) LOCALONLY;

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriverUserClient.cpp
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriverUserClient.cpp
@@ -144,8 +144,6 @@ kern_return_t TinyGPUDriverUserClient::ExternalMethod(uint64_t selector, IOUserC
 			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA requires an ool output buffer >= 4097 bytes");
 			return kIOReturnBadArgument;
 		}
-		if (ivars->ensureDMACap(ivars->dmaCount + 1)) return kIOReturnNoMemory;
-
 		uint64_t size = 0;
 		args->structureOutputDescriptor->GetLength(&size);
 
@@ -154,33 +152,55 @@ kern_return_t TinyGPUDriverUserClient::ExternalMethod(uint64_t selector, IOUserC
 		err = IOMemoryDescriptor::CreateWithMemoryDescriptors(kIOMemoryDirectionInOut, 1, sources, &dmaMem);
 		if (err || !dmaMem) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA wrapper failed err=%d", err); return err ?: kIOReturnError; }
 
-		IODMACommand* dmaCmd = nullptr;
-		IOAddressSegment segments[32];
-		uint32_t segCount = 32;
-		uint64_t dmaFlags = 0;
-		err = ivars->provider->SetupDMA(dmaMem, size, &dmaCmd, segments, &segCount, &dmaFlags);
-		if (err) { dmaMem->release(); return err; }
-		if ((dmaFlags & kIOMemoryDirectionInOut) != kIOMemoryDirectionInOut) {
-			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA mapping is not read+write (flags=0x%llx), refusing", dmaFlags);
-			dmaCmd->CompleteDMA(kIODMACommandCompleteDMANoOptions); dmaCmd->release(); dmaMem->release();
-			return kIOReturnNotWritable;
-		}
-
 		// The [addr, len, ..., 0, 0] table goes to the head of the buffer itself (the app reads it from the shared mapping).
 		IOMemoryMap* outMap = nullptr;
 		err = args->structureOutputDescriptor->CreateMapping(0, 0, 0, 0, 0, &outMap);
-		if (err || !outMap) {
-			os_log(OS_LOG_DEFAULT, "tinygpu: output map failed err=%d", err);
-			dmaCmd->CompleteDMA(kIODMACommandCompleteDMANoOptions); dmaCmd->release(); dmaMem->release();
-			return err ?: kIOReturnError;
-		}
+		if (err || !outMap) { os_log(OS_LOG_DEFAULT, "tinygpu: output map failed err=%d", err); dmaMem->release(); return err ?: kIOReturnError; }
 		uint64_t* out = (uint64_t*)outMap->GetAddress();
-		for (uint32_t i = 0; i < segCount; i++) { out[i * 2] = segments[i].address; out[i * 2 + 1] = segments[i].length; }
-		out[segCount * 2] = 0; out[segCount * 2 + 1] = 0;
-		outMap->release();
+		const uint64_t maxEntries = size / 16 - 1; // leave room for the terminator
 
-		os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA size=%llu segs=%u flags=0x%llx", size, segCount, dmaFlags);
-		ivars->dmas[ivars->dmaCount++] = {dmaMem, dmaCmd}; // keep the wrapper alive as long as the DMA command that references it
+		// DriverKit's PrepareForDMA returns at most 32 segments per call. With an IOMMU the whole buffer is one segment, without one it
+		// is 4KB pages, so map the buffer in windows (one IODMACommand each) and fail instead of silently truncating the list.
+		uint64_t done = 0, total = 0, dmaFlags = 0;
+		const size_t firstCmd = ivars->dmaCount;
+		size_t windows = 0;
+		while (done < size) {
+			if (ivars->ensureDMACap(ivars->dmaCount + 1)) { err = kIOReturnNoMemory; break; }
+			IODMACommand* dmaCmd = nullptr;
+			IOAddressSegment segments[32];
+			uint32_t segCount = 32;
+			err = ivars->provider->SetupDMA(dmaMem, done, size - done, &dmaCmd, segments, &segCount, &dmaFlags);
+			if (err) break;
+			ivars->dmas[ivars->dmaCount++] = {nullptr, dmaCmd};
+			windows++;
+			if (segCount == 0) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareForDMA returned no segments at off=%llu", done); err = kIOReturnNoSpace; break; }
+			for (uint32_t i = 0; i < segCount; i++) {
+				if (total >= maxEntries) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA segment table does not fit in the buffer"); err = kIOReturnNoSpace; break; }
+				out[total * 2] = segments[i].address; out[total * 2 + 1] = segments[i].length;
+				total++; done += segments[i].length;
+			}
+			if (err) break;
+		}
+		if (!err && (dmaFlags & kIOMemoryDirectionInOut) != kIOMemoryDirectionInOut) {
+			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA mapping is not read+write (flags=0x%llx), refusing", dmaFlags);
+			err = kIOReturnNotWritable;
+		}
+		if (err) {
+			for (size_t i = firstCmd; i < ivars->dmaCount; i++) {
+				ivars->dmas[i].dmaCmd->CompleteDMA(kIODMACommandCompleteDMANoOptions);
+				ivars->dmas[i].dmaCmd->release();
+				ivars->dmas[i] = {nullptr, nullptr};
+			}
+			ivars->dmaCount = firstCmd;
+			outMap->release();
+			dmaMem->release();
+			return err;
+		}
+		out[total * 2] = 0; out[total * 2 + 1] = 0;
+		outMap->release();
+		ivars->dmas[firstCmd].sharedBuf = dmaMem; // keep the wrapper alive as long as the DMA commands that reference it
+
+		os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA size=%llu segs=%llu windows=%zu flags=0x%llx", size, total, windows, dmaFlags);
 		return kIOReturnSuccess;
 	}
 

--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriverUserClient.cpp
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriverUserClient.cpp
@@ -86,6 +86,10 @@ kern_return_t TinyGPUDriverUserClient::Stop_Impl(IOService* in_provider)
 				d.dmaCmd->release();
 				d.dmaCmd = nullptr;
 			}
+			if (d.sharedBuf) {
+				d.sharedBuf->release();
+				d.sharedBuf = nullptr;
+			}
 		}
 		ivars->dmaCount = 0;
 		IOSafeDeleteNULL(ivars->dmas, TinyGPUCreateDMAResp, ivars->dmaCap);
@@ -130,34 +134,53 @@ kern_return_t TinyGPUDriverUserClient::ExternalMethod(uint64_t selector, IOUserC
 		os_log(OS_LOG_DEFAULT, "tinygpu: reset");
 		return ivars->provider->ResetDevice();
 	} else if (selector == TinyGPURPC::PrepareDMA) {
-		// both input and output buffers must be >= 4097 bytes for IOMemoryDescriptor
-		if (!args->structureInputDescriptor || !args->structureOutputDescriptor) {
-			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA requires buffers >= 4097 bytes");
+		// The DMA buffer is the caller's (out-of-line, >= 4097 bytes) OUTPUT struct; the inband INPUT struct carries flags.
+		//
+		// The kernel wraps an ool input struct in a kIODirectionOut descriptor and an ool output struct in a kIODirectionIn one. A
+		// kIODirectionOut descriptor is prepared read-only for DMA, and IOMMUs that honour the access bits (Intel AppleVTD) silently
+		// drop every device write into it, which is how GSP-RM ended up unable to post its RPC queue on an Intel Mac Pro. Wrapping the
+		// output descriptor in an InOut multi-descriptor makes IODMACommand map it read+write (IOMemoryDescriptor::dmaMap).
+		if (!args->structureOutputDescriptor) {
+			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA requires an ool output buffer >= 4097 bytes");
 			return kIOReturnBadArgument;
 		}
 		if (ivars->ensureDMACap(ivars->dmaCount + 1)) return kIOReturnNoMemory;
 
 		uint64_t size = 0;
-		args->structureInputDescriptor->GetLength(&size);
+		args->structureOutputDescriptor->GetLength(&size);
+
+		IOMemoryDescriptor* dmaMem = nullptr;
+		IOMemoryDescriptor* sources[1] = { args->structureOutputDescriptor };
+		err = IOMemoryDescriptor::CreateWithMemoryDescriptors(kIOMemoryDirectionInOut, 1, sources, &dmaMem);
+		if (err || !dmaMem) { os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA wrapper failed err=%d", err); return err ?: kIOReturnError; }
 
 		IODMACommand* dmaCmd = nullptr;
 		IOAddressSegment segments[32];
 		uint32_t segCount = 32;
-		err = ivars->provider->SetupDMA(args->structureInputDescriptor, size, &dmaCmd, segments, &segCount);
-		if (err) return err;
+		uint64_t dmaFlags = 0;
+		err = ivars->provider->SetupDMA(dmaMem, size, &dmaCmd, segments, &segCount, &dmaFlags);
+		if (err) { dmaMem->release(); return err; }
+		if ((dmaFlags & kIOMemoryDirectionInOut) != kIOMemoryDirectionInOut) {
+			os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA mapping is not read+write (flags=0x%llx), refusing", dmaFlags);
+			dmaCmd->CompleteDMA(kIODMACommandCompleteDMANoOptions); dmaCmd->release(); dmaMem->release();
+			return kIOReturnNotWritable;
+		}
 
-		// write physical addresses to output: [addr0, len0, addr1, len1, ..., 0, 0]
+		// The [addr, len, ..., 0, 0] table goes to the head of the buffer itself (the app reads it from the shared mapping).
 		IOMemoryMap* outMap = nullptr;
 		err = args->structureOutputDescriptor->CreateMapping(0, 0, 0, 0, 0, &outMap);
-		if (err || !outMap) { os_log(OS_LOG_DEFAULT, "tinygpu: output map failed err=%d", err); dmaCmd->release(); return err; }
-
+		if (err || !outMap) {
+			os_log(OS_LOG_DEFAULT, "tinygpu: output map failed err=%d", err);
+			dmaCmd->CompleteDMA(kIODMACommandCompleteDMANoOptions); dmaCmd->release(); dmaMem->release();
+			return err ?: kIOReturnError;
+		}
 		uint64_t* out = (uint64_t*)outMap->GetAddress();
 		for (uint32_t i = 0; i < segCount; i++) { out[i * 2] = segments[i].address; out[i * 2 + 1] = segments[i].length; }
 		out[segCount * 2] = 0; out[segCount * 2 + 1] = 0;
 		outMap->release();
 
-		os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA size=%llu segs=%u", size, segCount);
-		ivars->dmas[ivars->dmaCount++] = {nullptr, dmaCmd};
+		os_log(OS_LOG_DEFAULT, "tinygpu: PrepareDMA size=%llu segs=%u flags=0x%llx", size, segCount, dmaFlags);
+		ivars->dmas[ivars->dmaCount++] = {dmaMem, dmaCmd}; // keep the wrapper alive as long as the DMA command that references it
 		return kIOReturnSuccess;
 	}
 


### PR DESCRIPTION
Part 2 of the split of #17767, stacked on #17776 (the first commit here is that PR, only the second commit is new). Draft until #17776 lands.

DriverKit's `PrepareForDMA` returns at most 32 segments per call (`IOAddressSegment segments[32]` in the ABI). With an IOMMU every buffer is a single segment so this never mattered, but without DMA remapping (`dart=0` on an Intel Mac) the dext silently truncated the address table at 32 pages and tinygrad mapped a partial buffer, which failed later in `init_gsp_image`.

Map the buffer in windows of up to 32 segments, one `IODMACommand` per window, write the full table to the head of the buffer, and fail with `kIOReturnNoSpace` if the table does not fit. `SetupDMA` takes the window offset.

Tested with an IOMMU (every buffer one segment, `windows=1`), which is the normal configuration. The multi window path compiles and follows the same code but I have not run it, `dart=0` needs SIP off.
