### PR TITLE
add associative scan

### DIFF
--- a/test/test_tiny.py
+++ b/test/test_tiny.py
@@ -31,6 +31,29 @@ class TestTiny(unittest.TestCase):
     out = Tensor.ones(16).contiguous() + Tensor.ones(16).contiguous()
     self.assertListEqual(out.tolist(), [2]*16)
 
+  def test_associative_scan(self):
+    def add(a, b): return a+b
+    self.assertListEqual(Tensor([1,2,3,4]).associative_scan(add).tolist(), [1,3,6,10])
+    self.assertListEqual(Tensor([[1,2,3],[4,5,6]]).associative_scan(add, axis=-1).tolist(), [[1,3,6],[4,9,15]])
+    self.assertListEqual(Tensor([1,2,3,4]).associative_scan(add, reverse=True).tolist(), [10,9,7,4])
+    self.assertEqual(Tensor(3).associative_scan(add).item(), 3)
+    self.assertListEqual(Tensor.empty(0).associative_scan(add).tolist(), [])
+
+    calls = 0
+    def counted_add(a, b):
+      nonlocal calls
+      calls += 1
+      return a+b
+    Tensor.empty(1024).associative_scan(counted_add)
+    self.assertLessEqual(calls, 20)
+
+  def test_associative_scan_noncommutative(self):
+    x = Tensor([[[1,1],[0,1]], [[1,0],[1,1]], [[2,0],[0,1]]])
+    self.assertListEqual(x.associative_scan(lambda a, b: a@b).tolist(),
+                         [[[1,1],[0,1]], [[2,1],[1,1]], [[4,1],[2,1]]])
+    self.assertListEqual(x.associative_scan(lambda a, b: a@b, reverse=True).tolist(),
+                         [[[2,2],[1,2]], [[2,0],[1,1]], [[2,0],[0,1]]])
+
   def test_cat(self):
     out = Tensor.cat(Tensor.ones(8).contiguous(), Tensor.zeros(8).contiguous())
     self.assertListEqual(out.tolist(), [1]*8+[0]*8)

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -767,6 +767,32 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     base = chunks[..., -1]._cumalu(-1, op)._pad_constant((None,)*(chunks.ndim-2) + ((1, -1),), value)
     return chunks.alu(op, base.unsqueeze(-1)).flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
 
+  def associative_scan(self, fn:Callable[[Self, Self], Self], axis:int=0, reverse:bool=False) -> Self:
+    """Computes an inclusive scan along `axis` using associative binary function `fn`."""
+    if self.ndim == 0: return self
+    axis = self._resolve_dim(axis)
+    n = self.shape[axis]
+    if not isinstance(n, int): raise RuntimeError(f"associative_scan requires a static scan dimension, got {n}")
+    if n < 2: return self
+
+    def _slice(x:Self, start:int|None=None, stop:int|None=None, step:int|None=None) -> Self:
+      return x[(slice(None),)*axis + (slice(start, stop, step),)]
+
+    def _scan(x:Self) -> Self:
+      n = x.shape[axis]
+      assert isinstance(n, int)
+      if n < 2: return x
+      odd = _scan(fn(_slice(x, None, -1, 2), _slice(x, 1, None, 2)))
+      even = _slice(x, None, 1)
+      if n > 2:
+        prev = _slice(odd, None, -1) if n%2 == 0 else odd
+        even = even.cat(fn(prev, _slice(x, 2, None, 2)), dim=axis)
+      ret = _slice(even, None, odd.shape[axis]).stack(odd, dim=axis+1).flatten(axis, axis+1)
+      return ret.cat(_slice(even, odd.shape[axis], None), dim=axis) if n%2 else ret
+
+    ret = _scan(self.flip(axis) if reverse else self)
+    return ret.flip(axis) if reverse else ret
+
   def cumsum(self, axis:int=0) -> Self:
     """
     Computes the cumulative sum of the tensor along the specified `axis`.


### PR DESCRIPTION
Adds `Tensor.associative_scan` for inclusive associative prefix scans across static axes, including reverse scans and noncommutative operators.

Validation:
- `python3.13 -m unittest test.test_tiny`: 24 tests passed, 2 skipped
- `python3.13 -m unittest test.null.test_tensor_uop_mixin`: 215 tests passed
- 1024-element scan uses 19 batched combine calls
- Ruff on changed files, compileall, and `git diff --check` passed

Fixes #3039

AI disclosure: AI assistance was used to develop and review the implementation and tests. I reviewed the final diff and ran the local validation.
