### PR TITLE
add parallel associative scan

### DIFF
--- a/docs/tensor/ops.md
+++ b/docs/tensor/ops.md
@@ -30,6 +30,7 @@
 ::: tinygrad.Tensor.dot
 ::: tinygrad.Tensor.matmul
 ::: tinygrad.Tensor.einsum
+::: tinygrad.Tensor.associative_scan
 ::: tinygrad.Tensor.cumsum
 ::: tinygrad.Tensor.cumprod
 ::: tinygrad.Tensor.cummax

--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1142,6 +1142,26 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], torch.nn.functional.mish, Tensor.mish)
     helper_test_op([()], torch.nn.functional.mish, Tensor.mish)
 
+  def test_associative_scan(self):
+    helper_test_op([(10,)], lambda x: torch.cumsum(x, dim=0), lambda x: x.associative_scan(lambda a, b: a+b))
+    helper_test_op([(3,4)], lambda x: torch.cumsum(x, dim=1), lambda x: x.associative_scan(lambda a, b: a+b, axis=-1))
+    helper_test_op([(9,)], lambda x: torch.flip(torch.cumsum(torch.flip(x, (0,)), dim=0), (0,)),
+                   lambda x: x.associative_scan(lambda a, b: a+b, reverse=True))
+    helper_test_op([(0,3)], lambda x: x, lambda x: x.associative_scan(lambda a, b: a+b), forward_only=True)
+    helper_test_op([(1,)], lambda x: x, lambda x: x.associative_scan(lambda a, b: a+b))
+    helper_test_op([()], lambda x: x, lambda x: x.associative_scan(lambda a, b: a+b))
+
+  def test_associative_scan_noncommutative(self):
+    def torch_scan(x, reverse=False):
+      if reverse: x = torch.flip(x, (0,))
+      out = [x[0]]
+      for i in range(1, x.shape[0]): out.append(out[-1] @ x[i])
+      ret = torch.stack(out)
+      return torch.flip(ret, (0,)) if reverse else ret
+    helper_test_op([(5,2,2)], torch_scan, lambda x: x.associative_scan(lambda a, b: a@b), forward_only=True, atol=1e-5, rtol=1e-5)
+    helper_test_op([(5,2,2)], lambda x: torch_scan(x, True), lambda x: x.associative_scan(lambda a, b: a@b, reverse=True),
+                   forward_only=True, atol=1e-5, rtol=1e-5)
+
   def test_small_cumsum(self):
     helper_test_op([(10)], lambda x: torch.cumsum(x, dim=0), lambda x: Tensor.cumsum(x, axis=0))
   @slow_test

--- a/test/null/test_tensor_uop_mixin.py
+++ b/test/null/test_tensor_uop_mixin.py
@@ -154,6 +154,16 @@ class TestTensorUOpGetitem(unittest.TestCase):
     self.assertIs(_strip_unique(_t(4,5)[[[0,1],[2,3]]].uop), _strip_unique(_t(4,5).uop[[[0,1],[2,3]]]))
 
 class TestTensorUOpCumalu(unittest.TestCase):
+  def test_associative_scan(self): _check(self, _t(5), lambda x: x.associative_scan(lambda a, b: a+b))
+  def test_associative_scan_reverse(self): _check(self, _t(3, 4), lambda x: x.associative_scan(lambda a, b: a+b, axis=1, reverse=True))
+  def test_associative_scan_log_depth(self):
+    calls = 0
+    def add(a, b):
+      nonlocal calls
+      calls += 1
+      return a+b
+    _t(1024).associative_scan(add)
+    self.assertLessEqual(calls, 2*math.ceil(math.log2(1024)))
   def test_cumsum_1d(self):       _check(self, _t(5), lambda x: x.cumsum())
   def test_cumsum_2d(self):       _check(self, _t(3, 4), lambda x: x.cumsum(1))
   def test_cumsum_non_last(self): _check(self, _t(3, 4), lambda x: x.cumsum(0))

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -767,6 +767,41 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     base = chunks[..., -1]._cumalu(-1, op)._pad_constant((None,)*(chunks.ndim-2) + ((1, -1),), value)
     return chunks.alu(op, base.unsqueeze(-1)).flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
 
+  def associative_scan(self, fn:Callable[[Self, Self], Self], axis:int=0, reverse:bool=False) -> Self:
+    """
+    Computes an inclusive scan along `axis` using associative binary function `fn`.
+
+    `fn` does not need to be commutative. The scan preserves the left-to-right order of the input.
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor([1, 2, 3, 4])
+    print(t.associative_scan(lambda x, y: x + y).numpy())
+    ```
+    """
+    axis = self._resolve_dim(axis)
+    if self.ndim == 0: return self
+    if not isinstance(self.shape[axis], int): raise RuntimeError(f"associative_scan requires a static scan dimension, got {self.shape[axis]}")
+    if self.shape[axis] < 2: return self
+
+    def _slice(x:Self, start:int|None=None, stop:int|None=None, step:int|None=None) -> Self:
+      return x[(slice(None),)*axis + (slice(start, stop, step),)]
+
+    def _scan(x:Self) -> Self:
+      assert isinstance(n:=x.shape[axis], int)
+      if n < 2: return x
+
+      odd = _scan(fn(_slice(x, None, -1, 2), _slice(x, 1, None, 2)))
+      tails = _slice(x, 2, None, 2)
+      prev = _slice(odd, None, -1) if n % 2 == 0 else odd
+      even = _slice(x, None, 1)
+      if tails.shape[axis]: even = even.cat(fn(prev, tails), dim=axis)
+
+      paired = _slice(even, None, odd.shape[axis]).stack(odd, dim=axis+1).flatten(axis, axis+1)
+      return paired.cat(_slice(even, odd.shape[axis], None), dim=axis) if n % 2 else paired
+
+    ret = _scan(self.flip(axis) if reverse else self)
+    return ret.flip(axis) if reverse else ret
+
   def cumsum(self, axis:int=0) -> Self:
     """
     Computes the cumulative sum of the tensor along the specified `axis`.


### PR DESCRIPTION
Implements #3039.

Adds Tensor.associative_scan using recursive pair reduction, with axis/reverse support and preserved operand order for noncommutative associative operations.

Tests cover addition, reverse and non-last axes, edge sizes, matrix multiplication, Tensor/UOp parity, and logarithmic combine depth.

AI disclosure: AI assistance was used to develop and review the implementation and tests. I reviewed the final diff and ran the local validation.