### PR TITLE
fix relu6 cancellation at large inputs

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1129,6 +1129,7 @@ class TestOps(unittest.TestCase):
   def test_relu6(self):
     helper_test_op([(45,65)], torch.nn.functional.relu6, Tensor.relu6)
     helper_test_op([()], torch.nn.functional.relu6, Tensor.relu6)
+    helper_test_op(None, torch.nn.functional.relu6, Tensor.relu6, vals=[[6.71089e7, 2.68435e8, 1e9]])
   def test_hardswish(self):
     helper_test_op([(45,65)], torch.nn.functional.hardswish, Tensor.hardswish, grad_atol=1e-6)
     helper_test_op([()], torch.nn.functional.hardswish, Tensor.hardswish, grad_atol=1e-6)

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -705,7 +705,7 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-9., -6., -3., 0., 3., 6., 9.]).relu6().numpy())
     ```
     """
-    return self.relu() - (self-6).relu()
+    return self.relu().minimum(6)
 
   def hardswish(self) -> Self:
     """


### PR DESCRIPTION
relu6 is `relu(x) - relu(x-6)`, which cancels once ulp(x) > 6. float16 returns
8 at 8192 and 0 at 32768, float32 returns 8 at 6.71e7 and 0 from 2.68e8.
hardswish inherits it.

helper_test_op defaults to low=-2 high=2, so test_relu6 never sampled a value
where the two forms differ.

test: python -m pytest test/backend/test_ops.py -k "relu6 or hardswish"
