### PR TITLE
[WIP] adding commutativity support for buffers and args on backends

### DIFF
--- a/test/backend/test_commutative_params.py
+++ b/test/backend/test_commutative_params.py
@@ -10,126 +10,126 @@ from tinygrad.device import Buffer
 from tinygrad.engine.realize import get_runtime
 
 class TestCommutativeParams(unittest.TestCase):
-    def _test_template(self,
-                       out_slot: int,
-                       in_slot: int,
-                       variable_slots: tuple[int, ...],
-                       values: tuple[int, ...]):
-        # let's first build a micro operation
-        output_uop = UOp.param(out_slot, dtypes.float32, shape=(4,))
-        input_uop = UOp.param(in_slot, dtypes.float32, shape=(4,))
+  def _test_template(self,
+           out_slot: int,
+           in_slot: int,
+           variable_slots: tuple[int, ...],
+           values: tuple[int, ...]):
+    # let's first build a micro operation
+    output_uop = UOp.param(out_slot, dtypes.float32, shape=(4,))
+    input_uop = UOp.param(in_slot, dtypes.float32, shape=(4,))
 
-        variables = []
+    variables = []
 
-        for index, slot in enumerate(variable_slots):
-            variable = UOp.variable(f"var_{index}", min_val = 0, max_val = 42,
-                                    dtype=dtypes.int32, param = True)
-            # my idea here to create a variable to break the assumption
-            # in codegen that buffers are always before variables
-            replaced_arg = replace(variable.arg, slot = slot)
-            variable = variable.replace(arg = replaced_arg)
-            variables.append(variable)
+    for index, slot in enumerate(variable_slots):
+      variable = UOp.variable(f"var_{index}", min_val = 0, max_val = 42,
+                  dtype=dtypes.int32, param = True)
+      # my idea here to create a variable to break the assumption
+      # in codegen that buffers are always before variables
+      replaced_arg = replace(variable.arg, slot = slot)
+      variable = variable.replace(arg = replaced_arg)
+      variables.append(variable)
 
-        assert len(variables) == len(variable_slots)
+    assert len(variables) == len(variable_slots)
 
-        v_range = UOp.range(4, 0)
+    v_range = UOp.range(4, 0)
 
-        value = input_uop.index(v_range).load()
-        value = value * variables[0].cast(dtypes.float32)
+    value = input_uop.index(v_range).load()
+    value = value * variables[0].cast(dtypes.float32)
 
-        for variable in variables[1:]:
-            value = value + variable.cast(dtypes.float32)
+    for variable in variables[1:]:
+      value = value + variable.cast(dtypes.float32)
 
-        value = output_uop.index(v_range).store(value)
-        value = value.end(v_range)
+    value = output_uop.index(v_range).store(value)
+    value = value.end(v_range)
 
-        kernel_name = f"commutative_params_order_{out_slot}_{in_slot}_"
-        kernel_name += "_".join(str(slot) for slot in variable_slots)
+    kernel_name = f"commutative_params_order_{out_slot}_{in_slot}_"
+    kernel_name += "_".join(str(slot) for slot in variable_slots)
 
-        uop_graph_root = value.sink(arg=KernelInfo(name=kernel_name))
+    uop_graph_root = value.sink(arg=KernelInfo(name=kernel_name))
 
-        # self.assertTrue(Device.DEFAULT in Device)
-        default_renderer = Device[Device.DEFAULT].renderer
+    # self.assertTrue(Device.DEFAULT in Device)
+    default_renderer = Device[Device.DEFAULT].renderer
 
-        # okay, so now we have the program generated
-        program = to_program(ast = uop_graph_root, renderer = default_renderer)
+    # okay, so now we have the program generated
+    program = to_program(ast = uop_graph_root, renderer = default_renderer)
 
-        program_signature = program.to_elf().signature
+    program_signature = program.to_elf().signature
 
-        self.assertIsNotNone(program_signature)
+    self.assertIsNotNone(program_signature)
 
-        # we need to make sure every parameter is in the right order
-        check_slots = [element[1] for element in program_signature]
-        self.assertEqual(check_slots, list(range(len(program_signature))))
+    # we need to make sure every parameter is in the right order
+    check_slots = [element[1] for element in program_signature]
+    self.assertEqual(check_slots, list(range(len(program_signature))))
 
