### PR TITLE
fix mod returning inf when the quotient overflows

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -647,6 +647,10 @@ class TestOps(unittest.TestCase):
         helper_test_op(None, lambda x: 100%x, forward_only=True, vals=[va])
         helper_test_op(None, lambda x: 100.5%x, lambda x: (100.5%x).clone(), forward_only=True, vals=[va])
 
+  def test_mod_large_ratio(self):
+    # a/b overflows to inf, a - inf*b used to leave +-inf which is outside [0,|b|)
+    np.testing.assert_equal(np.isfinite((Tensor([1e30, -1e30, 1e20]) % Tensor([1e-30, 1e-30, 1e-24])).numpy()), True)
+
   def test_fmod(self):
     a = [-4, 7, 5, 4, -7, 8, -9]
     b = [2, -3, 8, -2, 3, 5, -5]

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -211,7 +211,9 @@ class ElementwiseMixin(CreationMixin):
     """
     a, b = self._broadcasted(x, reverse)
     if dtypes.is_int(a.dtype) and dtypes.is_int(b.dtype): return a.alu(Ops.FLOORMOD, b)
-    return a - a.div(b, rounding_mode="floor") * b
+    # a/b overflows to inf when |a| >> |b|, and a - inf*b leaves +-inf, outside [0,|b|)
+    r = a - a.div(b, rounding_mode="floor") * b
+    return r.isinf().where(a.const_like(0), r)
 
   def fmod(self, x: Self | ConstType) -> Self:
     """


### PR DESCRIPTION
mod is `a - floor(a/b)*b`, so when |a| >> |b| the division overflows to inf and `a - inf*b` leaves +-inf. a modulo result has to be in [0,|b|), inf never is. 1e30 % 1e-30 gives -inf today.

guarding on isinf keeps mod-by-zero as nan, since inf*0 is already nan and isinf is false for nan. integer mod is unaffected, it goes through FLOORMOD.

test: python -m pytest test/backend/test_ops.py -k mod
