### PR TITLE
matvec heuristic: match fused quantized GEMV

### DIFF
--- a/tinygrad/codegen/opt/heuristic.py
+++ b/tinygrad/codegen/opt/heuristic.py
@@ -5,6 +5,10 @@ from tinygrad.uop.ops import Ops, resolve, AxisType
 from tinygrad.codegen.late.coalesce import image_valid_dims
 from tinygrad.codegen.opt.postrange import Scheduler
 
+def _peel_cast(u):
+  while u.op is Ops.CAST: u = u.src[0]
+  return u
+
 def hand_coded_optimizations(k:Scheduler) -> Scheduler:
   # first try the tensor cores
   """ Attempts to apply a tensor core optimization to the kernel. If one exists and applies properly, return true, otherwise return false.
@@ -58,24 +62,37 @@ def hand_coded_optimizations(k:Scheduler) -> Scheduler:
             k.apply_opt(Opt(OptOps.UNROLL, k.unrollable_dims.index(axis), 4))
 
   # should use matvec - TODO: adjust/tune based on the wide vs tall/large vs small mat
+  # also matches fused quantized GEMV (one MUL operand is a load, the other is packed dequant)
   MV_BLOCKSIZE, MV_THREADS_PER_ROW, MV_ROWS_PER_THREAD = getenv("MV_BLOCKSIZE", 4), getenv("MV_THREADS_PER_ROW", 8), getenv("MV_ROWS_PER_THREAD", 4)
   if k.ren.has_local and getenv("MV",1) != 0 and (MV_BLOCKSIZE > 1 or MV_THREADS_PER_ROW > 1 or MV_ROWS_PER_THREAD > 1) and  \
-    k.reduceop is not None and k.reduceop.arg[0] is Ops.ADD and len(k.full_shape) >= 2 and k.ren.has_shared and \
-    (mulop:=k.reduceop.src[0]).op is Ops.MUL and mulop.src[0].op is Ops.INDEX and mulop.src[1].op is Ops.INDEX:
-    idx0, idx1 = mulop.src[0].src[1].get_idx(), mulop.src[1].src[1].get_idx()
-    if k.ranges_of(AxisType.REDUCE):
+    k.reduceop is not None and k.reduceop.arg[0] is Ops.ADD and len(k.full_shape) >= 2 and k.ren.has_shared:
+    mulop = _peel_cast(k.reduceop.src[0])
+    vecs = [_peel_cast(s) for s in mulop.src] if mulop.op is Ops.MUL else []
+    vecs = [s for s in vecs if s.op is Ops.INDEX]
+    if vecs and k.ranges_of(AxisType.REDUCE):
       first_reduce_rng = k.ranges_of(AxisType.REDUCE)[0]
-      if any(u is first_reduce_rng for u in idx0.split_uop(Ops.ADD)) and all(r in idx1.ranges for r in idx0.ranges):
+      if len(vecs) == 2:
+        idx0, idx1 = vecs[0].src[1].get_idx(), vecs[1].src[1].get_idx()
+        matvec = any(u is first_reduce_rng for u in idx0.split_uop(Ops.ADD)) and all(r in idx1.ranges for r in idx0.ranges)
+      else:
+        matvec = first_reduce_rng in vecs[0].src[1].get_idx().ranges
+      if matvec:
         for global_idx in k.axes_of(AxisType.GLOBAL):
-          if first_reduce_rng.src[0].divides(MV_THREADS_PER_ROW) is not None and k.full_shape[global_idx]%(MV_BLOCKSIZE*MV_ROWS_PER_THREAD) == 0:
-            if DEBUG >= 3:
-              print(f"MATVEC: {k.full_shape=} {first_reduce_rng.render()} {MV_BLOCKSIZE=} {MV_THREADS_PER_ROW=} {MV_ROWS_PER_THREAD=}")
-            try:
-              if MV_THREADS_PER_ROW > 1: k.apply_opt(Opt(OptOps.GROUP, 0, MV_THREADS_PER_ROW))
-            except KernelOptError: pass
-            if MV_BLOCKSIZE > 1: k.apply_opt(Opt(OptOps.LOCAL, global_idx, MV_BLOCKSIZE))
-            if MV_ROWS_PER_THREAD > 1: k.apply_opt(Opt(OptOps.UPCAST, global_idx, MV_ROWS_PER_THREAD))
-            return k
+          if not resolve(k.full_shape[global_idx]%(MV_BLOCKSIZE*MV_ROWS_PER_THREAD) == 0, False): continue
+          # dense gemv uses 8 threads/row. fused dequant uses 8 if it divides the leading reduce, else 16/32.
+          # grouping by 4 was a regression on Q3_K (heavy ALU); skip matvec if nothing fits.
+          threads = MV_THREADS_PER_ROW
+          if len(vecs) == 1:
+            threads = next((t for t in (8, 16, 32) if first_reduce_rng.src[0].divides(t) is not None), 0)
+          if not threads or first_reduce_rng.src[0].divides(threads) is None: continue
+          if DEBUG >= 3:
+            print(f"MATVEC: {k.full_shape=} {first_reduce_rng.render()} {threads=} {MV_BLOCKSIZE=} {MV_ROWS_PER_THREAD=}")
+          try:
+            if threads > 1: k.apply_opt(Opt(OptOps.GROUP, 0, threads))
+          except KernelOptError: pass
+          if MV_BLOCKSIZE > 1: k.apply_opt(Opt(OptOps.LOCAL, global_idx, MV_BLOCKSIZE))
+          if MV_ROWS_PER_THREAD > 1: k.apply_opt(Opt(OptOps.UPCAST, global_idx, MV_ROWS_PER_THREAD))
+          return k
 
   # are we grouping? (requires local shape support)
   if resolve(prod(k.output_shape[i] for i in k.upcastable_dims) <= (240 if NOLOCALS else 2048), False):

--- a/tinygrad/llm/gguf.py
+++ b/tinygrad/llm/gguf.py
@@ -40,8 +40,8 @@ def ggml_data_to_tensor(t: Tensor, n: int, ggml_type: int) -> Tensor:
 
   def q_to_uint8(t: Tensor, b: int) -> Tensor:
     # TODO: rewrite with arange?
-    shift_tensor, bitmask = Tensor.const(tuple(2**(i*b) for i in range(8//b)), t.dtype), 0xff >> (8 - b)
-    return t.unsqueeze(-1).div(shift_tensor, rounding_mode="trunc").bitwise_and(bitmask).transpose(-1, -2).flatten(-2)
+    shift_tensor, bitmask = Tensor.const(tuple(i*b for i in range(8//b)), t.dtype), 0xff >> (8 - b)
+    return t.unsqueeze(-1).rshift(shift_tensor).bitwise_and(bitmask).transpose(-1, -2).flatten(-2)
 
   if (nelements_nbytes := _GGML_QUANT.get(ggml_type)) is not None:
     from tinygrad.runtime.autogen import ggml_common as _ggml


### PR DESCRIPTION
Draft / question, not asking to merge yet.

Fused GGUF dequant GEMV does not look like INDEX*INDEX, so hand_coded_optimizations never applies the matvec GROUP/LOCAL/UPCAST path. This peels CASTs and matches a single INDEX on the reduce so those kernels can use it. Fused dequant picks 8/16/32 threads/row; grouping by 4 was a regression on Q3_K.

Also q_to_uint8 uses rshift instead of trunc-div (same values).

Benchmark, RTX 5080 16GB, same command both times:
JITBEAM=2 DEV=CUDA python -m tinygrad.llm -m Qwen3.8-27B-UD-Q4_K_M.gguf --warmup --benchmark 20

before (UD dequant only): 0.98 tok/s mean (0.74-1.20), 16 GB/s
after (this change): 4.12 tok/s mean (2.56-4.52), 69 GB/s
~4.2x decode. 17/20 after tokens were 4.1-4.5 tok/s.

Is matching fused dequant in the matvec heuristic the right place, or do you want this left to BEAM?