### PR TITLE
NIR: request nearest-even for float16 casts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -655,6 +655,9 @@ jobs:
         shell: bash
         if: contains(matrix.dev, 'a630')
         run: DEBUG=7 python3 test/backend/test_ops.py TestOps.test_gemm | grep isam
+      - name: Test IR3 cast rounding
+        if: contains(matrix.dev, 'IR3')
+        run: python -m pytest -n=auto test/null/test_compile_failures.py::TestDisassembly::test_float16_cast_rounding
       - name: Run test_ops
         shell: bash
         run: |

--- a/test/backend/test_dtype.py
+++ b/test/backend/test_dtype.py
@@ -5,7 +5,7 @@ from typing import Any, List
 from tinygrad.helpers import getenv, DEBUG, EMULATED_DTYPES, DEV
 from tinygrad.dtype import DType, DTYPES_DICT, least_upper_dtype, fp8_to_float, float_to_fp8, _to_np_dtype, _to_torch_dtype, truncate
 from tinygrad.renderer.ptx import PTXRenderer
-from tinygrad.renderer.nir import NIRRenderer
+from tinygrad.renderer.nir import NIRRenderer, LVPRenderer
 from tinygrad import Context, Device, Tensor, dtypes
 from hypothesis import given, settings, strategies as strat
 from test.helpers import rand_for_dtype, min_normal
@@ -236,6 +236,13 @@ class TestFloatDType(TestDType):
 @unittest.skipUnless(dtypes.double in supported_dtypes, f"no double on {Device.DEFAULT}")
 class TestDoubleDType(TestDType):
   DTYPE = dtypes.double
+  @unittest.skipUnless(isinstance(Device[Device.DEFAULT].renderer, LVPRenderer), "LVP double-to-half lowering")
+  def test_float64_to_half_rounding(self):
+    # A float32 intermediate loses which side of the half-way boundary the float64 input was on.
+    values = np.array([sign * (1 + 2**-11 + delta) for sign in [1, -1] for delta in [-2**-40, 0, 2**-40]], dtype=np.float64)
+    actual = Tensor(values).cast(dtypes.half).bitcast(dtypes.ushort).numpy()
+    np.testing.assert_array_equal(actual, [0x3c00, 0x3c00, 0x3c01, 0xbc00, 0xbc00, 0xbc01])
+
   @unittest.skipIf((DEV.interface.startswith("MOCK") and Device.DEFAULT in {"CUDA", "NV"}) or \
    isinstance(Device[Device.DEFAULT].renderer, (PTXRenderer, NIRRenderer)), "conversion not supported on CI CUDA, PTX, and NIR")  # TODO: why not?
   def test_float64_increased_precision(self):

--- a/test/null/test_compile_failures.py
+++ b/test/null/test_compile_failures.py
@@ -4,6 +4,7 @@ from tinygrad import Tensor, dtypes, Device
 from tinygrad.helpers import OSX
 from tinygrad.engine.realize import compile_linear
 from tinygrad.codegen import to_program
+from tinygrad.renderer.nir import IR3Renderer
 
 class TestCompileFailures(unittest.TestCase):
   def compile(self, out:Tensor):
@@ -16,6 +17,18 @@ class TestCompileFailures(unittest.TestCase):
     self.compile((Tensor.empty(1024, dtype='uint8') + Tensor.empty(1024, dtype='uint8')).max())
 
 class TestDisassembly(unittest.TestCase):
+  @unittest.skipUnless(isinstance(Device[Device.DEFAULT].renderer, IR3Renderer), "IR3 rounding encoding")
+  def test_float16_cast_rounding(self):
+    # Half casts use nearest-even; IR3's default conversion mode truncates instead.
+    c = Tensor.empty(8, dtype=dtypes.float32).cast(dtypes.float16).bitcast(dtypes.uint16)
+    p = to_program(c.schedule_linear().src[-1].src[0], Device[Device.DEFAULT].renderer)
+    lib = Device[Device.DEFAULT].compiler.compile(p.src[2].arg)
+    out = io.StringIO()
+    with redirect_stdout(out): Device[Device.DEFAULT].compiler.disassemble(lib)
+    conversions = [line for line in out.getvalue().splitlines() if "cov.f32f16" in line]
+    self.assertTrue(conversions, out.getvalue())
+    self.assertTrue(all("(even)" in line for line in conversions), "\n".join(conversions))
+
   @unittest.skipUnless(Device.DEFAULT == "CPU" and OSX, "m series cpus support fp16 arithmetic")
   def test_float16_alu(self):
     c = Tensor([1], dtype=dtypes.float16) + Tensor([1], dtype=dtypes.float16)

--- a/tinygrad/renderer/nir.py
+++ b/tinygrad/renderer/nir.py
@@ -25,7 +25,8 @@ aop = {**{x:u_aop for x in (dtypes.bool,)+dtypes.uints}, **{x:s_aop for x in dty
 
 def c(t:DType, u:bool=True) -> str: return "u" if t in dtypes.uints and u else ("i" if t in dtypes.ints else ("f" if t in dtypes.floats else "b"))
 def ncast(b:mesa.nir_builder, src:mesa.nir_def, it:DType, ot:DType) -> mesa.nir_def:
-  return nalu(b, f"{c(it)}2{c(it) if it in dtypes.ints and ot in dtypes.ints else c(ot, ot == dtypes.bool)}{ot.bitsize}", src)
+  op = f"{c(it)}2{c(it) if it in dtypes.ints and ot in dtypes.ints else c(ot, ot == dtypes.bool)}{ot.bitsize}"
+  return nalu(b, op + ("_rtne" if op == "f2f16" else ""), src)
 
 def nif(b:mesa.nir_builder, cond:mesa.nir_def, then_fn:Callable, else_fn:Callable):
   nif = mesa.nir_push_if(b, cond)


### PR DESCRIPTION
Fixes #18071

Request `f2f16_rtne` for NIR floating-point conversions to half. Generic `f2f16` loses the float64 midpoint distinction during CPU:LVP lowering and leaves IR3 float32-to-half conversions with round-toward-zero encoding. Explicit nearest-even fixes both paths while leaving other cast opcodes unchanged.

Adds an exact-bit CPU:LVP regression for both signs around a half midpoint and an IR3 disassembly regression, wired into the existing compile-only CI matrix. Both fail before the renderer fix and pass after it; neither requires the unmerged QCOM emulator.

Local validation with tinymesa 25.2.7.2:

- CPU:LVP dtype suite: 203 passed, 36 skipped; the new regression is the only failure on the matched baseline.
- Upstream IR3 compile-only test_ops plus the new regression: 406 passed, 26 skipped, 109 subtests; no existing result changed.
- Ruff and mypy passed (215 source files).

The full suites ran at upstream ab24cc89e79c3fc30c2ee32f40cf805f168f94b7 plus this patch. The branch is based on d53f06b0995709a682a9f913b5de37ff8bd65eed; the only intervening change removed unrelated Metal tests, and the public reproducer and focused regressions were rechecked against the final source. No QCOM hardware numerical validation is claimed.

AI assistance disclosure: investigation, implementation and tests used Codex, including a separate AI code/causal review. The stated validation was executed locally; no personal human code review is claimed.
