### PR TITLE
makes kernel buffers and variables commute

### DIFF
--- a/test/backend/test_commutative_params.py
+++ b/test/backend/test_commutative_params.py
@@ -1,123 +1,57 @@
-
 import numpy as np
 import unittest
-from tinygrad.device import Device
-from tinygrad.uop.ops import UOp, KernelInfo
-from tinygrad import dtypes
-from tinygrad.codegen import to_program
 from dataclasses import replace
-from tinygrad.device import Buffer
+from tinygrad import Tensor, Context, dtypes
+from tinygrad.device import Device, Buffer
+from tinygrad.uop.ops import UOp, KernelInfo
+from tinygrad.codegen import to_program
 from tinygrad.engine.realize import get_runtime
 
 class TestCommutativeParams(unittest.TestCase):
-  def _test_template(self,
-           out_slot: int,
-           in_slot: int,
-           variable_slots: tuple[int, ...],
-           values: tuple[int, ...]):
-    # let's first build a micro operation
+  def _test_template(self, out_slot:int, in_slot:int, variable_slots:tuple[int, ...], values:tuple[int, ...]):
     output_uop = UOp.param(out_slot, dtypes.float32, shape=(4,))
     input_uop = UOp.param(in_slot, dtypes.float32, shape=(4,))
 
     variables = []
-
     for index, slot in enumerate(variable_slots):
-      variable = UOp.variable(f"var_{index}", min_val = 0, max_val = 42,
-                  dtype=dtypes.int32, param = True)
-      # my idea here to create a variable to break the assumption
-      # in codegen that buffers are always before variables
-      replaced_arg = replace(variable.arg, slot = slot)
-      variable = variable.replace(arg = replaced_arg)
-      variables.append(variable)
-
-    assert len(variables) == len(variable_slots)
+      variable = UOp.variable(f"var_{index}", 0, 42, dtypes.int32, param=True)
+      variables.append(variable.replace(arg=replace(variable.arg, slot=slot)))
 
     v_range = UOp.range(4, 0)
-
-    value = input_uop.index(v_range).load()
-    value = value * variables[0].cast(dtypes.float32)
-
+    value = input_uop.index(v_range).load() * variables[0].cast(dtypes.float32)
     for variable in variables[1:]:
       value = value + variable.cast(dtypes.float32)
+    value = output_uop.index(v_range).store(value).end(v_range)
 
-    value = output_uop.index(v_range).store(value)
-    value = value.end(v_range)
-
-    kernel_name = f"commutative_params_order_{out_slot}_{in_slot}_"
-    kernel_name += "_".join(str(slot) for slot in variable_slots)
-
+    kernel_name = f"commutative_params_order_{out_slot}_{in_slot}_" + "_".join(str(slot) for slot in variable_slots)
     uop_graph_root = value.sink(arg=KernelInfo(name=kernel_name))
-
-    # self.assertTrue(Device.DEFAULT in Device)
-    default_renderer = Device[Device.DEFAULT].renderer
-
-    # okay, so now we have the program generated
-    program = to_program(ast = uop_graph_root, renderer = default_renderer)
+    program = to_program(uop_graph_root, Device[Device.DEFAULT].renderer)
 
     program_signature = program.to_elf().signature
-
-    self.assertIsNotNone(program_signature)
-
-    # we need to make sure every parameter is in the right order
     check_slots = [element[1] for element in program_signature]
     self.assertEqual(check_slots, list(range(len(program_signature))))
 
-    # does the pre-linearized UOp graph align? note that
-    # from what I can tell the globals and vars are in from_sink
     check_tuple = (in_slot, out_slot)
     if out_slot < in_slot:
       check_tuple = (out_slot, in_slot)
-
     self.assertEqual(program.arg.globals, check_tuple)
-
-    program_arg_variable_splots = tuple(var.arg.slot for var in program.arg.vars)
-    self.assertEqual(program_arg_variable_splots, variable_slots)
-
-    # now we are done with "compile time" checks time to run the kernel
+    self.assertEqual(tuple(var.arg.slot for var in program.arg.vars), variable_slots)
 
     input_data = np.arange(4, dtype=np.float32)
+    output_buf = Buffer(Device.DEFAULT, 4, dtypes.float32).allocate()
+    input_buf = Buffer(Device.DEFAULT, 4, dtypes.float32, initial_value=input_data.tobytes())
 
-    output_buf = Buffer(device = Device.DEFAULT,
-              size = 4,
-              dtype = dtypes.float32).allocate()
-
-    # because we are passing initial_value, the allocation
-    # happens automatically
-    # todo(hayder): double check this later
-    input_buf = Buffer(device = Device.DEFAULT,
-             size = 4,
-             dtype = dtypes.float32,
-             initial_value = input_data.tobytes())
-
-    runtime = get_runtime(device = Device.DEFAULT, ast = program)
-
-    global_size, local_size = program.arg.launch_dims(var_vals = {})
-
+    runtime = get_runtime(Device.DEFAULT, program)
+    global_size, local_size = program.arg.launch_dims({})
     slot_to_buffer_map = {in_slot: input_buf, out_slot: output_buf}
-
-    # put the buffers in the order of the slots
     device_specific_buffers = [slot_to_buffer_map[slot]._buf for slot in program.arg.globals]
+    runtime(*device_specific_buffers, global_size=global_size, local_size=local_size, vals=values, wait=True)
 
-    runtime(*device_specific_buffers,
-        global_size = global_size,
-        local_size = local_size,
-        vals = values,
-        wait = True)
-
-    # we computed this above using the kernel
-    # now doing it in plain ol' python
     expected_answer = input_data * values[0] + sum(values[1:])
-
-    # the output should be stored in... your guessed it!... the output buffer
     actual_answer = np.frombuffer(output_buf.as_memoryview(), dtype=np.float32)
-
-    # todo: assert_equal instead of assert_allclose *should* be the right move
-    # here since we are storing an integer as a float and
-    # we are not testing between multiple backends, but confirm this
     np.testing.assert_equal(actual_answer, expected_answer)
 
   def test_commutative_params(self):
-    # now for some table driven tests (yes, i used to code in go)
     cases = [
       (0, 1, (2,), (3,)),
       (1, 0, (2,), (2,)),
@@ -126,10 +60,42 @@ class TestCommutativeParams(unittest.TestCase):
       (0, 2, (1, 3), (4, 2)),
       (3, 2, (0, 1), (2, 4)),
     ]
-
     for case in cases:
       with self.subTest(case=case):
         self._test_template(*case)
+
+  def test_params_beyond_abi_registers(self):
+    # x86 passes the first 6 params in registers, the rest go on the stack
+    buffer_uops = [UOp.param(i, dtypes.float32, shape=(4,)) for i in range(8)]
+    v_range = UOp.range(4, 0)
+    value = buffer_uops[1].index(v_range).load()
+    for buffer_uop in buffer_uops[2:]:
+      value = value + buffer_uop.index(v_range).load()
+    value = buffer_uops[0].index(v_range).store(value).end(v_range)
+    program = to_program(value.sink(arg=KernelInfo(name="params_beyond_abi_registers")), Device[Device.DEFAULT].renderer)
+    self.assertEqual([element[1] for element in program.to_elf().signature], list(range(8)))
+
+    input_data = [np.full(4, i, dtype=np.float32) for i in range(1, 8)]
+    buffers = [Buffer(Device.DEFAULT, 4, dtypes.float32).allocate()]
+    buffers += [Buffer(Device.DEFAULT, 4, dtypes.float32, initial_value=data.tobytes()) for data in input_data]
+    global_size, local_size = program.arg.launch_dims({})
+    get_runtime(Device.DEFAULT, program)(*[b._buf for b in buffers], global_size=global_size, local_size=local_size, wait=True)
+    np.testing.assert_equal(np.frombuffer(buffers[0].as_memoryview(), dtype=np.float32), sum(input_data))
+
+  @unittest.skipUnless(Device.DEFAULT == "CL", "images need CL")
+  def test_image_and_flat_view_of_one_buffer(self):
+    x = Tensor.rand(16, 10, 27).realize()
+    weight = Tensor.rand(10).realize()
+    target = Tensor.uniform(16, 27, low=0, high=10, dtype=dtypes.int32).realize()
+    x_np = x.numpy()
+    target_np = target.numpy()
+    weight_np = weight.numpy()
+    picked = np.take_along_axis(x_np, target_np[:,None,:], axis=1).squeeze(1)
+    expected = -(picked * weight_np[target_np]).sum() / weight_np[target_np].sum()
+
+    with Context(IMAGE=1):
+      loss = x.nll_loss(target, weight=weight).numpy()
+    np.testing.assert_allclose(loss, expected, atol=1e-5, rtol=1e-5)
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/backend/test_commutative_params.py
+++ b/test/backend/test_commutative_params.py
@@ -10,126 +10,126 @@ from tinygrad.device import Buffer
 from tinygrad.engine.realize import get_runtime
 
 class TestCommutativeParams(unittest.TestCase):
