### PR TITLE
QCOM A630 mock: run real submissions without hardware

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -552,8 +552,16 @@ jobs:
       matrix:
         include:
           - renderer: IR3
+            # Ignored files reproduce separately reported upstream defects and are expected to fail until fixed.
             targets: >-
               test/mockgpu/qcom
+              --ignore=test/mockgpu/qcom/test_image_dot_broadcast.py
+              --ignore=test/mockgpu/qcom/test_image_mutability.py
+              --ignore=test/mockgpu/qcom/test_image_load_dtype.py
+              --ignore=test/mockgpu/qcom/test_conversion_rounding.py
+              --ignore=test/mockgpu/qcom/test_tensor_semantics.py
+              --ignore=test/mockgpu/qcom/test_image_symbolic.py
+              --ignore=test/mockgpu/qcom/test_argument_binding.py
               test/testextra/test_qcom_driver.py
               test/testextra/test_qcom_driver_folding.py
               test/testextra/test_qcom_driver_repairs.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -552,9 +552,21 @@ jobs:
       matrix:
         include:
           - renderer: IR3
-            compiler_probe: test/mockgpu/qcom/test_integration.py::TestQCOMIntegration::test_emitted_instruction_bytes_are_required_for_execution
+            targets: >-
+              test/mockgpu/qcom
+              test/testextra/test_qcom_driver.py
+              test/testextra/test_qcom_driver_folding.py
+              test/testextra/test_qcom_driver_repairs.py
+              test/backend/test_jit.py::TestJit::test_simple_jit
+          # CL stays bounded because libllvm-qcom.so is arm64 and runs under qemu on x86 runners.
           - renderer: CL
-            compiler_probe: >-
+            targets: >-
+              test/mockgpu/qcom/test_integration.py::TestQCOMIntegration::test_real_submissions_cover_odd_shapes_and_repeated_programs
+              'test/mockgpu/qcom/test_image_integration.py::test_image_matmul_preserves_nonuniform_values_and_odd_channels[False]'
+              'test/mockgpu/qcom/test_image_integration.py::test_image_matmul_preserves_nonuniform_values_and_odd_channels[True]'
+              test/backend/test_jit.py::TestJit::test_simple_jit
+              test/testextra/test_qcom_driver.py::QCOMDriverTests::test_native_callback_latches_failure_and_preserves_original_cause
+              test/testextra/test_qcom_driver.py::QCOMDriverTests::test_native_callback_forwards_real_descriptor
               test/mockgpu/qcom/test_qcomcl.py::test_generated_add_uses_every_lane_and_workgroup
               test/mockgpu/qcom/test_qcomcl.py::test_jit_refreshes_arguments_without_reusing_previous_values
     name: Linux (QCOM A630 mock ${{ matrix.renderer }})
@@ -582,18 +594,12 @@ jobs:
           deps: "testing_unit mesa"
           llvm: 'true'
           qemu: ${{ matrix.renderer == 'CL' }}
-      - name: Run representative QCOM compilation and submission regressions
+      - name: Run QCOM compilation and submission regressions
         # Image tests assert actual image instruction execution and FP16 storage.
-        # The broad execution/backend/image matrix is release/local qualification.
+        # The six-cell backend/image matrix remains release/local qualification.
         run: >-
           python -m pytest -n 2 --dist worksteal
-          test/mockgpu/qcom/test_integration.py::TestQCOMIntegration::test_real_submissions_cover_odd_shapes_and_repeated_programs
-          'test/mockgpu/qcom/test_image_integration.py::test_image_matmul_preserves_nonuniform_values_and_odd_channels[False]'
-          'test/mockgpu/qcom/test_image_integration.py::test_image_matmul_preserves_nonuniform_values_and_odd_channels[True]'
-          test/backend/test_jit.py::TestJit::test_simple_jit
-          test/testextra/test_qcom_driver.py::QCOMDriverTests::test_native_callback_latches_failure_and_preserves_original_cause
-          test/testextra/test_qcom_driver.py::QCOMDriverTests::test_native_callback_forwards_real_descriptor
-          ${{ matrix.compiler_probe }}
+          ${{ matrix.targets }}
 
   testamd:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -546,6 +546,55 @@ jobs:
       - name: Run disk copy tests on MOCKPCI
         run: python -m pytest test/unit/test_disk_tensor.py -k test_copy_from_disk
 
+  testqcom:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - renderer: IR3
+            compiler_probe: test/mockgpu/qcom/test_integration.py::TestQCOMIntegration::test_emitted_instruction_bytes_are_required_for_execution
+          - renderer: CL
+            compiler_probe: >-
+              test/mockgpu/qcom/test_qcomcl.py::test_generated_add_uses_every_lane_and_workgroup
+              test/mockgpu/qcom/test_qcomcl.py::test_jit_refreshes_arguments_without_reusing_previous_values
+    name: Linux (QCOM A630 mock ${{ matrix.renderer }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      DEV: MOCK+QCOM:${{ matrix.renderer }}
+      HCQ_RUNTIME_DEV: CPU
+      IMAGE: 0
+      FLOAT16: 0
+      RUN_SLOW: 1
+      SKIP_SLOW_TEST: 0
+      TEST_TIMEOUT: 7200
+      PARALLEL: 0
+      CACHELEVEL: 0
+      OMP_NUM_THREADS: 1
+      PYTHONPATH: .
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Setup Environment
+        uses: ./.github/actions/setup-tinygrad
+        with:
+          key: qcom-mock-${{ matrix.renderer }}
+          deps: "testing_unit mesa"
+          llvm: 'true'
+          qemu: ${{ matrix.renderer == 'CL' }}
+      - name: Run representative QCOM compilation and submission regressions
+        # Image tests assert actual image instruction execution and FP16 storage.
+        # The broad execution/backend/image matrix is release/local qualification.
+        run: >-
+          python -m pytest -n 2 --dist worksteal
+          test/mockgpu/qcom/test_integration.py::TestQCOMIntegration::test_real_submissions_cover_odd_shapes_and_repeated_programs
+          'test/mockgpu/qcom/test_image_integration.py::test_image_matmul_preserves_nonuniform_values_and_odd_channels[False]'
+          'test/mockgpu/qcom/test_image_integration.py::test_image_matmul_preserves_nonuniform_values_and_odd_channels[True]'
+          test/backend/test_jit.py::TestJit::test_simple_jit
+          test/testextra/test_qcom_driver.py::QCOMDriverTests::test_native_callback_latches_failure_and_preserves_original_cause
+          test/testextra/test_qcom_driver.py::QCOMDriverTests::test_native_callback_forwards_real_descriptor
+          ${{ matrix.compiler_probe }}
+
   testamd:
     strategy:
       fail-fast: false

--- a/test/mockgpu/mockgpu.py
+++ b/test/mockgpu/mockgpu.py
@@ -5,11 +5,20 @@ from tinygrad.runtime.autogen import libc
 from test.mockgpu.nv.nvdriver import NVDriver
 from test.mockgpu.amd.amddriver import AMDDriver
 from test.mockgpu.am.amdriver import AMDriver, AMUSBDriver
+from test.mockgpu.qcom.qcomdriver import QCOMDriver, make_ioctl_callback
 start = time.perf_counter()
 
 drivers = [cls() for t in DEV.value if (cls:={"MOCKPCI+AMD": AMDriver, "MOCKKFD+AMD": AMDDriver, "MOCK+AMD": AMDDriver, "MOCKUSB+AMD": AMUSBDriver,
-                                              "MOCK+NV": NVDriver}.get(f"{t.interface}+{t.device}"))]
+                                              "MOCK+NV": NVDriver, "MOCK+QCOM": QCOMDriver}.get(f"{t.interface}+{t.device}"))]
 tracked_fds: dict[int, typing.Any] = {}
+# Native HCQ2 calls this retained callback; it routes QCOM descriptors to the
+# Python driver and lets unrelated descriptors continue through the real ioctl.
+ioctl_callback = make_ioctl_callback(tracked_fds, libc.dll.ioctl) if any(isinstance(d, QCOMDriver) for d in drivers) else None
+
+def check_qcom_errors():
+  # Recover a Python failure captured while execution was inside a C callback.
+  for driver in drivers:
+    if isinstance(driver, QCOMDriver): driver.check_error()
 
 original_memoryview = builtins.memoryview
 class TrackedMemoryView:

--- a/test/mockgpu/qcom/emu.py
+++ b/test/mockgpu/qcom/emu.py
@@ -198,10 +198,18 @@ def _validate_operands(op, operands, fields, category):
     # QCOMCL's sine reduction selects between one full register and its FNEG.
     # Other operand layouts, modifiers and conversions need separate evidence.
     first, condition, third = (operands[name] for name in ('SRC1', 'SRC2', 'SRC3'))
-    if (any(o.kind != 'register' or o.half or o.relative or o.repeat for o in operands.values()) or
-        first.index != third.index or (first.modifier, condition.modifier, third.modifier) != (1, 0, 0) or
-        fields.get('REPEAT', 0) or fields.get('SAT', 0) or fields.get('NOP', 0)):
-      raise RuntimeError('IR3 unsupported SEL.F32 form')
+    if any(operand.kind != 'register' for operand in operands.values()):
+      raise RuntimeError('IR3 unsupported SEL.F32 form: every operand must be a register')
+    if any(operand.half for operand in operands.values()):
+      raise RuntimeError('IR3 unsupported SEL.F32 form: half registers')
+    if any(operand.relative or operand.repeat for operand in operands.values()):
+      raise RuntimeError('IR3 unsupported SEL.F32 form: relative or repeated operands')
+    if first.index != third.index:
+      raise RuntimeError('IR3 unsupported SEL.F32 form: sources are not one register and its own negation')
+    if (first.modifier, condition.modifier, third.modifier) != (1, 0, 0):
+      raise RuntimeError('IR3 unsupported SEL.F32 form: only the first source may be negated')
+    if marked := [name for name in ('REPEAT', 'SAT', 'NOP') if fields.get(name, 0)]:
+      raise RuntimeError(f'IR3 unsupported SEL.F32 form: {" ".join(marked)}')
   if op == 'getbit.b':
     # QCOMCL restores loop-hoisted packed booleans with a half-register bit
     # test into p0.x..w. Other result representations are not qualified here.

--- a/test/mockgpu/qcom/emu.py
+++ b/test/mockgpu/qcom/emu.py
@@ -52,7 +52,7 @@ SUPPORTED = set(
     'mov swz nop end predt predf prede bar fence br brao braa jump call ret ldg stg ldg.a stg.a ldl stl ldp stp '
     'add.u add.s add.f sub.u sub.s sub.f mul.f mul.s24 mul.u24 mull.u madsh.m16 mad.u16 mad.s24 mad.f32 mad.f16 '
     'shl.b shr.b ashr.b shrg shrm shlm shlg andg and.b or.b xor.b not.b absneg.s absneg.f sign.f clz.b getbit.b '
-    'min.u min.s min.f max.u max.s max.f sel.b32 sel.b16 sel.s32 cmps.u cmps.s cmps.f cmpv.s cmpv.f cmpv.u '
+    'min.u min.s min.f max.u max.s max.f sel.b32 sel.b16 sel.s32 sel.f32 cmps.u cmps.s cmps.f cmpv.s cmpv.f cmpv.u '
     'floor.f ceil.f trunc.f rcp sqrt rsq exp2 log2 sin cos sad.s16 sad.s32'
   ).split()
 )
@@ -194,6 +194,14 @@ def _validate_operands(op, operands, fields, category):
   # Mesa ir3_cf.c and ir3_validate.c forbid 16-bit inputs/outputs for MAD.x24.
   if op == 'mad.s24' and any(operand.half for operand in operands.values()):
     raise RuntimeError('IR3 mad.s24 requires full registers')
+  if op == 'sel.f32':
+    # QCOMCL's sine reduction selects between one full register and its FNEG.
+    # Other operand layouts, modifiers and conversions need separate evidence.
+    first, condition, third = (operands[name] for name in ('SRC1', 'SRC2', 'SRC3'))
+    if (any(o.kind != 'register' or o.half or o.relative or o.repeat for o in operands.values()) or
+        first.index != third.index or (first.modifier, condition.modifier, third.modifier) != (1, 0, 0) or
+        fields.get('REPEAT', 0) or fields.get('SAT', 0) or fields.get('NOP', 0)):
+      raise RuntimeError('IR3 unsupported SEL.F32 form')
   if op == 'getbit.b':
     # QCOMCL restores loop-hoisted packed booleans with a half-register bit
     # test into p0.x..w. Other result representations are not qualified here.
@@ -549,6 +557,21 @@ class Workgroup:
   def alu(self, ins, lanes, repeat):
     op, fields, operands = ins.op, ins.fields, ins.operands
     dst = operands['DST']
+    if op == 'sel.f32':
+      payload = self.read(operands['SRC1'], lanes, repeat)
+      condition = self.read(operands['SRC2'], lanes, repeat)
+      # The traced comparison/COV/integer-minus-one producer emits only these
+      # two words. Ordered and sign predicates agree here, not on general F32.
+      if np.any((condition != 0x3f7fffff) & (condition != 0xffffffff)):
+        raise RuntimeError('IR3 SEL.F32 condition outside admitted domain')
+      # Only normal finite payloads are established. Do not guess signed-zero,
+      # denormal flushing or NaN propagation from ordinary sine observations.
+      exponent = (payload >> 23) & 255
+      if np.any((exponent == 0) | (exponent == 255)):
+        raise RuntimeError('IR3 SEL.F32 payload outside admitted domain')
+      value = np.where(condition == 0x3f7fffff, payload ^ np.uint32(0x80000000), payload)
+      self.write(dst, lanes, value, repeat)
+      return
     if op == 'mov':
       # MOV/COV has explicit source and destination types and a rounding mode.
       src = operands['SRC']

--- a/test/mockgpu/qcom/emu.py
+++ b/test/mockgpu/qcom/emu.py
@@ -1,0 +1,1049 @@
+"""A630 scalar ISA semantics evaluated over NumPy lanes of one workgroup."""
+
+import ctypes, functools, itertools, math, os
+from dataclasses import dataclass, replace
+import numpy as np
+from tinygrad.runtime.autogen import libc, mesa
+from test.mockgpu.qcom.image import ImageBindings
+
+
+# qcomgpu.Launch.apply supplies the validated shader image, constant bytes,
+# dispatch dimensions and register/resource configuration recovered from PM4.
+# This module turns that image into instructions, then evolves each workgroup:
+# fetch at a lane's PC -> select operands -> compute -> write back state.
+# Global writes use the caller's staged memory; the queue owns their commit.
+
+
+# An operand identifies a scalar component in a register bank, a constant slot,
+# or an immediate value. Precision and modifiers travel with that selection.
+@dataclass(frozen=True)
+class Operand:
+  kind: str
+  index: int
+  half: bool = False
+  repeat: bool = False
+  modifier: int = 0
+  relative: bool = False
+
+
+# Keep encoding/flags alongside normalized operands: decoding establishes what
+# an instruction may do, while execution supplies the current lane values.
+@dataclass(frozen=True)
+class Instruction:
+  op: str
+  fields: dict
+  operands: dict
+  raw: int
+
+
+# Numeric and instruction policy. These tables describe the supported ISA
+# forms and the conversions permitted between full and half register results.
+# Despite its U8 name, cat1 conversion sign-extends byte inputs. Mesa emits
+# AND 0xff instead for unsigned widening (ir3_compiler_nir.c:create_cov).
+TYPES = (np.float16, np.float32, np.uint16, np.uint32, np.int16, np.int32, np.int8, np.uint8)
+# Keep the ISA's FLUT index order, including the final 4.0 slot.
+FLUT = (
+  0.0, 0.5, 1.0, 2.0,
+  math.e, math.pi, 1 / math.pi,
+  math.log(2), math.log2(math.e), 1 / math.log2(10), math.log2(10), 4.0,
+)
+SUPPORTED = set(
+  (
+    'mov swz nop end predt predf prede bar fence br brao braa jump call ret ldg stg ldg.a stg.a ldl stl ldp stp '
+    'add.u add.s add.f sub.u sub.s sub.f mul.f mul.s24 mul.u24 mull.u madsh.m16 mad.u16 mad.s24 mad.f32 mad.f16 '
+    'shl.b shr.b ashr.b shrg shrm shlm shlg andg and.b or.b xor.b not.b absneg.s absneg.f sign.f clz.b getbit.b '
+    'min.u min.s min.f max.u max.s max.f sel.b32 sel.b16 sel.s32 cmps.u cmps.s cmps.f cmpv.s cmpv.f cmpv.u '
+    'floor.f ceil.f trunc.f rcp sqrt rsq exp2 log2 sin cos sad.s16 sad.s32'
+  ).split()
+)
+FIELD_NAMES = set(
+  (
+    'SY SS JP SAT REPEAT NOP UL NAME EI DST_HALF DST DST0 DST1 SRC0 SRC1 SRC2 SRC3 SRC SRC_R LAST ABSNEG HALF '
+    'GPR SWIZ CONST IMMED SRC_TYPE DST_TYPE ROUND TYPE TYPE_HALF OFF SIZE COND INV1 COMP1 INV2 COMP2 EQ G L R W REG '
+    'SRC1_NEG SRC2_NEG SRC3_NEG SRC1_R SRC2_R SRC3_R FULL_SHIFT TYPE_SHIFT SRC2_SHIFT OFFSET'
+  ).split()
+)
+BITWISE_OPS = {'and.b', 'or.b', 'not.b', 'xor.b', 'shl.b', 'shr.b', 'ashr.b'}
+SIGNED_OUTPUTS = {'add.s', 'sub.s', 'min.s', 'max.s', 'absneg.s', 'mul.s24', 'mad.s24', 'sad.s16', 'sad.s32'}
+FLOAT_OUTPUTS = {'add.f', 'mul.f', 'mad.f16', 'mad.f32'}
+UNSIGNED_OUTPUTS = {
+  'add.u', 'sub.u', 'min.u', 'max.u', 'mull.u', 'mul.u24', 'mad.u16',
+  'shrg', 'shrm', 'shlm', 'shlg', 'andg',
+  'cmps.u', 'cmps.s', 'cmps.f', 'cmpv.s', 'cmpv.f', 'cmpv.u', 'getbit.b',
+} | BITWISE_OPS
+UNARY_BASES = {
+  'not', 'absneg', 'sign', 'clz',
+  'floor', 'ceil', 'trunc',
+  'rcp', 'sqrt', 'rsq',
+  'exp2', 'log2',
+  'sin', 'cos',
+}
+
+
+# Representation boundaries: register storage carries bits; ALU operations
+# temporarily interpret those bits as the instruction's numeric type.
+def _typed(bits, typ):
+  dtype = np.dtype(TYPES[typ])
+  unsigned = np.dtype(f'u{dtype.itemsize}')
+  return bits.astype(unsigned).view(dtype)
+
+
+def _signed(value, width):
+  # Encoded immediates and offsets share two's-complement sign extension, but
+  # retain their own field widths (11, 13, 24 or 32 bits at the call sites).
+  sign = 1 << (width - 1)
+  return ((value & (2 * sign - 1)) ^ sign) - sign
+
+
+def _bits(value, typ, round_zero=False):
+  dtype = np.dtype(TYPES[typ])
+  with np.errstate(over='ignore', invalid='ignore'):
+    converted = np.asarray(value).astype(dtype)
+    if round_zero and dtype.kind == 'f':
+      # Start from the nearest value and step toward zero only if it overshot.
+      overshot = np.abs(converted.astype(np.float64)) > np.abs(np.asarray(value).astype(np.float64))
+      converted = np.where(overshot, np.nextafter(converted, np.zeros_like(converted)), converted)
+  return converted.view(np.dtype(f'u{dtype.itemsize}')).astype(np.uint32)
+
+
+def _source_typed(bits, operand, typ, *, constant_demotion=True):
+  # CONSTANT_DEMOTION_ENABLE keeps each constant slot 32 bits wide. A half
+  # floating source converts its F32 value; an integer source takes low bits.
+  # Model the implicit conversion as the default narrowing COV that Mesa folds
+  # into ALU sources (ir3.h:is_const_mov), independently of output rounding.
+  if constant_demotion and operand.kind == 'constant' and typ == 0:
+    bits = _bits(_typed(bits, 1), 0, round_zero=True)
+  return _typed(bits, typ)
+
+
+# Decode one operand's nested Mesa fields before discarding their local order.
+# The same field name can recur in another operand, so a whole-instruction
+# dictionary alone cannot select register/constant components correctly.
+def _operand(name, fields, top, source_half, raw):
+  values = dict(fields)
+  default_half = top.get('DST_HALF', top.get('TYPE_HALF', 0)) if name.startswith('DST') else source_half
+  half = bool(values.get('HALF', values.get('DST_HALF', default_half)))
+  modifier = values.get('ABSNEG', top.get(name + '_NEG', 0))
+  repeat = bool(values.get('SRC_R', top.get(name + '_R', 0)))
+  category, destination = raw >> 61, name.startswith('DST')
+  relative = relative_constant = False
+  if category == 1 and (raw >> 57) & 3 == 0:
+    relative = bool(raw & (1 << 49)) if destination else bool(raw & (1 << 11)) and (raw >> 53) & 3 == 0
+    relative_constant = not destination and bool(raw & (1 << 10))
+  elif category in (2, 4) and not destination:
+    encoded = (raw >> (16 if name == 'SRC2' else 0)) & 0xffff
+    relative = (encoded >> 11) & 7 == 1
+    relative_constant = bool(encoded & (1 << 10))
+  if relative:
+    # Cat1 destinations have unsigned8 offsets; relative sources use signed10.
+    # Both offsets count scalar components in the bank selected by the operand.
+    # The display callback omits OFFSET when it is zero, so use the mode bits.
+    offset = (raw >> 32) & 255 if destination else _signed(values.get('OFFSET', 0), 10)
+    return Operand('constant' if relative_constant else 'register', offset, half, repeat, modifier, relative=True)
+  if 'OFFSET' in values:
+    raise RuntimeError('IR3 unexpected relative-address field')
+  if 'IMMED' in values:
+    kind = 'float_immediate' if 'SRC_TYPE' not in top and (fields[0][1] >> 11) & 7 == 5 else 'immediate'
+    if kind == 'float_immediate' and values['IMMED'] >= len(FLUT):
+      raise RuntimeError('IR3 invalid floating immediate')
+    if kind == 'float_immediate':
+      half = bool(fields[0][1] & (1 << 10))
+      if half != source_half:
+        raise RuntimeError('IR3 mixed precision immediate is unsupported')
+    if repeat:
+      raise RuntimeError('IR3 repeated immediate operands are unsupported')
+    immediate = values['IMMED']
+    if 'SRC_TYPE' not in top and (fields[0][1] >> 11) & 7 == 4:
+      immediate = _signed(immediate, 11)
+    return Operand(kind, immediate, half, repeat, modifier)
+  if 'CONST' in values:
+    return Operand('constant', values['CONST'] * 4 + values.get('SWIZ', 0), half, repeat, modifier)
+  index = values['GPR'] * 4 + values.get('SWIZ', 0) if 'GPR' in values else fields[0][1] & 255
+  return Operand('register', index, half, repeat, modifier)
+
+
+def memory_roles(op):
+  # ld/st selects direction; g/l/p selects global, local/shared or private
+  # storage. In a local/private store, DST names an address rather than a result.
+  base = op.split('.')[0]
+  loading = base.startswith('ld')
+  address = 'SRC1' if base.endswith('g') else 'SRC' if loading else 'DST'
+  return address, 'DST' if loading else 'SRC3' if base.endswith('g') else 'SRC'
+
+
+# Reject unsupported operand forms before they can enter the state-update loop.
+def _validate_operands(op, operands, fields, category):
+  if op == 'swz':
+    expected = {'DST0', 'DST1', 'SRC0', 'SRC1'}
+  elif op in ('ldg', 'ldg.a'):
+    expected = {'DST', 'SRC1'} | ({'SRC2'} if op.endswith('.a') else set())
+  elif op in ('stg', 'stg.a'):
+    expected = {'SRC1', 'SRC3'} | ({'SRC2'} if op.endswith('.a') else set())
+  elif category in (0, 7):
+    expected = set()
+  elif category in (1, 4, 6):
+    expected = {'DST', 'SRC'}
+  elif op.split('.')[0] in UNARY_BASES:
+    expected = {'DST', 'SRC1'}
+  elif category == 3:
+    expected = {'DST', 'SRC1', 'SRC2', 'SRC3'}
+  else:
+    expected = {'DST', 'SRC1', 'SRC2'}
+  if set(operands) != expected:
+    raise RuntimeError(f'IR3 {op}: invalid operand schema')
+  # Mesa ir3_cf.c and ir3_validate.c forbid 16-bit inputs/outputs for MAD.x24.
+  if op == 'mad.s24' and any(operand.half for operand in operands.values()):
+    raise RuntimeError('IR3 mad.s24 requires full registers')
+  if op == 'getbit.b':
+    # QCOMCL restores loop-hoisted packed booleans with a half-register bit
+    # test into p0.x..w. Other result representations are not qualified here.
+    dst, source, bit = (operands[name] for name in ('DST', 'SRC1', 'SRC2'))
+    if (dst.half or not 248 <= dst.index <= 251 or source.kind != 'register' or not source.half or
+        bit.kind != 'immediate' or not 0 <= bit.index < 16 or fields.get('REPEAT', 0)):
+      raise RuntimeError('IR3 unsupported GETBIT predicate form')
+  if op.startswith(('cmps.', 'cmpv.')) and not 0 <= fields.get('COND', -1) <= 5:
+    raise RuntimeError('IR3 invalid comparison condition')
+  if op.startswith(('cmps.', 'cmpv.')) and fields.get('SAT', 0):
+    # QCOMCL uses this bit to invert F32 LE/GE predicate comparisons. Other
+    # comparison/destination forms need their own compiler evidence.
+    if (op != 'cmps.f' or fields['COND'] not in (1, 3) or
+        not 248 <= operands['DST'].index <= 251 or any(operand.half for operand in operands.values())):
+      raise RuntimeError('IR3 unsupported comparison modifier')
+  modifier_mask = (
+    1
+    if op in BITWISE_OPS or category == 3 and op.startswith('mad.f')
+    else (3 if '.f' in op or category == 4 or op == 'absneg.s' else 0)
+  )
+  memory_data = memory_roles(op)[1] if category == 6 else None
+  for name, operand in operands.items():
+    allowed_modifier = int(name == 'SRC2') if op.startswith('sad.') else modifier_mask
+    if operand.modifier & ~allowed_modifier:
+      raise RuntimeError(f'IR3 {op}: unsupported source modifier')
+    destination = name.startswith('DST') and op not in ('stl', 'stp')
+    if destination and operand.kind != 'register':
+      raise RuntimeError('IR3 invalid destination operand')
+    last = fields.get('REPEAT', 0) if destination or operand.repeat else 0
+    if category == 6:
+      last = fields['SIZE'] - 1 if name == memory_data else int(name == 'SRC1' and op.startswith(('ldg', 'stg')))
+      if operand.kind != 'register' or operand.relative:
+        raise RuntimeError('IR3 invalid memory register operand')
+    if operand.kind == 'register' and not operand.relative and not 0 <= operand.index <= 255 - last:
+      raise RuntimeError(f'IR3 {"destination" if destination else "source"} register span out of bounds')
+  if category in (2, 3, 4):
+    source = next(operand for name, operand in operands.items() if name.startswith('SRC'))
+    # Cat4 explicitly encodes opposite-precision destinations with DST_CONV.
+    if operands['DST'].half != source.half and category != 4 and op not in SIGNED_OUTPUTS | UNSIGNED_OUTPUTS | FLOAT_OUTPUTS:
+      raise RuntimeError(f'IR3 {op}: unsupported output conversion')
+
+
+# One 64-bit encoding becomes a decoded instruction with checked operand roles.
+def _instruction(fields, raw):
+  top = dict(fields)
+  # Mesa's MOVA display omits its implicit destination and types from callbacks.
+  # Recover those exact cat1 fields before using the ordinary MOV machinery.
+  category, destination = raw >> 61, (raw >> 32) & 255
+  source_type, destination_type = (raw >> 50) & 7, (raw >> 46) & 7
+  if category == 1 and (destination, source_type, destination_type) in ((244, 4, 4), (245, 2, 2)) and 'SRC_TYPE' not in top:
+    fields = [('DST', destination), ('DST_HALF', 1), ('SRC_TYPE', source_type), ('DST_TYPE', destination_type), *fields]
+    if 'IMMED' in top and not raw & (1 << 49):
+      # SRC_R on an immediate MOVA is a hazard marker, not source repetition.
+      fields = [(name, 0 if name == 'SRC_R' else value) for name, value in fields]
+    top = dict(fields)
+  op = top.get('NAME', 'swz' if 'DST0' in top else 'mov' if 'SRC_TYPE' in top else '')
+  # Mesa uses distinct cat4 opcodes for these half special functions. Their
+  # numeric operation is shared; FULL and DST_CONV still select the banks and
+  # rounding in operand admission and ALU writeback (ir3-cat4.xml).
+  if raw >> 61 == 4:
+    op = {'hrsq': 'rsq', 'hlog2': 'log2', 'hexp2': 'exp2'}.get(op, op)
+  if op in ('isam', 'stib.b', 'ldib.b'):
+    return _image_instruction(top, raw)
+  if op not in SUPPORTED:
+    raise RuntimeError(f'IR3 unsupported instruction {op or hex(raw)}')
+  if unknown := top.keys() - FIELD_NAMES:
+    raise RuntimeError(f'IR3 unsupported fields {sorted(unknown)}')
+  if top.get('ROUND', 0) and not (op == 'mov' and top['ROUND'] == 1 and top['DST_TYPE'] in (0, 1)):
+    raise RuntimeError('IR3 conversion rounding mode is unsupported')
+  if op == 'swz' and top['SRC_TYPE'] != top['DST_TYPE']:
+    raise RuntimeError('IR3 converting swizzles are unsupported')
+  if op == 'mov' and (
+    (top['SRC_TYPE'] == 6 and top['DST_TYPE'] in (0, 1))
+    or (top['DST_TYPE'] == 6 and top['SRC_TYPE'] in (0, 1))
+  ):
+    raise RuntimeError('IR3 direct byte/float conversion is unsupported')
+  # EQ on NOP ends fragment helper invocations (ir3_legalize.c:helper_sched).
+  # Compute has no helper lanes. Keep other EQ forms unsupported; some cat0
+  # display callbacks omit EQ, so read its common encoding bit directly.
+  end_of_quad = raw >> 61 == 0 and bool(raw & (1 << 48))
+  # OpenCL hadd directly emits ADD.U(EI): retain the carry bit until the
+  # mathematical sum is halved. Other EI forms are still unsupported.
+  halving_add = op == 'add.u' and bool(raw & (1 << 52)) and not top.get('DST_HALF', 0)
+  if (end_of_quad and op != 'nop') or (top.get('EI', 0) and not halving_add):
+    raise RuntimeError('IR3 unsupported execution modifier')
+  if top.get('SAT', 0) and '.f' not in op and raw >> 61 != 4:
+    raise RuntimeError('IR3 integer saturation is unsupported')
+  operands = {}
+  # FULL is not printed for immediate operands, so it has no field callback.
+  # Its shared cat2/cat4 encoding is bit 52 (ir3-cat2.xml, ir3-cat4.xml).
+  source_half = not bool(raw & (1 << 52)) if raw >> 61 in (2, 4) else top.get('HALF', 0)
+  # Nested field names repeat. Preserve the leaf values within each operand.
+  names = (
+    ('DST0', 'DST1', 'SRC0', 'SRC1')
+    if op == 'swz'
+    else ('DST', 'SRC')
+    if 'SRC_TYPE' in top or raw >> 61 == 4
+    else (('DST', 'SRC1', 'SRC2', 'SRC3') if raw >> 61 in (2, 3) else ('DST', 'SRC1', 'SRC2', 'SRC3', 'SRC'))
+  )
+  starts: list[tuple[int, str]] = []
+  for i, (name, _) in enumerate(fields):
+    if name in names and name not in [x[1] for x in starts]:
+      starts.append((i, name))
+  for k, (start, name) in enumerate(starts):
+    stop = starts[k + 1][0] if k + 1 < len(starts) else len(fields)
+    operands[name] = _operand(name, fields[start:stop], top, source_half, raw)
+  if op == 'mad.u16':
+    # The compiler's wide MAD.U16 uses full GPR/constant slots: only the two
+    # multiplicands' low16 bits participate, while the accumulator is full32.
+    # Mesa's derived HALF labels describe the digit width for this opcode.
+    if operands['DST'].half:
+      raise RuntimeError('IR3 MAD.U16 half destination is unsupported')
+    for name in ('SRC1', 'SRC2', 'SRC3'):
+      operands[name] = replace(operands[name], half=False)
+  if op in ('ldg', 'stg', 'ldg.a', 'stg.a', 'ldl', 'stl', 'ldp', 'stp') and not 1 <= top.get('SIZE', 0) <= 4:
+    raise RuntimeError('IR3 invalid memory vector width')
+  if raw >> 61 == 6:
+    address, data = memory_roles(op)
+    operands[address] = replace(operands[address], half=False)
+    operands[data] = replace(operands[data], half=top['TYPE'] in (0, 2, 4, 6))
+    if op.endswith('.a'):
+      # Mesa's display callbacks may emit only FULL_SHIFT when OFF is zero.
+      # Retain the actual A6xx address-calculation fields independently of display.
+      top['SRC2_SHIFT'], top['OFF'] = raw >> 12 & 3, raw >> 9 & 3
+      operands['SRC2'] = replace(operands['SRC2'], half=False)
+  _validate_operands(op, operands, top, raw >> 61)
+  return Instruction(op, top, operands, raw)
+
+
+def _image_instruction(fields, raw):
+  # Image instructions have different operand roles from buffer cat6 operations.
+  # Decode those roles explicitly: cat5's empty SRC2 is not a register, and the
+  # cat6 OFFSET printed after SRC2 belongs to the instruction, not its register.
+  op = fields['NAME']
+  typ = fields['TYPE']
+  if typ not in (0, 1):
+    raise RuntimeError('IR3 image instructions require a floating data type')
+  if op == 'isam':
+    destination, coordinates = fields['DST'], fields['SRC1']
+    mask = fields['WRMASK']
+    if not mask or not 0 <= destination <= 256 - mask.bit_length() or not 0 <= coordinates <= 254:
+      raise RuntimeError('IR3 image register span out of bounds')
+    expected = (5 << 61) | (fields['SY'] << 60) | (fields['JP'] << 59)
+    expected |= typ << 44 | mask << 40 | destination << 32 | coordinates << 1 | 1
+    operands = {
+      'DST': Operand('register', destination, half=typ == 0),
+      'COORD': Operand('register', coordinates),
+    }
+    if raw & (1 << 51):
+      # The non-bindless uniform S2EN form selects texture then sampler from a
+      # pair of half registers. This is emitted when sampler index exceeds 15.
+      indices = fields['SRC3']
+      if not 0 <= indices <= 254:
+        raise RuntimeError('IR3 image index register span out of bounds')
+      expected |= (1 << 51) | indices << 21
+      operands['INDICES'] = Operand('register', indices, half=True)
+    else:
+      expected |= fields['SAMP'] << 21 | fields['TEX'] << 25
+    if raw != expected:
+      raise RuntimeError('IR3 unsupported image sampling mode')
+  else:
+    data, coordinates, index = fields['SRC1'], fields['SRC2'], fields['SSBO']
+    if fields['D'] != 2 or fields['TYPED'] != 1 or fields['TYPE_SIZE'] != 4:
+      raise RuntimeError('IR3 unsupported image load/store shape')
+    if not 0 <= data <= 252 or not 0 <= coordinates <= 254:
+      raise RuntimeError('IR3 image register span out of bounds')
+    # MODE=0 selects a bound descriptor by immediate index. The opcode's .b
+    # suffix names the A6xx encoding; it does not itself select bindless access.
+    expected = (6 << 61) | fields['SY'] << 60 | fields['JP'] << 59 | (2 << 52)
+    expected |= typ << 49 | index << 41 | data << 32 | coordinates << 24
+    opcode = 6 if op == 'ldib.b' else 29
+    expected |= (6 << 20) | (opcode << 14) | (3 << 12) | (1 << 11) | (1 << 9)  # Four typed components, 2D.
+    # Mesa marks LDIB bit 0 as dontcare; QCOMCL sets it, while IR3 clears it.
+    if op == 'ldib.b': expected |= raw & 1
+    if raw != expected:
+      raise RuntimeError('IR3 unsupported image load/store mode')
+    operands = {
+      'DST' if op == 'ldib.b' else 'DATA': Operand('register', data, half=typ == 0),
+      'COORD': Operand('register', coordinates),
+    }
+  return Instruction(op, fields, operands, raw)
+
+
+# Decode is shared by identical images. All words, including padding after END,
+# are checked before execute() creates any mutable workgroup state.
+@functools.lru_cache(maxsize=256)
+def decode(image):
+  if not image or len(image) % 8:
+    raise RuntimeError('IR3 image must contain complete 64-bit instructions')
+  result, fields, errors = [], [], []
+
+  # Consume structured callbacks rather than printed assembly. Callback errors
+  # must cross the C boundary explicitly, since ctypes otherwise reports and
+  # suppresses exceptions raised by a Python callback.
+  @ctypes.CFUNCTYPE(
+    None, ctypes.c_void_p, ctypes.POINTER(ctypes.c_char), ctypes.POINTER(mesa.struct_isa_decode_value)
+  )
+  def field(_, name, value):
+    try:
+      content = (
+        ctypes.string_at(value.contents.str).decode() if value.contents.str else int(value.contents.num)
+      )
+      fields.append((ctypes.string_at(name).decode(), content))
+    except Exception as error:
+      errors.append(error)
+
+  @ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_uint32, ctypes.c_void_p)
+  def post(_, index, raw):
+    try:
+      result.append(
+        _instruction(fields.copy(), ctypes.cast(raw, ctypes.POINTER(ctypes.c_uint64)).contents.value)
+      )
+    except Exception as error:
+      errors.append(error)
+    finally:
+      fields.clear()
+
+  @ctypes.CFUNCTYPE(
+    None, ctypes.POINTER(mesa.struct__IO_FILE), ctypes.POINTER(ctypes.c_uint32), ctypes.c_uint64
+  )
+  def unmatched(_, words, count):
+    # The Qualcomm compiler emits legacy BAR/FENCE without Mesa's fixed bit49.
+    # Decode only that explicit zero-reserved-bit layout, retaining the actual
+    # word and all synchronization flags. Other unmatched encodings stay errors.
+    try:
+      flags = {'SS':44, 'W':51, 'R':52, 'L':53, 'G':54, 'JP':59, 'SY':60}
+      allowed = (1 << 55) | sum(1 << shift for shift in flags.values())
+      raw = int(words[0]) | int(words[1]) << 32 if count == 2 else 0
+      if raw & ~allowed != 7 << 61:
+        raise RuntimeError('IR3 unrecognized encoding')
+      values: list[tuple[str, str|int]] = [('NAME', 'fence' if raw & (1 << 55) else 'bar')]
+      values += [(name, raw >> shift & 1) for name, shift in flags.items()]
+      result.append(_instruction(values, raw))
+    except Exception as error:
+      errors.append(error)
+    finally:
+      fields.clear()
+
+  stream = libc.fopen(b'/dev/null', b'w')
+  if not stream:
+    raise RuntimeError('IR3 decoder output could not be opened')
+  try:
+    options = mesa.struct_isa_decode_options(
+      gpu_id=630, field_cb=field, post_instr_cb=post, no_match_cb=unmatched
+    )
+    mesa.ir3_isa_disasm(image, len(image), ctypes.cast(stream, ctypes.POINTER(mesa.struct__IO_FILE)), options)
+  finally:
+    libc.fclose(stream)
+  if errors:
+    raise RuntimeError(f'IR3 decode failed: {errors[0]}') from errors[0]
+  if len(result) * 8 != len(image):
+    raise RuntimeError('IR3 decoder omitted an instruction')
+  for pc, ins in enumerate(result):
+    if ins.op in ('br', 'brao', 'braa', 'jump', 'call'):
+      offset = _signed(ins.fields['IMMED'], 32)
+      if not 0 <= pc + offset < len(result):
+        raise RuntimeError('IR3 branch target out of bounds')
+  return tuple(result)
+
+
+# Each register-bank column is one invocation lane; rows are scalar register
+# components. NumPy evaluates the selected lane columns together.
+# PC, predicate mode/mask and barrier waiting have distinct transition rules.
+class Workgroup:
+  def __init__(self, constants, local_size, group, wgid, lid, wgsize, memory, shared_bytes, private_bytes, *,
+               image_bindings=ImageBindings(), opencl=False, wgoffset=0xfc, groups=(1, 1, 1),
+               constant_demotion=True, entry_pc=0):
+    self.count = math.prod(local_size)
+    self.registers = (np.zeros((256, self.count), np.uint32), np.zeros((256, self.count), np.uint16))
+    self.constants = np.frombuffer(constants, dtype='<u4').copy()
+    self.constant_demotion = constant_demotion
+    self.opencl = opencl
+    self.memory = memory
+    self.image_bindings = image_bindings
+    self.pc = np.full(self.count, entry_pc, np.int64)
+    self.return_stack:list[list[int]] = [[] for _ in range(self.count)]
+    self.predicate = np.ones(self.count, bool)
+    self.predicate_mode = np.zeros(self.count, np.int8)
+    self.waiting = np.zeros(self.count, bool)
+
+    # Shared bytes belong to this workgroup; each private row belongs to one
+    # lane. Only the supplied global-memory transaction spans workgroups.
+    self.shared = np.zeros(shared_bytes, np.uint8)
+    self.private = np.zeros((self.count, private_bytes), np.uint8)
+
+    # The launch chooses where workgroup/local IDs and local dimensions live.
+    # 0xfc means that the compiled shader does not consume that input.
+    if wgid != 0xFC:
+      self.registers[0][wgid : wgid + 3] = np.array(group, np.uint32)[:, None]
+    if lid != 0xFC:
+      lanes = np.arange(self.count, dtype=np.uint32)
+      self.registers[0][lid : lid + 3] = np.array([
+        lanes % local_size[0],
+        lanes // local_size[0] % local_size[1],
+        lanes // (local_size[0] * local_size[1]),
+      ])
+    if opencl:
+      # QCOMCL builtin reads: local dimensions in r48.xyz, group-origin in
+      # r51.xyz, global dimensions in c0.xyz, and group counts in c5.xyz.
+      # The register positions are carried by the launch, not inferred from code.
+      if wgsize != 0xFC:
+        self.registers[0][wgsize : wgsize + 3] = np.array(local_size, np.uint32)[:, None]
+      if wgoffset != 0xFC:
+        self.registers[0][wgoffset : wgoffset + 3] = (np.array(group, np.uint32) * local_size)[:, None]
+      self.constants[:3] = np.array(groups, np.uint32) * local_size
+      self.constants[8:11] = 0 # get_global_offset: the admitted producer has zero offsets.
+      self.constants[18] = 3 # get_work_dim: NDRANGE admission requires three dimensions.
+      self.constants[20:23] = groups
+      self.constants[28:31] = 0 # No dispatch splitting adds an extra group origin.
+    elif wgsize != 0xFC:
+      self.constants[wgsize : wgsize + 3] = local_size
+
+  def _operand_index(self, operand, lanes, advance, limit):
+    index = operand.index + advance
+    if operand.relative:
+      # a0.x is a per-lane signed16 address register, in scalar components.
+      index = index + self.registers[True][244, lanes].view(np.int16).astype(np.int32)
+      valid = np.all((index >= 0) & (index < limit))
+    else:
+      # Keep ordinary scalar indexing on its existing inexpensive path.
+      valid = 0 <= index < limit
+    if not valid:
+      bank = 'constant register' if operand.kind == 'constant' else 'register'
+      raise RuntimeError(f"IR3 {'relative ' if operand.relative else ''}{bank} index out of bounds")
+    return index
+
+  def read(self, operand, lanes, repeat=0):
+    # A repeated instruction advances only sources carrying the (r) flag.
+    mask = 0xFFFF if operand.half else 0xFFFFFFFF
+    if operand.kind in ('immediate', 'float_immediate'):
+      index = operand.index + repeat * operand.repeat
+      return np.full(len(lanes), index & mask, np.uint32)
+    if operand.kind == 'constant':
+      constants = self.constants.view('<u2') if operand.half and not self.constant_demotion else self.constants
+      index = self._operand_index(operand, lanes, repeat * operand.repeat, len(constants))
+      # The instruction has not selected a numeric type yet. In particular,
+      # discarding the upper bits here would destroy a floating constant.
+      return constants[index].astype(np.uint32) if operand.relative else np.full(len(lanes), constants[index], np.uint32)
+    index = self._operand_index(operand, lanes, repeat * operand.repeat, 244 if operand.relative else 256)
+    return self.registers[operand.half][index, lanes].astype(np.uint32)
+
+  def write(self, operand, lanes, value, repeat=0):
+    # Destinations advance on every repeat, independently of source flags.
+    index = self._operand_index(operand, lanes, repeat, 244 if operand.relative else 256)
+    self.registers[operand.half][index, lanes] = value
+
+  def refresh_predicate(self, lanes):
+    # Mode 0 enables all lanes; +1/-1 select true/false p0.x. Keep the resulting
+    # mask separately so ordinary register writes do not silently refresh it.
+    mode = self.predicate_mode[lanes]
+    self.predicate[lanes] = (mode == 0) | ((self.registers[0][248, lanes] != 0) == (mode == 1))
+
+  def alu(self, ins, lanes, repeat):
+    op, fields, operands = ins.op, ins.fields, ins.operands
+    dst = operands['DST']
+    if op == 'mov':
+      # MOV/COV has explicit source and destination types and a rounding mode.
+      src = operands['SRC']
+      value = self.read(src, lanes, repeat)
+      if fields['SRC_TYPE'] != fields['DST_TYPE'] or src.kind == 'constant' and fields['SRC_TYPE'] == 0:
+        value = _bits(
+          _source_typed(value, src, fields['SRC_TYPE'], constant_demotion=self.constant_demotion),
+          fields['DST_TYPE'], round_zero=fields.get('ROUND', 0) == 0
+        )
+      elif src.half:
+        value &= 0xFFFF
+      self.write(dst, lanes, value, repeat)
+      return
+    base = op.split('.')[0]
+    floating = '.f' in op or ins.raw >> 61 == 4
+    signed = '.s' in op or op == 'ashr.b'
+    values = []
+    names = [name for name in operands if name.startswith('SRC')]
+
+    # Select current values first, then apply the opcode's interpretation and
+    # source modifiers. A NEG bit means bitwise inversion for bitwise opcodes.
+    for name in names:
+      src = operands[name]
+      value = self.read(src, lanes, repeat)
+      if floating:
+        # cat2/cat4's FLUT immediate is a numeric table index, not IEEE bits.
+        if src.kind == 'float_immediate':
+          immediate = np.float16(FLUT[src.index]) if src.half else np.float32(FLUT[src.index])
+          value = np.full(len(lanes), immediate, np.float32)
+        else:
+          value = _source_typed(value, src, 0 if src.half else 1, constant_demotion=self.constant_demotion).astype(np.float32)
+      elif signed:
+        value = _typed(value, 4 if src.half else 5).astype(np.int32)
+      else:
+        # Integer constant demotion is truncation before comparisons/shifts,
+        # not merely a mask applied when the destination is written.
+        value = _typed(value, 2 if src.half else 3).astype(np.uint32)
+      if src.modifier & 2:
+        value = np.abs(value)
+      if src.modifier & 1:
+        value = ~value if op in BITWISE_OPS else -value
+        if src.half and op in BITWISE_OPS:
+          # BNOT complements the selected source width before a shift can
+          # consume its high bits. Preserve signed interpretation for ASHR.
+          value = value.astype(np.int16 if signed else np.uint16).astype(value.dtype)
+      values.append(value)
+    source_half = operands[names[0]].half
+
+    # Each case also states its operand count. Calculations operate on the
+    # selected lane vectors; precision conversion happens at writeback below.
+    match base, values:
+      case 'add', [a, b]:
+        if fields.get('EI'):
+          value = ((a.astype(np.uint64) + b.astype(np.uint64)) >> 1).astype(np.uint32)
+        else:
+          value = a + b
+      case 'sad', [a, b, c]:
+        # QCOMCL emits SAD for three-source signed sums, including 3*index
+        # and pointer high-word carry. Only its second source admits negation.
+        value = a + b + c
+      case 'sub', [a, b]:
+        value = a - b
+      case 'mul', [a, b]:
+        if op == 'mul.s24':
+          value = _signed(a, 24) * _signed(b, 24)
+        elif op == 'mul.u24':
+          value = (a & 0xffffff) * (b & 0xffffff)
+        else:
+          value = a * b
+      case 'mull', [a, b]:
+        # MULL uses the low 16-bit parts; MADSH adds a shifted high-half term.
+        value = (a & 65535) * (b & 65535)
+      case 'madsh', [a, b, c]:
+        value = ((a * (b >> 16)) << 16) + c
+      case 'mad', [a, b, c]:
+        # Integer MAD narrows its multiplicands and keeps the full accumulator.
+        # Floating MAD is unfused: round the product before the addition.
+        if op == 'mad.u16':
+          product = (a & 65535) * (b & 65535)
+        elif op == 'mad.s24':
+          product = _signed(a, 24) * _signed(b, 24)
+        else:
+          product = a * b
+        if op == 'mad.f16':
+          product = product.astype(np.float16).astype(np.float32)
+        value = product + c
+      case 'shl', [a, b]:
+        value = a << (b & 31)
+      case 'shr' | 'ashr', [a, b]:
+        value = a >> (b & 31)
+      case 'shrg', [a, b, c]:
+        value = (b >> (a & 31)) | c
+      case 'shrm', [a, b, c]:
+        value = (b >> (a & 31)) & c
+      case 'shlm', [a, b, c]:
+        value = (b << (a & 31)) & c
+      case 'shlg', [a, b, c]:
+        value = (b << (a & 31)) | c
+      case 'andg', [a, b, c]:
+        value = (b & a) | c
+      case 'and', [a, b]:
+        value = a & b
+      case 'or', [a, b]:
+        value = a | b
+      case 'xor', [a, b]:
+        value = a ^ b
+      case 'not', [a]:
+        value = ~a
+      case 'absneg', [a]:
+        value = a
+      case 'sign', [a]:
+        value = np.where(np.isnan(a), np.float32(0), np.where(a == 0, a, np.copysign(np.float32(1), a)))
+      case 'getbit', [a, b]:
+        value = (a >> b) & 1
+      case 'clz', [a]:
+        value = np.where(a == 0, -1, (16 if source_half else 32) - np.frexp(a.astype(np.float64))[1])
+      case 'min', [a, b]:
+        value = np.fmin(a, b) if floating else np.minimum(a, b)
+      case 'max', [a, b]:
+        value = np.fmax(a, b) if floating else np.maximum(a, b)
+      case 'sel', [a, b, c]:
+        # SEL.S32 maps OpenCL vector-select's signed/MSB condition; SEL.B32
+        # retains the scalar nonzero convention. Data bits are preserved.
+        value = np.where(b >= 0 if op == 'sel.s32' else b != 0, a, c)
+      case 'cmps' | 'cmpv', [a, b]:
+        value = (a < b, a <= b, a > b, a >= b, a == b, a != b)[fields['COND']].astype(np.uint32)
+        if fields.get('SAT', 0):
+          value = np.uint32(1) - value
+        if base == 'cmpv':
+          # Vector compares provide bit masks for the compiler's following AND;
+          # scalar compares retain their existing 0/1 predicate convention.
+          value = np.uint32(0) - value
+      case 'floor', [a]:
+        value = np.floor(a)
+      case 'ceil', [a]:
+        value = np.ceil(a)
+      case 'trunc', [a]:
+        value = np.trunc(a)
+      case 'rcp', [a]:
+        value = 1 / a
+      case 'sqrt', [a]:
+        value = np.sqrt(a)
+      case 'rsq', [a]:
+        value = 1 / np.sqrt(a)
+      case 'exp2', [a]:
+        value = np.exp2(a)
+      case 'log2', [a]:
+        value = np.log2(a)
+      case 'sin', [a]:
+        value = np.sin(a)
+      case 'cos', [a]:
+        value = np.cos(a)
+      case _:
+        raise RuntimeError(f'IR3 unsupported arithmetic or operand count for {op}')
+
+    # Most operations complete at source width before destination conversion.
+    # The 24-bit multiplies and MAD.U16 retain their wider integer result even
+    # with half sources; only their destination may truncate it.
+    # Comparisons already produce integer 0/1 values.
+    if floating and base not in ('cmps', 'cmpv'):
+      if source_half:
+        value = value.astype(np.float16).astype(np.float32)
+      if fields.get('SAT', 0):
+        value = np.clip(value, 0, 1)
+      value = _bits(value, 0 if dst.half else 1, round_zero=source_half != dst.half)
+    elif source_half and base not in ('cmps', 'cmpv') and op not in ('mul.s24', 'mul.u24', 'mad.u16'):
+      value = value.astype(np.uint16)
+      if op in SIGNED_OUTPUTS:
+        value = value.view(np.int16).astype(np.int32)
+    self.write(dst, lanes, value, repeat)
+
+  def transfer(self, addresses, width, values=None, storage=None, lanes=None):
+    # One word-access path serves all three memory spaces. Explicit storage
+    # denotes this workgroup's shared/private bytes; None selects mapped global
+    # regions through the caller. A supplied value vector selects stores.
+    # Private offsets are checked per lane before selecting a flattened view.
+    if storage is not None:
+      limit = storage.shape[-1]
+      if limit < width or np.any(addresses > limit - width):
+        raise RuntimeError('IR3 local/private memory out of bounds')
+      if storage.ndim == 2:
+        addresses = addresses + lanes.astype(np.uint64) * limit
+      storage = storage.reshape(-1)
+    output = np.empty(len(addresses), np.uint32)
+    remaining = np.ones(len(addresses), bool)
+    while remaining.any():
+      # Process one backing allocation at a time; lanes may address different
+      # allocations even though they execute the same memory instruction.
+      first = int(np.flatnonzero(remaining)[0])
+      base, data = self.memory.region(int(addresses[first]), width) if storage is None else (0, storage)
+      selected = remaining & (addresses >= base) & (addresses <= base + len(data) - width)
+      offsets = (addresses[selected] - base).astype(np.int64)
+      # This owned buffer view exposes a little-endian word at every byte offset,
+      # including unaligned addresses, and never extends past its allocation.
+      words: np.ndarray = np.ndarray((len(data) - width + 1,), dtype=f'<u{width}', buffer=data, strides=(1,))
+      if values is not None and storage is None:
+        # Resolving readable bytes does not imply permission to modify them.
+        start, end = int(addresses[selected].min()), int(addresses[selected].max()) + width
+        self.memory.validate(start, end - start, write=True)
+      if values is None:
+        output[selected] = words[offsets]
+      else:
+        words[offsets] = values[selected] & 0xFFFFFFFF
+      remaining[selected] = False
+    return output
+
+  def memory_instruction(self, ins, lanes):
+    op, fields, operands = ins.op, ins.fields, ins.operands
+    space = op.split('.')[0][-1]
+    loading = op.startswith('ld')
+    address_name, data_name = memory_roles(op)
+    typ = fields['TYPE']
+    width = np.dtype(TYPES[typ]).itemsize
+    pointer = operands[address_name]
+    addresses = self.read(pointer, lanes).astype(np.uint64)
+
+    # Global pointers use consecutive low/high full registers. Shared/private
+    # addresses are byte offsets into the selected workgroup or lane storage.
+    if space == 'g':
+      addresses |= self.registers[0][pointer.index + 1, lanes].astype(np.uint64) << 32
+    # Mesa's numeric callback preserves the encoded 13-bit offset bits.
+    if op.endswith('.a'):
+      # A6xx ldg.a/stg.a zero-extend before scaling: no intermediate u32 wrap.
+      # Mesa ir3-cat6.xml specifies ((index << shift) + offset) * element_size.
+      index = self.read(operands['SRC2'], lanes).astype(np.uint64)
+      addresses += ((index << fields['SRC2_SHIFT']) + fields['OFF']) * width
+    else:
+      offset = _signed(fields.get('OFF', 0), 13)
+      addresses = addresses + offset if offset >= 0 else addresses - (-offset)
+    # The CL compiler's signed-byte form uses TYPE=7 and a half-register result;
+    # generated consumers immediately read that half bank while full pointers
+    # stay live. Mesa's GL convention instead names this type U8_32.
+    signed_byte = self.opencl and typ == 7
+    register = replace(operands[data_name], half=typ in (0, 2, 4, 6) or signed_byte)
+    storage = None if space == 'g' else self.private if space == 'p' else self.shared
+
+    # Preserve component order for vector loads/stores. The base addresses are
+    # selected once, so a load cannot change its own remaining address operands.
+    for component in range(fields['SIZE']):
+      address = addresses + component * width
+      value = None if loading else self.read(replace(register, index=register.index + component), lanes)
+      result = self.transfer(address, width, value, storage, lanes)
+      if loading:
+        if signed_byte:
+          result = result.astype(np.uint8).view(np.int8).astype(np.int16).view(np.uint16)
+        self.write(register, lanes, result, component)
+
+  def image_instruction(self, ins, lanes):
+    bindings = self.image_bindings
+    if ins.op == 'isam':
+      if 'INDICES' in ins.operands:
+        register = ins.operands['INDICES'].index
+        textures = self.registers[1][register, lanes]
+        samplers = self.registers[1][register + 1, lanes]
+        if np.any(textures != textures[0]) or np.any(samplers != samplers[0]):
+          raise RuntimeError('IR3 uniform image indices differ between lanes')
+        texture_index, sampler_index = int(textures[0]), int(samplers[0])
+      else:
+        texture_index, sampler_index = ins.fields['TEX'], ins.fields['SAMP']
+      if not 0 <= texture_index < len(bindings.textures) or not 0 <= sampler_index < bindings.sampler_count:
+        raise RuntimeError('IR3 image texture or sampler index out of bounds')
+      image = bindings.textures[texture_index]
+    else:
+      index = ins.fields['SSBO']
+      if not 0 <= index < len(bindings.outputs):
+        raise RuntimeError('IR3 image output index out of bounds')
+      image = bindings.outputs[index]
+
+    # Capture full-width signed coordinates before destination writes. A texture
+    # coordinate outside either dimension selects black, never a wrapped row.
+    coordinate = ins.operands['COORD'].index
+    x = self.registers[0][coordinate, lanes].view(np.int32).astype(np.int64)
+    y = self.registers[0][coordinate + 1, lanes].view(np.int32).astype(np.int64)
+    valid = (x >= 0) & (x < image.width) & (y >= 0) & (y < image.height)
+    # Formatted GL image loads return zero for invalid texels; stores have no
+    # effect there. Descriptor and registered-allocation checks still precede
+    # these coordinate rules, so an absent binding is never treated as padding.
+    addresses = (image.base + y[valid] * image.pitch + x[valid] * 4 * image.component_bytes).astype(np.uint64)
+    storage_type = 0 if image.component_bytes == 2 else 1
+
+    for component in range(4):
+      if ins.op in ('isam', 'ldib.b'):
+        if ins.op == 'isam' and not ins.fields['WRMASK'] & (1 << component):
+          continue
+        values = np.zeros(len(lanes), np.float32)
+        if valid.any():
+          bits = self.transfer(addresses + component * image.component_bytes, image.component_bytes)
+          values[valid] = _typed(bits, storage_type)
+        self.write(ins.operands['DST'], lanes, _bits(values, ins.fields['TYPE']), component)
+      else:
+        data = replace(ins.operands['DATA'], index=ins.operands['DATA'].index + component)
+        values = _typed(self.read(data, lanes[valid]), ins.fields['TYPE'])
+        bits = _bits(values, storage_type)
+        self.transfer(addresses + component * image.component_bytes, image.component_bytes, bits)
+
+  def run(self, instructions):
+    # This is the functional scheduling loop. Ended lanes have PC -1; waiting
+    # lanes keep their PC but cannot run. Dependency hints model no extra latency.
+    # Accumulated normalization gradients can exceed one million scheduler
+    # steps. Keep a finite default and permit explicit limits for larger tests.
+    max_steps = int(os.getenv('MOCK_QCOM_MAX_STEPS', '20000000'))
+    if max_steps <= 0:
+      raise ValueError('MOCK_QCOM_MAX_STEPS must be positive')
+    for steps in range(max_steps):
+      alive = self.pc >= 0
+      if not alive.any():
+        return
+      runnable = alive & ~self.waiting
+      if not runnable.any():
+        # A shader barrier releases only when every lane is still alive and has
+        # reached the same barrier. PM4 queue waits are handled outside this loop.
+        if not alive.all() or len(np.unique(self.pc)) != 1:
+          raise RuntimeError('IR3 divergent workgroup barrier')
+        self.waiting[:] = False
+        self.pc += 1
+        continue
+
+      # Fetch one instruction for the lanes currently at its PC. Choosing the
+      # lowest runnable PC groups work without erasing per-lane branch history.
+      pc = int(self.pc[runnable].min())
+      if pc >= len(instructions):
+        raise RuntimeError('IR3 execution escaped the program')
+      ins = instructions[pc]
+      lanes = np.flatnonzero((self.pc == pc) & runnable)
+
+      # Fall-through is the default. A branch replaces selected PCs; a barrier
+      # restores this PC while parked. Control handling precedes ordinary effects.
+      self.pc[lanes] += 1
+      op, fields, operands = ins.op, ins.fields, ins.operands
+      if fields.get('JP', 0):
+        # JP refreshes the saved mask while preserving true/false/none mode.
+        self.refresh_predicate(lanes)
+      if op == 'end':
+        self.pc[lanes] = -1
+      elif op in ('nop', 'fence'):
+        # Memory operations already finish synchronously in staged storage.
+        # A fence preserves compiler order; only BAR rendezvous parks lanes.
+        pass
+      elif op in ('predt', 'predf', 'prede'):
+        self.predicate_mode[lanes] = {'predt': 1, 'predf': -1, 'prede': 0}[op]
+        self.refresh_predicate(lanes)
+      elif op == 'bar':
+        self.waiting[lanes] = True
+        self.pc[lanes] = pc
+      else:
+        # Predicated-off lanes still advance through the instruction stream but
+        # do not perform these register or memory updates.
+        lanes = lanes[self.predicate[lanes]]
+        if not len(lanes):
+          continue
+        if op in ('br', 'brao', 'braa', 'jump'):
+          taken = np.ones(len(lanes), bool)
+          if op != 'jump':
+            taken = (self.registers[0][248 + fields['COMP1'], lanes] != 0) ^ bool(fields['INV1'])
+          if op in ('brao', 'braa'):
+            other = (self.registers[0][248 + fields['COMP2'], lanes] != 0) ^ bool(fields['INV2'])
+            taken = taken | other if op == 'brao' else taken & other
+          offset = _signed(fields['IMMED'], 32)
+          self.pc[lanes[taken]] = pc + offset
+        elif op == 'call':
+          # CALL offsets use the same full-program instruction coordinates as
+          # branches. Each lane retains its own return path across divergence.
+          for lane in lanes:
+            if len(self.return_stack[lane]) >= 64:
+              raise RuntimeError('IR3 call stack budget exhausted')
+            self.return_stack[lane].append(pc + 1)
+          self.pc[lanes] = pc + _signed(fields['IMMED'], 32)
+        elif op == 'ret':
+          for lane in lanes:
+            if not self.return_stack[lane]:
+              raise RuntimeError('IR3 return without a call')
+            self.pc[lane] = self.return_stack[lane].pop()
+        elif op in ('ldg', 'stg', 'ldg.a', 'stg.a', 'ldl', 'stl', 'ldp', 'stp'):
+          self.memory_instruction(ins, lanes)
+        elif op in ('isam', 'stib.b', 'ldib.b'):
+          self.image_instruction(ins, lanes)
+        elif op == 'swz':
+          # Read both sides before writing either, including an in-place swap.
+          values = [self.read(operands[name], lanes) for name in ('SRC0', 'SRC1')]
+          for name, value in zip(('DST0', 'DST1'), values):
+            self.write(operands[name], lanes, value)
+        else:
+          for repeat in range(fields.get('REPEAT', 0) + 1):
+            self.alu(ins, lanes, repeat)
+    if (self.pc < 0).all():
+      return
+    raise RuntimeError(f'IR3 instruction budget exhausted ({max_steps} steps)')
+
+
+def validate_invocation_registers(wgid, lid):
+  # Invocation coordinates occupy three scalar registers below the reserved
+  # register bank; 0xfc means unused. Planning and execution share this contract
+  # so a known invalid launch cannot follow an already published wait prefix.
+  if any(reg != 0xFC and not 0 <= reg <= 241 for reg in (wgid, lid)):
+    raise RuntimeError('IR3 invalid invocation register')
+
+
+def validate_image_bindings(instructions, bindings):
+  # Immediate resource references can be admitted before any command action.
+  # S2EN's live register values remain an execution check, but it still requires
+  # declared tables; it never creates a descriptor from an unregistered address.
+  for ins in instructions:
+    if ins.op == 'isam':
+      if not bindings.textures or not bindings.sampler_count:
+        raise RuntimeError('IR3 image sampling requires textures and samplers')
+      if 'INDICES' not in ins.operands and (
+        not 0 <= ins.fields['TEX'] < len(bindings.textures) or not 0 <= ins.fields['SAMP'] < bindings.sampler_count
+      ):
+        raise RuntimeError('IR3 image texture or sampler index out of bounds')
+    elif ins.op in ('stib.b', 'ldib.b') and not 0 <= ins.fields['SSBO'] < len(bindings.outputs):
+      raise RuntimeError('IR3 image output index out of bounds')
+
+
+def validate_constant_footprint(instructions, slots, *, constant_demotion=True, entry_pc=0):
+  # Admission uses immutable decoded indices, never live constant contents.
+  # Track PC and whether predication is active: a predicated JUMP can fall
+  # through. Mode zero always has a true saved mask, including after JP.
+  if type(entry_pc) is not int or not 0 <= entry_pc < len(instructions):
+    raise RuntimeError('IR3 entry point is outside the program')
+  pending, visited = [(entry_pc, False, False)], set()
+  while pending:
+    pc, predicated, in_call = pending.pop()
+    if (pc, predicated, in_call) in visited or pc == len(instructions):
+      continue
+    visited.add((pc, predicated, in_call))
+    ins = instructions[pc]
+    for operand in ins.operands.values():
+      if operand.kind == 'constant':
+        capacity = slots * 2 if operand.half and not constant_demotion else slots
+        if operand.relative:
+          # Its address depends on live lane values, like a global-memory load.
+          # Direct indices remain checked here; relative lookups check the actual
+          # upload bounds before reading or changing their destination.
+          if capacity == 0:
+            raise RuntimeError('IR3 relative constant source has no supplied slots')
+          continue
+        last = operand.index + (ins.fields.get('REPEAT', 0) if operand.repeat else 0)
+        if not 0 <= operand.index <= last < capacity:
+          raise RuntimeError('IR3 constant source span exceeds supplied slots')
+
+    # All words still undergo decode/schema validation. Only structurally
+    # unreachable words are excluded here: END has no successor, but an earlier
+    # branch may reach code beyond it. Dynamic conditions take both paths.
+    if ins.op == 'end':
+      continue
+    if ins.op == 'ret':
+      if not in_call:
+        raise RuntimeError('IR3 return is reachable without a call')
+      if not predicated:
+        continue
+    if ins.op in ('predt', 'predf', 'prede'):
+      predicated = ins.op != 'prede'
+    if ins.op in ('br', 'brao', 'braa', 'jump', 'call'):
+      pending.append((pc + _signed(ins.fields['IMMED'], 32), predicated, in_call or ins.op == 'call'))
+      if ins.op == 'jump' and not predicated:
+        continue
+      if ins.op == 'call':
+        # A callee can change predicate mode before RET. Both caller
+        # continuations remain possible until actual lane data is executed.
+        pending.append((pc + 1, not predicated, in_call))
+    # A call explores both its callee and the continuation it may return to.
+    # This bounded over-approximation checks constants without simulating data.
+    pending.append((pc + 1, predicated, in_call))
+
+
+# Launch entry: qcomgpu supplies the state; decoding may be reused, but every
+# dispatched workgroup gets fresh lane, shared and private state.
+def execute(
+  image, constants, groups, local_size, wgid, lid, memory, *, shared_bytes=0, private_bytes=0, wgsize=0xFC,
+  image_bindings=ImageBindings(),
+  opencl=False, wgoffset=0xfc, constant_demotion=True, entry_pc=0,
+):
+  instructions = decode(image)
+  if (
+    len(groups) != 3
+    or len(local_size) != 3
+    or any(type(n) is not int or n <= 0 for n in (*groups, *local_size))
+  ):
+    raise RuntimeError('IR3 invalid launch dimensions')
+  if math.prod(local_size) > 1024 or len(constants) % 4 or shared_bytes < 0 or private_bytes < 0:
+    raise RuntimeError('IR3 invalid launch resources')
+  validate_invocation_registers(wgid, lid)
+  if opencl:
+    validate_invocation_registers(wgsize, wgoffset)
+    if len(constants) < 32 * 4:
+      raise RuntimeError('IR3 OpenCL builtin constants are incomplete')
+  elif wgsize != 0xFC and not 0 <= wgsize <= len(constants) // 4 - 3:
+    raise RuntimeError('IR3 invalid workgroup-size constant')
+  validate_constant_footprint(instructions, len(constants) // 4, constant_demotion=constant_demotion, entry_pc=entry_pc)
+  validate_image_bindings(instructions, image_bindings)
+  image_bindings.validate(memory)
+  with np.errstate(divide='ignore', invalid='ignore', over='ignore', under='ignore'):
+    for group in itertools.product(*(range(n) for n in groups)):
+      Workgroup(constants, local_size, group, wgid, lid, wgsize, memory, shared_bytes, private_bytes,
+                image_bindings=image_bindings, opencl=opencl, wgoffset=wgoffset, groups=groups,
+                constant_demotion=constant_demotion, entry_pc=entry_pc).run(
+        instructions
+      )

--- a/test/mockgpu/qcom/image.py
+++ b/test/mockgpu/qcom/image.py
@@ -1,0 +1,74 @@
+"""Immutable configuration for the QCOM producer's linear RGBA float images.
+
+Descriptors choose storage, not its lifetime. PM4 reads them through the current
+transaction; both planning and IR3 validate the registered pixel allocations.
+"""
+from dataclasses import dataclass
+import struct
+
+from tinygrad.runtime.autogen import mesa
+
+
+@dataclass(frozen=True)
+class Image2D:
+  base: int
+  width: int
+  height: int
+  pitch: int
+  component_bytes: int
+
+  def validate(self, memory, write=False):
+    if self.component_bytes not in (2, 4) or not 0 < self.width <= 16384 or not 0 < self.height <= 16384:
+      raise RuntimeError("unsupported image dimensions or component width")
+    if self.base <= 0 or self.base % 32 or self.pitch < self.width * 4 * self.component_bytes or self.pitch % 64:
+      raise RuntimeError("invalid image base or row pitch")
+    size = (self.height - 1) * self.pitch + self.width * 4 * self.component_bytes
+    memory.validate(self.base, size, write=write)
+
+
+@dataclass(frozen=True)
+class ImageBindings:
+  textures: tuple[Image2D, ...] = ()
+  outputs: tuple[Image2D, ...] = ()
+  sampler_count: int = 0  # Admitted leading samplers; reserved zero slots are inaccessible.
+
+  def validate(self, memory):
+    for texture in self.textures:
+      texture.validate(memory)
+    for output in self.outputs:
+      output.validate(memory, write=True)
+
+
+def decode_image_descriptor(data: bytes, texture: bool) -> Image2D:
+  if len(data) != 64:
+    raise RuntimeError("an image descriptor must contain sixteen words")
+  words = struct.unpack("<16I", data)
+  pixel_format = (words[0] & mesa.A6XX_TEX_CONST_0_FMT__MASK) >> mesa.A6XX_TEX_CONST_0_FMT__SHIFT
+  formats = {mesa.FMT6_16_16_16_16_FLOAT: 2, mesa.FMT6_32_32_32_32_FLOAT: 4}
+  if pixel_format not in formats:
+    raise RuntimeError("unsupported image pixel format")
+
+  # ops_qcom emits linear, unmipped 2D images. Texture fetches use the identity
+  # swizzle; typed UAV stores do not use those swizzle bits. Keep the producer's
+  # fixed words explicit rather than silently accepting tiling or compression.
+  swizzle = (1 << 7) | (2 << 10) | (3 << 13) | 8 if texture else 0
+  if words[0] != (pixel_format << 22 | swizzle) or words[1] & ~0x3fffffff:
+    raise RuntimeError("unsupported image layout or swizzle")
+  width, height = words[1] & 0x7fff, words[1] >> 15
+  pitch = (words[2] & mesa.A6XX_TEX_CONST_2_PITCH__MASK) >> mesa.A6XX_TEX_CONST_2_PITCH__SHIFT
+  pitch_alignment = (pitch & -pitch).bit_length() - 7
+  expected_pitch = mesa.A6XX_TEX_2D << 29 | pitch << 7 | pitch_alignment
+  if pitch_alignment < 0 or words[2] != expected_pitch:
+    raise RuntimeError("unsupported image pitch or texture type")
+  if words[3] or words[4] & 31 or words[5] & ~0x1ffff:
+    raise RuntimeError("unsupported image layers or base address")
+  if words[6:] != (0x40000000, 13, 0, 0, 0, 0, 0, 0, 0, 0):
+    raise RuntimeError("unsupported image planes or compression")
+  return Image2D(words[4] | words[5] << 32, width, height, pitch, formats[pixel_format])
+
+
+def validate_sampler(data: bytes):
+  # The current producer supplies nearest, unnormalized coordinates and a black
+  # border. The associated zero border allocation is checked by PM4 as well.
+  if len(data) != 16 or struct.unpack("<4I", data) != (3 << 5 | 3 << 8 | 3 << 11, 0x30, 0, 0):
+    raise RuntimeError("unsupported image sampler")

--- a/test/mockgpu/qcom/qcomdriver.py
+++ b/test/mockgpu/qcom/qcomdriver.py
@@ -1,0 +1,493 @@
+"""The KGSL boundary for the A630 mock; PM4 runs against staged, mapped memory."""
+from __future__ import annotations
+import collections, ctypes, dataclasses, functools, mmap, os, struct, sys, threading, time
+from typing import Callable
+from tinygrad.runtime.autogen import kgsl, libc
+from test.mockgpu.driver import VirtDriver, VirtFileDesc, VirtFile
+
+# Read from the outside inward:
+#   native ioctl -> QCOMDriver -> Context queue -> qcomgpu.execute_command
+#   PM4 actions / IR3 lanes -> MemoryTransaction -> AddressSpace -> host memory
+# The driver owns resource lifetimes and queue progress. The PM4 layer interprets
+# commands; the IR3 layer advances shader lanes. Only transaction.commit publishes
+# their staged memory effects back to the host program.
+
+
+# Host transport: copy bytes across the native ABI without using a guest address
+# as an unchecked Python pointer. Both read and write select endpoints for the
+# same kernel copy operation; the local bytearray remains alive for that call.
+
+class IOVec(ctypes.Structure):
+  _fields_ = [("base", ctypes.c_void_p), ("size", ctypes.c_size_t)]
+
+
+def host_transfer(address:int, data:bytearray, write:bool):
+  # Kernel copy APIs reject stale/unmapped host pointers instead of dereferencing
+  # them in Python. Guest addresses additionally need an AddressSpace mapping.
+  if address <= 0 or len(data) > 1 << 30 or address + len(data) > 1 << 64:
+    raise ValueError("invalid host memory span")
+  if not data:
+    return
+  local = (ctypes.c_ubyte * len(data)).from_buffer(data)
+  source, destination = (ctypes.addressof(local), address) if write else (address, ctypes.addressof(local))
+  if sys.platform == "darwin":
+    task, copied = ctypes.c_uint.in_dll(libc.dll, "mach_task_self_").value, ctypes.c_uint64()
+    result = libc.dll.mach_vm_read_overwrite(ctypes.c_uint(task), ctypes.c_uint64(source), ctypes.c_uint64(len(data)),
+                                             ctypes.c_uint64(destination), ctypes.byref(copied))
+    complete = result == 0 and copied.value == len(data)
+  elif sys.platform == "linux":
+    source_vec, destination_vec = IOVec(source, len(data)), IOVec(destination, len(data))
+    libc.dll.process_vm_readv.restype = ctypes.c_ssize_t
+    copied_bytes = libc.dll.process_vm_readv(ctypes.c_int(os.getpid()), ctypes.byref(destination_vec), ctypes.c_ulong(1),
+                                           ctypes.byref(source_vec), ctypes.c_ulong(1), ctypes.c_ulong(0))
+    complete = copied_bytes == len(data)
+  else:
+    raise NotImplementedError("QCOM mock host memory needs Linux or macOS")
+  if not complete:
+    raise ValueError(f"host memory {'write' if write else 'read'} failed at {address:#x}")
+
+
+def read_host(address:int, size:int) -> bytes:
+  if not 0 <= size <= 1 << 30:
+    raise ValueError("invalid host memory size")
+  data = bytearray(size)
+  host_transfer(address, data, False)
+  return bytes(data)
+
+
+def write_host(address:int, data:bytes|bytearray):
+  host_transfer(address, bytearray(data), True)
+
+
+def validate_host_mapping(address:int, size:int, write:bool=True):
+  # Walk the complete requested interval, not just its first page. This checks
+  # current host permissions; AddressSpace separately checks guest registration.
+  end, cursor = address + size, address
+  if sys.platform == "linux":
+    with open("/proc/self/maps") as maps:
+      for line in maps:
+        extent, permissions = line.split()[:2]
+        start, stop = (int(part, 16) for part in extent.split("-"))
+        if start <= cursor < stop and permissions[0] == "r" and (not write or permissions[1] == "w"):
+          cursor = min(stop, end)
+        if cursor == end:
+          return
+  elif sys.platform == "darwin":
+    task = ctypes.c_uint.in_dll(libc.dll, "mach_task_self_").value
+    while cursor < end:
+      start, length, count = ctypes.c_uint64(cursor), ctypes.c_uint64(), ctypes.c_uint(9)
+      info, object_name = (ctypes.c_int * 9)(), ctypes.c_uint()
+      result = libc.dll.mach_vm_region(ctypes.c_uint(task), ctypes.byref(start), ctypes.byref(length), ctypes.c_int(9),
+                                        info, ctypes.byref(count), ctypes.byref(object_name))
+      if object_name.value:
+        libc.dll.mach_port_deallocate(ctypes.c_uint(task), object_name)
+      required = 3 if write else 1
+      if result or start.value > cursor or not length.value or info[0] & required != required:
+        break
+      cursor = min(start.value + length.value, end)
+    if cursor == end:
+      return
+  raise ValueError("GPU access needs a live host range with the requested permissions")
+
+
+@dataclasses.dataclass
+class Mapping:
+  # Address/allocation indexes share one record; owner_fd names its descriptor.
+  # Object identity matters: replacing a mapping at the same address must not
+  # silently revive a transaction that observed the earlier allocation.
+  base:int
+  size:int
+  owner:object # None means borrowed storage; True denotes a native allocation.
+  owner_fd:int|None=None
+
+
+class AddressSpace:
+  # Guest registration retains an optional owner but does not allocate or pin
+  # host storage. Host permissions and validity still need separate checks.
+  def __init__(self):
+    self.mappings:dict[int, Mapping] = {}
+
+  def map(self, base:int, size:int, owner:object=None, owner_fd:int|None=None) -> Mapping:
+    if base <= 0 or not 0 < size <= 1 << 30 or base + size > 1 << 64:
+      raise ValueError("invalid GPU mapping")
+    if any(base < entry.base + entry.size and entry.base < base + size for entry in self.mappings.values()):
+      raise ValueError("overlapping GPU mapping")
+    validate_host_mapping(base, size)
+    self.mappings[base] = entry = Mapping(base, size, owner, owner_fd)
+    return entry
+
+  def unmap(self, base:int):
+    if base not in self.mappings:
+      raise ValueError("unknown GPU mapping")
+    del self.mappings[base]
+
+  def mapping(self, address:int, size:int) -> Mapping:
+    if size < 0:
+      raise ValueError("negative GPU access size")
+    for entry in self.mappings.values():
+      if entry.base <= address and address + size <= entry.base + entry.size:
+        return entry
+    raise ValueError(f"unmapped GPU memory span {address:#x}+{size}")
+
+  def transaction(self) -> MemoryTransaction:
+    return MemoryTransaction(self)
+
+
+class MemoryTransaction:
+  # A transaction is one scheduler segment's working memory. Small writes use
+  # ordered overlays; IR3 requests a whole-region snapshot for NumPy views.
+  # Reads remain live until that region is snapshotted, so a later queue pass can
+  # observe a signal written by another context instead of retaining an old wait.
+  def __init__(self, space:AddressSpace):
+    self.space = space
+    self.snapshots:dict[int, bytearray] = {}
+    self.overlays:list[tuple[int, bytes]] = []
+    self.entries:dict[int, Mapping] = {}
+    self.finished = False
+
+  def mapping(self, address:int, size:int) -> Mapping:
+    if self.finished:
+      raise ValueError("transaction already committed")
+    entry = self.space.mapping(address, size)
+    # Keep the first allocation identity even after a later lookup. Old overlays
+    # and snapshots belong to that record, so reject replacement before exposing
+    # cached data or staging any further access against a new allocation.
+    if self.entries.setdefault(entry.base, entry) is not entry:
+      raise ValueError("GPU mapping changed during transaction")
+    return entry
+
+  def read(self, address:int, size:int) -> bytes:
+    entry = self.mapping(address, size)
+    if entry.base in self.snapshots:
+      return bytes(self.snapshots[entry.base][address-entry.base:address-entry.base+size])
+    data = bytearray(read_host(address, size))
+    for start, payload in self.overlays:
+      low, high = max(address, start), min(address + size, start + len(payload))
+      if low < high:
+        data[low-address:high-address] = payload[low-start:high-start]
+    return bytes(data)
+
+  def validate(self, address:int, size:int, write:bool=False):
+    self.mapping(address, size)
+    validate_host_mapping(address, size, write)
+
+  def write(self, address:int, data:bytes|bytearray):
+    entry, payload = self.mapping(address, len(data)), bytes(data)
+    if entry.base in self.snapshots:
+      self.snapshots[entry.base][address-entry.base:address-entry.base+len(payload)] = payload
+    else:
+      self.overlays.append((address, payload))
+
+  def region(self, address:int, size:int) -> tuple[int, bytearray]:
+    # Fold earlier overlays into the snapshot once. The returned bytearray owns
+    # the storage behind IR3 views and stays alive until this segment finishes.
+    entry = self.mapping(address, size)
+    if entry.base not in self.snapshots:
+      self.snapshots[entry.base] = bytearray(self.read(entry.base, entry.size))
+      self.overlays = [(start, data) for start, data in self.overlays if not entry.base <= start < entry.base + entry.size]
+    return entry.base, self.snapshots[entry.base]
+
+  def commit(self):
+    # Validate every retained mapping identity and write destination before the
+    # first copy. Publication itself is a sequence of host writes, not an OS-wide
+    # atomic transaction; a host mapping race can still make a later copy fail.
+    if self.finished:
+      raise ValueError("transaction already committed")
+    for base, entry in self.entries.items():
+      if self.space.mappings.get(base) is not entry:
+        raise ValueError("GPU mapping changed during transaction")
+      if entry.owner is None:
+        validate_host_mapping(base, entry.size)
+    writes = [*self.snapshots.items(), *self.overlays]
+    for address, data in writes:
+      validate_host_mapping(address, len(data), write=True)
+    for address, data in writes:
+      write_host(address, data)
+    self.finished = True
+
+
+@dataclasses.dataclass
+class Context:
+  # queued advances on acceptance. consumed records the front command's first
+  # successful scheduler segment, including a wait at cursor zero; retired waits
+  # for its final action. pending holds (words, timestamp, continuation cursor).
+  owner_fd:int
+  queued:int=0
+  consumed:int=0
+  retired:int=0
+  pending:collections.deque=dataclasses.field(default_factory=collections.deque)
+
+
+class QCOMFileDesc(VirtFileDesc):
+  # Adapt the generic mock-file interface to one shared driver instance. The
+  # descriptor is the ownership key used when locating contexts and allocations.
+  def __init__(self, fd:int, driver:QCOMDriver):
+    super().__init__(fd)
+    self.driver = driver
+
+  def ioctl(self, fd, request, argp):
+    return self.driver.ioctl(fd, request, argp)
+  def mmap(self, start, size, prot, flags, fd, offset):
+    return self.driver.mmap(fd, start, size, prot, flags, offset)
+  def close(self, fd):
+    self.driver.close(fd)
+
+
+def ioctl_number(fn):
+  direction, group, number, typ = fn.args
+  return direction << 30 | ctypes.sizeof(typ) << 16 | group << 8 | number
+
+
+# Decode request numbers from the existing generated ABI. The table selects a
+# request name and structure type; ioctl below still validates its allowed fields.
+IOCTLS = {
+  ioctl_number(fn): (name.removeprefix("IOCTL_KGSL_"), fn.args[3])
+  for name, fn in vars(kgsl).items()
+  if name.startswith("IOCTL_KGSL_") and isinstance(fn, functools.partial) and fn.args[3] is not None
+}
+CONTEXT_FLAGS = (kgsl.KGSL_CONTEXT_PREAMBLE | kgsl.KGSL_CONTEXT_PWR_CONSTRAINT | kgsl.KGSL_CONTEXT_NO_FAULT_TOLERANCE |
+                 kgsl.KGSL_CONTEXT_NO_GMEM_ALLOC | kgsl.KGSL_CONTEXT_PRIORITY_MASK | kgsl.KGSL_CONTEXT_PREEMPT_STYLE_MASK)
+ALLOCATION_FLAGS = kgsl.KGSL_MEMFLAGS_USE_CPU_MAP | kgsl.KGSL_MEMALIGN_MASK | kgsl.KGSL_CACHEMODE_MASK
+
+
+def read_struct(address:int, typ, writable:bool=False):
+  alignment = max(ctypes.alignment(field[1]) for field in typ._real_fields_)
+  if address % alignment:
+    raise ValueError("misaligned KGSL structure")
+  if writable:
+    validate_host_mapping(address, ctypes.sizeof(typ), write=True)
+  return typ.from_buffer_copy(read_host(address, ctypes.sizeof(typ)))
+
+
+class QCOMDriver(VirtDriver):
+  # Control plane: serialize descriptor/resource operations and queue execution.
+  # allocations and borrowed select the same Mapping representation, but only
+  # allocations may release driver-owned native storage when a descriptor closes.
+  def __init__(self, execute:Callable|None=None):
+    super().__init__()
+    self.tracked_files = [VirtFile("/dev/kgsl-3d0", QCOMFileDesc)]
+    self.memory, self.execute = AddressSpace(), execute
+    self.allocations:dict[int, Mapping] = {}
+    self.borrowed:dict[int, Mapping] = {}
+    self.contexts:dict[int, Context] = {}
+    self.next_fd, self.next_id, self.next_context = 1 << 28, 1, 1
+    self.lock, self.executing = threading.RLock(), False
+    self.error:Exception|None = None
+
+  def open(self, name, flags, mode, virtfile):
+    with self.lock:
+      fd = QCOMFileDesc(self.next_fd, self)
+      self.next_fd += 1
+      return fd
+
+  def check_error(self):
+    # A ctypes callback cannot propagate a Python exception through native HCQ2.
+    # make_ioctl_callback saves it; the Python execution boundary re-raises it.
+    if self.error is not None:
+      raise RuntimeError(f"QCOM mock submission failed: {self.error}") from self.error
+
+  def context(self, fd:int, context_id:int) -> Context:
+    if context_id not in self.contexts or self.contexts[context_id].owner_fd != fd:
+      raise ValueError("unknown KGSL context")
+    return self.contexts[context_id]
+
+  def mmap(self, fd, start, size, prot, flags, offset):
+    # Allocation reservation and native mapping are separate lifetime steps.
+    # On registration failure, release the new host mapping before propagating.
+    with self.lock:
+      self.check_error()
+      allocation = self.allocations.get(offset // 4096)
+      if start or offset % 4096 or allocation is None or allocation.owner_fd != fd or allocation.base or size != allocation.size:
+        raise ValueError("invalid KGSL mmap")
+      if prot != mmap.PROT_READ | mmap.PROT_WRITE or flags != mmap.MAP_SHARED:
+        raise ValueError("unsupported KGSL mmap flags")
+      address = libc.mmap(0, size, prot, mmap.MAP_ANONYMOUS | mmap.MAP_PRIVATE, -1, 0)
+      if address == ctypes.c_void_p(-1).value:
+        raise MemoryError("QCOM mock mmap failed")
+      try:
+        entry = self.memory.map(address, size, owner=True, owner_fd=fd)
+      except Exception:
+        libc.munmap(address, size)
+        raise
+      self.allocations[offset // 4096] = entry
+      return address
+
+  def close(self, fd:int):
+    # Closing discards this descriptor's contexts and unregisters its resources.
+    # Borrowed CPU storage survives; native allocations owned here are unmapped.
+    with self.lock:
+      self.contexts = {key: context for key, context in self.contexts.items() if context.owner_fd != fd}
+      for resources, owned in ((self.borrowed, False), (self.allocations, True)):
+        for key, allocation in list(resources.items()):
+          if allocation.owner_fd != fd:
+            continue
+          if allocation.base:
+            self.memory.unmap(allocation.base)
+            if owned:
+              libc.munmap(allocation.base, allocation.size)
+          del resources[key]
+
+  def drain(self):
+    # Cooperative scheduling: advance each context's front command until a full
+    # pass makes no progress. A wait yields at its cursor; another context may
+    # publish the signal that lets it resume. The re-entry latch prevents nested
+    # callbacks from starting a second scheduler over these same queues.
+    if self.executing:
+      return
+    self.executing = True
+    try:
+      progress = True
+      while progress:
+        progress = False
+        for context in self.contexts.values():
+          if not context.pending:
+            continue
+          words, timestamp, cursor = context.pending[0]
+          transaction = self.memory.transaction()
+          if self.execute is None:
+            from test.mockgpu.qcom.qcomgpu import execute_command
+            self.execute = execute_command
+          complete, next_cursor = self.execute(words, transaction, time.monotonic_ns() * 192 // 10000, cursor)
+          if not isinstance(complete, bool) or not isinstance(next_cursor, int) or next_cursor < cursor:
+            raise ValueError("invalid PM4 execution progress")
+          # A valid prefix's signals must be visible to other contexts before a
+          # later wait can resume. Rejected segments never reach this commit.
+          transaction.commit()
+          # Start-of-pipeline is observed at successful segment publication in
+          # this synchronous mock, not at a physical GPU cycle. A planning or
+          # commit rejection publishes no new start; retries retain the same one.
+          context.consumed = timestamp
+          if complete:
+            context.pending.popleft()
+            context.retired, progress = timestamp, True
+          else:
+            context.pending[0] = words, timestamp, next_cursor
+            progress |= next_cursor != cursor
+    finally:
+      self.executing = False
+
+  def ioctl(self, fd:int, request:int, argp:int):
+    # Copy the caller's ABI structure, select a supported transition, then return
+    # its updated fields. Validation stays beside the state/effect it protects.
+    # Read the branches in groups: contexts, device properties, memory lifetime,
+    # command submission, and completion observation.
+    with self.lock:
+      self.check_error()
+      if request not in IOCTLS:
+        raise ValueError(f"unknown KGSL ioctl {request:#x}")
+      name, typ = IOCTLS[request]
+      req = read_struct(argp, typ, writable=True)
+      if name == "DRAWCTXT_CREATE":
+        if req.flags & ~CONTEXT_FLAGS or self.next_context > 0xffffffff:
+          raise ValueError("unsupported KGSL context")
+        req.drawctxt_id = self.next_context
+        self.contexts[self.next_context] = Context(fd)
+        self.next_context += 1
+      elif name == "DRAWCTXT_DESTROY":
+        if self.context(fd, req.drawctxt_id).pending:
+          raise ValueError("KGSL context has pending commands")
+        del self.contexts[req.drawctxt_id]
+      elif name == "DEVICE_GETPROPERTY":
+        # Device identity and the narrow power contract expected by QCOMDevice.
+        if req.type != kgsl.KGSL_PROP_DEVICE_INFO or req.sizebytes != ctypes.sizeof(kgsl.struct_kgsl_devinfo):
+          raise ValueError("unsupported KGSL property")
+        write_host(req.value, bytes(kgsl.struct_kgsl_devinfo(chip_id=0x06030000, gpu_id=630, mmu_enabled=1)))
+      elif name == "SETPROPERTY":
+        if req.type != kgsl.KGSL_PROP_PWR_CONSTRAINT or req.sizebytes != 24:
+          raise ValueError("unsupported KGSL power property")
+        kind, context_id, power, power_size = struct.unpack("=IIQQ", read_host(req.value, 24))
+        self.context(fd, context_id)
+        if kind != 1 or power_size != 4 or struct.unpack("=I", read_host(power, 4))[0] != 1:
+          raise ValueError("unsupported KGSL power constraint")
+      elif name == "GPUOBJ_ALLOC":
+        # Reserve metadata now; mmap supplies the native address later.
+        if not 0 < req.size <= 1 << 30 or req.size % 4096 or req.mmapsize != req.size or req.metadata_len:
+          raise ValueError("unsupported KGSL allocation")
+        if req.flags & ~ALLOCATION_FLAGS or not req.flags & kgsl.KGSL_MEMFLAGS_USE_CPU_MAP:
+          raise ValueError("KGSL mock needs supported CPU mapped allocation flags")
+        if (req.flags & kgsl.KGSL_MEMALIGN_MASK) >> kgsl.KGSL_MEMALIGN_SHIFT > 12:
+          raise ValueError("KGSL mock allocations guarantee at most 4096-byte alignment")
+        if req.va_len or req.metadata or self.next_id > 0xffffffff:
+          raise ValueError("unsupported KGSL allocation metadata")
+        req.id = self.next_id
+        self.allocations[req.id] = Mapping(0, req.size, owner=True, owner_fd=fd)
+        self.next_id += 1
+      elif name == "MAP_USER_MEM":
+        # Borrow a caller-owned range; registration does not transfer ownership.
+        if req.memtype != kgsl.KGSL_USER_MEM_TYPE_ADDR or req.offset or req.flags:
+          raise ValueError("unsupported KGSL user mapping")
+        self.borrowed[req.hostptr] = self.memory.map(req.hostptr, req.len, owner_fd=fd)
+        req.gpuaddr = req.hostptr
+      elif name in ("GPUOBJ_FREE", "SHAREDMEM_FREE"):
+        # Remove guest visibility only when no queued work can still reference it.
+        owned = name == "GPUOBJ_FREE"
+        resources, key = (self.allocations, req.id) if owned else (self.borrowed, req.gpuaddr)
+        allocation = resources.get(key)
+        if allocation is None or allocation.owner_fd != fd or (owned and (req.flags or req.priv or req.type or req.len)):
+          raise ValueError("unknown or unsupported KGSL free" if owned else "unknown KGSL user mapping")
+        if not owned and ((mapping := self.memory.mappings.get(key)) is None or mapping.owner is not None):
+          raise ValueError("unknown KGSL user mapping")
+        if any(context.pending for context in self.contexts.values()):
+          raise ValueError(f"cannot {'free' if owned else 'unmap'} with pending commands")
+        if allocation.base:
+          self.memory.unmap(allocation.base)
+        del resources[key] # Explicit free retains CPU storage; QCOMDevice._gpu_free owns its CPU munmap.
+      elif name == "GPU_COMMAND":
+        # Capture command words at submission, assign their ordered timestamp,
+        # and let drain advance PM4/IR3 work through transaction segments.
+        context = self.context(fd, req.context_id)
+        if (req.numcmds != 1 or req.cmdsize != ctypes.sizeof(kgsl.struct_kgsl_command_object) or req.flags or
+            req.objlist or req.objsize or req.numobjs or req.synclist or req.syncsize or req.numsyncs):
+          raise ValueError("unsupported KGSL command list")
+        obj = read_struct(req.cmdlist, kgsl.struct_kgsl_command_object)
+        if obj.flags != kgsl.KGSL_CMDLIST_IB or obj.offset or obj.id or not 0 < obj.size <= 64 << 20 or obj.size % 4 or obj.gpuaddr % 4:
+          raise ValueError("unsupported KGSL command object")
+        if context.queued == 0xffffffff:
+          raise ValueError("KGSL timestamp exhausted")
+        data = self.memory.transaction().read(obj.gpuaddr, obj.size)
+        context.queued += 1
+        req.timestamp = context.queued
+        context.pending.append((struct.unpack(f"<{len(data)//4}I", data), req.timestamp, 0))
+        self.drain()
+      elif name == "CMDSTREAM_READTIMESTAMP_CTXTID":
+        # Polling also gives queues another opportunity to observe live signals.
+        context = self.context(fd, req.context_id)
+        if req.type not in (kgsl.KGSL_TIMESTAMP_QUEUED, kgsl.KGSL_TIMESTAMP_RETIRED, kgsl.KGSL_TIMESTAMP_CONSUMED):
+          raise ValueError("unsupported KGSL timestamp type")
+        self.drain()
+        req.timestamp = {
+          kgsl.KGSL_TIMESTAMP_QUEUED:context.queued,
+          kgsl.KGSL_TIMESTAMP_CONSUMED:context.consumed,
+          kgsl.KGSL_TIMESTAMP_RETIRED:context.retired,
+        }[req.type]
+      elif name == "DEVICE_WAITTIMESTAMP_CTXTID":
+        context = self.context(fd, req.context_id)
+        self.drain()
+        if context.retired < req.timestamp:
+          raise TimeoutError("QCOM mock wait has no runnable producer")
+      else:
+        raise NotImplementedError(f"unsupported KGSL ioctl {name}")
+      write_host(argp, bytes(req))
+      return 0
+
+
+def make_ioctl_callback(tracked_fds:dict, real_ioctl):
+  # Data-plane entry from native HCQ2. Untracked descriptors use the real ioctl;
+  # tracked QCOM descriptors enter the driver. Retain the first Python failure so
+  # it reaches the caller at the Python boundary instead of disappearing in C.
+  # ioctl is variadic: Darwin arm64 needs its fixed arguments declared so the
+  # native fallback places the third argument according to the variadic ABI.
+  real_ioctl.argtypes = (ctypes.c_int, ctypes.c_ulong)
+  real_ioctl.restype = ctypes.c_int
+  @ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_int, ctypes.c_ulong, ctypes.c_void_p)
+  def callback(fd, request, argp):
+    target = tracked_fds.get(fd)
+    if not isinstance(target, QCOMFileDesc):
+      return real_ioctl(ctypes.c_int(fd), ctypes.c_ulong(request), ctypes.c_void_p(argp))
+    try:
+      return target.ioctl(fd, request, argp)
+    except Exception as error:
+      if target.driver.error is None:
+        target.driver.error = error
+      return -1
+  return callback

--- a/test/mockgpu/qcom/qcomgpu.py
+++ b/test/mockgpu/qcom/qcomgpu.py
@@ -1,0 +1,510 @@
+"""A630 compute PM4: validate a complete command, then execute resumable actions."""
+# The KGSL driver owns contexts, queued command words, and the AddressSpace.
+# It supplies a MemoryTransaction to this module for one execution segment.
+# PM4 turns those words into validated actions; a launch delegates its image,
+# constants, and workgroup geometry to IR3. PM4/global accesses use the transaction.
+# The driver publishes staged writes and records progress after this module returns.
+
+from dataclasses import dataclass
+import functools, math, operator, time
+from typing import Literal
+from tinygrad.runtime.autogen import mesa
+from test.mockgpu.qcom.image import ImageBindings, decode_image_descriptor, validate_sampler
+
+
+class PM4Fault(RuntimeError):
+  pass
+
+
+def require(condition, message):
+  if not condition:
+    raise PM4Fault(message)
+
+
+@dataclass(frozen=True)
+class Packet:
+  # Framing is decoded here; opcode/register semantics are checked during planning.
+  # A type-4 target is a register address; a type-7 target is an opcode.
+  kind:int
+  target:int
+  words:tuple[int, ...]
+
+
+def decode_packets(words:tuple[int, ...]) -> tuple[Packet, ...]:
+  require(
+    all(type(word) is int and 0 <= word <= 0xffffffff for word in words),
+    "PM4 words must be unsigned 32-bit integers",
+  )
+  packets, cursor = [], 0
+
+  while cursor < len(words):
+    header, kind = words[cursor], words[cursor] >> 28
+    if kind == 7:
+      count, target = header & 0x3fff, header >> 16 & 0x7f
+      expected = mesa.CP_TYPE7_PKT | count | ((1 ^ (count.bit_count() & 1)) << 15)
+      expected |= target << 16 | ((1 ^ (target.bit_count() & 1)) << 23)
+    elif kind == 4:
+      count, target = header & 0x7f, header >> 8 & 0x3ffff
+      require(count > 0 and target + count <= 0x40000, "PM4 register packet extent is invalid")
+      expected = mesa.CP_TYPE4_PKT | count | ((1 ^ (count.bit_count() & 1)) << 7)
+      expected |= target << 8 | ((1 ^ (target.bit_count() & 1)) << 27)
+    else:
+      raise PM4Fault(f"unsupported PM4 packet type {kind}")
+
+    # Reconstructing the full header checks parity and every reserved bit together.
+    require(header == expected, "PM4 header parity or reserved bits are invalid")
+    end = cursor + count + 1
+    require(end <= len(words), "truncated PM4 packet")
+    packets.append(Packet(kind, target, tuple(words[cursor + 1:end])))
+    cursor = end
+  return tuple(packets)
+
+
+def field(value:int, name:str) -> int:
+  return (value & getattr(mesa, name + "__MASK")) >> getattr(mesa, name + "__SHIFT")
+
+
+# Register admission is finite and explicit. Fixed values select supported modes;
+# masks admit individual fields whose relationships are checked by launch().
+FIXED_REGISTERS = {
+  mesa.REG_A6XX_SP_UPDATE_CNTL: (0, mesa.A6XX_SP_UPDATE_CNTL_CS_STATE | mesa.A6XX_SP_UPDATE_CNTL_CS_UAV),
+  mesa.REG_A6XX_SP_CS_TSIZE: (0x80,),
+  mesa.REG_A6XX_SP_CS_USIZE: (0x40,),
+  mesa.REG_A6XX_SP_MODE_CNTL: (
+    mesa.ISAMMODE_GL << mesa.A6XX_SP_MODE_CNTL_ISAMMODE__SHIFT | mesa.A6XX_SP_MODE_CNTL_CONSTANT_DEMOTION_ENABLE,
+    mesa.ISAMMODE_CL << mesa.A6XX_SP_MODE_CNTL_ISAMMODE__SHIFT,
+  ),
+  mesa.REG_A6XX_SP_PERFCTR_SHADER_MASK: (mesa.A6XX_SP_PERFCTR_SHADER_MASK_CS,),
+  mesa.REG_A6XX_TPL1_MODE_CNTL: (
+    mesa.ISAMMODE_GL << mesa.A6XX_TPL1_MODE_CNTL_ISAMMODE__SHIFT,
+    mesa.ISAMMODE_CL << mesa.A6XX_TPL1_MODE_CNTL_ISAMMODE__SHIFT,
+  ),
+  **dict.fromkeys((
+    mesa.REG_A6XX_TPL1_DBG_ECO_CNTL,
+    mesa.REG_A6XX_SP_CS_BOOLEAN_CF_MASK,
+    mesa.REG_A6XX_SP_CS_NDRANGE_2,
+    mesa.REG_A6XX_SP_CS_NDRANGE_4,
+    mesa.REG_A6XX_SP_CS_NDRANGE_6,
+  ), (0,)),
+  **dict.fromkeys((
+    mesa.REG_A6XX_SP_REG_PROG_ID_0,
+    mesa.REG_A6XX_SP_REG_PROG_ID_1,
+    mesa.REG_A6XX_SP_REG_PROG_ID_2,
+  ), (0xfcfcfcfc,)),
+  mesa.REG_A6XX_SP_REG_PROG_ID_3: (0xfc,),
+}
+
+# Each row names one exact register and its admitted fields; no register range is inferred.
+REGISTER_MASKS = {
+  getattr(mesa, f"REG_A6XX_SP_CS_{register}"): functools.reduce(
+    operator.or_,
+    (getattr(mesa, f"A6XX_SP_CS_{register}_{name}") for name in fields),
+    0,
+  )
+  for register, fields in {
+    "CONST_CONFIG": ("CONSTLEN__MASK", "ENABLED"),
+    "CNTL_0": ("HALFREGFOOTPRINT__MASK", "FULLREGFOOTPRINT__MASK", "BRANCHSTACK__MASK", "THREADSIZE__MASK"),
+    "CNTL_1": ("SHARED_SIZE__MASK", "CONSTANTRAMMODE__MASK"),
+    "PVT_MEM_PARAM": ("MEMSIZEPERITEM__MASK",),
+    "PVT_MEM_SIZE": ("TOTALPVTMEMSIZE__MASK",),
+    "PVT_MEM_STACK_OFFSET": ("OFFSET__MASK",),
+    "WGE_CNTL": ("LINEARLOCALIDREGID__MASK", "THREADSIZE__MASK"),
+  }.items()
+}
+
+# These words carry full addresses, dimensions, or fields interpreted at launch.
+REGISTER_MASKS.update(dict.fromkeys((
+  mesa.REG_A6XX_SP_CS_BASE,
+  mesa.REG_A6XX_SP_CS_BASE + 1,
+  mesa.REG_A6XX_SP_CS_PVT_MEM_BASE,
+  mesa.REG_A6XX_SP_CS_PVT_MEM_BASE + 1,
+  mesa.REG_A6XX_SP_CS_INSTR_SIZE,
+  mesa.REG_A6XX_SP_CS_PROGRAM_COUNTER_OFFSET,
+  mesa.REG_A6XX_SP_CS_NDRANGE_0,
+  mesa.REG_A6XX_SP_CS_NDRANGE_1,
+  mesa.REG_A6XX_SP_CS_NDRANGE_3,
+  mesa.REG_A6XX_SP_CS_NDRANGE_5,
+  mesa.REG_A6XX_SP_CS_CONST_CONFIG_0,
+  mesa.REG_A6XX_SP_CS_KERNEL_GROUP_X,
+  mesa.REG_A6XX_SP_CS_KERNEL_GROUP_Y,
+  mesa.REG_A6XX_SP_CS_KERNEL_GROUP_Z,
+), 0xffffffff))
+REGISTER_MASKS[mesa.REG_A6XX_SP_CS_CONFIG] = (
+  mesa.A6XX_SP_CS_CONFIG_ENABLED | mesa.A6XX_SP_CS_CONFIG_NTEX__MASK |
+  mesa.A6XX_SP_CS_CONFIG_NSAMP__MASK | mesa.A6XX_SP_CS_CONFIG_NUAV__MASK
+)
+# Resource bases are optional: their count fields decide whether a launch uses
+# them. They must not become required register state for ordinary buffer kernels.
+RESOURCE_BASES = (
+  mesa.REG_A6XX_SP_CS_SAMPLER_BASE, mesa.REG_A6XX_SP_CS_TEXMEMOBJ_BASE,
+  mesa.REG_A6XX_SP_CS_UAV_BASE, mesa.REG_A6XX_TPL1_CS_BORDER_COLOR_BASE,
+)
+OPTIONAL_REGISTERS = {register + part for register in RESOURCE_BASES for part in (0, 1)}
+REGISTER_MASKS.update(dict.fromkeys(OPTIONAL_REGISTERS, 0xffffffff))
+REGISTER_NAMES = {
+  value:name for name,value in vars(mesa).items()
+  if name.startswith("REG_A6XX_") and type(value) is int
+}
+
+
+def register_write(registers:dict[int, int], address:int, value:int):
+  name = REGISTER_NAMES.get(address, hex(address))
+  if address in FIXED_REGISTERS:
+    require(value in FIXED_REGISTERS[address], f"unsupported {name} configuration")
+  elif address in REGISTER_MASKS:
+    require(value & ~REGISTER_MASKS[address] == 0, f"unsupported {name} fields")
+  else:
+    raise PM4Fault(f"unsupported PM4 register {name}")
+
+  # Only the command-local planning state changes here; no guest write is staged.
+  registers[address] = value
+
+
+def address64(low:int, high:int, alignment:int=4) -> int:
+  address = low | high << 32
+  require(address > 0 and address % alignment == 0, f"PM4 address must be nonzero and aligned to {alignment} bytes")
+  return address
+
+
+@dataclass(frozen=True)
+class MemoryAction:
+  # The operation selects a footprint and residual behavior. Planning validates
+  # the footprint; application samples live data/time or stages a write.
+  operation:Literal["wait", "store", "timestamp"]
+  address:int
+  value:int=0
+
+  @property
+  def size(self) -> int:
+    return 8 if self.operation == "timestamp" else 4
+
+  def apply(self, memory) -> bool:
+    # False means this action is blocked; its cursor must be retained by the driver.
+    if self.operation == "wait":
+      return int.from_bytes(memory.read(self.address, self.size), "little") >= self.value
+
+    # Timestamps use 19.2 MHz counter units and are sampled during application.
+    value = time.perf_counter_ns() * 192 // 10000 if self.operation == "timestamp" else self.value
+    memory.write(self.address, value.to_bytes(self.size, "little"))
+    return True
+
+
+@dataclass(frozen=True)
+class Launch:
+  # This immutable snapshot records one launch's validated inputs. Later register
+  # packets cannot alter its geometry, resource sizes, or selected shader image.
+  image:bytes
+  image_address:int
+  constants_address:int
+  constants_size:int
+
+  groups:tuple[int, int, int]
+  local:tuple[int, int, int]
+
+  # ABI positions for workgroup ID, local ID, and workgroup-size values.
+  wgid:int
+  lid:int
+  wgsize:int
+
+  shared_bytes:int
+  private_bytes:int
+  image_bindings:ImageBindings=ImageBindings()
+  image_uploads:tuple[tuple[int, bytes], ...]=()
+  opencl:bool=False
+  wgoffset:int=0xfc
+  entry_pc:int=0
+
+  def apply(self, memory) -> bool:
+    from test.mockgpu.qcom import emu
+
+    # Prior actions may have staged writes. The shader must still match the plan;
+    # constants are read now so those prior writes are visible to this launch.
+    require(memory.read(self.image_address, len(self.image)) == self.image, "shader image changed after PM4 prevalidation")
+    for address, data in self.image_uploads:
+      require(memory.read(address, len(data)) == data, "image configuration changed after PM4 prevalidation")
+    emu.execute(
+      self.image, memory.read(self.constants_address, self.constants_size), self.groups, self.local, self.wgid,
+      self.lid, memory, shared_bytes=self.shared_bytes, private_bytes=self.private_bytes, wgsize=self.wgsize,
+      image_bindings=self.image_bindings,
+      opencl=self.opencl, wgoffset=self.wgoffset, constant_demotion=not self.opencl,
+      entry_pc=self.entry_pc,
+    )
+    return True
+
+
+def image_resources(registers:dict[int, int], loads:dict[tuple[int, int], tuple[int, int]], memory):
+  config = registers[mesa.REG_A6XX_SP_CS_CONFIG]
+  require(config & mesa.A6XX_SP_CS_CONFIG_ENABLED, "compute configuration is disabled")
+  texture_count = field(config, "A6XX_SP_CS_CONFIG_NTEX")
+  sampler_count = field(config, "A6XX_SP_CS_CONFIG_NSAMP")
+  output_count = field(config, "A6XX_SP_CS_CONFIG_NUAV")
+  uploads = []
+
+  def table(block, kind, count, register, unit_size, alignment, prefetch=None):
+    if count == 0:
+      return b""
+    require(register in registers and register + 1 in registers, "missing image resource base")
+    address = address64(registers[register], registers[register + 1], alignment)
+    expected_units = count if prefetch is None else min(prefetch, count)
+    require(loads.get((block, kind)) == (address, expected_units), "image resource load and configuration disagree")
+    memory.validate(address, count * unit_size)
+    data = memory.read(address, count * unit_size)
+    uploads.append((address, data))
+    return data
+
+  sampler_data = table(mesa.SB6_CS_TEX, mesa.ST_SHADER, sampler_count, mesa.REG_A6XX_SP_CS_SAMPLER_BASE, 16, 16)
+  texture_data = table(mesa.SB6_CS_TEX, mesa.ST_CONSTANTS, texture_count, mesa.REG_A6XX_SP_CS_TEXMEMOBJ_BASE, 64, 64, 16)
+  output_data = table(mesa.SB6_CS_SHADER, mesa.ST6_UAV, output_count, mesa.REG_A6XX_SP_CS_UAV_BASE, 64, 16)
+  # The CL producer reserves a trailing zero sampler record. Keep it in the
+  # upload snapshot, but do not admit an instruction that tries to execute it.
+  active_sampler_count = sampler_count
+  while active_sampler_count and sampler_data[(active_sampler_count - 1) * 16:active_sampler_count * 16] == bytes(16):
+    active_sampler_count -= 1
+  for offset in range(0, active_sampler_count * 16, 16):
+    validate_sampler(sampler_data[offset:offset + 16])
+  if sampler_count:
+    register = mesa.REG_A6XX_TPL1_CS_BORDER_COLOR_BASE
+    require(register in registers and register + 1 in registers, "missing image border color base")
+    address = address64(registers[register], registers[register + 1], 64)
+    memory.validate(address, 4096)
+    border = memory.read(address, 4096)
+    require(not any(border), "unsupported nonzero image border color")
+    uploads.append((address, border))
+
+  bindings = ImageBindings(
+    tuple(decode_image_descriptor(texture_data[offset:offset + 64], True) for offset in range(0, len(texture_data), 64)),
+    tuple(decode_image_descriptor(output_data[offset:offset + 64], False) for offset in range(0, len(output_data), 64)),
+    active_sampler_count,
+  )
+  bindings.validate(memory)
+  return bindings, tuple(uploads)
+
+
+def launch(registers:dict[int, int], loads:dict[tuple[int, int], tuple[int, int]], groups:tuple[int, int, int],
+           memory, *, opencl:bool=False) -> Launch:
+  # A register file is local to this command. No state is inferred from a prior
+  # submission or from the shape/length of a known command stream.
+  required = (set(REGISTER_MASKS) | set(FIXED_REGISTERS)) - OPTIONAL_REGISTERS - {mesa.REG_A6XX_SP_UPDATE_CNTL}
+  missing = required - registers.keys()
+  require(
+    not missing,
+    "incomplete PM4 compute register state: " + ", ".join(REGISTER_NAMES.get(reg, hex(reg)) for reg in sorted(missing)),
+  )
+  shader_key, constant_key = (mesa.SB6_CS_SHADER, mesa.ST_SHADER), (mesa.SB6_CS_SHADER, mesa.ST_CONSTANTS)
+  require(shader_key in loads and constant_key in loads, "compute launch needs shader and constant loads")
+  # Compiler conventions are selected together: CL uses packed half constants
+  # and CP_RUN_OPENCL builtin state; Mesa IR3 uses constant demotion and CP_EXEC_CS.
+  mode = mesa.ISAMMODE_CL if opencl else mesa.ISAMMODE_GL
+  expected_sp = mode << mesa.A6XX_SP_MODE_CNTL_ISAMMODE__SHIFT
+  if not opencl:
+    expected_sp |= mesa.A6XX_SP_MODE_CNTL_CONSTANT_DEMOTION_ENABLE
+  require(registers[mesa.REG_A6XX_SP_MODE_CNTL] == expected_sp and
+          registers[mesa.REG_A6XX_TPL1_MODE_CNTL] == mode << mesa.A6XX_TPL1_MODE_CNTL_ISAMMODE__SHIFT,
+          "compute dispatch and compiler modes disagree")
+
+  # Dispatch counts, register dimensions, and local workgroup shape must agree.
+  range_control = registers[mesa.REG_A6XX_SP_CS_NDRANGE_0]
+  require(field(range_control, "A6XX_SP_CS_NDRANGE_0_KERNELDIM") == 3, "unsupported compute kernel dimensions")
+  local = (
+    field(range_control, "A6XX_SP_CS_NDRANGE_0_LOCALSIZEX") + 1,
+    field(range_control, "A6XX_SP_CS_NDRANGE_0_LOCALSIZEY") + 1,
+    field(range_control, "A6XX_SP_CS_NDRANGE_0_LOCALSIZEZ") + 1,
+  )
+  declared_groups = tuple(registers[reg] for reg in (
+    mesa.REG_A6XX_SP_CS_KERNEL_GROUP_X,
+    mesa.REG_A6XX_SP_CS_KERNEL_GROUP_Y,
+    mesa.REG_A6XX_SP_CS_KERNEL_GROUP_Z,
+  ))
+  global_size = tuple(registers[reg] for reg in (
+    mesa.REG_A6XX_SP_CS_NDRANGE_1,
+    mesa.REG_A6XX_SP_CS_NDRANGE_3,
+    mesa.REG_A6XX_SP_CS_NDRANGE_5,
+  ))
+  require(all(value > 0 for value in groups + global_size), "compute dimensions must be positive")
+  require(
+    groups == declared_groups == tuple((size + block - 1) // block for size, block in zip(global_size, local)),
+    "compute dispatch and NDRANGE dimensions disagree",
+  )
+
+  # The register footprint bounds how many invocations can share one workgroup.
+  control = registers[mesa.REG_A6XX_SP_CS_CNTL_0]
+  require(field(control, "A6XX_SP_CS_CNTL_0_THREADSIZE") == mesa.THREAD64, "unsupported compute thread size")
+  full = field(control, "A6XX_SP_CS_CNTL_0_FULLREGFOOTPRINT")
+  half = field(control, "A6XX_SP_CS_CNTL_0_HALFREGFOOTPRINT")
+  max_threads = min(1024, (384 * 32 // (max(1, full + (half + 1) // 2) * 128)) * 128)
+  require(math.prod(local) <= max_threads, "compute workgroup exceeds its register resource limit")
+
+  # Decode shared/private capacities, and validate the producer's mapped stack.
+  # IR3 uses the per-invocation private capacity rather than the native stack address.
+  control = registers[mesa.REG_A6XX_SP_CS_CNTL_1]
+  require(field(control, "A6XX_SP_CS_CNTL_1_CONSTANTRAMMODE") == mesa.CONSTLEN_256, "unsupported compute constant RAM mode")
+  shared_encoding = field(control, "A6XX_SP_CS_CNTL_1_SHARED_SIZE")
+  shared_bytes = (shared_encoding + 1) * 1024 if shared_encoding else 32768
+
+  # Per-invocation private capacity is in 512-byte blocks; stack offsets use 2 KiB.
+  private_units = field(registers[mesa.REG_A6XX_SP_CS_PVT_MEM_PARAM], "A6XX_SP_CS_PVT_MEM_PARAM_MEMSIZEPERITEM")
+  require(registers[mesa.REG_A6XX_SP_CS_PVT_MEM_SIZE] == private_units * 256, "inconsistent compute private memory size")
+  private_address = address64(
+    registers[mesa.REG_A6XX_SP_CS_PVT_MEM_BASE], registers[mesa.REG_A6XX_SP_CS_PVT_MEM_BASE + 1],
+  )
+  per_sp_bytes = registers[mesa.REG_A6XX_SP_CS_PVT_MEM_STACK_OFFSET] << 11
+  stack_bytes = per_sp_bytes * 4 # Preserve the producer's conservative four-times-per-SP allocation policy.
+  require(stack_bytes > 0, "compute private stack allocation is missing")
+  memory.validate(private_address, stack_bytes, write=True)
+
+  # Shader load units are 128 bytes. Constant load units are vec4s (16 bytes),
+  # while CONSTLEN encodes groups of four vec4s. Validate each in its own units.
+  shader_address, shader_units = loads[shader_key]
+  require(
+    shader_address == address64(registers[mesa.REG_A6XX_SP_CS_BASE], registers[mesa.REG_A6XX_SP_CS_BASE + 1], 128),
+    "shader load and program base disagree",
+  )
+  require(shader_units == registers[mesa.REG_A6XX_SP_CS_INSTR_SIZE], "shader load and instruction size disagree")
+
+  constants_address, constant_units = loads[constant_key]
+  constants_size = constant_units * 16
+  constant_config = registers[mesa.REG_A6XX_SP_CS_CONST_CONFIG]
+  constant_vec4s = field(constant_config, "A6XX_SP_CS_CONST_CONFIG_CONSTLEN") << 2
+  require(
+    constant_config & mesa.A6XX_SP_CS_CONST_CONFIG_ENABLED and 0 < constant_vec4s <= 256,
+    "constant configuration is disabled or exceeds the RAM bank",
+  )
+  require(constants_size <= constant_vec4s * 16, "constant load exceeds its declared configuration")
+  memory.validate(constants_address, constants_size)
+
+  image = memory.read(shader_address, shader_units * 128)
+  entry_pc = registers[mesa.REG_A6XX_SP_CS_PROGRAM_COUNTER_OFFSET]
+  from test.mockgpu.qcom import emu
+  # Check every encoding, then the reachable constant spans against the actual
+  # upload. A short upload is valid; its contents stay live until application.
+  emu.validate_constant_footprint(emu.decode(image), constants_size // 4,
+                                constant_demotion=not opencl, entry_pc=entry_pc)
+  image_bindings, image_uploads = image_resources(registers, loads, memory)
+  emu.validate_image_bindings(emu.decode(image), image_bindings)
+
+  # The compiler ABI selects invocation-register and constant positions; 0xfc
+  # denotes an unused position. These coordinates seed the IR3 workgroup state.
+  config = registers[mesa.REG_A6XX_SP_CS_CONST_CONFIG_0]
+  wgid = field(config, "A6XX_SP_CS_CONST_CONFIG_0_WGIDCONSTID")
+  lid = field(config, "A6XX_SP_CS_CONST_CONFIG_0_LOCALIDREGID")
+  wgsize = field(config, "A6XX_SP_CS_CONST_CONFIG_0_WGSIZECONSTID")
+  wgoffset = field(config, "A6XX_SP_CS_CONST_CONFIG_0_WGOFFSETCONSTID")
+  emu.validate_invocation_registers(wgid, lid)
+  if opencl:
+    emu.validate_invocation_registers(wgsize, wgoffset)
+    require(constants_size >= 32 * 4, "OpenCL builtin constant range is incomplete")
+  else:
+    require(wgoffset == 0xfc, "workgroup offsets are unsupported")
+    require(wgsize == 0xfc or (wgsize + 3) * 4 <= constants_size, "workgroup size constant range is invalid")
+
+  wave = registers[mesa.REG_A6XX_SP_CS_WGE_CNTL]
+  require(
+    field(wave, "A6XX_SP_CS_WGE_CNTL_LINEARLOCALIDREGID") == 0xfc and
+    field(wave, "A6XX_SP_CS_WGE_CNTL_THREADSIZE") == mesa.THREAD64,
+    "unsupported compute workgroup execution mode",
+  )
+  return Launch(
+    image, shader_address, constants_address, constants_size, groups, local, wgid, lid, wgsize, shared_bytes, private_units * 512,
+    image_bindings, image_uploads,
+    opencl=opencl, wgoffset=wgoffset, entry_pc=entry_pc,
+  )
+
+
+def compile_plan(words:tuple[int, ...], memory) -> tuple[MemoryAction|Launch, ...]:
+  # Walk the entire command before applying any action. Register/load declarations
+  # update this local state; effect packets append immutable actions in order.
+  registers:dict[int, int] = {}
+  loads:dict[tuple[int, int], tuple[int, int]] = {}
+  actions:list[MemoryAction|Launch] = []
+  compute_mode = False
+
+  try:
+    for packet in decode_packets(words):
+      if packet.kind == 4:
+        for index, value in enumerate(packet.words):
+          register_write(registers, packet.target + index, value)
+        continue
+
+      opcode, payload = packet.target, packet.words
+      if opcode in (mesa.CP_WAIT_FOR_IDLE, mesa.CP_WAIT_MEM_WRITES):
+        require(len(payload) == 0, "invalid wait packet length")
+      elif opcode == mesa.CP_SET_MARKER:
+        require(payload == (mesa.RM6_COMPUTE,), "unsupported PM4 marker mode")
+        compute_mode = True
+      elif opcode == mesa.CP_EVENT_WRITE:
+        if payload == (mesa.CACHE_INVALIDATE,):
+          continue
+        require(len(payload) == 4 and payload[0] == mesa.CACHE_FLUSH_TS, "unsupported PM4 event write")
+        actions.append(MemoryAction(operation="store", address=address64(payload[1], payload[2]), value=payload[3]))
+      elif opcode == mesa.CP_WAIT_REG_MEM:
+        control = (
+          mesa.WRITE_GE << mesa.CP_WAIT_REG_MEM_0_FUNCTION__SHIFT | mesa.POLL_MEMORY << mesa.CP_WAIT_REG_MEM_0_POLL__SHIFT
+        )
+        require(len(payload) == 6 and payload[0] == control and payload[4] == 0xffffffff, "unsupported PM4 memory wait")
+        actions.append(MemoryAction(operation="wait", address=address64(payload[1], payload[2]), value=payload[3]))
+      elif opcode == mesa.CP_REG_TO_MEM:
+        control = (
+          mesa.REG_A6XX_CP_ALWAYS_ON_COUNTER | 2 << mesa.CP_REG_TO_MEM_0_CNT__SHIFT | mesa.CP_REG_TO_MEM_0_64B
+        )
+        require(len(payload) == 3 and payload[0] == control, "unsupported PM4 register-to-memory transfer")
+        actions.append(MemoryAction(operation="timestamp", address=address64(payload[1], payload[2], 8)))
+      elif opcode == mesa.CP_LOAD_STATE6_FRAG:
+        require(len(payload) == 3, "unsupported PM4 state load length")
+        control = payload[0]
+        kind = field(control, "CP_LOAD_STATE6_0_STATE_TYPE")
+        block = field(control, "CP_LOAD_STATE6_0_STATE_BLOCK")
+        units = field(control, "CP_LOAD_STATE6_0_NUM_UNIT")
+        alignment = {
+          (mesa.SB6_CS_SHADER, mesa.ST_SHADER): 128,
+          (mesa.SB6_CS_SHADER, mesa.ST_CONSTANTS): 16,
+          (mesa.SB6_CS_SHADER, mesa.ST6_UAV): 16,
+          (mesa.SB6_CS_TEX, mesa.ST_SHADER): 16,
+          (mesa.SB6_CS_TEX, mesa.ST_CONSTANTS): 64,
+        }.get((block, kind))
+        if alignment is None:
+          raise PM4Fault("unsupported PM4 resource load")
+        require(
+          field(control, "CP_LOAD_STATE6_0_STATE_SRC") == mesa.SS6_INDIRECT and
+          field(control, "CP_LOAD_STATE6_0_DST_OFF") == 0 and units > 0,
+          "unsupported PM4 resource load",
+        )
+        loads[(block, kind)] = address64(payload[1], payload[2], alignment), units
+      elif opcode == mesa.CP_EXEC_CS:
+        require(len(payload) == 4 and payload[0] == 0 and compute_mode, "unsupported PM4 compute dispatch")
+        actions.append(launch(registers, loads, (payload[1], payload[2], payload[3]), memory))
+      elif opcode == mesa.CP_RUN_OPENCL:
+        require(payload == (0,) and compute_mode, "unsupported PM4 OpenCL dispatch")
+        groups = (
+          registers.get(mesa.REG_A6XX_SP_CS_KERNEL_GROUP_X, 0),
+          registers.get(mesa.REG_A6XX_SP_CS_KERNEL_GROUP_Y, 0),
+          registers.get(mesa.REG_A6XX_SP_CS_KERNEL_GROUP_Z, 0),
+        )
+        actions.append(launch(registers, loads, groups, memory, opencl=True))
+      else:
+        raise PM4Fault(f"unsupported PM4 opcode {opcode:#x}")
+
+    # Even a fault in a late action's footprint must reject before a valid prefix
+    # writes. Launch resources were validated when each launch snapshot was built.
+    for action in actions:
+      if isinstance(action, MemoryAction):
+        memory.validate(action.address, action.size, write=action.operation != "wait")
+  except (ValueError, RuntimeError) as error:
+    if isinstance(error, PM4Fault):
+      raise
+    raise PM4Fault(f"PM4 prevalidation failed: {error}") from error
+  return tuple(actions)
+
+
+def execute_command(words:tuple[int, ...], memory, timestamp:int, start:int=0) -> tuple[bool, int]:
+  # Revalidate the whole command on each resume, against the current transaction.
+  # The cursor counts actions, not packets: the driver commits a successful prefix
+  # and resumes at a blocked wait without repeating earlier stores or timestamps.
+  # The timestamp argument is retained for the driver interface; timestamp actions
+  # sample their own time in MemoryAction.apply().
+  actions = compile_plan(words, memory)
+  require(type(start) is int and 0 <= start <= len(actions), "invalid PM4 action cursor")
+
+  for cursor in range(start, len(actions)):
+    if not actions[cursor].apply(memory):
+      return False, cursor
+  return True, len(actions)

--- a/test/mockgpu/qcom/test_argument_binding.py
+++ b/test/mockgpu/qcom/test_argument_binding.py
@@ -1,0 +1,18 @@
+"""Compact compiled signatures must select the corresponding raw call arguments."""
+import numpy as np
+from tinygrad import Tensor, dtypes
+from tinygrad.uop.ops import KernelInfo, UOp
+
+
+def test_unused_middle_buffer_does_not_replace_the_live_input():
+  # Program.globals is (0,2), whereas the call still carries all three buffers.
+  # Distinct input values expose accidentally binding compact slot1 to raw slot1.
+  def kernel(output:UOp, unused:UOp, source:UOp):
+    index = UOp.range(5, 0)
+    return output[index].store(source[index] * 3 - 1).end(index).sink(arg=KernelInfo(name='sparse_arguments'))
+
+  output = Tensor.empty(5, dtype=dtypes.int32)
+  unused = Tensor(np.array([100, 200, 300, 400, 500], dtype=np.int32))
+  source = Tensor(np.array([-7, 0, 2, 9, 23], dtype=np.int32))
+  actual = Tensor.custom_kernel(output, unused, source, fxn=kernel)[0].numpy()
+  np.testing.assert_array_equal(actual, [-22, -1, 5, 26, 68])

--- a/test/mockgpu/qcom/test_arithmetic.py
+++ b/test/mockgpu/qcom/test_arithmetic.py
@@ -1,0 +1,191 @@
+import struct
+import numpy as np
+import pytest
+from test.mockgpu.qcom.emu import Operand,Instruction,Workgroup,decode
+from test.mockgpu.qcom.test_emu import Memory
+
+
+def evaluate(op,inputs,*,source_half=False,dest_half=False,fields=None,modifiers=None):
+  lanes=np.arange(len(inputs[0]))
+  state=Workgroup(bytes(64),(len(lanes),1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  operands={'DST':Operand('register',20,dest_half)}
+  for i,values in enumerate(inputs):
+    state.registers[source_half][i] = np.asarray(values,np.uint16 if source_half else np.uint32)
+    operands['SRC'+str(i+1)]=Operand('register',i,source_half,modifier=(modifiers or [0]*len(inputs))[i])
+  ins=Instruction(op,fields or {},operands,4<<61 if op in ('rcp','sqrt','exp2','log2','sin','cos') else 3<<61)
+  state.alu(ins,lanes,0)
+  return state.registers[dest_half][20].copy()
+
+
+def test_multiply_split_halves_matches_full_width_product():
+  # Adreno compiler expands imul as mull plus two high-half madsh terms.
+  a=np.array([0x10001,0xffff0001,0xffffffff,0x80008000,123456789],np.uint32)
+  b=np.array([0x20003,0x0002ffff,0xffffffff,0x8000ffff,987654321],np.uint32)
+  low=evaluate('mull.u',[a,b])
+  first=evaluate('madsh.m16',[a,b,low])
+  result=evaluate('madsh.m16',[b,a,first])
+  expected=np.array([(int(x)*int(y))&0xffffffff for x,y in zip(a,b)],np.uint32)
+  np.testing.assert_array_equal(result,expected)
+
+@pytest.mark.parametrize('condition,expected',[(0,[1,0,0]),(1,[1,1,0]),(2,[0,0,1]),(3,[0,1,1]),(4,[0,1,0]),(5,[1,0,1])])
+def test_signed_comparisons_write_boolean_not_float(condition,expected):
+  result=evaluate('cmps.s',[[0xffffffff,0,1],[0,0,0]],fields={'COND':condition},dest_half=True)
+  np.testing.assert_array_equal(result,np.array(expected,np.uint16))
+
+
+def test_half_float_arithmetic_and_absneg():
+  a=np.array([-1.5,2.5,-3.25],np.float16).view(np.uint16)
+  b=np.array([.5,-.5,4.25],np.float16).view(np.uint16)
+  result=evaluate('add.f',[a,b],source_half=True,dest_half=True,modifiers=[2,1]).view(np.float16)
+  np.testing.assert_array_equal(result,np.array([1.,3.,-1.],np.float16))
+
+
+def test_swap_reads_both_sources_before_writing():
+  state=Workgroup(bytes(64),(2,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  state.registers[0][0]=[10,20]
+  state.registers[0][1]=[30,40]
+  swap=Instruction('swz',{},dict(DST0=Operand('register',0),DST1=Operand('register',1),SRC0=Operand('register',1),SRC1=Operand('register',0)),1<<61)
+  state.run((swap,Instruction('end',{}, {},0)))
+  np.testing.assert_array_equal(state.registers[0][:2],[[30,40],[10,20]])
+
+
+def test_repeated_destination_and_source_advance_independently():
+  state=Workgroup(bytes(64),(2,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  state.registers[0][0:3]=[[10,20],[30,40],[50,60]]
+  ins=Instruction('add.u',{'REPEAT':2},dict(DST=Operand('register',10),SRC1=Operand('register',0,repeat=True),SRC2=Operand('immediate',7)),2<<61)
+  state.run((ins,Instruction('end',{}, {},0)))
+  np.testing.assert_array_equal(state.registers[0][10:13],[[17,27],[37,47],[57,67]])
+
+def test_conversion_rounds_toward_zero_instead_of_nearest():
+  # Mesa round_t ROUND_ZERO=0; 2051 is midway between half 2050 and 2052.
+  group=Workgroup(bytes(64),(2,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  group.registers[1][0]=[2051,65535]
+  convert=Instruction('mov',{'SRC_TYPE':2,'DST_TYPE':0},dict(DST=Operand('register',1,True),SRC=Operand('register',0,True)),1<<61)
+  group.run((convert,Instruction('end',{}, {},0)))
+  np.testing.assert_array_equal(group.registers[1][1],[0x6801,0x7bff])
+
+def test_mad_rounds_the_product_before_adding():
+  # Mesa commit 92d2671 explicitly identifies mad.f16/mad.f32 as unfused.
+  a=np.array([1+2**-23],np.float32).view(np.uint32)
+  b=np.array([1-2**-23],np.float32).view(np.uint32)
+  c=np.array([-1],np.float32).view(np.uint32)
+  result=evaluate('mad.f32',[a,b,c]).view(np.float32)
+  np.testing.assert_array_equal(result,[0.])
+
+def test_encoded_bitwise_source_negation_complements_bits():
+  # ir3.h:ir3_cat2_absneg maps AND's NEG source flag to IR3_REG_BNOT.
+  group=Workgroup(bytes(64),(4,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  a=np.array([0,1,0xffffffff,0x80000000],np.uint32)
+  b=np.array([0xffffffff,7,0xaaaaaaaa,0xffffffff],np.uint32)
+  group.registers[0][0],group.registers[0][1]=a,b
+  word = (2<<61)|(28<<53)|(1<<52)|(2<<32)|(1<<16)|(1<<14)
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  np.testing.assert_array_equal(group.registers[0][2],~a&b)
+
+@pytest.mark.parametrize('opcode,a,b,expected',[
+  (16,65535,1,0),                    # ADD_U wraps at 16 bits, then zero-extends.
+  (17,32767,1,0xffff8000),           # ADD_S wraps at 16 bits, then sign-extends.
+  (56,65535,0,65535),                # ASHR_B shifts signed, then zero-extends.
+  (0,0x3c00,0x1000,0x3f800000),     # ADD_F rounds its half result before widening.
+])
+def test_encoded_half_alu_result_converts_after_source_width_arithmetic(opcode,a,b,expected):
+  group=Workgroup(bytes(64),(1,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  group.registers[1][0],group.registers[1][1]=a,b
+  word=(2<<61)|(opcode<<53)|(1<<46)|(2<<32)|(1<<16)
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  np.testing.assert_array_equal(group.registers[0][2],[expected])
+
+def test_encoded_half_float_table_immediate_rounds_before_arithmetic():
+  group=Workgroup(bytes(64),(1,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  # Add h(pi) to half zero, with a full-width destination.
+  word=(2<<61)|(1<<46)|(2<<32)|(5<<11)|(1<<10)|5
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  np.testing.assert_array_equal(group.registers[0][2].view(np.float32),[3.140625])
+
+def test_encoded_float_alu_output_narrowing_uses_round_toward_zero():
+  # ir3_cf.c folds only ROUND_ZERO conversions into a supported ALU output.
+  group=Workgroup(bytes(64),(1,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  group.registers[0][0]=np.array([1],np.float32).view(np.uint32)
+  group.registers[0][1]=np.array([2**-11+2**-13],np.float32).view(np.uint32)
+  word=(2<<61)|(1<<52)|(1<<46)|(2<<32)|(1<<16)
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  np.testing.assert_array_equal(group.registers[1][2],[0x3c00])
+
+@pytest.mark.parametrize('immediate',[-1,-1024])
+def test_encoded_signed_integer_immediate(immediate):
+  group=Workgroup(bytes(64),(1,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  source=(4<<11)|(immediate&2047)
+  word=(2<<61)|(16<<53)|(1<<52)|(2<<32)|(source<<16)
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  np.testing.assert_array_equal(group.registers[0][2],[immediate&0xffffffff])
+
+def test_encoded_andg_combines_masks():
+  # ir3-cat3.xml: ANDG computes (SRC2 & SRC1) | SRC3.
+  group=Workgroup(bytes(64),(4,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  a=np.array([0,0xffffffff,0xff00ff00,0x12345678],np.uint32)
+  b=np.array([0xffffffff,0xaaaaaaaa,0x0f0f0f0f,0xfedcba98],np.uint32)
+  c=np.array([3,0x55555555,0x80000001,0],np.uint32)
+  group.registers[0][0],group.registers[0][1],group.registers[0][2]=a,b,c
+  word=(3<<61)|(12<<55)|(1<<47)|(1<<42)|(3<<32)|(2<<16)|(1<<13)
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  np.testing.assert_array_equal(group.registers[0][3],(a&b)|c)
+
+@pytest.mark.parametrize('opcode,left,merge',[(8,False,False),(9,True,False),(11,True,True)])
+def test_encoded_shift_combines_mask_or_merge(opcode,left,merge):
+  # The cat3 alternate SHRM/SHLM/SHLG forms combine a shift with AND/OR.
+  group=Workgroup(bytes(64),(4,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  shifts=np.array([0,1,4,31],np.uint32)
+  values=np.array([0x12345678,0x87654321,0xffffffff,1],np.uint32)
+  masks=np.array([0x0f0f0f0f,0x80000000,0xff00ff00,0xffffffff],np.uint32)
+  group.registers[0][0],group.registers[0][1],group.registers[0][2]=shifts,values,masks
+  word=(3<<61)|(opcode<<55)|(1<<47)|(1<<42)|(3<<32)|(2<<16)|(1<<13)
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  shifted=values<<shifts if left else values>>shifts
+  np.testing.assert_array_equal(group.registers[0][3],shifted|masks if merge else shifted&masks)
+
+@pytest.mark.parametrize('opcode,expected',[(4,[0,1,0,-1]),(5,[1,0,-1,0])])
+def test_encoded_trigonometric_source_is_radians(opcode,expected):
+  # ir3_nir_trig.py reduces to [-pi,pi]; ISA SIN/COS consume radians.
+  group=Workgroup(bytes(64),(4,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  group.registers[0][0]=np.array([0,np.pi/2,np.pi,-np.pi/2],np.float32).view(np.uint32)
+  word=(4<<61)|(opcode<<53)|(1<<52)|(1<<32)
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  np.testing.assert_allclose(group.registers[0][1].view(np.float32),expected,atol=1e-6)
+
+@pytest.mark.parametrize('rounding,expected',[(0,[0x3c00,0xbc00,0x6801]),(1,[0x3c01,0xbc01,0x6802])])
+def test_encoded_half_conversion_rounding_modes(rounding,expected):
+  group=Workgroup(bytes(64),(3,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  group.registers[0][0]=np.array([1.0006,-1.0006,2051],np.float32).view(np.uint32)
+  # cat1 source typeF32=1, destinationF16=0, gpr source, explicitROUND[56:55].
+  word=(1<<61)|(rounding<<55)|(1<<50)|(1<<32)
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  np.testing.assert_array_equal(group.registers[1][1],expected)
+
+def test_encoded_sign_and_count_leading_zero():
+  group=Workgroup(bytes(64),(4,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  group.registers[0][0]=np.array([-3.,-0.,0.,2.],np.float32).view(np.uint32)
+  sign=(2<<61)|(4<<53)|(1<<52)|(1<<32)
+  group.run(decode(struct.pack('<2Q',sign,6<<55)))
+  np.testing.assert_array_equal(group.registers[0][1],np.array([-1.,-0.,0.,1.],np.float32).view(np.uint32))
+  group=Workgroup(bytes(64),(4,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  group.registers[0][0]=[0,1,8,0xffffffff]
+  clz=(2<<61)|(53<<53)|(1<<52)|(1<<32)
+  group.run(decode(struct.pack('<2Q',clz,6<<55)))
+  np.testing.assert_array_equal(group.registers[0][1],[0xffffffff,31,28,0])
+
+@pytest.mark.parametrize('half',[False,True])
+def test_encoded_count_leading_zero_uses_minus_one_for_zero(half):
+  # ir3_compiler_nir.c ufind_msb keeps CLZ's zero result unchanged; NIR requires -1.
+  group=Workgroup(bytes(64),(1,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  word=(2<<61)|(53<<53)|(int(not half)<<52)|(1<<32)
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  np.testing.assert_array_equal(group.registers[half][1],[0xffff if half else 0xffffffff])
+
+def test_encoded_signed_24bit_multiply_sign_extends_and_wraps():
+  group=Workgroup(bytes(64),(6,1,1),(0,0,0),0xfc,0xfc,0xfc,Memory({}),0,0)
+  group.registers[0][0]=[0x7fffff,0x800000,0xffffff,0x01000001,0xffffffff,0x7fffff]
+  group.registers[0][1]=[2,2,2,0xffffff,0x800000,0x7fffff]
+  word=(2<<61)|(49<<53)|(1<<52)|(2<<32)|(1<<16)
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  expected=[0xfffffe,0xff000000,0xfffffffe,0xffffffff,0x800000,0xff000001]
+  np.testing.assert_array_equal(group.registers[0][2],expected)

--- a/test/mockgpu/qcom/test_budget.py
+++ b/test/mockgpu/qcom/test_budget.py
@@ -1,0 +1,76 @@
+"""The scheduler budget bounds finite work without changing shader loop counts."""
+import numpy as np
+import pytest
+from test.mockgpu.qcom.emu import Instruction
+from test.mockgpu.qcom.test_control import END, I, R, add, branch, jump, move, state
+
+
+def finite_reduction():
+  # Three increments, with one comparison/backedge per increment: 11 steps.
+  compare = Instruction('cmps.u', {'COND': 0}, dict(DST=R(248), SRC1=R(0), SRC2=I(3)), 2 << 61)
+  return (move(0, 0), add(0, 0, 1), compare, branch(-2), END)
+
+
+def test_finite_loop_completes_at_exact_budget(monkeypatch):
+  monkeypatch.setenv('MOCK_QCOM_MAX_STEPS', '11')
+  group = state()
+  group.run(finite_reduction())
+  np.testing.assert_array_equal(group.registers[0][0], [3, 3, 3, 3])
+  assert (group.pc == -1).all()
+
+
+def test_finite_loop_reports_exhaustion_before_end(monkeypatch):
+  monkeypatch.setenv('MOCK_QCOM_MAX_STEPS', '10')
+  group = state()
+  with pytest.raises(RuntimeError, match='instruction budget exhausted'):
+    group.run(finite_reduction())
+  assert (group.pc == 4).all()
+
+
+def test_configured_budget_still_bounds_nonterminating_loop(monkeypatch):
+  monkeypatch.setenv('MOCK_QCOM_MAX_STEPS', '7')
+  group = state()
+  with pytest.raises(RuntimeError, match='instruction budget exhausted'):
+    group.run((add(0, 0, 1), jump(-1)))
+  np.testing.assert_array_equal(group.registers[0][0], [4, 4, 4, 4])
+
+
+@pytest.mark.parametrize('limit', ['0', '-1'])
+def test_nonpositive_budget_rejects_before_execution(monkeypatch, limit):
+  monkeypatch.setenv('MOCK_QCOM_MAX_STEPS', limit)
+  group = state()
+  with pytest.raises(ValueError, match='MOCK_QCOM_MAX_STEPS must be positive'):
+    group.run((move(0, 99), END))
+  np.testing.assert_array_equal(group.registers[0][0], [0, 0, 0, 0])
+
+
+@pytest.mark.parametrize('limit, completed', [(2, False), (3, True)])
+def test_barrier_release_consumes_one_scheduler_step(monkeypatch, limit, completed):
+  monkeypatch.setenv('MOCK_QCOM_MAX_STEPS', str(limit))
+  group = state()
+  program = (Instruction('bar', {}, {}, 7 << 61), END)
+  if completed:
+    group.run(program)
+    assert (group.pc == -1).all()
+  else:
+    with pytest.raises(RuntimeError, match='instruction budget exhausted'):
+      group.run(program)
+    assert (group.pc == 1).all()
+  assert not group.waiting.any()
+
+
+@pytest.mark.parametrize('limit, completed', [(3, False), (5, True)])
+def test_budget_completion_requires_every_divergent_lane_to_end(monkeypatch, limit, completed):
+  monkeypatch.setenv('MOCK_QCOM_MAX_STEPS', str(limit))
+  group = state(lanes=2)
+  group.registers[0][248] = [1, 0]
+  program = (branch(3), move(0, 1), END, move(0, 2), END)
+  if completed:
+    group.run(program)
+    np.testing.assert_array_equal(group.registers[0][0], [2, 1])
+    assert (group.pc == -1).all()
+  else:
+    with pytest.raises(RuntimeError, match='instruction budget exhausted'):
+      group.run(program)
+    np.testing.assert_array_equal(group.pc, [3, -1])
+    np.testing.assert_array_equal(group.registers[0][0], [0, 1])

--- a/test/mockgpu/qcom/test_comparison_modifier.py
+++ b/test/mockgpu/qcom/test_comparison_modifier.py
@@ -1,0 +1,55 @@
+"""Floating comparison branches emitted by the ordinary QCOMCL compiler."""
+import struct
+import numpy as np
+import pytest
+from tinygrad import Tensor, dtypes
+from test.mockgpu.qcom import emu
+from test.mockgpu.qcom.test_qcomcl import requires_qcomcl, source_kernel
+
+
+@requires_qcomcl
+@pytest.mark.parametrize('comparison,compare', [('<', np.less), ('<=', np.less_equal), ('>', np.greater),
+                                               ('>=', np.greater_equal), ('==', np.equal), ('!=', np.not_equal)])
+@pytest.mark.parametrize('negate', [False, True])
+def test_compiled_float_branches_include_nan_and_threshold_neighbors(comparison, compare, negate, monkeypatch):
+  # Volatile stores keep the compiler's control-flow comparison observable.
+  condition = f'fabs(input[i]) {comparison} 1.5f'
+  if negate: condition = f'!({condition})'
+  source = f'''__kernel void compare_values(__global volatile uint *out, __global const float *input) {{
+    uint i = get_global_id(0);
+    if ({condition}) {{
+      for (uint k = 0; k < 3; k++) out[i * 3 + k] = 17 + k;
+    }} else {{
+      for (uint k = 0; k < 3; k++) out[i * 3 + k] = 81 + k;
+    }}
+  }}'''
+  below = np.nextafter(np.float32(1.5), np.float32(0))
+  above = np.nextafter(np.float32(1.5), np.float32(2))
+  values = np.array([-np.inf, -above, -1.5, -below, -0.0, 0.0, below, 1.5, above, np.inf, np.nan], dtype=np.float32)
+  comparisons: list[tuple[int, int]] = []
+  original = emu.execute
+
+  def record(image, *args, **kwargs):
+    result = original(image, *args, **kwargs)
+    comparisons.extend((ins.fields['COND'], ins.fields.get('SAT', 0)) for ins in emu.decode(image) if ins.op == 'cmps.f')
+    return result
+
+  monkeypatch.setattr(emu, 'execute', record)
+  actual = source_kernel(source, 'compare_values', Tensor.empty(len(values), 3, dtype=dtypes.uint32),
+                         (1, 1, 1), (len(values), 1, 1), inputs=(Tensor(values),)).numpy()
+  expected_condition = compare(np.abs(values), np.float32(1.5))
+  if negate: expected_condition = ~expected_condition
+  expected = np.where(expected_condition[:, None], np.array([17, 18, 19]), np.array([81, 82, 83]))
+  np.testing.assert_array_equal(actual, expected)
+  assert comparisons
+  if comparison in ('<=', '>='):
+    assert any(saturate for _, saturate in comparisons), comparisons
+
+
+@pytest.mark.parametrize('change', [1 << 52, 248 << 32, 1 << 48, 2 << 53])
+def test_other_comparison_modifier_forms_remain_unsupported(change):
+  # The observed F32 LE predicate word cannot admit half sources, ordinary
+  # destinations, an unqualified condition, or a different comparison opcode.
+  word = 0x40b104f8106c8005 ^ change
+  with pytest.raises(RuntimeError, match='unsupported comparison modifier|unsupported instruction'):
+    emu.decode(struct.pack('<Q', word))

--- a/test/mockgpu/qcom/test_constant_admission.py
+++ b/test/mockgpu/qcom/test_constant_admission.py
@@ -1,0 +1,196 @@
+"""A630-7: immutable constant spans are admitted before workgroup or queue effects.
+
+Ordinary ADD bytecode is decoded once. All host boundaries use owned bytearrays;
+synthetic decoded control graphs isolate reachability without a native decoder.
+"""
+import contextlib, struct, unittest
+from unittest.mock import patch
+import numpy as np
+from tinygrad.runtime.autogen import mesa
+from tinygrad.runtime.ops_qcom import qreg
+from test.mockgpu.qcom import emu, qcomdriver, qcomgpu
+from test.mockgpu.qcom.test_pm4 import ADD, Memory, launch_words, packet, signal
+from test.mockgpu.qcom.test_launch_admission import wait_for
+
+
+END = emu.Instruction('end', {}, {}, 0)
+
+
+def constant_move(index, *, repeat=0, advance=False, half=False):
+  return emu.Instruction('mov', {'SRC_TYPE':2 if half else 3, 'DST_TYPE':2 if half else 3, 'REPEAT':repeat},
+                         {'DST':emu.Operand('register', 8, half),
+                          'SRC':emu.Operand('constant', index, half, advance)}, 1 << 61)
+
+
+def control(op, offset=0, **fields):
+  return emu.Instruction(op, {'IMMED':offset & 0xffffffff, 'INV1':0, 'COMP1':0, 'INV2':0, 'COMP2':1, **fields}, {}, 0)
+
+
+def short_load(memory, units):
+  words = launch_words(memory)
+  address = memory.base + 8192
+  load = qreg.cp_load_state6_0(state_type=mesa.ST_CONSTANTS, state_src=mesa.SS6_INDIRECT,
+                             state_block=mesa.SB6_CS_SHADER, num_unit=units)
+  return words[:-5] + packet(mesa.CP_LOAD_STATE6_FRAG, load, address & 0xffffffff, address >> 32) + words[-5:]
+
+
+@contextlib.contextmanager
+def inert_queue(memory, words, instructions):
+  with patch.object(emu, 'decode', return_value=instructions), \
+       patch.object(qcomdriver, 'read_host', side_effect=memory.read), \
+       patch.object(qcomdriver, 'write_host', side_effect=memory.write) as publish, \
+       patch.object(qcomdriver, 'validate_host_mapping', side_effect=memory.validate):
+    driver = qcomdriver.QCOMDriver()
+    driver.memory.map(memory.base, len(memory.data), owner=memory)
+    context = driver.contexts[1] = qcomdriver.Context(1, queued=1)
+    context.pending.append((words, 1, 0))
+    yield driver, context, publish
+
+
+class TestConstantAdmission(unittest.TestCase):
+  add: tuple[emu.Instruction, ...]
+
+  @classmethod
+  def setUpClass(cls):
+    cls.add = emu.decode(struct.pack('<11Q', *ADD).ljust(128, b'\0'))
+
+  def admit(self, instructions, slots, accepted):
+    # The boundary is before any Workgroup allocation, not a late read failure.
+    with patch.object(emu, 'decode', return_value=instructions), patch.object(emu, 'Workgroup') as group:
+      if accepted:
+        emu.execute(b'', bytes(slots * 4), (1, 1, 1), (1, 1, 1), 252, 252, Memory())
+        group.assert_called_once()
+      else:
+        with self.assertRaisesRegex(RuntimeError, 'constant.*(span|footprint)'):
+          emu.execute(b'', bytes(slots * 4), (1, 1, 1), (1, 1, 1), 252, 252, Memory())
+        group.assert_not_called()
+
+  def test_direct_rejects_missing_constant_before_workgroup_creation(self):
+    for slots in (0, 1, 4, 5):
+      with self.subTest(slots=slots): self.admit(self.add, slots, False)
+    for slots in (6, 8, 512):
+      with self.subTest(slots=slots): self.admit(self.add, slots, True)
+
+  def test_scalar_slot_and_repeat_endpoints_for_both_source_widths(self):
+    for half in (False, True):
+      for repeat in range(4):
+        for advance in (False, True):
+          indices = [3 + i if advance else 3 for i in range(repeat + 1)]
+          instructions = (constant_move(3, repeat=repeat, advance=advance, half=half), END)
+          for slots in (3, 4, 5, 6, 7, 8):
+            with self.subTest(half=half, repeat=repeat, advance=advance, slots=slots):
+              self.admit(instructions, slots, all(index < slots for index in indices))
+
+  def test_all_synthetic_arithmetic_source_roles_contribute(self):
+    # Enumerate generic operand roles. Cat3 SRC2 is GPR-only in actual decoded
+    # images; that extra synthetic case checks enumeration, not ISA admission.
+    for op, category, count in (('add.u', 2, 2), ('mad.f32', 3, 3), ('rcp', 4, 1)):
+      for selected in range(1, count + 1):
+        operands = {'DST':emu.Operand('register', 8)}
+        operands.update({f'SRC{i}':emu.Operand('constant' if i == selected else 'register', 4)
+                         for i in range(1, count + 1)})
+        if category == 4: operands['SRC'] = operands.pop('SRC1')
+        instructions = (emu.Instruction(op, {}, operands, category << 61), END)
+        with self.subTest(op=op, source=selected):
+          self.admit(instructions, 4, False)
+          self.admit(instructions, 5, True)
+
+  def test_end_and_enabled_jump_exclude_structurally_unreachable_references(self):
+    missing = constant_move(100)
+    for instructions in ((END, missing), (control('jump', 2), missing, END),
+                         (control('predt'), END, missing),
+                         (control('predf'), control('prede'), control('jump', 2, JP=1), missing, END)):
+      with self.subTest(instructions=instructions): self.admit(instructions, 0, True)
+
+  def test_branch_targets_after_an_earlier_end_remain_reachable(self):
+    for op in ('br', 'brao', 'braa', 'jump'):
+      with self.subTest(op=op):
+        self.admit((control(op, 2), END, constant_move(4), END), 4, False)
+
+  def test_predicated_jump_includes_fallthrough_even_when_current_mask_is_false(self):
+    for pred in ('predt', 'predf'):
+      for jp in (0, 1):
+        with self.subTest(pred=pred, jp=jp):
+          self.admit((control(pred), control('jump', 2, JP=jp), constant_move(4), END), 4, False)
+
+  def test_merging_modes_and_backward_edges_does_not_lose_a_path(self):
+    # PC3 is first reachable unpredicated, then through predt. Only its latter
+    # arrival permits falling through the jump into the missing reference.
+    graph = (control('br', 3), control('predt'), control('jump', 1), control('jump', 2), constant_move(4), END)
+    self.admit(graph, 4, False)
+    self.admit((constant_move(0), control('br', -1), END), 1, True)
+    self.admit((control('jump', 0), constant_move(100), END), 0, True)
+
+  def test_conditional_paths_are_not_pruned_using_live_values(self):
+    # p0 starts false, but admission deliberately does not evaluate shader data.
+    self.admit((control('predt'), constant_move(4), END), 4, False)
+    for op in ('br', 'brao', 'braa'):
+      with self.subTest(op=op): self.admit((control(op, 2), constant_move(4), END), 4, False)
+
+  def test_insufficient_upload_rejects_queue_prefix_with_or_without_wait(self):
+    for blocked in (False, True):
+      with self.subTest(blocked=blocked):
+        memory = Memory(65536)
+        words = signal(memory.base, 123) + (wait_for(memory) if blocked else ()) + short_load(memory, 1)
+        before = bytes(memory.data)
+        with inert_queue(memory, words, self.add) as (driver, context, publish), \
+             patch.object(qcomgpu.MemoryAction, 'apply', side_effect=AssertionError('prefix applied')):
+          with self.assertRaisesRegex(qcomgpu.PM4Fault, 'constant.*(span|footprint)'): driver.drain()
+          publish.assert_not_called()
+          self.assertEqual(bytes(memory.data), before)
+          self.assertEqual(list(context.pending), [(words, 1, 0)])
+          self.assertEqual((context.queued, context.consumed, context.retired), (1, 0, 0))
+
+  def test_short_and_larger_uploads_execute_and_resume_with_live_contents(self):
+    for units in (2, 128):
+      for blocked in (False, True):
+        with self.subTest(units=units, blocked=blocked):
+          memory = Memory(65536)
+          words = signal(memory.base, 123) + (wait_for(memory) if blocked else ()) + short_load(memory, units)
+          with inert_queue(memory, words, self.add) as (driver, context, publish):
+            driver.drain()
+            if blocked:
+              self.assertEqual(context.pending[0][2], 1)
+              self.assertEqual((context.consumed, context.retired), (1, 0))
+              # Change the output pointer's contents without changing upload size.
+              memory.write(memory.base + 8192, struct.pack('<Q', memory.base + 28))
+              memory.write(memory.base, struct.pack('<I', 456))
+              memory.write(memory.base + 4, struct.pack('<I', 1))
+              driver.drain()
+            self.assertEqual(memory.read(memory.base + (28 if blocked else 16), 4), struct.pack('<I', 26))
+            self.assertEqual(memory.read(memory.base, 4), struct.pack('<I', 456 if blocked else 123))
+            self.assertEqual((context.queued, context.consumed, context.retired), (1, 1, 1))
+            self.assertFalse(context.pending)
+            self.assertGreater(publish.call_count, 0)
+
+  def test_staged_constant_contents_are_visible_to_short_launch(self):
+    memory = Memory(65536)
+    launch = short_load(memory, 2)
+    words = signal(memory.base + 8192, (memory.base + 28) & 0xffffffff) + launch
+    with inert_queue(memory, words, self.add) as (driver, context, _):
+      driver.drain()
+      self.assertEqual(memory.read(memory.base + 28, 4), struct.pack('<I', 26))
+      self.assertEqual(memory.read(memory.base + 16, 4), bytes(4))
+      self.assertEqual(context.retired, 1)
+
+  def test_planner_shares_repeat_and_reachability_admission(self):
+    cases = (((constant_move(3, repeat=2, advance=True), END), False),
+             ((constant_move(3, repeat=2), END), True),
+             ((control('jump', 2), constant_move(4), END), True),
+             ((control('predt'), control('jump', 2), constant_move(4), END), False))
+    for instructions, accepted in cases:
+      memory = Memory(65536)
+      words = short_load(memory, 1)
+      with self.subTest(instructions=instructions), patch.object(emu, 'decode', return_value=instructions):
+        if accepted: self.assertIsInstance(qcomgpu.compile_plan(words, memory)[-1], qcomgpu.Launch)
+        else:
+          with self.assertRaisesRegex(qcomgpu.PM4Fault, 'constant.*(span|footprint)'): qcomgpu.compile_plan(words, memory)
+
+  def test_runtime_constant_read_bounds_remain_a_backstop(self):
+    group = emu.Workgroup(bytes(16), (1, 1, 1), (0, 0, 0), 252, 252, 252, Memory(), 0, 0)
+    for index in (-1, 4):
+      with self.subTest(index=index), self.assertRaisesRegex(RuntimeError, 'constant register index out of bounds'):
+        group.read(emu.Operand('constant', index), np.array([0]))
+
+
+if __name__ == '__main__': unittest.main()

--- a/test/mockgpu/qcom/test_control.py
+++ b/test/mockgpu/qcom/test_control.py
@@ -1,0 +1,141 @@
+import struct
+import numpy as np
+import pytest
+from test.mockgpu.qcom.emu import Operand,Instruction,Workgroup,decode
+from test.mockgpu.qcom.test_emu import Memory
+
+def R(index): return Operand('register',index)
+def I(value): return Operand('immediate',value)
+END=Instruction('end',{}, {},0)
+
+
+def state(lanes=4,shared_bytes=0,private_bytes=0,memory=None):
+  return Workgroup(bytes(64),(lanes,1,1),(0,0,0),0xfc,0xfc,0xfc,memory or Memory({}),shared_bytes,private_bytes)
+
+
+def move(dst,value):
+  return Instruction('mov',{'SRC_TYPE':3,'DST_TYPE':3},{'DST':R(dst),'SRC':I(value)},1<<61)
+
+
+def add(dst,source,value):
+  return Instruction('add.u',{},dict(DST=R(dst),SRC1=R(source),SRC2=I(value)),2<<61)
+
+
+def branch(offset):
+  return Instruction('br',{'INV1':0,'COMP1':0,'IMMED':offset}, {},0)
+
+
+def jump(offset):
+  return Instruction('jump',{'IMMED':offset&0xffffffff},{},0)
+
+
+def test_divergent_lanes_reconverge_with_their_own_values():
+  group=state()
+  group.registers[0][0]=[0,1,2,3]
+  compare=Instruction('cmps.u',{'COND':0},dict(DST=R(248),SRC1=R(0),SRC2=I(2)),2<<61)
+  group.run((compare,branch(3),move(1,20),jump(2),move(1,10),add(1,1,1),END))
+  np.testing.assert_array_equal(group.registers[0][1],[11,11,21,21])
+
+
+def test_backward_branch_has_independent_lane_trip_counts():
+  group=state()
+  group.registers[0][0]=[0,1,2,3]
+  compare=Instruction('cmps.u',{'COND':0},dict(DST=R(248),SRC1=R(1),SRC2=R(0)),2<<61)
+  group.run((compare,branch(2),jump(3),add(1,1,1),jump(-4),END))
+  np.testing.assert_array_equal(group.registers[0][1],[0,1,2,3])
+
+
+def test_predicated_else_and_end_restore_lane_execution():
+  group=state()
+  group.registers[0][248]=[0,1,0,1]
+  group.run((Instruction('predt',{}, {},0),move(0,10),Instruction('predf',{}, {},0),move(0,20),
+             Instruction('prede',{}, {},0),add(0,0,1),END))
+  np.testing.assert_array_equal(group.registers[0][0],[21,11,21,11])
+
+
+@pytest.mark.parametrize('repeat', [0, 3])
+def test_end_of_quad_nop_preserves_compute_lanes_and_predication(repeat):
+  # ir3_legalize.c:helper_sched uses EQ to end fragment helper invocations.
+  # A compute workgroup has no helper lanes; EQ must not end ordinary lanes or
+  # change the predicate mask while the compiler's image program continues.
+  nop = decode(struct.pack('<Q', (1 << 48) | (repeat << 40)))[0]
+  assert nop.op == 'nop' and nop.fields['EQ'] == 1
+  group = state()
+  group.registers[0][0] = [1, 2, 3, 4]
+  group.registers[0][248] = [0, 1, 0, 1]
+  group.run((Instruction('predt', {}, {}, 0), add(0, 0, 10), nop,
+             Instruction('predf', {}, {}, 0), add(0, 0, 20), Instruction('prede', {}, {}, 0), add(0, 0, 1), END))
+  np.testing.assert_array_equal(group.registers[0][0], [22, 13, 24, 15])
+
+
+@pytest.mark.parametrize('opcode', [2, 4, 6])
+def test_end_of_quad_on_other_control_instructions_remains_unsupported(opcode):
+  with pytest.raises(RuntimeError, match='unsupported execution modifier'):
+    decode(struct.pack('<Q', (opcode << 55) | (1 << 48)))
+
+
+def test_shared_barrier_exposes_all_participating_lane_stores():
+  group=state(shared_bytes=16)
+  group.registers[0][0]=[0,4,8,12]
+  group.registers[0][1]=[1,2,3,4]
+  group.registers[0][2]=[4,8,12,0]
+  store=Instruction('stl',{'TYPE':3,'SIZE':1},dict(DST=R(0),SRC=R(1)),6<<61)
+  load=Instruction('ldl',{'TYPE':3,'SIZE':1},dict(DST=R(3),SRC=R(2)),6<<61)
+  group.run((store,Instruction('bar',{}, {},7<<61),load,END))
+  np.testing.assert_array_equal(group.registers[0][3],[2,3,4,1])
+
+
+def test_nonparticipating_lane_rejects_divergent_barrier():
+  group=state()
+  group.registers[0][248]=[1,0,0,0]
+  with pytest.raises(RuntimeError,match='divergent.*barrier'):
+    group.run((branch(2),Instruction('bar',{}, {},7<<61),END))
+
+
+def test_signed_memory_offset_and_private_lane_isolation():
+  memory=Memory({0x1000:struct.pack('<4I',11,22,33,44)})
+  group=state(memory=memory,private_bytes=8)
+  group.registers[0][0]=0x1008
+  load=Instruction('ldg',{'TYPE':3,'SIZE':2,'OFF':(1<<64)-8},dict(DST=R(2),SRC1=R(0)),6<<61)
+  group.run((load,END))
+  np.testing.assert_array_equal(group.registers[0][2:4],[[11]*4,[22]*4])
+  group=state(private_bytes=8)
+  group.registers[0][1]=[11,22,33,44]
+  store=Instruction('stp',{'TYPE':3,'SIZE':1},dict(DST=R(0),SRC=R(1)),6<<61)
+  load=Instruction('ldp',{'TYPE':3,'SIZE':1},dict(DST=R(2),SRC=R(0)),6<<61)
+  group.run((store,load,END))
+  np.testing.assert_array_equal(group.registers[0][2],[11,22,33,44])
+
+
+def test_memory_vector_must_fit_every_lane():
+  group=state(private_bytes=4)
+  load=Instruction('ldp',{'TYPE':3,'SIZE':2},dict(DST=R(2),SRC=R(0)),6<<61)
+  with pytest.raises(RuntimeError,match='out of bounds'): group.run((load,END))
+
+@pytest.mark.parametrize('initial_predicate,predication_opcode',[(1,13),(0,14)])
+def test_jump_point_refreshes_predication_from_machine_code(initial_predicate,predication_opcode):
+  # ir3-cat0.xml predt docs: JP refreshes the predicate mask and retains its mode.
+  def mov_word(dst,value,jp=False): return 0x204cc00000000000 | dst<<32 | value | int(jp)<<59
+  words = (mov_word(248,initial_predicate), (predication_opcode<<55)|(1<<49), mov_word(0,11),
+           mov_word(248,1-initial_predicate), mov_word(0,22,jp=True), (15<<55)|(1<<49), 6<<55)
+  group=state(lanes=1)
+  group.run(decode(struct.pack('<7Q',*words)))
+  np.testing.assert_array_equal(group.registers[0][0],[11])
+
+@pytest.mark.parametrize('opcode',[4,5])
+def test_encoded_half_store_uses_full_address_and_half_data_registers(opcode):
+  group=state(lanes=1,shared_bytes=8,private_bytes=8)
+  group.registers[0][0]=2
+  group.registers[1][0]=6
+  group.registers[1][1]=0xabcd
+  word=(6<<61)|(opcode<<54)|(2<<49)|(1<<40)|(1<<24)|(1<<23)|(1<<1)
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  storage=group.shared if opcode==4 else group.private[0]
+  np.testing.assert_array_equal(storage,[0,0,0xcd,0xab,0,0,0,0])
+
+def test_encoded_negative_global_offset():
+  group=state(lanes=1,memory=Memory({0x1000:struct.pack('<2I',11,22)}))
+  group.registers[0][0]=0x1004
+  word=(6<<61)|(3<<49)|(2<<32)|(1<<24)|(1<<23)|((-4&8191)<<1)|1
+  group.run(decode(struct.pack('<2Q',word,6<<55)))
+  np.testing.assert_array_equal(group.registers[0][2],[11])

--- a/test/mockgpu/qcom/test_conversion_rounding.py
+++ b/test/mockgpu/qcom/test_conversion_rounding.py
@@ -1,0 +1,19 @@
+"""Generated conversions must preserve tinygrad's numeric rounding contract."""
+import numpy as np
+import pytest
+from tinygrad import Tensor, dtypes
+
+
+@pytest.mark.parametrize('dtype,values,expected', [
+  (np.int32, [19958399, -19958399, 16777219, -16777219], [19958400, -19958400, 16777220, -16777220]),
+  (np.uint32, [19958399, 16777219, 33554431, 4294967295], [19958400, 16777220, 33554432, 4294967296]),
+])
+def test_integer_to_float32_uses_nearest_even(dtype, values, expected):
+  # Odd halfway significands must round to the even F32 neighbor, not toward zero.
+  result = Tensor(np.array(values, dtype=dtype)).cast(dtypes.float32).numpy()
+  np.testing.assert_array_equal(result, np.array(expected, dtype=np.float32))
+
+
+def test_float_to_integer_still_truncates_toward_zero():
+  result = Tensor(np.array([-2.9, -1.5, 0, 1.5, 2.9], dtype=np.float32)).cast(dtypes.int32).numpy()
+  np.testing.assert_array_equal(result, [-2, -1, 0, 1, 2])

--- a/test/mockgpu/qcom/test_emu.py
+++ b/test/mockgpu/qcom/test_emu.py
@@ -1,0 +1,77 @@
+import struct
+import pytest
+from test.mockgpu.qcom.emu import execute,decode
+
+# Mesa 25.2.7 ir3-cat1/cat2/cat6 encodings: load pointers, add, store, end.
+# Deliberately varied memory values verify arithmetic rather than image recognition.
+ADD = (0x202cc00000000002, 0x202cc00100000003, 0x202cc00300000004, 0x202cc00400000005,
+       0x202cc00500000000, 0x202cc00600000001, 0xc006000201800001, 0xc00600070180c001,
+       0x5218080200070002, 0xc0c60b0001800004, 0x0300000000000000)
+
+class Memory:
+  def __init__(self, regions): self.regions = {a:bytearray(v) for a,v in regions.items()}
+  def region(self, address, size):
+    for base, data in self.regions.items():
+      if base <= address and address + size <= base + len(data): return base, data
+    raise RuntimeError(f"unmapped memory: {address:#x}+{size}")
+  def read(self, address, size):
+    base,data = self.region(address,size)
+    return bytes(data[address-base:address-base+size])
+  def write(self, address, value):
+    base,data = self.region(address,len(value))
+    data[address-base:address-base+len(value)] = value
+  def validate(self,address,size,write=False): self.region(address,size)
+
+@pytest.mark.parametrize("a,b", [(7,19),(0xffffffff,2),(0x80000000,0x80000000)])
+def test_real_machine_code_integer_add(a,b):
+  memory = Memory({0x1000:bytes(4),0x2000:struct.pack('<I',a),0x3000:struct.pack('<I',b)})
+  execute(struct.pack('<11Q',*ADD),struct.pack('<3Q',0x1000,0x2000,0x3000),(1,1,1),(1,1,1),0xfc,0xfc,memory)
+  assert memory.read(0x1000,4) == struct.pack('<I',(a+b)&0xffffffff)
+
+def test_invalid_encoding_does_not_write():
+  memory = Memory({0x1000:b'keep'})
+  with pytest.raises(RuntimeError,match='IR3|ir3'):
+    execute(bytes.fromhex('ffffffffffffffff'),b'',(1,1,1),(1,1,1),0xfc,0xfc,memory)
+  assert memory.read(0x1000,4) == b'keep'
+
+def test_valid_but_unsupported_opcode_is_rejected_before_the_first_store():
+  # cat0 emit is a valid graphics opcode, unsupported by this compute emulator.
+  image = struct.pack('<12Q',*ADD[:-1],0x0380000000000000,ADD[-1])
+  memory = Memory({0x1000:b'keep',0x2000:struct.pack('<I',3),0x3000:struct.pack('<I',9)})
+  with pytest.raises(RuntimeError,match='unsupported'):
+    execute(image,struct.pack('<3Q',0x1000,0x2000,0x3000),(1,1,1),(1,1,1),0xfc,0xfc,memory)
+  assert memory.read(0x1000,4) == b'keep'
+
+def test_nondefault_rounding_is_rejected_at_decode():
+  # ir3-cat1.xml ROUND[56:55]. The default conversion contract uses mode 0.
+  with pytest.raises(RuntimeError,match='rounding'):
+    decode(struct.pack('<Q',ADD[0] | (1<<55)))
+
+def test_store_checks_permission_before_mutating_a_mapped_region():
+  class ReadOnlyMemory(Memory):
+    def validate(self,address,size,write=False):
+      if write: raise RuntimeError('read-only allocation')
+      return super().validate(address,size,write)
+  memory = ReadOnlyMemory({0x1000:b'keep',0x2000:struct.pack('<I',3),0x3000:struct.pack('<I',9)})
+  with pytest.raises(RuntimeError,match='read-only'):
+    execute(struct.pack('<11Q',*ADD),struct.pack('<3Q',0x1000,0x2000,0x3000),(1,1,1),(1,1,1),0xfc,0xfc,memory)
+  assert memory.read(0x1000,4) == b'keep'
+
+@pytest.mark.parametrize('condition',[6,7])
+def test_unknown_comparison_condition_is_rejected_from_machine_code(condition):
+  # cat2 compare COND is three bits, but Mesa defines only LT..NE (0..5).
+  word = (2<<61)|(20<<53)|(1<<52)|(condition<<48)|(248<<32)|1<<16
+  with pytest.raises(RuntimeError,match='condition'):
+    decode(struct.pack('<2Q',word,6<<55))
+
+def test_repeated_destination_must_fit_the_register_file_at_decode():
+  # A repeat on destination r63.w would run past the final scalar register.
+  word = (2<<61)|(16<<53)|(1<<52)|(1<<40)|(255<<32)|1<<16
+  with pytest.raises(RuntimeError,match='destination'):
+    decode(struct.pack('<2Q',word,6<<55))
+
+@pytest.mark.parametrize('rounding',[2,3])
+def test_directed_float_rounding_remains_unsupported(rounding):
+  word=(1<<61)|(rounding<<55)|(1<<50)|(1<<32)
+  with pytest.raises(RuntimeError,match='rounding'):
+    decode(struct.pack('<2Q',word,6<<55))

--- a/test/mockgpu/qcom/test_half_constants.py
+++ b/test/mockgpu/qcom/test_half_constants.py
@@ -1,0 +1,182 @@
+"""A630-1 regressions: constant-slot storage and typed half consumption.
+
+The Tensor cases use ordinary allocations through HCQ2. Encoded-instruction
+cases use one Workgroup and inert memory, including the mock's admitted cat4
+constant form that the pinned compiler does not emit.
+"""
+import struct
+import numpy as np
+import pytest
+from tinygrad import Tensor
+from test.mockgpu.qcom.emu import Workgroup, decode
+from test.mockgpu.qcom.test_emu import Memory
+
+
+VALUES = np.array([-10.25, -3.5, -1.25, -0.125, 0, 0.125, 0.5, 1.25, 3.5, 10.25], dtype=np.float16)
+
+
+def workgroup(constants, count=1):
+  return Workgroup(struct.pack(f'<{len(constants)}I', *constants), (count, 1, 1), (0, 0, 0),
+                   0xfc, 0xfc, 0xfc, Memory({}), 0, 0)
+
+
+def run_word(group, word):
+  instructions = decode(struct.pack('<2Q', word, 6 << 55))
+  group.run(instructions)
+  return instructions[0]
+
+
+@pytest.mark.parametrize('operation', ['add', 'multiply', 'multiply_add'])
+def test_non_flut_half_constants_through_hcq2(operation):
+  # Retain the reviewer's three failing ordinary expressions and expectations.
+  a = Tensor(VALUES)
+  if operation == 'add':
+    result, expected = a + 2.345703125, VALUES + np.float16(2.345703125)
+  elif operation == 'multiply':
+    result, expected = a * 1.234375, VALUES * np.float16(1.234375)
+  else:
+    result = a * 1.234375 + 2.345703125
+    expected = VALUES * np.float16(1.234375) + np.float16(2.345703125)
+  np.testing.assert_array_equal(result.numpy(), expected)
+
+
+def test_compiler_emitted_mad_f16_constant_operands_in_workgroup():
+  # Exact pinned Mesa word and F32 constant slots from the original red trace.
+  constants = [0] * 18
+  constants[16:18] = [0x40162000, 0x3f9e0000]
+  group = workgroup(constants, len(VALUES))
+  group.registers[1][1] = VALUES.view(np.uint16)
+  instruction = run_word(group, 0x7300880110109011)
+  assert instruction.op == 'mad.f16'
+  assert instruction.operands['SRC1'].kind == instruction.operands['SRC3'].kind == 'constant'
+  expected = VALUES * np.float16(1.234375) + np.float16(2.345703125)
+  np.testing.assert_array_equal(group.registers[1][1].view(np.float16), expected)
+
+
+@pytest.mark.parametrize('value,expected_bits', [
+  (1.0006, 0x3c00), (-1.0006, 0xbc00),
+  (2051, 0x6801), (-2051, 0xe801),
+  (65536, 0x7bff), (-65536, 0xfbff),
+  (2**-25, 0x0000), (-2**-25, 0x8000),
+  (2**-24, 0x0001), (-2**-24, 0x8001),
+  (0.0, 0x0000), (-0.0, 0x8000),
+])
+def test_implicit_constant_demotion_uses_default_conversion_rounding(value, expected_bits):
+  # Model constant demotion as the narrowing COV it replaces: ROUND_ZERO.
+  # These nonrepresentable values specify the mock rule; no hardware oracle
+  # is claimed for the tie, subnormal, overflow or signed-zero boundaries.
+  bits = struct.unpack('<I', struct.pack('<f', value))[0]
+  group = workgroup([bits])
+  word = (2 << 61) | (6 << 53) | (2 << 32) | 0x1000  # absneg.f hr0.z, hc0.x
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[1][2], [expected_bits])
+
+
+@pytest.mark.parametrize('dest_half', [False, True])
+def test_constant_demotion_precedes_arithmetic_and_uses_source_precision(dest_half):
+  group = workgroup([0x3f8013a9])  # F32 1.0006, demoted to half 1.0 before ADD.
+  group.registers[1][1] = np.array([-1], np.float16).view(np.uint16)
+  word = (2 << 61) | (int(not dest_half) << 46) | (2 << 32) | (1 << 16) | 0x1000
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[dest_half][2], [0])
+
+
+def test_full_float_constant_keeps_its_full_source_precision():
+  group = workgroup([0x3f8013a9])
+  group.registers[0][1] = np.array([-1], np.float32).view(np.uint32)
+  word = (2 << 61) | (1 << 52) | (2 << 32) | (1 << 16) | 0x1000
+  run_word(group, word)
+  expected = np.float32(1.0006) - np.float32(1)
+  np.testing.assert_array_equal(group.registers[0][2].view(np.float32), [expected])
+
+
+def test_half_float_comparison_demotes_before_writing_boolean_result():
+  group = workgroup([0x3f8013a9])
+  group.registers[1][1] = 0x3c00
+  # cmps.f.eq: 1.0006 demotes to 1.0, so the half operands compare equal.
+  word = (2 << 61) | (5 << 53) | (4 << 48) | (2 << 32) | (1 << 16) | 0x1000
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[1][2], [1])
+
+
+@pytest.mark.parametrize('modifier,expected', [(0, -2.345703125), (1, 2.345703125), (2, 2.345703125), (3, -2.345703125)])
+def test_constant_float_modifiers_follow_numeric_demotion(modifier, expected):
+  group = workgroup([0xc0162000])
+  word = (2 << 61) | (6 << 53) | (2 << 32) | (modifier << 14) | 0x1000
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[1][2].view(np.float16), [expected])
+
+
+def test_repeated_half_constant_sources_advance_by_full_slots():
+  constants = np.array([2.345703125, 1.234375, -3.5], np.float32).view(np.uint32)
+  group = workgroup(constants)
+  word = (2 << 61) | (2 << 40) | (1 << 43) | (2 << 32) | (1 << 16) | 0x1000
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[1][2:5, 0].view(np.float16), constants.view(np.float32))
+
+
+@pytest.mark.parametrize('half', [False, True])
+def test_unsigned_constant_comparison_truncates_only_at_half_width(half):
+  group = workgroup([0x12340002])
+  group.registers[half][1] = 3
+  # cmps.u.lt destination, constant, register. Truncation must precede compare.
+  word = (2 << 61) | (20 << 53) | (int(not half) << 52) | (2 << 32) | (1 << 16) | 0x1000
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[half][2], [int(half)])
+
+
+def test_signed_half_constant_uses_integer_low_bits():
+  group = workgroup([0x12348001])
+  word = (2 << 61) | (17 << 53) | (1 << 46) | (2 << 32) | (1 << 16) | 0x1000
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[0][2], [0xffff8001])
+
+
+def test_half_gpr_float_bits_are_not_constant_slots():
+  group = workgroup([0x40162000])
+  group.registers[1][0] = 0x3c01
+  word = (2 << 61) | (6 << 53) | (2 << 32)
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[1][2], [0x3c01])
+
+
+def test_half_float_table_immediate_keeps_its_table_index():
+  group = workgroup([0x40162000])
+  word = (2 << 61) | (2 << 32) | (1 << 16) | (5 << 11) | (1 << 10) | 5
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[1][2], [0x4248])  # half pi
+
+
+@pytest.mark.parametrize('rounding,expected', [(0, 0x3c00), (1, 0x3c01)])
+def test_explicit_full_float_constant_conversion_keeps_output_rounding(rounding, expected):
+  group = workgroup([0x3f8013a9])
+  word = (1 << 61) | (rounding << 55) | (1 << 53) | (1 << 50) | (2 << 32)
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[1][2], [expected])
+
+
+@pytest.mark.parametrize('src_type,constant,expected', [(0, 0x3f8013a9, 1.0), (2, 0xdead3c01, 15361.0), (4, 0xbeef8001, -32767.0)])
+def test_explicit_half_constant_conversion_selects_its_source_type(src_type, constant, expected):
+  group = workgroup([constant])
+  word = (1 << 61) | (1 << 53) | (src_type << 50) | (1 << 46) | (2 << 32)
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[0][2].view(np.float32), [expected])
+
+
+@pytest.mark.parametrize('src_type,constant,expected', [(0, 0x3f8013a9, 0x3c00), (2, 0xdead3c01, 0x3c01), (4, 0xbeef8001, 0x8001)])
+def test_same_type_half_constant_move_consumes_the_declared_type(src_type, constant, expected):
+  group = workgroup([constant])
+  word = (1 << 61) | (1 << 53) | (src_type << 50) | (src_type << 46) | (2 << 32)
+  run_word(group, word)
+  np.testing.assert_array_equal(group.registers[1][2], [expected])
+
+
+def test_admitted_cat4_constant_uses_the_same_typed_demotion_rule():
+  # Mesa 25.2.7 ir3.c rejects const/imm for compiler cat4 sources. The emulator
+  # already accepts this multisrc encoding, so cover its chosen mock semantics.
+  group = workgroup([0x3f8013a9])
+  word = (4 << 61) | (2 << 32) | 0x1000  # rcp hr0.z, hc0.x
+  instruction = run_word(group, word)
+  assert instruction.op == 'rcp'
+  assert instruction.operands['SRC'].kind == 'constant'
+  np.testing.assert_array_equal(group.registers[1][2].view(np.float16), [1.0])

--- a/test/mockgpu/qcom/test_half_sfu.py
+++ b/test/mockgpu/qcom/test_half_sfu.py
@@ -1,0 +1,32 @@
+"""Half special functions share the lane engine without losing operand precision."""
+import struct
+import numpy as np
+import pytest
+from tinygrad import Tensor, dtypes
+from test.mockgpu.qcom.emu import Workgroup, decode
+from test.mockgpu.qcom.test_emu import Memory
+
+
+@pytest.mark.parametrize('opcode,values,expected', [
+  (9, [0.25, 1, 4, 16], [2, 1, 0.5, 0.25]),
+  (10, [0.25, 1, 2, 16], [-2, 0, 1, 4]),
+  (11, [-2, 0, 1, 4], [0.25, 1, 2, 16]),
+])
+@pytest.mark.parametrize('full_destination', [False, True])
+def test_encoded_half_special_functions_use_half_sources(opcode, values, expected, full_destination):
+  # Mesa 25.2.7 ir3-cat4.xml assigns HRSQ/HLOG2/HEXP2 opcodes 9/10/11.
+  # FULL=0 selects half sources; DST_CONV widens the already-half result.
+  group = Workgroup(bytes(16), (4, 1, 1), (0, 0, 0), 0xfc, 0xfc, 0xfc, Memory({}), 0, 0)
+  group.registers[True][0] = np.array(values, dtype=np.float16).view(np.uint16)
+  word = (4 << 61) | (opcode << 53) | (int(full_destination) << 46) | (4 << 32)
+  group.run(decode(struct.pack('<2Q', word, 6 << 55)))
+  result = group.registers[not full_destination][4].view(np.float32 if full_destination else np.float16)
+  np.testing.assert_array_equal(result, expected)
+
+
+def test_compiler_generated_half_exponential_preserves_fractional_values():
+  # This ordinary Tensor path previously failed admission at Mesa's HEXP2.
+  values = np.array([-2, -0.5, 0, 0.5, 1, 2, 4], dtype=np.float16)
+  actual = Tensor(values, dtype=dtypes.half).exp2().numpy()
+  expected = np.exp2(values.astype(np.float32)).astype(np.float16)
+  np.testing.assert_allclose(actual, expected, rtol=0.003, atol=0.001)

--- a/test/mockgpu/qcom/test_image_admission.py
+++ b/test/mockgpu/qcom/test_image_admission.py
@@ -1,0 +1,248 @@
+"""PM4 image configuration and transaction boundaries over controlled bytes."""
+import contextlib
+import struct
+from dataclasses import replace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from tinygrad.runtime.autogen import mesa
+from tinygrad.runtime.ops_qcom import pkt4_hdr, qreg
+from test.mockgpu.qcom import qcomdriver, qcomgpu
+from test.mockgpu.qcom.emu import decode, validate_image_bindings
+from test.mockgpu.qcom.test_image_execution import compile_image_program
+from test.mockgpu.qcom.test_pm4 import Memory, launch_words, packet, signal
+
+
+def register(address, *values):
+  return (pkt4_hdr(address, len(values)), *values)
+
+
+def image_descriptor(address, texture=True, width=4, height=3, pitch=64, half=False):
+  # Reproduce the producer's descriptor ABI, not the emulator's parser.
+  fmt = mesa.FMT6_16_16_16_16_FLOAT if half else mesa.FMT6_32_32_32_32_FLOAT
+  swizzle = dict(swiz_x=0, swiz_y=1, swiz_z=2, swiz_w=3) if texture else {}
+  words = [
+    qreg.a6xx_tex_const_0(8 if texture else 0, fmt=fmt, **swizzle),
+    qreg.a6xx_tex_const_1(width=width, height=height),
+    qreg.a6xx_tex_const_2(type=mesa.A6XX_TEX_2D, pitch=pitch, pitchalign=(pitch & -pitch).bit_length() - 7),
+    0, address & 0xffffffff, address >> 32, qreg.a6xx_tex_const_6(plane_pitch=0x400000), 13,
+    0, 0, 0, 0, 0, 0, 0, 0,
+  ]
+  return struct.pack("<16I", *words)
+
+
+def image_command(memory, count=1):
+  program = compile_image_program(textures=count)
+  base = memory.base
+  textures, outputs, samplers, border = (base + offset for offset in (0x9000, 0xa000, 0xa100, 0xb000))
+  words = launch_words(memory, local=program.local, image=program.image)[:-5]
+  memory.write(base + 8192, program.constants.ljust(2048, b"\0"))
+  units = len(program.image) // 128
+  words += register(mesa.REG_A6XX_SP_CS_INSTR_SIZE, units)
+  words += packet(mesa.CP_LOAD_STATE6_FRAG,
+                  qreg.cp_load_state6_0(state_type=mesa.ST_SHADER, state_src=mesa.SS6_INDIRECT,
+                                       state_block=mesa.SB6_CS_SHADER, num_unit=units),
+                  (base + 4096) & 0xffffffff, (base + 4096) >> 32)
+  words += register(mesa.REG_A6XX_SP_CS_CONST_CONFIG_0,
+                    qreg.a6xx_sp_cs_const_config_0(wgidconstid=program.wgid, localidregid=program.lid,
+                                                 wgsizeconstid=program.wgsize, wgoffsetconstid=0xfc))
+  pixels = np.arange(48, dtype=np.float32).reshape(3, 4, 4)
+  for index in range(count):
+    address = base + 0x10000 + index * 0x1000
+    memory.write(address, (pixels + index).tobytes())
+    memory.write(textures + index * 64, image_descriptor(address))
+  memory.write(base + 0x30000, np.full((3, 4, 4), -77, np.float32).tobytes())
+  memory.write(outputs, image_descriptor(base + 0x30000, texture=False))
+  sampler = struct.pack("<4I", qreg.a6xx_tex_samp_0(wrap_s=3, wrap_t=3, wrap_r=3),
+                        qreg.a6xx_tex_samp_1(unnorm_coords=True, cubemapseamlessfiltoff=True), 0, 0)
+  memory.write(samplers, sampler * count)
+  words += register(mesa.REG_A6XX_SP_CS_CONFIG, qreg.a6xx_sp_cs_config(enabled=True, ntex=count, nsamp=count, nuav=1))
+  for block, kind, address, load_count, target in (
+    (mesa.SB6_CS_TEX, mesa.ST_CONSTANTS, textures, min(count, 16), mesa.REG_A6XX_SP_CS_TEXMEMOBJ_BASE),
+    (mesa.SB6_CS_TEX, mesa.ST_SHADER, samplers, count, mesa.REG_A6XX_SP_CS_SAMPLER_BASE),
+    (mesa.SB6_CS_SHADER, mesa.ST6_UAV, outputs, 1, mesa.REG_A6XX_SP_CS_UAV_BASE),
+  ):
+    words += packet(mesa.CP_LOAD_STATE6_FRAG,
+                    qreg.cp_load_state6_0(state_type=kind, state_src=mesa.SS6_INDIRECT, state_block=block, num_unit=load_count),
+                    address & 0xffffffff, address >> 32)
+    words += register(target, address & 0xffffffff, address >> 32)
+  words += register(mesa.REG_A6XX_TPL1_CS_BORDER_COLOR_BASE, border & 0xffffffff, border >> 32)
+  return words + packet(mesa.CP_EXEC_CS, 0, 1, 1, 1)
+
+
+@contextlib.contextmanager
+def driver_for(memory, command):
+  # Replace only native byte transport. Mapping identity, transactions, PM4,
+  # real shader decoding, image execution and the queue scheduler remain real.
+  with patch.object(qcomdriver, "read_host", side_effect=memory.read), \
+       patch.object(qcomdriver, "write_host", side_effect=memory.write), \
+       patch.object(qcomdriver, "validate_host_mapping", side_effect=memory.validate):
+    driver = qcomdriver.QCOMDriver()
+    driver.memory.map(memory.base, len(memory.data), owner=memory)
+    context = driver.contexts[1] = qcomdriver.Context(1, queued=1)
+    context.pending.append((command, 1, 0))
+    yield driver, context
+
+
+def output_pixels(memory):
+  return np.frombuffer(memory.read(memory.base + 0x30000, 192), np.float32).reshape(3, 4, 4)
+
+
+@pytest.mark.parametrize("count", [1, 2, 17])
+def test_pm4_uses_full_descriptor_tables_and_distinct_upload_kinds(count):
+  memory = Memory(0x40000)
+  words = image_command(memory, count)
+  with driver_for(memory, words) as (driver, context):
+    driver.drain()
+    assert not context.pending and context.retired == 1
+  pixels = np.arange(48, dtype=np.float32).reshape(3, 4, 4)
+  np.testing.assert_array_equal(output_pixels(memory), pixels * count + count * (count - 1) // 2)
+
+
+@pytest.mark.parametrize("offset,value", [
+  (0x9000, 0),                       # Unsupported texture format.
+  (0x9004, 3 << 15),                 # Zero width.
+  (0x9008, 1 << 29 | 32 << 7),       # Row pitch cannot hold this image.
+  (0x900c, 1),                       # Unsupported layer pitch.
+  (0xa100, 0),                       # Sampler changes from border to repeat.
+  (0xb000, 1),                       # Nonblack border configuration.
+  (0xa010, 0xfffffff0),              # Output span does not belong to memory.
+])
+def test_invalid_late_image_configuration_rejects_before_prefix(offset, value):
+  memory = Memory(0x40000)
+  words = image_command(memory)
+  memory.write(memory.base + offset, struct.pack("<I", value))
+  command = signal(memory.base, 123) + words
+  before = bytes(memory.data)
+  with driver_for(memory, command) as (driver, context):
+    with pytest.raises(qcomgpu.PM4Fault):
+      driver.drain()
+    assert bytes(memory.data) == before
+    assert context.pending[0][2] == 0 and context.consumed == context.retired == 0
+
+
+def test_staged_descriptor_change_does_not_replace_prevalidated_configuration():
+  memory = Memory(0x40000)
+  words = image_command(memory)
+  # The altered width is itself valid, but belongs to a different configuration
+  # than the one admitted before the preceding store action ran.
+  command = signal(memory.base + 0x9004, 3 << 15 | 3) + words
+  before = bytes(memory.data)
+  with driver_for(memory, command) as (driver, _):
+    with pytest.raises(qcomgpu.PM4Fault, match="image configuration changed"):
+      driver.drain()
+  assert bytes(memory.data) == before
+
+
+def test_short_image_backing_rejects_before_any_action():
+  memory = Memory(0x40000)
+  words = image_command(memory)
+  memory.write(memory.base + 0xa000, image_descriptor(memory.base + len(memory.data) - 64, texture=False))
+  before = bytes(memory.data)
+  with pytest.raises(qcomgpu.PM4Fault):
+    qcomgpu.execute_command(signal(memory.base, 123) + words, memory, 1)
+  assert bytes(memory.data) == before
+
+
+def test_read_only_image_output_rejects_before_any_action():
+  class ReadOnlyOutputMemory(Memory):
+    def validate(self, address, size, write=False):
+      super().validate(address, size, write)
+      output = self.base + 0x30000
+      if write and address < output + 192 and output < address + size:
+        raise RuntimeError("read-only image output")
+
+  memory = ReadOnlyOutputMemory(0x40000)
+  words = image_command(memory)
+  before = bytes(memory.data)
+  with pytest.raises(qcomgpu.PM4Fault, match="read-only image output"):
+    qcomgpu.execute_command(signal(memory.base, 123) + words, memory, 1)
+  assert bytes(memory.data) == before
+
+
+@pytest.mark.parametrize("replacement", [
+  lambda base: register(mesa.REG_A6XX_SP_CS_CONFIG, qreg.a6xx_sp_cs_config(enabled=True, ntex=2, nsamp=1, nuav=1)),
+  lambda base: register(mesa.REG_A6XX_SP_CS_TEXMEMOBJ_BASE, (base + 0x9040) & 0xffffffff, (base + 0x9040) >> 32),
+])
+def test_resource_count_or_base_mismatch_rejects_before_any_action(replacement):
+  memory = Memory(0x40000)
+  words = image_command(memory)
+  words = words[:-5] + replacement(memory.base) + words[-5:]
+  before = bytes(memory.data)
+  with pytest.raises(qcomgpu.PM4Fault, match="resource load and configuration disagree"):
+    qcomgpu.execute_command(signal(memory.base, 123) + words, memory, 1)
+  assert bytes(memory.data) == before
+
+
+def test_resource_after_the_texture_prefetch_limit_is_also_prevalidated():
+  memory = Memory(0x40000)
+  words = image_command(memory, count=17)
+  memory.write(memory.base + 0x9000 + 16 * 64 + 4, struct.pack("<I", 0))
+  before = bytes(memory.data)
+  with pytest.raises(qcomgpu.PM4Fault):
+    qcomgpu.execute_command(signal(memory.base, 123) + words, memory, 1)
+  assert bytes(memory.data) == before
+
+
+def command_with_reserved_sampler(memory):
+  words = image_command(memory)
+  address = memory.base + 0xa100
+  extra = register(mesa.REG_A6XX_SP_CS_CONFIG, qreg.a6xx_sp_cs_config(enabled=True, ntex=1, nsamp=2, nuav=1))
+  extra += packet(mesa.CP_LOAD_STATE6_FRAG,
+                  qreg.cp_load_state6_0(state_type=mesa.ST_SHADER, state_src=mesa.SS6_INDIRECT,
+                                       state_block=mesa.SB6_CS_TEX, num_unit=2), address & 0xffffffff, address >> 32)
+  return words[:-5] + extra + words[-5:]
+
+
+def test_unused_zero_sampler_slot_matches_the_qcomcl_producer():
+  # QCOMProgramData._parse_lib pads its one real sampler with one zero record.
+  # This slot is configuration padding, not an executable repeat-mode sampler.
+  memory = Memory(0x40000)
+  words = command_with_reserved_sampler(memory)
+  with driver_for(memory, words) as (driver, _):
+    driver.drain()
+  np.testing.assert_array_equal(output_pixels(memory), np.arange(48, dtype=np.float32).reshape(3, 4, 4))
+
+
+def test_reserved_sampler_slot_cannot_be_used_by_an_instruction():
+  memory = Memory(0x40000)
+  launch, = qcomgpu.compile_plan(command_with_reserved_sampler(memory), memory)
+  assert isinstance(launch, qcomgpu.Launch)
+  instruction = next(ins for ins in decode(launch.image) if ins.op == "isam")
+  changed = replace(instruction, fields={**instruction.fields, "SAMP": 1})
+  with pytest.raises(RuntimeError, match="sampler index out of bounds"):
+    validate_image_bindings((changed,), launch.image_bindings)
+
+
+def test_staged_pixel_change_is_visible_to_image_execution():
+  memory = Memory(0x40000)
+  words = image_command(memory)
+  command = signal(memory.base + 0x10000, 0x42280000) + words  # float32 42
+  with driver_for(memory, command) as (driver, _):
+    driver.drain()
+  expected = np.arange(48, dtype=np.float32).reshape(3, 4, 4)
+  expected[0, 0, 0] = 42
+  np.testing.assert_array_equal(output_pixels(memory), expected)
+
+
+def test_wait_resume_rechecks_images_without_repeating_the_published_prefix():
+  memory = Memory(0x40000)
+  words = image_command(memory)
+  address = memory.base + 4
+  wait = packet(mesa.CP_WAIT_REG_MEM, qreg.cp_wait_reg_mem_0(function=mesa.WRITE_GE, poll=mesa.POLL_MEMORY),
+                address & 0xffffffff, address >> 32, 1, 0xffffffff, 32)
+  command = signal(memory.base, 123) + wait + words
+  with driver_for(memory, command) as (driver, context):
+    driver.drain()
+    assert context.pending[0][2] == 1 and context.retired == 0
+    assert memory.read(memory.base, 4) == struct.pack("<I", 123)
+    memory.write(memory.base, struct.pack("<2I", 456, 1))
+    memory.write(memory.base + 0x10000, struct.pack("<f", 99))
+    driver.drain()
+    assert memory.read(memory.base, 4) == struct.pack("<I", 456)
+    assert not context.pending and context.retired == 1
+  expected = np.arange(48, dtype=np.float32).reshape(3, 4, 4)
+  expected[0, 0, 0] = 99
+  np.testing.assert_array_equal(output_pixels(memory), expected)

--- a/test/mockgpu/qcom/test_image_dot_broadcast.py
+++ b/test/mockgpu/qcom/test_image_dot_broadcast.py
@@ -1,0 +1,103 @@
+"""Image matmul must broadcast batch axes before folding them into convolution groups."""
+import pytest
+
+from tinygrad import Tensor
+from tinygrad.helpers import Context
+from test.mockgpu.qcom.test_image_integration import run_image_program
+
+
+@pytest.mark.parametrize("left_shape,right_shape", [
+  ((3, 5), (5, 7)),
+  ((2, 3, 5), (2, 5, 7)),
+  ((2, 3, 5), (5, 7)),
+  ((3, 5), (2, 5, 7)),
+  ((2, 1, 3, 5), (1, 4, 5, 7)),
+  ((2, 3, 4, 5), (2, 1, 5, 7)),
+  ((2, 1, 4, 5), (2, 3, 5, 7)),
+  ((2, 1, 3, 4, 5), (1, 4, 1, 5, 7)),
+  ((5,), (5,)),
+  ((3, 5), (5,)),
+  ((5,), (5, 7)),
+  ((2, 3, 5), (5,)),
+], ids=["matrix", "batched", "right", "left", "both", "right-singleton", "left-singleton", "multiple-axes",
+        "vector-vector", "matrix-vector", "vector-matrix", "batched-matrix-vector"])
+@pytest.mark.parametrize("half_storage", [False, True], ids=["float-storage", "half-storage"])
+def test_image_matmul_broadcast_matches_cpu_references(left_shape, right_shape, half_storage):
+  run_image_program(f"""
+import torch
+from tinygrad.helpers import Context
+torch.set_num_threads(1)
+rng = np.random.default_rng(97)
+left = rng.uniform(-1, 1, {left_shape!r}).astype(np.float32)
+right = rng.uniform(-1, 1, {right_shape!r}).astype(np.float32)
+for image_mode in (0, 1):
+  # FLOAT16 changes image storage only. Preserve original float32 input arrays
+  # for both Tensor paths, and round only the independent image-mode reference.
+  reference_left, reference_right = left, right
+  if image_mode and {half_storage!r}:
+    reference_left = left.astype(np.float16).astype(np.float32)
+    reference_right = right.astype(np.float16).astype(np.float32)
+    assert np.any(left != reference_left) and np.any(right != reference_right)
+  expected = reference_left @ reference_right
+  torch_expected = (torch.tensor(reference_left) @ torch.tensor(reference_right)).numpy()
+  with Context(IMAGE=image_mode):
+    actual = (Tensor(left) @ Tensor(right)).numpy()
+  assert actual.shape == expected.shape == torch_expected.shape
+  assert actual.dtype == np.float32
+  np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+  np.testing.assert_allclose(actual, torch_expected, rtol=1e-6, atol=1e-6)
+  if image_mode == 0:
+    executed_image_ops.clear()
+    executed_component_bytes.clear()
+""", half_storage=half_storage)
+
+
+@pytest.mark.parametrize("left_shape,right_shape", [
+  ((3, 5), (2, 5, 7)),
+  ((2, 1, 3, 5), (1, 4, 5, 7)),
+  ((2, 3, 4, 5), (2, 1, 5, 7)),
+], ids=["left", "both", "right-singleton"])
+@pytest.mark.parametrize("half_storage", [False, True], ids=["float-storage", "half-storage"])
+def test_image_matmul_gradients_reduce_broadcast_axes(left_shape, right_shape, half_storage):
+  run_image_program(f"""
+import torch
+from tinygrad.helpers import Context
+torch.set_num_threads(1)
+rng = np.random.default_rng(101)
+left = rng.uniform(-1, 1, {left_shape!r}).astype(np.float32)
+right = rng.uniform(-1, 1, {right_shape!r}).astype(np.float32)
+cotangent = rng.uniform(-1, 1, (left @ right).shape).astype(np.float32)
+for image_mode in (0, 1):
+  reference_left, reference_right = left, right
+  if image_mode and {half_storage!r}:
+    reference_left = left.astype(np.float16).astype(np.float32)
+    reference_right = right.astype(np.float16).astype(np.float32)
+  torch_left = torch.tensor(reference_left, requires_grad=True)
+  torch_right = torch.tensor(reference_right, requires_grad=True)
+  ((torch_left @ torch_right) * torch.tensor(cotangent)).sum().backward()
+  with Context(IMAGE=image_mode):
+    actual_left, actual_right = Tensor(left), Tensor(right)
+    gradients = ((actual_left @ actual_right) * Tensor(cotangent)).sum().gradient(actual_left, actual_right)
+    # Differentiating expansion must sum the replicated batches back into the
+    # original operand shapes; gradient cotangents do not acquire half storage.
+    for gradient, reference in zip(gradients, (torch_left.grad, torch_right.grad)):
+      actual = gradient.numpy()
+      assert actual.shape == tuple(reference.shape)
+      np.testing.assert_allclose(actual, reference.numpy(), rtol=1e-6, atol=1e-6)
+  if image_mode == 0:
+    executed_image_ops.clear()
+    executed_component_bytes.clear()
+""", half_storage=half_storage)
+
+
+@pytest.mark.parametrize("image_mode", [0, 1])
+@pytest.mark.parametrize("half_storage", [0, 1])
+def test_image_matmul_rejects_incompatible_batch_and_contracting_axes(image_mode, half_storage):
+  # Batch incompatibility must fail at shape validation, before flattening can
+  # divide by zero or accidentally reinterpret a different grouping as valid.
+  with Context(IMAGE=image_mode, FLOAT16=half_storage):
+    for left_shape, right_shape in [((2, 3, 5), (3, 5, 7)), ((2, 1, 3, 5), (3, 2, 5, 7)), ((2, 3, 4, 5), (3, 2, 5, 7))]:
+      with pytest.raises(IndexError):
+        Tensor.empty(left_shape, device="CPU").matmul(Tensor.empty(right_shape, device="CPU"))
+    with pytest.raises(RuntimeError):
+      Tensor.empty(2, 3, 5, device="CPU").matmul(Tensor.empty(2, 4, 7, device="CPU"))

--- a/test/mockgpu/qcom/test_image_execution.py
+++ b/test/mockgpu/qcom/test_image_execution.py
@@ -281,3 +281,23 @@ def test_image_store_filters_invalid_lanes_and_preserves_valid_lane_values():
   expected[0, 1] = [200, 201, 202, 203]
   actual = np.frombuffer(memory.read(image.base, 192), np.float32).reshape(3, 4, 4)
   np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.parametrize('readonly,access', [(None, mesa.ACCESS_CAN_REORDER), (True, mesa.ACCESS_CAN_REORDER), (False, 0)])
+def test_image_load_fixture_keyword_preserves_the_existing_renderer_default(readonly, access):
+  # The fixture may request a coherent load without changing any renderer call:
+  # omitted and explicit-True permissions must remain identical to the base.
+  renderer = IR3Renderer(Target(device='QCOM', renderer='IR3', arch='a630'))
+  renderer.prerender([])
+  builder = renderer.b
+  try:
+    zero = nimm(builder, 0, dtypes.int)
+    value = _nload_img(builder, zero, zero, zero, dtypes.float, **({} if readonly is None else {'readonly': readonly}))
+    instruction = ctypes.cast(value.parent_instr, ctypes.POINTER(mesa.nir_intrinsic_instr)).contents
+    info = mesa.nir_intrinsic_infos[instruction.intrinsic]
+    assert instruction.const_index[info.index_map[mesa.NIR_INTRINSIC_ACCESS] - 1] == access
+    assert instruction.const_index[info.index_map[mesa.NIR_INTRINSIC_IMAGE_DIM] - 1] == mesa.GLSL_SAMPLER_DIM_2D
+    assert instruction.const_index[info.index_map[mesa.NIR_INTRINSIC_DEST_TYPE] - 1] == mesa.nir_type_float32
+    assert value.num_components == 4 and value.bit_size == 32
+  finally:
+    mesa.ralloc_free(builder.shader)

--- a/test/mockgpu/qcom/test_image_execution.py
+++ b/test/mockgpu/qcom/test_image_execution.py
@@ -1,0 +1,283 @@
+"""Compiler-produced image instructions, with independently populated pixels.
+
+Only valid NIR enters the native compiler/decoder. Rejection cases manipulate
+Python descriptor records and controlled byte storage, never host pointers.
+"""
+import base64
+import ctypes
+import functools
+from dataclasses import dataclass, replace
+
+import numpy as np
+import pytest
+
+from tinygrad.dtype import dtypes
+from tinygrad.helpers import Target
+from tinygrad.renderer.nir import IR3Renderer, nalu, nchannel, nimm, nlid, _nload_img, nstore_img
+from tinygrad.runtime.autogen import mesa
+from tinygrad.runtime.support.compiler_mesa import IR3Compiler
+from test.mockgpu.qcom.emu import Workgroup, _image_instruction, decode, execute, validate_image_bindings
+from test.mockgpu.qcom.image import Image2D, ImageBindings
+from test.mockgpu.qcom.test_emu import Memory
+
+
+@dataclass(frozen=True)
+class ImageProgram:
+  image: bytes
+  constants: bytes
+  local: tuple[int, int, int]
+  wgid: int
+  lid: int
+  wgsize: int
+
+
+@functools.lru_cache(maxsize=32)
+def compile_image_program(local=(4, 3, 1), textures=1, component=None, read_offset=(0, 0), half_store=False, coherent=False):
+  # Use the same NIR image helper calls as IR3Renderer. Giving each lane a
+  # different coordinate exercises the actual compiled register allocation.
+  renderer = IR3Renderer(Target(device="QCOM", renderer="IR3", arch="a630"))
+  renderer.prerender([])
+  builder = renderer.b
+  builder.shader.contents.info.workgroup_size[:] = local
+  builder.shader.contents.info.num_images = 1 if coherent else textures + 1
+  coordinates = nlid(builder)
+  x, y = (nchannel(builder, coordinates, axis) for axis in (0, 1))
+  read_x = nalu(builder, "iadd", x, nimm(builder, read_offset[0], dtypes.int))
+  read_y = nalu(builder, "iadd", y, nimm(builder, read_offset[1], dtypes.int))
+  values = [
+    _nload_img(builder, nimm(builder, index, dtypes.int), read_y, read_x, dtypes.float, readonly=not coherent)
+    for index in range(textures)
+  ]
+  value = values[0]
+  for additional in values[1:]:
+    value = nalu(builder, "fadd", value, additional)
+  if component is not None:
+    selected = nchannel(builder, value, component)
+    value = nalu(builder, "vec4", selected, selected, selected, selected)
+  if half_store:
+    value = nalu(builder, "f2f16_rtne", value)
+  nstore_img(builder, nimm(builder, 0, dtypes.int), y, x, value, dtypes.half if half_store else dtypes.float)
+  mesa.nir_validate_shader(builder.shader, b"image execution test")
+  blob = mesa.struct_blob()
+  mesa.nir_serialize(blob, builder.shader, False)
+  try:
+    source = base64.b64encode(ctypes.string_at(blob.data, blob.size)).decode()
+    variant, state, immediates, image = IR3Compiler.unpack_lib(renderer.compiler.compile(source))
+    offset = state.allocs.max_const_offset_vec4 * 16
+    constants = bytes(offset) + immediates
+    allocation = state.allocs.consts[mesa.IR3_CONST_ALLOC_DRIVER_PARAMS]
+    wgsize = allocation.offset_vec4 * 4 + 8 if allocation.size_vec4 else 0xfc
+    if wgsize != 0xfc:
+      constants = constants.ljust((wgsize + 3) * 4, b"\0")
+    return ImageProgram(image, constants, local, variant.cs.work_group_id, variant.cs.local_invocation_id, wgsize)
+  finally:
+    mesa.ralloc_free(builder.shader)
+    ctypes.CDLL(None).free(blob.data)
+
+
+def image_storage(values, base, pitch=64):
+  height, width, _ = values.shape
+  data = bytearray(b"\x5a" * (height * pitch))
+  for row in range(height):
+    pixels = values[row].tobytes()
+    data[row * pitch:row * pitch + len(pixels)] = pixels
+  return Image2D(base, width, height, pitch, values.dtype.itemsize), data
+
+
+def run_image(program, inputs, output_dtype=np.float32):
+  regions, textures = {}, []
+  for index, values in enumerate(inputs):
+    texture, data = image_storage(values, 0x10000 * (index + 1))
+    textures.append(texture)
+    regions[texture.base] = data
+  shape = (program.local[1], program.local[0], 4)
+  output, data = image_storage(np.full(shape, -77, dtype=output_dtype), 0x400000)
+  regions[output.base] = data
+  memory = Memory(regions)
+  bindings = ImageBindings(tuple(textures), (output,), len(textures))
+  execute(program.image, program.constants, (1, 1, 1), program.local, program.wgid, program.lid, memory,
+          wgsize=program.wgsize, image_bindings=bindings)
+  rows = [np.frombuffer(memory.read(output.base + row * output.pitch, shape[1] * 4 * output.component_bytes), output_dtype)
+          for row in range(shape[0])]
+  actual = np.stack(rows).reshape(shape)
+  # A pitch error or a store beyond the fourth component corrupts this padding.
+  row_bytes = shape[1] * 4 * output.component_bytes
+  for row in range(shape[0]):
+    assert memory.read(output.base + row * output.pitch + row_bytes, output.pitch - row_bytes) == b"\x5a" * (output.pitch - row_bytes)
+  return actual
+
+
+@pytest.mark.parametrize("storage", [np.float32, np.float16])
+def test_compiled_image_copy_respects_both_coordinates_and_storage_precision(storage):
+  values = (np.arange(48).reshape(3, 4, 4) / 8 - 2).astype(storage)
+  actual = run_image(compile_image_program(), [values], output_dtype=storage)
+  np.testing.assert_array_equal(actual, values)
+
+
+def test_partial_texture_mask_keeps_original_channel_positions():
+  values = np.arange(48, dtype=np.float32).reshape(3, 4, 4)
+  program = compile_image_program(component=1)
+  assert any(ins.op == "isam" and ins.fields["WRMASK"] == 2 for ins in decode(program.image))
+  actual = run_image(program, [values])
+  np.testing.assert_array_equal(actual, np.repeat(values[:, :, 1:2], 4, axis=2))
+
+
+@pytest.mark.parametrize("count", [2, 17])
+def test_distinct_textures_and_uniform_indirect_indexing(count):
+  values = [np.arange(48, dtype=np.float32).reshape(3, 4, 4) / 16 + index for index in range(count)]
+  program = compile_image_program(textures=count)
+  if count == 17:
+    assert any(ins.op == "isam" and "INDICES" in ins.operands for ins in decode(program.image))
+  actual = run_image(program, values)
+  np.testing.assert_array_equal(actual, np.sum(values, axis=0))
+
+
+@pytest.mark.parametrize("offset", [(-1, 0), (1, 0), (0, -1), (0, 1)])
+def test_outside_texture_coordinates_select_black_without_wrapping_rows(offset):
+  values = (np.arange(48, dtype=np.float32).reshape(3, 4, 4) + 1)
+  actual = run_image(compile_image_program(read_offset=offset), [values])
+  expected = np.zeros_like(values)
+  if offset == (-1, 0):
+    expected[:, 1:] = values[:, :-1]
+  elif offset == (1, 0):
+    expected[:, :-1] = values[:, 1:]
+  elif offset == (0, -1):
+    expected[1:] = values[:-1]
+  else:
+    expected[:-1] = values[1:]
+  np.testing.assert_array_equal(actual, expected)
+
+
+def test_padded_rows_do_not_become_extra_pixels():
+  values = np.arange(36, dtype=np.float32).reshape(3, 3, 4)
+  actual = run_image(compile_image_program(local=(3, 3, 1)), [values])
+  np.testing.assert_array_equal(actual, values)
+
+
+def test_half_store_uses_half_data_registers_and_nearest_even_conversion():
+  values = np.resize(np.array([1.0006, -1.0006, 1.0015, -1.0015], np.float32), (3, 4, 4))
+  actual = run_image(compile_image_program(half_store=True), [values], output_dtype=np.float16)
+  np.testing.assert_array_equal(actual.view(np.uint16), values.astype(np.float16).view(np.uint16))
+
+
+def test_full_float_store_converts_to_half_image_storage():
+  values = np.resize(np.array([1.0006, -1.0006, 1.0015, -1.0015], np.float32), (3, 4, 4))
+  actual = run_image(compile_image_program(), [values], output_dtype=np.float16)
+  np.testing.assert_array_equal(actual.view(np.uint16), values.astype(np.float16).view(np.uint16))
+
+
+@pytest.mark.parametrize("storage", [np.float16, np.float32])
+def test_height_one_image_uses_the_declared_byte_pitch(storage):
+  values = np.arange(16, dtype=storage).reshape(1, 4, 4) / 8
+  actual = run_image(compile_image_program(local=(4, 1, 1)), [values], output_dtype=storage)
+  np.testing.assert_array_equal(actual, values)
+
+
+@pytest.mark.parametrize("field,value", [("TEX", 1), ("SAMP", 1)])
+def test_static_sampling_indices_require_declared_resources(field, value):
+  instruction = next(ins for ins in decode(compile_image_program().image) if ins.op == "isam")
+  changed = replace(instruction, fields={**instruction.fields, field: value})
+  bindings = ImageBindings((Image2D(0x10000, 4, 3, 64, 4),), (), 1)
+  # This is pure admission of a Python instruction record; no altered encoding
+  # enters the native disassembler.
+  with pytest.raises(RuntimeError, match="index out of bounds"):
+    validate_image_bindings((changed,), bindings)
+
+
+@pytest.mark.parametrize("operation", ["stib.b", "ldib.b"])
+def test_uav_index_requires_a_declared_writable_image(operation):
+  program = compile_image_program(coherent=operation == "ldib.b")
+  instruction = next(ins for ins in decode(program.image) if ins.op == operation)
+  bindings = ImageBindings(textures=(Image2D(0x10000, 4, 3, 64, 4),), sampler_count=1)
+  with pytest.raises(RuntimeError, match="output index out of bounds"):
+    validate_image_bindings((instruction,), bindings)
+
+
+@pytest.mark.parametrize("indices", [((17, 17), (0, 0)), ((0, 1), (0, 0)), ((0, 0), (0, 17))])
+def test_indirect_sampling_validates_live_index_values_before_access(indices):
+  instruction = next(ins for ins in decode(compile_image_program(textures=17).image) if "INDICES" in ins.operands)
+  texture = Image2D(0x10000, 4, 3, 64, 4)
+  # Empty storage makes an accidental pixel access fail independently. The
+  # required error concerns the live resource indices, before any such access.
+  group = Workgroup(b"", (2, 1, 1), (0, 0, 0), 0xfc, 0xfc, 0xfc, Memory({}), 0, 0,
+                    image_bindings=ImageBindings((texture,) * 17, (), 17))
+  register = instruction.operands["INDICES"].index
+  group.registers[1][register] = indices[0]
+  group.registers[1][register + 1] = indices[1]
+  with pytest.raises(RuntimeError, match="indices differ|index out of bounds"):
+    group.image_instruction(instruction, np.array([0, 1]))
+
+
+@pytest.mark.parametrize("operation,field,value,shift,width", [
+  ("isam", "DST", 255, 32, 8),
+  ("isam", "SRC1", 255, 1, 8),
+  ("stib.b", "SRC1", 254, 32, 8),
+  ("stib.b", "SRC2", 255, 24, 8),
+])
+def test_image_register_spans_are_checked_without_native_decoding(operation, field, value, shift, width):
+  instruction = next(ins for ins in decode(compile_image_program().image) if ins.op == operation)
+  raw = instruction.raw & ~(((1 << width) - 1) << shift) | value << shift
+  with pytest.raises(RuntimeError, match="register span out of bounds"):
+    _image_instruction({**instruction.fields, field: value}, raw)
+
+
+@pytest.mark.parametrize("operation,bit", [("isam", 0), ("isam", 48), ("isam", 52), ("stib.b", 8), ("stib.b", 23),
+                                         ("ldib.b", 8), ("ldib.b", 23)])
+def test_unimplemented_image_modes_are_rejected_in_python(operation, bit):
+  instruction = next(ins for ins in decode(compile_image_program(coherent=operation == "ldib.b").image) if ins.op == operation)
+  # A pure Python schema check covers unknown mode flags without feeding altered
+  # bytes to the native ISA decoder or touching a host allocation.
+  with pytest.raises(RuntimeError, match="unsupported image.*mode"):
+    _image_instruction(instruction.fields, instruction.raw ^ (1 << bit))
+
+
+@pytest.mark.parametrize("coordinates", [(0, 0), (-1, 0), (4, 0), (0, -1), (0, 3)])
+def test_coherent_load_uses_the_writable_table_and_zero_for_invalid_texels(coordinates):
+  instruction = next(ins for ins in decode(compile_image_program(coherent=True).image) if ins.op == "ldib.b")
+  values = np.arange(48, dtype=np.float32).reshape(3, 4, 4) + 1
+  image, storage = image_storage(values, 0x10000)
+  memory = Memory({image.base:storage})
+  group = Workgroup(b"", (1, 1, 1), (0, 0, 0), 0xfc, 0xfc, 0xfc, memory, 0, 0,
+                    image_bindings=ImageBindings(outputs=(image,)))
+  register = instruction.operands["COORD"].index
+  group.registers[0][register:register + 2, 0] = np.array(coordinates, np.int32).view(np.uint32)
+  group.image_instruction(instruction, np.array([0]))
+  destination = instruction.operands["DST"].index
+  actual = group.registers[0][destination:destination + 4, 0].view(np.float32)
+  np.testing.assert_array_equal(actual, [1, 2, 3, 4] if coordinates == (0, 0) else [0, 0, 0, 0])
+  assert memory.read(image.base, len(storage)) == storage
+
+
+def test_invalid_store_coordinates_leave_every_registered_pixel_unchanged():
+  # ARB_shader_image_load_store defines invalid-texel stores as having no
+  # effect. The image is still a valid, writable registered resource.
+  instruction = next(ins for ins in decode(compile_image_program().image) if ins.op == "stib.b")
+  values = np.arange(48, dtype=np.float32).reshape(3, 4, 4)
+  image, storage = image_storage(values, 0x10000)
+  memory = Memory({image.base:storage})
+  group = Workgroup(b"", (2, 1, 1), (0, 0, 0), 0xfc, 0xfc, 0xfc, memory, 0, 0,
+                    image_bindings=ImageBindings(outputs=(image,)))
+  register = instruction.operands["COORD"].index
+  group.registers[0][register, :] = np.array([-1, 4], np.int32).view(np.uint32)
+  group.image_instruction(instruction, np.array([0, 1]))
+  assert memory.read(image.base, len(storage)) == storage
+
+
+def test_image_store_filters_invalid_lanes_and_preserves_valid_lane_values():
+  instruction = next(ins for ins in decode(compile_image_program().image) if ins.op == "stib.b")
+  values = np.arange(48, dtype=np.float32).reshape(3, 4, 4)
+  image, storage = image_storage(values, 0x10000)
+  memory = Memory({image.base:storage})
+  group = Workgroup(b"", (3, 1, 1), (0, 0, 0), 0xfc, 0xfc, 0xfc, memory, 0, 0,
+                    image_bindings=ImageBindings(outputs=(image,)))
+  data = instruction.operands["DATA"].index
+  coordinate = instruction.operands["COORD"].index
+  payload = np.array([[100, 200, 300], [101, 201, 301], [102, 202, 302], [103, 203, 303]], np.float32)
+  group.registers[0][data:data + 4] = payload.view(np.uint32)
+  group.registers[0][coordinate] = np.array([-1, 1, 4], np.int32).view(np.uint32)
+  group.registers[0][coordinate + 1] = 0
+  group.image_instruction(instruction, np.array([0, 1, 2]))
+  expected = values.copy()
+  expected[0, 1] = [200, 201, 202, 203]
+  actual = np.frombuffer(memory.read(image.base, 192), np.float32).reshape(3, 4, 4)
+  np.testing.assert_array_equal(actual, expected)

--- a/test/mockgpu/qcom/test_image_half_storage.py
+++ b/test/mockgpu/qcom/test_image_half_storage.py
@@ -1,0 +1,178 @@
+"""Explicit references for FLOAT16 image storage with original float32 inputs.
+
+These tests do not change shared backend tolerances or their float32 references.
+They check the image frontend's explicit half casts, followed by float32 math.
+"""
+import pytest
+
+from test.mockgpu.qcom.test_image_integration import run_image_program
+
+
+def test_half_image_matmul_quantizes_original_inputs_before_float32_accumulation():
+  run_image_program("""
+rng = np.random.default_rng(71)
+left = rng.uniform(-2, 2, (3, 5)).astype(np.float32)
+right = rng.uniform(-2, 2, (5, 7)).astype(np.float32)
+stored_left = left.astype(np.float16).astype(np.float32)
+stored_right = right.astype(np.float16).astype(np.float32)
+assert np.any(left != stored_left) and np.any(right != stored_right)
+actual = (Tensor(left) @ Tensor(right)).numpy()
+expected = stored_left @ stored_right
+np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+""", half_storage=True)
+
+
+def test_half_image_convolution_quantizes_original_inputs_and_weights():
+  run_image_program("""
+import torch
+import torch.nn.functional as functional
+torch.set_num_threads(1)
+rng = np.random.default_rng(73)
+values = rng.uniform(-2, 2, (1, 3, 4, 5)).astype(np.float32)
+weights = rng.uniform(-2, 2, (2, 3, 2, 3)).astype(np.float32)
+stored_values = values.astype(np.float16).astype(np.float32)
+stored_weights = weights.astype(np.float16).astype(np.float32)
+assert np.any(values != stored_values) and np.any(weights != stored_weights)
+actual = Tensor(values).conv2d(Tensor(weights), padding=1, stride=2).numpy()
+expected = functional.conv2d(torch.tensor(stored_values), torch.tensor(stored_weights), padding=1, stride=2).numpy()
+np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+""", half_storage=True)
+
+
+def test_half_image_pointwise_gradients_use_stored_values_and_float32_sums():
+  # Image lowering elides adjacent float->half->float casts without storage
+  # (pm_simplify_add_image). The forward contiguous half buffers still round
+  # inputs/weights. For these pointwise products, dX is the stored weight and
+  # dW is a float32 sum of stored inputs; no extra half gradient store exists.
+  run_image_program("""
+values = (np.arange(24, dtype=np.float32).reshape(1, 4, 2, 3) - 10) / 7
+weights = np.array([0.12345, -1.2345, 0.33337, 2.71828], np.float32).reshape(4, 1, 1, 1)
+stored_values = values.astype(np.float16).astype(np.float32)
+stored_weights = weights.astype(np.float16).astype(np.float32)
+assert np.any(values != stored_values) and np.any(weights != stored_weights)
+left, kernel = Tensor(values), Tensor(weights)
+left_gradient, weight_gradient = left.conv2d(kernel, groups=4).sum().gradient(left, kernel)
+expected_left = np.broadcast_to(stored_weights.reshape(1, 4, 1, 1), values.shape)
+expected_weight = stored_values.sum(axis=(0, 2, 3)).reshape(weights.shape)
+np.testing.assert_array_equal(left_gradient.numpy(), expected_left)
+np.testing.assert_array_equal(weight_gradient.numpy(), expected_weight)
+""", half_storage=True)
+
+
+@pytest.mark.parametrize("left_shape,right_shape", [
+  ((2, 3, 5), (2, 5, 7)),
+  ((2, 3, 5), (5, 7)),
+  ((2, 3, 4, 5), (5, 7)),
+  ((2, 3, 4, 5), (3, 5, 7)),
+  ((3, 5), (2, 5, 7)),
+  ((2, 1, 3, 5), (1, 4, 5, 7)),
+], ids=["batched", "broadcast-right", "broadcast-right-multiple-axes", "broadcast-right-leading-axis", "broadcast-left", "broadcast-both"])
+def test_half_image_matmul_batch_and_broadcast_storage(left_shape, right_shape):
+  # image_dot lowers each broadcasted batch to image_conv2d; only its input
+  # and weight stores round, while products and their reduction stay float32.
+  run_image_program(f"""
+rng = np.random.default_rng(79)
+left = rng.uniform(-2, 2, {left_shape!r}).astype(np.float32)
+right = rng.uniform(-2, 2, {right_shape!r}).astype(np.float32)
+stored_left = left.astype(np.float16).astype(np.float32)
+stored_right = right.astype(np.float16).astype(np.float32)
+assert np.any(left != stored_left) and np.any(right != stored_right)
+actual = (Tensor(left) @ Tensor(right)).numpy()
+expected = stored_left @ stored_right
+assert np.max(np.abs(expected - left @ right)) > 1e-5
+np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+""", half_storage=True)
+
+
+@pytest.mark.parametrize("operation,values_shape,weights_shape,options", [
+  ("conv2d", (2, 4, 4, 5), (6, 2, 2, 3), {"groups": 2, "padding": 1}),
+  ("conv2d", (1, 3, 5, 6), (5, 3, 2, 3), {"stride": (2, 1), "padding": 1}),
+  ("conv2d", (1, 4, 5, 6), (4, 1, 2, 2), {"groups": 4, "dilation": (2, 1), "padding": 1}),
+  ("conv_transpose2d", (1, 3, 3, 4), (3, 2, 2, 3), {"stride": (2, 1), "padding": 1, "output_padding": (1, 0)}),
+  ("conv_transpose2d", (1, 4, 3, 4), (4, 3, 2, 2), {"groups": 2, "dilation": (2, 1), "padding": 1}),
+], ids=["grouped", "strided", "depthwise-dilated", "transposed-strided", "transposed-grouped-dilated"])
+@pytest.mark.parametrize("backward", [False, True], ids=["forward", "gradients"])
+def test_half_image_convolution_variants_storage_and_gradients(operation, values_shape, weights_shape, options, backward):
+  # conv_transpose2d only reshapes/flips/zero-inserts before image_conv2d's
+  # storage boundary. Bias is added after the float32 reduction and stays float32.
+  # Backward follows the stored forward operands; adjacent gradient half casts
+  # are elided by pm_simplify_add_image when no half storage separates them.
+  run_image_program(f"""
+import torch
+import torch.nn.functional as functional
+torch.set_num_threads(1)
+rng = np.random.default_rng(83)
+values = rng.uniform(-1, 1, {values_shape!r}).astype(np.float32)
+weights = rng.uniform(-1, 1, {weights_shape!r}).astype(np.float32)
+options = {options!r}
+channels = weights.shape[1] * options.get("groups", 1) if {operation!r} == "conv_transpose2d" else weights.shape[0]
+bias = rng.uniform(-1, 1, channels).astype(np.float32)
+stored_values = values.astype(np.float16).astype(np.float32)
+stored_weights = weights.astype(np.float16).astype(np.float32)
+assert np.any(values != stored_values) and np.any(weights != stored_weights)
+assert np.any(bias != bias.astype(np.float16).astype(np.float32))
+left, kernel, offset = Tensor(values), Tensor(weights), Tensor(bias)
+actual = getattr(left, {operation!r})(kernel, offset, **options)
+reference_left = torch.tensor(stored_values, requires_grad=True)
+reference_kernel = torch.tensor(stored_weights, requires_grad=True)
+reference_bias = torch.tensor(bias, requires_grad=True)
+reference_op = getattr(functional, {operation!r})
+expected = reference_op(reference_left, reference_kernel, reference_bias, **options)
+full_precision = reference_op(torch.tensor(values), torch.tensor(weights), torch.tensor(bias), **options).detach().numpy()
+assert np.max(np.abs(expected.detach().numpy() - full_precision)) > 1e-5
+if {backward!r}:
+  # Nonuniform, non-half-representable cotangents expose unintended rounding
+  # in backward even when the forward operands were correctly stored as half.
+  cotangent = rng.uniform(-1, 1, tuple(expected.shape)).astype(np.float32)
+  assert np.any(cotangent != cotangent.astype(np.float16).astype(np.float32))
+  gradients = (actual * Tensor(cotangent)).sum().gradient(left, kernel, offset)
+  (expected * torch.tensor(cotangent)).sum().backward()
+np.testing.assert_allclose(actual.numpy(), expected.detach().numpy(), rtol=1e-6, atol=1e-6)
+if {backward!r}:
+  for actual_gradient, expected_gradient in zip(gradients, (reference_left.grad, reference_kernel.grad, reference_bias.grad)):
+    np.testing.assert_allclose(actual_gradient.numpy(), expected_gradient.numpy(), rtol=1e-6, atol=1e-6)
+""", half_storage=True)
+
+
+@pytest.mark.parametrize("query_heads,key_heads,query_length,key_length,mask_kind", [
+  (2, 2, 3, 3, "none"),
+  (2, 2, 4, 4, "causal"),
+  (2, 2, 3, 5, "none"),
+  (2, 2, 5, 3, "causal"),
+  (4, 2, 3, 5, "none"),
+  (2, 2, 3, 5, "additive"),
+  (4, 2, 3, 5, "additive"),
+], ids=["plain", "causal", "unequal-lengths", "causal-unequal-lengths", "gqa", "additive-mask", "gqa-additive-mask"])
+def test_half_image_attention_rounds_at_both_matmul_storage_boundaries(query_heads, key_heads, query_length, key_length, mask_kind):
+  # scaled_dot_product_attention: q/k half stores -> float32 score, mask and
+  # softmax -> probability/v half stores -> float32 output accumulation.
+  # In particular, neither the additive mask nor the softmax math is half.
+  run_image_program(f"""
+rng = np.random.default_rng(89)
+query = rng.uniform(-2, 2, (2, {query_heads}, {query_length}, 4)).astype(np.float32)
+key = rng.uniform(-2, 2, (2, {key_heads}, {key_length}, 4)).astype(np.float32)
+value = rng.uniform(-2, 2, (2, {key_heads}, {key_length}, 5)).astype(np.float32)
+def stored(array): return array.astype(np.float16).astype(np.float32)
+assert all(np.any(array != stored(array)) for array in (query, key, value))
+repeats = {query_heads} // {key_heads}
+stored_key = np.repeat(stored(key), repeats, axis=1)
+stored_value = np.repeat(stored(value), repeats, axis=1)
+scores = (stored(query) @ stored_key.swapaxes(-2, -1)) / np.float32(2)
+mask = None
+if {mask_kind!r} == "causal":
+  scores = np.where(np.tri({query_length}, {key_length}, dtype=bool), scores, np.float32(-np.inf))
+elif {mask_kind!r} == "additive":
+  mask = rng.uniform(-1, 1, ({query_length}, {key_length})).astype(np.float32)
+  assert np.any(mask != stored(mask))
+  scores = scores + mask
+exponentials = np.exp(scores - scores.max(axis=-1, keepdims=True))
+probabilities = exponentials / exponentials.sum(axis=-1, keepdims=True)
+assert np.any(probabilities != stored(probabilities))
+expected = stored(probabilities) @ stored_value
+# This counterfactual rejects omitting the second, probability storage boundary.
+assert np.max(np.abs(expected - probabilities @ stored_value)) > 1e-5
+actual = Tensor(query).scaled_dot_product_attention(
+  Tensor(key), Tensor(value), attn_mask=None if mask is None else Tensor(mask),
+  is_causal={mask_kind == 'causal'!r}, enable_gqa={query_heads != key_heads!r}).numpy()
+np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+""", half_storage=True)

--- a/test/mockgpu/qcom/test_image_integration.py
+++ b/test/mockgpu/qcom/test_image_integration.py
@@ -1,0 +1,124 @@
+"""Image results must come from compiler-generated instructions through HCQ2."""
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+import pytest
+from tinygrad.helpers import DEV
+
+
+def run_image_program(code, half_storage=False, required_ops=("isam", "stib.b")):
+  # Preserve the real compiler, submission, decoder and executor. Recording the
+  # executed instructions prevents a numerically correct buffer fallback from
+  # silently satisfying the image contract.
+  renderer = DEV.target("QCOM").renderer or "IR3"
+  setup = """import numpy as np
+from tinygrad import Device, Tensor
+from test.mockgpu.qcom import emu
+Device["QCOM"]
+executed_image_ops = set()
+executed_texture_counts = set()
+executed_indirect_sampling = []
+executed_direct_textures = set()
+executed_component_bytes = set()
+executed_compiler_modes = set()
+executed_fences = 0
+original_execute = emu.execute
+def record_execution(image, *args, **kwargs):
+  global executed_fences
+  result = original_execute(image, *args, **kwargs)
+  executed_compiler_modes.add(kwargs.get("opencl", False))
+  instructions = emu.decode(image)
+  executed_fences += sum(ins.op == "fence" for ins in instructions)
+  executed_image_ops.update(ins.op for ins in instructions if ins.raw >> 61 in (5, 6))
+  executed_texture_counts.add(len(kwargs["image_bindings"].textures))
+  bindings = kwargs["image_bindings"]
+  executed_component_bytes.update(resource.component_bytes for resource in bindings.textures + bindings.outputs)
+  executed_indirect_sampling.extend(ins for ins in instructions if ins.op == "isam" and "INDICES" in ins.operands)
+  executed_direct_textures.update(ins.fields["TEX"] for ins in instructions if ins.op == "isam" and "INDICES" not in ins.operands)
+  return result
+emu.execute = record_execution
+"""
+  finish = f"assert {set(required_ops)!r} <= executed_image_ops, executed_image_ops\n" + """
+from test.mockgpu.mockgpu import drivers
+assert drivers[0].error is None
+assert all(ctx.retired == ctx.queued and not ctx.pending for ctx in drivers[0].contexts.values())
+"""
+  finish += f"assert {2 if half_storage else 4} in executed_component_bytes, executed_component_bytes\n"
+  finish += f"assert executed_compiler_modes == {{{renderer == 'CL'!r}}}, executed_compiler_modes\n"
+  with tempfile.TemporaryDirectory() as cache:
+    environment = {
+      **os.environ, "DEV": f"MOCK+QCOM:{renderer}", "HCQ_RUNTIME_DEV": "CPU", "PARALLEL": "0",
+      "CACHELEVEL": "0", "OMP_NUM_THREADS": "1", "IMAGE": "1", "FLOAT16": str(int(half_storage)),
+      "XDG_CACHE_HOME": cache, "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    result = subprocess.run(
+      [sys.executable, "-c", setup + code + finish], cwd=pathlib.Path(__file__).parents[3],
+      env=environment, capture_output=True, text=True, timeout=120,
+    )
+  assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("half_storage", [False, True])
+def test_image_matmul_preserves_nonuniform_values_and_odd_channels(half_storage):
+  # Wrong descriptor table selection, x/y order or channel padding changes these
+  # independent NumPy results; an image-only allowlist change cannot pass.
+  run_image_program("""
+left = np.arange(15, dtype=np.float32).reshape(3, 5) / 8 - 1
+right = np.arange(35, dtype=np.float32).reshape(5, 7) / 16 - 0.75
+actual = (Tensor(left) @ Tensor(right)).numpy()
+np.testing.assert_allclose(actual, left @ right, rtol=2e-3, atol=2e-3)
+""", half_storage)
+
+
+def test_seventeen_image_inputs_run_through_hcq2_without_truncating_the_table():
+  run_image_program("""
+values = [np.arange(768, dtype=np.float32).reshape(3, 64, 4) / 16 + index for index in range(17)]
+inputs = [Tensor(value).realize() for value in values]
+actual = sum(inputs).numpy()
+np.testing.assert_array_equal(actual, np.sum(values, axis=0))
+assert 17 in executed_texture_counts, executed_texture_counts
+# Mesa uses a distinct sampler per texture and reaches the indirect form at
+# sampler 16. QCOMCL shares a sampler and can encode texture 16 directly.
+if Device["QCOM"].renderer.target.renderer == "IR3":
+  assert executed_indirect_sampling
+else:
+  assert 16 in executed_direct_textures, executed_direct_textures
+""")
+
+
+@pytest.mark.parametrize("half_storage", [False, True])
+@pytest.mark.parametrize("depthwise", [False, True])
+def test_image_convolution_padding_and_groups(half_storage, depthwise):
+  run_image_program(f"""
+import torch
+import torch.nn.functional as functional
+torch.set_num_threads(1)
+values = (np.arange(60, dtype=np.float32).reshape(1, 3, 4, 5) % 13 - 6) / 8
+groups, output_channels = (3, 3) if {depthwise!r} else (1, 5)
+weight_shape = (output_channels, 3 // groups, 3, 2)
+weights = (np.arange(np.prod(weight_shape), dtype=np.float32).reshape(weight_shape) % 11 - 5) / 8
+actual = Tensor(values).conv2d(Tensor(weights), groups=groups, padding=1).numpy()
+expected = functional.conv2d(torch.tensor(values), torch.tensor(weights), groups=groups, padding=1).numpy()
+np.testing.assert_allclose(actual, expected, rtol=3e-3, atol=3e-3)
+""", half_storage)
+
+
+@pytest.mark.parametrize("half_storage", [False, True])
+def test_image_convolution_backward_uses_real_image_results(half_storage):
+  run_image_program("""
+import torch
+import torch.nn.functional as functional
+torch.set_num_threads(1)
+values = (np.arange(48, dtype=np.float32).reshape(1, 3, 4, 4) % 9 - 4) / 8
+weights = (np.arange(36, dtype=np.float32).reshape(3, 3, 2, 2) % 7 - 3) / 8
+left, kernel = Tensor(values), Tensor(weights)
+left_gradient, kernel_gradient = left.conv2d(kernel, padding=1).square().sum().gradient(left, kernel)
+reference_left = torch.tensor(values, requires_grad=True)
+reference_kernel = torch.tensor(weights, requires_grad=True)
+functional.conv2d(reference_left, reference_kernel, padding=1).square().sum().backward()
+np.testing.assert_allclose(left_gradient.numpy(), reference_left.grad.numpy(), rtol=4e-3, atol=4e-3)
+np.testing.assert_allclose(kernel_gradient.numpy(), reference_kernel.grad.numpy(), rtol=4e-3, atol=4e-3)
+""", half_storage)

--- a/test/mockgpu/qcom/test_image_load_dtype.py
+++ b/test/mockgpu/qcom/test_image_load_dtype.py
@@ -1,0 +1,57 @@
+"""Promoting a memory view to an image must preserve the value dtype of its load."""
+import pytest
+from tinygrad import dtypes
+from tinygrad.codegen.late.coalesce import pm_simplify_add_image
+from tinygrad.helpers import Context, Target, is_image_shape
+from tinygrad.renderer import Renderer
+from tinygrad.uop.ops import Ops, UOp, graph_rewrite
+from test.mockgpu.qcom.test_image_integration import run_image_program
+
+
+@pytest.mark.parametrize('dtype', [dtypes.half, dtypes.float])
+def test_image_promotion_preserves_load_dtype_beside_scalar_buffer_load(dtype):
+  # Coalescing can promote four adjacent components while a masked scalar read
+  # of the same allocation remains a buffer access. Their arithmetic must stay
+  # well typed; changing only the vector load's dtype leaves a mixed-type ADD.
+  buffer = UOp.param(0, dtype, 256)
+  vector = UOp(Ops.SHRINK, src=(buffer, UOp.const(0), UOp.const(4))).load()
+  scalar = buffer.index(UOp.const(5)).load()
+  value = vector.index(0) + scalar
+  renderer = Renderer(Target(device='QCOM', arch='a630,IMAGE_PITCH_ALIGNMENT=64'))
+  with Context(IMAGE=1):
+    promoted = graph_rewrite(value, pm_simplify_add_image, ctx=({}, renderer), bottom_up=True)
+  assert promoted.dtype == dtype
+  assert all(source.dtype == dtype for source in promoted.src)
+  params = [u for u in promoted.toposort() if u.op is Ops.PARAM]
+  assert len(params) == 2 and {u.arg.slot for u in params} == {0}
+  assert any(is_image_shape(u._shape) for u in params)
+  assert any(not is_image_shape(u._shape) for u in params)
+
+
+@pytest.mark.parametrize('half_input', [False, True])
+def test_image_mutation_preserves_half_and_float_loads_in_mixed_views(half_input):
+  run_image_program(f"""
+from collections import Counter
+from tinygrad.runtime.ops_qcom import QCOMComputeQueue
+observed_mixed_views = []
+original_kernargs = QCOMComputeQueue.kernargs
+def record_kernargs(self, call, program, data):
+  counts = Counter(slot for _, slot, _, _ in data.signature if slot < len(program.arg.globals))
+  if any(count > 1 for count in counts.values()):
+    observed_mixed_views.append(True)
+  return original_kernargs(self, call, program, data)
+QCOMComputeQueue.kernargs = record_kernargs
+values = (np.arange(256, dtype=np.float32).reshape(4, 64) / 8 - 7).astype(np.float16 if {half_input!r} else np.float32)
+image = Tensor(values).contiguous().realize()
+expected = values.copy()
+for bound in (3, 15, 32, 1, 63):
+  masked = image[:, :bound].pad((None, (0, 64 - bound)), value=2)
+  image.assign(image + masked).realize()
+  increment = np.full_like(expected, 2)
+  increment[:, :bound] = expected[:, :bound]
+  expected += increment
+  actual = image.numpy()
+  assert actual.dtype == expected.dtype
+  np.testing.assert_array_equal(actual, expected)
+assert observed_mixed_views
+""", half_storage=half_input, required_ops=('ldib.b', 'stib.b'))

--- a/test/mockgpu/qcom/test_image_mutability.py
+++ b/test/mockgpu/qcom/test_image_mutability.py
@@ -1,0 +1,103 @@
+"""Mutable images keep writable bindings and observe ordered image stores."""
+import pytest
+
+from tinygrad.helpers import DEV
+from test.mockgpu.qcom.test_image_integration import run_image_program
+
+
+def test_masked_view_assignment_retains_its_writable_image_binding():
+  # Retain the ordinary assignment that exposed a texture-only declaration for
+  # an argument which the generated shader also writes.
+  run_image_program("""
+a = Tensor.ones(4, 4).contiguous().realize()
+b = a.shrink((None, (0, 2))).pad((None, (0, 2)), value=2)
+a.assign(a + b).realize()
+np.testing.assert_array_equal(a.numpy(), [[2, 2, 3, 3]] * 4)
+""", required_ops=("ldib.b", "stib.b"))
+
+
+@pytest.mark.parametrize("half_storage", [False, True])
+def test_initialized_mutable_image_reads_a_prior_store(half_storage):
+  # The second row must consume the first row's updated pixels in the same
+  # shader. Reorderable texture reads can retain the old values instead.
+  run_image_program(f"""
+from tinygrad.uop.ops import KernelInfo
+def update(image):
+  first = image[0].store(image[0] + 1)
+  updated = image.after(first)
+  second = updated[1].store(updated[0] * 2)
+  return second.sink(arg=KernelInfo(name="image_store_then_load", opts_to_apply=()))
+values = np.arange(32, dtype=np.float32).reshape(4, 8) / 8
+values = values.astype(np.float16 if {half_storage!r} else np.float32)
+image = Tensor(values).contiguous().realize()
+actual = image.custom_kernel(fxn=update)[0].numpy()
+expected = values.copy()
+expected[0] += 1
+expected[1] = expected[0] * 2
+np.testing.assert_array_equal(actual, expected)
+if Device["QCOM"].renderer.target.renderer == "IR3" and {{"ldg", "ldib.b", "stib.b"}} <= executed_image_ops:
+  assert executed_fences > 0
+""", half_storage, required_ops=("ldib.b", "stib.b"))
+
+
+def test_read_only_texture_and_mutable_image_keep_separate_resource_slots():
+  run_image_program("""
+left = np.arange(16, dtype=np.float32).reshape(4, 4) / 8
+right = np.arange(16, dtype=np.float32).reshape(4, 4) / 16 + 3
+a, b = Tensor(left).realize(), Tensor(right).realize()
+a.assign(a + b).realize()
+np.testing.assert_array_equal(a.numpy(), left + right)
+""", required_ops=("isam", "ldib.b", "stib.b"))
+
+
+def test_read_only_image_inputs_do_not_get_mixed_view_fences():
+  run_image_program("""
+left = np.arange(768, dtype=np.float32).reshape(3, 64, 4) / 8
+right = np.arange(768, dtype=np.float32).reshape(3, 64, 4) / 16 + 3
+actual = (Tensor(left) + Tensor(right)).numpy()
+np.testing.assert_array_equal(actual, left + right)
+assert executed_fences == 0
+""")
+
+
+@pytest.mark.skipif(DEV.target("QCOM").renderer != "CL", reason="QCOMCL compiler metadata and image qualifiers")
+def test_qcomcl_read_write_images_compile_with_writable_metadata_and_ordered_reads():
+  run_image_program("""
+from tinygrad.runtime.ops_qcom import _qcom_program_cache
+from tinygrad.uop.ops import KernelInfo
+compiled_sources = []
+compiler = Device["QCOM"].renderer.compiler
+original_compile = compiler.compile
+def record_source(source):
+  library = original_compile(source)
+  compiled_sources.append(source)
+  return library
+compiler.compile = record_source
+left = np.arange(16, dtype=np.float32).reshape(4, 4) / 8
+right = left / 2 + 3
+a, b = Tensor(left).realize(), Tensor(right).realize()
+a.assign(a + b).realize()
+np.testing.assert_array_equal(a.numpy(), left + right)
+def update(image):
+  first = image[0].store(image[0] + 1)
+  updated = image.after(first)
+  return updated[1].store(updated[0] * 2).sink(arg=KernelInfo(name="image_store_then_load", opts_to_apply=()))
+values = np.arange(32, dtype=np.float32).reshape(4, 8) / 8
+image = Tensor(values).contiguous().realize()
+actual = image.custom_kernel(fxn=update)[0].numpy()
+expected = values.copy()
+expected[0] += 1
+expected[1] = expected[0] * 2
+np.testing.assert_array_equal(actual, expected)
+mutable_sources = [source for source in compiled_sources if "read_write image2d_t" in source]
+assert mutable_sources
+# Guarded samplerless reads preserve border zero after image mask elimination.
+assert all("(float4)(0.0f)" in source and "(uint)(" in source for source in mutable_sources)
+assert any("atomic_work_item_fence(CLK_IMAGE_MEM_FENCE, memory_order_acq_rel, memory_scope_work_item)" in source
+           for source in mutable_sources)
+mutable_programs = [data for data, _ in _qcom_program_cache.values()
+                    if not data.NIR and any(ins.op == "ldib.b" for ins in emu.decode(data.image))]
+# Compiler type 3 must be an IBO, alongside the independent read-only texture.
+assert any(data.ibo_cnt == 1 and data.tex_cnt == 1 and data.buf_offs == [] for data in mutable_programs)
+assert any(ins.op == "ldib.b" and ins.raw & 1 for data in mutable_programs for ins in emu.decode(data.image))
+""", required_ops=("isam", "ldib.b", "stib.b"))

--- a/test/mockgpu/qcom/test_image_symbolic.py
+++ b/test/mockgpu/qcom/test_image_symbolic.py
@@ -1,0 +1,40 @@
+"""Scalar arguments follow all signature views of each logical buffer."""
+import pytest
+from test.mockgpu.qcom.test_image_integration import run_image_program
+
+
+@pytest.mark.parametrize('half_storage', [False, True])
+def test_symbolic_image_mutation_binds_integer_bounds_through_jit_replays(half_storage):
+  run_image_program(f"""
+from collections import Counter
+from tinygrad import TinyJit, Variable
+from tinygrad.runtime.ops_qcom import QCOMComputeQueue
+observed_mixed_signature = []
+original_kernargs = QCOMComputeQueue.kernargs
+def record_kernargs(self, call, program, data):
+  buffer_count = len(program.arg.globals)
+  counts = Counter(slot for _, slot, _, _ in data.signature if slot < buffer_count)
+  if any(count > 1 for count in counts.values()) and program.arg.vars:
+    scalar_types = [dtype for _, slot, dtype, _ in data.signature if slot >= buffer_count]
+    assert len(scalar_types) == 1 and scalar_types[0].name == 'int'
+    observed_mixed_signature.append(True)
+  return original_kernargs(self, call, program, data)
+QCOMComputeQueue.kernargs = record_kernargs
+
+@TinyJit
+def mutate(image, bound):
+  masked = image[:, :bound].pad((None, (0, image.shape[1] - bound)), value=2)
+  image.assign(image + masked).realize()
+  return image
+
+values = (np.arange(256, dtype=np.float32).reshape(4, 64) / 8 - 7).astype(np.float16 if {half_storage!r} else np.float32)
+image = Tensor(values).contiguous().realize()
+expected = values.copy()
+for size in (3, 15, 32, 1, 63):
+  actual = mutate(image, Variable('columns', 1, 63).bind(size)).numpy()
+  increment = np.full_like(expected, 2)
+  increment[:, :size] = expected[:, :size]
+  expected += increment
+  np.testing.assert_array_equal(actual, expected)
+assert observed_mixed_signature
+""", half_storage, required_ops=('ldib.b', 'stib.b'))

--- a/test/mockgpu/qcom/test_integer_width_repairs.py
+++ b/test/mockgpu/qcom/test_integer_width_repairs.py
@@ -1,0 +1,175 @@
+"""A630-5/6: source modifiers, arithmetic results and destination widths.
+
+These finite-data checks run decoded instructions in inert Workgroups. Scalar
+Python arithmetic supplies the expected results independently of NumPy and the
+interpreter's conversion helpers; explicit NOT instructions supply a second
+check of folded modifiers. No native guest memory or hardware is involved.
+"""
+import itertools
+import operator
+import struct
+import numpy as np
+import pytest
+from test.mockgpu.qcom.emu import Instruction, Operand, Workgroup, decode
+
+
+def machine(a, b, half, constants=()):
+  group = Workgroup(struct.pack(f'<{len(constants)}I', *constants), (len(a), 1, 1), (0, 0, 0),
+                    0xfc, 0xfc, 0xfc, object(), 0, 0)
+  modulus = 2**(16 if half else 32)
+  group.registers[half][0] = [x % modulus for x in a]
+  group.registers[half][1] = [x % modulus for x in b]
+  return group
+
+
+def cat2(opcode, half, dest_half, src1=0, src2=1, dst=8, modifiers=(0, 0)):
+  # Mesa cat2 shares source precision, with a separate destination conversion.
+  return ((2 << 61) | (opcode << 53) | (int(not half) << 52) | (int(half != dest_half) << 46) |
+          (dst << 32) | (src2 << 16) | src1 | (modifiers[0] << 14) | (modifiers[1] << 30))
+
+
+def run(group, *words):
+  instructions = decode(struct.pack(f'<{len(words) + 1}Q', *words, 6 << 55))
+  group.run(instructions)
+  return instructions
+
+
+def signed_integer(value, width):
+  value %= 2**width
+  return value if value < 2**(width - 1) else value - 2**width
+
+
+@pytest.mark.parametrize('half', [False, True])
+@pytest.mark.parametrize('dest_half', [False, True])
+@pytest.mark.parametrize('opcode', [54, 55, 56])
+@pytest.mark.parametrize('modifiers', [(0, 0), (1, 0), (0, 1), (1, 1)])
+@pytest.mark.parametrize('constant_role', [None, 0, 1])
+def test_folded_shift_modifiers_match_scalar_arithmetic_and_materialized_not(half, dest_half, opcode, modifiers, constant_role):
+  # A late half mask cannot undo high complement bits shifted into the result.
+  # Also protect signed ASHR and the low-five-bit shift-count contract, including
+  # a complement on SRC2 and counts at/above each source precision.
+  pairs = list(itertools.product([0, 1, 0x7fff, 0x8000, 0xffff, 0x12345678, 0x80000000, 0xffffffff],
+                                 [0, 1, 2, 7, 15, 16, 31, 32, 33, 63, 0xffffffff]))
+  a, b = ([pair[i] for pair in pairs] for i in (0, 1))
+  constants = (0xabcd8000, 0xdead0021)
+  if constant_role == 0:
+    a = [constants[0]] * len(a)
+  if constant_role == 1:
+    b = [constants[1]] * len(b)
+  sources = [0x1000 if constant_role == 0 else 0, 0x1001 if constant_role == 1 else 1]
+  folded, expanded = (machine(a, b, half, constants) for _ in range(2))
+  instruction = run(folded, cat2(opcode, half, dest_half, sources[0], sources[1], modifiers=modifiers))[0]
+  assert instruction.op == {54: 'shl.b', 55: 'shr.b', 56: 'ashr.b'}[opcode]
+
+  words = []
+  for index, modifier in enumerate(modifiers):
+    if modifier:
+      words.append(cat2(30, half, half, sources[index], 0, dst=6 + index))
+      sources[index] = 6 + index
+  run(expanded, *words, cat2(opcode, half, dest_half, *sources))
+
+  width = 16 if half else 32
+  expected = []
+  for left, right in zip(a, b):
+    left, right = left % 2**width, right % 2**width
+    if modifiers[0]:
+      left = 2**width - 1 - left
+    if modifiers[1]:
+      right = 2**width - 1 - right
+    if opcode == 56:
+      left = signed_integer(left, width)
+    scale = 2**(right % 32)
+    result = left * scale if opcode == 54 else left // scale
+    expected.append((result % 2**width) % 2**(16 if dest_half else 32))
+  assert expanded.registers[dest_half][8].tolist() == expected
+  assert folded.registers[dest_half][8].tolist() == expected
+
+
+@pytest.mark.parametrize('dest_half', [False, True])
+def test_repeated_half_constant_complements_are_narrowed_before_each_shift(dest_half):
+  constants = (0xabcd0000, 0xdead7fff, 0xbeef8000, 0x1234ffff)
+  group = machine([0], [1], True, constants)
+  # REPEAT=3; SRC1_R advances by complete constant slots. SRC2 stays fixed.
+  word = cat2(55, True, dest_half, 0x1000, modifiers=(1, 0)) | (3 << 40) | (1 << 43)
+  run(group, word)
+  assert group.registers[dest_half][8:12, 0].tolist() == [32767, 16384, 16383, 0]
+
+
+MULTIPLY_SOURCES = [(None, 0)] + list(itertools.product([0, 1], [300, -300, 32767, -32768]))
+
+
+@pytest.mark.parametrize('half', [False, True])
+@pytest.mark.parametrize('dest_half', [False, True])
+@pytest.mark.parametrize('constant_role,constant_value', MULTIPLY_SOURCES)
+def test_mul_s24_keeps_the_signed_product_until_destination_conversion(half, dest_half, constant_role, constant_value):
+  # Products cross 16-bit boundaries in both directions, but half sources fit
+  # exactly in signed 16 bits. The oracle receives the original numeric values.
+  values = [-32768, -32767, -301, -1, 0, 1, 301, 32767]
+  pairs = list(itertools.product(values, repeat=2))
+  a, b = ([pair[i] for pair in pairs] for i in (0, 1))
+  if constant_role == 0:
+    a = [constant_value] * len(a)
+  if constant_role == 1:
+    b = [constant_value] * len(b)
+  # Half constants ignore the upper 16 bits. Full MUL_S24 ignores the upper
+  # eight bits while sign-interpreting its selected low-24-bit integer.
+  slot = (0xbeef0000 | (constant_value % 2**16)) if half else (0xa5000000 | (constant_value % 2**24))
+  group = machine(a, b, half, (slot,))
+  sources = [0x1000 if constant_role == 0 else 0, 0x1000 if constant_role == 1 else 1]
+  assert run(group, cat2(49, half, dest_half, *sources))[0].op == 'mul.s24'
+  expected = [(left * right) % 2**(16 if dest_half else 32) for left, right in zip(a, b)]
+  assert group.registers[dest_half][8].tolist() == expected
+
+
+@pytest.mark.parametrize('dest_half', [False, True])
+def test_full_mul_s24_wraps_its_product_at_32_bits(dest_half):
+  # Hand-calculated products include selected 24-bit extrema and overflow.
+  group = machine([0x007fffff, 0x00800000, 0x01ffffff, 0xffffffff],
+                  [0x007fffff, 0x00800000, 2, 0x00800000], False)
+  run(group, cat2(49, False, dest_half))
+  expected = [0xff000001, 0x00000000, 0xfffffffe, 0x00800000]
+  assert group.registers[dest_half][8].tolist() == [value % 2**(16 if dest_half else 32) for value in expected]
+
+
+NARROW_OPERATIONS = [(16, 'add.u', operator.add), (17, 'add.s', operator.add), (18, 'sub.u', operator.sub),
+                     (19, 'sub.s', operator.sub), (22, 'min.u', min), (23, 'min.s', min),
+                     (24, 'max.u', max), (25, 'max.s', max)]
+
+
+@pytest.mark.parametrize('opcode,name,operation', NARROW_OPERATIONS)
+@pytest.mark.parametrize('dest_half', [False, True])
+@pytest.mark.parametrize('constant_role', [None, 0, 1])
+def test_ordinary_half_integer_results_still_complete_before_widening(opcode, name, operation, dest_half, constant_role):
+  # The MUL_S24 exception must not turn a half ADD/SUB into full arithmetic or
+  # change signed/unsigned constant comparisons and their destination extension.
+  a, b = [65535, 32767, 32768, 0, 1, 0x1234], [1, 1, 65535, 65535, 32768, 0x4321]
+  slot = 0xbeefffff
+  if constant_role == 0:
+    a = [65535] * len(a)
+  if constant_role == 1:
+    b = [65535] * len(b)
+  group = machine(a, b, True, (slot,))
+  sources = [0x1000 if constant_role == 0 else 0, 0x1000 if constant_role == 1 else 1]
+  assert run(group, cat2(opcode, True, dest_half, *sources))[0].op == name
+  expected = []
+  for left, right in zip(a, b):
+    if name.endswith('.s'):
+      left, right = signed_integer(left, 16), signed_integer(right, 16)
+    result = operation(left, right) % 2**16
+    if name.endswith('.s'):
+      result = signed_integer(result, 16)
+    expected.append(result % 2**(16 if dest_half else 32))
+  assert group.registers[dest_half][8].tolist() == expected
+
+
+def test_half_multiply_then_widen_remains_distinct_from_a_full_product():
+  # An explicitly half destination loses bits; a later COV must not recover
+  # them. A630-6 preserves the wider product only when that destination allows it.
+  half_product, full_product = (machine([300, -300], [300, 300], True) for _ in range(2))
+  run(half_product, cat2(49, True, True))
+  run(full_product, cat2(49, True, False))
+  conversion = Instruction('mov', {'SRC_TYPE': 4, 'DST_TYPE': 5},
+                           {'DST': Operand('register', 9), 'SRC': Operand('register', 8, True)}, 1 << 61)
+  half_product.alu(conversion, np.arange(2), 0)
+  assert half_product.registers[0][9].tolist() == [24464, 0xffffa070]
+  assert full_product.registers[0][8].tolist() == [90000, 0xfffea070]

--- a/test/mockgpu/qcom/test_integration.py
+++ b/test/mockgpu/qcom/test_integration.py
@@ -1,0 +1,82 @@
+"""These process-level checks require the real MOCK+QCOM HCQ2 submission path."""
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from tinygrad.helpers import DEV
+
+
+class TestQCOMIntegration(unittest.TestCase):
+  def run_qcom(self, code, renderer=None):
+    renderer = renderer or DEV.target('QCOM').renderer or 'IR3'
+    with tempfile.TemporaryDirectory() as cache:
+      result = subprocess.run([sys.executable, '-c', code], cwd=pathlib.Path(__file__).parents[3],
+                              env={**os.environ, 'DEV':f'MOCK+QCOM:{renderer}', 'CACHELEVEL':'0', 'PARALLEL':'0', 'XDG_CACHE_HOME':cache},
+                              capture_output=True, text=True, timeout=60)
+    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+    self.assertNotIn('Exception ignored', result.stderr)
+    self.assertNotIn('Traceback', result.stderr)
+    return result.stdout
+
+  def test_real_submissions_cover_odd_shapes_and_repeated_programs(self):
+    self.run_qcom('''import numpy as np
+from tinygrad import Device, Tensor, dtypes
+Device["QCOM"]
+from test.mockgpu.mockgpu import drivers
+driver = drivers[0]
+for size in (1,3,17,65,257):
+  before = sum(ctx.queued for ctx in driver.contexts.values())
+  left = np.arange(size,dtype=np.int32) * 19 - 77
+  right = np.arange(size,dtype=np.int32) * -7 + 5
+  result = (Tensor(left,dtype=dtypes.int32) + Tensor(right,dtype=dtypes.int32)).numpy()
+  np.testing.assert_array_equal(result,left+right)
+  assert sum(ctx.queued for ctx in driver.contexts.values()) > before
+  assert all(ctx.retired == ctx.queued and not ctx.pending for ctx in driver.contexts.values())
+assert driver.error is None
+''')
+
+  def test_emitted_instruction_bytes_are_required_for_execution(self):
+    output = self.run_qcom('''from tinygrad import Tensor, dtypes
+from tinygrad.runtime.support.compiler_mesa import IR3Compiler
+original = IR3Compiler.compile
+def unsupported_instruction(self, source):
+  library = original(self, source)
+  image = self.unpack_lib(library)[3]
+  return library[:-len(image)] + bytes.fromhex("ffffffffffffffff") + image[8:]
+IR3Compiler.compile = unsupported_instruction
+try:
+  (Tensor([2,5,9],dtype=dtypes.int32) + Tensor([7,4,3],dtype=dtypes.int32)).tolist()
+except RuntimeError as error:
+  assert "IR3" in str(error), str(error)
+  from test.mockgpu.mockgpu import drivers
+  assert drivers[0].error is not None
+  print("compiled instruction mutation rejected")
+else:
+  raise AssertionError("modified machine code unexpectedly executed")
+''', renderer='IR3')
+    self.assertIn('compiled instruction mutation rejected', output)
+
+  def test_mapping_churn_does_not_leave_trackers_or_guest_authority(self):
+    self.run_qcom('''from tinygrad import Device
+device = Device["QCOM"]
+from test.mockgpu.mockgpu import drivers
+driver = drivers[0]
+before = len(driver.memory.mappings),len(driver.allocations),len(driver.tracked_addresses)
+for attempt in range(100):
+  buffer = device._gpu_alloc(17)
+  address = buffer.va_addr
+  device._gpu_free(buffer)
+  try:
+    driver.memory.transaction().read(address,1)
+  except ValueError:
+    pass
+  else:
+    raise AssertionError("freed guest address remained readable")
+assert (len(driver.memory.mappings),len(driver.allocations),len(driver.tracked_addresses)) == before
+''')
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/mockgpu/qcom/test_launch_admission.py
+++ b/test/mockgpu/qcom/test_launch_admission.py
@@ -1,0 +1,110 @@
+"""A630-2: static launch admission must precede even a resumable prefix.
+
+All shader decoding and host-memory boundaries are inert in these tests.
+"""
+import contextlib, unittest
+from unittest.mock import patch
+from tinygrad.runtime.autogen import mesa
+from tinygrad.runtime.ops_qcom import pkt4_hdr, qreg
+from test.mockgpu.qcom import emu, qcomdriver, qcomgpu
+from test.mockgpu.qcom.test_pm4 import Memory, launch_words, packet, signal
+
+
+def invocation_launch(memory, role, index):
+  words = launch_words(memory)
+  config = dict(wgidconstid=0xfc, localidregid=0xfc, wgsizeconstid=0xfc, wgoffsetconstid=0xfc)
+  config[role] = index
+  # Override the named ABI register immediately before the dispatch packet.
+  return words[:-5] + (pkt4_hdr(mesa.REG_A6XX_SP_CS_CONST_CONFIG_0, 1), qreg.a6xx_sp_cs_const_config_0(**config)) + words[-5:]
+
+
+def wait_for(memory):
+  address = memory.base + 4
+  return packet(mesa.CP_WAIT_REG_MEM, qreg.cp_wait_reg_mem_0(function=mesa.WRITE_GE, poll=mesa.POLL_MEMORY),
+                address & 0xffffffff, address >> 32, 1, 0xffffffff, 32)
+
+
+@contextlib.contextmanager
+def inert_driver(memory, command):
+  with patch.object(emu, 'decode', return_value=(emu.Instruction('end', {}, {}, 0),)), \
+       patch.object(qcomdriver, 'read_host', side_effect=memory.read), \
+       patch.object(qcomdriver, 'write_host', side_effect=memory.write) as publish, \
+       patch.object(qcomdriver, 'validate_host_mapping', side_effect=memory.validate):
+    driver = qcomdriver.QCOMDriver()
+    driver.memory.map(memory.base, len(memory.data), owner=memory)
+    context = driver.contexts[1] = qcomdriver.Context(1, queued=1)
+    context.pending.append((command, 1, 0))
+    yield driver, context, publish
+
+
+class TestLaunchAdmission(unittest.TestCase):
+  def test_planner_and_executor_agree_for_every_encoded_base(self):
+    with patch.object(emu, 'decode', return_value=(emu.Instruction('end', {}, {}, 0),)):
+      for role in ('wgidconstid', 'localidregid'):
+        for index in range(256):
+          with self.subTest(role=role, index=index):
+            memory = Memory(65536)
+            words = invocation_launch(memory, role, index)
+            wgid, lid = (index, 0xfc) if role == 'wgidconstid' else (0xfc, index)
+            accepted = index <= 241 or index == 0xfc
+            # Expected admission is independently stated, not derived from the
+            # shared validator: the executor must retain its defensive check.
+            if accepted:
+              emu.execute(b'', b'', (1, 1, 1), (1, 1, 1), wgid, lid, memory)
+              self.assertIsInstance(qcomgpu.compile_plan(words, memory)[-1], qcomgpu.Launch)
+            else:
+              with self.assertRaisesRegex(RuntimeError, 'invalid invocation register'):
+                emu.execute(b'', b'', (1, 1, 1), (1, 1, 1), wgid, lid, memory)
+              with self.assertRaises(qcomgpu.PM4Fault):
+                qcomgpu.compile_plan(words, memory)
+
+  def test_executor_rejects_bases_outside_encoded_range(self):
+    with patch.object(emu, 'decode', return_value=(emu.Instruction('end', {}, {}, 0),)):
+      for wgid, lid in ((-1, 0xfc), (256, 0xfc), (0xfc, -1), (0xfc, 256)):
+        with self.subTest(wgid=wgid, lid=lid), self.assertRaisesRegex(RuntimeError, 'invalid invocation register'):
+          emu.execute(b'', b'', (1, 1, 1), (1, 1, 1), wgid, lid, Memory())
+
+  def test_invalid_suffix_rejects_before_prefix_with_or_without_wait(self):
+    for role in ('wgidconstid', 'localidregid'):
+      for index in (*range(242, 252), 253, 254, 255):
+        for blocked in (False, True):
+          with self.subTest(role=role, index=index, blocked=blocked):
+            memory = Memory(65536)
+            suffix = invocation_launch(memory, role, index)
+            command = signal(memory.base, 123) + (wait_for(memory) if blocked else ()) + suffix
+            original = bytes(memory.data)
+            with inert_driver(memory, command) as (driver, context, publish), \
+                 patch.object(qcomgpu.MemoryAction, 'apply', side_effect=AssertionError('prefix reached application')):
+              with self.assertRaises(qcomgpu.PM4Fault):
+                driver.drain()
+              publish.assert_not_called()
+              self.assertEqual(bytes(memory.data), original)
+              self.assertEqual(list(context.pending), [(command, 1, 0)])
+              self.assertEqual((context.queued, context.retired), (1, 0))
+              self.assertFalse(driver.executing)
+
+  def test_valid_boundaries_keep_wait_progress_and_do_not_replay_prefix(self):
+    for role in ('wgidconstid', 'localidregid'):
+      for index in (0, 241, 252):
+        with self.subTest(role=role, index=index):
+          memory = Memory(65536)
+          command = signal(memory.base, 123) + wait_for(memory) + invocation_launch(memory, role, index)
+          with inert_driver(memory, command) as (driver, context, publish):
+            driver.drain()
+            self.assertEqual(memory.read(memory.base, 4), (123).to_bytes(4, 'little'))
+            self.assertEqual(context.pending[0][2], 1)
+            self.assertEqual(context.retired, 0)
+            self.assertEqual(publish.call_count, 1)
+            # Another context/caller may update the signal while this one waits.
+            # Resumption starts at the wait and must preserve that newer value.
+            memory.write(memory.base, (456).to_bytes(4, 'little'))
+            memory.write(memory.base + 4, (1).to_bytes(4, 'little'))
+            driver.drain()
+            self.assertEqual(memory.read(memory.base, 4), (456).to_bytes(4, 'little'))
+            self.assertFalse(context.pending)
+            self.assertEqual(context.retired, 1)
+            self.assertEqual(publish.call_count, 1)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/mockgpu/qcom/test_mad24.py
+++ b/test/mockgpu/qcom/test_mad24.py
@@ -1,0 +1,60 @@
+"""Signed 24-bit multiply-add emitted by QCOMCL image address arithmetic."""
+import struct
+import numpy as np
+import pytest
+from tinygrad import Tensor, dtypes
+from test.mockgpu.qcom import emu
+from test.mockgpu.qcom.test_control import state
+from test.mockgpu.qcom.test_qcomcl import requires_qcomcl, source_kernel
+
+
+def mad24_word(destination=3):
+  # ir3-cat3.xml: opcode5, full sources r0.x/r0.y/r0.z, destination r0.w.
+  return (3 << 61) | (5 << 55) | (destination << 32) | (1 << 47) | (2 << 16)
+
+
+def test_signed_mad24_uses_low_signed_24_bits_and_full_accumulator():
+  left = [0x007fffff, 0x00800000, 0xfffffff9, 0xaa800001]
+  right = [3, -3, -17, 0x00ffffff]
+  accumulator = [0x7fffffff, 0x81234567, 0xdeadbeef, 0x89abcdef]
+  group = state()
+  for index, values in enumerate((left, right, accumulator)):
+    group.registers[0][index] = np.array([value & 0xffffffff for value in values], dtype=np.uint32)
+  group.run(emu.decode(struct.pack('<2Q', mad24_word(), 6 << 55)))
+  expected = []
+  for a, b, c in zip(left, right, accumulator):
+    a, b = ((value & 0xffffff) - (0x1000000 if value & 0x800000 else 0) for value in (a, b))
+    expected.append((a * b + c) & 0xffffffff)
+  np.testing.assert_array_equal(group.registers[0][3], expected)
+
+
+def test_signed_mad24_rejects_half_destination():
+  # Mesa ir3_cf.c and ir3_validate.c prohibit mad.x24 with 16-bit in/out.
+  with pytest.raises(RuntimeError, match='full registers'):
+    emu.decode(struct.pack('<Q', mad24_word() | (1 << 46)))
+
+
+@requires_qcomcl
+def test_compiler_generated_signed_mad24_with_negative_inputs_and_wrapping_sum(monkeypatch):
+  source = '''__kernel void signed_mad(__global int *out, __global const int *left,
+                                      __global const int *right, __global const int *accumulator) {
+    uint i = get_global_id(0);
+    out[i] = mad24(left[i], right[i], accumulator[i]);
+  }'''
+  left = np.array([8388607, -8388608, -7, 1234567, -8000000], np.int32)
+  right = np.array([-13, 3, -17, 2000000, -8000000], np.int32)
+  accumulator = np.array([2147483647, -2147483648, -123456789, 987654321, 19], np.int32)
+  executed: set[str] = set()
+  original = emu.execute
+
+  def record(image, *args, **kwargs):
+    result = original(image, *args, **kwargs)
+    executed.update(instruction.op for instruction in emu.decode(image))
+    return result
+
+  monkeypatch.setattr(emu, 'execute', record)
+  actual = source_kernel(source, 'signed_mad', Tensor.empty(5, dtype=dtypes.int32), (1, 1, 1), (5, 1, 1),
+                         inputs=(Tensor(left), Tensor(right), Tensor(accumulator))).numpy()
+  expected = (left.astype(np.int64) * right + accumulator).astype(np.int32)
+  np.testing.assert_array_equal(actual, expected)
+  assert 'mad.s24' in executed, executed

--- a/test/mockgpu/qcom/test_mad24.py
+++ b/test/mockgpu/qcom/test_mad24.py
@@ -58,3 +58,29 @@ def test_compiler_generated_signed_mad24_with_negative_inputs_and_wrapping_sum(m
   expected = (left.astype(np.int64) * right + accumulator).astype(np.int32)
   np.testing.assert_array_equal(actual, expected)
   assert 'mad.s24' in executed, executed
+
+
+@pytest.mark.parametrize('factor', [1, 0xffff, 0x10000, 0x12345678, 0xabcd5678, 0x1234ffff])
+def test_constant_mad_u16_uses_full_banks_low_digits_and_full_accumulator(factor):
+  # Exact QCOMCL instruction from ulong multiplication: mad.u16 r0.w,c23.x,r1.z,r0.w.
+  # Ordinary masked-uint and ushort-cast kernels emit the same form with renamed
+  # GPRs. Complete compiler-image probes establish the reference, not this helper.
+  word = 0x600340030003105c
+  code = emu.decode(struct.pack('<2Q', word, 6 << 55))
+  assert code[0].op == 'mad.u16' and code[0].raw == word
+  assert [(code[0].operands[name].kind, code[0].operands[name].index, code[0].operands[name].half)
+          for name in ('DST', 'SRC1', 'SRC2', 'SRC3')] == [
+            ('register', 3, False), ('constant', 92, False), ('register', 6, False), ('register', 3, False)]
+  left = [0, 1, 0xffff, 0x10000, 0xffff0001, 0x12345678, 0x8000ffff, 0xffffffff]
+  accumulator = [0x12345678, 0xffffffff, 7, 0x80000000, 0xfeed0001, 0x10000, 0x89abcdef, 0xffff0000]
+  group = state(lanes=len(left))
+  group.constant_demotion = False
+  group.constants = np.zeros(128, dtype=np.uint32)
+  group.constants[92] = factor
+  group.constants[46] = 0xfacebeef  # Packed half slot 92 must not alias full slot 92.
+  group.registers[0][6], group.registers[0][3] = left, accumulator
+  group.registers[1][6] = np.arange(3, 3 + len(left), dtype=np.uint16)
+  group.registers[1][3] = np.arange(11, 11 + len(left), dtype=np.uint16)
+  group.run(code)
+  expected = [((factor & 0xffff) * (value & 0xffff) + addend) & 0xffffffff for value, addend in zip(left, accumulator)]
+  np.testing.assert_array_equal(group.registers[0][3], expected)

--- a/test/mockgpu/qcom/test_memory_carrier.py
+++ b/test/mockgpu/qcom/test_memory_carrier.py
@@ -1,0 +1,72 @@
+import gc, weakref
+import numpy as np
+import pytest
+from test.mockgpu.qcom.emu import Instruction, Operand, Workgroup
+from test.mockgpu.qcom.test_emu import Memory
+
+
+def group(memory=None, count=3, private_bytes=8, shared_bytes=16):
+  return Workgroup(bytes(64),(count,1,1),(0,0,0),0xfc,0xfc,0xfc,memory or Memory({}),shared_bytes,private_bytes)
+
+
+@pytest.mark.parametrize('width',[1,2,4])
+def test_global_unaligned_gather_and_scatter_across_allocations(width):
+  memory=Memory({0x1000:bytes(range(16)),0x2000:bytes(range(16,32))})
+  machine=group(memory)
+  addresses=np.array([0x1001,0x2003,0x1007],np.uint64)
+  expected=[int.from_bytes(memory.read(int(address),width),'little') for address in addresses]
+  np.testing.assert_array_equal(machine.transfer(addresses,width),expected)
+  values=np.array([0xfedcba98,0x01234567,0],np.uint32)
+  machine.transfer(addresses,width,values)
+  for address,value in zip(addresses,values):
+    assert memory.read(int(address),width) == int(value).to_bytes(4,'little')[:width]
+
+
+@pytest.mark.parametrize('space', ['l','p'])
+def test_unaligned_half_storage_keeps_address_space_identity(space):
+  machine=group()
+  machine.registers[0][0]=[1,3,5]
+  machine.registers[1][1]=[0xaabb,0xccdd,0xeeff]
+  store=Instruction('st'+space,{'TYPE':2,'SIZE':1},dict(DST=Operand('register',0),SRC=Operand('register',1)),6<<61)
+  load=Instruction('ld'+space,{'TYPE':2,'SIZE':1},dict(DST=Operand('register',2),SRC=Operand('register',0)),6<<61)
+  machine.run((store,load,Instruction('end',{}, {},0)))
+  np.testing.assert_array_equal(machine.registers[1][2],[0xaabb,0xccdd,0xeeff])
+
+
+def test_private_span_cannot_spill_into_the_following_lane():
+  machine=group(count=2,private_bytes=8)
+  machine.private[:] = np.arange(16,dtype=np.uint8).reshape(2,8)
+  machine.registers[0][0]=[7,0]
+  machine.registers[1][1]=[0xaaaa,0xbbbb]
+  before=machine.private.copy()
+  store=Instruction('stp',{'TYPE':2,'SIZE':1},dict(DST=Operand('register',0),SRC=Operand('register',1)),6<<61)
+  with pytest.raises(RuntimeError,match='out of bounds'):
+    machine.run((store,Instruction('end',{}, {},0)))
+  np.testing.assert_array_equal(machine.private,before)
+
+
+def test_global_view_retains_its_buffer_owner_through_permission_check():
+  class OwnedBytes(bytearray): pass
+  class EphemeralMemory:
+    def region(self,address,size):
+      data=OwnedBytes(bytes(8))
+      self.owner=weakref.ref(data)
+      return 0x1000,data
+    def validate(self,address,size,write=False):
+      gc.collect()
+      assert self.owner() is not None
+      assert (address,size,write)==(0x1001,4,True)
+  memory=EphemeralMemory()
+  group(memory,count=1).transfer(np.array([0x1001],np.uint64),4,np.array([0x12345678],np.uint32))
+
+
+def test_overlapping_global_stores_preserve_lane_order():
+  memory=Memory({0x1000:bytes(8)})
+  group(memory,count=2).transfer(np.array([0x1000,0x1001],np.uint64),4,np.array([0x11223344,0xaabbccdd],np.uint32))
+  assert memory.read(0x1000,5) == bytes.fromhex('44ddccbbaa')
+
+def test_global_store_does_not_admit_floating_values_as_integer_bits():
+  memory=Memory({0x1000:bytes(8)})
+  with pytest.raises(TypeError):
+    group(memory,count=1).transfer(np.array([0x1000],np.uint64),4,np.array([1.5],np.float32))
+  assert memory.read(0x1000,8) == bytes(8)

--- a/test/mockgpu/qcom/test_pm4.py
+++ b/test/mockgpu/qcom/test_pm4.py
@@ -1,0 +1,302 @@
+import ctypes, mmap, os, pathlib, struct, subprocess, sys, tempfile
+import unittest
+from tinygrad.runtime.autogen import mesa
+from tinygrad.runtime.ops_qcom import pkt4_hdr, pkt7_hdr, qreg
+
+
+class Memory:
+  def __init__(self, size=64):
+    self.base = 0x123400001000
+    self.data = bytearray(size)
+
+  def read(self, address, size):
+    offset = address - self.base
+    if offset < 0 or offset + size > len(self.data):
+      raise ValueError("outside test allocation")
+    return bytes(self.data[offset:offset + size])
+
+  def validate(self, address, size, write=False): self.read(address, size)
+
+  def region(self, address, size):
+    self.read(address, size)
+    return self.base, self.data
+
+  def write(self, address, data):
+    self.read(address, len(data))
+    offset = address - self.base
+    self.data[offset:offset + len(data)] = data
+
+
+def packet(opcode, *payload):
+  return (pkt7_hdr(opcode, len(payload)), *payload)
+
+
+def signal(address, value):
+  return packet(mesa.CP_EVENT_WRITE, mesa.CACHE_FLUSH_TS, address & 0xffffffff, address >> 32, value)
+
+
+class TestPM4(unittest.TestCase):
+  def test_relocated_signal_and_full_word_wait(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command
+    memory = Memory()
+    address = memory.base + 12
+    words = signal(address, 0x12340007) + packet(mesa.CP_WAIT_REG_MEM,
+      qreg.cp_wait_reg_mem_0(function=mesa.WRITE_GE, poll=mesa.POLL_MEMORY),
+      address & 0xffffffff, address >> 32, 5, 0xffffffff, 32)
+    self.assertEqual(execute_command(words, memory, 1), (True, 2))
+    self.assertEqual(memory.read(address, 4), struct.pack('<I', 0x12340007))
+
+  def test_unsatisfied_wait_does_not_execute_tail(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command
+    memory = Memory()
+    words = packet(mesa.CP_WAIT_REG_MEM,
+      qreg.cp_wait_reg_mem_0(function=mesa.WRITE_GE, poll=mesa.POLL_MEMORY),
+      memory.base & 0xffffffff, memory.base >> 32, 1, 0xffffffff, 32) + signal(memory.base + 8, 123)
+    self.assertEqual(execute_command(words, memory, 1), (False, 0))
+    self.assertEqual(memory.data, bytes(64))
+
+  def test_validate_whole_stream_before_any_effect(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+    memory = Memory()
+    with self.assertRaisesRegex(PM4Fault, "opcode"):
+      execute_command(signal(memory.base, 77) + packet(0x7f), memory, 1)
+    self.assertEqual(memory.data, bytes(64))
+
+  def test_parity_and_reserved_bits(self):
+    from test.mockgpu.qcom.qcomgpu import decode_packets, PM4Fault
+    valid = signal(0x100001000, 9)
+    for bit in (14, 15, 23, 24, 27):
+      with self.subTest(bit=bit), self.assertRaises(PM4Fault):
+        decode_packets((valid[0] ^ (1 << bit), *valid[1:]))
+    type4 = (pkt4_hdr(mesa.REG_A6XX_SP_CS_CONFIG, 1), mesa.A6XX_SP_CS_CONFIG_ENABLED)
+    for bit in (7, 26, 27):
+      with self.subTest(type4_bit=bit), self.assertRaises(PM4Fault):
+        decode_packets((type4[0] ^ (1 << bit), type4[1]))
+
+  def test_truncation_and_packet_extent(self):
+    from test.mockgpu.qcom.qcomgpu import decode_packets, PM4Fault
+    valid = signal(0x1000, 9)
+    for count in range(1, len(valid)):
+      with self.subTest(count=count), self.assertRaises(PM4Fault):
+        decode_packets(valid[:count])
+    with self.assertRaises(PM4Fault):
+      decode_packets((pkt4_hdr(0x3ffff, 2), 0, 0))
+
+  def test_unknown_register_and_dispatch_without_state(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+    for words in ((pkt4_hdr(1, 1), 0), packet(mesa.CP_EXEC_CS, 0, 1, 1, 1)):
+      with self.subTest(words=words), self.assertRaises(PM4Fault):
+        execute_command(words, Memory(), 1)
+
+  def test_signal_alignment_and_unsupported_wait(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+    memory = Memory()
+    with self.assertRaises(PM4Fault):
+      execute_command(signal(memory.base + 1, 7), memory, 1)
+    words = packet(mesa.CP_WAIT_REG_MEM, 0, memory.base & 0xffffffff, memory.base >> 32, 0, 0xffffffff, 32)
+    with self.assertRaises(PM4Fault):
+      execute_command(words, memory, 1)
+
+  def test_partial_wait_mask_is_explicitly_unsupported(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+    memory = Memory()
+    words = packet(mesa.CP_WAIT_REG_MEM, qreg.cp_wait_reg_mem_0(function=mesa.WRITE_GE, poll=mesa.POLL_MEMORY),
+                   memory.base & 0xffffffff, memory.base >> 32, 5, 0xff, 32)
+    with self.assertRaises(PM4Fault): execute_command(words, memory, 1)
+
+  def test_signal_prefix_then_wait_resumes_without_repeating_prefix(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command
+    memory = Memory()
+    words = signal(memory.base, 7) + packet(mesa.CP_WAIT_REG_MEM,
+      qreg.cp_wait_reg_mem_0(function=mesa.WRITE_GE, poll=mesa.POLL_MEMORY),
+      (memory.base + 4) & 0xffffffff, (memory.base + 4) >> 32, 1, 0xffffffff, 32) + signal(memory.base + 8, 9)
+    self.assertEqual(execute_command(words, memory, 1), (False, 1))
+    memory.write(memory.base, struct.pack('<I', 8))
+    memory.write(memory.base + 4, struct.pack('<I', 1))
+    self.assertEqual(execute_command(words, memory, 1, start=1), (True, 3))
+    self.assertEqual(struct.unpack('<3I', memory.read(memory.base, 12)), (8, 1, 9))
+
+  def test_late_unmapped_signal_does_not_publish_valid_prefix(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+    memory = Memory()
+    with self.assertRaises(PM4Fault): execute_command(signal(memory.base, 7) + signal(memory.base + 64, 9), memory, 1)
+    self.assertEqual(memory.data, bytes(64))
+
+  def test_each_timestamp_samples_its_action_time(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command
+    from unittest.mock import patch
+    memory = Memory()
+    control = qreg.cp_reg_to_mem_0(reg=mesa.REG_A6XX_CP_ALWAYS_ON_COUNTER, cnt=2, _64b=True)
+    words = packet(mesa.CP_REG_TO_MEM, control, memory.base & 0xffffffff, memory.base >> 32)
+    words += packet(mesa.CP_REG_TO_MEM, control, (memory.base + 8) & 0xffffffff, (memory.base + 8) >> 32)
+    with patch('test.mockgpu.qcom.qcomgpu.time.perf_counter_ns', side_effect=(10000, 15000)):
+      self.assertEqual(execute_command(words, memory, 999), (True, 2))
+    self.assertEqual(struct.unpack('<2Q', memory.read(memory.base, 16)), (192, 288))
+
+
+ADD = (0x202cc00000000002, 0x202cc00100000003, 0x202cc00300000004, 0x202cc00400000005,
+       0x202cc00500000000, 0x202cc00600000001, 0xc006000201800001, 0xc00600070180c001,
+       0x5218080200070002, 0xc0c60b0001800004, 0x0300000000000000)
+
+
+def launch_words(memory, groups=(1, 1, 1), local=(1, 1, 1), image=None, base=None):
+  # This fixture uses the current producer's named registers and a real IR3 add.
+  if base is None: base = memory.base
+  image_address, constants_address, private_address = base + 4096, base + 8192, base + 16384
+  memory.write(image_address, image if image is not None else struct.pack('<11Q', *ADD).ljust(128, b'\0'))
+  memory.write(constants_address, struct.pack('<3Q', base + 16, base + 20, base + 24))
+  memory.write(base + 20, struct.pack('<2I', 7, 19))
+  words = packet(mesa.CP_SET_MARKER, mesa.RM6_COMPUTE)
+  def reg(address, *values):
+    nonlocal words
+    words += (pkt4_hdr(address, len(values)), *values)
+  reg(mesa.REG_A6XX_SP_UPDATE_CNTL, qreg.a6xx_sp_update_cntl(cs_state=True, cs_uav=True))
+  reg(mesa.REG_A6XX_SP_UPDATE_CNTL, 0)
+  reg(mesa.REG_A6XX_SP_CS_TSIZE, 0x80)
+  reg(mesa.REG_A6XX_SP_CS_USIZE, 0x40)
+  reg(mesa.REG_A6XX_SP_MODE_CNTL, qreg.a6xx_sp_mode_cntl(isammode=mesa.ISAMMODE_GL, constant_demotion_enable=True))
+  reg(mesa.REG_A6XX_SP_PERFCTR_SHADER_MASK, mesa.A6XX_SP_PERFCTR_SHADER_MASK_CS)
+  reg(mesa.REG_A6XX_TPL1_MODE_CNTL, qreg.a6xx_tpl1_mode_cntl(isammode=mesa.ISAMMODE_GL))
+  reg(mesa.REG_A6XX_TPL1_DBG_ECO_CNTL, 0)
+  reg(mesa.REG_A6XX_SP_CS_NDRANGE_0,
+      qreg.a6xx_sp_cs_ndrange_0(kerneldim=3, localsizex=local[0]-1, localsizey=local[1]-1, localsizez=local[2]-1),
+      groups[0]*local[0], 0, groups[1]*local[1], 0, groups[2]*local[2], 0, 0xccc0cf,
+      0xfc | qreg.a6xx_sp_cs_wge_cntl(threadsize=mesa.THREAD64), *groups)
+  reg(mesa.REG_A6XX_SP_CS_CNTL_0, qreg.a6xx_sp_cs_cntl_0(threadsize=mesa.THREAD64, fullregfootprint=2),
+      qreg.a6xx_sp_cs_cntl_1(constantrammode=mesa.CONSTLEN_256, shared_size=1), 0, 0,
+      image_address & 0xffffffff, image_address >> 32, 0, private_address & 0xffffffff, private_address >> 32, 0)
+  words += packet(mesa.CP_LOAD_STATE6_FRAG,
+                  qreg.cp_load_state6_0(state_type=mesa.ST_CONSTANTS, state_src=mesa.SS6_INDIRECT,
+                                       state_block=mesa.SB6_CS_SHADER, num_unit=128), constants_address & 0xffffffff, constants_address >> 32)
+  words += packet(mesa.CP_LOAD_STATE6_FRAG,
+                  qreg.cp_load_state6_0(state_type=mesa.ST_SHADER, state_src=mesa.SS6_INDIRECT,
+                                       state_block=mesa.SB6_CS_SHADER, num_unit=1), image_address & 0xffffffff, image_address >> 32)
+  reg(mesa.REG_A6XX_SP_REG_PROG_ID_0, 0xfcfcfcfc, 0xfcfcfcfc, 0xfcfcfcfc, 0xfc,
+      qreg.a6xx_sp_cs_const_config(constlen=64, enabled=True)) # Four vec4 constants per encoded unit.
+  reg(mesa.REG_A6XX_SP_CS_PVT_MEM_STACK_OFFSET, 2) # 4096 bytes per SP, encoded in 2 KiB units
+  reg(mesa.REG_A6XX_SP_CS_INSTR_SIZE, 1)
+  reg(mesa.REG_A6XX_SP_CS_CONFIG, mesa.A6XX_SP_CS_CONFIG_ENABLED)
+  reg(mesa.REG_A6XX_SP_CS_CONST_CONFIG_0,
+      qreg.a6xx_sp_cs_const_config_0(wgidconstid=0xfc, wgsizeconstid=0xfc, wgoffsetconstid=0xfc, localidregid=0xfc),
+      qreg.a6xx_sp_cs_wge_cntl(linearlocalidregid=0xfc, threadsize=mesa.THREAD64))
+  return words + packet(mesa.CP_EXEC_CS, 0, *groups)
+
+
+class TestPM4Launch(unittest.TestCase):
+  def test_shared_memory_encoding_covers_zero_and_every_nonzero_value(self):
+    from test.mockgpu.qcom.qcomgpu import compile_plan, Launch
+    expected = (32768, 2048, 3072, 4096, 5120, 6144, 7168, 8192,
+                9216, 10240, 11264, 12288, 13312, 14336, 15360, 16384,
+                17408, 18432, 19456, 20480, 21504, 22528, 23552, 24576,
+                25600, 26624, 27648, 28672, 29696, 30720, 31744, 32768)
+    for encoded, byte_size in enumerate(expected):
+      memory = Memory(65536)
+      words = launch_words(memory)
+      control = qreg.a6xx_sp_cs_cntl_1(constantrammode=mesa.CONSTLEN_256, shared_size=encoded)
+      words = words[:-5] + (pkt4_hdr(mesa.REG_A6XX_SP_CS_CNTL_1, 1), control) + words[-5:]
+      action = next(action for action in compile_plan(words, memory) if isinstance(action, Launch))
+      self.assertEqual(action.shared_bytes, byte_size, f"shared encoding {encoded}")
+
+  def test_constant_configuration_bounds_uploaded_bytes(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+    for config in (0x100, 0x110, 0x40): # Zero capacity, 1024-byte capacity, disabled bank.
+      memory = Memory(65536)
+      words = launch_words(memory)
+      words = words[:-5] + (pkt4_hdr(mesa.REG_A6XX_SP_CS_CONST_CONFIG, 1), config) + words[-5:]
+      with self.assertRaises(PM4Fault): execute_command(signal(memory.base, 1) + words, memory, 1)
+      self.assertEqual(memory.read(memory.base, 4), b'\0' * 4)
+
+  def test_stack_offset_units_cover_all_four_sp_allocations(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+    memory = Memory(24576) # Private base + 8192 bytes; four 4096-byte SP slices do not fit.
+    with self.assertRaises(PM4Fault): execute_command(launch_words(memory), memory, 1)
+
+  def test_staged_shader_modification_is_rejected_without_host_commit(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+    from test.mockgpu.qcom.qcomdriver import AddressSpace
+    with mmap.mmap(-1, 65536) as host:
+      base = ctypes.addressof(ctypes.c_char.from_buffer(host))
+      space = AddressSpace()
+      space.map(base, 65536, host)
+      setup = space.transaction()
+      words = launch_words(setup, base=base)
+      setup.commit()
+      before = bytes(host)
+      with self.assertRaisesRegex(PM4Fault, "shader.*changed"):
+        execute_command(signal(base + 4096, 0xffffffff) + words, space.transaction(), 1)
+      self.assertEqual(bytes(host), before)
+
+  def test_real_shader_launch_uses_relocated_constants_and_dimensions(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command
+    for groups, local in (((1, 1, 1), (1, 1, 1)), ((2, 1, 1), (2, 1, 1))):
+      memory = Memory(65536)
+      words = launch_words(memory, groups, local)
+      self.assertEqual(execute_command(words, memory, 1), (True, 1))
+      self.assertEqual(struct.unpack('<I', memory.read(memory.base + 16, 4)), (26,))
+
+  def test_shader_encoding_is_validated_before_prefix_signal(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+    memory = Memory(65536)
+    words = launch_words(memory, image=b'\xff' * 128)
+    with self.assertRaises(PM4Fault): execute_command(signal(memory.base, 77) + words, memory, 1)
+    self.assertEqual(memory.read(memory.base, 4), b'\0' * 4)
+
+  def test_unsupported_image_config_and_dispatch_mismatch_are_rejected(self):
+    from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+    memory = Memory(65536)
+    words = launch_words(memory)
+    for corrupt in (words[:-4] + (0, 2, 1, 1),
+                    words[:-5] + (pkt4_hdr(mesa.REG_A6XX_SP_CS_CONFIG, 1),
+                                  mesa.A6XX_SP_CS_CONFIG_ENABLED | (1 << mesa.A6XX_SP_CS_CONFIG_NTEX__SHIFT)) + words[-5:]):
+      with self.assertRaises(PM4Fault): execute_command(corrupt, memory, 1)
+      self.assertEqual(memory.read(memory.base + 16, 4), b'\0' * 4)
+
+  def test_qcom_producer_scales_private_stack_register_and_keeps_byte_allocation(self):
+    # Generate a real NIR kernel; vary only its compiler-private-memory metadata
+    # to cover the allocation unit boundary without relying on a chosen spill.
+    code = '''import struct
+from tinygrad import Device, Tensor
+from tinygrad.engine.realize import lower_and_compile
+from tinygrad.runtime.autogen import mesa
+from tinygrad.runtime.ops_qcom import QCOMComputeQueue
+from tinygrad.runtime.support.hcq2 import EncodeCtx, make_submit
+from tinygrad.uop.ops import Ops
+from test.mockgpu.qcom.qcomgpu import decode_packets
+device = Device["QCOM"]
+linear, _ = Tensor.linear_with_vars(Tensor.ones(1).contiguous())
+call = lower_and_compile(linear).src[0]
+program = call.src[0]
+for private_bytes, expected_field, expected_allocation in ((0, 2, 16384), (1, 512, 4194304),
+                                                          (512, 512, 4194304), (513, 1024, 8388608)):
+  variant = mesa.struct_ir3_shader_variant.from_buffer_copy(program.src[3].arg)
+  variant.pvtmem_size = private_bytes
+  binary = bytes(variant) + program.src[3].arg[len(bytes(variant)):]
+  changed = program.replace(src=program.src[:3] + (program.src[3].replace(arg=binary),))
+  current = call.replace(src=(changed, *call.src[1:]))
+  queue = QCOMComputeQueue(EncodeCtx(("QCOM",)), make_submit(current, devs="QCOM", queue="COMPUTE:0"))
+  queue.exec(current, changed)
+  for packet in decode_packets(struct.unpack(f"<{len(queue.blob)//4}I", queue.blob)):
+    config_index = mesa.REG_A6XX_SP_CS_CONST_CONFIG - packet.target
+    if packet.kind == 4 and 0 <= config_index < len(packet.words):
+      assert packet.words[config_index] == 0x140, ("constant config", packet.words[config_index])
+    index = mesa.REG_A6XX_SP_CS_PVT_MEM_STACK_OFFSET - packet.target
+    if packet.kind == 4 and 0 <= index < len(packet.words):
+      assert packet.words[index] == expected_field, (private_bytes, packet.words[index], expected_field)
+      break
+  else: raise AssertionError("stack register was not emitted")
+  requested = {node.max_numel() for _, value in queue.patches for node in value.toposort() if node.op is Ops.PARAM and node.tag == "stack"}
+  assert requested == {expected_allocation}, (private_bytes, requested, expected_allocation)
+  buffer = device._ensure_stack_size(requested.pop())
+  assert buffer.nbytes == expected_allocation and buffer._buf.size == expected_allocation
+print("private stack producer passed")
+'''
+    with tempfile.TemporaryDirectory() as cache:
+      result = subprocess.run([sys.executable, "-c", code], cwd=pathlib.Path(__file__).parents[3],
+                              env={**os.environ, "DEV":"MOCK+QCOM:IR3", "PARALLEL":"0", "XDG_CACHE_HOME":cache},
+                              capture_output=True, text=True, timeout=20)
+    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+    self.assertIn("private stack producer passed", result.stdout)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/mockgpu/qcom/test_pm4_folding.py
+++ b/test/mockgpu/qcom/test_pm4_folding.py
@@ -1,0 +1,143 @@
+"""PM4 folding contracts: exact admission policy and a typed memory-effect carrier."""
+from dataclasses import FrozenInstanceError
+from unittest.mock import patch
+import struct
+import unittest
+from tinygrad.runtime.autogen import mesa
+from tinygrad.runtime.ops_qcom import qreg
+from test.mockgpu.qcom import qcomgpu as pm4
+from test.mockgpu.qcom.test_pm4 import Memory, packet, signal, launch_words
+
+
+class TestPM4Folding(unittest.TestCase):
+  def memory_packets(self, memory):
+    address = memory.base
+    wait = packet(mesa.CP_WAIT_REG_MEM, qreg.cp_wait_reg_mem_0(function=mesa.WRITE_GE, poll=mesa.POLL_MEMORY),
+                  address & 0xffffffff, address >> 32, 7, 0xffffffff, 32)
+    timestamp = packet(mesa.CP_REG_TO_MEM, qreg.cp_reg_to_mem_0(reg=mesa.REG_A6XX_CP_ALWAYS_ON_COUNTER, cnt=2, _64b=True),
+                       (address + 8) & 0xffffffff, (address + 8) >> 32)
+    return signal(address, 7), wait, timestamp
+
+  def test_memory_actions_share_named_effect_contract(self):
+    # One typed carrier makes the operation, address, operand, and footprint inspectable.
+    memory = Memory()
+    words = sum(self.memory_packets(memory), ())
+    actions = pm4.compile_plan(words, memory)
+    self.assertTrue(hasattr(pm4, 'MemoryAction'), 'scalar PM4 effects need a common typed carrier')
+    memory_actions = [action for action in actions if isinstance(action, pm4.MemoryAction)]
+    self.assertEqual(len(memory_actions), len(actions))
+    self.assertEqual([(action.operation, action.address, action.value, action.size) for action in memory_actions],
+                     [('store', memory.base, 7, 4), ('wait', memory.base, 7, 4), ('timestamp', memory.base + 8, 0, 8)])
+    with self.assertRaises(FrozenInstanceError): setattr(actions[0], 'address', 0)
+    self.assertEqual(memory.data, bytes(64))
+    with patch('test.mockgpu.qcom.qcomgpu.time.perf_counter_ns', return_value=10000) as clock:
+      self.assertEqual(pm4.execute_command(words, memory, 999), (True, 3))
+    self.assertEqual(clock.call_count, 1)
+    self.assertEqual(struct.unpack('<I4xQ', memory.read(memory.base, 16)), (7, 192))
+
+  def test_each_memory_effect_is_prevalidated_with_its_full_access(self):
+    # A valid prefix cannot publish when any later effect lacks its exact access footprint.
+    for denied_operation, denied_write, denied_size in (('store', True, 4), ('wait', False, 4), ('timestamp', True, 8)):
+      memory = Memory()
+      store, wait, timestamp = self.memory_packets(memory)
+      words = {'store':store, 'wait':wait, 'timestamp':timestamp}[denied_operation]
+      original = memory.validate
+      def reject_selected(address, size, write=False):
+        if address != memory.base + 24 and size == denied_size and write == denied_write: raise ValueError('effect access denied')
+        return original(address, size, write)
+      with patch.object(memory, 'validate', side_effect=reject_selected):
+        with self.subTest(operation=denied_operation), self.assertRaisesRegex(pm4.PM4Fault, 'effect access denied'):
+          pm4.execute_command(signal(memory.base + 24, 123) + words, memory, 1)
+      self.assertEqual(memory.data, bytes(64))
+
+  def test_wait_resume_does_not_resample_a_completed_timestamp(self):
+    memory = Memory()
+    store, wait, timestamp = self.memory_packets(memory)
+    with patch('test.mockgpu.qcom.qcomgpu.time.perf_counter_ns', return_value=10000) as clock:
+      self.assertEqual(pm4.execute_command(timestamp + wait + store, memory, 1), (False, 1))
+      memory.write(memory.base, struct.pack('<I', 7))
+      self.assertEqual(pm4.execute_command(timestamp + wait + store, memory, 1, start=1), (True, 3))
+    self.assertEqual(clock.call_count, 1)
+
+  def test_exact_register_whitelist_and_masks(self):
+    # Independent baseline values prevent grouped policy from admitting neighbors or extra bits.
+    fixed = {
+      0xa9b2:(0,), 0xa9ba:(0x80,), 0xaa00:(0x40,), 0xab00:(5,2), 0xae0f:(0x20,),
+      0xb309:(2,1), 0xb600:(0,), 0xb983:(0xfcfcfcfc,), 0xb984:(0xfcfcfcfc,), 0xb985:(0xfcfcfcfc,), 0xb986:(0xfc,),
+      0xb992:(0,), 0xb994:(0,), 0xb996:(0,), 0xbb08:(0, 0x60),
+    }
+    masks = {
+      0xa9b0:0x1fdffe, 0xa9b1:0x7f, 0xa9b3:0xffffffff, 0xa9b4:0xffffffff, 0xa9b5:0xffffffff, 0xa9b6:0xff, 0xa9b7:0xffffffff,
+      0xa9b8:0xffffffff, 0xa9b9:0x3ffff, 0xa9bc:0xffffffff, 0xa9bd:0x7ffff, 0xb987:0x1ff, 0xb990:0xffffffff,
+      0xb991:0xffffffff, 0xb993:0xffffffff, 0xb995:0xffffffff, 0xb997:0xffffffff, 0xb998:0x2ff,
+      0xb999:0xffffffff, 0xb99a:0xffffffff, 0xb99b:0xffffffff,
+      # A6xx compute resource counts and their optional 64-bit table bases.
+      # Bindless flags (bits 0-3 of SP_CS_CONFIG) remain outside this contract.
+      0xa9bb:0x1fffff00, 0xa9e2:0xffffffff, 0xa9e3:0xffffffff, 0xa9e6:0xffffffff, 0xa9e7:0xffffffff,
+      0xa9f2:0xffffffff, 0xa9f3:0xffffffff, 0xb180:0xffffffff, 0xb181:0xffffffff,
+    }
+    self.assertEqual(pm4.FIXED_REGISTERS, fixed)
+    self.assertEqual(pm4.REGISTER_MASKS, masks)
+    self.assertEqual(set(pm4.FIXED_REGISTERS) & set(pm4.REGISTER_MASKS), set())
+    allowed = set(pm4.FIXED_REGISTERS) | set(pm4.REGISTER_MASKS)
+    for address in range(0xa000, 0xbc00):
+      if address in allowed: continue
+      with self.subTest(address=hex(address)), self.assertRaises(pm4.PM4Fault): pm4.register_write({}, address, 0)
+    for address, mask in pm4.REGISTER_MASKS.items():
+      for bit in range(32):
+        registers:dict[int, int] = {}
+        if mask & (1 << bit):
+          pm4.register_write(registers, address, 1 << bit)
+          self.assertEqual(registers, {address:1 << bit})
+        else:
+          with self.assertRaises(pm4.PM4Fault): pm4.register_write(registers, address, 1 << bit)
+          self.assertEqual(registers, {})
+
+  def test_packet_shapes_remain_exact(self):
+    # Structural matching must retain every prior payload-length boundary before effects.
+    memory = Memory(65536)
+    state = launch_words(memory)[:-5]
+    store, wait, timestamp = self.memory_packets(memory)
+    cases = [packet(mesa.CP_WAIT_FOR_IDLE), packet(mesa.CP_WAIT_MEM_WRITES), packet(mesa.CP_SET_MARKER, mesa.RM6_COMPUTE),
+             packet(mesa.CP_EVENT_WRITE, mesa.CACHE_INVALIDATE), store, wait, timestamp, packet(mesa.CP_EXEC_CS, 0, 1, 1, 1),
+             packet(mesa.CP_LOAD_STATE6_FRAG, qreg.cp_load_state6_0(state_type=mesa.ST_SHADER, state_src=mesa.SS6_INDIRECT,
+                    state_block=mesa.SB6_CS_SHADER, num_unit=1), (memory.base + 4096) & 0xffffffff, (memory.base + 4096) >> 32)]
+    for encoded in cases:
+      parsed, = pm4.decode_packets(encoded)
+      pm4.compile_plan(state + encoded, memory)
+      malformed = [parsed.words[:size] for size in range(len(parsed.words))] + [parsed.words + (0,)]
+      for payload in malformed:
+        with self.subTest(opcode=parsed.target, payload=payload), self.assertRaises(pm4.PM4Fault):
+          pm4.execute_command(signal(memory.base, 123) + state + packet(parsed.target, *payload), memory, 1)
+        self.assertEqual(memory.read(memory.base, 4), bytes(4))
+
+  def test_launch_keeps_its_explicit_observation_fields(self):
+    memory = Memory(65536)
+    action, = pm4.compile_plan(launch_words(memory), memory)
+    assert isinstance(action, pm4.Launch)
+    self.assertEqual((action.image_address, action.constants_address, action.constants_size),
+                     (memory.base + 4096, memory.base + 8192, 2048))
+    self.assertEqual((action.groups, action.local, action.wgid, action.lid, action.wgsize, action.shared_bytes, action.private_bytes),
+                     ((1, 1, 1), (1, 1, 1), 0xfc, 0xfc, 0xfc, 2048, 0))
+
+  def test_malformed_payload_diagnostics_are_preserved(self):
+    cases = (
+      (mesa.CP_WAIT_FOR_IDLE, (1,), 'invalid wait packet length'),
+      (mesa.CP_WAIT_MEM_WRITES, (1,), 'invalid wait packet length'),
+      (mesa.CP_SET_MARKER, (0,), 'unsupported PM4 marker mode'),
+      (mesa.CP_EVENT_WRITE, (), 'unsupported PM4 event write'),
+      (mesa.CP_WAIT_REG_MEM, (), 'unsupported PM4 memory wait'),
+      (mesa.CP_REG_TO_MEM, (), 'unsupported PM4 register-to-memory transfer'),
+      (mesa.CP_LOAD_STATE6_FRAG, (), 'unsupported PM4 state load length'),
+      (mesa.CP_EXEC_CS, (), 'unsupported PM4 compute dispatch'),
+      (0x7f, (), 'unsupported PM4 opcode 0x7f'),
+    )
+    for opcode, payload, expected in cases:
+      memory = Memory()
+      with self.subTest(opcode=opcode), self.assertRaises(pm4.PM4Fault) as raised:
+        pm4.execute_command(signal(memory.base, 123) + packet(opcode, *payload), memory, 1)
+      self.assertEqual(str(raised.exception), expected)
+      self.assertEqual(memory.data, bytes(64))
+
+
+if __name__ == '__main__': unittest.main()

--- a/test/mockgpu/qcom/test_qcomcl.py
+++ b/test/mockgpu/qcom/test_qcomcl.py
@@ -1,0 +1,435 @@
+"""QCOMCL compiler-generated programs exercise the real HCQ2 mock launch path."""
+import math
+import struct
+import numpy as np
+import pytest
+from tinygrad import Device, Tensor, TinyJit, Variable, dtypes
+from tinygrad.helpers import DEV
+from tinygrad.uop.ops import KernelInfo, Ops, ProgramInfo, UOp
+
+
+requires_qcomcl = pytest.mark.skipif(
+  DEV.device != 'QCOM' or DEV.renderer != 'CL' or not DEV.interface.startswith('MOCK'),
+  reason='requires the MOCK+QCOM:CL compiler profile',
+)
+
+
+def source_kernel(source, name, output, groups, local, *, inputs=()):
+  """Compile ordinary OpenCL and retain the normal PROGRAM/kernargs/HCQ2 route."""
+  renderer = Device[output.device].renderer
+  binary = renderer.compiler.compile_cached(source)
+
+  def program(out, *args):
+    sink = UOp.sink(out, *args, arg=KernelInfo(name=name))
+    info = ProgramInfo(name=name, global_size=groups, local_size=local, globals=tuple(range(len(args) + 1)),
+                       outs=(0,), ins=tuple(range(1, len(args) + 1)), target=renderer.target)
+    return UOp(Ops.PROGRAM, arg=info, src=(sink, UOp(Ops.LINEAR, src=tuple(sink.toposort())),
+                                         UOp(Ops.SOURCE, arg=source), UOp(Ops.BINARY, arg=binary)))
+
+  return Tensor.custom_kernel(output, *inputs, fxn=program)[0]
+
+
+@requires_qcomcl
+def test_generated_add_uses_every_lane_and_workgroup():
+  # Reject a missing CL dispatch, missing group offset, or incorrect address carry.
+  left = (np.arange(407, dtype=np.float32).reshape(37, 11) - 93) / 8
+  right = (np.arange(407, dtype=np.float32).reshape(37, 11) % 19) / 4
+  np.testing.assert_array_equal((Tensor(left) + Tensor(right)).numpy(), left + right)
+
+
+@requires_qcomcl
+@pytest.mark.parametrize('groups,local', [((3, 1, 1), (7, 1, 1)), ((2, 3, 2), (3, 2, 2))])
+def test_opencl_invocation_builtins(groups, local):
+  # Each builtin occupies its own output field; swaps cannot cancel numerically.
+  source = '''__kernel void invocation_ids(__global uint *out) {
+    uint x = get_global_id(0), y = get_global_id(1), z = get_global_id(2);
+    uint index = (x + get_global_size(0) * (y + get_global_size(1) * z)) * 19;
+    for (uint axis = 0; axis < 3; axis++) {
+      out[index + axis] = get_global_id(axis);
+      out[index + 3 + axis] = get_local_id(axis);
+      out[index + 6 + axis] = get_group_id(axis);
+      out[index + 9 + axis] = get_global_size(axis);
+      out[index + 12 + axis] = get_local_size(axis);
+      out[index + 15 + axis] = get_num_groups(axis);
+    }
+    out[index + 18] = get_work_dim();
+  }'''
+  global_size = tuple(g * l for g, l in zip(groups, local))
+  output = Tensor.empty(math.prod(global_size) * 19, dtype=dtypes.uint32)
+  actual = source_kernel(source, 'invocation_ids', output, groups, local).numpy().reshape(-1, 19)
+  expected = []
+  for z in range(global_size[2]):
+    for y in range(global_size[1]):
+      for x in range(global_size[0]):
+        position = (x, y, z)
+        expected.append((*position, *(v % l for v, l in zip(position, local)),
+                         *(v // l for v, l in zip(position, local)), *global_size, *local, *groups, 3))
+  np.testing.assert_array_equal(actual, np.array(expected, dtype=np.uint32))
+
+
+@requires_qcomcl
+def test_jit_refreshes_arguments_without_reusing_previous_values():
+  # Cached shader/command structure must still consume the current input buffers.
+  @TinyJit
+  def calculate(left, right):
+    return (left * 3 + right).realize()
+
+  for step in range(5):
+    left = np.arange(65, dtype=np.int32) - step * 7
+    right = np.arange(65, dtype=np.int32)[::-1].copy() + step * 11
+    np.testing.assert_array_equal(calculate(Tensor(left), Tensor(right)).numpy(), left * 3 + right)
+
+
+@requires_qcomcl
+@pytest.mark.parametrize('dtype', [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64])
+def test_generated_integer_widths_and_selection(dtype):
+  # Compiler-selected narrow loads, widened arithmetic and writeback keep values.
+  left = np.array([0, 1, 7, 31, 63, 127], dtype=dtype)
+  right = np.array([127, 63, 31, 7, 1, 0], dtype=dtype)
+  expected = np.where(left > right, left * 3, right + 5).astype(dtype)
+  a, b = Tensor(left), Tensor(right)
+  np.testing.assert_array_equal((a > b).where(a * 3, b + 5).numpy(), expected)
+
+
+@requires_qcomcl
+def test_generated_signed_pointer_offsets_stay_within_the_input():
+  # Reversing a buffer exercises negative index offsets without invalid addresses.
+  values = np.arange(53, dtype=np.int32) * 17 - 421
+  np.testing.assert_array_equal((Tensor(values).flip(0) + 3).numpy(), values[::-1] + 3)
+
+
+@requires_qcomcl
+def test_generated_signed_byte_extremes_are_extended_before_arithmetic():
+  values = np.array([-128, -127, -17, -1, 0, 1, 17, 127], dtype=np.int8)
+  actual = (Tensor(values).cast(dtypes.int16) + 200).numpy()
+  np.testing.assert_array_equal(actual, values.astype(np.int16) + 200)
+
+
+@requires_qcomcl
+def test_generated_reduction_and_barrier():
+  values = (np.arange(13 * 67, dtype=np.float32).reshape(13, 67) % 23 - 11) / 8
+  np.testing.assert_array_equal(Tensor(values).sum(axis=1).numpy(), values.sum(axis=1))
+
+
+@requires_qcomcl
+def test_generated_float_arithmetic_and_conversion():
+  values = np.array([-10.25, -3.5, -.125, 0, .5, 1.25, 7.75], dtype=np.float32)
+  actual = (Tensor(values) * 1.234375 + 2.345703125).numpy()
+  expected = values * np.float32(1.234375) + np.float32(2.345703125)
+  np.testing.assert_array_equal(actual, expected)
+  np.testing.assert_array_equal(Tensor(values).cast(dtypes.int32).numpy(), values.astype(np.int32))
+
+
+@requires_qcomcl
+def test_jit_refreshes_symbolic_scalar_arguments():
+  # The compiled loop bound comes from a current scalar kernarg on every replay.
+  @TinyJit
+  def reduce_columns(value):
+    return (value * 2 - 1).sum().realize()
+
+  values = np.arange(30, dtype=np.float32).reshape(3, 10) / 8
+  data = Tensor(values).realize()
+  for columns in (1, 3, 5, 2, 10):
+    bound = Variable('columns', 1, 10).bind(columns)
+    np.testing.assert_array_equal(reduce_columns(data[:, :bound]).numpy(), (values[:, :columns] * 2 - 1).sum())
+
+
+@requires_qcomcl
+def test_compiler_packed_half_constants_are_not_float32_demotions():
+  # The QCOMCL compiler stores two half constants per 32-bit constant word.
+  source = '''#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+  __kernel void packed_half(__global float *out) {
+    uint i = get_global_id(0);
+    half value = convert_half_rte((float)i / 8.0f - 4.0f);
+    half product = value * (half)1.234375f;
+    out[i] = convert_float(product + (half)2.345703125f);
+  }'''
+  values = (np.arange(65, dtype=np.float32) / 8 - 4).astype(np.float16)
+  expected = (values * np.float16(1.234375) + np.float16(2.345703125)).astype(np.float32)
+  actual = source_kernel(source, 'packed_half', Tensor.empty(65, dtype=dtypes.float32), (5, 1, 1), (13, 1, 1)).numpy()
+  np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.parametrize('index,expected', [(0, 0xbd00), (1, 0x40b1)])
+def test_half_sources_select_both_halves_of_a_packed_constant_word(index, expected):
+  from test.mockgpu.qcom.emu import Workgroup, decode, validate_constant_footprint
+  from test.mockgpu.qcom.test_emu import Memory
+  # Inert exact-value fixture: -1.25 and 2.345703125 occupy adjacent half slots.
+  group = Workgroup(struct.pack('<HH', 0xbd00, 0x40b1), (1, 1, 1), (0, 0, 0),
+                    0xfc, 0xfc, 0xfc, Memory({}), 0, 0, constant_demotion=False)
+  word = (2 << 61) | (6 << 53) | (2 << 32) | 0x1000 | index
+  instructions = decode(struct.pack('<2Q', word, 6 << 55))
+  validate_constant_footprint(instructions, 1, constant_demotion=False)
+  group.run(instructions)
+  assert int(group.registers[1][2, 0]) == expected
+
+
+@pytest.mark.parametrize('dispatch,shader_cl,sampler_cl', [(True, False, False), (False, True, True), (True, True, False)])
+def test_inconsistent_compiler_modes_reject_before_a_prefix_store(dispatch, shader_cl, sampler_cl):
+  from tinygrad.runtime.autogen import mesa
+  from tinygrad.runtime.ops_qcom import pkt4_hdr, qreg
+  from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+  from test.mockgpu.qcom.test_pm4 import Memory, launch_words, packet, signal
+  memory = Memory(65536)
+  words = launch_words(memory)[:-5]
+  words += (pkt4_hdr(mesa.REG_A6XX_SP_MODE_CNTL, 1),
+            qreg.a6xx_sp_mode_cntl(isammode=mesa.ISAMMODE_CL if shader_cl else mesa.ISAMMODE_GL, constant_demotion_enable=not shader_cl))
+  words += (pkt4_hdr(mesa.REG_A6XX_TPL1_MODE_CNTL, 1),
+            qreg.a6xx_tpl1_mode_cntl(isammode=mesa.ISAMMODE_CL if sampler_cl else mesa.ISAMMODE_GL))
+  words += packet(mesa.CP_RUN_OPENCL, 0) if dispatch else packet(mesa.CP_EXEC_CS, 0, 1, 1, 1)
+  with pytest.raises(PM4Fault):
+    execute_command(signal(memory.base, 91) + words, memory, 0)
+  assert memory.read(memory.base, 4) == bytes(4)
+
+
+def test_short_opencl_builtin_bank_rejects_before_a_prefix_store():
+  from tinygrad.runtime.autogen import mesa
+  from tinygrad.runtime.ops_qcom import pkt4_hdr, qreg
+  from test.mockgpu.qcom.qcomgpu import execute_command, PM4Fault
+  from test.mockgpu.qcom.test_pm4 import Memory, launch_words, packet, signal
+  memory = Memory(65536)
+  words = launch_words(memory)[:-5]
+  words += (pkt4_hdr(mesa.REG_A6XX_SP_MODE_CNTL, 1), qreg.a6xx_sp_mode_cntl(isammode=mesa.ISAMMODE_CL))
+  words += (pkt4_hdr(mesa.REG_A6XX_TPL1_MODE_CNTL, 1), qreg.a6xx_tpl1_mode_cntl(isammode=mesa.ISAMMODE_CL))
+  words += packet(mesa.CP_LOAD_STATE6_FRAG,
+                  qreg.cp_load_state6_0(state_type=mesa.ST_CONSTANTS, state_src=mesa.SS6_INDIRECT,
+                                       state_block=mesa.SB6_CS_SHADER, num_unit=4),
+                  (memory.base + 8192) & 0xffffffff, (memory.base + 8192) >> 32)
+  words += packet(mesa.CP_RUN_OPENCL, 0)
+  with pytest.raises(PM4Fault):
+    execute_command(signal(memory.base, 91) + words, memory, 0)
+  assert memory.read(memory.base, 4) == bytes(4)
+
+
+@requires_qcomcl
+def test_generated_nonzero_entry_point_and_helper_return():
+  # The ordinary compiler places this helper before the kernel's entry point.
+  # Starting at zero or returning to the wrong lane PC produces a wrong result.
+  source = '''__attribute__((noinline)) float helper(float value) { return value * value + 1.0f; }
+  __kernel void call_helper(__global float *out, __global const float *input) {
+    uint i = get_global_id(0);
+    out[i] = helper(input[i]);
+  }'''
+  values = (np.arange(21, dtype=np.float32) - 10) / 4
+  actual = source_kernel(source, 'call_helper', Tensor.empty(21, dtype=dtypes.float32), (7, 1, 1), (3, 1, 1),
+                         inputs=(Tensor(values),)).numpy()
+  np.testing.assert_array_equal(actual, values * values + 1)
+
+
+def test_callee_predicate_changes_are_included_in_constant_admission():
+  from test.mockgpu.qcom.emu import validate_constant_footprint
+  from test.mockgpu.qcom.test_constant_admission import END, constant_move, control
+  # Callee PREDF/PREDT can make the caller's JUMP fall through after RET.
+  for predicate in ('predf', 'predt'):
+    program = (control('call', 4), control('jump', 2), constant_move(7), END,
+               control(predicate), control('ret'))
+    with pytest.raises(RuntimeError, match='constant source span'):
+      validate_constant_footprint(program, 1)
+
+
+def test_entry_point_ignores_uncalled_helper_constants_but_checks_called_helpers():
+  from test.mockgpu.qcom.emu import validate_constant_footprint
+  from test.mockgpu.qcom.test_constant_admission import END, constant_move, control
+  program = (constant_move(7), control('ret'), END, control('call', -3), END)
+  validate_constant_footprint(program, 1, entry_pc=2)
+  with pytest.raises(RuntimeError, match='constant source span'):
+    validate_constant_footprint(program, 1, entry_pc=3)
+  with pytest.raises(RuntimeError, match='return.*without a call'):
+    validate_constant_footprint(program, 8, entry_pc=1)
+
+
+@pytest.mark.parametrize('entry', [-1, 1, True])
+def test_entry_point_must_select_an_existing_instruction(entry):
+  from test.mockgpu.qcom.emu import validate_constant_footprint
+  from test.mockgpu.qcom.test_constant_admission import END
+  with pytest.raises(RuntimeError, match='entry point'):
+    validate_constant_footprint((END,), 0, entry_pc=entry)
+
+
+@pytest.mark.parametrize('word,expected', [
+  (0x50f20001105f0000, [0, 0, 0xffffffff, 0]),
+  (0x40f5080500000000, [0, 0, 0, 0xffffffff]),
+])
+def test_generated_float_comparisons_keep_integer_mask_bits(word, expected):
+  from test.mockgpu.qcom.emu import Workgroup, decode
+  from test.mockgpu.qcom.test_emu import Memory
+  # Exact CMPV.F words emitted by the ordinary float-to-half conversion kernel.
+  # Numeric conversion of the result to float would corrupt the following masks.
+  group = Workgroup(bytes(96 * 4), (4, 1, 1), (0, 0, 0), 0xfc, 0xfc, 0xfc, Memory({}), 0, 0)
+  group.registers[0][0] = np.array([-1, 0, .5, np.nan], dtype=np.float32).view(np.uint32)
+  instructions = decode(struct.pack('<2Q', word, 6 << 55))
+  group.run(instructions)
+  destination = instructions[0].operands['DST'].index
+  np.testing.assert_array_equal(group.registers[0][destination], np.array(expected, dtype=np.uint32))
+
+
+def test_compiler_legacy_barrier_waits_for_later_lane_stores():
+  from test.mockgpu.qcom.emu import Instruction, decode
+  from test.mockgpu.qcom.test_control import END, R, branch, jump, state
+  # One lane reaches the barrier before the remaining lanes' stores at PC10.
+  # Replacing the barrier with a NOP makes lane0 observe stale neighbor bytes.
+  group = state(shared_bytes=16)
+  group.registers[0][248] = [0, 1, 1, 1]
+  group.registers[0][0] = [0, 4, 8, 12]
+  group.registers[0][1] = [1, 2, 3, 4]
+  group.registers[0][2] = [4, 8, 12, 0]
+  store = Instruction('stl', {'TYPE':3, 'SIZE':1}, {'DST':R(0), 'SRC':R(1)}, 6 << 61)
+  load = Instruction('ldl', {'TYPE':3, 'SIZE':1}, {'DST':R(3), 'SRC':R(2)}, 6 << 61)
+  # These exact legacy FENCE/BAR forms came from the QCOMCL GEMV compiler.
+  fence, barrier = decode(struct.pack('<2Q', 0xe098000000000000, 0xf000000000000000))
+  nop = Instruction('nop', {}, {}, 0)
+  group.run((branch(10), store, jump(3), nop, nop, barrier, load, jump(5), nop, nop, store, jump(-6), fence, END))
+  np.testing.assert_array_equal(group.registers[0][3], [2, 3, 4, 1])
+
+
+@pytest.mark.parametrize('extra', [1, 1 << 32, 1 << 45, 1 << 50])
+def test_legacy_barrier_does_not_admit_unrecognized_reserved_bits(extra):
+  from test.mockgpu.qcom.emu import decode
+  with pytest.raises(RuntimeError, match='unrecognized encoding'):
+    decode(struct.pack('<Q', 0xf000000000000000 | extra))
+
+
+def test_generated_unsigned_mad_uses_low_digits_and_preserves_its_wide_result():
+  from test.mockgpu.qcom.emu import Workgroup, decode
+  from test.mockgpu.qcom.test_emu import Memory
+  # Exact MAD.U16 from QCOMCL range reduction. Real compiler kernels establish
+  # full register slots despite the disassembler's HALF labels; multiplying
+  # only low16 digits and retaining carries are separate arithmetic obligations.
+  group = Workgroup(b'', (4, 1, 1), (0, 0, 0), 0xfc, 0xfc, 0xfc, Memory({}), 0, 0)
+  group.registers[False][5] = [0xdead03e8, 65535, 0x10000, 0xabc0007b]
+  group.registers[False][9] = [0xdead03e8, 0x1234ffff, 0xffffffff, 0xface01c8]
+  group.registers[False][6] = [2000, 65535, 7, 789]
+  group.run(decode(struct.pack('<2Q', 0x6004c80900068005, 6 << 55)))
+  np.testing.assert_array_equal(group.registers[False][9], np.array([1002000, 4294901760, 7, 56877], dtype=np.uint32))
+
+
+def test_generated_unsigned_comparison_masks_do_not_sign_extend_inputs():
+  from test.mockgpu.qcom.emu import Workgroup, decode
+  from test.mockgpu.qcom.test_emu import Memory
+  # Actual CMPV.U r0.x,r0.x,64 from QCOMCL's compiled software range reduction.
+  group = Workgroup(b'', (4, 1, 1), (0, 0, 0), 0xfc, 0xfc, 0xfc, Memory({}), 0, 0)
+  group.registers[False][0] = [0, 63, 64, 0xffffffff]
+  group.run(decode(struct.pack('<2Q', 0x4430000020400000, 6 << 55)))
+  np.testing.assert_array_equal(group.registers[False][0], np.array([0xffffffff, 0xffffffff, 0, 0], dtype=np.uint32))
+
+
+@requires_qcomcl
+def test_compiler_masked_mad_uses_full_register_inputs_and_accumulator():
+  # Current compiler loads these arguments into full registers and emits one
+  # MAD.U16. Its two multiplicands use low16 bits; the accumulator stays32 bits.
+  source = '''__kernel void masked_mad(__global uint *out, __global const uint *a,
+                                     __global const uint *b, __global const uint *c) {
+    uint i = get_global_id(0);
+    out[i] = (a[i] & 65535u) * (b[i] & 65535u) + c[i];
+  }'''
+  left = np.array([3, 0x10002, 65535, 0x1234ffff], dtype=np.uint32)
+  right = np.array([5, 0x20003, 65535, 0xf7654321], dtype=np.uint32)
+  addend = np.array([7, 0x12345678, 0xffffffff, 0xabcd1234], dtype=np.uint32)
+  expected = (((left & 65535).astype(np.uint64) * (right & 65535).astype(np.uint64) + addend) & 0xffffffff).astype(np.uint32)
+  actual = source_kernel(source, 'masked_mad', Tensor.empty(4, dtype=dtypes.uint32), (2, 1, 1), (2, 1, 1),
+                         inputs=(Tensor(left), Tensor(right), Tensor(addend))).numpy()
+  np.testing.assert_array_equal(actual, expected)
+
+
+@requires_qcomcl
+def test_compiler_unsigned_halving_add_avoids_overflow(monkeypatch):
+  from test.mockgpu.qcom.emu import Workgroup
+  # Standard OpenCL hadd computes the full mathematical sum before halving.
+  # The vendor compiler maps it directly to full-width ADD.U with EI set.
+  source = '''__kernel void half_sum(__global uint *out, __global const uint *a, __global const uint *b) {
+    uint i = get_global_id(0);
+    out[i] = hadd(a[i], b[i]);
+  }'''
+  left = np.array([0, 1, 0xffffffff, 0xffffffff, 0x80000000, 0x12345678], dtype=np.uint32)
+  right = np.array([1, 2, 0xffffffff, 1, 0x80000000, 0x9abcdef0], dtype=np.uint32)
+  expected = np.array([0, 1, 0xffffffff, 0x80000000, 0x80000000, 0x56789ab4], dtype=np.uint32)
+  observed = []
+  original = Workgroup.alu
+
+  def record(self, instruction, lanes, repeat):
+    if instruction.op == 'add.u' and instruction.fields.get('EI'):
+      observed.append(len(lanes))
+    return original(self, instruction, lanes, repeat)
+
+  monkeypatch.setattr(Workgroup, 'alu', record)
+  actual = source_kernel(source, 'half_sum', Tensor.empty(6, dtype=dtypes.uint32), (2, 1, 1), (3, 1, 1),
+                         inputs=(Tensor(left), Tensor(right))).numpy()
+  np.testing.assert_array_equal(actual, expected)
+  assert sum(observed) == 6
+
+
+@pytest.mark.parametrize('word', [0x5230800000010000, 0x5200800000010000, 0x5210c00000010000])
+def test_other_ei_arithmetic_forms_remain_unsupported(word):
+  from test.mockgpu.qcom.emu import decode
+  # The new exception covers only the compiler-proven full-width unsigned form.
+  with pytest.raises(RuntimeError, match='unsupported execution modifier'):
+    decode(struct.pack('<2Q', word, 6 << 55))
+
+
+@requires_qcomcl
+def test_compiler_vector_select_uses_integer_msb_not_float_condition(monkeypatch):
+  from test.mockgpu.qcom.emu import Workgroup
+  # OpenCL vector select uses the condition's MSB. NaN/-0-shaped integer words
+  # distinguish that contract from interpreting condition bits as floating data.
+  source = '''__kernel void vector_select(__global float4 *out, __global const float4 *left,
+                                        __global const float4 *right, __global const int4 *condition) {
+    uint i = get_global_id(0);
+    out[i] = select(left[i], right[i], condition[i]);
+  }'''
+  left = np.arange(10, 18, dtype=np.float32)
+  right = np.arange(30, 38, dtype=np.float32)
+  condition = np.array([0, 0x80000000, 0xffffffff, 0x7fc00000, 0xffc00000, 1, 0xfffffffe, 0x7fffffff], dtype=np.uint32).view(np.int32)
+  observed = []
+  original = Workgroup.alu
+
+  def record(self, instruction, lanes, repeat):
+    if instruction.op == 'sel.s32':
+      observed.append(len(lanes))
+    return original(self, instruction, lanes, repeat)
+
+  monkeypatch.setattr(Workgroup, 'alu', record)
+  actual = source_kernel(source, 'vector_select', Tensor.empty(8, dtype=dtypes.float32), (2, 1, 1), (1, 1, 1),
+                         inputs=(Tensor(left), Tensor(right), Tensor(condition))).numpy()
+  np.testing.assert_array_equal(actual, np.array([10, 31, 32, 13, 34, 15, 36, 17], dtype=np.float32))
+  assert sum(observed) == 8
+
+
+@requires_qcomcl
+def test_compiler_packed_predicate_bits_guard_transposed_convolution_loads(monkeypatch):
+  from test.mockgpu.qcom.emu import Workgroup
+  # Several independent edge conditions live across the reduction loop. The
+  # compiler packs them into a half register and GETBIT restores each predicate.
+  values = (np.arange(2 * 4 * 9 * 9, dtype=np.float32).reshape(2, 4, 9, 9) % 11) - 5
+  weights = (np.arange(4 * 4 * 3 * 3, dtype=np.float32).reshape(4, 4, 3, 3) % 7) - 3
+  bias = np.array([-2, -1, 1, 2], dtype=np.float32)
+  expected = np.zeros((2, 4, 11, 11), dtype=np.float32)
+  for incoming in range(4):
+    for outgoing in range(4):
+      for y in range(3):
+        for x in range(3):
+          expected[:, outgoing, y:y+9, x:x+9] += values[:, incoming] * weights[incoming, outgoing, y, x]
+  expected += bias.reshape(1, 4, 1, 1)
+  observed = []
+  original = Workgroup.alu
+
+  def record(self, instruction, lanes, repeat):
+    if instruction.op == 'getbit.b':
+      observed.append(len(lanes))
+    return original(self, instruction, lanes, repeat)
+
+  monkeypatch.setattr(Workgroup, 'alu', record)
+  actual = Tensor(values).conv_transpose2d(Tensor(weights), Tensor(bias)).numpy()
+  np.testing.assert_array_equal(actual, expected)
+  assert sum(observed) > 0
+
+
+@pytest.mark.parametrize('word', [
+  0x4760000020000009,  # A normal GPR destination has no proven numeric result representation.
+  0x477040f920000009,  # Full-register packed input is not emitted by this producer fixture.
+  0x476000f900080009,  # A register-selected bit index is not qualified.
+  0x476000f920100009,  # Bit 16 lies beyond the admitted half-register source.
+])
+def test_other_getbit_forms_remain_unsupported(word):
+  from test.mockgpu.qcom.emu import decode
+  with pytest.raises(RuntimeError, match='unsupported GETBIT predicate form'):
+    decode(struct.pack('<2Q', word, 6 << 55))

--- a/test/mockgpu/qcom/test_relative_registers.py
+++ b/test/mockgpu/qcom/test_relative_registers.py
@@ -1,0 +1,137 @@
+"""Address-register indexing preserves per-lane data and checks every selected span."""
+import struct
+import numpy as np
+import pytest
+from test.mockgpu.qcom.emu import Workgroup, decode, validate_constant_footprint
+from test.mockgpu.qcom.test_emu import Memory
+
+
+def group_with_addresses(addresses, constants=b'', *, constant_demotion=True):
+  group = Workgroup(constants, (len(addresses), 1, 1), (0, 0, 0), 0xfc, 0xfc, 0xfc,
+                    Memory({}), 0, 0, constant_demotion=constant_demotion)
+  group.registers[True][0] = np.array(addresses, dtype=np.int16).view(np.uint16)
+  return group
+
+
+def run_words(group, *words):
+  group.run(decode(struct.pack('<' + 'Q' * (len(words) + 1), *words, 6 << 55)))
+
+
+# Mesa25.2.7 cat1 MOVA override: S16 source/destination, implicit a0.x (244).
+MOVA = 0x201100f400000000
+
+
+@pytest.mark.parametrize('left,right', [(8, 9), (16, 13), (200, 201)])
+def test_swizzle_source_bits_are_not_mistaken_for_relative_move_flags(left, right):
+  # Cat1 opcode2 uses source-register bits where opcode0 has relative flags.
+  group = group_with_addresses([0, 0])
+  group.registers[False][left], group.registers[False][right] = [11, 22], [33, 44]
+  swap = (1 << 61) | (2 << 57) | (3 << 50) | (3 << 46) | (right << 32) | (left << 16) | (right << 8) | left
+  run_words(group, swap)
+  np.testing.assert_array_equal(group.registers[False][left], [33, 44])
+  np.testing.assert_array_equal(group.registers[False][right], [11, 22])
+
+
+def test_immediate_mova_hazard_marker_is_not_a_repeated_source():
+  group = group_with_addresses([0, 0])
+  group.registers[False][23] = [11, 22]
+  immediate_mova = MOVA | (1 << 54) | (1 << 43) | 23
+  relative_read = (1 << 61) | (3 << 50) | (3 << 46) | (8 << 32) | (1 << 11)
+  run_words(group, immediate_mova, relative_read)
+  np.testing.assert_array_equal(group.registers[False][8], [11, 22])
+
+
+def test_mova_and_relative_register_read_select_each_lanes_value():
+  group = group_with_addresses([20, 23, 21, 22])
+  group.registers[False][20:24] = np.array([[11], [22], [33], [44]], dtype=np.uint32)
+  # MOV.U32 r2.x, r<a0.x>: bit11 selects relative source, bit10=0 selects GPR.
+  relative_read = (1 << 61) | (3 << 50) | (3 << 46) | (8 << 32) | (1 << 11)
+  run_words(group, MOVA, relative_read)
+  np.testing.assert_array_equal(group.registers[False][8], [11, 44, 22, 33])
+
+
+def test_relative_register_destination_keeps_lanes_and_source_values_separate():
+  group = group_with_addresses([20, 23, 21, 22])
+  group.registers[False][0] = [101, 202, 303, 404]
+  # Cat1 DST_REL=bit49; destination offset is unsigned in bits39:32.
+  relative_write = (1 << 61) | (3 << 50) | (3 << 46) | (1 << 49)
+  run_words(group, MOVA, relative_write)
+  np.testing.assert_array_equal(group.registers[False][20:24],
+                                [[101, 0, 0, 0], [0, 0, 303, 0], [0, 0, 0, 404], [0, 202, 0, 0]])
+
+
+@pytest.mark.parametrize('offset,typ', [(244, 4), (245, 2)])
+def test_relative_destination_offset_survives_the_mova_display_alias(offset, typ):
+  # Mesa displays these encodings as MOVA/MOVA1 and omits the relative OFFSET.
+  # The unsigned destination offset still combines with the signed a0 value.
+  group = group_with_addresses([-offset, 1 - offset])
+  group.registers[True][2] = [101, 202]
+  write = (1 << 61) | (typ << 50) | (typ << 46) | (1 << 49) | (offset << 32) | 2
+  run_words(group, MOVA, write)
+  assert group.registers[True][0, 0] == 101
+  assert group.registers[True][1, 1] == 202
+  np.testing.assert_array_equal(group.registers[True][2], [101, 202])
+
+
+def test_relative_source_offsets_are_signed():
+  group = group_with_addresses([21, 24, 22, 23])
+  group.registers[False][20:24] = np.array([[11], [22], [33], [44]], dtype=np.uint32)
+  relative_read = (1 << 61) | (3 << 50) | (3 << 46) | (8 << 32) | (1 << 11) | 0x3ff
+  run_words(group, MOVA, relative_read)
+  np.testing.assert_array_equal(group.registers[False][8], [11, 44, 22, 33])
+
+
+def test_relative_constants_use_current_address_for_each_lane():
+  constants = np.array([0.25, 1.5, 2.75, 3.125], dtype=np.float32).tobytes()
+  group = group_with_addresses([3, 0, 2, 1], constants)
+  # Cat1 bit10 selects constants rather than the GPR bank.
+  relative_read = (1 << 61) | (1 << 50) | (1 << 46) | (8 << 32) | (1 << 11) | (1 << 10)
+  instructions = decode(struct.pack('<3Q', MOVA, relative_read, 6 << 55))
+  validate_constant_footprint(instructions, 4)
+  group.run(instructions)
+  np.testing.assert_array_equal(group.registers[False][8].view(np.float32), [3.125, 0.25, 2.75, 1.5])
+
+
+def test_relative_packed_half_constants_use_half_slot_units():
+  group = group_with_addresses([0, 1], struct.pack('<I', 0x40b1bd00), constant_demotion=False)
+  convert = (1 << 61) | (1 << 46) | (8 << 32) | (1 << 11) | (1 << 10)
+  run_words(group, MOVA, convert)
+  np.testing.assert_array_equal(group.registers[False][8].view(np.float32), [-1.25, 2.345703125])
+
+
+def test_relative_cat2_constant_source_preserves_other_operand():
+  group = group_with_addresses([3, 0, 2, 1], struct.pack('<4I', 10, 20, 30, 40))
+  group.registers[False][1] = [3, 4, 5, 6]
+  # ADD.U r2.x, c<a0.x>, r0.y: cat2 relative multisrc shares the signed10-bit offset.
+  add = (2 << 61) | (16 << 53) | (1 << 52) | (8 << 32) | (1 << 16) | 0xc00
+  run_words(group, MOVA, add)
+  np.testing.assert_array_equal(group.registers[False][8], [43, 14, 35, 26])
+
+
+@pytest.mark.parametrize('address', [-1, 244, 32767])
+def test_bad_relative_register_index_rejects_before_any_destination_lane_changes(address):
+  group = group_with_addresses([20, address])
+  group.registers[False][8] = 77
+  relative_read = (1 << 61) | (3 << 50) | (3 << 46) | (8 << 32) | (1 << 11)
+  with pytest.raises(RuntimeError, match='relative register'):
+    run_words(group, MOVA, relative_read)
+  np.testing.assert_array_equal(group.registers[False][8], [77, 77])
+
+
+def test_bad_relative_destination_does_not_partially_scatter():
+  group = group_with_addresses([20, 244])
+  group.registers[False][0] = [101, 202]
+  relative_write = (1 << 61) | (3 << 50) | (3 << 46) | (1 << 49)
+  with pytest.raises(RuntimeError, match='relative register'):
+    run_words(group, MOVA, relative_write)
+  np.testing.assert_array_equal(group.registers[False][20], [0, 0])
+
+
+@pytest.mark.parametrize('address', [-1, 4])
+def test_relative_constant_outside_upload_is_rejected_without_negative_wrap(address):
+  group = group_with_addresses([0, address], struct.pack('<4I', 10, 20, 30, 40))
+  group.registers[False][8] = 77
+  relative_read = (1 << 61) | (3 << 50) | (3 << 46) | (8 << 32) | 0xc00
+  with pytest.raises(RuntimeError, match='constant register'):
+    run_words(group, MOVA, relative_read)
+  np.testing.assert_array_equal(group.registers[False][8], [77, 77])

--- a/test/mockgpu/qcom/test_sel_f32.py
+++ b/test/mockgpu/qcom/test_sel_f32.py
@@ -1,0 +1,123 @@
+"""Bounded QCOMCL SEL.F32 sign selection; unproved conditions and payloads fail closed."""
+import math
+import struct
+import numpy as np
+import pytest
+from tinygrad import Tensor
+from test.mockgpu.qcom.emu import Workgroup, decode
+from test.mockgpu.qcom.test_qcomcl import requires_qcomcl
+
+SEL = 0x6680800200004000  # sel.f32 r0.z, -r0.x, r0.y, r0.x
+END = 6 << 55
+CONDITIONS = (0x3f7fffff, 0xffffffff)
+
+
+def state(payloads, conditions):
+  group = Workgroup(b'', (len(payloads), 1, 1), (0, 0, 0), 0xfc, 0xfc, 0xfc, object(), 0, 0)
+  group.registers[0][0] = payloads
+  group.registers[0][1] = conditions
+  return group
+
+
+def expected_sign_choice(payload, condition):
+  # Scalar IEEE conversion, Python negation and bit packing are independent of
+  # the emulator's raw-bit implementation. Normal F32 negation is exact.
+  value = struct.unpack('<f', struct.pack('<I', payload))[0]
+  selected = -value if condition == 0x3f7fffff else value
+  return struct.unpack('<I', struct.pack('<f', selected))[0]
+
+
+@pytest.mark.parametrize('word', [SEL, SEL & ~(255 << 32)])
+def test_raw_payload_sign_and_source_order_with_destination_alias(word):
+  payloads = [0x3fa00000, 0xbfa00000, 0x40000000, 0xc0600000, 0x00800000, 0x80800000, 0x7f7fffff, 0xff7fffff]
+  random = np.random.default_rng(630).integers(0, 2**32, 256, dtype=np.uint32)
+  payloads += [int(value) for value in random if 0 < (int(value) >> 23 & 255) < 255]
+  pairs = [(payload, condition) for payload in payloads for condition in CONDITIONS]
+  group = state([p for p, _ in pairs], [c for _, c in pairs])
+  instructions = decode(struct.pack('<2Q', word, END))
+  assert instructions[0].op == 'sel.f32'
+  assert instructions[0].operands['SRC1'].modifier == 1
+  assert instructions[0].operands['SRC2'].index == 1
+  group.run(instructions)
+  expected = [expected_sign_choice(p, c) for p, c in pairs]
+  # Original oracle seed, then its negative payload, under both condition words.
+  assert expected[:4] == [0xbfa00000, 0x3fa00000, 0x3fa00000, 0xbfa00000]
+  assert expected == [p ^ (0x80000000 if c == 0x3f7fffff else 0) for p, c in pairs]
+  np.testing.assert_array_equal(group.registers[0][instructions[0].operands['DST'].index], expected)
+
+
+def test_every_other_condition_class_rejects_before_any_destination_write():
+  conditions = [0, 0x80000000, 1, 0x80000001, 0x3f800000, 0xbf800000, 0x7f800000, 0xff800000,
+                0x7fc00001, 0xffc00001, 0x3f7ffffe, 0x3f800001, 0xfffffffe]
+  conditions += [int(x) for x in np.random.default_rng(631).integers(0, 2**32, 1024, dtype=np.uint32) if int(x) not in CONDITIONS]
+  instructions = decode(struct.pack('<2Q', SEL, END))
+  for condition in conditions:
+    group = state([0x3fa00000] * 3, [CONDITIONS[0], condition, CONDITIONS[1]])
+    group.registers[0][2] = 0xdeadbeef
+    before = group.registers[0].copy()
+    with pytest.raises(RuntimeError, match='SEL.F32 condition outside admitted domain'):
+      group.run(instructions)
+    np.testing.assert_array_equal(group.registers[0], before)
+
+
+@pytest.mark.parametrize('condition', CONDITIONS)
+@pytest.mark.parametrize('payload', [0, 0x80000000, 1, 0x80000001, 0x007fffff, 0x807fffff,
+                                    0x7f800000, 0xff800000, 0x7fc12345, 0xffc12345, 0x7f812345, 0xff812345])
+def test_unverified_zero_subnormal_infinite_and_nan_payloads_reject(payload, condition):
+  # These raw words remain an oracle question, not extrapolated from sine.
+  group = state([0x3fa00000, payload, 0xbfa00000], [condition] * 3)
+  group.registers[0][2] = 0xdeadbeef
+  before = group.registers[0].copy()
+  with pytest.raises(RuntimeError, match='SEL.F32 payload outside admitted domain'):
+    group.run(decode(struct.pack('<2Q', SEL, END)))
+  np.testing.assert_array_equal(group.registers[0], before)
+
+
+@pytest.mark.parametrize('word', [
+  SEL ^ (1 << 14),   # No negation on SRC1 is a different form.
+  SEL | (1 << 30),   # A modified condition is not the traced producer.
+  SEL | (1 << 31),   # Negating both data choices is not established.
+  SEL | (1 << 16),   # Different SRC3 storage is not the bounded sign choice.
+  SEL | (1 << 12),   # A constant source is not this register-only form.
+  SEL | (1 << 40),   # Repeated execution needs separate evidence.
+  SEL | (1 << 42),   # Saturated output is not admitted.
+  SEL | (1 << 43),   # At zero repeat this decodes as NOP=1, not source advancement.
+  SEL | (1 << 15),   # At zero repeat this decodes as NOP=2.
+  SEL | (1 << 29),   # Advancing SRC3 is not admitted.
+  SEL | (1 << 46),   # Half-width output is not admitted.
+])
+def test_unverified_encoded_forms_reject_during_decode(word):
+  with pytest.raises(RuntimeError, match='unsupported SEL.F32 form'):
+    decode(struct.pack('<2Q', word, END))
+
+
+def test_madsh_u16_stays_unsupported():
+  with pytest.raises(RuntimeError, match='unsupported instruction madsh.u16'):
+    decode(struct.pack('<2Q', 0x608a800b000b000d, END))
+
+
+@requires_qcomcl
+def test_real_compiler_sine_range_and_original_cosine_reproduction(monkeypatch):
+  # Independent range/quarter-turn/large-argument data separated the six payload
+  # models before admission. The original reproduction retains both assertions.
+  from test.mockgpu.qcom.test_tensor_semantics import test_trigonometric_reduction_preserves_large_arguments
+  grid = np.linspace(-128, 128, 1025, dtype=np.float32)
+  quadrants = np.arange(-32, 33, dtype=np.float64) * (math.pi / 2)
+  boundaries = (quadrants[:, None] + np.array([-1e-5, 0, 1e-5])).reshape(-1).astype(np.float32)
+  large = np.array([-1e6, -1e5, -1e4, -1000, -10, -.5, 0, .5, 10, 1000, 1e4, 1e5, 1e6], np.float32)
+  values = np.unique(np.concatenate((grid, boundaries, large)))
+  expected = np.sin(values)
+  scalar = np.array([math.sin(float(value)) for value in values], np.float32)
+  np.testing.assert_allclose(expected, scalar, rtol=1e-6, atol=1e-7)
+  observed = set()
+  original = Workgroup.alu
+
+  def record(self, instruction, lanes, repeat):
+    if instruction.op == 'sel.f32':
+      observed.update(map(int, self.read(instruction.operands['SRC2'], lanes, repeat)))
+    return original(self, instruction, lanes, repeat)
+
+  monkeypatch.setattr(Workgroup, 'alu', record)
+  np.testing.assert_allclose(Tensor(values).sin().numpy(), expected, atol=3e-3, rtol=3e-3)
+  assert observed == set(CONDITIONS)
+  test_trigonometric_reduction_preserves_large_arguments()

--- a/test/mockgpu/qcom/test_sel_f32.py
+++ b/test/mockgpu/qcom/test_sel_f32.py
@@ -109,7 +109,7 @@ def test_real_compiler_sine_range_and_original_cosine_reproduction(monkeypatch):
   expected = np.sin(values)
   scalar = np.array([math.sin(float(value)) for value in values], np.float32)
   np.testing.assert_allclose(expected, scalar, rtol=1e-6, atol=1e-7)
-  observed = set()
+  observed: set[int] = set()
   original = Workgroup.alu
 
   def record(self, instruction, lanes, repeat):

--- a/test/mockgpu/qcom/test_tensor_semantics.py
+++ b/test/mockgpu/qcom/test_tensor_semantics.py
@@ -1,0 +1,51 @@
+import numpy as np
+from tinygrad import Tensor,dtypes
+
+
+def test_float_add_nonuniform_odd_shape():
+  a=np.arange(407,dtype=np.float32).reshape(37,11)/13-9
+  b=np.cos(np.arange(407,dtype=np.float32)).reshape(37,11)
+  np.testing.assert_allclose((Tensor(a)+Tensor(b)).numpy(),a+b,rtol=1e-6,atol=1e-6)
+
+
+def test_integer_full_width_multiply_and_bitwise_source_negation():
+  a=np.array([0x10001,0xffff0001,0xffffffff,0x80008000,123456789],np.uint32)
+  b=np.array([0x20003,0x0002ffff,0xffffffff,0x8000ffff,987654321],np.uint32)
+  np.testing.assert_array_equal((Tensor(a)*Tensor(b)).numpy(),a*b)
+  np.testing.assert_array_equal((~Tensor(a)&Tensor(b)).numpy(),~a&b)
+
+
+def test_signed_byte_conversion():
+  a=np.array([-128,-17,-1,0,1,17,127],np.int8)
+  np.testing.assert_array_equal(Tensor(a).cast(dtypes.int32).numpy(),a.astype(np.int32))
+
+def test_float_to_half_conversion_uses_nearest_even():
+  values=np.array([1.0006,-1.0006,1.0015,-1.0015,2051,65520],np.float32)
+  with np.errstate(over='ignore'):
+    expected=values.astype(np.float16).view(np.uint16)
+  actual=Tensor(values).cast(dtypes.half).numpy().view(np.uint16)
+  np.testing.assert_array_equal(actual,expected)
+
+def test_trigonometric_reduction_preserves_large_arguments():
+  values=np.array([0,.5,-.5,10,1e4,1e6,-1e6],np.float32)
+  np.testing.assert_allclose(Tensor(values).sin().numpy(),np.sin(values),atol=3e-3,rtol=3e-3)
+  np.testing.assert_allclose(Tensor(values).cos().numpy(),np.cos(values),atol=3e-3,rtol=3e-3)
+
+
+def test_half_gemm_nonuniform():
+  a=(np.arange(9*17).reshape(9,17)%11-5).astype(np.float16)/8
+  b=(np.arange(17*7).reshape(17,7)%13-6).astype(np.float16)/8
+  np.testing.assert_allclose((Tensor(a)@Tensor(b)).numpy(),a@b,rtol=1e-3,atol=2e-3)
+
+
+def test_reductions_and_divergent_selection():
+  a=(np.arange(513,dtype=np.float32)%17)-8
+  out=(Tensor(a)>0).where(Tensor(a)*3,Tensor(a)-2)
+  np.testing.assert_array_equal(out.numpy(),np.where(a>0,a*3,a-2))
+  np.testing.assert_equal(out.sum().numpy(),np.where(a>0,a*3,a-2).sum())
+
+
+def test_float_gemv_nonuniform():
+  a=(np.arange(64,dtype=np.float32)%11-5).reshape(1,64)/8
+  b=(np.arange(4096,dtype=np.float32).reshape(64,64)%13-6)/8
+  np.testing.assert_allclose((Tensor(a)@Tensor(b)).numpy(),a@b,rtol=1e-5,atol=1e-5)

--- a/test/testextra/test_qcom_driver.py
+++ b/test/testextra/test_qcom_driver.py
@@ -1,0 +1,324 @@
+import ctypes, importlib, mmap, os, pathlib, subprocess, sys, tempfile, unittest
+from tinygrad.helpers import DEV
+from tinygrad.runtime.autogen import kgsl, libc
+
+
+def request_number(fn):
+  direction, group, number, typ = fn.args
+  return direction << 30 | ctypes.sizeof(typ) << 16 | group << 8 | number
+
+
+class QCOMDriverTests(unittest.TestCase):
+  def setUp(self):
+    path = pathlib.Path(__file__).parents[1] / "mockgpu/qcom/qcomdriver.py"
+    self.assertTrue(path.is_file(), "QCOM memory and driver implementation is missing")
+    self.module = importlib.import_module("test.mockgpu.qcom.qcomdriver")
+    self.storage = (ctypes.c_ubyte * 64)(*range(64))
+    self.base = ctypes.addressof(self.storage)
+    self.space = self.module.AddressSpace()
+    self.space.map(self.base, 64, self.storage)
+
+  def test_transaction_commit_and_discard(self):
+    # Removing staging would expose partial command writes before commit.
+    tx = self.space.transaction()
+    tx.write(self.base + 3, b"abc")
+    self.assertEqual(bytes(self.storage)[3:6], b"\x03\x04\x05")
+    self.assertEqual(tx.read(self.base + 2, 5), b"\x02abc\x06")
+    tx.commit()
+    self.assertEqual(bytes(self.storage)[3:6], b"abc")
+    later = self.space.transaction()
+    later.write(self.base + 3, b"bad")
+    with self.assertRaises(ValueError): later.write(self.base + 63, b"xx")
+    self.assertEqual(bytes(self.storage)[3:6], b"abc")
+
+  def test_ordered_overlays_and_numpy_region_share_changes(self):
+    # Losing overlay order or keeping disconnected region snapshots changes data.
+    tx = self.space.transaction()
+    tx.write(self.base + 2, b"ABCD")
+    tx.write(self.base + 3, b"xy")
+    base, data = tx.region(self.base + 2, 4)
+    self.assertEqual(base, self.base)
+    self.assertEqual(data[2:6], b"AxyD")
+    data[4] = ord("Z")
+    self.assertEqual(tx.read(self.base + 2, 4), b"AxZD")
+    tx.write(self.base + 3, b"!")
+    self.assertEqual(data[2:6], b"A!ZD")
+    tx.commit()
+    self.assertEqual(bytes(self.storage)[2:6], b"A!ZD")
+
+  def test_mappings_reject_overlap_and_out_of_range_without_reads(self):
+    # A guest address outside registered storage must never reach a native read.
+    with self.assertRaises(ValueError): self.space.map(self.base + 1, 8, self.storage)
+    with self.assertRaises(ValueError): self.space.transaction().read(self.base + 64, 1)
+    with self.assertRaises(ValueError): self.space.transaction().write(self.base - 1, b"x")
+    self.space.unmap(self.base)
+    with self.assertRaises(ValueError): self.space.transaction().read(self.base, 1)
+
+  def test_changed_mapping_cannot_commit_stale_bytes(self):
+    # Reusing an address after unmap must not accept an old transaction's writes.
+    tx = self.space.transaction()
+    tx.write(self.base, b"bad")
+    self.space.unmap(self.base)
+    self.space.map(self.base, 64, self.storage)
+    with self.assertRaises(ValueError): tx.commit()
+    self.assertEqual(bytes(self.storage)[:3], b"\x00\x01\x02")
+
+  def test_readonly_host_memory_is_rejected_as_gpu_mapping(self):
+    # An accepted mapping must allow staged GPU writes to commit safely.
+    address = libc.mmap(0, 4096, mmap.PROT_READ, mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS, -1, 0)
+    self.addCleanup(libc.munmap, address, 4096)
+    with self.assertRaises(ValueError): self.space.map(address, 4096)
+
+  def test_commit_preflights_all_write_permissions_before_publication(self):
+    address = libc.mmap(0, 4096, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS, -1, 0)
+    self.addCleanup(libc.munmap, address, 4096)
+    # Retaining an owner does not make a later protection change writable.
+    self.space.map(address, 4096, self.storage)
+    transaction = self.space.transaction()
+    transaction.write(self.base, b"changed")
+    transaction.write(address, b"later")
+    libc.mprotect(address, 4096, mmap.PROT_READ)
+    with self.assertRaises(ValueError): transaction.commit()
+    self.assertEqual(bytes(self.storage)[:7], bytes(range(7)))
+
+  def test_ioctl_output_span_is_validated_before_resource_creation(self):
+    driver, fd = self.driver(lambda *args: (True, 1))
+    address = libc.mmap(0, 4096, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS, -1, 0)
+    self.addCleanup(libc.munmap, address, 4096)
+    libc.mprotect(address, 4096, mmap.PROT_READ)
+    with self.assertRaises(ValueError):
+      fd.ioctl(fd.fd, request_number(kgsl.IOCTL_KGSL_DRAWCTXT_CREATE), address)
+    self.assertEqual(driver.contexts, {})
+    self.assertEqual(driver.next_context, 1)
+
+  def test_ioctl_struct_alignment_precedes_resource_creation(self):
+    driver, fd = self.driver(lambda *args: (True, 1))
+    storage = (ctypes.c_ubyte * 32)()
+    with self.assertRaises(ValueError):
+      fd.ioctl(fd.fd, request_number(kgsl.IOCTL_KGSL_DRAWCTXT_CREATE), ctypes.addressof(storage) + 1)
+    self.assertEqual(driver.contexts, {})
+
+  def test_unsupported_context_and_allocation_flags_do_not_create_resources(self):
+    driver, fd = self.driver(lambda *args: (True, 1))
+    with self.assertRaises(ValueError): self.ioctl(fd, kgsl.IOCTL_KGSL_DRAWCTXT_CREATE, flags=kgsl.KGSL_CONTEXT_IFH_NOP)
+    self.assertEqual(driver.contexts, {})
+    with self.assertRaises(ValueError):
+      self.ioctl(fd, kgsl.IOCTL_KGSL_GPUOBJ_ALLOC, size=4096, mmapsize=4096, flags=kgsl.KGSL_MEMFLAGS_USE_CPU_MAP | (1 << 63))
+    self.assertEqual(driver.allocations, {})
+
+  def test_allocation_alignment_request_must_be_honored_or_rejected(self):
+    driver, fd = self.driver(lambda *args: (True, 1))
+    flags = kgsl.KGSL_MEMFLAGS_USE_CPU_MAP | (13 << kgsl.KGSL_MEMALIGN_SHIFT)
+    with self.assertRaises(ValueError):
+      self.ioctl(fd, kgsl.IOCTL_KGSL_GPUOBJ_ALLOC, size=4096, mmapsize=4096, flags=flags)
+    self.assertEqual(driver.allocations, {})
+
+  def test_timestamp_cannot_wrap_or_publish_an_unrepresentable_receipt(self):
+    driver, fd = self.driver(lambda *args: self.fail("overflowing receipt executed"))
+    context = self.context(fd)
+    driver.contexts[context].queued = 0xffffffff
+    with self.assertRaises(ValueError): self.submit(driver, fd, context, (0,))
+    self.assertEqual(driver.contexts[context].queued, 0xffffffff)
+    self.assertEqual(len(driver.contexts[context].pending), 0)
+
+  def test_transaction_preflight_distinguishes_read_and_write_permissions(self):
+    # PM4 prevalidation must check a write target without creating a full snapshot.
+    address = libc.mmap(0, 4096, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS, -1, 0)
+    self.addCleanup(libc.munmap, address, 4096)
+    self.space.map(address, 4096)
+    libc.mprotect(address, 4096, mmap.PROT_READ)
+    transaction = self.space.transaction()
+    transaction.validate(address, 4)
+    with self.assertRaises(ValueError): transaction.validate(address, 4, write=True)
+
+  def test_signal_before_later_wait_allows_acyclic_context_dependencies(self):
+    # A merged stream may publish A, wait B, then finish; rolling the first signal
+    # back at that wait deadlocks the other context even though the graph is acyclic.
+    for index in range(3): self.storage[index] = 0
+    def execute(words, memory, timestamp, start=0):
+      for cursor in range(start, len(words)):
+        action = words[cursor]
+        if action == 1: memory.write(self.base, b"\x01")
+        elif action == 2:
+          if memory.read(self.base + 1, 1) != b"\x01": return False, cursor
+        elif action == 3: memory.write(self.base + 2, b"\x01")
+        elif action == 4:
+          if memory.read(self.base, 1) != b"\x01": return False, cursor
+        elif action == 5: memory.write(self.base + 1, b"\x01")
+      return True, len(words)
+    driver, fd = self.driver(execute)
+    first, second = self.context(fd), self.context(fd)
+    self.submit(driver, fd, first, (1, 2, 3))
+    self.assertEqual(bytes(self.storage)[:3], b"\x01\x00\x00")
+    self.assertEqual(driver.contexts[first].retired, 0)
+    self.submit(driver, fd, second, (4, 5))
+    self.assertEqual(bytes(self.storage)[:3], b"\x01\x01\x01")
+    self.assertEqual((driver.contexts[first].retired, driver.contexts[second].retired), (1, 1))
+
+  def driver(self, executor):
+    driver = self.module.QCOMDriver(executor)
+    fd = driver.open("/dev/kgsl-3d0", os.O_RDWR, 0o777, driver.tracked_files[0])
+    self.addCleanup(fd.close, fd.fd)
+    driver.memory.map(self.base, 64, self.storage)
+    return driver, fd
+
+  def ioctl(self, fd, fn, **fields):
+    req = fn.args[3](**fields)
+    fd.ioctl(fd.fd, request_number(fn), ctypes.addressof(req))
+    return req
+
+  def context(self, fd): return self.ioctl(fd, kgsl.IOCTL_KGSL_DRAWCTXT_CREATE).drawctxt_id
+
+  def submit(self, driver, fd, context, words):
+    data = (ctypes.c_uint32 * len(words))(*words)
+    address = ctypes.addressof(data)
+    driver.memory.map(address, ctypes.sizeof(data), data)
+    self.addCleanup(driver.memory.unmap, address)
+    obj = kgsl.struct_kgsl_command_object(gpuaddr=address, size=ctypes.sizeof(data), flags=kgsl.KGSL_CMDLIST_IB)
+    return self.ioctl(fd, kgsl.IOCTL_KGSL_GPU_COMMAND, context_id=context, cmdlist=ctypes.addressof(obj),
+                      cmdsize=ctypes.sizeof(obj), numcmds=1)
+
+  def test_scheduler_waits_roll_back_then_resume_fifo(self):
+    # Advancing blocked commands, committing partial output, or bypassing FIFO fails.
+    def execute(words, memory, timestamp, start=0):
+      if words[0] == 1:
+        if memory.read(self.base, 1) != b"S": return False, start
+        memory.write(self.base + 8, b"resumed")
+      elif words[0] == 2: memory.write(self.base, b"S")
+      else: memory.write(self.base + 15, b"last")
+      return True, 1
+    driver, fd = self.driver(execute)
+    first, second = self.context(fd), self.context(fd)
+    request = self.submit(driver, fd, first, (1,))
+    self.assertEqual(bytes(self.storage)[8:15], bytes(range(8, 15)))
+    self.submit(driver, fd, first, (3,))
+    self.assertEqual(bytes(self.storage)[15:19], bytes(range(15, 19)))
+    self.submit(driver, fd, second, (2,))
+    self.assertEqual(bytes(self.storage)[8:19], b"resumedlast")
+    retired = self.ioctl(fd, kgsl.IOCTL_KGSL_CMDSTREAM_READTIMESTAMP_CTXTID, context_id=first, type=kgsl.KGSL_TIMESTAMP_RETIRED)
+    self.assertGreaterEqual(retired.timestamp, request.timestamp)
+
+  def test_driver_allocation_free_leaves_cpu_unmap_to_runtime(self):
+    # KGSL free must remove GPU access without double-unmapping host storage.
+    driver, fd = self.driver(lambda *args: (True, 1))
+    allocation = self.ioctl(fd, kgsl.IOCTL_KGSL_GPUOBJ_ALLOC, size=4096, mmapsize=4096, flags=kgsl.KGSL_MEMFLAGS_USE_CPU_MAP)
+    addr = fd.mmap(0, 4096, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, fd.fd, allocation.id * 4096)
+    self.addCleanup(libc.munmap, addr, 4096)
+    tx = driver.memory.transaction()
+    tx.write(addr, b"mapped")
+    tx.commit()
+    self.ioctl(fd, kgsl.IOCTL_KGSL_GPUOBJ_FREE, id=allocation.id)
+    self.assertEqual(self.module.read_host(addr, 6), b"mapped")
+    with self.assertRaises(ValueError): driver.memory.transaction().read(addr, 1)
+
+  def test_close_releases_unfreed_owned_mapping(self):
+    # A descriptor that closes without a GPUOBJ_FREE must not leak its mmap.
+    driver, fd = self.driver(lambda *args: (True, 1))
+    allocation = self.ioctl(fd, kgsl.IOCTL_KGSL_GPUOBJ_ALLOC, size=4096, mmapsize=4096, flags=kgsl.KGSL_MEMFLAGS_USE_CPU_MAP)
+    address = fd.mmap(0, 4096, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, fd.fd, allocation.id * 4096)
+    fd.close(fd.fd)
+    with self.assertRaises(ValueError): self.module.read_host(address, 1)
+
+  def test_borrowed_mapping_is_owned_by_descriptor_but_not_freed_on_close(self):
+    # Closing a descriptor removes its guest mapping but must retain caller bytes.
+    driver, fd = self.driver(lambda *args: (True, 1))
+    driver.memory.unmap(self.base)
+    req = self.ioctl(fd, kgsl.IOCTL_KGSL_MAP_USER_MEM, hostptr=self.base, len=64, memtype=kgsl.KGSL_USER_MEM_TYPE_ADDR)
+    other = driver.open("/dev/kgsl-3d0", os.O_RDWR, 0o777, driver.tracked_files[0])
+    self.addCleanup(other.close, other.fd)
+    with self.assertRaises(ValueError): self.ioctl(other, kgsl.IOCTL_KGSL_SHAREDMEM_FREE, gpuaddr=req.gpuaddr)
+    fd.close(fd.fd)
+    self.assertEqual(bytes(self.storage)[:3], b"\x00\x01\x02")
+    with self.assertRaises(ValueError): driver.memory.transaction().read(self.base, 1)
+
+  def test_reentrant_scheduler_does_not_repeat_inflight_command(self):
+    # Host memory callbacks may ask for progress while a command already runs.
+    def execute(words, memory, timestamp, start=0):
+      driver.drain()
+      old = memory.read(self.base, 1)[0]
+      memory.write(self.base, bytes([old + 1]))
+      return True, 1
+    driver, fd = self.driver(execute)
+    self.submit(driver, fd, self.context(fd), (0,))
+    self.assertEqual(self.storage[0], 1)
+
+  def test_submit_shape_is_validated_before_execution(self):
+    # Empty lists and foreign context IDs cannot become successful submissions.
+    driver, fd = self.driver(lambda *args: self.fail("invalid request executed"))
+    context = self.context(fd)
+    with self.assertRaises(ValueError): self.ioctl(fd, kgsl.IOCTL_KGSL_GPU_COMMAND, context_id=context)
+    with self.assertRaises(ValueError): self.submit(driver, fd, context + 100, (0,))
+
+  def test_native_callback_latches_failure_and_preserves_original_cause(self):
+    # ctypes must receive an integer; Python must subsequently observe the error.
+    def execute(words, memory, timestamp, start=0):
+      memory.write(self.base, b"bad")
+      raise ValueError("unsupported test command")
+    driver, fd = self.driver(execute)
+    context = self.context(fd)
+    data = (ctypes.c_uint32 * 1)(0)
+    address = ctypes.addressof(data)
+    driver.memory.map(address, 4, data)
+    obj = kgsl.struct_kgsl_command_object(gpuaddr=address, size=4, flags=kgsl.KGSL_CMDLIST_IB)
+    req = kgsl.struct_kgsl_gpu_command(context_id=context, cmdlist=ctypes.addressof(obj), cmdsize=ctypes.sizeof(obj), numcmds=1)
+    callback = self.module.make_ioctl_callback({fd.fd: fd}, libc.dll.ioctl)
+    self.assertEqual(callback(fd.fd, request_number(kgsl.IOCTL_KGSL_GPU_COMMAND), ctypes.addressof(req)), -1)
+    self.assertEqual(bytes(self.storage)[:3], b"\x00\x01\x02")
+    with self.assertRaisesRegex(RuntimeError, "unsupported test command") as raised: driver.check_error()
+    self.assertIsInstance(raised.exception.__cause__, ValueError)
+    self.assertEqual(callback(fd.fd, request_number(kgsl.IOCTL_KGSL_GPU_COMMAND), ctypes.addressof(req)), -1)
+    with self.assertRaises(RuntimeError) as again: driver.check_error()
+    self.assertIs(again.exception.__cause__, raised.exception.__cause__)
+
+  def test_native_callback_forwards_real_descriptor(self):
+    # A real pipe remains serviced by the OS, outside the QCOM tracked descriptors.
+    import termios
+    reader, writer = os.pipe()
+    self.addCleanup(os.close, reader)
+    self.addCleanup(os.close, writer)
+    os.write(writer, b"hello")
+    length = ctypes.c_int()
+    callback = self.module.make_ioctl_callback({}, libc.dll.ioctl)
+    self.assertEqual(callback(reader, termios.FIONREAD, ctypes.addressof(length)), 0)
+    self.assertEqual(length.value, 5)
+
+  def test_nv_and_qcom_descriptors_do_not_replace_each_other(self):
+    # All mock drivers share tracked_fds, so backend-local ranges must differ.
+    from test.mockgpu.nv.nvdriver import NVDriver
+    driver, fd = self.driver(lambda *args: (True, 1))
+    nv = NVDriver(gpus=0)
+    nvfd = nv.open("/dev/nvidiactl", os.O_RDWR, 0o777, nv.tracked_files[0])
+    descriptors = {fd.fd:fd, nvfd.fd:nvfd}
+    self.assertEqual(len(descriptors), 2)
+    self.assertIs(descriptors[fd.fd], fd)
+
+  def test_hcq2_native_submission_reports_callback_failure_before_next_fence(self):
+    # A callback failure must raise from ordinary Tensor.realize, without waiting
+    # for a later copy-out or hanging in the next replay's native fence loop.
+    code = '''from tinygrad import Device, Tensor
+Device["QCOM"]
+from test.mockgpu.mockgpu import drivers
+from tinygrad.engine.realize import compile_linear, link_linear, run_linear
+def reject(*args): raise ValueError("fixture command rejected")
+drivers[0].execute = reject
+output = Tensor.ones(1).contiguous()
+linear, variables = Tensor.linear_with_vars(output)
+linked = link_linear(compile_linear(linear))
+for attempt in range(2):
+  try:
+    run_linear(linked, variables, jit=True)
+  except RuntimeError as error:
+    assert "fixture command rejected" in str(error), str(error)
+    print("native callback failure surfaced", flush=True)
+  else: raise AssertionError("failed submit returned successfully")
+'''
+    with tempfile.TemporaryDirectory() as cache:
+      renderer = DEV.target("QCOM").renderer or "IR3"
+      result = subprocess.run([sys.executable, "-c", code], cwd=pathlib.Path(__file__).parents[2],
+                              env={**os.environ, "DEV":f"MOCK+QCOM:{renderer}", "PARALLEL":"0", "XDG_CACHE_HOME":cache},
+                              capture_output=True, text=True, timeout=60)
+    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+    self.assertEqual(result.stdout.count("native callback failure surfaced"), 2)
+
+
+if __name__ == "__main__": unittest.main()

--- a/test/testextra/test_qcom_driver_folding.py
+++ b/test/testextra/test_qcom_driver_folding.py
@@ -1,0 +1,141 @@
+import ctypes, mmap, os, types, unittest
+from unittest.mock import patch
+from test.mockgpu.qcom import qcomdriver
+from tinygrad.runtime.autogen import kgsl, libc
+
+
+class QCOMDriverFoldingTests(unittest.TestCase):
+  def test_darwin_copy_uses_source_destination_with_full_length_receipt(self):
+    # Both directions have the same copy contract, including a short-copy veto.
+    storage = (ctypes.c_ubyte * 4)(10, 20, 30, 40)
+    address, calls = ctypes.addressof(storage), []
+    incoming, outgoing = bytearray(4), bytearray(b"ABCD")
+    def copy(task, source, size, destination, receipt):
+      calls.append((source.value, size.value, destination.value))
+      if source.value == address: incoming[:] = bytes(storage)
+      else: storage[:] = outgoing
+      receipt._obj.value = size.value
+      return 0
+    api = types.SimpleNamespace(mach_vm_read_overwrite=copy)
+    task = types.SimpleNamespace(value=1)
+    with patch.object(qcomdriver.sys, "platform", "darwin"), patch.object(qcomdriver.libc, "dll", api), \
+         patch.object(qcomdriver.ctypes, "c_uint", wraps=ctypes.c_uint) as uint:
+      uint.in_dll.return_value = task
+      qcomdriver.host_transfer(address, incoming, False)
+      self.assertEqual(incoming, bytes(storage))
+      self.assertEqual(calls[-1][0], address)
+      self.assertEqual(calls[-1][1], 4)
+      qcomdriver.host_transfer(address, outgoing, True)
+      self.assertEqual(bytes(storage), b"ABCD")
+      self.assertEqual(calls[-1], (ctypes.addressof((ctypes.c_ubyte * 4).from_buffer(outgoing)), 4, address))
+      def short_copy(task, source, size, destination, receipt):
+        receipt._obj.value = size.value - 1
+        return 0
+      api.mach_vm_read_overwrite = short_copy
+      for write in (False, True):
+        with self.assertRaises(ValueError): qcomdriver.host_transfer(address, bytearray(4), write)
+
+  def test_linux_copy_vectors_select_direction_and_reject_short_copies(self):
+    storage = (ctypes.c_ubyte * 4)(10, 20, 30, 40)
+    address, calls = ctypes.addressof(storage), []
+    incoming, outgoing = bytearray(4), bytearray(b"ABCD")
+    def copy(pid, local, local_count, remote, remote_count, flags):
+      destination, source = local._obj, remote._obj
+      calls.append((source.base, source.size, destination.base, destination.size))
+      if source.base == address: incoming[:] = bytes(storage)
+      else: storage[:] = outgoing
+      return source.size
+    api = types.SimpleNamespace(process_vm_readv=copy)
+    with patch.object(qcomdriver.sys, "platform", "linux"), patch.object(qcomdriver.libc, "dll", api):
+      qcomdriver.host_transfer(address, incoming, False)
+      self.assertEqual(incoming, bytes(storage))
+      self.assertEqual(calls[-1][0], address)
+      self.assertEqual(calls[-1][1], 4)
+      qcomdriver.host_transfer(address, outgoing, True)
+      self.assertEqual(bytes(storage), b"ABCD")
+      self.assertEqual(calls[-1], (ctypes.addressof((ctypes.c_ubyte * 4).from_buffer(outgoing)), 4, address, 4))
+      def short_copy(*args): return 3
+      api.process_vm_readv = short_copy
+      for write in (False, True):
+        with self.assertRaises(ValueError): qcomdriver.host_transfer(address, bytearray(4), write)
+
+  def test_native_copy_rejects_inaccessible_source_and_destination(self):
+    # Kernel carriers must report faults without Python dereferencing the pointer.
+    for write in (False, True):
+      with self.assertRaises(ValueError): qcomdriver.host_transfer(1, bytearray(4), write)
+
+  def driver(self):
+    driver = qcomdriver.QCOMDriver(lambda *args: (True, 1))
+    fd = driver.open("/dev/kgsl-3d0", os.O_RDWR, 0o777, driver.tracked_files[0])
+    self.addCleanup(fd.close, fd.fd)
+    return driver, fd
+
+  def ioctl(self, fd, fn, **fields):
+    req = fn.args[3](**fields)
+    fd.ioctl(fd.fd, qcomdriver.ioctl_number(fn), ctypes.addressof(req))
+    return req
+
+  def allocate(self, fd):
+    req = self.ioctl(fd, kgsl.IOCTL_KGSL_GPUOBJ_ALLOC, size=4096, mmapsize=4096, flags=kgsl.KGSL_MEMFLAGS_USE_CPU_MAP)
+    address = fd.mmap(0, 4096, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, fd.fd, req.id * 4096)
+    return req.id, address
+
+  def test_resource_mapping_identity_preserves_transaction_tombstones(self):
+    driver, fd = self.driver()
+    key, address = self.allocate(fd)
+    self.assertIs(driver.allocations[key], driver.memory.mappings[address])
+    old = driver.memory.transaction()
+    old.write(address, b"stale")
+    self.ioctl(fd, kgsl.IOCTL_KGSL_GPUOBJ_FREE, id=key)
+    self.addCleanup(libc.munmap, address, 4096)
+    self.ioctl(fd, kgsl.IOCTL_KGSL_MAP_USER_MEM, hostptr=address, len=4096, memtype=kgsl.KGSL_USER_MEM_TYPE_ADDR)
+    self.assertIs(driver.borrowed[address], driver.memory.mappings[address])
+    with self.assertRaises(ValueError): old.commit()
+    self.assertEqual(qcomdriver.read_host(address, 5), bytes(5))
+
+  def test_close_keeps_foreign_owned_storage_and_caller_borrowed_storage(self):
+    driver, fd = self.driver()
+    other = driver.open("/dev/kgsl-3d0", os.O_RDWR, 0o777, driver.tracked_files[0])
+    self.addCleanup(other.close, other.fd)
+    _, first_address = self.allocate(fd)
+    _, other_address = self.allocate(other)
+    storage = (ctypes.c_ubyte * 4)(1, 2, 3, 4)
+    borrowed = ctypes.addressof(storage)
+    self.ioctl(fd, kgsl.IOCTL_KGSL_MAP_USER_MEM, hostptr=borrowed, len=4, memtype=kgsl.KGSL_USER_MEM_TYPE_ADDR)
+    fd.close(fd.fd)
+    with self.assertRaises(ValueError): qcomdriver.read_host(first_address, 1)
+    with self.assertRaises(ValueError): driver.memory.transaction().read(borrowed, 1)
+    self.assertEqual(qcomdriver.read_host(borrowed, 4), bytes(storage))
+    self.assertEqual(driver.memory.transaction().read(other_address, 4), bytes(4))
+
+  def test_free_invalid_fields_and_pending_work_preserve_resources(self):
+    driver, fd = self.driver()
+    key, address = self.allocate(fd)
+    for field in ("flags", "priv", "type", "len"):
+      with self.subTest(field=field), self.assertRaises(ValueError):
+        self.ioctl(fd, kgsl.IOCTL_KGSL_GPUOBJ_FREE, id=key, **{field:1})
+      self.assertEqual(driver.memory.transaction().read(address, 4), bytes(4))
+    storage = (ctypes.c_ubyte * 4)(1, 2, 3, 4)
+    borrowed = ctypes.addressof(storage)
+    self.ioctl(fd, kgsl.IOCTL_KGSL_MAP_USER_MEM, hostptr=borrowed, len=4, memtype=kgsl.KGSL_USER_MEM_TYPE_ADDR)
+    context = self.ioctl(fd, kgsl.IOCTL_KGSL_DRAWCTXT_CREATE).drawctxt_id
+    driver.contexts[context].pending.append(((0,), 1, 0))
+    for fn, fields in ((kgsl.IOCTL_KGSL_GPUOBJ_FREE, {"id":key}), (kgsl.IOCTL_KGSL_SHAREDMEM_FREE, {"gpuaddr":borrowed})):
+      with self.assertRaises(ValueError): self.ioctl(fd, fn, **fields)
+    self.assertEqual(driver.memory.transaction().read(borrowed, 4), bytes(storage))
+    self.assertEqual(driver.memory.transaction().read(address, 4), bytes(4))
+    driver.contexts[context].pending.clear()
+
+  def test_borrowed_mapping_requires_full_range_liveness_even_without_writes(self):
+    driver, fd = self.driver()
+    size = 2 * mmap.PAGESIZE
+    address = libc.mmap(0, size, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS, -1, 0)
+    self.addCleanup(libc.munmap, address, size)
+    self.ioctl(fd, kgsl.IOCTL_KGSL_MAP_USER_MEM, hostptr=address, len=size, memtype=kgsl.KGSL_USER_MEM_TYPE_ADDR)
+    transaction = driver.memory.transaction()
+    transaction.read(address, 4)
+    self.assertEqual(libc.mprotect(address + mmap.PAGESIZE, mmap.PAGESIZE, mmap.PROT_READ), 0)
+    with self.assertRaises(ValueError): transaction.commit()
+
+
+if __name__ == "__main__": unittest.main()

--- a/test/testextra/test_qcom_driver_repairs.py
+++ b/test/testextra/test_qcom_driver_repairs.py
@@ -1,0 +1,254 @@
+"""A630-3/4 contract regressions with inert host and ABI boundaries.
+
+Addresses are keys into a bytearray. No native pointer, allocation, permission
+probe, or host copy is used; the actual transaction and scheduler remain active.
+"""
+import collections, ctypes, unittest
+from unittest.mock import patch
+from test.mockgpu.qcom import qcomdriver as driver
+from tinygrad.runtime.autogen import kgsl
+
+
+class InertDriverTest(unittest.TestCase):
+  def setUp(self):
+    self.base = 4096
+    self.storage = bytearray(range(32))
+    self.transfers = []
+    self.enterContext(patch.object(driver, "validate_host_mapping"))
+    self.enterContext(patch.object(driver, "read_host", side_effect=self.read_host))
+    self.enterContext(patch.object(driver, "write_host", side_effect=self.write_host))
+
+  def read_host(self, address, size):
+    self.assertTrue(self.base <= address <= address + size <= self.base + len(self.storage))
+    self.transfers.append(("read", address, size))
+    return bytes(self.storage[address - self.base:address - self.base + size])
+
+  def write_host(self, address, data):
+    self.assertTrue(self.base <= address <= address + len(data) <= self.base + len(self.storage))
+    self.transfers.append(("write", address, len(data)))
+    self.storage[address - self.base:address - self.base + len(data)] = data
+
+
+class MappingIdentityRepairTests(InertDriverTest):
+  def transaction(self, snapshot=False):
+    space = driver.AddressSpace()
+    first = space.map(self.base, len(self.storage), owner=self.storage)
+    transaction = space.transaction()
+    transaction.write(self.base, b"old")
+    if snapshot: transaction.region(self.base, 4)
+    return space, first, transaction
+
+  def later_access(self, transaction, operation):
+    if operation == "read": return transaction.read(self.base, 4)
+    if operation == "validate": return transaction.validate(self.base, 4, write=True)
+    if operation == "write": return transaction.write(self.base + 8, b"new")
+    return transaction.region(self.base, 4)
+
+  def test_replacement_rejects_every_access_before_cached_data_or_new_staging(self):
+    # Replacing the retained record would mix old overlays/snapshots with a new
+    # allocation. Equal field values still do not make two Mapping objects one.
+    for snapshot in (False, True):
+      for operation in ("read", "validate", "write", "region"):
+        with self.subTest(snapshot=snapshot, operation=operation):
+          space, first, transaction = self.transaction(snapshot)
+          space.unmap(self.base)
+          second = space.map(self.base, len(self.storage), owner=self.storage)
+          self.assertEqual(first, second)
+          overlays = list(transaction.overlays)
+          snapshots = {base:bytes(data) for base, data in transaction.snapshots.items()}
+          transfers = list(self.transfers)
+          with self.assertRaisesRegex(ValueError, "mapping changed"):
+            self.later_access(transaction, operation)
+          self.assertIs(transaction.entries[self.base], first)
+          self.assertIs(space.mappings[self.base], second)
+          self.assertEqual(transaction.overlays, overlays)
+          self.assertEqual(transaction.snapshots, snapshots)
+          self.assertEqual(self.transfers, transfers)
+          with self.assertRaisesRegex(ValueError, "mapping changed"): transaction.commit()
+          self.assertEqual(bytes(self.storage), bytes(range(32)))
+          self.assertFalse(transaction.finished)
+
+  def test_immediate_commit_rejects_replacement_without_modifying_live_record(self):
+    for snapshot in (False, True):
+      with self.subTest(snapshot=snapshot):
+        space, first, transaction = self.transaction(snapshot)
+        space.unmap(self.base)
+        second = space.map(self.base, len(self.storage), owner=self.storage)
+        with self.assertRaisesRegex(ValueError, "mapping changed"): transaction.commit()
+        self.assertIs(transaction.entries[self.base], first)
+        self.assertIs(space.mappings[self.base], second)
+        self.assertEqual(bytes(self.storage), bytes(range(32)))
+
+  def test_unmapped_allocation_never_exposes_cached_data(self):
+    for operation in ("read", "validate", "write", "region"):
+      with self.subTest(operation=operation):
+        space, first, transaction = self.transaction(snapshot=True)
+        space.unmap(self.base)
+        with self.assertRaisesRegex(ValueError, "unmapped"):
+          self.later_access(transaction, operation)
+        with self.assertRaisesRegex(ValueError, "mapping changed"): transaction.commit()
+        self.assertIs(transaction.entries[self.base], first)
+        self.assertEqual(bytes(self.storage), bytes(range(32)))
+
+  def test_same_mapping_preserves_live_reads_overlay_order_and_region_updates(self):
+    space, first, transaction = self.transaction()
+    self.storage[8] = ord("L")
+    self.assertEqual(transaction.read(self.base + 8, 1), b"L")
+    transaction.write(self.base + 1, b"XY")
+    _, region = transaction.region(self.base, 4)
+    self.assertEqual(region[:3], b"oXY")
+    transaction.validate(self.base, 4, write=True)
+    transaction.write(self.base + 2, b"Z")
+    self.assertEqual(transaction.read(self.base, 3), b"oXZ")
+    self.assertIs(transaction.entries[self.base], first)
+    transaction.commit()
+    self.assertEqual(self.storage[:3], b"oXZ")
+    self.assertIs(space.mappings[self.base], first)
+
+  def test_fresh_transaction_can_use_replacement_after_old_transaction_rejects(self):
+    space, _, old = self.transaction()
+    space.unmap(self.base)
+    second = space.map(self.base, len(self.storage), owner=self.storage)
+    with self.assertRaisesRegex(ValueError, "mapping changed"): old.read(self.base, 3)
+    fresh = space.transaction()
+    fresh.write(self.base, b"new")
+    fresh.commit()
+    self.assertEqual(self.storage[:3], b"new")
+    self.assertIs(space.mappings[self.base], second)
+    with self.assertRaisesRegex(ValueError, "mapping changed"): old.commit()
+    self.assertEqual(self.storage[:3], b"new")
+
+
+class ConsumedTimestampRepairTests(InertDriverTest):
+  def query(self, qcom, kind, context_id=1):
+    req = kgsl.struct_kgsl_cmdstream_readtimestamp_ctxtid(context_id=context_id, type=kind)
+    # Drop only the ABI response. A query drains queues, so staged publications
+    # must still reach the inert storage through the actual transaction commit.
+    def write(address, data):
+      if address != 0: self.write_host(address, data)
+    with patch.object(driver, "read_struct", return_value=req), patch.object(driver, "write_host", side_effect=write):
+      qcom.ioctl(qcom.contexts[context_id].owner_fd, driver.ioctl_number(kgsl.IOCTL_KGSL_CMDSTREAM_READTIMESTAMP_CTXTID), 0)
+    return req.timestamp
+
+  def timestamps(self, qcom, context_id=1):
+    return tuple(self.query(qcom, kind, context_id) for kind in (
+      kgsl.KGSL_TIMESTAMP_QUEUED, kgsl.KGSL_TIMESTAMP_CONSUMED, kgsl.KGSL_TIMESTAMP_RETIRED))
+
+  def observe_without_scheduling(self, qcom, context_id=1):
+    # A nested ioctl observes state while the scheduler re-entry latch is held.
+    with patch.object(qcom, "executing", True): return self.timestamps(qcom, context_id)
+
+  def test_queued_commands_become_consumed_only_when_their_fifo_turn_starts(self):
+    released, seen = set(), []
+    def execute(words, memory, timestamp, cursor):
+      seen.append(words[0])
+      return words[0] in released, cursor
+    qcom = driver.QCOMDriver(execute)
+    qcom.contexts[1] = driver.Context(owner_fd=7, queued=2,
+                                    pending=collections.deque([((1,), 1, 0), ((2,), 2, 0)]))
+    self.assertEqual(self.observe_without_scheduling(qcom), (2, 0, 0))
+    for _ in range(3): self.assertEqual(self.timestamps(qcom), (2, 1, 0))
+    self.assertEqual(set(seen), {1})
+    self.assertEqual(qcom.contexts[1].pending[0][2], 0)
+    released.add(1)
+    self.assertEqual(self.timestamps(qcom), (2, 2, 1))
+    released.add(2)
+    self.assertEqual(self.timestamps(qcom), (2, 2, 2))
+    self.assertFalse(qcom.contexts[1].pending)
+
+  def test_prefix_wait_reports_start_before_retirement_and_resumes_once(self):
+    actions = []
+    def execute(words, memory, timestamp, start):
+      for cursor in range(start, 3):
+        if cursor == 0: memory.write(self.base, b"P")
+        elif cursor == 1:
+          if memory.read(self.base + 1, 1) != b"S": return False, cursor
+        else: memory.write(self.base + 2, b"E")
+        actions.append(cursor)
+      return True, 3
+    qcom = driver.QCOMDriver(execute)
+    qcom.memory.map(self.base, len(self.storage), owner=self.storage)
+    qcom.contexts[1] = driver.Context(owner_fd=7, queued=1, pending=collections.deque([((0,), 1, 0)]))
+    for _ in range(3): self.assertEqual(self.timestamps(qcom), (1, 1, 0))
+    self.assertEqual(self.storage[:3], b"P\x01\x02")
+    self.assertEqual(actions, [0])
+    self.assertEqual(qcom.contexts[1].pending[0][2], 1)
+    self.storage[1] = ord("S")
+    for _ in range(3): self.assertEqual(self.timestamps(qcom), (1, 1, 1))
+    self.assertEqual(self.storage[:3], b"PSE")
+    self.assertEqual(actions, [0, 1, 2])
+
+  def test_contexts_keep_independent_started_and_retired_progress(self):
+    qcom = driver.QCOMDriver(lambda words, memory, timestamp, cursor: (words[0] == 2, cursor))
+    qcom.contexts[1] = driver.Context(owner_fd=7, queued=1, pending=collections.deque([((1,), 1, 0)]))
+    qcom.contexts[2] = driver.Context(owner_fd=8, queued=2, pending=collections.deque([((2,), 1, 0), ((2,), 2, 0)]))
+    self.assertEqual(self.timestamps(qcom, 1), (1, 1, 0))
+    self.assertEqual(self.timestamps(qcom, 2), (2, 2, 2))
+    self.assertEqual(self.timestamps(qcom, 1), (1, 1, 0))
+
+  def test_invalid_whole_command_plan_does_not_publish_a_start(self):
+    # Type-zero PM4 framing rejects in the real planner, before any host access.
+    from test.mockgpu.qcom.qcomgpu import PM4Fault
+    qcom = driver.QCOMDriver()
+    qcom.contexts[1] = driver.Context(owner_fd=7, queued=1, pending=collections.deque([((0,), 1, 0)]))
+    with self.assertRaisesRegex(PM4Fault, "unsupported PM4 packet type"): qcom.drain()
+    self.assertEqual(self.observe_without_scheduling(qcom), (1, 0, 0))
+    self.assertEqual(qcom.contexts[1].pending[0][2], 0)
+    self.assertFalse(qcom.executing)
+    self.assertEqual(self.transfers, [])
+
+  def test_rejected_retry_retains_the_last_successful_start_observation(self):
+    def execute(words, memory, timestamp, cursor):
+      if cursor == 0: return False, 1
+      raise ValueError("rejected retry")
+    qcom = driver.QCOMDriver(execute)
+    qcom.contexts[1] = driver.Context(owner_fd=7, queued=1, pending=collections.deque([((0,), 1, 0)]))
+    with self.assertRaisesRegex(ValueError, "rejected retry"): qcom.drain()
+    self.assertEqual(self.observe_without_scheduling(qcom), (1, 1, 0))
+    self.assertEqual(qcom.contexts[1].pending[0][2], 1)
+    self.assertFalse(qcom.executing)
+
+  def test_invalid_execution_progress_does_not_publish_a_start(self):
+    for result in ((False, -1), (False, "1"), (1, 1)):
+      with self.subTest(result=result):
+        qcom = driver.QCOMDriver(lambda *args: result)
+        qcom.contexts[1] = driver.Context(owner_fd=7, queued=1, pending=collections.deque([((0,), 1, 0)]))
+        with self.assertRaisesRegex(ValueError, "invalid PM4 execution progress"): qcom.drain()
+        self.assertEqual(self.observe_without_scheduling(qcom), (1, 0, 0))
+        self.assertEqual(qcom.contexts[1].pending[0][2], 0)
+
+  def test_failed_commit_does_not_publish_a_start_or_staged_bytes(self):
+    def execute(words, memory, timestamp, cursor):
+      memory.write(self.base, b"bad")
+      qcom.memory.unmap(self.base)
+      qcom.memory.map(self.base, len(self.storage), owner=self.storage)
+      return False, 1
+    qcom = driver.QCOMDriver(execute)
+    qcom.memory.map(self.base, len(self.storage), owner=self.storage)
+    qcom.contexts[1] = driver.Context(owner_fd=7, queued=1, pending=collections.deque([((0,), 1, 0)]))
+    with self.assertRaisesRegex(ValueError, "mapping changed"): qcom.drain()
+    self.assertEqual(self.observe_without_scheduling(qcom), (1, 0, 0))
+    self.assertEqual(self.storage, bytes(range(32)))
+    self.assertEqual(qcom.contexts[1].pending[0][2], 0)
+
+  def test_last_timestamp_is_consumed_and_retired_without_wrapping(self):
+    ready = False
+    qcom = driver.QCOMDriver(lambda *args: (ready, 0))
+    qcom.memory.map(self.base, len(self.storage), owner=self.storage)
+    qcom.contexts[1] = driver.Context(owner_fd=7, queued=0xfffffffe)
+    obj = kgsl.struct_kgsl_command_object(gpuaddr=self.base, size=4, flags=kgsl.KGSL_CMDLIST_IB)
+    def submit():
+      req = kgsl.struct_kgsl_gpu_command(context_id=1, cmdsize=ctypes.sizeof(obj), numcmds=1)
+      with patch.object(driver, "read_struct", side_effect=[req, obj]), patch.object(driver, "write_host"):
+        qcom.ioctl(7, driver.ioctl_number(kgsl.IOCTL_KGSL_GPU_COMMAND), 0)
+      return req.timestamp
+    self.assertEqual(submit(), 0xffffffff)
+    self.assertEqual(self.timestamps(qcom), (0xffffffff, 0xffffffff, 0))
+    with self.assertRaisesRegex(ValueError, "timestamp exhausted"): submit()
+    self.assertEqual(self.timestamps(qcom), (0xffffffff, 0xffffffff, 0))
+    self.assertEqual(len(qcom.contexts[1].pending), 1)
+    ready = True
+    self.assertEqual(self.timestamps(qcom), (0xffffffff, 0xffffffff, 0xffffffff))
+
+
+if __name__ == "__main__": unittest.main()

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import cast, Iterator, Any, Sequence
 import weakref, decimal, array
 from dataclasses import dataclass, replace, field
-from tinygrad.helpers import colored, DEBUG, GlobalCounters, ansipad, prod, flatten, Context, to_tuple, tqdm, dedup
+from tinygrad.helpers import colored, DEBUG, GlobalCounters, ansipad, prod, flatten, Context, to_tuple, tqdm, dedup, DEV
 from tinygrad.helpers import BEAM, size_to_str, time_to_str, VALIDATE_WITH_CPU, PROFILE, ProfilePointEvent, cpu_events, perf_counter_us
 from tinygrad.uop.ops import Ops, PatternMatcher, UOp, UPat, AxisType, sym_infer, graph_rewrite, ProgramInfo
 from tinygrad.device import Device, Buffer, MultiBuffer, ProfileGraphEntry
@@ -193,11 +193,18 @@ def exec_graph(ctx:ExecContext, call:UOp, ast:UOp) -> list[float|None]:
   return [get_graph_runtime(ast, ctx.input_uops)(ctx.input_uops, ctx.var_vals, wait=ctx.wait)]
 
 def exec_hcq(ctx:ExecContext, call:UOp, ast:UOp) -> list[float|None]:
+  # Native submission cannot carry a Python exception back through its C ABI.
+  # Check the mock driver's retained error before and after the native graph.
+  qcom_mock = any(t.device == "QCOM" and t.interface == "MOCK" for t in DEV.value)
+  if qcom_mock:
+    from test.mockgpu.mockgpu import check_qcom_errors
+    check_qcom_errors()
   if (info:=call.arg.aux).inputs:
     addrs = [cast(Buffer, _resolve(u, ctx.input_uops).buffer).get_buf(dev).va_addr + off for u, dev, off in info.inputs]
     cast(Buffer, call.src[1 + info.table].buffer)._buf.cpu_view().view(fmt='Q')[:] = array.array('Q', addrs)
   ctx = replace(ctx, var_vals={**ctx.var_vals, **{k: v for d in info.device for k, v in cast(Any, Device[d]).var_vals.items()}})
   ets = exec_kernel(ctx, call, ast, devices=(HCQ_RUNTIME_DEV.value,))
+  if qcom_mock: check_qcom_errors()
   if not (ctx.wait or PROFILE): return ets
 
   slots = {d: cast(Buffer, call.src[1 + i].buffer) for d, i in info.slots}

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -1468,6 +1468,10 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     if not (self.ndim > 0 and w.ndim > 0): raise RuntimeError(f"both tensors need to be at least 1D, got {self.ndim=}, {w.ndim=}")
     if self.shape[-1] != w.shape[-min(w.ndim, 2)]: raise RuntimeError(f"cannot image_dot {self.shape} and {w.shape}")
 
+    # w's batch dims become conv groups and self's batch is divided by them, so the two batch
+    # shapes must agree before folding. (3,5) @ (2,5,7) otherwise gives groups > bs and reshapes to 0.
+    if (batch := _broadcast_shape(self.shape[0:-2], w.shape[0:-2])) != self.shape[0:-2]:
+      self = self._broadcast_to(batch + self.shape[-2:])
     bs, groups, cin, cout = prod(self.shape[0:-2]), prod(w.shape[0:-2]), w.shape[-2], w.shape[-1]
     out_shape_t = self.shape[0:-2] + (cout,-1) if len(self.shape) > 1 else (cout,)
 

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -1468,10 +1468,12 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     if not (self.ndim > 0 and w.ndim > 0): raise RuntimeError(f"both tensors need to be at least 1D, got {self.ndim=}, {w.ndim=}")
     if self.shape[-1] != w.shape[-min(w.ndim, 2)]: raise RuntimeError(f"cannot image_dot {self.shape} and {w.shape}")
 
-    # w's batch dims become conv groups and self's batch is divided by them, so the two batch
-    # shapes must agree before folding. (3,5) @ (2,5,7) otherwise gives groups > bs and reshapes to 0.
-    if (batch := _broadcast_shape(self.shape[0:-2], w.shape[0:-2])) != self.shape[0:-2]:
-      self = self._broadcast_to(batch + self.shape[-2:])
+    # w's batch dims become conv groups and self's batch is divided by them, so both batch shapes
+    # must agree before folding. Otherwise (3,5) @ (2,5,7) gives groups > bs and a zero-sized
+    # reshape, and (2,3,4,5) @ (2,1,5,7) groups along an axis w has not been expanded over.
+    batch = _broadcast_shape(self.shape[0:-2], w.shape[0:-2])
+    if batch != self.shape[0:-2]: self = self._broadcast_to(batch + self.shape[-2:])
+    if batch != w.shape[0:-2]: w = w._broadcast_to(batch + w.shape[-2:])
     bs, groups, cin, cout = prod(self.shape[0:-2]), prod(w.shape[0:-2]), w.shape[-2], w.shape[-1]
     out_shape_t = self.shape[0:-2] + (cout,-1) if len(self.shape) > 1 else (cout,)
 

--- a/tinygrad/renderer/nir.py
+++ b/tinygrad/renderer/nir.py
@@ -279,10 +279,11 @@ nstore_img = nir_instr(has_def=False, df=lambda img:img, num_components=lambda v
   srcs=lambda b,img,idx_y,idx_x,val:[nsrc(x) for x in [img, tovec(b, idx_y, idx_x), nundef(b, dtypes.int), val, nimm(b, 0, dtypes.int)]])(
     lambda b,img,idx_y,idx_x,val,dtype:mesa.nir_intrinsic_instr_create(b.shader,g("nir_intrinsic_image_store")))
 
-_nload_img = nir_instr(intrins=lambda dtype:{'IMAGE_DIM':mesa.GLSL_SAMPLER_DIM_2D, 'ACCESS':mesa.ACCESS_CAN_REORDER, 'DEST_TYPE':nfloat(dtype)},
+_nload_img = nir_instr(intrins=lambda dtype,readonly:{'IMAGE_DIM':mesa.GLSL_SAMPLER_DIM_2D,
+  'ACCESS':mesa.ACCESS_CAN_REORDER if readonly else 0, 'DEST_TYPE':nfloat(dtype)},
   nc=4, bs=32, num_components=4,
   srcs=lambda b,img,idx_y,idx_x:[nsrc(x) for x in [img, tovec(b, idx_y, idx_x), nundef(b, dtypes.int), nimm(b, 0, dtypes.int)]])(
-      lambda b,img,idx_y,idx_x,dtype: mesa.nir_intrinsic_instr_create(b.shader, g("nir_intrinsic_image_load")))
+      lambda b,img,idx_y,idx_x,dtype,readonly=True: mesa.nir_intrinsic_instr_create(b.shader, g("nir_intrinsic_image_load")))
 
 class IR3Renderer(NIRRenderer):
   def nload_img(ctx,img,idx_y,idx_x):

--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -165,9 +165,10 @@ class QCOMComputeQueue(HWQueue):
     self.cmd(mesa.CP_LOAD_STATE6_FRAG, qreg.cp_load_state6_0(state_type=mesa.ST_SHADER, state_src=mesa.SS6_INDIRECT,
                                                              state_block=mesa.SB6_CS_SHADER, num_unit=ceildiv(data.image_size, 128)), lib_addr)
 
-    self.reg(mesa.REG_A6XX_SP_REG_PROG_ID_0, 0xfcfcfcfc, 0xfcfcfcfc, 0xfcfcfcfc, 0xfc, qreg.a6xx_sp_cs_const_config(constlen=1024 // 4, enabled=True))
+    self.reg(mesa.REG_A6XX_SP_REG_PROG_ID_0, 0xfcfcfcfc, 0xfcfcfcfc, 0xfcfcfcfc, 0xfc,
+             qreg.a6xx_sp_cs_const_config(constlen=(1024 // 4) >> 2, enabled=True))
 
-    self.reg(mesa.REG_A6XX_SP_CS_PVT_MEM_STACK_OFFSET, qreg.a6xx_sp_cs_pvt_mem_stack_offset(data.hw_stack_offset))
+    self.reg(mesa.REG_A6XX_SP_CS_PVT_MEM_STACK_OFFSET, qreg.a6xx_sp_cs_pvt_mem_stack_offset(data.hw_stack_offset >> 11))
     # image_size is in bytes, but INSTR_SIZE is measured in units of instruction groups (16 instructions, 8 bytes each)
     # https://elixir.bootlin.com/mesa/mesa-26.1.5/source/src/freedreno/ir3/ir3_shader.h#L719-L723
     self.reg(mesa.REG_A6XX_SP_CS_INSTR_SIZE, qreg.a6xx_sp_cs_instr_size(ceildiv(data.image_size, 128)))

--- a/tinygrad/runtime/support/hcq2.py
+++ b/tinygrad/runtime/support/hcq2.py
@@ -75,6 +75,11 @@ def make_submit(*cmds, devs:str|tuple[str, ...], queue:str) -> UOp:
 @functools.cache
 def cfunc_buf(lib:str, name:str) -> Buffer:
   fn = getattr(importlib.import_module(f"tinygrad.runtime.autogen.{lib}").dll, name)
+  # Give the generated HCQ2 graph the QCOM mock's native-compatible entrypoint.
+  # mockgpu retains its owner; the buffer below carries only the function address.
+  if (lib, name) == ("libc", "ioctl") and any(t.device == "QCOM" and t.interface == "MOCK" for t in DEV.value):
+    from test.mockgpu.mockgpu import ioctl_callback
+    fn = unwrap(ioctl_callback)
   (b:=Buffer(HCQ_RUNTIME_DEV.value, 1, dtypes.uint64, preallocate=True))._buf.view.view(fmt='Q')[0] = unwrap(ctypes.cast(fn, ctypes.c_void_p).value)
   return b
 


### PR DESCRIPTION
```text
                                                                                                                                      ..     .
                                                                                                                                    ,r,    ;sr
                                                                                                                                  .s5r  .r59s  .r;.
                                                                                                                                .s5ir.;h##XXsih9i.   ,..
           ,.                                                                                                                 .iXr2SSG3Xis&M#i;rssir;.
            &i,                                                                                                             ;hG35G9&sH@#@2ii2H#MM#Xr;.
            SB#sr,                                                                                                      :;iXG&H@53&5HH5XH@@GXh5hhS5&GShr.
           .rrXh;rrr;.                                                                                               .iSSXhhXXG9@@9@@9H@52&A@H9H5253hir,
     .,,.X2r;rrshiXGGH3i;:                                                                                         ,r33XXSX3X2h5@@##@@&@&AX&@GAMM@#M@Gh,
     .;;;rih25Hi@9GX5A5GG5&hr;.                                                                                ;;rsXX22222X333S&@#@#@H@@h@@HG255sShS2ir
        :rihsrhs2h2shhA#@9&9@@A2si;                                                                        .rsXhhhhhhhhhh2XX3&@#@#@##@HA@@H@#MBBBBM@r.
          ..ih&32s2XS5X59&##HG5XXishir;.   .,.                                                           .r2Xhhhhhhhhhshh5&@#M&@###AM@#@BB@##H5GXi;.
         .,.:XhsS##9#B@@9s5GhG&5GAShshhX2hsssh55hi;.                                                   ,hShhhsshhhshhhSG@@@@#@@M###MGMH##A5S2993h:
           rshiihhrirhh@#MMBB5#@95&@95Sh5G95SXhh25AHsr:.                                             rs2hssssssssssshh2H@&A@M9##G#@G##G@&G&#M5;
              .rsG#BBBB#232hGA#BM@9&HHHBMhS&#@h@@5G52SGHhr;..                                     ;shhssssssssshssshXSAH9@@@MS#5hh@@G2S5##@G;
                ;ss;;shhH#MBM@S9A3BBM@2&MBM5@@@H#MB@XHA55GH5i;,.....          .                 .s5hssssssssssssssXS32GA#MG@M@GGH@XshM#A5si.
                  .;X@MBA5SX2#MBMGG2h#MM9s&#BG9MMM#MBM##@h#5G@5i;,...;isr;:,..,.::rrr.....    ;h5hsssssssssssshssh2X599SS&&HS5#S2s2MGsXAs.
                     ;rshh@BBBhi3A#BBM35MBB5@MB@G@#M9@#B#&H@#&5@@5;iShii;:::;ririirirr::.,,ri5Ghsssssissssssssshh2hG@G5&@GhG@AssM@hr55r.
                        .rh&A#5AMBB&GXHBM#5@M#@3#M@#MB#5@#A@#S##A#HX#BBBBMGMBBBBBB@hhr;;. rh5Shhhsssisiissiiiis55G#Ahh95rH@hiAMSi9MX;
                              ,rhX5#MBB#sGMM#h5BM@GAM##MMM##@GM#HM&MMMBBBBBBBB#55hh#H5r;;.X95hsirrrrriiiirrrs&hXH@G@#S595r&#&h#BGs;
                                    ,;ihX#BM#MBB59MB##@5MB#X@#B##MHMGr.;HBBB@s,  ,i#MS2r;,:2i:..,::,,;;rrriXSGGX2@@G&H9MM9;M#Xr.
                                          .;rh9MMMBBB#SMBM#&@#M##M@MB#s::MB#&. ::r#BM@sir:,;r.     ,;.,rrrrsh2A@X5@#MHHM@hr,
                                                 .:;ihhA#BB#@BBB@#M@BBBBiXB@3.,@#MBBMhXrr::,r::..,h@hirXXS25@M#@#MM@3i;.
                                                           .,;ris2&5#BBB#X#5r.i#BBB#i5r;r;r,r;,.,,:r@BBBBBBBB@sr;:.
                                                                   .sHBBBB5h;&#BBBHr2irr;::;;;:;;r;rri2SXii;.
      A630 -- QCOM mock GPU                                          ;XHMBBG#BB#GsrXirrrrrr;;r;;;rrrs232hi;:
                                                                       ;:riA95hsiishssirr;.:isshiiirih2SG&G&9hr;.
      real KGSL / PM4 / IR3 submissions,                                          ;sissssshhhshhsiiiihhX&9A9@A9##&isr.
      executed without hardware                                                     h&ShXXhhXhsshhhhisXX##@@MMM#MB@X5#9hr;
                                                                                   iBBBA##B##B#hrrhiissS2#####MB9GSH#Xsh29Gs:
                                                                                  rMBBB#M@##@#MMh:isiis2SHMM@5Ghi5&9sis2HGGr.
                                                                                   &###25HM@2@5#Xr,rr;ihs2A##&A5HrrAGS@X;,
                                                                                   i#M#h2&@@sG#X&i;,.:iB3h5S#@h&@Siisr,
                                                                                    rih#MMMBhS##2SHrr;;;ris5HGShr
                                                                                           .
```

# QCOM A630 mock: run real submissions without hardware

`DEV=MOCK+QCOM` stops at the driver boundary today. This runs the rest of the path.

KGSL ioctls land in a mock driver that owns mappings and per-context command queues. PM4
packets are decoded and the whole command is validated before any action applies. Emitted IR3
is decoded and executed per lane over NumPy arrays. Global writes stage into a transaction and
publish only when a segment completes, so a rejected segment leaves memory untouched.

Both compiler routes run for real: Mesa IR3, and the vendor QCOMCL shared object. Neither is
stubbed — the emulator consumes actual compiler output rather than substituting a CPU result.

## Production diff: 5 files, +25 −5

`sz.py` goes 25201 → 25214.

| file | what |
|---|---|
| `engine/realize.py`, `runtime/support/hcq2.py` | mock callback wiring and retained-error delivery, gated on `QCOM`+`MOCK` |
| `renderer/nir.py` | optional `readonly` arg on the private `_nload_img` helper; existing callers keep their behaviour |
| `runtime/ops_qcom.py` | `CONSTLEN` and `PVT_MEM_STACK_OFFSET` were encoded unshifted |
| `mixin/op.py` | `image_dot` folded unbroadcast batch dims |

The last two are real bugs, not mock accommodations. `a6xx.xml` gives `SP_CS_CONST_CONFIG`
(0xb987) `CONSTLEN` `shr=2` and `SP_CS_PVT_MEM_STACK_OFFSET` (0xa9bd) `OFFSET` `shr=11`; the
generated Python bindings drop `shr` entirely, so `_qreg_exec` cannot apply it. `constlen=256`
lands as zero in an 8-bit field, and the stack offset arrives 2048× too large. Strict launch
validation is what surfaced it. Two other `shr` fields are already pre-scaled by their callers,
so applying `shr` centrally in the encoder would double-shift them.

`image_dot` folds `self`'s batch dims into the conv batch and `w`'s into conv groups, then
divides one by the other. Neither operand is broadcast first, so `(3,5) @ (2,5,7)` gives groups
greater than bs and a zero-sized reshape, and `(2,3,4,5) @ (2,1,5,7)` groups along an axis `w`
was never expanded over. Broadcasting both to the common batch shape first, as `dot` already
does, fixes both; shapes that already divided cleanly are unchanged.

Rank-one right operands are still unsupported here and reported separately in [#18049](https://github.com/tinygrad/tinygrad/issues/18049).

Everything else is under `test/mockgpu/qcom/` and `test/testextra/`.

## CI

One job, two routes, `timeout-minutes: 15`, matching the rest of the file.

The IR3 leg runs the whole emulator suite: 679 cases, 8,590 observations counting subtests, in
about a minute. The CL leg stays at eight cases because `libllvm-qcom.so` is an arm64 binary and
runs under qemu here.

Seven files are excluded with `--ignore`. Each reproduces a defect reported separately, and each
is expected to fail until that defect is fixed — they are diagnostics attached to those reports,
not assertions about the emulator.

The first filed defect reports are [right-hand vector indexing (#18049)](https://github.com/tinygrad/tinygrad/issues/18049)
and [QCOM disassembly generation selection (#18050)](https://github.com/tinygrad/tinygrad/issues/18050).

## Not supported

`MADSH.U16` raises. `SEL.F32` is admitted only for the form actually traced out of QCOMCL:
full registers, one negated source shared with the third operand, the two condition words the
comparison/COV/minus-one sequence emits, and normal finite payloads. Half registers, other
modifier combinations, NOP-marked encodings, and zero/subnormal/inf/NaN payloads raise before
writeback rather than being guessed.

## Run it

```sh
DEV=MOCK+QCOM:IR3 HCQ_RUNTIME_DEV=CPU PYTHONPATH=. python -m pytest test/mockgpu/qcom -n12
```

The CL route additionally needs `LLVM_QCOM_PATH` pointing at `libllvm-qcom.so`.

## Module flows

One diagram per module, annotated with function names and line references.

<img width="1800" height="1350" alt="01-qcomdriver" src="https://github.com/user-attachments/assets/800e1d41-21ac-441d-943d-edd8c52c6f9d" />
<img width="1800" height="1350" alt="02-qcomgpu" src="https://github.com/user-attachments/assets/5b892ece-95d3-43fc-96cd-6b1c2093abbe" />
<img width="1800" height="1350" alt="03-emu" src="https://github.com/user-attachments/assets/92f8b38c-4fba-4ffc-83fa-bc22a1fded74" />


## AI use

Jeremy Cull, Astra (ChatGPT) and Claude collaborated on this work. The AI contributions were
significant, and covered implementation, test development, documentation and review. They were
accelerants, not architects or curators. Direction, scope, the decision about what belongs in the
emulator versus what is a defect report, and every judgment about what ships were mine.

I take responsibility for what is here and can explain and defend it.

## Why Merge Statement

For the same reason every civilization has a pyramid: build a simple layer, and see how high it can go. Because "it's there".

[module_flowcharts.pdf](https://github.com/user-attachments/files/31934273/module_flowcharts.pdf)
