### PR TITLE
fix atan, asinh and acosh overflowing for large inputs

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -967,6 +967,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], lambda x: x.atan(), low=-300, high=-297)
     helper_test_op([(45,65)], lambda x: x.atan(), low=300, high=303)
     helper_test_op(None, lambda x: x.atan(), vals=[[-0.5, 0., 0.5]])
+    helper_test_op(None, lambda x: x.atan(), vals=[[-1e30, -1e20, 0., 1e20, 1e30]])
 
   def test_relu(self):
     helper_test_op([(64,64)], lambda x: x.relu())
@@ -1835,11 +1836,13 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=-300, high=-297)
     helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=300, high=303)
     helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=-1e10, high=-1e9)
+    helper_test_op(None, lambda x: x.asinh(), vals=[[-1e30, -1e20, 0., 1e20, 1e30]])
     helper_test_op(None, lambda x: x.asinh(), grad_atol=1e-6, vals=[[-1.0, 0.0, 1.0]])
   def test_acosh(self):
     helper_test_op([(45,65)], lambda x: x.acosh(), grad_atol=1e-6)
     helper_test_op([(45,65)], lambda x: x.acosh(), grad_atol=1e-3, grad_rtol=1e-2, low=-300, high=-297)
     helper_test_op([(45,65)], lambda x: x.acosh(), grad_atol=1e-6, low=300, high=303)
+    helper_test_op(None, lambda x: x.acosh(), vals=[[1.5, 1e20, 1e30]])
   def test_atanh(self):
     helper_test_op([(45,65)], lambda x: x.atanh(), grad_atol=1e-6)
     helper_test_op([(45,65)], lambda x: x.atanh(), grad_atol=1e-6, low=-300, high=-297)

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -874,7 +874,11 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).asinh().numpy())
     ```
     """
-    return (sg:=(self<0).where(-1.0, 1.0)) * (self*sg + (self.square() + 1).sqrt()).log()
+    # self.square() overflows to inf for |x| > 1.8e19 in float32, giving asinh(x) = inf. for a > 1 the a factors out:
+    # log(a + sqrt(a*a + 1)) = log(a) + log(1 + sqrt(1 + 1/(a*a))), which never squares a large value.
+    # max(a, 1) keeps the -inf of log(0) out of the where() branch that is not selected, which would nan the gradient at 0
+    am = (a := (sg := (self < 0).where(-1.0, 1.0)) * self).maximum(1.0)
+    return sg * (a > 1).where(am.log() + (1 + (1 + am.square().reciprocal()).sqrt()).log(), (a + (a.square() + 1).sqrt()).log())
 
   def acosh(self) -> Self:
     """
@@ -886,7 +890,12 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).acosh().numpy())
     ```
     """
-    return (self + (self.square() - 1).sqrt()).log()
+    # self.square() overflows to inf for x > 1.8e19 in float32, giving acosh(x) = inf. for x > 1 the x factors out:
+    # log(x + sqrt(x*x - 1)) = log(x) + log(1 + sqrt(1 - 1/(x*x))), which never squares a large value.
+    # x <= 2 keeps the original expression, so the nan below the domain still reaches the gradient and the sqrt of the
+    # factored form, whose derivative is infinite at x = 1, stays out of the where() branch that is not selected
+    xm = self.maximum(2.0)
+    return (self > 2).where(xm.log() + (1 + (1 - xm.square().reciprocal()).sqrt()).log(), (self + (self.square() - 1).sqrt()).log())
 
   def round(self) -> Self:
     """
@@ -959,7 +968,10 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).atan().numpy())
     ```
     """
-    return (self / (1 + self * self).sqrt()).asin()
+    # self*self overflows to inf for |x| > 1.8e19 in float32 (atan -> 0, nan at inf), so |x| > 1 folds to pi/2 - atan(1/x).
+    # max(a, 1) keeps an inf out of the unselected where() branch, which would nan the gradient at 0
+    t = (big := (a := (s := (self >= 0).where(1.0, -1.0)) * self) > 1).where(a.maximum(1.0).reciprocal(), a)
+    return s * big.where(math.pi / 2 - (at := (t / (1 + t * t).sqrt()).asin()), at)
 
   def elu(self, alpha=1.0) -> Self:
     """


### PR DESCRIPTION
`atan`, `asinh` and `acosh` all square the input. `x*x` overflows to inf for |x| > 1.8e19 in float32, so all three break at the same threshold, in two different ways:

```
atan(1e19)  = 1.5707964   ok          asinh(1e19) = 44.442   ok
atan(1e20)  = 0.0         want pi/2   asinh(1e20) = inf      want 46.745
atan(1e30)  = 0.0         want pi/2   asinh(1e30) = inf      want 69.771
atan(inf)   = nan         want pi/2   acosh(1e30) = inf      want 69.771
```

atan returns **0 instead of pi/2** because `x/inf` is 0, and nan at inf because `inf/inf` is nan. asinh and acosh return inf where the true answer is small and perfectly representable. Silent wrong answers, no exception.

Fixes, both of which avoid ever squaring a large value:

    atan(x)                = pi/2 - atan(1/x)                        for |x| > 1
    log(a + sqrt(a*a + 1)) = log(a) + log(1 + sqrt(1 + 1/(a*a)))
    log(x + sqrt(x*x - 1)) = log(x) + log(1 + sqrt(1 - 1/(x*x)))

atan also gains accuracy well below the overflow, since `asin(u)` is ill-conditioned as u approaches 1: **max abs error over the whole range drops from 1e-4 (at x=1e4) to 2.3e-7**.

Three details in the diff, each guarding a gradient:
- abs() is spelled `s*self`, so the gradient survives at 0 (same reason as #17861 and #17862).
- The reciprocals are of `max(a, 1)`, so the where() branch that is *not* selected never holds an inf, which would otherwise nan the gradient at 0.
- acosh switches at x > 2 rather than x > 1, because the factored form has an infinite derivative at x = 1 and would nan the gradient there through the unselected branch. Below that the original expression is kept, so the nan outside the acosh domain still reaches the gradient.

Checked against a master worktree over ~280 points from +/-1e-4 to +/-1e30 plus 0, 1, 2 and +/-inf, on both value and gradient: **0 regressions**, 41 forward values fixed for asinh, 22 for acosh, and atan correct across the whole range. No forward value that master got right becomes non-finite.

(Supersedes #17883, which is folded in here — same root cause.)