-    def _test_template(self,
-                       out_slot: int,
-                       in_slot: int,
-                       variable_slots: tuple[int, ...],
-                       values: tuple[int, ...]):
-        # let's first build a micro operation
-        output_uop = UOp.param(out_slot, dtypes.float32, shape=(4,))
-        input_uop = UOp.param(in_slot, dtypes.float32, shape=(4,))
+  def _test_template(self,
+           out_slot: int,
+           in_slot: int,
+           variable_slots: tuple[int, ...],
+           values: tuple[int, ...]):
+    # let's first build a micro operation
+    output_uop = UOp.param(out_slot, dtypes.float32, shape=(4,))
+    input_uop = UOp.param(in_slot, dtypes.float32, shape=(4,))
 
-        variables = []
+    variables = []
 
-        for index, slot in enumerate(variable_slots):
-            variable = UOp.variable(f"var_{index}", min_val = 0, max_val = 42,
-                                    dtype=dtypes.int32, param = True)
-            # my idea here to create a variable to break the assumption
-            # in codegen that buffers are always before variables
-            replaced_arg = replace(variable.arg, slot = slot)
-            variable = variable.replace(arg = replaced_arg)
-            variables.append(variable)
+    for index, slot in enumerate(variable_slots):
+      variable = UOp.variable(f"var_{index}", min_val = 0, max_val = 42,
+                  dtype=dtypes.int32, param = True)
+      # my idea here to create a variable to break the assumption
+      # in codegen that buffers are always before variables
+      replaced_arg = replace(variable.arg, slot = slot)
+      variable = variable.replace(arg = replaced_arg)
+      variables.append(variable)
 
-        assert len(variables) == len(variable_slots)
+    assert len(variables) == len(variable_slots)
 
-        v_range = UOp.range(4, 0)
+    v_range = UOp.range(4, 0)
 
-        value = input_uop.index(v_range).load()
-        value = value * variables[0].cast(dtypes.float32)
+    value = input_uop.index(v_range).load()
+    value = value * variables[0].cast(dtypes.float32)
 
-        for variable in variables[1:]:
-            value = value + variable.cast(dtypes.float32)
+    for variable in variables[1:]:
+      value = value + variable.cast(dtypes.float32)
 
-        value = output_uop.index(v_range).store(value)
-        value = value.end(v_range)
+    value = output_uop.index(v_range).store(value)
+    value = value.end(v_range)
 
-        kernel_name = f"commutative_params_order_{out_slot}_{in_slot}_"
-        kernel_name += "_".join(str(slot) for slot in variable_slots)
+    kernel_name = f"commutative_params_order_{out_slot}_{in_slot}_"
+    kernel_name += "_".join(str(slot) for slot in variable_slots)
 
-        uop_graph_root = value.sink(arg=KernelInfo(name=kernel_name))
+    uop_graph_root = value.sink(arg=KernelInfo(name=kernel_name))
 
-        # self.assertTrue(Device.DEFAULT in Device)
-        default_renderer = Device[Device.DEFAULT].renderer
+    # self.assertTrue(Device.DEFAULT in Device)
+    default_renderer = Device[Device.DEFAULT].renderer
 
-        # okay, so now we have the program generated
-        program = to_program(ast = uop_graph_root, renderer = default_renderer)
+    # okay, so now we have the program generated
+    program = to_program(ast = uop_graph_root, renderer = default_renderer)
 
-        program_signature = program.to_elf().signature
+    program_signature = program.to_elf().signature
 
-        self.assertIsNotNone(program_signature)
+    self.assertIsNotNone(program_signature)
 
-        # we need to make sure every parameter is in the right order
-        check_slots = [element[1] for element in program_signature]
-        self.assertEqual(check_slots, list(range(len(program_signature))))
+    # we need to make sure every parameter is in the right order
+    check_slots = [element[1] for element in program_signature]
+    self.assertEqual(check_slots, list(range(len(program_signature))))
 
-        # does the pre-linearized UOp graph align? note that
-        # from what I can tell the globals and vars are in from_sink
-        check_tuple = (in_slot, out_slot)
-        if out_slot < in_slot:
-            check_tuple = (out_slot, in_slot)
+    # does the pre-linearized UOp graph align? note that
+    # from what I can tell the globals and vars are in from_sink
+    check_tuple = (in_slot, out_slot)
+    if out_slot < in_slot:
+      check_tuple = (out_slot, in_slot)
 
-        self.assertEqual(program.arg.globals, check_tuple)
+    self.assertEqual(program.arg.globals, check_tuple)
 
-        program_arg_variable_splots = tuple(var.arg.slot for var in program.arg.vars)
-        self.assertEqual(program_arg_variable_splots, variable_slots)
+    program_arg_variable_splots = tuple(var.arg.slot for var in program.arg.vars)
+    self.assertEqual(program_arg_variable_splots, variable_slots)
 
-        # now we are done with "compile time" checks time to run the kernel
+    # now we are done with "compile time" checks time to run the kernel
 
-        input_data = np.arange(4, dtype=np.float32)
+    input_data = np.arange(4, dtype=np.float32)
 
-        output_buf = Buffer(device = Device.DEFAULT,
-                            size = 4,
-                            dtype = dtypes.float32).allocate()
+    output_buf = Buffer(device = Device.DEFAULT,
+              size = 4,
+              dtype = dtypes.float32).allocate()
 
-        # because we are passing initial_value, the allocation
-        # happens automatically
-        # todo(hayder): double check this later
-        input_buf = Buffer(device = Device.DEFAULT,
-                           size = 4,
-                           dtype = dtypes.float32,
-                           initial_value = input_data.tobytes())
+    # because we are passing initial_value, the allocation
+    # happens automatically
+    # todo(hayder): double check this later
+    input_buf = Buffer(device = Device.DEFAULT,
+             size = 4,
+             dtype = dtypes.float32,
+             initial_value = input_data.tobytes())
 
-        runtime = get_runtime(device = Device.DEFAULT, ast = program)
+    runtime = get_runtime(device = Device.DEFAULT, ast = program)
 
-        global_size, local_size = program.arg.launch_dims(var_vals = {})
+    global_size, local_size = program.arg.launch_dims(var_vals = {})
 
-        slot_to_buffer_map = {in_slot: input_buf, out_slot: output_buf}
+    slot_to_buffer_map = {in_slot: input_buf, out_slot: output_buf}
 
-        # put the buffers in the order of the slots
-        device_specific_buffers = [slot_to_buffer_map[slot]._buf for slot in program.arg.globals]
+    # put the buffers in the order of the slots
+    device_specific_buffers = [slot_to_buffer_map[slot]._buf for slot in program.arg.globals]
 
-        runtime(*device_specific_buffers,
-                global_size = global_size,
-                local_size = local_size,
-                vals = values,
-                wait = True)
+    runtime(*device_specific_buffers,
+        global_size = global_size,
+        local_size = local_size,
+        vals = values,
+        wait = True)
 
-        # we computed this above using the kernel
-        # now doing it in plain ol' python
-        expected_answer = input_data * values[0] + sum(values[1:])
+    # we computed this above using the kernel
+    # now doing it in plain ol' python
+    expected_answer = input_data * values[0] + sum(values[1:])
 
-        # the output should be stored in... your guessed it!... the output buffer
-        actual_answer = np.frombuffer(output_buf.as_memoryview(), dtype=np.float32)
+    # the output should be stored in... your guessed it!... the output buffer
+    actual_answer = np.frombuffer(output_buf.as_memoryview(), dtype=np.float32)
 
-        # todo: assert_equal instead of assert_allclose *should* be the right move
-        # here since we are storing an integer as a float and
-        # we are not testing between multiple backends, but confirm this
-        np.testing.assert_equal(actual_answer, expected_answer)
+    # todo: assert_equal instead of assert_allclose *should* be the right move
+    # here since we are storing an integer as a float and
+    # we are not testing between multiple backends, but confirm this
+    np.testing.assert_equal(actual_answer, expected_answer)
 
