### PR TITLE
fix elu/celu/selu gradient being nan on large inputs

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -983,6 +983,7 @@ class TestOps(unittest.TestCase):
   def test_selu(self):
     helper_test_op([(45,65)], torch.nn.functional.selu, Tensor.selu)
     helper_test_op([(3,3)], torch.nn.functional.selu, Tensor.selu, low=300, high=400)
+    helper_test_op(None, torch.nn.functional.selu, Tensor.selu, vals=[[-1.,0.,1.]])
     helper_test_op([()], torch.nn.functional.selu, Tensor.selu)
   def test_silu(self):
     helper_test_op([(45,65)], torch.nn.functional.silu, Tensor.silu)

--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -978,9 +978,11 @@ class TestOps(unittest.TestCase):
   def test_celu(self):
     for val in range(1, 5):
       helper_test_op([(45,65)], lambda x: torch.nn.functional.celu(x,val), lambda x: x.celu(val))
+      helper_test_op([(45,65)], lambda x: torch.nn.functional.celu(x,val), lambda x: x.celu(val), low=300, high=400)
       helper_test_op([()], lambda x: torch.nn.functional.celu(x,val), lambda x: x.celu(val))
   def test_selu(self):
     helper_test_op([(45,65)], torch.nn.functional.selu, Tensor.selu)
+    helper_test_op([(45,65)], torch.nn.functional.selu, Tensor.selu, low=300, high=400)
     helper_test_op([()], torch.nn.functional.selu, Tensor.selu)
   def test_silu(self):
     helper_test_op([(45,65)], torch.nn.functional.silu, Tensor.silu)
@@ -1117,6 +1119,8 @@ class TestOps(unittest.TestCase):
   def test_elu(self):
     helper_test_op([(45,65)], torch.nn.functional.elu, Tensor.elu)
     helper_test_op([(45,65)], lambda x: torch.nn.functional.elu(x, alpha=0.1), lambda x: Tensor.elu(x, alpha=0.1))
+    helper_test_op([(45,65)], torch.nn.functional.elu, Tensor.elu, low=300, high=400)
+    helper_test_op(None, torch.nn.functional.elu, Tensor.elu, vals=[[-1.,0,1]])
     helper_test_op([()], torch.nn.functional.elu, Tensor.elu)
   def test_relu6(self):
     helper_test_op([(45,65)], torch.nn.functional.relu6, Tensor.relu6)

--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -978,11 +978,11 @@ class TestOps(unittest.TestCase):
   def test_celu(self):
     for val in range(1, 5):
       helper_test_op([(45,65)], lambda x: torch.nn.functional.celu(x,val), lambda x: x.celu(val))
-      helper_test_op([(45,65)], lambda x: torch.nn.functional.celu(x,val), lambda x: x.celu(val), low=300, high=400)
+      helper_test_op([(3,3)], lambda x: torch.nn.functional.celu(x,val), lambda x: x.celu(val), low=300, high=400)
       helper_test_op([()], lambda x: torch.nn.functional.celu(x,val), lambda x: x.celu(val))
   def test_selu(self):
     helper_test_op([(45,65)], torch.nn.functional.selu, Tensor.selu)
-    helper_test_op([(45,65)], torch.nn.functional.selu, Tensor.selu, low=300, high=400)
+    helper_test_op([(3,3)], torch.nn.functional.selu, Tensor.selu, low=300, high=400)
     helper_test_op([()], torch.nn.functional.selu, Tensor.selu)
   def test_silu(self):
     helper_test_op([(45,65)], torch.nn.functional.silu, Tensor.silu)
@@ -1119,8 +1119,7 @@ class TestOps(unittest.TestCase):
   def test_elu(self):
     helper_test_op([(45,65)], torch.nn.functional.elu, Tensor.elu)
     helper_test_op([(45,65)], lambda x: torch.nn.functional.elu(x, alpha=0.1), lambda x: Tensor.elu(x, alpha=0.1))
-    helper_test_op([(45,65)], torch.nn.functional.elu, Tensor.elu, low=300, high=400)
-    helper_test_op(None, torch.nn.functional.elu, Tensor.elu, vals=[[-1.,0,1]])
+    helper_test_op([(3,3)], torch.nn.functional.elu, Tensor.elu, low=300, high=400)
     helper_test_op([()], torch.nn.functional.elu, Tensor.elu)
   def test_relu6(self):
     helper_test_op([(45,65)], torch.nn.functional.relu6, Tensor.relu6)

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -971,7 +971,7 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).elu().numpy())
     ```
     """
-    return self.relu() - alpha*(1-self.exp()).relu()
+    return (self > 0).where(self, alpha*((self - self.relu()).exp() - 1))
 
   def celu(self, alpha=1.0) -> Self:
     """
@@ -983,7 +983,7 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).celu().numpy())
     ```
     """
-    return self.maximum(0) + (alpha * ((self / alpha).exp() - 1)).minimum(0)
+    return (self > 0).where(self, alpha * (((self - self.relu()) / alpha).exp() - 1))
 
   def selu(self, alpha=1.67326, gamma=1.0507) -> Self:
     """
@@ -995,7 +995,7 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).selu().numpy())
     ```
     """
-    return gamma * (self >= 0).where(self, alpha * (self.exp() - 1))
+    return gamma * (self >= 0).where(self, alpha * ((self - self.relu()).exp() - 1))
 
   def softplus(self, beta=1.0) -> Self:
     """

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -983,7 +983,7 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).celu().numpy())
     ```
     """
-    return (self > 0).where(self, alpha * (((self - self.relu()) / alpha).exp() - 1))
+    return alpha * (self / alpha).elu()
 
   def selu(self, alpha=1.67326, gamma=1.0507) -> Self:
     """
@@ -995,7 +995,7 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).selu().numpy())
     ```
     """
-    return gamma * (self >= 0).where(self, alpha * ((self - self.relu()).exp() - 1))
+    return gamma * self.elu(alpha)
 
   def softplus(self, beta=1.0) -> Self:
     """


### PR DESCRIPTION
exp is taken over the whole input and the positive half is thrown away, so the gradient is nan past ~88.7. clamping the input to exp fixes it and the forward is unchanged. the tests only ran on [-2, 2].
