### PR TITLE
add associative scan

### DIFF
--- a/test/test_associative_scan.py
+++ b/test/test_associative_scan.py
@@ -1,0 +1,58 @@
+import unittest
+import numpy as np
+from tinygrad import Tensor, associative_scan
+
+class TestAssociativeScan(unittest.TestCase):
+  def test_add(self):
+    for size in (0, 1, 2, 5, 8):
+      x = Tensor.arange(size)
+      np.testing.assert_equal(associative_scan(lambda a,b: a+b, x, 0).numpy(), np.arange(size).cumsum())
+
+  def test_axis_and_reverse(self):
+    x = Tensor.arange(24).reshape(2, 3, 4)
+    np.testing.assert_equal(associative_scan(lambda a,b: a+b, x, -1).numpy(), np.arange(24).reshape(2, 3, 4).cumsum(-1))
+    np.testing.assert_equal(associative_scan(lambda a,b: a+b, x, 1, reverse=True).numpy(),
+                            np.flip(np.flip(np.arange(24).reshape(2, 3, 4), 1).cumsum(1), 1))
+
+  def test_noncommutative(self):
+    rng = np.random.default_rng(0)
+    mats = rng.normal(size=(7, 2, 2)).astype(np.float32)
+    expected = [mats[0]]
+    for mat in mats[1:]: expected.append(expected[-1] @ mat)
+    np.testing.assert_allclose(associative_scan(lambda a,b: a@b, Tensor(mats.tolist()), 0, combine_mode="generic").numpy(), expected, atol=1e-5)
+
+    reverse_expected = [mats[-1]]
+    for mat in mats[-2::-1]: reverse_expected.append(reverse_expected[-1] @ mat)
+    np.testing.assert_allclose(associative_scan(lambda a,b: a@b, Tensor(mats.tolist()), 0, reverse=True,
+                                                combine_mode="generic").numpy(), reverse_expected[::-1], atol=1e-5)
+
+    transposed = np.moveaxis(mats, 0, -1)
+    np.testing.assert_allclose(associative_scan(lambda a,b: a@b, Tensor(transposed.tolist()), -1,
+                                                combine_mode="generic").numpy(), np.moveaxis(expected, 0, -1), atol=1e-5)
+
+  def test_pytree(self):
+    a = Tensor([0.8, 0.6, 0.7, 0.5])
+    b = Tensor([1.0, 2.0, 3.0, 4.0])
+    def compose(x, y): return {"a":x["a"]*y["a"], "b":[y["a"]*x["b"][0]+y["b"][0]]}
+    out = associative_scan(compose, {"a":a, "b":[b]}, 0)
+    expected_a, expected_b = [a.numpy()[0]], [b.numpy()[0]]
+    for ai,bi in zip(a.numpy()[1:], b.numpy()[1:]):
+      expected_a.append(expected_a[-1]*ai)
+      expected_b.append(ai*expected_b[-1]+bi)
+    np.testing.assert_allclose(out["a"].numpy(), expected_a)
+    np.testing.assert_allclose(out["b"][0].numpy(), expected_b)
+
+  def test_gradient(self):
+    x = Tensor.arange(6, dtype="float32")
+    grad, = associative_scan(lambda a,b: a+b, x, 0).sum().gradient(x)
+    np.testing.assert_equal(grad.numpy(), np.arange(6, 0, -1))
+
+  def test_errors(self):
+    with self.assertRaisesRegex(ValueError, "same scan length"):
+      associative_scan(lambda a,b: (a[0]+b[0], a[1]+b[1]), (Tensor.ones(2), Tensor.ones(3)), 0)
+    with self.assertRaisesRegex(ValueError, "combine_mode"):
+      associative_scan(lambda a,b: a+b, Tensor.ones(2), 0, combine_mode="invalid")
+    with self.assertRaisesRegex(ValueError, "metadata"):
+      associative_scan(lambda a,b: a.sum(0), Tensor.ones(3, 2), 0)
+
+if __name__ == "__main__": unittest.main()

--- a/tinygrad/__init__.py
+++ b/tinygrad/__init__.py
@@ -2,7 +2,7 @@ import os
 if int(os.getenv("TYPED", "0")):
   from typeguard import install_import_hook
   install_import_hook(__name__)
-from tinygrad.tensor import Tensor                                    # noqa: F401
+from tinygrad.tensor import Tensor, associative_scan                  # noqa: F401
 from tinygrad.engine.jit import TinyJit                               # noqa: F401
 from tinygrad.function import function                                # noqa: F401
 from tinygrad.uop.ops import UOp

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -745,6 +745,64 @@ class Tensor(RandMixin):
     fn = UOp(Ops.CUSTOM_FUNCTION, src=(frame_pos.src[0], *[UOp.const(s) for s in shape]), arg="encdec")
     return Tensor(out.uop.after(fn.call(*[s.uop for s in srcs], frame_pos)))
 