-    def test_commutative_params(self):
-        # now for some table driven tests (yes, i used to code in go)
-        cases = [
-            (0, 1, (2,), (3,)),
-            (1, 0, (2,), (2,)),
-            (1, 2, (0,), (3,)),
-            (2, 1, (0,), (3,)),
-            (0, 2, (1, 3), (4, 2)),
-            (3, 2, (0, 1), (2, 4)),
-        ]
+  def test_commutative_params(self):
+    # now for some table driven tests (yes, i used to code in go)
+    cases = [
+      (0, 1, (2,), (3,)),
+      (1, 0, (2,), (2,)),
+      (1, 2, (0,), (3,)),
+      (2, 1, (0,), (3,)),
+      (0, 2, (1, 3), (4, 2)),
+      (3, 2, (0, 1), (2, 4)),
+    ]
 
-        for case in cases:
-            with self.subTest(case=case):
-                self._test_template(*case)
+    for case in cases:
+      with self.subTest(case=case):
+        self._test_template(*case)
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()

--- a/test/backend/test_commutative_params.py
+++ b/test/backend/test_commutative_params.py
@@ -1,0 +1,135 @@
+
+import numpy as np
+import unittest
+from tinygrad.device import Device
+from tinygrad.uop.ops import UOp, KernelInfo
+from tinygrad import dtypes
+from tinygrad.codegen import to_program
+from dataclasses import replace
+from tinygrad.device import Buffer
+from tinygrad.engine.realize import get_runtime
+
+class TestCommutativeParams(unittest.TestCase):
+    def _test_template(self,
+                       out_slot: int,
+                       in_slot: int,
+                       variable_slots: tuple[int, ...],
+                       values: tuple[int, ...]):
+        # let's first build a micro operation
+        output_uop = UOp.param(out_slot, dtypes.float32, shape=(4,))
+        input_uop = UOp.param(in_slot, dtypes.float32, shape=(4,))
+
+        variables = []
+
+        for index, slot in enumerate(variable_slots):
+            variable = UOp.variable(f"var_{index}", min_val = 0, max_val = 42,
+                                    dtype=dtypes.int32, param = True)
+            # my idea here to create a variable to break the assumption
+            # in codegen that buffers are always before variables
+            replaced_arg = replace(variable.arg, slot = slot)
+            variable = variable.replace(arg = replaced_arg)
+            variables.append(variable)
+
+        assert len(variables) == len(variable_slots)
+
+        v_range = UOp.range(4, 0)
+
+        value = input_uop.index(v_range).load()
+        value = value * variables[0].cast(dtypes.float32)
+
+        for variable in variables[1:]:
+            value = value + variable.cast(dtypes.float32)
+
+        value = output_uop.index(v_range).store(value)
+        value = value.end(v_range)
+
+        kernel_name = f"commutative_params_order_{out_slot}_{in_slot}_"
+        kernel_name += "_".join(str(slot) for slot in variable_slots)
+
+        uop_graph_root = value.sink(arg=KernelInfo(name=kernel_name))
+
+        # self.assertTrue(Device.DEFAULT in Device)
+        default_renderer = Device[Device.DEFAULT].renderer
+
+        # okay, so now we have the program generated
+        program = to_program(ast = uop_graph_root, renderer = default_renderer)
+
+        program_signature = program.to_elf().signature
+
+        self.assertIsNotNone(program_signature)
+
+        # we need to make sure every parameter is in the right order
+        check_slots = [element[1] for element in program_signature]
+        self.assertEqual(check_slots, list(range(len(program_signature))))
+
+        # does the pre-linearized UOp graph align? note that
+        # from what I can tell the globals and vars are in from_sink
+        check_tuple = (in_slot, out_slot)
+        if out_slot < in_slot:
+            check_tuple = (out_slot, in_slot)
+
+        self.assertEqual(program.arg.globals, check_tuple)
+
+        program_arg_variable_splots = tuple(var.arg.slot for var in program.arg.vars)
+        self.assertEqual(program_arg_variable_splots, variable_slots)
+
+        # now we are done with "compile time" checks time to run the kernel
+
+        input_data = np.arange(4, dtype=np.float32)
+
+        output_buf = Buffer(device = Device.DEFAULT,
+                            size = 4,
+                            dtype = dtypes.float32).allocate()
+
+        # because we are passing initial_value, the allocation
+        # happens automatically
+        # todo(hayder): double check this later
+        input_buf = Buffer(device = Device.DEFAULT,
+                           size = 4,
+                           dtype = dtypes.float32,
+                           initial_value = input_data.tobytes())
+
+        runtime = get_runtime(device = Device.DEFAULT, ast = program)
+
+        global_size, local_size = program.arg.launch_dims(var_vals = {})
+
+        slot_to_buffer_map = {in_slot: input_buf, out_slot: output_buf}
+
+        # put the buffers in the order of the slots
+        device_specific_buffers = [slot_to_buffer_map[slot]._buf for slot in program.arg.globals]
+
+        runtime(*device_specific_buffers,
+                global_size = global_size,
+                local_size = local_size,
+                vals = values,
+                wait = True)
+
+        # we computed this above using the kernel
+        # now doing it in plain ol' python
+        expected_answer = input_data * values[0] + sum(values[1:])
+
+        # the output should be stored in... your guessed it!... the output buffer
+        actual_answer = np.frombuffer(output_buf.as_memoryview(), dtype=np.float32)
+
+        # todo: assert_equal instead of assert_allclose *should* be the right move
+        # here since we are storing an integer as a float and
+        # we are not testing between multiple backends, but confirm this
+        np.testing.assert_equal(actual_answer, expected_answer)
+
+    def test_commutative_params(self):
+        # now for some table driven tests (yes, i used to code in go)
+        cases = [
+            (0, 1, (2,), (3,)),
+            (1, 0, (2,), (2,)),
+            (1, 2, (0,), (3,)),
+            (2, 1, (0,), (3,)),
+            (0, 2, (1, 3), (4, 2)),
+            (3, 2, (0, 1), (2, 4)),
+        ]
+
+        for case in cases:
+            with self.subTest(case=case):
+                self._test_template(*case)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_function.py
+++ b/test/unit/test_function.py
@@ -578,7 +578,7 @@ class TestFunctionTuple(unittest.TestCase):
       sink = UOp.sink(C.base, A.base, arg=KernelInfo(name="k"))
       return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.LINEAR, src=(*sink.src, sink)),
                                    UOp(Ops.SOURCE, arg=src), UOp(Ops.BINARY, arg=lib)),
-                 arg=ProgramInfo(name="k", global_size=(1, 1, 1), local_size=(1, 1, 1), globals=(0, 1)))
+                 arg=ProgramInfo(name="k", global_size=(1, 1, 1), local_size=(1, 1, 1), globals=(0, 1), parameters=sink.src))
 
     @function(precompile=True)
     def f(a:Tensor):

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -349,11 +349,13 @@ class TinyELF:
     value_iterator = iter(values)
 
     def _next() -> Generator:
-      for _,_,_,_,addrspace in signature:
-        if addrspace is AddrSpace.ALU:
-          yield next(value_iterator)
-        else:
-          yield next(buffer_iterator)
+      current, previous_slot = None, None
+      for _,slot,_,_,addrspace in signature:
+        if slot != previous_slot:
+          previous_slot = slot
+          current = next(value_iterator) if addrspace is AddrSpace.ALU else next(buffer_iterator)
+        yield current
+
     return list(_next())
 
 

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 from dataclasses import dataclass, replace
 from collections import defaultdict
-from typing import Any, Callable, Generic, TypeVar, Iterator, Generator, Self, TYPE_CHECKING
+from typing import Sequence, Any, Callable, Generic, TypeVar, Iterator, Generator, Self, TYPE_CHECKING
 import importlib, inspect, functools, pathlib, os, contextlib, re, atexit, pickle, decimal, subprocess, struct
 from tinygrad.helpers import LRU, getenv, diskcache_get, diskcache_put, DEBUG, GlobalCounters, PROFILE, temp, colored
 from tinygrad.helpers import Context, CCACHE, ALLOW_DEVICE_USAGE, MAX_BUFFER_SIZE, cpu_events, ProfileEvent, ProfilePointEvent, suppress_finalizing
 from tinygrad.helpers import select_by_name, select_first_inited, DEV, TracingKey, size_to_str, pluralize, Target, unwrap, round_up
-from tinygrad.dtype import DType, _to_np_dtype
+from tinygrad.dtype import DType, _to_np_dtype, AddrSpace
 if TYPE_CHECKING: from tinygrad.renderer import Renderer
 
 # **************** Device ****************
@@ -326,14 +326,36 @@ class TinyELF:
   name: str
   target: Target
   # tuple of (name, slot, dtype, shape)
-  signature: tuple[tuple[str|None, int, DType, tuple], ...]
+  signature: tuple[tuple[str|None, int, DType, tuple, AddrSpace], ...]
   profile_key: bytes|None = None
 
   @staticmethod