-        # does the pre-linearized UOp graph align? note that
-        # from what I can tell the globals and vars are in from_sink
-        check_tuple = (in_slot, out_slot)
-        if out_slot < in_slot:
-            check_tuple = (out_slot, in_slot)
+    # does the pre-linearized UOp graph align? note that
+    # from what I can tell the globals and vars are in from_sink
+    check_tuple = (in_slot, out_slot)
+    if out_slot < in_slot:
+      check_tuple = (out_slot, in_slot)
 
-        self.assertEqual(program.arg.globals, check_tuple)
+    self.assertEqual(program.arg.globals, check_tuple)
 
-        program_arg_variable_splots = tuple(var.arg.slot for var in program.arg.vars)
-        self.assertEqual(program_arg_variable_splots, variable_slots)
+    program_arg_variable_splots = tuple(var.arg.slot for var in program.arg.vars)
+    self.assertEqual(program_arg_variable_splots, variable_slots)
 
-        # now we are done with "compile time" checks time to run the kernel
+    # now we are done with "compile time" checks time to run the kernel
 
-        input_data = np.arange(4, dtype=np.float32)
+    input_data = np.arange(4, dtype=np.float32)
 
-        output_buf = Buffer(device = Device.DEFAULT,
-                            size = 4,
-                            dtype = dtypes.float32).allocate()
+    output_buf = Buffer(device = Device.DEFAULT,
+              size = 4,
+              dtype = dtypes.float32).allocate()
 
-        # because we are passing initial_value, the allocation
-        # happens automatically
-        # todo(hayder): double check this later
-        input_buf = Buffer(device = Device.DEFAULT,
-                           size = 4,
-                           dtype = dtypes.float32,
-                           initial_value = input_data.tobytes())
+    # because we are passing initial_value, the allocation
+    # happens automatically
+    # todo(hayder): double check this later
+    input_buf = Buffer(device = Device.DEFAULT,
+             size = 4,
+             dtype = dtypes.float32,
+             initial_value = input_data.tobytes())
 
-        runtime = get_runtime(device = Device.DEFAULT, ast = program)
+    runtime = get_runtime(device = Device.DEFAULT, ast = program)
 
-        global_size, local_size = program.arg.launch_dims(var_vals = {})
+    global_size, local_size = program.arg.launch_dims(var_vals = {})
 
-        slot_to_buffer_map = {in_slot: input_buf, out_slot: output_buf}
+    slot_to_buffer_map = {in_slot: input_buf, out_slot: output_buf}
 
-        # put the buffers in the order of the slots
-        device_specific_buffers = [slot_to_buffer_map[slot]._buf for slot in program.arg.globals]
+    # put the buffers in the order of the slots
+    device_specific_buffers = [slot_to_buffer_map[slot]._buf for slot in program.arg.globals]
 
-        runtime(*device_specific_buffers,
-                global_size = global_size,
-                local_size = local_size,
-                vals = values,
-                wait = True)
+    runtime(*device_specific_buffers,
+        global_size = global_size,
+        local_size = local_size,
+        vals = values,
+        wait = True)
 
-        # we computed this above using the kernel
-        # now doing it in plain ol' python
-        expected_answer = input_data * values[0] + sum(values[1:])
+    # we computed this above using the kernel
+    # now doing it in plain ol' python
+    expected_answer = input_data * values[0] + sum(values[1:])
 
-        # the output should be stored in... your guessed it!... the output buffer
-        actual_answer = np.frombuffer(output_buf.as_memoryview(), dtype=np.float32)
+    # the output should be stored in... your guessed it!... the output buffer
+    actual_answer = np.frombuffer(output_buf.as_memoryview(), dtype=np.float32)
 
-        # todo: assert_equal instead of assert_allclose *should* be the right move
-        # here since we are storing an integer as a float and
-        # we are not testing between multiple backends, but confirm this
-        np.testing.assert_equal(actual_answer, expected_answer)
+    # todo: assert_equal instead of assert_allclose *should* be the right move
+    # here since we are storing an integer as a float and
+    # we are not testing between multiple backends, but confirm this
+    np.testing.assert_equal(actual_answer, expected_answer)
 
