### PR TITLE
fix erf gradient being zero at x=0

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1096,6 +1096,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], torch.erf, Tensor.erf)
     helper_test_op([(45,65)], torch.erf, Tensor.erf, low=300, high=400)
     helper_test_op([(45,65)], torch.erf, Tensor.erf, low=-400, high=-300)
+    helper_test_op(None, torch.erf, Tensor.erf, vals=[[-1., 0., 1.]])
     helper_test_op([()], torch.erf, Tensor.erf)
 
   def test_gelu(self):

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -1066,8 +1066,8 @@ class ElementwiseMixin(CreationMixin):
     ```
     """
     # https://personal.math.ubc.ca/~cbm/aands/page_299.htm 7.1.26
-    t = 1.0 / (1.0 + 0.3275911 * self.abs())
-    return self.sign() * (1.0 - t * polyN(t, [1.061405429, -1.453152027, 1.421413741, -0.284496736, 0.254829592]) * (-self.square()).exp())
+    t = 1.0 / (1.0 + 0.3275911 * (s:=(self >= 0).where(1.0, -1.0)) * self)
+    return s * (1.0 - t * polyN(t, [1.061405429, -1.453152027, 1.421413741, -0.284496736, 0.254829592]) * (-self.square()).exp())
 
   def softsign(self) -> Self:
     """


### PR DESCRIPTION
`erf` was `self.sign() * f(self.abs())`. Both `sign()` and `abs()` have zero gradient at exactly 0, so the chain rule annihilated it and `d/dx erf(0)` came out `0.0` instead of `2/sqrt(pi)` ~= `1.1283792`.

It is a single point discontinuity, values on either side were already correct:

| x | before | torch |
|---|---|---|
| -1e-8 | 1.1283864 | 1.1283792 |
| **0.0** | **0.0** | **1.1283792** |
| +1e-8 | 1.1283864 | 1.1283792 |

Derive the sign factor once with a `where()` and form `abs(x)` as `s*x`, so the gradient at 0 takes the right-hand limit instead of being zeroed.

Forward output is unchanged (`erf(0)` is still exactly `0.0` in float32) and the line count is unchanged.

Checked against torch over 222 values including +/-0, +/-1e-30, +/-400: no divergences, max grad error 7.15e-6, which is the error of the Abramowitz-Stegun approximation itself.

Note: I could not run `test/backend/test_ops.py` locally (no clang available in my environment), so that path is only covered by CI here. `test/null/` passes, and `ruff` and `mypy` are clean.
