### PR TITLE
fix: image_dot handles 1D right-hand tensor without IndexError

### DIFF
--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -1467,6 +1467,10 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     # NOTE: we use a 1x1 conv2d to do the matmul. mxk @ kxn = (1,k,m,1).conv2d(n,k,1,1)
     if not (self.ndim > 0 and w.ndim > 0): raise RuntimeError(f"both tensors need to be at least 1D, got {self.ndim=}, {w.ndim=}")
     if self.shape[-1] != w.shape[-min(w.ndim, 2)]: raise RuntimeError(f"cannot image_dot {self.shape} and {w.shape}")
+    # 1D tensors don't have a -2 axis; promote w to 2D, recurse, then squeeze
+    if w.ndim == 1:
+      ret = self.image_dot(w.unsqueeze(-1), dtype=dtype)
+      return ret.squeeze(-1)
 
     bs, groups, cin, cout = prod(self.shape[0:-2]), prod(w.shape[0:-2]), w.shape[-2], w.shape[-1]
     out_shape_t = self.shape[0:-2] + (cout,-1) if len(self.shape) > 1 else (cout,)


### PR DESCRIPTION
## Summary

`Tensor.image_dot` crashes with `IndexError` when called with a 1D right-hand tensor. 1D tensors don't have the `-2` axis needed for conv2d matmul decomposition.

## Root Cause

In `tinygrad/mixin/op.py`, `image_dot` accesses `w.shape[-2]` to get `cin`, but a 1D tensor `(k,)` only has one axis, so `-2` is out of bounds.

## Fix

Before the bounds check, detect 1D `w`, promote it to 2D via `unsqueeze(-1)`, recurse, then `squeeze(-1)` the result to restore the original shape.

```python
if w.ndim == 1:
    ret = self.image_dot(w.unsqueeze(-1), dtype=dtype)
    return ret.squeeze(-1)
```

## Reproduction

```sh
DEV=PYTHON IMAGE=1 FLOAT16=0 python -c \
  "import numpy as np; from tinygrad import Tensor; \
   print((Tensor(np.eye(5,dtype=np.float32),device='PYTHON') \
          @ Tensor(np.arange(5,dtype=np.float32),device='PYTHON')).numpy())"
```

Before: `IndexError`
After: `[0., 1., 2., 3., 4.]`

Fixes #18049