-    def test_commutative_params(self):
-        # now for some table driven tests (yes, i used to code in go)
-        cases = [
-            (0, 1, (2,), (3,)),
-            (1, 0, (2,), (2,)),
-            (1, 2, (0,), (3,)),
-            (2, 1, (0,), (3,)),
-            (0, 2, (1, 3), (4, 2)),
-            (3, 2, (0, 1), (2, 4)),
-        ]
+  def test_commutative_params(self):
+    # now for some table driven tests (yes, i used to code in go)
+    cases = [
+      (0, 1, (2,), (3,)),
+      (1, 0, (2,), (2,)),
+      (1, 2, (0,), (3,)),
+      (2, 1, (0,), (3,)),
+      (0, 2, (1, 3), (4, 2)),
+      (3, 2, (0, 1), (2, 4)),
+    ]
 
-        for case in cases:
-            with self.subTest(case=case):
-                self._test_template(*case)
+    for case in cases:
+      with self.subTest(case=case):
+        self._test_template(*case)
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()

--- a/test/backend/test_commutative_params.py
+++ b/test/backend/test_commutative_params.py
@@ -1,0 +1,135 @@
+
+import numpy as np
+import unittest
+from tinygrad.device import Device
+from tinygrad.uop.ops import UOp, KernelInfo
+from tinygrad import dtypes
+from tinygrad.codegen import to_program
+from dataclasses import replace
+from tinygrad.device import Buffer
+from tinygrad.engine.realize import get_runtime
+
+class TestCommutativeParams(unittest.TestCase):
+    def _test_template(self,
+                       out_slot: int,
+                       in_slot: int,
+                       variable_slots: tuple[int, ...],
+                       values: tuple[int, ...]):
+        # let's first build a micro operation
+        output_uop = UOp.param(out_slot, dtypes.float32, shape=(4,))
+        input_uop = UOp.param(in_slot, dtypes.float32, shape=(4,))
+
+        variables = []
+
+        for index, slot in enumerate(variable_slots):
+            variable = UOp.variable(f"var_{index}", min_val = 0, max_val = 42,
+                                    dtype=dtypes.int32, param = True)
+            # my idea here to create a variable to break the assumption
+            # in codegen that buffers are always before variables
+            replaced_arg = replace(variable.arg, slot = slot)
+            variable = variable.replace(arg = replaced_arg)
+            variables.append(variable)
+
+        assert len(variables) == len(variable_slots)
+
+        v_range = UOp.range(4, 0)
+
+        value = input_uop.index(v_range).load()
+        value = value * variables[0].cast(dtypes.float32)
+
+        for variable in variables[1:]:
+            value = value + variable.cast(dtypes.float32)
+
+        value = output_uop.index(v_range).store(value)
+        value = value.end(v_range)
+
+        kernel_name = f"commutative_params_order_{out_slot}_{in_slot}_"
+        kernel_name += "_".join(str(slot) for slot in variable_slots)
+
+        uop_graph_root = value.sink(arg=KernelInfo(name=kernel_name))
+
+        # self.assertTrue(Device.DEFAULT in Device)
+        default_renderer = Device[Device.DEFAULT].renderer
+
+        # okay, so now we have the program generated
+        program = to_program(ast = uop_graph_root, renderer = default_renderer)
+
+        program_signature = program.to_elf().signature
+
+        self.assertIsNotNone(program_signature)
+
+        # we need to make sure every parameter is in the right order
+        check_slots = [element[1] for element in program_signature]
+        self.assertEqual(check_slots, list(range(len(program_signature))))
+
+        # does the pre-linearized UOp graph align? note that
+        # from what I can tell the globals and vars are in from_sink
+        check_tuple = (in_slot, out_slot)
+        if out_slot < in_slot:
+            check_tuple = (out_slot, in_slot)
+
+        self.assertEqual(program.arg.globals, check_tuple)
+
+        program_arg_variable_splots = tuple(var.arg.slot for var in program.arg.vars)
+        self.assertEqual(program_arg_variable_splots, variable_slots)
+
+        # now we are done with "compile time" checks time to run the kernel
+
+        input_data = np.arange(4, dtype=np.float32)
+
+        output_buf = Buffer(device = Device.DEFAULT,
+                            size = 4,
+                            dtype = dtypes.float32).allocate()
+
+        # because we are passing initial_value, the allocation
+        # happens automatically
+        # todo(hayder): double check this later
+        input_buf = Buffer(device = Device.DEFAULT,
+                           size = 4,
+                           dtype = dtypes.float32,
+                           initial_value = input_data.tobytes())
+
+        runtime = get_runtime(device = Device.DEFAULT, ast = program)
+
+        global_size, local_size = program.arg.launch_dims(var_vals = {})
+
+        slot_to_buffer_map = {in_slot: input_buf, out_slot: output_buf}
+
+        # put the buffers in the order of the slots
+        device_specific_buffers = [slot_to_buffer_map[slot]._buf for slot in program.arg.globals]
+
+        runtime(*device_specific_buffers,
+                global_size = global_size,
+                local_size = local_size,
+                vals = values,
+                wait = True)
+
+        # we computed this above using the kernel
+        # now doing it in plain ol' python
+        expected_answer = input_data * values[0] + sum(values[1:])
+
+        # the output should be stored in... your guessed it!... the output buffer
+        actual_answer = np.frombuffer(output_buf.as_memoryview(), dtype=np.float32)
+
+        # todo: assert_equal instead of assert_allclose *should* be the right move
+        # here since we are storing an integer as a float and
+        # we are not testing between multiple backends, but confirm this
+        np.testing.assert_equal(actual_answer, expected_answer)
+
+    def test_commutative_params(self):
+        # now for some table driven tests (yes, i used to code in go)
+        cases = [
+            (0, 1, (2,), (3,)),
+            (1, 0, (2,), (2,)),
+            (1, 2, (0,), (3,)),
+            (2, 1, (0,), (3,)),
+            (0, 2, (1, 3), (4, 2)),
+            (3, 2, (0, 1), (2, 4)),
+        ]
+
+        for case in cases:
+            with self.subTest(case=case):
+                self._test_template(*case)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 from dataclasses import dataclass, replace
 from collections import defaultdict
