### PR TITLE
CUDA 12 GPUOcelot sm_86 support

### DIFF
--- a/.github/actions/setup-tinygrad/action.yml
+++ b/.github/actions/setup-tinygrad/action.yml
@@ -262,7 +262,7 @@ runs:
       shell: bash
       run: |
         sudo mkdir -p /usr/local/lib
-        sudo curl --output-dir /usr/local/lib -fLO https://github.com/li0nr/gpuocelot/releases/download/cuda-12-support/libgpuocelot.${{ runner.os == 'Linux' && 'so' || 'dylib' }}
+        sudo curl --output-dir /usr/local/lib -fLO https://github.com/li0nr/gpuocelot/releases/download/cuda-12-support-v2/libgpuocelot.${{ runner.os == 'Linux' && 'so' || 'dylib' }}
 
     # **** WebGPU ****
 

--- a/.github/actions/setup-tinygrad/action.yml
+++ b/.github/actions/setup-tinygrad/action.yml
@@ -262,7 +262,7 @@ runs:
       shell: bash
       run: |
         sudo mkdir -p /usr/local/lib
-        sudo curl --output-dir /usr/local/lib -fLO https://github.com/li0nr/gpuocelot/releases/download/cuda-12-support-v2/libgpuocelot.${{ runner.os == 'Linux' && 'so' || 'dylib' }}
+        sudo curl --output-dir /usr/local/lib -fLO https://github.com/li0nr/gpuocelot/releases/download/cuda-12-support/libgpuocelot.${{ runner.os == 'Linux' && 'so' || 'dylib' }}
 
     # **** WebGPU ****
 

--- a/.github/actions/setup-tinygrad/action.yml
+++ b/.github/actions/setup-tinygrad/action.yml
@@ -262,7 +262,7 @@ runs:
       shell: bash
       run: |
         sudo mkdir -p /usr/local/lib
-        sudo curl --output-dir /usr/local/lib -fLO https://github.com/tinygrad/gpuocelot/releases/download/v0.1.0/libgpuocelot.${{ runner.os == 'Linux' && 'so' || 'dylib' }}
+        sudo curl --output-dir /usr/local/lib -fLO https://github.com/li0nr/gpuocelot/releases/download/cuda-12-support/libgpuocelot.${{ runner.os == 'Linux' && 'so' || 'dylib' }}
 
     # **** WebGPU ****
 

--- a/.github/actions/setup-tinygrad/action.yml
+++ b/.github/actions/setup-tinygrad/action.yml
@@ -251,7 +251,7 @@ runs:
       shell: bash
       run: |
         sudo mkdir -p /usr/local/cuda/targets/x86_64-linux
-        curl -fL https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/linux-x86_64/cuda_nvrtc-linux-x86_64-11.5.119-archive.tar.xz \
+        curl -fL https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/linux-x86_64/cuda_nvrtc-linux-x86_64-12.9.86-archive.tar.xz \
           | sudo tar -xJ -C /usr/local/cuda/targets/x86_64-linux --strip-components=1
         echo /usr/local/cuda/targets/x86_64-linux/lib | sudo tee /etc/ld.so.conf.d/cuda-nvrtc.conf
         sudo ldconfig

--- a/test/mockgpu/nv/nvdriver.py
+++ b/test/mockgpu/nv/nvdriver.py
@@ -168,7 +168,7 @@ class NVDriver(VirtDriver):
       else:
         for i,c in enumerate(classes): params.classList[i] = c
     elif struct.cmd == nv_gpu.NV2080_CTRL_CMD_GR_GET_INFO:
