### PR TITLE
cdna inst mapping

### DIFF
--- a/test/amd/test_sqtt_profiler.py
+++ b/test/amd/test_sqtt_profiler.py
@@ -8,7 +8,7 @@ from tinygrad.engine.realize import run_linear
 from tinygrad.codegen import to_program
 from tinygrad.viz.serve import load_amd_counters, VizData
 from tinygrad.renderer.amd.sqtt import decode, print_packets
-from tinygrad.renderer.amd.dsl import s
+from tinygrad.renderer.amd.dsl import s, v
 
 @contextlib.contextmanager
 def save_sqtt():
@@ -27,8 +27,28 @@ def map_sqtt(profile:list) -> list[dict]:
 def custom_asm_cdna(A:UOp):
   import tinygrad.runtime.autogen.amd.cdna.ins as cdna
   WAVE_SIZE = 64
-  insts = [cdna.s_nop(0), cdna.s_mov_b32(s[0], 10)]
-  return custom_asm(A, insts+[cdna.s_endpgm()], WAVE_SIZE*2)
+  insts = [
+    cdna.s_mov_b32(s[0], 1),
+
+    # taken: SCC=1, skip v0=0x11
+    cdna.s_cmp_eq_u32(s[0], 1),
+    cdna.s_cbranch_scc1(1),
+    cdna.v_mov_b32_e32(v[0], 0x11),
+    cdna.v_mov_b32_e32(v[0], 0x22),
+
+    # not taken: SCC=0, execute v1=0x33
+    cdna.s_cmp_eq_u32(s[0], 0),
+    cdna.s_cbranch_scc1(1),
+    cdna.v_mov_b32_e32(v[1], 0x33),
+
+    # unconditional: skip v2=0x44
+    cdna.s_branch(1),
+    cdna.v_mov_b32_e32(v[2], 0x44),
+    cdna.v_mov_b32_e32(v[2], 0x55),
+
+    cdna.s_endpgm(),
+  ]
+  return custom_asm(A, insts, WAVE_SIZE)
 
 def custom_asm_rdna(A:UOp):
   import tinygrad.runtime.autogen.amd.rdna3.ins as rdna3

--- a/test/amd/test_sqtt_profiler.py
+++ b/test/amd/test_sqtt_profiler.py
@@ -1,5 +1,6 @@
 import unittest, contextlib
 from tinygrad import Device, Tensor, Context, TinyJit, dtypes
+from tinygrad.dtype import AddrSpace
 from test.helpers import is_hcq2_device
 from tinygrad.uop.ops import UOp, Ops, KernelInfo
 from tinygrad.device import Compiled, ProfileProgramEvent
@@ -28,27 +29,45 @@ def custom_asm_cdna(A:UOp):
   import tinygrad.runtime.autogen.amd.cdna.ins as cdna
   WAVE_SIZE = 64
   insts = [
-    cdna.s_mov_b32(s[0], 1),
+    cdna.s_barrier(),
+    cdna.s_getreg_b32(s[0], cdna.HWREG.HW_REG_HW_ID.value | (4 << 6) | (1 << 11)),
 
-    # taken: SCC=1, skip v0=0x11
-    cdna.s_cmp_eq_u32(s[0], 1),
-    cdna.s_cbranch_scc1(1),
-    cdna.v_mov_b32_e32(v[0], 0x11),
-    cdna.v_mov_b32_e32(v[0], 0x22),
-
-    # not taken: SCC=0, execute v1=0x33
     cdna.s_cmp_eq_u32(s[0], 0),
-    cdna.s_cbranch_scc1(1),
-    cdna.v_mov_b32_e32(v[1], 0x33),
+    cdna.s_cbranch_scc1(16),
 
-    # unconditional: skip v2=0x44
-    cdna.s_branch(1),
-    cdna.v_mov_b32_e32(v[2], 0x44),
-    cdna.v_mov_b32_e32(v[2], 0x55),
+    cdna.s_cmp_eq_u32(s[0], 1),
+    cdna.s_cbranch_scc1(9),
 
+    cdna.s_cmp_eq_u32(s[0], 2),
+    cdna.s_cbranch_scc1(3),
+
+    # SIMD 3
+    cdna.v_mov_b32_e32(v[0], 3),
+    cdna.s_nop(3),
+    cdna.s_endpgm(),
+
+    # SIMD 2
+    cdna.v_mov_b32_e32(v[0], 2),
+    cdna.s_nop(2),
+    cdna.s_nop(2),
+    cdna.s_endpgm(),
+
+    # SIMD 1
+    cdna.v_mov_b32_e32(v[0], 1),
+    cdna.s_nop(1),
+    cdna.s_nop(1),
+    cdna.s_nop(1),
+    cdna.s_endpgm(),
+
+    # SIMD 0
+    cdna.v_mov_b32_e32(v[0], 0),
+    cdna.s_nop(0),
+    cdna.s_nop(0),
+    cdna.s_nop(0),
+    cdna.s_nop(0),
     cdna.s_endpgm(),
   ]