-from typing import Any, Callable, Generic, TypeVar, Iterator, Generator, Self, TYPE_CHECKING
+from typing import Sequence, Any, Callable, Generic, TypeVar, Iterator, Generator, Self, TYPE_CHECKING
 import importlib, inspect, functools, pathlib, os, contextlib, re, atexit, pickle, decimal, subprocess, struct
 from tinygrad.helpers import LRU, getenv, diskcache_get, diskcache_put, DEBUG, GlobalCounters, PROFILE, temp, colored
 from tinygrad.helpers import Context, CCACHE, ALLOW_DEVICE_USAGE, MAX_BUFFER_SIZE, cpu_events, ProfileEvent, ProfilePointEvent, suppress_finalizing
 from tinygrad.helpers import select_by_name, select_first_inited, DEV, TracingKey, size_to_str, pluralize, Target, unwrap, round_up
-from tinygrad.dtype import DType, _to_np_dtype
+from tinygrad.dtype import DType, _to_np_dtype, AddrSpace
 if TYPE_CHECKING: from tinygrad.renderer import Renderer
 
 # **************** Device ****************
@@ -326,14 +326,36 @@ class TinyELF:
   name: str
   target: Target
   # tuple of (name, slot, dtype, shape)
-  signature: tuple[tuple[str|None, int, DType, tuple], ...]
+  signature: tuple[tuple[str|None, int, DType, tuple, AddrSpace], ...]
   profile_key: bytes|None = None
 
   @staticmethod
