### PR TITLE
fix hardsigmoid cancellation at large inputs

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1089,6 +1089,8 @@ class TestOps(unittest.TestCase):
   def test_hardsigmoid_extreme(self):
     helper_test_op([(45,65)], torch.nn.functional.hardsigmoid, Tensor.hardsigmoid, low=300, high=400)
     helper_test_op([(45,65)], torch.nn.functional.hardsigmoid, Tensor.hardsigmoid, low=-400, high=-300)
+    helper_test_op(None, torch.nn.functional.hardsigmoid, Tensor.hardsigmoid, vals=[[1e7, 1e8, 2.68e8, 1e9]])
+    helper_test_op(None, torch.nn.functional.hardsigmoid, Tensor.hardsigmoid, vals=[[-3.1, -3., -2.9, 2.9, 3., 3.1]])
   def test_softplus(self):
     helper_test_op([(45,65)], torch.nn.functional.softplus, Tensor.softplus, grad_atol=1e-6)
     helper_test_op([(45,65)], lambda t: torch.nn.functional.softplus(t, beta=3), lambda t: Tensor.softplus(t, beta=3), grad_atol=1e-6)

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -730,7 +730,7 @@ class ElementwiseMixin(CreationMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).hardsigmoid().numpy())
     ```
     """
-    return (alpha * self + beta).relu() - (alpha * self + beta - 1).relu()
+    return ((y:=(alpha * self + beta).relu()) < 1).where(y, 1)
 
   def hardtanh(self, min_val=-1, max_val=1) -> Self:
     """


### PR DESCRIPTION
hardsigmoid is relu(ax+b) - relu(ax+b-1), which cancels once ulp(ax+b) > 1. float16 returns 2 at 8192 and 0 from 16384, float32 returns 2 at 1e8 and 0 from 2.68e8. inf returns nan, torch gives 1. clamping the top instead of subtracting is 16 uops to 11, and the gradient at 3 becomes 0, matching torch. clip(0,1) lowers to the same 11 but keeps 1/6 there and test_hardsigmoid_extreme only sampled 300 to 400, below where the two forms differ

test: python -m pytest test/backend/test_ops.py -k hardsigmoid
