### PR TITLE
compiler: don't destroy if init failed

### DIFF
--- a/tinygrad/runtime/support/compiler_mesa.py
+++ b/tinygrad/runtime/support/compiler_mesa.py
@@ -60,7 +60,8 @@ class NAKCompiler(Compiler):
     self.nir_options = bytes(mesa.nak_nir_options(self.cc).contents)
     super().__init__(f"compile_nak_{arch}")
 
-  def __del__(self): mesa.nak_compiler_destroy(self.cc)
+  def __del__(self):
+    if hasattr(self, 'cc'): mesa.nak_compiler_destroy(self.cc)
 
   def __reduce__(self): return NAKCompiler, (self.arch,)
 
@@ -103,7 +104,8 @@ class IR3Compiler(Compiler):
     self.nir_options = bytes(mesa.ir3_get_compiler_options(self.cc).contents)
     super().__init__(f"compile_ir3_{arch}")
 
-  def __del__(self): mesa.ir3_compiler_destroy(self.cc)
+  def __del__(self):
+    if hasattr(self, 'cc'): mesa.ir3_compiler_destroy(self.cc)
 
   def __reduce__(self): return IR3Compiler, (self.arch,)
 

--- a/tinygrad/runtime/support/compiler_qcom.py
+++ b/tinygrad/runtime/support/compiler_qcom.py
@@ -20,7 +20,9 @@ class QCOMCompiler(Compiler):
                                                 f"-e PYTHONPATH={root} -e QEMU_CPU=max,pauth=off gcr.io/distroless/static python3"), arch)
     super().__init__(f"compile_qcomcl_{arch}")
 
-  def __del__(self): llvm_qcom.cl_compiler_destroy_llvm_instance(self.llvm_inst) if platform.machine() == "aarch64" else self.compiler_process.kill()
+  def __del__(self):
+    if hasattr(self, 'llvm_inst'): llvm_qcom.cl_compiler_destroy_llvm_instance(self.llvm_inst)
+    elif hasattr(self, 'compiler_process'): self.compiler_process.kill()
 
   def __reduce__(self): return QCOMCompiler, (self.arch,)
 


### PR DESCRIPTION
If IR3/NAK/QCOM compiler `__init__` fails before the native handle is set, `__del__` raises `AttributeError` and hides the original exception.

Same `hasattr` pattern as `LLVMCompiler`.