-  def iter_sig(signature:tuple[tuple[str|None, int, DType, tuple], ...], offset:int=0) -> Generator[tuple[int, DType], None, None]:
-    for _,_,dt,_ in signature:
-      yield (offset:=round_up(offset, dt.itemsize)), dt
+  def iter_sig(signature:tuple[tuple[str|None, int, DType, tuple, AddrSpace], ...], offset:int=0) \
+    -> Generator[tuple[int, DType, AddrSpace], None, None]:
+    for _,_,dt,_,addrspace in signature:
+      # we need to handle buffers differently
+      if addrspace is not AddrSpace.ALU:
+        yield (offset:=round_up(offset, 8)), dt, addrspace
+        offset += 8
+        continue
+
+      yield (offset:=round_up(offset, dt.itemsize)), dt, addrspace
       offset += dt.itemsize
+
+  @staticmethod
+  def merge_args(signature:tuple[tuple[str|None, int, DType, tuple, AddrSpace], ...],
+                 buffers:Sequence, values:Sequence) -> list:
+    buffer_iterator = iter(buffers)
+    value_iterator = iter(values)
+
+    def _next() -> Generator:
+      for _,_,_,_,addrspace in signature:
+        if addrspace is AddrSpace.ALU:
+          yield next(value_iterator)
+        else:
+          yield next(buffer_iterator)
+    return list(_next())
+
 
 class Program(Generic[DeviceType]):
   def __init__(self, dev:DeviceType, obj:TinyELF): pass

--- a/tinygrad/runtime/ops_cl.py
+++ b/tinygrad/runtime/ops_cl.py
@@ -54,7 +54,7 @@ class CLProgram(Program['CLDevice']):
 
   def __call__(self, *bufs:cl.cl_mem, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]|None=None, vals:tuple[int, ...]=(),
                wait=False, **kw) -> float|None:
-    for i, (_, slot, dt, shape) in enumerate(self.signature):
+    for i, (_, slot, dt, shape, _) in enumerate(self.signature):
       b = bufs[slot] if slot < len(bufs) else getattr(ctypes, f"c_int{dt.bitsize}")(vals[slot-len(bufs)])
       if is_image_shape(shape):
         pitch = (round_up(shape[1], 256) if OSX else shape[1]) * 4 * dt.itemsize

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -158,11 +158,12 @@ class CPUProgram(Program['CPUDevice']):
     if self.lvp:
       lvp_args = bytearray(12 + (len(bufs) + len(vals)) * 8)
       addr = mv_address(lvp_args)
-      struct.pack_into(f'<3I{len(bufs)}Q', lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2, *[b.va_addr for b in bufs])
-      for v,(off,dt) in zip(vals, TinyELF.iter_sig(self.signature[-len(vals):], len(bufs)*8)): struct.pack_into(f'<{dt.fmt}', lvp_args, 12+off, v)
+      struct.pack_into("<3I", lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2)
+      for v,(off,dt,addrspace) in zip(TinyELF.merge_args(self.signature, [b.va_addr for b in bufs], vals), TinyELF.iter_sig(self.signature)):
+        struct.pack_into(f'<{dt.fmt}' if addrspace is AddrSpace.ALU else '<Q', lvp_args, 12+off, v)
       self.fxn(addr)
     else:
-      args = [*[cast(int, b.va_addr) for b in bufs], *cast(tuple[int, ...], vals)]
+      args = TinyELF.merge_args(self.signature, [cast(int, b.va_addr) for b in bufs], cast(tuple[int, ...], vals))
       assert len(args) <= MAX_ARGS, f"CPU programs support at most {MAX_ARGS} arguments, got {len(args)}"
       for tid in range(global_size[0]):
         if 'core_id' in self.runtimevars: args[self.runtimevars['core_id']] = tid

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -17,7 +17,8 @@ def check(status):
 
 def encode_args(args, vals, signature) -> tuple[ctypes.Structure, ctypes.Array]:
   fields = ([(f'f{i}', cuda.CUdeviceptr_v2, i*8) for i in range(len(args))] +
-            [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), off) for i,(off,dt) in enumerate(TinyELF.iter_sig(signature[len(args):], len(args)*8))])
+            [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), off)
+             for i,(off,dt,_) in enumerate(TinyELF.iter_sig(signature[len(args):], len(args)*8))])
   c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
   vargs = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), ctypes.cast(ctypes.byref(c_args), ctypes.c_void_p), ctypes.c_void_p(2),
                                 ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(c_args))), ctypes.c_void_p), ctypes.c_void_p(0))

