### PR TITLE
fix Conv2d same padding with per axis dilation

### DIFF
--- a/test/backend/test_nn.py
+++ b/test/backend/test_nn.py
@@ -135,7 +135,7 @@ class TestNN(unittest.TestCase):
   def test_conv2d_same_padding_large_kernel(self):
     self._test_conv(Conv2d, torch.nn.Conv2d, BS=16, C1=16, DIMS=[28, 33], C2=32, K=9, S=1, P='same')
   def test_conv2d_same_padding_with_dilation(self):
-    self._test_conv(Conv2d, torch.nn.Conv2d, BS=16, C1=3, DIMS=[28, 28], C2=32, K=3, S=1, P='same', D=3)
+    self._test_conv(Conv2d, torch.nn.Conv2d, BS=16, C1=3, DIMS=[28, 31], C2=32, K=(3,5), S=1, P='same', D=(2,3))
 
   def test_conv2d_same_padding_invalid_stride(self):
     self.assertRaises(ValueError, Conv2d, in_channels=16, out_channels=32, kernel_size=2, stride=2, padding='same')

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -99,7 +99,7 @@ class Conv2d:
     if isinstance(padding, str):
       if padding.lower() != 'same': raise ValueError(f"Invalid padding string {padding!r}, only 'same' is supported")
       if stride != 1: raise ValueError("padding='same' is not supported for strided convolutions")
-      pad = [(d*(k-1)//2, d*(k-1) - d*(k-1)//2) for d,k in zip(make_tuple(dilation, len(self.kernel_size)), self.kernel_size[::-1])]
+      pad = [(d*(k-1)//2, d*(k-1) - d*(k-1)//2) for d,k in zip(make_tuple(dilation, len(self.kernel_size))[::-1], self.kernel_size[::-1])]
       padding = tuple(flatten(pad))
     self.stride, self.dilation, self.groups, self.padding = stride, dilation, groups, padding
     scale = 1 / math.sqrt(in_channels * prod(self.kernel_size))


### PR DESCRIPTION
`Conv2d(padding='same')` reverses `kernel_size` to build the pad tuple, since padding is ordered last axis first, but not `dilation`, so each axis gets the other axis's dilation. `Conv2d(3, 8, kernel_size=(3,5), padding='same', dilation=(2,3))` on `(1,3,28,31)` comes out `(1,8,30,27)`; torch gives `(1,8,28,31)`.

The old test used `K=3, D=3`, where both orderings are the same tuple. Changed it to `K=(3,5), D=(2,3)`; it fails on master and passes here.