-  def iter_sig(signature:tuple[tuple[str|None, int, DType, tuple], ...], offset:int=0) -> Generator[tuple[int, DType], None, None]:
-    for _,_,dt,_ in signature:
-      yield (offset:=round_up(offset, dt.itemsize)), dt
+  def iter_sig(signature:tuple[tuple[str|None, int, DType, tuple, AddrSpace], ...], offset:int=0) \
+    -> Generator[tuple[int, DType, AddrSpace], None, None]:
+    for _,_,dt,_,addrspace in signature:
+      # we need to handle buffers differently
+      if addrspace is not AddrSpace.ALU:
+        yield (offset:=round_up(offset, 8)), dt, addrspace
+        offset += 8
+        continue
+
+      yield (offset:=round_up(offset, dt.itemsize)), dt, addrspace
       offset += dt.itemsize
+
+  @staticmethod
+  def merge_args(signature:tuple[tuple[str|None, int, DType, tuple, AddrSpace], ...],
+                 buffers:Sequence, values:Sequence) -> list:
+    buffer_iterator = iter(buffers)
+    value_iterator = iter(values)
+
+    def _next() -> Generator:
+      for _,_,_,_,addrspace in signature:
+        if addrspace is AddrSpace.ALU:
+          yield next(value_iterator)
+        else:
+          yield next(buffer_iterator)
+    return list(_next())
+
 
 class Program(Generic[DeviceType]):
   def __init__(self, dev:DeviceType, obj:TinyELF): pass

--- a/tinygrad/runtime/graph/metal.py
+++ b/tinygrad/runtime/graph/metal.py
@@ -3,6 +3,7 @@ import ctypes, decimal, struct
 from tinygrad.helpers import dedup, getenv, unwrap, PROFILE
 from tinygrad.device import Buffer, Device, ProfileGraphEntry, ProfileGraphEvent
 from tinygrad.uop.ops import UOp, Ops
+from tinygrad.dtype import AddrSpace
 from tinygrad.engine.jit import GraphRunner, GraphException
 from tinygrad.runtime.ops_metal import MetalDevice, MetalAllocator, wait_check, to_ns_str
 from tinygrad.runtime.autogen import metal
@@ -26,7 +27,7 @@ class MetalGraph(GraphRunner):
 
     self.var_bind_data = []
     if len(self.vars):
-      self.var_buf = self.dev.allocator.alloc(sum(dt.itemsize for r in self.runtimes for (_,_,dt,s) in unwrap(r).signature if s == ()))
+      self.var_buf = self.dev.allocator.alloc(sum(dt.itemsize for r in self.runtimes for (_,_,dt,_,a) in unwrap(r).signature if a is AddrSpace.ALU))
       self.var_buf_view, var_buf_offset = cast(MetalAllocator, self.dev.allocator)._as_buffer(self.var_buf), 0
 
     all_pipelines, all_resources = [], [self.var_buf.buf] if len(self.vars) else []
@@ -35,12 +36,15 @@ class MetalGraph(GraphRunner):
       icb_command = self.icb.indirectComputeCommandAtIndex(j).retained()
       icb_command.setComputePipelineState(runtime.pipeline_state)
       all_pipelines.append(runtime.pipeline_state)
-      for i, b in enumerate(bufs):
-        if not any(pos == i for pos, _ in replace):
-          icb_command.setKernelBuffer_offset_atIndex(b._buf.buf, b._buf.offset, i)
+      buf_slots = [slot for _,slot,_,_,addrspace in runtime.signature if addrspace is not AddrSpace.ALU]
+      for pos, (slot, b) in enumerate(zip(buf_slots, bufs)):
+        if not any(p == pos for p, _ in replace):
+          icb_command.setKernelBuffer_offset_atIndex(b._buf.buf, b._buf.offset, slot)
           all_resources.append(b._buf.buf)
-      for nm,i,dt,_ in runtime.signature[len(bufs):]:
-        icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, i)
+      self.uop_replace[j] = [(buf_slots[pos], iidx) for pos, iidx in replace]
+      for nm,slot,dt,_,addrspace in runtime.signature:
+        if addrspace is not AddrSpace.ALU: continue
+        icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, slot)
         self.var_bind_data.append((nm, var_buf_offset, dt.fmt))
         var_buf_offset += dt.itemsize
       global_size, local_size = ast.arg.launch_dims({v: 0 for v in self.vars})
@@ -61,9 +65,9 @@ class MetalGraph(GraphRunner):
     updated_bufs = []
     for j in self.updatable:
       computeCommand = self.icb.indirectComputeCommandAtIndex(j)
-      for pos, iidx in self.uop_replace[j]:
+      for slot, iidx in self.uop_replace[j]:
         buf = cast(Buffer, input_uops[iidx].buffer)
-        computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, pos)
+        computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, slot)
         updated_bufs.append(buf._buf.buf)
 
     all_resources = dedup(self.all_resources + updated_bufs)

--- a/tinygrad/runtime/ops_cl.py
+++ b/tinygrad/runtime/ops_cl.py
@@ -6,6 +6,7 @@ from tinygrad.runtime.support import c
 from tinygrad.helpers import to_char_p_p, from_mv, OSX, DEBUG, mv_address, suppress_finalizing, unwrap, round_up, is_image_shape
 from tinygrad.renderer.cstyle import OpenCLRenderer
 from tinygrad.device import BufferSpec, LRUAllocator, Compiled, Compiler, CompileError, TinyELF, Program
+from tinygrad.dtype import AddrSpace
 
 CC_CB = c.CFUNCTYPE[None, [c.POINTER[ctypes.c_char], c.POINTER[None], cl.size_t, c.POINTER[None]]]
 BP_CB = c.CFUNCTYPE[None, [cl.cl_program, c.POINTER[None]]]
@@ -54,8 +55,8 @@ class CLProgram(Program['CLDevice']):
 
   def __call__(self, *bufs:cl.cl_mem, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]|None=None, vals:tuple[int, ...]=(),
                wait=False, **kw) -> float|None:
-    for i, (_, slot, dt, shape, _) in enumerate(self.signature):
-      b = bufs[slot] if slot < len(bufs) else getattr(ctypes, f"c_int{dt.bitsize}")(vals[slot-len(bufs)])
+    for a, (_, i, dt, shape, addrspace) in zip(TinyELF.merge_args(self.signature, bufs, vals), self.signature):
+      b = getattr(ctypes, f"c_int{dt.bitsize}")(a) if addrspace is AddrSpace.ALU else a
       if is_image_shape(shape):
         pitch = (round_up(shape[1], 256) if OSX else shape[1]) * 4 * dt.itemsize
         fmt = cl.cl_image_format(cl.CL_RGBA, {2:cl.CL_HALF_FLOAT, 4:cl.CL_FLOAT}[dt.itemsize])

--- a/tinygrad/runtime/ops_cl.py
+++ b/tinygrad/runtime/ops_cl.py
@@ -55,7 +55,7 @@ class CLProgram(Program['CLDevice']):
 
   def __call__(self, *bufs:cl.cl_mem, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]|None=None, vals:tuple[int, ...]=(),
                wait=False, **kw) -> float|None:
-    for a, (_, i, dt, shape, addrspace) in zip(TinyELF.merge_args(self.signature, bufs, vals), self.signature):
+    for i, (a, (_, _, dt, shape, addrspace)) in enumerate(zip(TinyELF.merge_args(self.signature, bufs, vals), self.signature)):
       b = getattr(ctypes, f"c_int{dt.bitsize}")(a) if addrspace is AddrSpace.ALU else a
       if is_image_shape(shape):
         pitch = (round_up(shape[1], 256) if OSX else shape[1]) * 4 * dt.itemsize

--- a/tinygrad/runtime/ops_cl.py
+++ b/tinygrad/runtime/ops_cl.py
@@ -54,7 +54,7 @@ class CLProgram(Program['CLDevice']):
 
   def __call__(self, *bufs:cl.cl_mem, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]|None=None, vals:tuple[int, ...]=(),
                wait=False, **kw) -> float|None:
-    for i, (_, slot, dt, shape) in enumerate(self.signature):
+    for i, (_, slot, dt, shape, _) in enumerate(self.signature):
       b = bufs[slot] if slot < len(bufs) else getattr(ctypes, f"c_int{dt.bitsize}")(vals[slot-len(bufs)])
       if is_image_shape(shape):
         pitch = (round_up(shape[1], 256) if OSX else shape[1]) * 4 * dt.itemsize

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -158,11 +158,12 @@ class CPUProgram(Program['CPUDevice']):
     if self.lvp:
       lvp_args = bytearray(12 + (len(bufs) + len(vals)) * 8)
       addr = mv_address(lvp_args)
