### PR TITLE
fix vmin/vmax clamping a signed cast that actually wraps

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -295,6 +295,8 @@ class TestOps(unittest.TestCase):
 
   def test_arange_big(self):
     helper_test_op([], lambda: torch.arange(256, dtype=torch.int32), lambda: Tensor.arange(256), forward_only=True)
+    helper_test_op([], lambda: torch.arange(256, dtype=torch.int32).to(torch.int8) < 0, lambda: Tensor.arange(256).cast(dtypes.int8) < 0,
+                   forward_only=True)
 
   def test_arange_4096(self):
     helper_test_op([], lambda: torch.arange(4096, dtype=torch.int32), lambda: Tensor.arange(4096), forward_only=True)

--- a/test/null/test_uop_vmin_vmax.py
+++ b/test/null/test_uop_vmin_vmax.py
@@ -134,6 +134,11 @@ class TestVminVmaxProperties(unittest.TestCase):
     self.assertEqual(UOp.variable('x', -1, 10).cast(dtypes.uint8)._min_max, (0, 255))
     self.assertEqual(UOp.variable('x', 250, 260).cast(dtypes.uint8)._min_max, (0, 255))
 
+  def test_vmin_vmax_cast_signed(self):
+    self.assertEqual(UOp.variable('x', 5, 10).cast(dtypes.int8)._min_max, (5, 10))
+    self.assertEqual(UOp.variable('x', 0, 255).cast(dtypes.int8)._min_max, (-128, 127))
+    self.assertEqual(UOp.variable('x', -200, 5).cast(dtypes.int8)._min_max, (-128, 127))
+
   def test_vmin_vmax_xor_neg1(self):
     x = UOp.variable('x', 3, 7)
     uop = x ^ -1

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1112,8 +1112,8 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
       smin, smax = self.src[0]._min_max
       trunc = truncate.get(self.dtype) if dtypes.is_float(self.dtype) else math.trunc if dtypes.is_int(self.dtype) else None
       if trunc is not None and all(math.isfinite(v) for v in (smin, smax)): smin, smax = trunc(smin), trunc(smax)
-      if dtypes.is_unsigned(self.dtype) and 0 <= smin and smax <= self.dtype.max: return smin, smax
-      if self.dtype in dtypes.floats+dtypes.sints+(dtypes.weakint,): return max(self.dtype.min, smin), min(smax, self.dtype.max)
+      if dtypes.is_int(self.dtype) and self.dtype.min <= smin and smax <= self.dtype.max: return smin, smax
+      if self.dtype in dtypes.floats: return max(self.dtype.min, smin), min(smax, self.dtype.max)
     return self.dtype.min, self.dtype.max
 
   @functools.cached_property


### PR DESCRIPTION
a cast to a signed int wraps, but _min_max clamped the source bounds to the dtype range.
Tensor.arange(256).cast(dtypes.int8) < 0 got bounds (0, 127) and folded to False.
the unsigned path already only kept bounds when the source fits, same rule for all ints now.
