### PR TITLE
fix atan returning 0 for large inputs

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -967,6 +967,8 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], lambda x: x.atan(), low=-300, high=-297)
     helper_test_op([(45,65)], lambda x: x.atan(), low=300, high=303)
     helper_test_op(None, lambda x: x.atan(), vals=[[-0.5, 0., 0.5]])
+    helper_test_op([(45,65)], lambda x: x.atan(), low=-1e20, high=-1e19)
+    helper_test_op([(45,65)], lambda x: x.atan(), low=1e19, high=1e20)
 
   def test_relu(self):
     helper_test_op([(64,64)], lambda x: x.relu())

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -959,7 +959,9 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).atan().numpy())
     ```
     """
-    return (self / (1 + self * self).sqrt()).asin()
+    x = (big:=self.abs() > 1).where(big.where(self, 1).reciprocal(), self)
+    y = (x / (1 + x*x).sqrt()).asin()
+    return big.where(self.sign() * (math.pi/2) - y, y)
 
   def elu(self, alpha=1.0) -> Self:
     """


### PR DESCRIPTION
atan is asin(x / sqrt(1 + x*x)), and 1 + x*x overflows past ~1.8e19 in float32, so atan(1e20) comes back 0 instead of pi/2. Big inputs now go through pi/2 - atan(1/x). The reciprocal is masked off the small branch, otherwise its gradient at 0 is inf and the where turns that into nan.