-      struct.pack_into(f'<3I{len(bufs)}Q', lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2, *[b.va_addr for b in bufs])
-      for v,(off,dt) in zip(vals, TinyELF.iter_sig(self.signature[-len(vals):], len(bufs)*8)): struct.pack_into(f'<{dt.fmt}', lvp_args, 12+off, v)
+      struct.pack_into("<3I", lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2)
+      for v,(off,dt,addrspace) in zip(TinyELF.merge_args(self.signature, [b.va_addr for b in bufs], vals), TinyELF.iter_sig(self.signature)):
+        struct.pack_into(f'<{dt.fmt}' if addrspace is AddrSpace.ALU else '<Q', lvp_args, 12+off, v)
       self.fxn(addr)
     else:
-      args = [*[cast(int, b.va_addr) for b in bufs], *cast(tuple[int, ...], vals)]
+      args = TinyELF.merge_args(self.signature, [cast(int, b.va_addr) for b in bufs], cast(tuple[int, ...], vals))
       assert len(args) <= MAX_ARGS, f"CPU programs support at most {MAX_ARGS} arguments, got {len(args)}"
       for tid in range(global_size[0]):
         if 'core_id' in self.runtimevars: args[self.runtimevars['core_id']] = tid

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
-import ctypes
+import ctypes, itertools
 from tinygrad.helpers import DEBUG, DEV, getenv, mv_address, suppress_finalizing
 from tinygrad.device import Compiled, BufferSpec, LRUAllocator, Program, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.renderer.cstyle import CUDARenderer, NVCCRenderer
 from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.runtime.autogen import cuda
@@ -16,10 +17,11 @@ def check(status):
     raise RuntimeError(f"CUDA Error {status}, {error}")
 
 def encode_args(args, vals, signature) -> tuple[ctypes.Structure, ctypes.Array]:
-  fields = ([(f'f{i}', cuda.CUdeviceptr_v2, i*8) for i in range(len(args))] +
-            [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), off)
-             for i,(off,dt,_) in enumerate(TinyELF.iter_sig(signature[len(args):], len(args)*8))])
-  c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
+  nbufs, nvals = itertools.count(), itertools.count()
+  fields = [(f'v{next(nvals)}', getattr(ctypes, f"c_int{dt.bitsize}"), off) if addrspace is AddrSpace.ALU else
+            (f'f{next(nbufs)}', cuda.CUdeviceptr_v2, off) for off,dt,addrspace in TinyELF.iter_sig(signature)]
+  c_args_t = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))
+  c_args = c_args_t(*TinyELF.merge_args(signature, args, vals))
   vargs = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), ctypes.cast(ctypes.byref(c_args), ctypes.c_void_p), ctypes.c_void_p(2),
                                 ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(c_args))), ctypes.c_void_p), ctypes.c_void_p(0))
   return c_args, vargs

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -17,7 +17,8 @@ def check(status):
 
 def encode_args(args, vals, signature) -> tuple[ctypes.Structure, ctypes.Array]:
   fields = ([(f'f{i}', cuda.CUdeviceptr_v2, i*8) for i in range(len(args))] +
-            [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), off) for i,(off,dt) in enumerate(TinyELF.iter_sig(signature[len(args):], len(args)*8))])
+            [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), off)
+             for i,(off,dt,_) in enumerate(TinyELF.iter_sig(signature[len(args):], len(args)*8))])
   c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
   vargs = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), ctypes.cast(ctypes.byref(c_args), ctypes.c_void_p), ctypes.c_void_p(2),
                                 ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(c_args))), ctypes.c_void_p), ctypes.c_void_p(0))

--- a/tinygrad/runtime/ops_dsp.py
+++ b/tinygrad/runtime/ops_dsp.py
@@ -66,7 +66,7 @@ class DSPProgram(Program['DSPDevice']):
     pra, fds, attrs, _ = rpc_prep_args(ins=[var_vals_mv:=memoryview(bytearray((len(bufs)+len(vals))*8)), off_mv:=memoryview(bytearray(len(bufs)*4))],
                                        outs=[timer:=memoryview(bytearray(8)).cast('Q')], in_fds=[b.share_info.fd for b in bufs])
     for i,b in enumerate(bufs): struct.pack_into('i', var_vals_mv, i*8, b.size)
-    for i,(v,(_,_,dt,_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
+    for i,(v,(_,_,dt,_,_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
     off_mv.cast('I')[:] = array.array('I', tuple(b.offset for b in bufs))
     self.dev.exec_lib(self.lib, rpc_sc(method=2, ins=2, outs=1, fds=len(bufs)), pra, fds, attrs)
     return timer[0] / 1e6
@@ -282,7 +282,7 @@ class MockDSPProgram(Program[DSPDevice]):
       os.chmod(dsp_lib.name, 0o0777)
       proc = subprocess.run(["qemu-hexagon-static", *(['-strace'] if DEBUG >= 5 else []), dsp_lib.name],
         input=b''.join([bytes(to_mv(x.va_addr, x.size)) for x in bufs] +
-                       [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,_) in zip(vals, self.signature[len(bufs):])]),
+                       [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,_,_) in zip(vals, self.signature[len(bufs):])]),
         stdout=subprocess.PIPE, check=True)
     offset = 4
     for x in bufs:

--- a/tinygrad/runtime/ops_dsp.py
+++ b/tinygrad/runtime/ops_dsp.py
@@ -33,9 +33,9 @@ class DSPRenderer(ClangRenderer):
     msrc += [f'{self._render_dtype(b[1][0].dtype) if b[1][0].addrspace == AddrSpace.ALU else "int"} sz_or_val_{i} = '
              f'*({self._render_dtype(b[1][0].dtype) if b[1][0].addrspace == AddrSpace.ALU else "int"}*)((char*)pra[0].buf.pv+{i*8});'
              for i,b in enumerate(bufs)]
-    msrc += [f'int off{i} = ((int*)pra[1].buf.pv)[{i}];' for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
-    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{i+3}].dma.fd,0)+off{i};'
-             for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
+    gbufs = [i for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
+    msrc += [f'int off{i} = ((int*)pra[1].buf.pv)[{j}];' for j,i in enumerate(gbufs)]
+    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{j+3}].dma.fd,0)+off{i};' for j,i in enumerate(gbufs)]
     msrc += ["unsigned long long start = HAP_perf_get_time_us();"]
     fbufs = [(f'buf_{i}' if b[1][0].addrspace == AddrSpace.GLOBAL else f'sz_or_val_{i}') for i,b in enumerate(bufs)]
     msrc += [f"{function_name}({', '.join(fbufs)});"]
@@ -65,8 +65,9 @@ class DSPProgram(Program['DSPDevice']):
 
     pra, fds, attrs, _ = rpc_prep_args(ins=[var_vals_mv:=memoryview(bytearray((len(bufs)+len(vals))*8)), off_mv:=memoryview(bytearray(len(bufs)*4))],
                                        outs=[timer:=memoryview(bytearray(8)).cast('Q')], in_fds=[b.share_info.fd for b in bufs])
-    for i,b in enumerate(bufs): struct.pack_into('i', var_vals_mv, i*8, b.size)
-    for i,(v,(_,_,dt,_,_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
+    for i,(a,(_,_,dt,_,addrspace)) in enumerate(zip(TinyELF.merge_args(self.signature, bufs, vals), self.signature)):
+      if addrspace is AddrSpace.ALU: struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, a)
+      else: struct.pack_into('i', var_vals_mv, i*8, a.size)
     off_mv.cast('I')[:] = array.array('I', tuple(b.offset for b in bufs))
     self.dev.exec_lib(self.lib, rpc_sc(method=2, ins=2, outs=1, fds=len(bufs)), pra, fds, attrs)
     return timer[0] / 1e6
@@ -281,8 +282,8 @@ class MockDSPProgram(Program[DSPDevice]):
       dsp_lib.flush()
       os.chmod(dsp_lib.name, 0o0777)
       proc = subprocess.run(["qemu-hexagon-static", *(['-strace'] if DEBUG >= 5 else []), dsp_lib.name],
-        input=b''.join([bytes(to_mv(x.va_addr, x.size)) for x in bufs] +
-                       [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,_,_) in zip(vals, self.signature[len(bufs):])]),
+        input=b''.join([struct.pack(unwrap(dt.fmt), a) if addrspace is AddrSpace.ALU else bytes(to_mv(a.va_addr, a.size))
+                        for a,(_,_,dt,_,addrspace) in zip(TinyELF.merge_args(self.signature, bufs, vals), self.signature)]),
         stdout=subprocess.PIPE, check=True)
     offset = 4
     for x in bufs:

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -38,7 +38,7 @@ class HIPProgram(Program[HIPDevice]):
     check(hip.hipSetDevice(self.dev.device_id))
     if not hasattr(self, "vargs"):
       fields = ([(f'f{i}', hip.hipDeviceptr_t, i*8) for i in range(len(args))] +
-        [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), o) for i,(o,dt) in enumerate(TinyELF.iter_sig(self.signature[len(args):], len(args)*8))])
+        [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), o) for i,(o,dt,_) in enumerate(TinyELF.iter_sig(self.signature[len(args):], len(args)*8))])
       self.c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
       self.vargs = (ctypes.c_void_p * 5)(1, ctypes.cast(ctypes.byref(self.c_args), ctypes.c_void_p), 2,
                                          ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(self.c_args))), ctypes.c_void_p), 3)

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -1,6 +1,7 @@
-import ctypes
+import ctypes, itertools
 from tinygrad.helpers import mv_address, getenv, suppress_finalizing
 from tinygrad.device import Compiled, LRUAllocator, BufferSpec, Program, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.runtime.autogen import hip
 from tinygrad.renderer.cstyle import HIPRenderer
 from tinygrad.runtime.support.c import init_c_var, init_c_struct_t
