### PR TITLE
metal: use metal4.1 language standard on macOS 27+

### DIFF
--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -85,7 +85,8 @@ class MetalCompiler(Compiler):
 
     # no changes for compute in 2.0 - 2.4 specs, use 2.0 as default for old versions.
     macos_major = int(platform.mac_ver()[0].split('.')[0])
-    metal_version = "metal4.0" if macos_major >= 26 else "metal3.1" if macos_major >= 14 else "metal3.0" if macos_major >= 13 else "macos-metal2.0"
+    metal_version = "metal4.1" if macos_major >= 27 else "metal4.0" if macos_major >= 26 else "metal3.1" if macos_major >= 14 else \
+      "metal3.0" if macos_major >= 13 else "macos-metal2.0"
 
     # llvm will create modules.timestamp in cache path and cache compilation of metal stdlib (250ms => 8ms compilation time)
     # note that llvm won't necessarily create anything else here as apple has prebuilt versions of many standard libraries


### PR DESCRIPTION
Xcode 27 / macOS 27 add the `metal4.1` shading language standard. Select it on macOS 27+, the same way `metal4.0` is selected on macOS 26.

Verified on macOS 27.0 (26A5425a), Xcode 27, Apple M4 Pro, Python 3.14:
- the runtime `MTLCodeGenService` path accepts `-std=metal4.1`
- 24 captured tinygrad kernels (matmul with TC, half matmul, reductions, softmax, conv, cumsum, transpose, argmax, layernorm) compile to identical AIR instructions under 4.0 and 4.1; only the language-version metadata differs
- `test/backend`, `test/unit`, `test/device/test_metal.py`, and `test/opt/test_tensor_cores.py` pass on METAL

No behavior change on macOS 26 and earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)