--- a/tinygrad/runtime/ops_dsp.py
+++ b/tinygrad/runtime/ops_dsp.py
@@ -66,7 +66,7 @@ class DSPProgram(Program['DSPDevice']):
     pra, fds, attrs, _ = rpc_prep_args(ins=[var_vals_mv:=memoryview(bytearray((len(bufs)+len(vals))*8)), off_mv:=memoryview(bytearray(len(bufs)*4))],
                                        outs=[timer:=memoryview(bytearray(8)).cast('Q')], in_fds=[b.share_info.fd for b in bufs])
     for i,b in enumerate(bufs): struct.pack_into('i', var_vals_mv, i*8, b.size)
-    for i,(v,(_,_,dt,_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
+    for i,(v,(_,_,dt,_,_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
     off_mv.cast('I')[:] = array.array('I', tuple(b.offset for b in bufs))
     self.dev.exec_lib(self.lib, rpc_sc(method=2, ins=2, outs=1, fds=len(bufs)), pra, fds, attrs)
     return timer[0] / 1e6
@@ -282,7 +282,7 @@ class MockDSPProgram(Program[DSPDevice]):
       os.chmod(dsp_lib.name, 0o0777)
       proc = subprocess.run(["qemu-hexagon-static", *(['-strace'] if DEBUG >= 5 else []), dsp_lib.name],
         input=b''.join([bytes(to_mv(x.va_addr, x.size)) for x in bufs] +
-                       [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,_) in zip(vals, self.signature[len(bufs):])]),
+                       [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,_,_) in zip(vals, self.signature[len(bufs):])]),
         stdout=subprocess.PIPE, check=True)
     offset = 4
     for x in bufs:

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -38,7 +38,7 @@ class HIPProgram(Program[HIPDevice]):
     check(hip.hipSetDevice(self.dev.device_id))
     if not hasattr(self, "vargs"):
       fields = ([(f'f{i}', hip.hipDeviceptr_t, i*8) for i in range(len(args))] +
-        [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), o) for i,(o,dt) in enumerate(TinyELF.iter_sig(self.signature[len(args):], len(args)*8))])
+        [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), o) for i,(o,dt,_) in enumerate(TinyELF.iter_sig(self.signature[len(args):], len(args)*8))])
       self.c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
       self.vargs = (ctypes.c_void_p * 5)(1, ctypes.cast(ctypes.byref(self.c_args), ctypes.c_void_p), 2,
                                          ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(self.c_args))), ctypes.c_void_p), 3)

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -139,7 +139,7 @@ class MetalProgram(Program[MetalDevice]):
     encoder = command_buffer.computeCommandEncoder().retained()
     encoder.setComputePipelineState(self.pipeline_state)
     for i,a in enumerate(bufs): encoder.setBuffer_offset_atIndex(a.buf, a.offset, i)
-    for a,(_,i,dt,_) in zip(vals, self.signature[len(bufs):]):
+    for a,(_,i,dt,_,_) in zip(vals, self.signature[len(bufs):]):
       encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(a)), dt.itemsize, i)
     encoder.dispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
     encoder.endEncoding()

--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -203,8 +203,8 @@ class QCOMArgsState(HCQArgsState):
     super().__init__(buf, prg, bufs, vals=vals)
     ctypes.memset(int(self.buf.va_addr), 0, prg.kernargs_alloc_size)
 
-    ubos = [bufs[slot] for _,slot,_,shape in prg.signature if slot < len(bufs) and not is_image_shape(shape)]
-    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape in prg.signature if slot < len(bufs) and is_image_shape(shape)]
+    ubos = [bufs[slot] for _,slot,_,shape,_ in prg.signature if slot < len(bufs) and not is_image_shape(shape)]
+    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape,_ in prg.signature if slot < len(bufs) and is_image_shape(shape)]
     # NIR can reorder images to different texture slots
     ibos, texs = uavs[:prg.ibo_cnt], [uavs[prg.ibo_cnt + (prg.tex_to_image[i] if prg.NIR else i)] for i in range(prg.tex_cnt)]
     for cnst_val,cnst_off,cnst_sz in prg.consts_info:
