### PR TITLE
fix logcumsumexp on fully masked prefixes

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1803,6 +1803,7 @@ class TestOps(unittest.TestCase):
 
   def test_logcumsumexp_numerical(self):
     helper_test_op(None, lambda x: torch.logcumsumexp(x, dim=0), lambda x: x.logcumsumexp(), atol=1e-7, grad_atol=1e-7, vals=[[0.0, 100.0]])
+    helper_test_op(None, lambda x: torch.logcumsumexp(x, dim=0), lambda x: x.logcumsumexp(), vals=[[-math.inf, 0.0, 1.0]], forward_only=True)
 
   def test_sinh(self):
     helper_test_op([(45,65)], lambda x: x.sinh(), grad_atol=1e-6)

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -855,7 +855,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     x = self.transpose(axis, -1)
     last_dim_size = x.shape[-1]
     x_unsqueezed = x.unsqueeze(-2)
-    x_cummax = x.cummax(-1)[0].detach()
+    x_cummax = (mx:=x.cummax(-1)[0].detach()).isfinite().where(mx, 0)
     mask = self._tri(last_dim_size, last_dim_size, 1).logical_not()
     ret = mask.where(x_unsqueezed - x_cummax.unsqueeze(-1), self.dtype.min).exp().sum(-1).log() + x_cummax
     return ret.transpose(-1, axis)


### PR DESCRIPTION
same as #17822, logcumsumexp subtracts an unguarded cummax so an all -inf prefix does -inf - -inf and comes back nan.