+def _scan_map(fn:Callable[..., Any], *trees:Any) -> Any:
+  first = trees[0]
+  if isinstance(first, Tensor):
+    if not all(isinstance(x, Tensor) for x in trees): raise TypeError("associative_scan tree structures must match")
+    return fn(*trees)
+  if isinstance(first, dict):
+    keys = tuple(first)
+    if not all(isinstance(x, dict) and tuple(x) == keys for x in trees): raise TypeError("associative_scan tree structures must match")
+    return {k:_scan_map(fn, *(x[k] for x in trees)) for k in keys}
+  if isinstance(first, (list, tuple)):
+    if not all(type(x) is type(first) and len(x) == len(first) for x in trees): raise TypeError("associative_scan tree structures must match")
+    values = [_scan_map(fn, *(x[i] for x in trees)) for i in range(len(first))]
+    return type(first)(values)
+  raise TypeError(f"associative_scan only supports trees of Tensors, got {type(first).__name__}")
+
+def associative_scan(combine_fn:Callable[[Any, Any], Any], xs:Any, dim:int=0, reverse:bool=False, combine_mode:str="pointwise") -> Any:
+  """Performs an inclusive scan with an associative ``combine_fn`` in logarithmic depth.
+
+  ``xs`` can be a Tensor or a nested tree of Tensors with the same scan length.
+  Both ``combine_mode`` values use tinygrad's staged Tensor lowering.
+  """
+  if not callable(combine_fn): raise ValueError(f"combine_fn must be callable, got {combine_fn!r}")
+  if combine_mode not in ("pointwise", "generic"): raise ValueError(f"combine_mode must be 'pointwise' or 'generic', got {combine_mode!r}")
+  leaves:list[Tensor] = []
+  _scan_map(lambda x: leaves.append(x), xs)
+  if not leaves: raise ValueError("associative_scan requires at least one Tensor")
+  axis = leaves[0]._resolve_dim(dim)
+  if any(x.ndim <= axis for x in leaves): raise ValueError(f"all associative_scan inputs must have dimension {axis}")
+  sizes = [x.shape[axis] for x in leaves]
+  if not all(isinstance(size, int) for size in sizes): raise ValueError("associative_scan requires a concrete scan length")
+  if len(set(sizes)) != 1: raise ValueError(f"associative_scan inputs must have the same scan length, got {sizes}")
+  size = int(sizes[0])
+
+  def move_front(x:Tensor) -> Tensor:
+    return x if axis == 0 else x.permute((axis,)+tuple(i for i in range(x.ndim) if i != axis))
+
+  def move_back(x:Tensor) -> Tensor:
+    return x if axis == 0 else x.permute(tuple(range(1, axis+1))+(0,)+tuple(range(axis+1, x.ndim)))
+
+  def slice_tree(tree:Any, start:int|None, stop:int|None) -> Any:
+    return _scan_map(lambda x: x[start:stop], tree)
+
+  def join(prefix:Tensor, combined:Tensor, expected:int) -> Tensor:
+    if combined.ndim != prefix.ndim or combined.shape[1:] != prefix.shape[1:] or combined.shape[0] != expected or \
+       combined.dtype != prefix.dtype or combined.device != prefix.device:
+      raise ValueError("combine_fn must preserve the input tree structure and Tensor metadata")
+    return prefix.cat(combined).contiguous()
+
+  out = _scan_map(move_front, xs)
+  if reverse: out = _scan_map(lambda x: x.flip(0), out)
+  stride = 1
+  while stride < size:
+    combined = combine_fn(slice_tree(out, 0, size-stride), slice_tree(out, stride, size))
+    out = _scan_map(lambda x,y: join(x, y, size-stride), slice_tree(out, 0, stride), combined)
+    stride *= 2
+  if reverse: out = _scan_map(lambda x: x.flip(0), out)
+  return _scan_map(move_back, out)
+
 P = ParamSpec("P")
 T = TypeVar("T")
 


### PR DESCRIPTION
Refs #3039

Adds an inclusive `associative_scan(combine_fn, xs, dim, reverse=False, combine_mode="pointwise")` to the top-level tinygrad API. It accepts a Tensor or a nested dict/list/tuple tree, preserves operand order, supports reverse scans and arbitrary dimensions, and keeps gradients through the composed Tensor operations. `pointwise` and `generic` use the same staged lowering in tinygrad.

The implementation uses Hillis-Steele updates with a contiguous boundary at each power-of-two stride. I tested a work-efficient recursive version first, but its interleaving views took longer to schedule and run in tinygrad. This version supplies the general scan primitive needed by affine state-space and Mamba-style recurrences with logarithmic dependency depth.

On an Apple M4 using Metal, a 128 x 64 affine recurrence took a median 0.776 ms per TinyJit replay, compared with 3.053 ms for the serial recurrence. The parallel version scheduled 14 kernels; the serial version scheduled 264. These are medians of six replay calls after two capture/warmup calls.

Validation:

- repository pre-commit hooks, including the comprehensive suite
- focused tests on CPU and Metal
- focused tests with `TYPED=1`
- `ruff check .` and `mypy tinygrad/`
- differential checks against PyTorch 2.13 for a reverse scan, generic matrix scan on a non-leading dimension, and a nested-tree affine recurrence

AI disclosure: OpenAI Codex was used to research the PyTorch and JAX behavior, write the implementation and tests, run the benchmark and validation commands, and draft this description.