-      info = {nv_gpu.NV2080_CTRL_GR_INFO_INDEX_SM_VERSION: nv_gpu.NV2080_CTRL_GR_INFO_SM_VERSION_3_5,
+      info = {nv_gpu.NV2080_CTRL_GR_INFO_INDEX_SM_VERSION: nv_gpu.NV2080_CTRL_GR_INFO_SM_VERSION_5_0,
         nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_GPCS: 1,
         nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_TPC_PER_GPC: 1,
         nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_SM_PER_TPC: 1,

--- a/test/mockgpu/nv/nvdriver.py
+++ b/test/mockgpu/nv/nvdriver.py
@@ -168,7 +168,7 @@ class NVDriver(VirtDriver):
       else:
         for i,c in enumerate(classes): params.classList[i] = c
     elif struct.cmd == nv_gpu.NV2080_CTRL_CMD_GR_GET_INFO:
-      info = {nv_gpu.NV2080_CTRL_GR_INFO_INDEX_SM_VERSION: nv_gpu.NV2080_CTRL_GR_INFO_SM_VERSION_5_0,
+      info = {nv_gpu.NV2080_CTRL_GR_INFO_INDEX_SM_VERSION: nv_gpu.NV2080_CTRL_GR_INFO_SM_VERSION_8_6,
         nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_GPCS: 1,
         nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_TPC_PER_GPC: 1,
         nv_gpu.NV2080_CTRL_GR_INFO_INDEX_LITTER_NUM_SM_PER_TPC: 1,

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -426,7 +426,7 @@ class CUDARenderer(CStyleLanguage):
   type_map = {dtypes.uint32: "uint", dtypes.bfloat16: "nv_bfloat16", dtypes.fp8e4m3: "__nv_fp8_e4m3", dtypes.fp8e5m2: "__nv_fp8_e5m2"}
   extra_matcher = create_non_native_float_pats(dtypes.fp8s, casting=False) + PatternMatcher([
     (UPat(Ops.CAST, dtypes.fp8s, UPat.var("x", dtypes.fp8s), name='y'), lambda x,y: x.cast(dtypes.float).cast(y.dtype) if x.dtype!=y.dtype else None),
-    (UPat(Ops.CAST, (dtypes.char, dtypes.uchar, dtypes.long), (UPat.var("x", dtypes.half),), name="y"),
+    (UPat(Ops.CAST, (dtypes.char, dtypes.uchar, dtypes.long, dtypes.ulong, dtypes.bfloat16), (UPat.var("x", dtypes.half),), name="y"),
      lambda x,y: x.cast(dtypes.float).cast(y.dtype)),
   ])
   string_rewrite = PatternMatcher([

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -428,6 +428,14 @@ class CUDARenderer(CStyleLanguage):
     (UPat(Ops.CAST, dtypes.fp8s, UPat.var("x", dtypes.fp8s), name='y'), lambda x,y: x.cast(dtypes.float).cast(y.dtype) if x.dtype!=y.dtype else None),
     (UPat(Ops.CAST, (dtypes.char, dtypes.uchar, dtypes.long, dtypes.ulong, dtypes.bfloat16), (UPat.var("x", dtypes.half),), name="y"),
      lambda x,y: x.cast(dtypes.float).cast(y.dtype)),
+    (UPat(Ops.CAST, dtypes.half, (UPat.var("x", (dtypes.long, dtypes.ulong, dtypes.bfloat16)),)),
+     lambda x: x.cast(dtypes.float).cast(dtypes.half)),
+    (UPat(Ops.CAST, (dtypes.char, dtypes.uchar), (UPat.var("x", dtypes.bfloat16),), name="y"),
+     lambda x,y: x.cast(dtypes.float).cast(y.dtype)),
+    (UPat(Ops.CAST, (dtypes.long, dtypes.ulong), (UPat.var("x", dtypes.bfloat16),), name="y"),
+     lambda x,y: x.cast(dtypes.float).cast(y.dtype)),
+    (UPat(Ops.CAST, dtypes.bfloat16, (UPat.var("x", (dtypes.long, dtypes.ulong)),)),
+     lambda x: x.cast(dtypes.float).cast(dtypes.bfloat16)),
   ])
   string_rewrite = PatternMatcher([
     (UPat(Ops.BITCAST, name="x"), lambda ctx,x: f"tg_bitcast<{ctx.render_dtype(x.dtype)}>(({ctx.render_dtype(x.src[0].dtype)})({ctx[x.src[0]]}))"

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -426,6 +426,8 @@ class CUDARenderer(CStyleLanguage):
   type_map = {dtypes.uint32: "uint", dtypes.bfloat16: "nv_bfloat16", dtypes.fp8e4m3: "__nv_fp8_e4m3", dtypes.fp8e5m2: "__nv_fp8_e5m2"}
   extra_matcher = create_non_native_float_pats(dtypes.fp8s, casting=False) + PatternMatcher([
     (UPat(Ops.CAST, dtypes.fp8s, UPat.var("x", dtypes.fp8s), name='y'), lambda x,y: x.cast(dtypes.float).cast(y.dtype) if x.dtype!=y.dtype else None),
+    (UPat(Ops.CAST, (dtypes.char, dtypes.uchar, dtypes.long), (UPat.var("x", dtypes.half),), name="y"),
+     lambda x,y: x.cast(dtypes.float).cast(y.dtype)),
   ])
   string_rewrite = PatternMatcher([
     (UPat(Ops.BITCAST, name="x"), lambda ctx,x: f"tg_bitcast<{ctx.render_dtype(x.dtype)}>(({ctx.render_dtype(x.src[0].dtype)})({ctx[x.src[0]]}))"


### PR DESCRIPTION
Gpuocelot add support to cuda12 and sm_50 and sm_86.

at the beginng i just wanted for gpuocelot to run with cuda-12 with minimal arch support sm_50. but the changes where small we can see it in this branch https://github.com/li0nr/tinygrad/commits/gpuocelot-cuda-12.

so the next best thing was supporting sm_86 arch in gpuocelot. 

- this needs to be modfied after we merge the ocelot branch to the tinygrad repo.