### PR TITLE
fix jit accepting a bare buffer input of a different size

### DIFF
--- a/test/unit/test_jit.py
+++ b/test/unit/test_jit.py
@@ -113,6 +113,13 @@ class TestJit(unittest.TestCase):
     with self.assertRaises(JitError):
       add(a, bad)
 
+  def test_jit_size_mismatch(self):
+    @TinyJit
+    def double_sum(a): return (a*2).sum().realize()
+    for _ in range(3): double_sum(Tensor.ones(4).contiguous().realize())
+    with self.assertRaises(JitError):
+      double_sum(Tensor.ones(8).contiguous().realize())
+
   def test_jit_shape_views_mismatch(self):
     @TinyJit
     def add(a): return (a+1).realize()

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -163,7 +163,7 @@ class CapturedJit(Generic[ReturnType]):
   ret: Any  # includes the Tensors or any other returned object
   _linear: UOp
   expected_names: list[int|str]
-  expected_input_info: list[tuple[UOp, tuple[Variable, ...], DType, str]]  # (view, variables, dtype, device) per input
+  expected_input_info: list[tuple[UOp, tuple[Variable, ...], DType, str, int]]  # (view, variables, dtype, device, base size) per input
 
   @functools.cached_property
   def linear(self) -> UOp: return link_linear(self._linear)
@@ -204,10 +204,10 @@ def _prepare_jit_inputs(args, kwargs):
   # collect buffer UOps (including MultiBuffer)
   input_buf_uops: list[UOp] = [u.base for u in input_uops if u.base.realized is not None]
   if len(set(input_buf_uops)) != len(input_buf_uops): raise JitError("duplicate inputs to JIT")
-  inputs = [(*(u.substitute({u.base:UOp(Ops.NOOP)}, extra_pm=mop_cleanup).unbind_all()), u.dtype, u.device) for u in input_uops]
+  inputs = [(*(u.substitute({u.base:UOp(Ops.NOOP)}, extra_pm=mop_cleanup).unbind_all()), u.dtype, u.device, u.base.max_numel()) for u in input_uops]
   _var_vals = merge_dicts([x[1] for x in inputs] + [dict(v.unbind() for v in (args + tuple(kwargs.values())) if isinstance(v, UOp))])
   var_vals = {k.expr:v for k,v in _var_vals.items()}
-  expected_input_info = [(x[0], tuple(sorted(x[1].keys(), key=lambda v: v.expr)), x[2], x[3]) for x in inputs]
+  expected_input_info = [(x[0], tuple(sorted(x[1].keys(), key=lambda v: v.expr)), x[2], x[3], x[4]) for x in inputs]
   return input_buf_uops, var_vals, names, expected_input_info
 
 class _TinyJit(Generic[ReturnType]):


### PR DESCRIPTION
_prepare_jit_inputs swaps the base for a NOOP before recording the view, so a bare 1d buffer keeps nothing that says how big it is. A jit captured on Tensor.ones(4) then accepts Tensor.ones(8) and runs the 4 element kernel on it, (x*2).sum() gives 8 instead of 16. Any reshape or slice is already caught by the view, this only leaks for a plain realized buffer. Tracking the base size next to the view closes it.