@@ -37,9 +38,11 @@ class HIPProgram(Program[HIPDevice]):
   def __call__(self, *args, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(), wait=False, **kw):
     check(hip.hipSetDevice(self.dev.device_id))
     if not hasattr(self, "vargs"):
-      fields = ([(f'f{i}', hip.hipDeviceptr_t, i*8) for i in range(len(args))] +
-        [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), o) for i,(o,dt,_) in enumerate(TinyELF.iter_sig(self.signature[len(args):], len(args)*8))])
-      self.c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
+      nbufs, nvals = itertools.count(), itertools.count()
+      fields = [(f'v{next(nvals)}', getattr(ctypes, f"c_int{dt.bitsize}"), o) if addrspace is AddrSpace.ALU else
+                (f'f{next(nbufs)}', hip.hipDeviceptr_t, o) for o,dt,addrspace in TinyELF.iter_sig(self.signature)]
+      self.c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(
+        *TinyELF.merge_args(self.signature, args, vals))
       self.vargs = (ctypes.c_void_p * 5)(1, ctypes.cast(ctypes.byref(self.c_args), ctypes.c_void_p), 2,
                                          ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(self.c_args))), ctypes.c_void_p), 3)
 

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -139,7 +139,7 @@ class MetalProgram(Program[MetalDevice]):
     encoder = command_buffer.computeCommandEncoder().retained()
     encoder.setComputePipelineState(self.pipeline_state)
     for i,a in enumerate(bufs): encoder.setBuffer_offset_atIndex(a.buf, a.offset, i)
-    for a,(_,i,dt,_) in zip(vals, self.signature[len(bufs):]):
+    for a,(_,i,dt,_,_) in zip(vals, self.signature[len(bufs):]):
       encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(a)), dt.itemsize, i)
     encoder.dispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
     encoder.endEncoding()

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -2,6 +2,7 @@ import subprocess, pathlib, struct, ctypes, tempfile, functools, decimal, platfo
 from tinygrad.helpers import prod, to_mv, round_up, cache_dir, PROFILE, ProfileRangeEvent, cpu_profile, unwrap, suppress_finalizing
 import tinygrad.runtime.support.objc as objc
 from tinygrad.device import Compiled, Compiler, CompileError, Program, TinyELF, LRUAllocator, ProfileDeviceEvent
+from tinygrad.dtype import AddrSpace
 from tinygrad.renderer.cstyle import MetalRenderer
 from tinygrad.runtime.autogen import metal
 from tinygrad.runtime.support.c import DLL
@@ -138,9 +139,9 @@ class MetalProgram(Program[MetalDevice]):
     command_buffer = self.dev.mtl_queue.commandBuffer().retained()
     encoder = command_buffer.computeCommandEncoder().retained()
     encoder.setComputePipelineState(self.pipeline_state)
-    for i,a in enumerate(bufs): encoder.setBuffer_offset_atIndex(a.buf, a.offset, i)
-    for a,(_,i,dt,_,_) in zip(vals, self.signature[len(bufs):]):
-      encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(a)), dt.itemsize, i)
+    for a,(_,i,dt,_,addrspace) in zip(TinyELF.merge_args(self.signature, bufs, vals), self.signature):
+      if addrspace is AddrSpace.ALU: encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(a)), dt.itemsize, i)
+      else: encoder.setBuffer_offset_atIndex(a.buf, a.offset, i)
     encoder.dispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
     encoder.endEncoding()
     command_buffer.setLabel(to_ns_str(self.name)) # TODO: is this always needed?

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -3,7 +3,8 @@ import os, ctypes, contextlib, re, functools, mmap, struct, array, sys, weakref
 assert sys.platform != 'win32'
 from typing import cast
 from dataclasses import dataclass
-from tinygrad.runtime.support.hcq import HCQCompiled, HCQAllocator, HCQBuffer, HWQueue, CLikeArgsState, HCQProgram, HCQSignal, BumpAllocator
+from tinygrad.runtime.support.hcq import HCQCompiled, HCQAllocator, HCQBuffer, HWQueue, CLikeArgsState, HCQArgsState, HCQProgram, HCQSignal
+from tinygrad.runtime.support.hcq import BumpAllocator
 from tinygrad.runtime.support.hcq import MMIOInterface, FileIOInterface, hcq_filter_visible_devices, hcq_profile
 from tinygrad.uop.ops import sint
 from tinygrad.device import Compiled, BufferSpec, TinyELF
@@ -240,10 +241,12 @@ class NVVideoQueue(NVCommandQueue):
 
 class NVArgsState(CLikeArgsState):
   def __init__(self, buf:HCQBuffer, prg:NVProgram, bufs:tuple[HCQBuffer, ...], vals:tuple[int, ...]=()):
-    if (is_mock:=isinstance(prg.dev.iface, MOCKIface)): prg.cbuf_0[80:82] = [len(bufs), len(vals)]
-    super().__init__(buf, prg, bufs, vals=() if is_mock else vals, prefix=prg.cbuf_0 or None)
-    # mock expects all vars to be 64 bit
-    if is_mock and vals: self.bind_sints_to_buf(*vals, buf=self.buf, fmt='q', offset=len(prg.cbuf_0)*4 + len(bufs)*8)
+    if not isinstance(prg.dev.iface, MOCKIface): super().__init__(buf, prg, bufs, vals=vals, prefix=prg.cbuf_0 or None)
+    else:
+      HCQArgsState.__init__(self, buf, prg, bufs, vals=vals)
+      prg.cbuf_0[80:82] = [len(bufs)+len(vals), 0]
+      self.buf.cpu_view().view(size=len(prg.cbuf_0) * 4, fmt='I')[:] = array.array('I', prg.cbuf_0)
+      self.bind_sints_to_buf(*TinyELF.merge_args(prg.signature, [b.va_addr for b in bufs], vals), buf=self.buf, fmt='q', offset=len(prg.cbuf_0)*4)
 
 class NVProgram(HCQProgram['NVDevice']):
   def __init__(self, dev:NVDevice, obj:TinyELF):

--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -203,8 +203,8 @@ class QCOMArgsState(HCQArgsState):
     super().__init__(buf, prg, bufs, vals=vals)
     ctypes.memset(int(self.buf.va_addr), 0, prg.kernargs_alloc_size)
 
-    ubos = [bufs[slot] for _,slot,_,shape in prg.signature if slot < len(bufs) and not is_image_shape(shape)]
-    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape in prg.signature if slot < len(bufs) and is_image_shape(shape)]
+    ubos = [bufs[slot] for _,slot,_,shape,_ in prg.signature if slot < len(bufs) and not is_image_shape(shape)]
+    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape,_ in prg.signature if slot < len(bufs) and is_image_shape(shape)]
     # NIR can reorder images to different texture slots
     ibos, texs = uavs[:prg.ibo_cnt], [uavs[prg.ibo_cnt + (prg.tex_to_image[i] if prg.NIR else i)] for i in range(prg.tex_cnt)]
     for cnst_val,cnst_off,cnst_sz in prg.consts_info:
@@ -213,11 +213,11 @@ class QCOMArgsState(HCQArgsState):
     if prg.samp_cnt > 0: to_mv(int(self.buf.va_addr) + prg.samp_off, len(prg.samplers) * 4).cast('I')[:] = array.array('I', prg.samplers)
     if prg.NIR:
       self.bind_sints_to_buf(*[b.va_addr for b in ubos], buf=self.buf, fmt='Q', offset=prg.buf_off)
