### PR TITLE
fix simplify_valid rewriting an int bitwise and

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -825,6 +825,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([], lambda: tor&tor, lambda: ten&ten, forward_only=True)
     helper_test_op([], lambda: tor&0x1337, lambda: ten&0x1337, forward_only=True)
     helper_test_op([], lambda: 0x1337&tor, lambda: 0x1337&ten, forward_only=True)
+    helper_test_op([], lambda: (tor&12)&tor, lambda: (ten&12)&ten, forward_only=True)
 
     data = [[True, True, False, False], [True, False, True, False]]
     tor0, tor1 = torch.tensor(data[0], dtype=torch.bool),  torch.tensor(data[1], dtype=torch.bool)

--- a/test/null/test_simplify_valid_idx.py
+++ b/test/null/test_simplify_valid_idx.py
@@ -60,6 +60,10 @@ class TestValidIdxSimplification(unittest.TestCase):
     valid = (alu0 < 57) & (alu0 >= 1)
     self.assertIsNone(simplify_valid(valid))
 
+  def test_bitwise_and_is_not_a_valid(self):
+    ridx0 = Range(0, 16)
+    self.assertEqual(simplify_valid_idx(UOp.sink((ridx0 & UOp.const(12, dtypes.int)) & ridx0)).src[0].render(), "((int)(r0)&12&(int)(r0))")
+
   def test_valid_order_matters1(self):
     ridx0 = Range(0, 2)
     v0 = ridx0<1

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -439,7 +439,7 @@ def gated_given_valid(cond:UOp, x:UOp, i:UOp) -> UOp|None:
 
 pm_simplify_valid = PatternMatcher([
   # simplify valid
-  (UPat(Ops.AND, name="valid"), simplify_valid),
+  (UPat(Ops.AND, dtypes.bool, name="valid"), simplify_valid),
   (invalid_gate, gated_given_valid),
 ])
 


### PR DESCRIPTION
pm_simplify_valid matches every AND, so an int `(x & 12) & x` goes through simplify_valid as if it were a gate and comes back as `x*12`. `(Tensor.arange(16) & 12) & Tensor.arange(16)` returns multiples of 12 on master. Only bool ANDs are valids.
