### PR TITLE
fix strided setitem being a no-op on a realized tensor

### DIFF
--- a/test/backend/test_setitem.py
+++ b/test/backend/test_setitem.py
@@ -18,13 +18,16 @@ class TestSetitem(unittest.TestCase):
       ((4,4,4,4), (slice(1,3), slice(None), slice(None), slice(0,3)), 4),
       ((6,6), (slice(1,5,2), slice(0,5,3)), 1.0),
       ((6,6), (slice(5,1,-2), slice(5,0,-3)), 1.0),
+      ((6,6), (slice(None), slice(0,6,2)), 1.0),
     )
     for shp, slc, val in cases:
-      t = Tensor.zeros(shp).contiguous()
-      t[slc] = val
-      n = np.zeros(shp)
-      n[slc] = val.numpy() if isinstance(val, Tensor) else val
-      np.testing.assert_allclose(t.numpy(), n)
+      for realize in (False, True):
+        t = Tensor.zeros(shp).contiguous()
+        if realize: t.realize()
+        t[slc] = val
+        n = np.zeros(shp)
+        n[slc] = val.numpy() if isinstance(val, Tensor) else val
+        np.testing.assert_allclose(t.numpy(), n)
 
   def test_padded_setitem(self):
     t = Tensor.arange(10)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -257,6 +257,8 @@ def _apply_map_to_tensors(applied_map:dict[UOp, UOp], name:str) -> None:
       if s is ns: continue
       t.uop = ns
 
+def _tensor_holds(u:UOp) -> bool: return any((t:=tref()) is not None and t.uop is u for tref in list(all_tensors))
+
 # **** Tensor helper functions ****
 
 def is_numpy_ndarray(x) -> "TypeGuard[numpy.ndarray]": return str(type(x)) == "<class 'numpy.ndarray'>"
@@ -450,7 +452,7 @@ class Tensor(RandMixin):
     # STORE+AFTER: STORE is the write effect (void), AFTER wraps the view for correct shape/ranging
     assign = self.uop.after(self.uop.store(x.uop))
     ib = self.uop
-    while not ib.has_buffer_identity() and ib.op in GroupOp.Movement|{Ops.BITCAST, Ops.DETACH}: ib = ib.src[0]
+    while ib.op in GroupOp.Movement|{Ops.BITCAST, Ops.DETACH} and not (ib.has_buffer_identity() and _tensor_holds(ib)): ib = ib.src[0]
     if ib is not self.uop and ib.has_buffer_identity(after_ok=True):
       # view assign: replace at the buffer-identity level (e.g. RESHAPE(BUFFER)) so @function's substitution catches it
       _apply_map_to_tensors({ib: ib.after(assign)}, name="Embed View Assign")


### PR DESCRIPTION
the store is anchored on a reshape only the strided view holds, so `t[::2] = 1` on a realized tensor writes nothing. test_simple_setitem never realizes.