-  return custom_asm(A, insts, WAVE_SIZE)
+  return custom_asm(A, insts, WAVE_SIZE*4, 96*1024)
 
 def custom_asm_rdna(A:UOp):
   import tinygrad.runtime.autogen.amd.rdna3.ins as rdna3
@@ -56,8 +75,9 @@ def custom_asm_rdna(A:UOp):
   insts = [rdna3.s_nop(0), rdna3.s_mov_b32(s[0], 10)]
   return custom_asm(A, insts+[rdna3.s_endpgm()], WAVE_SIZE*2)
 
-def custom_asm(A, insts, num_threads) -> UOp:
-  return UOp(Ops.PROGRAM, src=(UOp.sink(A, UOp.special(num_threads, "lidx0"), arg=KernelInfo("asm")), \
+def custom_asm(A, insts, num_threads, lds_size=0) -> UOp:
+  lds = UOp.placeholder((lds_size,), dtypes.uint8, addrspace=AddrSpace.LOCAL) if lds_size else None
+  return UOp(Ops.PROGRAM, src=(UOp.sink(A, lds, UOp.special(num_threads, "lidx0"), arg=KernelInfo("asm")), \
       UOp(Ops.LINEAR, src=tuple([UOp(Ops.INS,arg=(x,dtypes.void)) for x in insts]))))
 
 @unittest.skipUnless(Device.DEFAULT == "AMD", "only runs on AMD")

--- a/tinygrad/renderer/amd/sqtt.py
+++ b/tinygrad/renderer/amd/sqtt.py
@@ -670,7 +670,12 @@ def map_insts(data:bytes, lib:bytes, target:str) -> Iterator[tuple[PacketType, I
       for wave in range(10):
         if (p.inst >> (wave * 2)) & 3 == 3:
           inst = pc_map[pc:=wave_pc[(p.simd, wave)]]
+          wave_pc[(p.simd, wave)] += inst.size()
           yield (p, InstructionInfo(pc, wave, inst))
+    elif isinstance(p, CDNA_INST):
+      inst = pc_map[pc:=wave_pc[(p.simd, p.wave)]]
+      wave_pc[(p.simd, p.wave)] += inst.size()
+      yield (p, InstructionInfo(pc, p.wave, inst))
     # map INST events on this SIMD to the program counter, we know the waves
     elif isinstance(p, (VALUINST, INST, INST_RDNA4, IMMEDIATE)) and not (isinstance(p, (INST, INST_RDNA4)) and p.op.name.startswith("OTHER_")):
       inst = pc_map[pc:=wave_pc[(simd, p.wave)]]

--- a/tinygrad/renderer/amd/sqtt.py
+++ b/tinygrad/renderer/amd/sqtt.py
@@ -670,11 +670,16 @@ def map_insts(data:bytes, lib:bytes, target:str) -> Iterator[tuple[PacketType, I
       for wave in range(10):
         if (p.inst >> (wave * 2)) & 3 == 3:
           inst = pc_map[pc:=wave_pc[(p.simd, wave)]]
+          if getattr(inst, 'op_name', '') not in {'S_NOP', 'S_WAITCNT'}: continue
           wave_pc[(p.simd, wave)] += inst.size()
           yield (p, InstructionInfo(pc, wave, inst))
     elif isinstance(p, CDNA_INST):
       inst = pc_map[pc:=wave_pc[(p.simd, p.wave)]]
-      wave_pc[(p.simd, p.wave)] += inst.size()
+      if p.op == InstOpCDNA.JUMP:
+        x = getattr(inst, 'simm16') & 0xffff
+        wave_pc[(p.simd, p.wave)] += inst.size() + (x - 0x10000 if x & 0x8000 else x)*4
+      else:
+        wave_pc[(p.simd, p.wave)] += inst.size()
       yield (p, InstructionInfo(pc, p.wave, inst))
     # map INST events on this SIMD to the program counter, we know the waves
     elif isinstance(p, (VALUINST, INST, INST_RDNA4, IMMEDIATE)) and not (isinstance(p, (INST, INST_RDNA4)) and p.op.name.startswith("OTHER_")):


### PR DESCRIPTION
works in ther asm gemm
<img width="3798" height="1204" alt="image" src="https://github.com/user-attachments/assets/e36ad4ca-5318-439c-9e71-f299c51d4145" />
even acc vgpr ops are MAI, so this can help find which MAI packets are MFMA (and should extend to 16 cycles instead of 4, and get another row)
<img width="1912" height="586" alt="Screenshot 2026-09-08 at 3 42 47 PM" src="https://github.com/user-attachments/assets/7e0296b0-71b5-4900-80e5-70d1b9e846d3" />
