### PR TITLE
cdna packets have a 4 cycle duration

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -381,8 +381,8 @@ def sqtt_timeline(data:bytes, lib:bytes, target:str) -> Generator[ProfileEvent, 
   def add(name:str, p:PacketType, wave:int|None=None, info:InstructionInfo|None=None) -> Generator[ProfileEvent, None, None]:
     row = f"WAVE:{wave}" if (wave:=getattr(p, "wave", wave)) is not None else f"{p.__class__.__name__}:0 {name.replace('_ALT', '')}"
     if (simd:=getattr(p, "simd", None)) is not None: row += f" SIMD:{simd}"
-    # by default we extend the packet to one cycle after timestamp
-    start_time, end_time = p._time, p._time+1
+    # extend packets to the architectural instruction issue interval
+    start_time, end_time = p._time, p._time+(4 if target.startswith("gfx9") else 1)
     # exec links to dispatch, dispatch links to PC
     link:dict|None = {"pc":info.pc} if info else None
     if isinstance(p, (ALUEXEC, VMEMEXEC)):


### PR DESCRIPTION
from distilling AMD's docs, CDNA issues 1 "wave instruction" per 4 cycles, RDNA can do 1 at every cycle.
So the natural "duration" of a packet in CDNA is 4 cycles. The math is:
```
CDNA: wave64 / SIMD16 = 4
RDNA: wave32 / SIMD32 = 1
```