### PR TITLE
fix max backward underflow with many ties

### DIFF
--- a/test/unit/test_gradient.py
+++ b/test/unit/test_gradient.py
@@ -135,6 +135,10 @@ class TestTensorGradient(unittest.TestCase):
     (Tensor.rand(()) + w).backward()
     self.assertIsNone(w.grad)
 
+  def test_max_backward_many_ties(self):
+    t = Tensor.ones(70000, dtype=dtypes.half).contiguous()
+    np.testing.assert_allclose(t.max().gradient(t)[0].sum().numpy(), 1.0, atol=1e-3)
+
 class TestMultiOutputGradient(unittest.TestCase):
   @staticmethod
   def addmul_kernel(C:UOp, D:UOp, A:UOp, B:UOp) -> UOp:

--- a/tinygrad/mixin/gradient.py
+++ b/tinygrad/mixin/gradient.py
@@ -7,7 +7,10 @@ from tinygrad.function import renumber_invalid_outputs
 
 def reduce_gradient(ctx:UOp, ret:UOp, op:Ops):
   if op == Ops.ADD: return (ctx._broadcast_to(ret.src[0].shape),)
-  if op == Ops.MAX: return (((mask:=ret.src[0].eq(ret).cast(ctx.dtype))/mask._rop(Ops.ADD, tuple(range(ret.arg[1])))) * ctx,)
+  if op == Ops.MAX:
+    # count the ties in the acc dtype, the count can overflow the gradient dtype
+    mask = ret.src[0].eq(ret).cast(sum_acc_dtype(ctx.dtype))
+    return ((mask/mask._rop(Ops.ADD, tuple(range(ret.arg[1])))).cast(ctx.dtype) * ctx,)
   if op == Ops.MUL:
     # d(prod x)/dx_j = prod_{i!=j} x_i: ret/x_j whenever x_j != 0 (any zero makes ret 0), else the product of the others
     safe_x, axes = (is_zero:=(x:=ret.src[0]).eq(0)).where(1, x), tuple(range(ret.arg[1]))


### PR DESCRIPTION
the tie mask is cast to the gradient dtype before the count is summed, so with 70000 ties in half the count overflows to inf and every gradient comes out 0. torch gives 1.43e-05 across all of them.

counting in sum_acc_dtype fixes it, same as the MUL branch right below already does. float32 is unaffected, sum_acc_dtype(float32) is float32.

fixes #12296

test: python -m pytest test/unit/test_gradient.py -k many_ties