@@ -213,11 +213,11 @@ class QCOMArgsState(HCQArgsState):
     if prg.samp_cnt > 0: to_mv(int(self.buf.va_addr) + prg.samp_off, len(prg.samplers) * 4).cast('I')[:] = array.array('I', prg.samplers)
     if prg.NIR:
       self.bind_sints_to_buf(*[b.va_addr for b in ubos], buf=self.buf, fmt='Q', offset=prg.buf_off)
-      for v,(o,dt) in zip(vals, TinyELF.iter_sig(prg.signature[len(bufs):], len(ubos)*8)):
+      for v,(o,dt,_) in zip(vals, TinyELF.iter_sig(prg.signature[len(bufs):], len(ubos)*8)):
         self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_off + o)
     else:
       for i, b in enumerate(ubos): self.bind_sints_to_buf(b.va_addr, buf=self.buf, fmt='Q', offset=prg.buf_offs[i])
-      for i,(v,(_,_,dt,_)) in enumerate(zip(vals, prg.signature[len(bufs):])):
+      for i,(v,(_,_,dt,_,_)) in enumerate(zip(vals, prg.signature[len(bufs):])):
         self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_offs[i+len(ubos)])
 
     def _tex(b, ibo=False):

--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -327,7 +327,7 @@ class CLikeArgsState(HCQArgsState[ProgramType]):
     if prefix is not None: self.buf.cpu_view().view(size=len(prefix) * 4, fmt='I')[:] = array.array('I', prefix)
 
     self.bind_sints_to_buf(*[b.va_addr for b in bufs], buf=self.buf, fmt='Q', offset=len(prefix or []) * 4)
-    for v,(val_offset,dt) in zip(vals, TinyELF.iter_sig(prg.signature[-len(vals):], len(bufs) * 8)):
+    for v,(val_offset,dt,_) in zip(vals, TinyELF.iter_sig(prg.signature[-len(vals):], len(bufs) * 8)):
       assert v is not None
       self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=len(prefix or []) * 4 + val_offset)
 

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1204,8 +1204,21 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
 
   def to_elf(self) -> TinyELF:
     assert self.op is Ops.PROGRAM and isinstance(self.arg, ProgramInfo), "to_elf should only be called on a PROGRAM ast"
-    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape)
-                for u in tuple(filter(lambda u: u.op is Ops.PARAM and u.addrspace != AddrSpace.ALU, self.src[1].src)) + self.arg.vars)
+    # instead of only storing Buffers we need to store both variables and buffers
+    parameters = set(u for u in self.src[1].src if u.op is Ops.PARAM)
+
+    # adding this because the old code had, i am not convinced this is necessary
+    # todo: double check if this is necessary
+    variables = set(self.arg.vars)
+
+    parameters = parameters.union(variables)
+    sorted_parameters = sorted(parameters, key=lambda u: u.arg.slot)
+
+    # we need the address space now because the compiler cannot assume
+    # something is a buffer or variable from the position so it
+    # will have to do the != AddrSpace.ALU check to see if something is a buffer.
+    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape, u.addrspace)
+                for u in sorted_parameters)
     return TinyELF(self.src[3].arg, self.arg.function_name, self.arg.target, sig, self.key)
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Hey folks!

I've been playing around with tinygrad for a moment and saw that this was an open issue / bounty.

i am following a test driven development approach here. I began with setting up some invariants which make sense if we want buffers and args to be supported in any order. Please take a look at them in test_commutative_params.py and let me know if they make sense, happy to iterate on them. Next, I am trying to fix the backends one step at a time. The PR in its current state works for CPU and LLVM on my Macbook. I am testing using 

```
DEV=CPU .venv/bin/python -m pytest test/backend/test_commutative_params.py -v 
```

I will try to wrap up the remaining backends quickly if this is the approach we decide to go with. Thank you! :) 

I know there is a No AI requirement on this one. The code is all handwritten + hand "thought" and I've gotten the carpal tunnel to prove it. However, I did use some AI as kind of a better livegrep / code explainer to help me understand e.g what some parts of the existing code were actually doing before I made my changes. Happy to close this PR or not accept the cash if that is disqualifying. 