### PR TITLE
QCOM: pass numeric GPU ID to the disassembler

### DIFF
--- a/test/unit/test_compiler_qcom.py
+++ b/test/unit/test_compiler_qcom.py
@@ -1,0 +1,21 @@
+import struct, unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+from tinygrad.runtime.support.compiler_qcom import QCOMCompiler
+
+class TestQCOMCompiler(unittest.TestCase):
+  def test_disassemble_gpu_id(self):
+    shader = b"shader payload"
+    offset = 0x120
+    lib = bytearray(offset + len(shader) + 8)
+    struct.pack_into("I", lib, 0xc0, offset)
+    struct.pack_into("I", lib, 0x100, len(shader))
+    lib[offset:offset+len(shader)] = shader
+    lib[-8:] = b"trailer!"
+    for arch in ("a630", "a630,IMAGE_PITCH_ALIGNMENT=64"):
+      with self.subTest(arch=arch), patch("tinygrad.runtime.support.compiler_qcom.disas_adreno") as disassemble:
+        QCOMCompiler.disassemble(SimpleNamespace(arch=arch, chip_id=0x6030001), bytes(lib))
+        disassemble.assert_called_once_with(shader, 630)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tinygrad/runtime/support/compiler_qcom.py
+++ b/tinygrad/runtime/support/compiler_qcom.py
@@ -43,5 +43,5 @@ class QCOMCompiler(Compiler):
     llvm_qcom.cl_compiler_free_assembly(ptr)
     return ret
 
-  def disassemble(self, lib: bytes): disas_adreno(lib[(ofs:=_read_lib(lib, 0xc0)):ofs+_read_lib(lib, 0x100)], self.chip_id)
+  def disassemble(self, lib: bytes): disas_adreno(lib[(ofs:=_read_lib(lib, 0xc0)):ofs+_read_lib(lib, 0x100)], int(self.arch.split(',')[0][1:]))
 


### PR DESCRIPTION
# QCOM: pass numeric GPU ID to the disassembler

QCOM disassembly passes the packed compiler chip ID (`0x6030001`) where
`disas_adreno` expects GPU ID `630`. Derive that ID from the architecture prefix,
including architectures with comma-separated options. Preserve the vendor
compiler ID and shader offset/length handling.

Fixes https://github.com/tinygrad/tinygrad/issues/18050

The regression checks both `a630` and `a630,IMAGE_PITCH_ALIGNMENT=64` and verifies
that only the shader payload reaches the decoder.

Validation (Python 3.12.12, macOS arm64, base fd78b62):
- CPU tests: `python -m pytest test/unit/test_compiler_qcom.py test/device/test_qcom.py test/test_tiny.py -n12 -q`
- Additional local reproducer: two parameterized cases failed before the fix
  and passed afterward.
- `python -m ruff check .` passed.
- `python -m mypy tinygrad/` passed (215 files).
- Native Adreno ISA decoding and vendor compilation were not tested. The
  regression mocks the decoder and checks the Python call boundary.

AI assistance: implementation, regression tests and this draft were prepared
with an AI coding assistant.