-      for v,(o,dt) in zip(vals, TinyELF.iter_sig(prg.signature[len(bufs):], len(ubos)*8)):
+      for v,(o,dt,_) in zip(vals, TinyELF.iter_sig(prg.signature[len(bufs):], len(ubos)*8)):
         self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_off + o)
     else:
       for i, b in enumerate(ubos): self.bind_sints_to_buf(b.va_addr, buf=self.buf, fmt='Q', offset=prg.buf_offs[i])
-      for i,(v,(_,_,dt,_)) in enumerate(zip(vals, prg.signature[len(bufs):])):
+      for i,(v,(_,_,dt,_,_)) in enumerate(zip(vals, prg.signature[len(bufs):])):
         self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_offs[i+len(ubos)])
 
     def _tex(b, ibo=False):

--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -203,8 +203,9 @@ class QCOMArgsState(HCQArgsState):
     super().__init__(buf, prg, bufs, vals=vals)
     ctypes.memset(int(self.buf.va_addr), 0, prg.kernargs_alloc_size)
 
-    ubos = [bufs[slot] for _,slot,_,shape,_ in prg.signature if slot < len(bufs) and not is_image_shape(shape)]
-    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape,_ in prg.signature if slot < len(bufs) and is_image_shape(shape)]
+    args = list(zip(TinyELF.merge_args(prg.signature, bufs, vals), prg.signature))
+    consts = [(a.va_addr if addrspace is not AddrSpace.ALU else a, dt, addrspace) for a,(_,_,dt,shape,addrspace) in args if not is_image_shape(shape)]
+    uavs = [(dt,shape,a) for a,(_,_,dt,shape,addrspace) in args if addrspace is not AddrSpace.ALU and is_image_shape(shape)]
     # NIR can reorder images to different texture slots
     ibos, texs = uavs[:prg.ibo_cnt], [uavs[prg.ibo_cnt + (prg.tex_to_image[i] if prg.NIR else i)] for i in range(prg.tex_cnt)]
     for cnst_val,cnst_off,cnst_sz in prg.consts_info:
@@ -212,13 +213,9 @@ class QCOMArgsState(HCQArgsState):
 
     if prg.samp_cnt > 0: to_mv(int(self.buf.va_addr) + prg.samp_off, len(prg.samplers) * 4).cast('I')[:] = array.array('I', prg.samplers)
     if prg.NIR:
-      self.bind_sints_to_buf(*[b.va_addr for b in ubos], buf=self.buf, fmt='Q', offset=prg.buf_off)
-      for v,(o,dt,_) in zip(vals, TinyELF.iter_sig(prg.signature[len(bufs):], len(ubos)*8)):
-        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_off + o)
-    else:
-      for i, b in enumerate(ubos): self.bind_sints_to_buf(b.va_addr, buf=self.buf, fmt='Q', offset=prg.buf_offs[i])
-      for i,(v,(_,_,dt,_,_)) in enumerate(zip(vals, prg.signature[len(bufs):])):
-        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_offs[i+len(ubos)])
+      offs = [o for o,_,_ in TinyELF.iter_sig(tuple(s for _,s in args if not is_image_shape(s[3])), prg.buf_off)]
+    else: offs = prg.buf_offs
+    for (v,dt,addrspace),o in zip(consts, offs): self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt if addrspace is AddrSpace.ALU else 'Q', offset=o)
 
     def _tex(b, ibo=False):
       imgdt, shape, buf = b

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -1,5 +1,6 @@
 import functools, struct
 from tinygrad.device import Compiled, Allocator, BufferSpec, Program, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.renderer.wgsl import WGSLRenderer
 from tinygrad.helpers import round_up, suppress_finalizing, getenv, to_mv
 from tinygrad.runtime.autogen import webgpu
@@ -51,7 +52,7 @@ QueueOnSubmittedWorkDone = synchronous(webgpu.enum_WGPUQueueWorkDoneStatus)(webg
 
 class WebGPUProgram(Program['WebGpuDevice']):
   def __init__(self, dev:'WebGpuDevice', obj:TinyELF):
-    self.dev, self.name = dev, to_wgpu_str(obj.name)
+    self.dev, self.name, self.signature = dev, to_wgpu_str(obj.name), obj.signature
 
     # Creating shader module
     shader = webgpu.WGPUShaderModuleWGSLDescriptor(code=to_wgpu_str(obj.lib.decode()),
@@ -74,8 +75,8 @@ class WebGPUProgram(Program['WebGpuDevice']):
     def bgl_entry(n:int, ty:str):
       return webgpu.WGPUBindGroupLayoutEntry(binding=n, visibility=webgpu.WGPUShaderStage_Compute,
                                              buffer=webgpu.WGPUBufferBindingLayout(type=getattr(webgpu, f'WGPUBufferBindingType_{ty}')))
-    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(bufs)+len(vals)))(
-      bgl_entry(0, 'Uniform'), *(bgl_entry(i+1, 'Uniform' if i >= len(bufs) else 'Storage') for i in range(len(bufs)+len(vals))))
+    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(self.signature)))(bgl_entry(0, 'Uniform'),
+      *(bgl_entry(i+1, 'Uniform' if addrspace is AddrSpace.ALU else 'Storage') for i,(*_,addrspace) in enumerate(self.signature)))
 
     webgpu.wgpuDevicePushErrorScope(self.dev.device_res, webgpu.WGPUErrorFilter_Validation)
     bind_layout = webgpu.wgpuDeviceCreateBindGroupLayout(self.dev.device_res,
@@ -94,7 +95,8 @@ class WebGPUProgram(Program['WebGpuDevice']):
     def bg_entry(n:int, x:webgpu.WGPUBuffer|int|float):
       buf = x if isinstance(x, webgpu.WGPUBuffer) else self.dev.create_uniform(x)
       return webgpu.WGPUBindGroupEntry(binding=n, buffer=buf, offset=0, size=webgpu.wgpuBufferGetSize(buf))
-    bindings = (webgpu.WGPUBindGroupEntry * (1+len(bufs)+len(vals)))(bg_entry(0, float('inf')), *(bg_entry(i+1, x) for i,x in enumerate(bufs+vals)))
+    args = TinyELF.merge_args(self.signature, bufs, vals)
+    bindings = (webgpu.WGPUBindGroupEntry * (1+len(args)))(bg_entry(0, float('inf')), *(bg_entry(i+1, x) for i,x in enumerate(args)))
 
     bind_group_desc = webgpu.WGPUBindGroupDescriptor(layout=bind_layout, entryCount=len(bindings), entries=bindings)
     webgpu.wgpuDevicePushErrorScope(self.dev.device_res, webgpu.WGPUErrorFilter_Validation)

--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -6,6 +6,7 @@ except ImportError: fcntl = None #type:ignore[assignment]
 from tinygrad.helpers import DEV, PROFILE, getenv, from_mv, cpu_profile, ProfileRangeEvent, unwrap
 from tinygrad.helpers import suppress_finalizing, pluralize, TracingKey
 from tinygrad.device import Device, BufferSpec, Compiled, LRUAllocator, ProfileDeviceEvent, ProfileProgramEvent, Program, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.uop.ops import sym_infer, sint, UOp
 from tinygrad.runtime.autogen import libc
 from tinygrad.runtime.support.memory import BumpAllocator, MMIOInterface
@@ -318,10 +319,9 @@ class CLikeArgsState(HCQArgsState[ProgramType]):
 
     if prefix is not None: self.buf.cpu_view().view(size=len(prefix) * 4, fmt='I')[:] = array.array('I', prefix)
 
-    self.bind_sints_to_buf(*[b.va_addr for b in bufs], buf=self.buf, fmt='Q', offset=len(prefix or []) * 4)
-    for v,(val_offset,dt,_) in zip(vals, TinyELF.iter_sig(prg.signature[-len(vals):], len(bufs) * 8)):
+    for v,(off,dt,addrspace) in zip(TinyELF.merge_args(prg.signature, [b.va_addr for b in bufs], vals), TinyELF.iter_sig(prg.signature)):
       assert v is not None
-      self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=len(prefix or []) * 4 + val_offset)
+      self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt if addrspace is AddrSpace.ALU else 'Q', offset=len(prefix or []) * 4 + off)
 
 class HCQProgram(Program[HCQDeviceType]):
   def __init__(self, args_state_t:Type[HCQArgsState], dev:HCQDeviceType, obj:TinyELF, kernargs_alloc_size:int, base:int|None=None):

