### PR TITLE
fix asinh and acosh overflowing to inf for large inputs

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1835,11 +1835,13 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=-300, high=-297)
     helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=300, high=303)
     helper_test_op([(45,65)], lambda x: x.asinh(), grad_atol=1e-6, low=-1e10, high=-1e9)
+    helper_test_op(None, lambda x: x.asinh(), vals=[[-1e30, -1e20, 0., 1e20, 1e30]])
     helper_test_op(None, lambda x: x.asinh(), grad_atol=1e-6, vals=[[-1.0, 0.0, 1.0]])
   def test_acosh(self):
     helper_test_op([(45,65)], lambda x: x.acosh(), grad_atol=1e-6)
     helper_test_op([(45,65)], lambda x: x.acosh(), grad_atol=1e-3, grad_rtol=1e-2, low=-300, high=-297)
     helper_test_op([(45,65)], lambda x: x.acosh(), grad_atol=1e-6, low=300, high=303)
+    helper_test_op(None, lambda x: x.acosh(), vals=[[1.5, 1e20, 1e30]])
   def test_atanh(self):
     helper_test_op([(45,65)], lambda x: x.atanh(), grad_atol=1e-6)
     helper_test_op([(45,65)], lambda x: x.atanh(), grad_atol=1e-6, low=-300, high=-297)

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -874,7 +874,11 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).asinh().numpy())
     ```
     """
-    return (sg:=(self<0).where(-1.0, 1.0)) * (self*sg + (self.square() + 1).sqrt()).log()
+    # self.square() overflows to inf for |x| > 1.8e19 in float32, giving asinh(x) = inf. for a > 1 the a factors out:
+    # log(a + sqrt(a*a + 1)) = log(a) + log(1 + sqrt(1 + 1/(a*a))), which never squares a large value.
+    # max(a, 1) keeps the -inf of log(0) out of the where() branch that is not selected, which would nan the gradient at 0
+    am = (a := (sg := (self < 0).where(-1.0, 1.0)) * self).maximum(1.0)
+    return sg * (a > 1).where(am.log() + (1 + (1 + am.square().reciprocal()).sqrt()).log(), (a + (a.square() + 1).sqrt()).log())
 
   def acosh(self) -> Self:
     """
@@ -886,7 +890,12 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).acosh().numpy())
     ```
     """
-    return (self + (self.square() - 1).sqrt()).log()
+    # self.square() overflows to inf for x > 1.8e19 in float32, giving acosh(x) = inf. for x > 1 the x factors out:
+    # log(x + sqrt(x*x - 1)) = log(x) + log(1 + sqrt(1 - 1/(x*x))), which never squares a large value.
+    # x <= 2 keeps the original expression, so the nan below the domain still reaches the gradient and the sqrt of the
+    # factored form, whose derivative is infinite at x = 1, stays out of the where() branch that is not selected
+    xm = self.maximum(2.0)
+    return (self > 2).where(xm.log() + (1 + (1 - xm.square().reciprocal()).sqrt()).log(), (self + (self.square() - 1).sqrt()).log())
 
   def round(self) -> Self:
     """


### PR DESCRIPTION
Same root cause as #17882. `asinh` is `log(x + sqrt(x*x + 1))` and `acosh` is `log(x + sqrt(x*x - 1))`. `self.square()` overflows to inf for |x| > 1.8e19 in float32, so both return inf where the true answer is small and perfectly representable.

```
asinh(1e19) = 44.442   ok
asinh(1e20) = inf      expected 46.745
asinh(1e30) = inf      expected 69.771
acosh(1e30) = inf      expected 69.771
```

Factor the large value out of the log, so nothing large is ever squared:

    log(a + sqrt(a*a + 1)) = log(a) + log(1 + sqrt(1 + 1/(a*a)))
    log(x + sqrt(x*x - 1)) = log(x) + log(1 + sqrt(1 - 1/(x*x)))

The small branch keeps the original expression, which matters for two reasons: the nan below the acosh domain still carries into the gradient, and the factored form has an infinite derivative at x = 1, which would nan the gradient through the where() branch that is not selected. acosh switches at x > 2 rather than x > 1 to stay clear of that.

Compared against master over 280 points from +/-1e-4 to +/-1e30 plus 0, 1, 2 and +/-inf, on both the value and the gradient: **0 regressions**, 41 forward values fixed for asinh and 22 for acosh. Gradients match 1/sqrt(x*x +- 1) wherever master already did.