--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -319,7 +319,7 @@ class CLikeArgsState(HCQArgsState[ProgramType]):
     if prefix is not None: self.buf.cpu_view().view(size=len(prefix) * 4, fmt='I')[:] = array.array('I', prefix)
 
     self.bind_sints_to_buf(*[b.va_addr for b in bufs], buf=self.buf, fmt='Q', offset=len(prefix or []) * 4)
-    for v,(val_offset,dt) in zip(vals, TinyELF.iter_sig(prg.signature[-len(vals):], len(bufs) * 8)):
+    for v,(val_offset,dt,_) in zip(vals, TinyELF.iter_sig(prg.signature[-len(vals):], len(bufs) * 8)):
       assert v is not None
       self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=len(prefix or []) * 4 + val_offset)
 

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1217,7 +1217,9 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
 
   def to_elf(self) -> TinyELF:
     assert self.op is Ops.PROGRAM and isinstance(self.arg, ProgramInfo), "to_elf should only be called on a PROGRAM ast"
-    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape, u.addrspace) for u in self.arg.parameters)
+    render_order = {u:i for i,u in enumerate(self.src[1].src) if u.op is Ops.PARAM}
+    params = sorted(self.arg.parameters, key=lambda u: (u.arg.slot, render_order.get(u, 0)))
+    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape, u.addrspace) for u in params)
     return TinyELF(self.src[3].arg, self.arg.function_name, self.arg.target, sig, self.key)
 
 @dataclass(frozen=True)

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1217,21 +1217,7 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
 
   def to_elf(self) -> TinyELF:
     assert self.op is Ops.PROGRAM and isinstance(self.arg, ProgramInfo), "to_elf should only be called on a PROGRAM ast"
-    # instead of only storing Buffers we need to store both variables and buffers
-    parameters = set(u for u in self.src[1].src if u.op is Ops.PARAM)
-
-    # adding this because the old code had, i am not convinced this is necessary
-    # todo: double check if this is necessary
-    variables = set(self.arg.vars)
-
-    parameters = parameters.union(variables)
-    sorted_parameters = sorted(parameters, key=lambda u: u.arg.slot)
-
-    # we need the address space now because the compiler cannot assume
-    # something is a buffer or variable from the position so it
-    # will have to do the != AddrSpace.ALU check to see if something is a buffer.
-    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape, u.addrspace)
-                for u in sorted_parameters)
+    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape, u.addrspace) for u in self.arg.parameters)
     return TinyELF(self.src[3].arg, self.arg.function_name, self.arg.target, sig, self.key)
 
 @dataclass(frozen=True)
@@ -1256,6 +1242,7 @@ class ProgramInfo:
   outs: tuple[int, ...] = ()
   ins: tuple[int, ...] = ()
   target: Target = Target()
+  parameters: tuple[UOp, ...] = ()
 
   @property
   def function_name(self): return to_function_name(self.name)
@@ -1274,15 +1261,14 @@ class ProgramInfo:
 
   @staticmethod
   def from_sink(sink:UOp, target:Target=Target()) -> ProgramInfo:
-    _vars: list[UOp] = []
-    _globals: list[int] = []
+    parameters: list[UOp] = []
     outs: list[int] = []
     ins: list[int] = []
     global_size: list[int] = [1, 1, 1]
     local_size: list[int]|None = [1, 1, 1]
     for u in sink.toposort():
-      if u.op is Ops.PARAM and u.addrspace == AddrSpace.ALU: _vars.append(u)
-      if u.op is Ops.PARAM and u.addrspace != AddrSpace.ALU: _globals.append(u.arg.slot)
+      if u.op is Ops.PARAM:
+        parameters.append(u)
       if u.op in (Ops.STORE, Ops.LOAD):
         if (idx:=u.src[0]).op in (Ops.INDEX, Ops.SHRINK) or (u.src[0].op is Ops.CAST and (idx:=u.src[0].src[0]).op is Ops.INDEX):
           if (buf:=idx.src[0].buf_uop).op is Ops.PARAM: (outs if u.op is Ops.STORE else ins).append(buf.arg.slot)
@@ -1290,10 +1276,12 @@ class ProgramInfo:
         if u.arg[0] == 'i': local_size = None
         special_size = local_size if u.arg[0] == 'l' else global_size
         if special_size is not None: special_size[int(u.arg[-1])] = cast(int, u.src[0].ssimplify())
-      if u.op is Ops.PARAM and u in _vars and u.expr == 'core_id': global_size[0] = int(u.vmax) + 1
+      if u.op is Ops.PARAM and u.addrspace == AddrSpace.ALU and u.expr == 'core_id': global_size[0] = int(u.vmax) + 1
+    parameters = sorted(parameters, key=lambda u: u.arg.slot)
     return ProgramInfo(sink.arg.name if isinstance(sink.arg, KernelInfo) else "test", tuple(global_size),
-                       tuple(local_size) if local_size is not None else None, tuple(sorted(dedup(_vars), key=lambda v: v.arg.slot)),
-                       tuple(sorted(dedup(_globals))), tuple(sorted(dedup(outs))), tuple(sorted(dedup(ins))), target)
+                       tuple(local_size) if local_size is not None else None, tuple(u for u in parameters if u.addrspace == AddrSpace.ALU),
+                       tuple(sorted(dedup(u.arg.slot for u in parameters if u.addrspace != AddrSpace.ALU))), tuple(sorted(dedup(outs))),
+                       tuple(sorted(dedup(ins))), target, tuple(parameters))
 
 @dataclass(frozen=True)
 class CallInfo:

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1217,8 +1217,21 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
 
   def to_elf(self) -> TinyELF:
     assert self.op is Ops.PROGRAM and isinstance(self.arg, ProgramInfo), "to_elf should only be called on a PROGRAM ast"
-    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape)
-                for u in tuple(filter(lambda u: u.op is Ops.PARAM and u.addrspace != AddrSpace.ALU, self.src[1].src)) + self.arg.vars)
+    # instead of only storing Buffers we need to store both variables and buffers
+    parameters = set(u for u in self.src[1].src if u.op is Ops.PARAM)
+
+    # adding this because the old code had, i am not convinced this is necessary
+    # todo: double check if this is necessary
+    variables = set(self.arg.vars)
+
+    parameters = parameters.union(variables)
+    sorted_parameters = sorted(parameters, key=lambda u: u.arg.slot)
+
+    # we need the address space now because the compiler cannot assume
+    # something is a buffer or variable from the position so it
+    # will have to do the != AddrSpace.ALU check to see if something is a buffer.
+    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape, u.addrspace)
+                for u in sorted_parameters)
     return TinyELF(self.src[3].arg, self.arg.function_name, self.arg.target, sig, self.key)
 
 @dataclass(frozen=True)


### PR DESCRIPTION
my initial and misguided attempt at this change can be found in this (rightfully) closed pr: https://github.com/tinygrad/tinygrad/pull/17786 apologies to @geohot for that and thank you for their patience with me.

as mentioned in the closed pr, i am following a test driven development approach here. I began with setting up some invariants which make sense if we want buffers and args to be supported in any order. i plug all the PARAMs with their addrspace in the order of the slots in the ProgramInfo class. The idea is for a given backend's runtime to be able to use this to distinguish between a buffer and a variable instead of distinguishing based on the position of the argument. I then did some surgery on TinyELF with the following reasoning: 

1) To help backends (e.g CUDA) that pack everything into a single contiguous memory block / packed C struct i yield the right byte offsets in `TinyELF.iter_sig`. 
2) To help backends (e.g CPU) that pass the arguments directly (and the other backends since I `zip` this), i make `TinyELF.merge_args` walk the signature and put the arguments in the right sequence

I went and then fixed every backend's runtime (except for python and null) so the runtime walks the ELF's signature instead of making the assumpton that buffers are placed before values.

For the tests I added, here is my reasoning:
1) interleaving buffer and variable slots should work

I noticed that the CI test for DEV=CPU:X86 failed which motivated changes to my code and this second test:

2. a kernel with more than 6 arguments should work (rules out linux and macOS issues at 6 and windows issues at 4 after which both pass the remaining arguments into the stack instead of in registers).

I noticed that the CL Image tests were failing and after some probing I was able to find an example in the logs:

```
(slot 0, int, (5,)), (slot 1, float, (5,)), (slot 1, float, (1,1,4)), (slot 2, float, (5,))
```

tinygrad's compiler emits two PARAMs for a single buffer. After understanding texture units, I figured out the issue and fixed this. This motivated the final test. 

3) if a kernel reads the same exact buffer as an image and as a pointer, nothing should break

