### PR TITLE
Preserve mixed buffer/scalar kernel argument order

### DIFF
--- a/test/backend/test_kernel_abi.py
+++ b/test/backend/test_kernel_abi.py
@@ -1,0 +1,332 @@
+import array, ctypes, struct, unittest
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tinygrad import Context, UOp, dtypes, Tensor, TinyJit
+from tinygrad.codegen import to_program
+from tinygrad.device import Buffer, Device, TinyELF
+from tinygrad.dtype import AddrSpace
+from tinygrad.engine.realize import compile_linear, get_call_arg_uops, get_call_outs_ins, run_linear
+from tinygrad.helpers import Target, HCQ2
+from tinygrad.runtime.ops_python import PythonRenderer
+from tinygrad.runtime.ops_cpu import CPUProgram
+from tinygrad.runtime.support.hcq2 import encode_kernargs_clike
+from tinygrad.uop.ops import KernelInfo, Ops, ProgramInfo
+
+
+@dataclass(frozen=True)
+class FakeProgramData:
+  kernargs_alloc_size:int
+
+
+def mixed_signature() -> tuple:
+  return ((None, 0, dtypes.float, (1,), AddrSpace.GLOBAL), ("val", 1, dtypes.int, (), AddrSpace.ALU),
+          (None, 2, dtypes.float, (1,), AddrSpace.GLOBAL))
+
+
+def make_mixed_call(order:tuple[str, ...], out_buf:Buffer, inp_buf:Buffer, scalar:int) -> UOp:
+  params = {
+    name: UOp.param(slot, dtypes.int if name == "val" else dtypes.float, () if name == "val" else 1,
+                    vmin_vmax=(0, 100) if name == "val" else None, name="mixed_val" if name == "val" else None,
+                    addrspace=AddrSpace.ALU if name == "val" else AddrSpace.GLOBAL)
+    for slot,name in enumerate(order)
+  }
+  sink = params["out"][0].store(params["inp"][0].load() + params["val"].cast(dtypes.float)).sink(arg=KernelInfo("mixed_abi"))
+  unused_buf = Buffer(out_buf.device, 1, dtypes.float, preallocate=True)
+  call_args = {"out": UOp.from_buffer(out_buf), "inp": UOp.from_buffer(inp_buf), "unused": UOp.from_buffer(unused_buf),
+               "val": UOp.variable("mixed_val", 0, 100, dtypes.int).bind(scalar)}
+  return sink.call(*(call_args[name] for name in order))
+
+
+def make_two_scalar_call(order:tuple[str, ...], out_buf:Buffer, inp_buf:Buffer, x:int, y:int) -> UOp:
+  params = {
+    name: UOp.param(slot, dtypes.int if name in {"x", "y"} else dtypes.float, () if name in {"x", "y"} else 1,
+                    vmin_vmax=(0, 100) if name in {"x", "y"} else None, name=name if name in {"x", "y"} else None,
+                    addrspace=AddrSpace.ALU if name in {"x", "y"} else AddrSpace.GLOBAL)
+    for slot,name in enumerate(order)
+  }
+  result = params["inp"][0].load() + params["x"].cast(dtypes.float) + params["y"].cast(dtypes.float)
+  sink = params["out"][0].store(result).sink(arg=KernelInfo("mixed_abi_two_scalars"))
+  call_args = {"out": UOp.from_buffer(out_buf), "inp": UOp.from_buffer(inp_buf),
+               "x": UOp.variable("x", 0, 100, dtypes.int).bind(x), "y": UOp.variable("y", 0, 100, dtypes.int).bind(y)}
+  return sink.call(*(call_args[name] for name in order))
+
+
+def cpu_buffer(values:list[float]) -> Buffer:
+  buf = Buffer("CPU", len(values), dtypes.float, preallocate=True)
+  buf.as_memoryview(force_zero_copy=True).cast("f")[:] = array.array("f", values)
+  return buf
+
+
+def device_buffer(device:str, values:list[float]) -> Buffer:
+  buf = Buffer(device, len(values), dtypes.float, preallocate=True)
+  src = Buffer("PYTHON", len(values), dtypes.float, opaque=memoryview(bytearray(array.array("f", values).tobytes())))
+  buf.copy_from(src)
+  return buf
+
+
+def run_mixed_cpu(order:tuple[str, ...], scalar:int=3, inp:float=5, hcq2:int=0, debug:int=0) -> float:
+  out_buf, inp_buf = cpu_buffer([0]), cpu_buffer([inp])
+  call = make_mixed_call(order, out_buf, inp_buf, scalar)
+  with Context(HCQ2=hcq2, DEBUG=debug):
+    run_linear(UOp(Ops.LINEAR, src=(call,)), var_vals={"mixed_val": scalar}, update_stats=debug == 0)
+  return float(out_buf.numpy()[0])
+
+
+def run_mixed_device(device:str, order:tuple[str, ...], scalar:int=3, inp:float=5) -> float:
+  out_buf, inp_buf = device_buffer(device, [0]), device_buffer(device, [inp])
+  call = make_mixed_call(order, out_buf, inp_buf, scalar)
+  run_linear(UOp(Ops.LINEAR, src=(call,)), var_vals={"mixed_val": scalar}, update_stats=False)
+  return float(out_buf.numpy()[0])
+
+
+def run_two_scalar_device(device:str, order:tuple[str, ...], x:int=3, y:int=4, inp:float=5) -> float:
+  out_buf, inp_buf = device_buffer(device, [0]), device_buffer(device, [inp])
+  call = make_two_scalar_call(order, out_buf, inp_buf, x, y)
+  run_linear(UOp(Ops.LINEAR, src=(call,)), var_vals={"x": x, "y": y}, update_stats=False)
+  return float(out_buf.numpy()[0])
+
+
+class TestKernelABIMetadata(unittest.TestCase):
+  def test_signature_preserves_interleaved_slots(self):
+    out = UOp.param(0, dtypes.float, 1)
+    val = UOp.param(1, dtypes.int, (), vmin_vmax=(0, 100), name="val", addrspace=AddrSpace.ALU)
+    inp = UOp.param(2, dtypes.float, 1)
+    sink = out[0].store(inp[0].load() + val.cast(dtypes.float)).sink(arg=KernelInfo("mixed_args"))
+
+    elf = to_program(sink, PythonRenderer(Target("PYTHON"))).to_elf()
+    self.assertEqual([slot for _,slot,_,_,_ in elf.signature], [0, 1, 2])
+    self.assertEqual([space for *_,space in elf.signature], [AddrSpace.GLOBAL, AddrSpace.ALU, AddrSpace.GLOBAL])
+    self.assertEqual([offset for offset,_,_ in TinyELF.iter_sig(elf.signature)], [0, 8, 16])
+
+  def test_signature_preserves_buffers_first(self):
+    out = UOp.param(0, dtypes.float, 1)
+    inp = UOp.param(1, dtypes.float, 1)
+    val = UOp.param(2, dtypes.int, (), vmin_vmax=(0, 100), name="val", addrspace=AddrSpace.ALU)
+    sink = out[0].store(inp[0].load() + val.cast(dtypes.float)).sink(arg=KernelInfo("buffers_first"))
+    elf = to_program(sink, PythonRenderer(Target("PYTHON"))).to_elf()
+    self.assertEqual([slot for _,slot,_,_,_ in elf.signature], [0, 1, 2])
+
+  def test_dependency_indices_use_compact_buffer_positions(self):
+    out_buf, inp_buf = cpu_buffer([0]), cpu_buffer([5])
+    call = make_mixed_call(("out", "unused", "val", "inp"), out_buf, inp_buf, 3)
+    program = to_program(call.src[0], PythonRenderer(Target("PYTHON")))
+    compiled_call = program.call(*call.src[1:])
+    self.assertEqual(get_call_arg_uops(compiled_call), (compiled_call.src[1], compiled_call.src[2], compiled_call.src[4]))
+    self.assertEqual(get_call_outs_ins(compiled_call), ((0,), (2,)))
+
+  def test_signature_maps_split_runtime_arguments_in_slot_order(self):
+    self.assertEqual([arg for _,arg in TinyELF.iter_args(mixed_signature(), ("out", "inp"), (7,))], ["out", 7, "inp"])
+    scalar_first = (("val", 0, dtypes.int, (), AddrSpace.ALU), (None, 1, dtypes.float, (1,), AddrSpace.GLOBAL))
+    self.assertEqual([arg for _,arg in TinyELF.iter_args(scalar_first, ("out",), (9,))], [9, "out"])
+
+  def test_signature_rejects_extra_or_missing_runtime_arguments(self):
+    with self.assertRaises(AssertionError): list(TinyELF.iter_args(mixed_signature(), ("out",), (7,)))
+    with self.assertRaises(AssertionError): list(TinyELF.iter_args(mixed_signature(), ("out", "inp", "extra"), (7,)))
+
+
+class TestCPUKernelABI(unittest.TestCase):
+  def test_timing_scratch_buffers_preserve_unused_slots(self):
+    from tinygrad.codegen.opt.postrange import args_from_ast
+    from tinygrad.codegen.opt.search import _time_program
+    out, inp = cpu_buffer([0]), cpu_buffer([5])
+    call = make_mixed_call(("val", "unused", "out", "inp"), out, inp, 3)
+    program = to_program(call.src[0], Device["CPU"].renderer)
+    scratch, values = args_from_ast(program.src[0], "CPU")
+    scratch[3].ensure_allocated().as_memoryview(force_zero_copy=True).cast('f')[:] = array.array('f', [5])
+    with Context(HCQ2=0):
+      self.assertEqual(len(_time_program(program, values, scratch, cnt=1, allow_test_size=False)), 1)
+    self.assertEqual(scratch[2].numpy().tolist(), [5 + values['mixed_val']])
+
+  def test_direct_execution_argument_orders(self):
+    for order in (("out", "val", "inp"), ("val", "out", "inp"), ("out", "inp", "val")):
+      with self.subTest(order=order): self.assertEqual(run_mixed_cpu(order), 8)
+
+  def test_hcq2_execution_argument_orders(self):
+    for order in (("out", "val", "inp"), ("val", "out", "inp"), ("out", "inp", "val")):
+      with self.subTest(order=order): self.assertEqual(run_mixed_cpu(order, hcq2=1), 8)
+
+  def test_unused_slot_does_not_shift_arguments(self):
+    for hcq2 in (0, 1):
+      with self.subTest(hcq2=hcq2): self.assertEqual(run_mixed_cpu(("out", "unused", "val", "inp"), hcq2=hcq2), 8)
+
+  def test_repeated_execution_updates_buffers_and_scalar(self):
+    self.assertEqual(run_mixed_cpu(("out", "val", "inp"), scalar=3, inp=5), 8)
+    self.assertEqual(run_mixed_cpu(("out", "val", "inp"), scalar=9, inp=4), 13)
+
+  def test_scalar_first_debug_stats_path(self):
+    self.assertEqual(run_mixed_cpu(("val", "out", "inp"), debug=2), 8)
+
+  def test_cpu_validation_preserves_mixed_and_unused_slots(self):
+    with Context(VALIDATE_WITH_CPU=1):
+      for order in (("out", "val", "inp"), ("val", "unused", "out", "inp")):
+        with self.subTest(order=order): self.assertEqual(run_mixed_cpu(order), 8)
+
+  def test_core_id_uses_compact_signature_position(self):
+    for hcq2 in (0, 1):
+      with self.subTest(hcq2=hcq2):
+        out = UOp.param(0, dtypes.float, 4)
+        core = UOp.param(2, dtypes.int, (), vmin_vmax=(0, 3), name="core_id", addrspace=AddrSpace.ALU)
+        sink = out[core].store(core.cast(dtypes.float)).sink(arg=KernelInfo("core_slot"))
+        out_buf, unused_buf = cpu_buffer([0, 0, 0, 0]), cpu_buffer([0])
+        args = (UOp.from_buffer(out_buf), UOp.from_buffer(unused_buf), UOp.variable("core_id", 0, 3, dtypes.int).bind(0))
+        with Context(HCQ2=hcq2): run_linear(UOp(Ops.LINEAR, src=(sink.call(*args),)), update_stats=False)
+        self.assertEqual(out_buf.numpy().tolist(), [0, 1, 2, 3])
+
+  def test_native_runtime_packs_interleaved_arguments(self):
+    program = object.__new__(CPUProgram)
+    program.lvp, program.runtimevars = False, {}
+    program.signature = ((None, 0, dtypes.float, (1,), AddrSpace.GLOBAL), ("val", 1, dtypes.int, (), AddrSpace.ALU),
+                         (None, 2, dtypes.float, (1,), AddrSpace.GLOBAL))
+    captured = []
+    program.fxn = lambda *args: captured.append(tuple(x.value for x in args))
+    program(SimpleNamespace(va_addr=0x1111), SimpleNamespace(va_addr=0x2222), vals=(7,))
+    self.assertEqual(captured, [(0x1111, 7, 0x2222)])
+
+  def test_lvp_runtime_packs_interleaved_payload(self):
+    program = object.__new__(CPUProgram)
+    program.lvp = True
+    program.signature = ((None, 0, dtypes.float, (1,), AddrSpace.GLOBAL), ("val", 1, dtypes.int, (), AddrSpace.ALU),
+                         (None, 2, dtypes.float, (1,), AddrSpace.GLOBAL))
+    captured:dict[str, bytes|int] = {}
+
+    def capture(header_addr:int):
+      lo, hi, dwords = struct.unpack("<3I", ctypes.string_at(header_addr, 12))
+      captured["dwords"] = dwords
+      captured["payload"] = ctypes.string_at(lo | hi << 32, dwords * 4)
+
+    program.fxn = capture
+    program(SimpleNamespace(va_addr=0x1111), SimpleNamespace(va_addr=0x2222), vals=(7,))
+    payload = captured["payload"]
+    assert isinstance(payload, bytes)
+    self.assertEqual(captured["dwords"], 6)
+    self.assertEqual(struct.unpack_from("<Q", payload, 0)[0], 0x1111)
+    self.assertEqual(struct.unpack_from("<i", payload, 8)[0], 7)
+    self.assertEqual(payload[12:16], bytes(4))
+    self.assertEqual(struct.unpack_from("<Q", payload, 16)[0], 0x2222)
+
+
+class TestHCQ2KernelABI(unittest.TestCase):
+  def test_clike_kernargs_preserve_slots_and_alignment(self):
+    out = UOp.placeholder((1,), dtypes.float, 100, device="CPU")
+    inp = UOp.placeholder((1,), dtypes.float, 200, device="CPU")
+    val = UOp.param(1, dtypes.int, (), vmin_vmax=(0, 100), name="val", addrspace=AddrSpace.ALU)
+    info = ProgramInfo(vars=(val,), globals=(0, 2), target=Target("CPU"))
+    program = UOp(Ops.PROGRAM, arg=(FakeProgramData(24), info))
+    call = program.call(out, UOp.variable("val", 0, 100, dtypes.int).bind(7), inp)
+    captured = []
+    with patch("tinygrad.runtime.support.hcq2.make_patches", side_effect=lambda _, patches: captured.extend(patches) or ()):
+      encode_kernargs_clike(call, program, "CPU")
+    self.assertEqual([offset for offset,_ in captured], [0, 8, 16])
+    self.assertEqual([value.op for _,value in captured], [Ops.GETADDR, Ops.PARAM, Ops.GETADDR])
+    self.assertIs(captured[1][1], val)
+
+
+class TestHIPKernelABI(unittest.TestCase):
+  def test_runtime_struct_preserves_interleaved_layout(self):
+    from tinygrad.runtime.ops_hip import encode_args
+    c_args, _ = encode_args((0x1111, 0x2222), (7,), mixed_signature())
+    self.assertEqual(ctypes.sizeof(c_args), 24)
+    self.assertEqual([(name, offset) for name,_,offset in c_args._real_fields_], [("f0", 0), ("v0", 8), ("f1", 16)])
+    self.assertEqual((c_args.f0, c_args.v0, c_args.f1), (0x1111, 7, 0x2222))
+
+  def test_runtime_struct_handles_multiple_interleaved_scalars(self):
+    from tinygrad.runtime.ops_hip import encode_args
+    signature = (("x", 0, dtypes.int, (), AddrSpace.ALU), (None, 1, dtypes.float, (1,), AddrSpace.GLOBAL),
+                 ("y", 2, dtypes.int, (), AddrSpace.ALU), (None, 3, dtypes.float, (1,), AddrSpace.GLOBAL))
+    c_args, _ = encode_args((0x1111, 0x2222), (3, 4), signature)
+    self.assertEqual(ctypes.sizeof(c_args), 32)
+    self.assertEqual([(name, offset) for name,_,offset in c_args._real_fields_], [("v0", 0), ("f0", 8), ("v1", 16), ("f1", 24)])
+    self.assertEqual((c_args.v0, c_args.f0, c_args.v1, c_args.f1), (3, 0x1111, 4, 0x2222))
+
+  def test_cached_runtime_struct_updates_buffers_and_scalar(self):
+    from tinygrad.runtime import ops_hip
+    program = object.__new__(ops_hip.HIPProgram)
+    program.dev, program.prg, program.signature = SimpleNamespace(device_id=0), object(), mixed_signature()
+    with patch.object(ops_hip, "check"), patch.object(ops_hip.hip, "hipSetDevice", return_value=0), \
+         patch.object(ops_hip.hip, "hipModuleLaunchKernel", return_value=0):
+      program(0x1111, 0x2222, vals=(7,))
+      program(0x3333, 0x4444, vals=(9,))
+    self.assertEqual((program.c_args.f0, program.c_args.v0, program.c_args.f1), (0x3333, 9, 0x4444))
+
+
+class TestCUDAKernelABI(unittest.TestCase):
+  def test_runtime_struct_preserves_interleaved_layout(self):
+    from tinygrad.runtime.ops_cuda import encode_args
+    c_args, _ = encode_args((0x1111, 0x2222), (7,), mixed_signature())
+    self.assertEqual(ctypes.sizeof(c_args), 24)
+    self.assertEqual([(name, offset) for name,_,offset in c_args._real_fields_], [("f0", 0), ("v0", 8), ("f1", 16)])
+    self.assertEqual((c_args.f0, c_args.v0, c_args.f1), (0x1111, 7, 0x2222))
+
+
+@unittest.skipUnless(Device.DEFAULT in {"CUDA", "HIP", "CL", "METAL", "WEBGPU", "AMD", "NV", "QCOM", "DSP"}, "mixed runtime backend required")
+class TestRuntimeKernelABI(unittest.TestCase):
+  def test_direct_execution_argument_orders(self):
+    for order in (("out", "val", "inp"), ("val", "out", "inp"), ("out", "inp", "val")):
+      with self.subTest(device=Device.DEFAULT, order=order): self.assertEqual(run_mixed_device(Device.DEFAULT, order), 8)
+
+  def test_repeated_execution_updates_buffers_and_scalar(self):
+    self.assertEqual(run_mixed_device(Device.DEFAULT, ("out", "val", "inp"), scalar=3, inp=5), 8)
+    self.assertEqual(run_mixed_device(Device.DEFAULT, ("out", "val", "inp"), scalar=9, inp=4), 13)
+
+  def test_unused_slot_does_not_shift_runtime_bindings(self):
+    self.assertEqual(run_mixed_device(Device.DEFAULT, ("out", "unused", "val", "inp")), 8)
+
+  def test_scalar_buffer_scalar_buffer_order(self):
+    self.assertEqual(run_two_scalar_device(Device.DEFAULT, ("x", "out", "y", "inp")), 12)
+
+
+class TestMixedABIReplay(unittest.TestCase):
+  def test_jit_replays_changed_input_buffers_and_scalars(self):
+    out = UOp.param(0, dtypes.float, 1)
+    val = UOp.param(1, dtypes.int, (), vmin_vmax=(0, 100), name="mixed_val", addrspace=AddrSpace.ALU)
+    inp = UOp.param(2, dtypes.float, 1)
+    sink = out[0].store(inp[0].load() + val.cast(dtypes.float)).sink(arg=KernelInfo("mixed_jit"))
+
+    @TinyJit
+    def run(inp_tensor, scalar):
+      output = Tensor.empty_like(inp_tensor)
+      return Tensor(output.uop.after(sink.call(output.uop, scalar, inp_tensor.uop))).realize()
+
+    for value, scalar in ((5, 3), (4, 9), (8, 2), (10, 7), (1, 6)):
+      actual = run(Tensor([value], dtype=dtypes.float).realize(), UOp.variable("mixed_val", 0, 100).bind(scalar))
+      self.assertEqual(actual.item(), value + scalar)
+
+  @unittest.skipUnless(Device.DEFAULT in {"METAL", "AMD", "NV", "QCOM"}, "graph backend required")
+  def test_graph_replays_scalar_first_unused_slots_and_input_buffers(self):
+    if HCQ2 and Device.DEFAULT == "AMD": self.skipTest("legacy HCQ graph needs an AMD device initialized with HCQ2=0")
+    from tinygrad.runtime.graph.hcq import HCQGraph
+    graph_type = HCQGraph
+    if Device.DEFAULT == "METAL":
+      from tinygrad.runtime.graph.metal import MetalGraph
+      graph_type = MetalGraph
+    for order in (("val", "out", "inp"), ("val", "unused", "out", "inp"), ("out", "val", "inp")):
+      with self.subTest(order=order), Context(HCQ2=0):
+        output, first = device_buffer(Device.DEFAULT, [0]), device_buffer(Device.DEFAULT, [5])
+        call = make_mixed_call(order, output, first, 3)
+        linear = compile_linear(UOp(Ops.LINEAR, src=(call,)))
+        linear = linear.substitute({UOp.from_buffer(first): UOp.param(0, dtypes.float, 1, Device.DEFAULT)}, walk=True)
+        graph = graph_type(UOp.custom_function("graph", linear), input_uops=(UOp.from_buffer(first),))
+        for value, scalar in ((5, 3), (4, 9), (8, 2)):
+          new_input = device_buffer(Device.DEFAULT, [value])
+          graph((UOp.from_buffer(new_input),), {"mixed_val": scalar}, wait=True)
+          self.assertEqual(float(output.numpy()[0]), value + scalar)
+
+
+@unittest.skipUnless(Device.DEFAULT == "METAL", "Metal device required")
+class TestMetalGraphKernelABI(unittest.TestCase):
+  def test_graph_execution_and_scalar_replay_preserve_interleaved_order(self):
+    from tinygrad.runtime.graph.metal import MetalGraph
+    out_buf, inp_buf = device_buffer("METAL", [0]), device_buffer("METAL", [5])
+    call = make_mixed_call(("out", "val", "inp"), out_buf, inp_buf, 3)
+    linear = compile_linear(UOp(Ops.LINEAR, src=(call,)))
+    graph = MetalGraph(UOp.custom_function("graph", linear))
+    graph((), {"mixed_val": 3}, wait=True)
+    self.assertEqual(float(out_buf.numpy()[0]), 8)
+    graph((), {"mixed_val": 9}, wait=True)
+    self.assertEqual(float(out_buf.numpy()[0]), 14)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/test/backend/test_kernel_abi_transports.py
+++ b/test/backend/test_kernel_abi_transports.py
@@ -1,0 +1,280 @@
+import ctypes, itertools, pathlib, shutil, struct, subprocess, tempfile, unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tinygrad import Context, UOp, dtypes
+from tinygrad.dtype import AddrSpace
+from tinygrad.device import TinyELF
+from tinygrad.helpers import Target, mv_address, to_mv
+from tinygrad.runtime.support.hcq import CLikeArgsState, HCQBuffer, HWQueue
+from tinygrad.runtime.support.memory import MMIOInterface
+
+
+def signature(order):
+  return tuple((name, i * 2, dtypes.int if name.startswith("v") else dtypes.float,
+                () if name.startswith("v") else (1,), AddrSpace.ALU if name.startswith("v") else AddrSpace.GLOBAL)
+               for i,name in enumerate(order))
+
+
+def argument_buffer(size=4096):
+  backing = bytearray(size)
+  address = mv_address(memoryview(backing))
+  return backing, HCQBuffer(address, size, view=MMIOInterface(address, size))
+
+
+class TestHCQArgumentTransport(unittest.TestCase):
+  def test_mixed_layouts_and_prefix(self):
+    for order, offsets in ((('b0', 'v0', 'b1'), (0, 8, 16)), (('v0', 'b0', 'v1', 'b1'), (0, 8, 16, 24)),
+                           (('b0', 'b1', 'v0'), (0, 8, 16)), (('b0', 'b1'), (0, 8)), (('v0',), (0,)), ((), ())):
+      for prefix in (None, [0x12345678] * 88):
+        with self.subTest(order=order, prefix=prefix is not None):
+          backing, buf = argument_buffer()
+          values = {'b0': 0x1122334455667788, 'b1': 0x2233445566778899, 'v0': 7, 'v1': 11}
+          bufs = tuple(HCQBuffer(values[n], 4) for n in order if n.startswith('b'))
+          vals = tuple(values[n] for n in order if n.startswith('v'))
+          state = CLikeArgsState(buf, SimpleNamespace(signature=signature(order)), bufs, vals, prefix=prefix)
+          HWQueue().bind_args_state(state)
+          base = len(prefix or []) * 4
+          if prefix: self.assertEqual(struct.unpack_from('I', backing)[0], prefix[0])
+          for name, off in zip(order, offsets):
+            self.assertEqual(struct.unpack_from('i' if name.startswith('v') else 'Q', backing, base + off)[0], values[name])
+
+  def test_symbolic_buffer_and_scalar_replay(self):
+    backing, buf = argument_buffer()
+    address = UOp.variable('address', 0, 0xffffffffffffffff, dtypes.uint64)
+    value = UOp.variable('value', 0, 100)
+    state = CLikeArgsState(buf, SimpleNamespace(signature=signature(('b0', 'v0', 'b1'))),
+                          (HCQBuffer(address, 4), HCQBuffer(0x2222, 4)), (value,))
+    queue = HWQueue()
+    queue.bind_args_state(state)
+    for addr, val in ((0x1111, 3), (0x3333, 9), (0x3333, 9)):
+      queue._apply_var_vals({'address': addr, 'value': val})
+      self.assertEqual(struct.unpack_from('Qi4xQ', backing), (addr, val, 0x2222))
+
+
+class TestQCOMArgumentTransport(unittest.TestCase):
+  def test_ir3_compiler_image_mapping_matches_runtime_bindings(self):
+    from tinygrad.codegen import to_program
+    from tinygrad.renderer.nir import IR3Renderer
+    from tinygrad.runtime.autogen import mesa
+    from tinygrad.runtime.ops_qcom import QCOMProgram, QCOMArgsState
+    from tinygrad.uop.ops import KernelInfo
+    if 'mesa' not in mesa.dll._loaded_: self.skipTest('tinymesa required for IR3 compilation')
+    renderer = IR3Renderer(Target('QCOM', 'IR3', 'a630,IMAGE_PITCH_ALIGNMENT=64'))
+    storage = []
+    def allocate(size, *args):
+      backing, buf = argument_buffer(size)
+      storage.append(backing)
+      return buf
+    dev = SimpleNamespace(renderer=renderer, device='QCOM', prof_prg_counter=itertools.count(), _ensure_stack_size=lambda _: None,
+                          allocator=SimpleNamespace(alloc=allocate, free=lambda *args: None))
+    for reverse in (False, True):
+      with self.subTest(reverse=reverse), Context(IMAGE=2):
+        out = UOp.param(2 if reverse else 0, dtypes.float, 256)
+        value = UOp.param(1, dtypes.int, (), vmin_vmax=(0, 100), name='value', addrspace=AddrSpace.ALU)
+        inp = UOp.param(0 if reverse else 2, dtypes.float, 256)
+        idx = UOp.range(256, 0)
+        sink = out[idx].store(inp[idx].load() + value.cast(dtypes.float)).end(idx).sink(arg=KernelInfo('image_mixed'))
+        elf = to_program(sink, renderer).to_elf()
+        self.assertEqual([s[3] for s in elf.signature], [(1, 64, 4), (), (1, 64, 4)])
+        prg = QCOMProgram(dev, elf)
+        self.assertEqual((prg.ibo_cnt, prg.tex_cnt), (2, 1))
+        self.assertEqual(prg.tex_to_image[0], 0 if reverse else 1)
+        backing, buf = argument_buffer(prg.kernargs_alloc_size)
+        state = QCOMArgsState(buf, prg, (HCQBuffer(0x10000, 1024), HCQBuffer(0x20000, 1024)), (7,))
+        HWQueue().bind_args_state(state)
+        self.assertEqual(struct.unpack_from('i', backing, prg.buf_off)[0], 7)
+        self.assertEqual(struct.unpack_from('Q', backing, prg.tex_off + 16)[0], 0x10000 if reverse else 0x20000)
+        for i,addr in enumerate((0x10000, 0x20000)):
+          self.assertEqual(struct.unpack_from('Q', backing, prg.ibo_off + i*64 + 16)[0], addr)
+
+  def program(self, sig, nir, **kwargs):
+    return SimpleNamespace(signature=sig, NIR=nir, kernargs_alloc_size=4096, consts_info=[(0x1234, 1000, 4)],
+                           samp_cnt=0, tex_cnt=0, ibo_cnt=0, tex_to_image=[], image_types=[], buf_off=64, buf_offs=[64, 88, 112, 136],
+                           tex_off=2048, ibo_off=2560, samp_off=3072, samplers=[], **kwargs)
+
+  def test_scalar_first_interleaved_and_unused_slots(self):
+    from tinygrad.runtime.ops_qcom import QCOMArgsState
+    for nir in (False, True):
+      with self.subTest(nir=nir):
+        backing, buf = argument_buffer()
+        sig = signature(('v0', 'b0', 'v1', 'b1'))
+        prg = self.program(sig, nir)
+        state = QCOMArgsState(buf, prg, (HCQBuffer(0x1111, 4), HCQBuffer(0x2222, 4)), (7, 11))
+        HWQueue().bind_args_state(state)
+        offsets = (64, 72, 80, 88) if nir else (64, 88, 112, 136)
+        for fmt, offset, value in zip(('i', 'Q', 'i', 'Q'), offsets, (7, 0x1111, 11, 0x2222)):
+          self.assertEqual(struct.unpack_from(fmt, backing, offset)[0], value)
+        self.assertEqual(struct.unpack_from('I', backing, 1000)[0], 0x1234)
+
+  def test_images_keep_resource_indices_separate_from_argument_slots(self):
+    from tinygrad.runtime.ops_qcom import QCOMArgsState
+    sig = (("v", 0, dtypes.int, (), AddrSpace.ALU), (None, 2, dtypes.float, (1, 16, 4), AddrSpace.GLOBAL),
+           (None, 4, dtypes.float, (1,), AddrSpace.GLOBAL), (None, 7, dtypes.float, (1, 16, 4), AddrSpace.GLOBAL))
+    for nir in (False, True):
+      with self.subTest(nir=nir):
+        backing, buf = argument_buffer()
+        prg = self.program(sig, nir)
+        prg.buf_offs = [64, 88]
+        prg.ibo_cnt, prg.tex_cnt, prg.tex_to_image, prg.image_types = 2 if nir else 1, 1, [1], [2, 1]
+        prg.samp_cnt, prg.samplers = 1, [11, 22, 33, 44]
+        state = QCOMArgsState(buf, prg, tuple(HCQBuffer(addr, 1024) for addr in (0x10000, 0x20000, 0x30000)), (7,))
+        HWQueue().bind_args_state(state)
+        self.assertEqual(struct.unpack_from('i', backing, 64)[0], 7)
+        self.assertEqual(struct.unpack_from('Q', backing, 72 if nir else 88)[0], 0x20000)
+        self.assertEqual(struct.unpack_from('Q', backing, prg.ibo_off + 16)[0], 0x10000)
+        self.assertEqual(struct.unpack_from('Q', backing, prg.tex_off + 16)[0], 0x30000)
+        self.assertEqual(struct.unpack_from('4I', backing, prg.samp_off), tuple(prg.samplers))
+
+  def test_cl_texture_before_output_image_uses_compiler_resource_types(self):
+    from tinygrad.runtime.ops_qcom import QCOMArgsState, BUFTYPE_TEX, BUFTYPE_IBO
+    sig = ((None, 0, dtypes.float, (1, 16, 4), AddrSpace.GLOBAL), ("v", 2, dtypes.int, (), AddrSpace.ALU),
+           (None, 4, dtypes.float, (1, 16, 4), AddrSpace.GLOBAL))
+    prg = self.program(sig, False)
+    prg.buf_offs, prg.image_types, prg.ibo_cnt, prg.tex_cnt = [64], [BUFTYPE_TEX, BUFTYPE_IBO], 1, 1
+    backing, buf = argument_buffer()
+    state = QCOMArgsState(buf, prg, (HCQBuffer(0x10000, 1024), HCQBuffer(0x20000, 1024)), (7,))
+    HWQueue().bind_args_state(state)
+    self.assertEqual(struct.unpack_from('Q', backing, prg.tex_off + 16)[0], 0x10000)
+    self.assertEqual(struct.unpack_from('Q', backing, prg.ibo_off + 16)[0], 0x20000)
+    self.assertEqual(struct.unpack_from('i', backing, 64)[0], 7)
+
+
+class TestNVArgumentTransport(unittest.TestCase):
+  def test_mock_and_native_layouts(self):
+    from tinygrad.runtime.ops_nv import NVArgsState, MOCKIface
+    for mock in (False, True):
+      with self.subTest(mock=mock):
+        backing, buf = argument_buffer()
+        prg = SimpleNamespace(signature=signature(('v0', 'b0', 'v1', 'b1')), cbuf_0=[0]*88,
+                              dev=SimpleNamespace(iface=object.__new__(MOCKIface) if mock else None))
+        state = NVArgsState(buf, prg, (HCQBuffer(0x1111, 4), HCQBuffer(0x2222, 4)), (-7, 11))
+        HWQueue().bind_args_state(state)
+        self.assertEqual(struct.unpack_from('qQqQ' if mock else 'i4xQi4xQ', backing, 0x160), (-7, 0x1111, 11, 0x2222))
+        if mock: self.assertEqual(struct.unpack_from('2I', backing, 80*4), (2, 2))
+
+
+class TestCUDAGraphArgumentTransport(unittest.TestCase):
+  def test_driver_boundary_preserves_layout_dependencies_and_replay(self):
+    from tinygrad.codegen import to_program
+    from tinygrad.device import Buffer
+    from tinygrad.engine.jit import GraphRunner
+    from tinygrad.runtime.graph.cuda import CUDAGraph
+    from tinygrad.runtime.ops_python import PythonRenderer
+    from tinygrad.runtime.autogen import cuda
+    from tinygrad.uop.ops import KernelInfo, Ops
+    out, inp = UOp.param(3, dtypes.float, 1), UOp.param(2, dtypes.float, 1)
+    val = UOp.param(0, dtypes.int, (), vmin_vmax=(0, 100), name='value', addrspace=AddrSpace.ALU)
+    sink = out[0].store(inp[0].load() + val.cast(dtypes.float)).sink(arg=KernelInfo('cuda_graph_mixed'))
+    program = to_program(sink, PythonRenderer(Target('PYTHON')))
+    output = Buffer('NULL', 1, dtypes.float, opaque=0x2000)
+    first = Buffer('NULL', 1, dtypes.float, opaque=0x1000)
+    unused = Buffer('NULL', 1, dtypes.float, opaque=0xDEAD)
+    call = program.call(UOp.variable('value', 0, 100).bind(3), UOp.from_buffer(unused),
+                        UOp.param(0, dtypes.float, 1, 'NULL'), UOp.from_buffer(output))
+    runtime = SimpleNamespace(prg=cuda.CUfunction(), smem=0, signature=program.to_elf().signature)
+    writes, launches, param_blocks = [], [], []
+    def add_node(node, graph, deps, count, params):
+      p = ctypes.cast(params, ctypes.POINTER(cuda.CUDA_KERNEL_NODE_PARAMS_v1)).contents
+      param_blocks.append(p.extra[1])
+      return 0
+    def launch(*args):
+      launches.append(struct.unpack('i4xQQ', bytes(to_mv(param_blocks[0], 24))))
+      return 0
+    original_access = GraphRunner._access_resources
+    def access(graph, bufs, written, new_dependency):
+      writes.append(tuple(written))
+      return original_access(graph, bufs, written, new_dependency)
+    mocked = dict(cuGraphCreate=lambda *a: 0, cuGraphAddKernelNode=add_node, cuGraphInstantiate_v2=lambda *a: 0,
+                  cuGraphExecKernelNodeSetParams=lambda *a: 0, cuGraphLaunch=launch, cuGraphDestroy=lambda *a: 0, cuGraphExecDestroy=lambda *a: 0)
+    with patch('tinygrad.engine.jit.get_runtime', return_value=runtime), patch.object(GraphRunner, '_access_resources', access), \
+         patch.multiple(cuda, **mocked):
+      graph = CUDAGraph(UOp.custom_function('graph', UOp(Ops.LINEAR, src=(call,))), input_uops=(UOp.from_buffer(first),))
+      self.assertEqual(writes, [(1,)])
+      for address, value in ((0x3000, 7), (0x4000, 11)):
+        replacement = Buffer('NULL', 1, dtypes.float, opaque=address)
+        graph((UOp.from_buffer(replacement),), {'value': value})
+      self.assertEqual(launches, [(7, 0x3000, 0x2000), (11, 0x4000, 0x2000)])
+      graph.__del__()
+      del graph.graph, graph.instance
+
+
+class TestDSPArgumentTransport(unittest.TestCase):
+  @unittest.skipUnless(shutil.which('clang'), "host clang required to execute the generated RPC wrapper")
+  def test_rpc_runtime_and_generated_wrapper_execute_together(self):
+    from tinygrad.runtime.ops_dsp import DSPRenderer, DSPProgram, DSPBuffer
+    renderer = object.__new__(DSPRenderer)
+    sig = (("v0", 0, dtypes.int, (), AddrSpace.ALU), (None, 2, dtypes.float, (1,), AddrSpace.GLOBAL),
+           ("v1", 4, dtypes.int64, (), AddrSpace.ALU), (None, 6, dtypes.float, (1,), AddrSpace.GLOBAL))
+    params = [(name or f'buf{slot}', (UOp.param(slot, dt, shape, addrspace=space), False)) for name,slot,dt,shape,space in sig]
+    source = '\n'.join(renderer._render_defines([])) + '''
+static void *buffers[2];
+void set_buffers(void *out, void *in) { buffers[0]=out; buffers[1]=in; }
+int HAP_power_set(void *handle, void *req) { return 0; }
+void *HAP_mmap(void *addr, int len, int prot, int flags, int fd, long off) { return buffers[fd == 20]; }
+int HAP_munmap(void *addr, int len) { return 0; }
+unsigned long long HAP_perf_get_time_us(void) { return 25; }
+void mixed(int v0, float *out, long long v1, float *in) { *out = *in + v0 + (v1 >> 32); }
+''' + renderer._render_entry('mixed', params)
+    with tempfile.TemporaryDirectory() as tmp:
+      path = pathlib.Path(tmp) / 'wrapper.so'
+      result = subprocess.run(['clang', '-shared', '-fPIC', '-x', 'c', '-', '-o', str(path)], input=source.encode(), capture_output=True)
+      self.assertEqual(result.returncode, 0, result.stderr.decode())
+      lib = ctypes.CDLL(str(path))
+      lib.set_buffers.argtypes = (ctypes.c_void_p, ctypes.c_void_p)
+      lib.entry.argtypes = (ctypes.c_ulonglong, ctypes.c_uint, ctypes.c_void_p)
+      def receive(binary, sc, pra, fds, attrs):
+        for i in range(3, len(fds)): pra[i].dma.fd = fds[i]
+        self.assertEqual(lib.entry(0, sc, pra), 0)
+      prg = DSPProgram(SimpleNamespace(exec_lib=receive), TinyELF(b'', 'mixed', Target('DSP'), sig))
+      for value, scalar, wide in ((5, 3, 4 << 32), (9, -2, 7 << 32)):
+        output, inp = ctypes.c_float(), ctypes.c_float(value)
+        lib.set_buffers(ctypes.byref(output), ctypes.byref(inp))
+        bufs = tuple(DSPBuffer(ctypes.addressof(b), 4, SimpleNamespace(fd=fd)) for b,fd in ((output, 10), (inp, 20)))
+        prg(*bufs, vals=(scalar, wide))
+        self.assertEqual(output.value, value + scalar + (wide >> 32))
+
+  def test_rpc_preserves_signature_order_and_compact_fd_offsets(self):
+    from tinygrad.runtime.ops_dsp import DSPProgram, DSPBuffer
+    for order in (('b0', 'v0', 'b1'), ('v0', 'b0', 'v1', 'b1'), ('b0', 'b1', 'v0')):
+      with self.subTest(order=order):
+        values = {'b0': 32, 'b1': 64, 'v0': 7, 'v1': 11}
+        def receive(lib, sc, pra, fds, attrs):
+          payload = bytes(to_mv(pra[0].buf.pv, pra[0].buf.len))
+          self.assertEqual(pra[0].buf.len, len(order)*8)
+          self.assertEqual([struct.unpack_from('i', payload, i*8)[0] for i in range(len(order))], [values[n] for n in order])
+          self.assertEqual(list(to_mv(pra[1].buf.pv, pra[1].buf.len).cast('I')), [4, 8])
+          self.assertEqual(list(fds), [-1, -1, -1, 10, 20])
+          to_mv(pra[2].buf.pv, 8).cast('Q')[0] = 25
+        bufs = (DSPBuffer(0x1000, 32, SimpleNamespace(fd=10), 4), DSPBuffer(0x2000, 64, SimpleNamespace(fd=20), 8))
+        prg = DSPProgram(SimpleNamespace(exec_lib=receive), TinyELF(b'', 'mixed', Target('DSP'), signature(order)))
+        self.assertEqual(prg(*bufs, vals=tuple(values[n] for n in order if n.startswith('v'))), 25 / 1e6)
+
+  def test_rpc_wrapper_uses_compact_buffer_indices(self):
+    from tinygrad.runtime.ops_dsp import DSPRenderer
+    renderer = object.__new__(DSPRenderer)
+    order = ('v0', 'b0', 'v1', 'b1')
+    params = [(n, (UOp.param(i, dtypes.int, () if n.startswith('v') else 1,
+                              addrspace=AddrSpace.ALU if n.startswith('v') else AddrSpace.GLOBAL), False)) for i,n in enumerate(order)]
+    source = renderer._render_entry('mixed', params)
+    self.assertIn('off1 = ((int*)pra[1].buf.pv)[0]', source)
+    self.assertIn('off3 = ((int*)pra[1].buf.pv)[1]', source)
+    self.assertIn('pra[3].dma.fd', source)
+    self.assertIn('pra[4].dma.fd', source)
+    self.assertNotIn('pra[6].dma.fd', source)
+    self.assertIn('mixed(sz_or_val_0, buf_1, sz_or_val_2, buf_3)', source)
+
+  def test_mock_serializes_in_receiver_order_and_copies_back_buffers(self):
+    from tinygrad.runtime.ops_dsp import MockDSPProgram, DSPBuffer
+    order = ('v0', 'b0', 'v1', 'b1')
+    first, second = bytearray(b'abcd'), bytearray(b'efgh')
+    bufs = tuple(DSPBuffer(mv_address(memoryview(x)), 4, None) for x in (first, second))
+    def receive(command, **kwargs):
+      self.assertEqual(kwargs['input'], struct.pack('i', 7) + b'abcd' + struct.pack('i', 11) + b'efgh')
+      return SimpleNamespace(stdout=struct.pack('I', 25) + b'ABCD' + b'EFGH')
+    prg = MockDSPProgram(None, TinyELF(b'', 'mixed', Target('DSP'), signature(order)))
+    with patch('tinygrad.runtime.ops_dsp.subprocess.run', side_effect=receive): self.assertEqual(prg(*bufs, vals=(7, 11)), 25 / 1e9)
+    self.assertEqual((first, second), (b'ABCD', b'EFGH'))
+
+
+if __name__ == '__main__': unittest.main()

--- a/tinygrad/codegen/opt/postrange.py
+++ b/tinygrad/codegen/opt/postrange.py
@@ -328,8 +328,11 @@ class Scheduler:
   def group_for_reduces(self) -> int: return len(self.axes_of(AxisType.GROUP_REDUCE))
 
 def args_from_ast(ast:UOp, dname:str) -> tuple[list[Buffer], dict[str, int]]:
-  glbls = sorted([x for x in ast.backward_slice if x.op is Ops.PARAM and x.arg.slot >= 0], key=lambda x: x.arg.slot)
-  return [Buffer(dname, x.max_numel(), x.dtype) for x in glbls], {k.expr:int(k.vmax+k.vmin)//2 for k in ast.variables()}
+  params = {x.arg.slot:x for x in ast.backward_slice if x.op is Ops.PARAM and x.arg.slot >= 0}
+  # Timing calls index this list by logical slot, including gaps left by unused parameters.
+  bufs = [Buffer(dname, params[i].max_numel(), params[i].dtype) if i in params else Buffer(dname, 1, dtypes.uint8)
+          for i in range(max(params, default=-1)+1)]
+  return bufs, {k.expr:int(k.vmax+k.vmin)//2 for k in ast.variables()}
 
 def apply_opts(ast:UOp, ren:Renderer, beam:int=0) -> UOp:
   if ast.tag is not None: return ast

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 from dataclasses import dataclass, replace
 from collections import defaultdict
-from typing import Any, Callable, Generic, TypeVar, Iterator, Generator, Self, TYPE_CHECKING
+from typing import Any, Callable, Generic, TypeVar, Iterator, Generator, Sequence, Self, TYPE_CHECKING
 import importlib, inspect, functools, pathlib, os, contextlib, re, atexit, pickle, decimal, subprocess, struct
 from tinygrad.helpers import LRU, getenv, diskcache_get, diskcache_put, DEBUG, GlobalCounters, PROFILE, temp, colored
 from tinygrad.helpers import Context, CCACHE, ALLOW_DEVICE_USAGE, MAX_BUFFER_SIZE, cpu_events, ProfileEvent, ProfilePointEvent, suppress_finalizing
 from tinygrad.helpers import select_by_name, select_first_inited, DEV, TracingKey, size_to_str, pluralize, Target, unwrap, round_up
-from tinygrad.dtype import DType, _to_np_dtype
+from tinygrad.dtype import DType, _to_np_dtype, AddrSpace
 if TYPE_CHECKING: from tinygrad.renderer import Renderer
 
 # **************** Device ****************
@@ -325,15 +325,35 @@ class TinyELF:
   lib: bytes
   name: str
   target: Target
-  # tuple of (name, slot, dtype, shape)
-  signature: tuple[tuple[str|None, int, DType, tuple], ...]
+  # tuple of (name, slot, dtype, shape, addrspace)
+  signature: tuple[tuple[str|None, int, DType, tuple, AddrSpace], ...]
   profile_key: bytes|None = None
 
   @staticmethod
-  def iter_sig(signature:tuple[tuple[str|None, int, DType, tuple], ...], offset:int=0) -> Generator[tuple[int, DType], None, None]:
-    for _,_,dt,_ in signature:
-      yield (offset:=round_up(offset, dt.itemsize)), dt
-      offset += dt.itemsize
+  def iter_sig(
+    signature:tuple[tuple[str|None, int, DType, tuple, AddrSpace], ...], offset:int=0, pointer_size:int=8, pointer_alignment:int=8,
+  ) -> Generator[tuple[int, DType, AddrSpace], None, None]:
+    for _,_,dt,_,addr_space in signature:
+      size = pointer_size if (addr_space == AddrSpace.GLOBAL) else dt.itemsize
+      alignment = pointer_alignment if (addr_space == AddrSpace.GLOBAL) else dt.itemsize
+      offset = round_up(offset, alignment)
+      yield (offset, dt, addr_space)
+      offset += size
+
+  @staticmethod
+  def iter_args(signature:tuple[tuple[str|None, int, DType, tuple, AddrSpace], ...], bufs:Sequence[Any], vals:Sequence[Any],
+                ) -> Generator[tuple[tuple[str|None, int, DType, tuple, AddrSpace], Any], None, None]:
+    buf_idx, val_idx = 0, 0
+    for sig in signature:
+      if sig[4] is AddrSpace.GLOBAL:
+        assert buf_idx < len(bufs), "signature has more buffers than provided arguments"
+        yield sig, bufs[buf_idx]
+        buf_idx += 1
+      else:
+        assert val_idx < len(vals), "signature has more scalars than provided arguments"
+        yield sig, vals[val_idx]
+        val_idx += 1
+    assert buf_idx == len(bufs) and val_idx == len(vals), "provided arguments do not match signature"
 
 class Program(Generic[DeviceType]):
   def __init__(self, dev:DeviceType, obj:TinyELF): pass

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -93,8 +93,10 @@ class GraphRunner:
     self.runtimes: list[Any|None] = []
     self.uop_replace: list[list[tuple[int, int]]] = []
     for call in self.linear.src:
-      replace = [(p, b.arg.slot) for p, b in enumerate(get_call_arg_uops(call)) if b.op is Ops.PARAM]
-      for dev_idx, (bufs, device_vars) in enumerate(unwrap_multi(call, resolve_params(call, input_uops))):
+      # A compiled kernel only takes the buffers in ProgramInfo.globals, in that compact order.
+      buffer_call = call.replace(src=(call.src[0], *(call.src[s+1] for s in call.src[0].arg.globals))) if call.src[0].op is Ops.PROGRAM else call
+      replace = [(p, b.arg.slot) for p, b in enumerate(get_call_arg_uops(buffer_call)) if b.op is Ops.PARAM]
+      for dev_idx, (bufs, device_vars) in enumerate(unwrap_multi(call, resolve_params(buffer_call, input_uops))):
         self.calls.append((dev_idx, call.src[0], [b.ensure_allocated() for b in bufs], device_vars))
         self.runtimes.append(get_runtime(bufs[0].device, call.src[0]) if call.src[0].op is Ops.PROGRAM else None)
         self.uop_replace.append(replace)

--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -21,7 +21,10 @@ def get_call_var_uops(call:UOp, prg:UOp) -> list[UOp]:
 
 def get_call_outs_ins(call:UOp) -> tuple[tuple[int, ...], tuple[int, ...]]:
   ast = call.src[0]
-  if ast.op is Ops.PROGRAM: return tuple(ast.arg.outs), tuple(ast.arg.ins)
+  if ast.op is Ops.PROGRAM:
+    # outs/ins use logical PARAM slots, while dependency tracking indexes get_call_arg_uops(call).
+    buffer_pos = {slot:pos for pos,(slot, _) in enumerate((x for x in enumerate(call.src[1:]) if not x[1].is_bound_var))}
+    return tuple(buffer_pos[x] for x in ast.arg.outs), tuple(buffer_pos[x] for x in ast.arg.ins)
   if ast.op is Ops.COPY: return (0,), (1,)
   if ast.op is Ops.CUSTOM_FUNCTION and ast.arg == "encdec": return (0,), tuple(range(1, len(get_call_arg_uops(call))))
   return (), ()
@@ -35,6 +38,9 @@ def get_call_kernels(call:UOp) -> list[tuple[str, UOp, tuple[str, Estimates, byt
     return [(d, call, (name, estimates, profile_key)) for devices,name,estimates,_,profile_key in call.arg.aux.kernels for d in devices]
   if ast.op is Ops.CUSTOM_FUNCTION and ast.arg == "graph": return [(to_tuple(ast.device)[0], call, None)]
   if ast.op is Ops.CUSTOM_FUNCTION and ast.arg == "validate": return []
+  if ast.op is Ops.PROGRAM:
+    launch_device = next((x.device for x in call.src[1:] if x.device is not None), ast.arg.target.device)
+    return [(d, call, None) for d in to_tuple(launch_device)]
   return [(d, call, None) for d in to_tuple(call.src[1].device)]
 
 def get_call_name(call:UOp, bufs:Sequence[Buffer|UOp], var_vals:dict[str, int]|None=None) -> str:
@@ -72,7 +78,7 @@ def track_stats(ctx:ExecContext, call:UOp, st:decimal.Decimal, ets:list[float|No
 
   kernels = get_call_kernels(call) # everything below is the per kernel display: exec events for the profiler and DEBUG=2 lines
   args = resolve_params(call, ctx.input_uops) if kernels and kernels[0][2] is None else []
-  lanes = list(unwrap_multi(call, [args[g] for g in call.src[0].arg.globals] if call.src[0].op is Ops.PROGRAM else args)) if args else []
+  lanes = list(unwrap_multi(call, args)) if args else []
   for i, (device, kcall, stats) in enumerate(kernels):
     et, bufs = ets[i] if i < len(ets) else None, lanes[i][0] if i < len(lanes) else []
     display_name = get_call_name(kcall, bufs, ctx.var_vals) if stats is None else stats[0]
@@ -185,8 +191,12 @@ def exec_copy(ctx:ExecContext, call:UOp, ast:UOp) -> list[float|None]:
 
 def exec_kernel(ctx:ExecContext, call:UOp, ast:UOp) -> list[float|None]:
   ets:list[float|None] = []
-  resolved = resolve_params(call, ctx.input_uops)
-  for device, (bufs, device_vars) in zip(to_tuple(call.src[1].device), unwrap_multi(call, [resolved[i] for i in ast.arg.globals])):
+  resolved = [_resolve(call.src[slot+1], ctx.input_uops) for slot in ast.arg.globals]
+  launch_device = next((x.device for x in resolved if x.device is not None), None)
+  if launch_device is None: launch_device = next((x.device for x in call.src[1:] if x.device is not None), ast.arg.target.device)
+  devices = to_tuple(launch_device)
+
+  for device, (bufs, device_vars) in zip(devices, unwrap_multi(call, resolved)):
     var_vals = {**ctx.var_vals, **device_vars}
     prg_bufs = [b.ensure_allocated() for b in bufs]
     rt = get_runtime(device, ast, cache=ctx.cache)
@@ -197,13 +207,17 @@ def exec_kernel(ctx:ExecContext, call:UOp, ast:UOp) -> list[float|None]:
 
 def exec_validate(ctx:ExecContext, call:UOp, ast:UOp) -> list[float|None]:
   import numpy as np
+  nargs = (len(call.src) - 1) // 2
+  buffer_pos = {slot:pos for pos,slot in enumerate(i for i,s in enumerate(call.src[1:nargs+1]) if not s.is_bound_var)}
   for bufs, device_vars in unwrap_multi(call, resolve_params(call, ctx.input_uops)):
     bufs, dev_bufs = bufs[:len(bufs)//2], bufs[len(bufs)//2:]
     var_vals = {**ctx.var_vals, **device_vars}
     cpu_rt = get_runtime("CPU", prg:=to_program(ast.src[0], Device["CPU"].renderer))
     global_size, local_size = prg.arg.launch_dims(var_vals)
-    cpu_rt(*[bufs[i].ensure_allocated()._buf for i in prg.arg.globals], global_size=global_size, local_size=local_size, vals=prg.arg.vals(var_vals))
-    for i in prg.arg.outs: np.testing.assert_allclose(dev_bufs[i].ensure_allocated().numpy(), bufs[i].numpy(), rtol=1e-3, atol=1e-3)
+    cpu_rt(*[bufs[buffer_pos[i]].ensure_allocated()._buf for i in prg.arg.globals], global_size=global_size, local_size=local_size,
+           vals=prg.arg.vals(var_vals))
+    for i in prg.arg.outs:
+      np.testing.assert_allclose(dev_bufs[buffer_pos[i]].ensure_allocated().numpy(), bufs[buffer_pos[i]].numpy(), rtol=1e-3, atol=1e-3)
   return []
 
 def exec_encdec(ctx:ExecContext, call:UOp, ast:UOp) -> list[float|None]:
@@ -244,7 +258,9 @@ def _validate(call:UOp, sink:UOp) -> UOp:
   params = get_call_arg_uops(call)
   shadows = tuple(UOp.new_buffer(("CPU",)*len(p.device) if isinstance(p.device, tuple) else "CPU", prod(p.max_shape), p.dtype) for p in params)
   copies = tuple(p.copy_to_device(s.device).call(s, p) for s, p in zip(shadows, params))
-  return UOp(Ops.LINEAR, src=copies + (call, UOp(Ops.CUSTOM_FUNCTION, src=(sink,), arg="validate").call(*shadows, *params)))
+  shadow_iter = iter(shadows)
+  shadow_args = tuple(s if s.is_bound_var else next(shadow_iter) for s in call.src[1:])
+  return UOp(Ops.LINEAR, src=copies + (call, UOp(Ops.CUSTOM_FUNCTION, src=(sink,), arg="validate").call(*shadow_args, *call.src[1:])))
 pm_validate = PatternMatcher([(UPat(Ops.CALL, src=(UPat(Ops.SINK, name="sink"),), name="call", allow_any_len=True), _validate)]) + pm_flatten_linear
 
 # ctx is beam value

--- a/tinygrad/renderer/nir.py
+++ b/tinygrad/renderer/nir.py
@@ -6,7 +6,7 @@ from tinygrad.renderer.cstyle import CUDARenderer
 from tinygrad.uop.ops import GroupOp, Ops, UOp, PatternMatcher, UPat, range_str
 from tinygrad.runtime.autogen import mesa, libc
 from tinygrad.runtime.support.c import POINTER
-import base64, ctypes, struct, functools, inspect, itertools
+import base64, ctypes, struct, functools, inspect
 
 def g(s:str): return getattr(mesa, s)
 def nsrc(d:mesa.nir_def) -> mesa.nir_src: return mesa.nir_src(ssa=ctypes.pointer(d))
@@ -315,12 +315,11 @@ class IR3Renderer(NIRRenderer):
                                                  for u in uops if u.op is Ops.PARAM and not is_image_shape(u._shape)), 0)
 
   def postrender(self, uops:list[UOp]):
-    bufs = [u for u in uops if u.op is Ops.PARAM and u.addrspace is not AddrSpace.ALU]
-    texs, imgs = itertools.count().__next__, itertools.count().__next__
-    for b in filter(lambda b: is_image_shape(b._shape), bufs):
-      nimm_set(self.r[b], texs() if b in self.texs else imgs(), dtypes.int)
-
-    self.b.shader.contents.info.num_ubos = len([u for u in bufs if not is_image_shape(u._shape)])
-    self.b.shader.contents.info.num_images = texs() + imgs()
+    params = [u for u in uops if u.op is Ops.PARAM]
+    images = [u for u in params if is_image_shape(u._shape)]
+    # Loads and stores share image indices; IR3 records which images also need texture descriptors.
+    for i,b in enumerate(images): nimm_set(self.r[b], i, dtypes.int)
+    self.b.shader.contents.info.num_ubos = int(any(not is_image_shape(u._shape) for u in params))
+    self.b.shader.contents.info.num_images = len(images)
 
   def supported_dtypes(self): return {d for d in NIRRenderer.supported_dtypes(self) if d != dtypes.double}

--- a/tinygrad/runtime/graph/cuda.py
+++ b/tinygrad/runtime/graph/cuda.py
@@ -19,7 +19,7 @@ class CUDAGraph(MultiGraphRunner):
         assert runtime is not None
         global_size, local_size = ast.arg.launch_dims({v: 0 for v in self.vars})
 
-        c_deps, new_node = self.new_node([b.base for b in bufs], ast.arg.outs)
+        c_deps, new_node = self.new_node([b.base for b in bufs], [ast.arg.globals.index(slot) for slot in ast.arg.outs])
         c_args, vargs = encode_args([b._buf for b in bufs], [device_vars.get(x.expr, 0) for x in ast.arg.vars], runtime.signature)
         kern_params = cuda.CUDA_KERNEL_NODE_PARAMS_v1(runtime.prg, *global_size, *local_size, runtime.smem,
                                                       ctypes.cast(0, ctypes.POINTER(ctypes.c_void_p)), vargs)

--- a/tinygrad/runtime/graph/hcq.py
+++ b/tinygrad/runtime/graph/hcq.py
@@ -125,7 +125,8 @@ class HCQGraph(MultiGraphRunner):
         self.rdma_deps[j] = (peer_queue, peer_sync_signals + peer_opt_deps, peer_out_signal, j + 1)
         self.last_j[peer_queue] = j
       else:
-        sync_signals, opt_deps, rdeps = self._resolve_deps(bufs, ast.arg.outs if runtime is not None else [0], enqueue_queue,
+        writes = [ast.arg.globals.index(slot) for slot in ast.arg.outs] if runtime is not None else [0]
+        sync_signals, opt_deps, rdeps = self._resolve_deps(bufs, writes, enqueue_queue,
           enqueue_dev, out_signal, j, is_copy=is_xfer)
 
       self.ji_schedule[j] = (enqueue_dev, enqueue_queue, sync_signals, opt_deps[::-1], out_signal, None if runtime is not None else (j + 1))

--- a/tinygrad/runtime/graph/metal.py
+++ b/tinygrad/runtime/graph/metal.py
@@ -6,6 +6,7 @@ from tinygrad.uop.ops import UOp, Ops
 from tinygrad.engine.jit import GraphRunner, GraphException
 from tinygrad.runtime.ops_metal import MetalDevice, MetalAllocator, wait_check, to_ns_str
 from tinygrad.runtime.autogen import metal
+from tinygrad.dtype import AddrSpace
 
 class MetalGraph(GraphRunner):
   def __init__(self, linear, input_uops=()):
@@ -26,23 +27,31 @@ class MetalGraph(GraphRunner):
 
     self.var_bind_data = []
     if len(self.vars):
-      self.var_buf = self.dev.allocator.alloc(sum(dt.itemsize for r in self.runtimes for (_,_,dt,s) in unwrap(r).signature if s == ()))
+      self.var_buf = self.dev.allocator.alloc(sum(dt.itemsize for r in self.runtimes for (_,_,dt,s,_) in unwrap(r).signature if s == ()))
       self.var_buf_view, var_buf_offset = cast(MetalAllocator, self.dev.allocator)._as_buffer(self.var_buf), 0
 
     all_pipelines, all_resources = [], [self.var_buf.buf] if len(self.vars) else []
+    self.buf_bind_idxs = []
     for j, ((_, ast, bufs, _), runtime, replace) in enumerate(zip(self.calls, self.runtimes, self.uop_replace)):
       assert runtime is not None
       icb_command = self.icb.indirectComputeCommandAtIndex(j).retained()
       icb_command.setComputePipelineState(runtime.pipeline_state)
       all_pipelines.append(runtime.pipeline_state)
-      for i, b in enumerate(bufs):
-        if not any(pos == i for pos, _ in replace):
-          icb_command.setKernelBuffer_offset_atIndex(b._buf.buf, b._buf.offset, i)
-          all_resources.append(b._buf.buf)
-      for nm,i,dt,_ in runtime.signature[len(bufs):]:
-        icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, i)
-        self.var_bind_data.append((nm, var_buf_offset, dt.fmt))
-        var_buf_offset += dt.itemsize
+      buf_idx, bind_idxs = 0, []
+      for i, (nm, _, dt, _, addr_space) in enumerate(runtime.signature):
+        if addr_space is AddrSpace.GLOBAL:
+          b = bufs[buf_idx]
+          bind_idxs.append(i)
+          if not any(pos == buf_idx for pos, _ in replace):
+            icb_command.setKernelBuffer_offset_atIndex(b._buf.buf, b._buf.offset, i)
+            all_resources.append(b._buf.buf)
+          buf_idx += 1
+        else:
+          icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, i)
+          self.var_bind_data.append((nm, var_buf_offset, dt.fmt))
+          var_buf_offset += dt.itemsize
+      assert buf_idx == len(bufs), "signature does not match Metal graph buffers"
+      self.buf_bind_idxs.append(tuple(bind_idxs))
       global_size, local_size = ast.arg.launch_dims({v: 0 for v in self.vars})
       icb_command.concurrentDispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
       icb_command.setBarrier()
@@ -63,7 +72,7 @@ class MetalGraph(GraphRunner):
       computeCommand = self.icb.indirectComputeCommandAtIndex(j)
       for pos, iidx in self.uop_replace[j]:
         buf = cast(Buffer, input_uops[iidx].buffer)
-        computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, pos)
+        computeCommand.setKernelBuffer_offset_atIndex(buf._buf.buf, buf._buf.offset, self.buf_bind_idxs[j][pos])
         updated_bufs.append(buf._buf.buf)
 
     all_resources = dedup(self.all_resources + updated_bufs)

--- a/tinygrad/runtime/ops_cl.py
+++ b/tinygrad/runtime/ops_cl.py
@@ -6,6 +6,7 @@ from tinygrad.runtime.support import c
 from tinygrad.helpers import to_char_p_p, from_mv, OSX, DEBUG, mv_address, suppress_finalizing, unwrap, round_up, is_image_shape
 from tinygrad.renderer.cstyle import OpenCLRenderer
 from tinygrad.device import BufferSpec, LRUAllocator, Compiled, Compiler, CompileError, TinyELF, Program
+from tinygrad.dtype import AddrSpace
 
 CC_CB = c.CFUNCTYPE[None, [c.POINTER[ctypes.c_char], c.POINTER[None], cl.size_t, c.POINTER[None]]]
 BP_CB = c.CFUNCTYPE[None, [cl.cl_program, c.POINTER[None]]]
@@ -54,8 +55,8 @@ class CLProgram(Program['CLDevice']):
 
   def __call__(self, *bufs:cl.cl_mem, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]|None=None, vals:tuple[int, ...]=(),
                wait=False, **kw) -> float|None:
-    for i, (_, slot, dt, shape) in enumerate(self.signature):
-      b = bufs[slot] if slot < len(bufs) else getattr(ctypes, f"c_int{dt.bitsize}")(vals[slot-len(bufs)])
+    for i, ((_, _, dt, shape, addr_space), arg) in enumerate(TinyELF.iter_args(self.signature, bufs, vals)):
+      b = arg if addr_space is AddrSpace.GLOBAL else getattr(ctypes, f"c_int{dt.bitsize}")(arg)
       if is_image_shape(shape):
         pitch = (round_up(shape[1], 256) if OSX else shape[1]) * 4 * dt.itemsize
         fmt = cl.cl_image_format(cl.CL_RGBA, {2:cl.CL_HALF_FLOAT, 4:cl.CL_FLOAT}[dt.itemsize])

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -14,7 +14,7 @@ from tinygrad.renderer.isa.x86 import X86Renderer
 from tinygrad.runtime.support.elf import jit_loader
 from tinygrad.runtime.autogen import libc
 from tinygrad.codegen import do_to_program
-from tinygrad.engine.realize import pm_flatten_linear, get_call_arg_uops, get_call_var_uops, get_runtime
+from tinygrad.engine.realize import pm_flatten_linear, get_call_var_uops, get_runtime
 from tinygrad import UOp, dtypes
 from tinygrad.dtype import AddrSpace
 from tinygrad.uop.ops import KernelInfo, Ops, UPat, PatternMatcher, graph_rewrite
@@ -65,10 +65,17 @@ def cpu_cmd(devs:tuple[str, ...], prog, *args:UOp) -> UOp:
   return UOp(Ops.INS, src=words + (UOp.const(0, dtypes.uint64),) * (CMD_SIZE - len(words)), arg=("cmd", dtypes.void))
 
 def cpu_exec(ctx:tuple[str, ...], call:UOp, prg:UOp) -> UOp:
-  args = [get_call_arg_uops(call)[i].getaddr(ctx) for i in prg.arg.globals] + [v.cast(dtypes.uint64) for v in get_call_var_uops(call, prg)]
-  if (core:=prg.arg.runtimevars.get('core_id')) is None: return cpu_cmd(ctx, prg, *args)
+  buffer_pairs = [(slot, call.src[slot+1].getaddr(ctx)) for slot in prg.arg.globals]
+  # User scalars stay symbolic across replay; _device_num is bound separately for each device lane.
+  scalar_pairs = [(var.arg.slot, (val if var.expr == '_device_num' else var).cast(dtypes.uint64))
+                  for var,val in zip(prg.arg.vars, get_call_var_uops(call, prg))]
+  sorted_pairs = sorted(buffer_pairs + scalar_pairs, key=lambda x: x[0])
+  args = [v for _, v in sorted_pairs]
 
-  la = [cpu_cmd(ctx,prg,*args[:(cid:=(len(prg.arg.globals)+core))],UOp.const(t, dtypes.uint64),*args[cid+1:]) for t in range(prg.arg.global_size[0])]
+  if (core:=prg.arg.runtimevars.get('core_id')) is None: return cpu_cmd(ctx, prg, *args)
+  core_slot = prg.arg.vars[core].arg.slot
+  cid = next(pos for pos, (slot, _) in enumerate(sorted_pairs) if slot == core_slot)
+  la = [cpu_cmd(ctx, prg, *args[:cid], UOp.const(t, dtypes.uint64), *args[cid+1:]) for t in range(prg.arg.global_size[0])]
   return UOp(Ops.LINEAR, src=tuple(la))
 
 pm_cpu_opsel = PatternMatcher([
@@ -118,7 +125,7 @@ class CPUProgram(Program['CPUDevice']):
 
   def __init__(self, dev:CPUDevice, obj:TinyELF):
     self.dev, self.name, self.signature = dev, obj.name, obj.signature
-    self.runtimevars = {name:slot for name,slot,*_ in obj.signature if name == 'core_id'}
+    self.runtimevars = {name:pos for pos,(name,*_) in enumerate(obj.signature) if name == 'core_id'}
     self.lvp = obj.target.renderer == "LVP"
 
     if sys.platform == "win32": # mypy doesn't understand when WIN is used here
@@ -156,13 +163,25 @@ class CPUProgram(Program['CPUDevice']):
                vals:tuple[int|None, ...]=(), wait:bool=False, timeout:int|None=None) -> float|None:
     st = time.perf_counter()
     if self.lvp:
-      lvp_args = bytearray(12 + (len(bufs) + len(vals)) * 8)
+      payload_size = 0
+      layout = tuple(TinyELF.iter_sig(self.signature))
+      if layout:
+        last_offset, last_dtype, last_addr_space = layout[-1]
+        last_size = 8 if last_addr_space is AddrSpace.GLOBAL else last_dtype.itemsize
+        payload_size = last_offset + last_size
+      lvp_args = bytearray(12 + payload_size)
       addr = mv_address(lvp_args)
-      struct.pack_into(f'<3I{len(bufs)}Q', lvp_args, 0, *data64_le(addr+12), (len(bufs)+len(vals))*2, *[b.va_addr for b in bufs])
-      for v,(off,dt) in zip(vals, TinyELF.iter_sig(self.signature[-len(vals):], len(bufs)*8)): struct.pack_into(f'<{dt.fmt}', lvp_args, 12+off, v)
-      self.fxn(addr)
+      struct.pack_into('<3I', lvp_args, 0, *data64_le(addr+12), (payload_size+3)//4)
+      lvp_values = list(TinyELF.iter_args(self.signature, bufs, vals))
+      for tid in range(global_size[0]):
+        for (offset, dtype, addr_space), ((name, *_), value) in zip(layout, lvp_values):
+          if addr_space == AddrSpace.GLOBAL: struct.pack_into('<Q', lvp_args, 12+offset, cast(int, value.va_addr))
+          else: struct.pack_into(f'<{dtype.fmt}', lvp_args, 12+offset, tid if name == 'core_id' else cast(int, value))
+        self.fxn(addr)
     else:
-      args = [*[cast(int, b.va_addr) for b in bufs], *cast(tuple[int, ...], vals)]
+      i = j = 0
+      args = [cast(int, bufs[(i:=i+1)-1].va_addr) if addr_space == AddrSpace.GLOBAL else cast(int, vals[(j:=j+1)-1])
+              for _, _, _, _, addr_space in self.signature]
       assert len(args) <= MAX_ARGS, f"CPU programs support at most {MAX_ARGS} arguments, got {len(args)}"
       for tid in range(global_size[0]):
         if 'core_id' in self.runtimevars: args[self.runtimevars['core_id']] = tid

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import ctypes
 from tinygrad.helpers import DEBUG, DEV, getenv, mv_address, suppress_finalizing
 from tinygrad.device import Compiled, BufferSpec, LRUAllocator, Program, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.renderer.cstyle import CUDARenderer, NVCCRenderer
 from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.runtime.autogen import cuda
@@ -16,9 +17,20 @@ def check(status):
     raise RuntimeError(f"CUDA Error {status}, {error}")
 
 def encode_args(args, vals, signature) -> tuple[ctypes.Structure, ctypes.Array]:
-  fields = ([(f'f{i}', cuda.CUdeviceptr_v2, i*8) for i in range(len(args))] +
-            [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), off) for i,(off,dt) in enumerate(TinyELF.iter_sig(signature[len(args):], len(args)*8))])
-  c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
+  fields, ordered, end = [], [], 0
+  buf_idx, val_idx = 0, 0
+  for off, dt, addr_space in TinyELF.iter_sig(signature):
+    if addr_space is AddrSpace.GLOBAL:
+      fields.append((f'f{buf_idx}', cuda.CUdeviceptr_v2, off))
+      ordered.append(args[buf_idx])
+      buf_idx, size = buf_idx + 1, 8
+    else:
+      fields.append((f'v{val_idx}', getattr(ctypes, f"c_int{dt.bitsize}"), off))
+      ordered.append(vals[val_idx])
+      val_idx, size = val_idx + 1, dt.itemsize
+    end = off + size
+  assert buf_idx == len(args) and val_idx == len(vals), "signature does not match CUDA arguments"
+  c_args = init_c_struct_t(end, tuple(fields))(*ordered)
   vargs = (ctypes.c_void_p * 5)(ctypes.c_void_p(1), ctypes.cast(ctypes.byref(c_args), ctypes.c_void_p), ctypes.c_void_p(2),
                                 ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(c_args))), ctypes.c_void_p), ctypes.c_void_p(0))
   return c_args, vargs

--- a/tinygrad/runtime/ops_dsp.py
+++ b/tinygrad/runtime/ops_dsp.py
@@ -33,9 +33,9 @@ class DSPRenderer(ClangRenderer):
     msrc += [f'{self._render_dtype(b[1][0].dtype) if b[1][0].addrspace == AddrSpace.ALU else "int"} sz_or_val_{i} = '
              f'*({self._render_dtype(b[1][0].dtype) if b[1][0].addrspace == AddrSpace.ALU else "int"}*)((char*)pra[0].buf.pv+{i*8});'
              for i,b in enumerate(bufs)]
-    msrc += [f'int off{i} = ((int*)pra[1].buf.pv)[{i}];' for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
-    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{i+3}].dma.fd,0)+off{i};'
-             for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
+    buffer_indices = [i for i,b in enumerate(bufs) if b[1][0].addrspace == AddrSpace.GLOBAL]
+    msrc += [f'int off{i} = ((int*)pra[1].buf.pv)[{j}];' for j,i in enumerate(buffer_indices)]
+    msrc += [f'void *buf_{i} = HAP_mmap(0,sz_or_val_{i},3,0,pra[{j+3}].dma.fd,0)+off{i};' for j,i in enumerate(buffer_indices)]
     msrc += ["unsigned long long start = HAP_perf_get_time_us();"]
     fbufs = [(f'buf_{i}' if b[1][0].addrspace == AddrSpace.GLOBAL else f'sz_or_val_{i}') for i,b in enumerate(bufs)]
     msrc += [f"{function_name}({', '.join(fbufs)});"]
@@ -65,8 +65,9 @@ class DSPProgram(Program['DSPDevice']):
 
     pra, fds, attrs, _ = rpc_prep_args(ins=[var_vals_mv:=memoryview(bytearray((len(bufs)+len(vals))*8)), off_mv:=memoryview(bytearray(len(bufs)*4))],
                                        outs=[timer:=memoryview(bytearray(8)).cast('Q')], in_fds=[b.share_info.fd for b in bufs])
-    for i,b in enumerate(bufs): struct.pack_into('i', var_vals_mv, i*8, b.size)
-    for i,(v,(_,_,dt,_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
+    for i,((_,_,dt,_,space),value) in enumerate(TinyELF.iter_args(self.signature, bufs, vals)):
+      struct.pack_into('i' if space is AddrSpace.GLOBAL else unwrap(dt.fmt), var_vals_mv, i*8,
+                       value.size if space is AddrSpace.GLOBAL else value)
     off_mv.cast('I')[:] = array.array('I', tuple(b.offset for b in bufs))
     self.dev.exec_lib(self.lib, rpc_sc(method=2, ins=2, outs=1, fds=len(bufs)), pra, fds, attrs)
     return timer[0] / 1e6
@@ -281,8 +282,8 @@ class MockDSPProgram(Program[DSPDevice]):
       dsp_lib.flush()
       os.chmod(dsp_lib.name, 0o0777)
       proc = subprocess.run(["qemu-hexagon-static", *(['-strace'] if DEBUG >= 5 else []), dsp_lib.name],
-        input=b''.join([bytes(to_mv(x.va_addr, x.size)) for x in bufs] +
-                       [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,_) in zip(vals, self.signature[len(bufs):])]),
+        input=b''.join(bytes(to_mv(value.va_addr, value.size)) if space is AddrSpace.GLOBAL else struct.pack(unwrap(dt.fmt), value)
+                       for (_,_,dt,_,space),value in TinyELF.iter_args(self.signature, bufs, vals)),
         stdout=subprocess.PIPE, check=True)
     offset = 4
     for x in bufs:

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -1,6 +1,7 @@
 import ctypes
 from tinygrad.helpers import mv_address, getenv, suppress_finalizing
 from tinygrad.device import Compiled, LRUAllocator, BufferSpec, Program, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.runtime.autogen import hip
 from tinygrad.renderer.cstyle import HIPRenderer
 from tinygrad.runtime.support.c import init_c_var, init_c_struct_t
@@ -8,6 +9,23 @@ if getenv("IOCTL"): import extra.hip_gpu_driver.hip_ioctl  # noqa: F401 # pylint
 
 def check(status):
   if status != 0: raise RuntimeError(f"HIP Error {status}, {ctypes.string_at(hip.hipGetErrorString(status)).decode()}")
+
+def encode_args(args, vals, signature) -> tuple[ctypes.Structure, ctypes.Array]:
+  fields, ordered, end = [], [], 0
+  buf_idx, val_idx = 0, 0
+  for (off, dt, addr_space), (_, arg) in zip(TinyELF.iter_sig(signature), TinyELF.iter_args(signature, args, vals), strict=True):
+    if addr_space is AddrSpace.GLOBAL:
+      fields.append((f'f{buf_idx}', hip.hipDeviceptr_t, off))
+      buf_idx, size = buf_idx + 1, 8
+    else:
+      fields.append((f'v{val_idx}', getattr(ctypes, f"c_int{dt.bitsize}"), off))
+      val_idx, size = val_idx + 1, dt.itemsize
+    ordered.append(arg)
+    end = off + size
+  c_args = init_c_struct_t(end, tuple(fields))(*ordered)
+  vargs = (ctypes.c_void_p * 5)(1, ctypes.cast(ctypes.byref(c_args), ctypes.c_void_p), 2,
+                                ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(c_args))), ctypes.c_void_p), 3)
+  return c_args, vargs
 
 class HIPDevice(Compiled):
   def __init__(self, device:str=""):
@@ -37,11 +55,7 @@ class HIPProgram(Program[HIPDevice]):
   def __call__(self, *args, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(), wait=False, **kw):
     check(hip.hipSetDevice(self.dev.device_id))
     if not hasattr(self, "vargs"):
-      fields = ([(f'f{i}', hip.hipDeviceptr_t, i*8) for i in range(len(args))] +
-        [(f'v{i}', getattr(ctypes, f"c_int{dt.bitsize}"), o) for i,(o,dt) in enumerate(TinyELF.iter_sig(self.signature[len(args):], len(args)*8))])
-      self.c_args = init_c_struct_t(fields[-1][2] + ctypes.sizeof(fields[-1][1]) if len(fields) else 0, tuple(fields))(*args, *vals)
-      self.vargs = (ctypes.c_void_p * 5)(1, ctypes.cast(ctypes.byref(self.c_args), ctypes.c_void_p), 2,
-                                         ctypes.cast(ctypes.pointer(ctypes.c_size_t(ctypes.sizeof(self.c_args))), ctypes.c_void_p), 3)
+      self.c_args, self.vargs = encode_args(args, vals, self.signature)
 
     for i in range(len(args)): self.c_args.__setattr__(f'f{i}', args[i])
     for i in range(len(vals)): self.c_args.__setattr__(f'v{i}', vals[i])

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -2,6 +2,7 @@ import subprocess, pathlib, struct, ctypes, tempfile, functools, decimal, platfo
 from tinygrad.helpers import prod, to_mv, round_up, cache_dir, PROFILE, ProfileRangeEvent, cpu_profile, unwrap, suppress_finalizing
 import tinygrad.runtime.support.objc as objc
 from tinygrad.device import Compiled, Compiler, CompileError, Program, TinyELF, LRUAllocator, ProfileDeviceEvent
+from tinygrad.dtype import AddrSpace
 from tinygrad.renderer.cstyle import MetalRenderer
 from tinygrad.runtime.autogen import metal
 from tinygrad.runtime.support.c import DLL
@@ -138,9 +139,9 @@ class MetalProgram(Program[MetalDevice]):
     command_buffer = self.dev.mtl_queue.commandBuffer().retained()
     encoder = command_buffer.computeCommandEncoder().retained()
     encoder.setComputePipelineState(self.pipeline_state)
-    for i,a in enumerate(bufs): encoder.setBuffer_offset_atIndex(a.buf, a.offset, i)
-    for a,(_,i,dt,_) in zip(vals, self.signature[len(bufs):]):
-      encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(a)), dt.itemsize, i)
+    for i, ((_, _, dt, _, addr_space), arg) in enumerate(TinyELF.iter_args(self.signature, bufs, vals)):
+      if addr_space is AddrSpace.GLOBAL: encoder.setBuffer_offset_atIndex(arg.buf, arg.offset, i)
+      else: encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(arg)), dt.itemsize, i)
     encoder.dispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
     encoder.endEncoding()
     command_buffer.setLabel(to_ns_str(self.name)) # TODO: is this always needed?

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -4,9 +4,10 @@ assert sys.platform != 'win32'
 from typing import cast
 from dataclasses import dataclass
 from tinygrad.runtime.support.hcq import HCQCompiled, HCQAllocator, HCQBuffer, HWQueue, CLikeArgsState, HCQProgram, HCQSignal, BumpAllocator
-from tinygrad.runtime.support.hcq import MMIOInterface, FileIOInterface, hcq_filter_visible_devices, hcq_profile
+from tinygrad.runtime.support.hcq import MMIOInterface, FileIOInterface, hcq_filter_visible_devices, hcq_profile, HCQArgsState
 from tinygrad.uop.ops import sint
 from tinygrad.device import Compiled, BufferSpec, TinyELF
+from tinygrad.dtype import AddrSpace, dtypes
 from tinygrad.helpers import getenv, mv_address, round_up, data64, data64_le, prod, OSX, hi32, lo32, PROFILE, ContextVar, VIZ, ProfileEvent
 from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.renderer.cstyle import CUDARenderer, NVCCRenderer
@@ -240,10 +241,14 @@ class NVVideoQueue(NVCommandQueue):
 
 class NVArgsState(CLikeArgsState):
   def __init__(self, buf:HCQBuffer, prg:NVProgram, bufs:tuple[HCQBuffer, ...], vals:tuple[int, ...]=()):
-    if (is_mock:=isinstance(prg.dev.iface, MOCKIface)): prg.cbuf_0[80:82] = [len(bufs), len(vals)]
-    super().__init__(buf, prg, bufs, vals=() if is_mock else vals, prefix=prg.cbuf_0 or None)
-    # mock expects all vars to be 64 bit
-    if is_mock and vals: self.bind_sints_to_buf(*vals, buf=self.buf, fmt='q', offset=len(prg.cbuf_0)*4 + len(bufs)*8)
+    if not isinstance(prg.dev.iface, MOCKIface): return super().__init__(buf, prg, bufs, vals=vals, prefix=prg.cbuf_0 or None)
+    HCQArgsState.__init__(self, buf, prg, bufs, vals)
+    prg.cbuf_0[80:82] = [len(bufs), len(vals)]
+    self.buf.cpu_view().view(size=len(prg.cbuf_0)*4, fmt='I')[:] = array.array('I', prg.cbuf_0)
+    # Ocelot consumes one 64-bit value per parameter, including scalars, in signature order.
+    for i,((_,_,dt,_,space),value) in enumerate(TinyELF.iter_args(prg.signature, bufs, vals)):
+      self.bind_sints_to_buf(value.va_addr if space is AddrSpace.GLOBAL else value, buf=self.buf,
+                            fmt='q' if space is AddrSpace.ALU and dt in dtypes.sints else 'Q', offset=len(prg.cbuf_0)*4 + i*8)
 
 class NVProgram(HCQProgram['NVDevice']):
   def __init__(self, dev:NVDevice, obj:TinyELF):

--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -203,22 +203,24 @@ class QCOMArgsState(HCQArgsState):
     super().__init__(buf, prg, bufs, vals=vals)
     ctypes.memset(int(self.buf.va_addr), 0, prg.kernargs_alloc_size)
 
-    ubos = [bufs[slot] for _,slot,_,shape in prg.signature if slot < len(bufs) and not is_image_shape(shape)]
-    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape in prg.signature if slot < len(bufs) and is_image_shape(shape)]
-    # NIR can reorder images to different texture slots
-    ibos, texs = uavs[:prg.ibo_cnt], [uavs[prg.ibo_cnt + (prg.tex_to_image[i] if prg.NIR else i)] for i in range(prg.tex_cnt)]
+    args = list(TinyELF.iter_args(prg.signature, bufs, vals))
+    uniforms = [(sig, value) for sig,value in args if not is_image_shape(sig[3])]
+    uavs = [(dt,shape,value) for (_,_,dt,shape,space),value in args if space is AddrSpace.GLOBAL and is_image_shape(shape)]
+    # NIR textures refer to the shared image table; the CL compiler describes each image's resource type.
+    if prg.NIR: ibos, texs = uavs, [uavs[prg.tex_to_image[i]] for i in range(prg.tex_cnt)]
+    else:
+      ibos = [arg for arg,typ in zip(uavs, prg.image_types, strict=True) if typ == BUFTYPE_IBO]
+      texs = [arg for arg,typ in zip(uavs, prg.image_types, strict=True) if typ == BUFTYPE_TEX]
     for cnst_val,cnst_off,cnst_sz in prg.consts_info:
       to_mv(cast(int, self.buf.va_addr) + cnst_off, cnst_sz)[:] = cnst_val.to_bytes(cnst_sz, byteorder='little')
 
     if prg.samp_cnt > 0: to_mv(int(self.buf.va_addr) + prg.samp_off, len(prg.samplers) * 4).cast('I')[:] = array.array('I', prg.samplers)
     if prg.NIR:
-      self.bind_sints_to_buf(*[b.va_addr for b in ubos], buf=self.buf, fmt='Q', offset=prg.buf_off)
-      for v,(o,dt) in zip(vals, TinyELF.iter_sig(prg.signature[len(bufs):], len(ubos)*8)):
-        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_off + o)
-    else:
-      for i, b in enumerate(ubos): self.bind_sints_to_buf(b.va_addr, buf=self.buf, fmt='Q', offset=prg.buf_offs[i])
-      for i,(v,(_,_,dt,_)) in enumerate(zip(vals, prg.signature[len(bufs):])):
-        self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=prg.buf_offs[i+len(ubos)])
+      offsets = [prg.buf_off + off for off,_,_ in TinyELF.iter_sig(tuple(sig for sig,_ in uniforms))]
+    else: offsets = prg.buf_offs
+    for ((_,_,dt,_,space),value),off in zip(uniforms, offsets, strict=True):
+      self.bind_sints_to_buf(value.va_addr if space is AddrSpace.GLOBAL else value, buf=self.buf,
+                            fmt='Q' if space is AddrSpace.GLOBAL else dt.fmt, offset=off)
 
     def _tex(b, ibo=False):
       imgdt, shape, buf = b
@@ -249,7 +251,7 @@ class QCOMProgram(HCQProgram['QCOMDevice']):
 
       # see https://elixir.bootlin.com/mesa/mesa-25.3.0/source/src/freedreno/ir3/ir3_shader.h#L525
       # and https://elixir.bootlin.com/mesa/mesa-25.3.0/source/src/freedreno/ir3/ir3_compiler_nir.c#L5389
-      self.samp_cnt, self.tex_cnt, self.ibo_cnt = (nt:=v.image_mapping.num_tex), nt, v.num_uavs - nt
+      self.samp_cnt, self.tex_cnt, self.ibo_cnt = (nt:=v.image_mapping.num_tex), nt, v.num_uavs
       self.tex_to_image = v.image_mapping.tex_to_image[:]
       # IR3 outputs a sampler for every texture (https://elixir.bootlin.com/mesa/mesa-25.3.0/source/src/freedreno/ir3/ir3_compiler_nir.c#L1714)
       self.samplers = [qreg.a6xx_tex_samp_0(wrap_s=(clamp_mode:=mesa.A6XX_TEX_CLAMP_TO_BORDER), wrap_t=clamp_mode, wrap_r=clamp_mode),
@@ -310,6 +312,7 @@ class QCOMProgram(HCQProgram['QCOMDevice']):
       binfos.append((offset_words * 4, typ))
       bdoff += length
     self.buf_offs = [off for off,typ in binfos if typ not in {BUFTYPE_TEX, BUFTYPE_IBO}]
+    self.image_types = [typ for _,typ in binfos if typ in {BUFTYPE_TEX, BUFTYPE_IBO}]
 
     # Setting correct offsets to textures/ibos.
     self.tex_cnt, self.ibo_cnt = sum(typ is BUFTYPE_TEX for _,typ in binfos), sum(typ is BUFTYPE_IBO for _,typ in binfos)

--- a/tinygrad/runtime/ops_webgpu.py
+++ b/tinygrad/runtime/ops_webgpu.py
@@ -4,6 +4,7 @@ from tinygrad.renderer.wgsl import WGSLRenderer
 from tinygrad.helpers import round_up, suppress_finalizing, getenv, to_mv
 from tinygrad.runtime.autogen import webgpu
 from tinygrad.runtime.support import c
+from tinygrad.dtype import AddrSpace
 from typing import Callable
 import ctypes
 
@@ -51,7 +52,7 @@ QueueOnSubmittedWorkDone = synchronous(webgpu.enum_WGPUQueueWorkDoneStatus)(webg
 
 class WebGPUProgram(Program['WebGpuDevice']):
   def __init__(self, dev:'WebGpuDevice', obj:TinyELF):
-    self.dev, self.name = dev, to_wgpu_str(obj.name)
+    self.dev, self.name, self.signature = dev, to_wgpu_str(obj.name), obj.signature
 
     # Creating shader module
     shader = webgpu.WGPUShaderModuleWGSLDescriptor(code=to_wgpu_str(obj.lib.decode()),
@@ -74,8 +75,9 @@ class WebGPUProgram(Program['WebGpuDevice']):
     def bgl_entry(n:int, ty:str):
       return webgpu.WGPUBindGroupLayoutEntry(binding=n, visibility=webgpu.WGPUShaderStage_Compute,
                                              buffer=webgpu.WGPUBufferBindingLayout(type=getattr(webgpu, f'WGPUBufferBindingType_{ty}')))
-    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(bufs)+len(vals)))(
-      bgl_entry(0, 'Uniform'), *(bgl_entry(i+1, 'Uniform' if i >= len(bufs) else 'Storage') for i in range(len(bufs)+len(vals))))
+    ordered_args = list(TinyELF.iter_args(self.signature, bufs, vals))
+    bind_entries = (webgpu.WGPUBindGroupLayoutEntry * (1+len(ordered_args)))(bgl_entry(0, 'Uniform'),
+      *(bgl_entry(i+1, 'Storage' if sig[4] is AddrSpace.GLOBAL else 'Uniform') for i,(sig, _) in enumerate(ordered_args)))
 
     webgpu.wgpuDevicePushErrorScope(self.dev.device_res, webgpu.WGPUErrorFilter_Validation)
     bind_layout = webgpu.wgpuDeviceCreateBindGroupLayout(self.dev.device_res,
@@ -94,7 +96,8 @@ class WebGPUProgram(Program['WebGpuDevice']):
     def bg_entry(n:int, x:webgpu.WGPUBuffer|int|float):
       buf = x if isinstance(x, webgpu.WGPUBuffer) else self.dev.create_uniform(x)
       return webgpu.WGPUBindGroupEntry(binding=n, buffer=buf, offset=0, size=webgpu.wgpuBufferGetSize(buf))
-    bindings = (webgpu.WGPUBindGroupEntry * (1+len(bufs)+len(vals)))(bg_entry(0, float('inf')), *(bg_entry(i+1, x) for i,x in enumerate(bufs+vals)))
+    bindings = (webgpu.WGPUBindGroupEntry * (1+len(ordered_args)))(bg_entry(0, float('inf')),
+      *(bg_entry(i+1, arg) for i,(_, arg) in enumerate(ordered_args)))
 
     bind_group_desc = webgpu.WGPUBindGroupDescriptor(layout=bind_layout, entryCount=len(bindings), entries=bindings)
     webgpu.wgpuDevicePushErrorScope(self.dev.device_res, webgpu.WGPUErrorFilter_Validation)

--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -6,6 +6,7 @@ except ImportError: fcntl = None #type:ignore[assignment]
 from tinygrad.helpers import DEV, PROFILE, getenv, from_mv, cpu_profile, ProfileRangeEvent, unwrap
 from tinygrad.helpers import suppress_finalizing, pluralize, TracingKey
 from tinygrad.device import Device, BufferSpec, Compiled, LRUAllocator, ProfileDeviceEvent, ProfileProgramEvent, Program, TinyELF
+from tinygrad.dtype import AddrSpace
 from tinygrad.uop.ops import sym_infer, sint, UOp
 from tinygrad.runtime.autogen import libc
 from tinygrad.runtime.support.memory import BumpAllocator, MMIOInterface
@@ -318,10 +319,10 @@ class CLikeArgsState(HCQArgsState[ProgramType]):
 
     if prefix is not None: self.buf.cpu_view().view(size=len(prefix) * 4, fmt='I')[:] = array.array('I', prefix)
 
-    self.bind_sints_to_buf(*[b.va_addr for b in bufs], buf=self.buf, fmt='Q', offset=len(prefix or []) * 4)
-    for v,(val_offset,dt) in zip(vals, TinyELF.iter_sig(prg.signature[-len(vals):], len(bufs) * 8)):
-      assert v is not None
-      self.bind_sints_to_buf(v, buf=self.buf, fmt=dt.fmt, offset=len(prefix or []) * 4 + val_offset)
+    for (off,dt,space), (_,value) in zip(TinyELF.iter_sig(prg.signature), TinyELF.iter_args(prg.signature, bufs, vals), strict=True):
+      assert value is not None
+      self.bind_sints_to_buf(value.va_addr if space is AddrSpace.GLOBAL else value, buf=self.buf,
+                            fmt='Q' if space is AddrSpace.GLOBAL else dt.fmt, offset=len(prefix or []) * 4 + off)
 
 class HCQProgram(Program[HCQDeviceType]):
   def __init__(self, args_state_t:Type[HCQArgsState], dev:HCQDeviceType, obj:TinyELF, kernargs_alloc_size:int, base:int|None=None):

--- a/tinygrad/runtime/support/hcq2.py
+++ b/tinygrad/runtime/support/hcq2.py
@@ -87,8 +87,13 @@ def make_call(name:str, body:UOp, info:HCQInfo) -> UOp: return UOp.custom_functi
 def encode_kernargs_clike(call:UOp, prg:UOp, devs:str|tuple[str, ...]) -> UOp:
   data, info = prg.arg
   buf = UOp.placeholder((data.kernargs_alloc_size // 4,), dtypes.uint32, next(UOp.unique_num), device=devs).rtag("kernargs")
-  words = [get_call_arg_uops(call)[gi].getaddr(devs) for gi in info.globals] + list(info.vars)
-  return buf.after(*make_patches(buf, list(zip(itertools.accumulate((w.dtype.itemsize for w in words), initial=0), words))))
+  params = [(slot, call.src[slot+1].getaddr(devs)) for slot in info.globals] + [(v.arg.slot, v) for v in info.vars]
+  offset, patches = 0, []
+  for _,param in sorted(params, key=lambda x: x[0]):
+    offset = round_up(offset, param.dtype.itemsize)
+    patches.append((offset, param))
+    offset += param.dtype.itemsize
+  return buf.after(*make_patches(buf, patches))
 
 def make_buf(devs, slot:int=0, tag:str="signal") -> UOp: return UOp.placeholder((1,), dtypes.uint64, slot, device=devs, volatile=True, tag=tag)
 
@@ -132,7 +137,7 @@ def stage_copy(dst:UOp, src:UOp) -> UOp|None:
 
 def _get_enqueue_devs(call:UOp) -> Any|None:
   if call.src[0].op not in (Ops.PROGRAM, Ops.COPY): return None # only these bodies can be enqueued
-  if not (bufs:=call.src[1:]) or not all(all_devices_in(b.device, HCQ_DEVS) for b in bufs): return None
+  if not (bufs:=tuple(b for b in call.src[1:] if b.device is not None)) or not all(all_devices_in(b.device, HCQ_DEVS) for b in bufs): return None
   if call.src[0].op is Ops.COPY: bufs = bufs[::-1] # copies push from the src device: p2p writes are faster than reads
   devs = min(bufs, key=lambda b: to_tuple(b.device)[0].startswith("CPU")).device # prio to enqueue on not CPU device
   return devs if all_devices_in(devs, HCQ_DEVS) else None
@@ -381,7 +386,7 @@ def replace_params(call:UOp) -> UOp|None:
   tops = body.toposort(gate=lambda u: u.op not in param_ops)
   args = dedup([s for u in tops for s in u.src if s.op in param_ops and s not in variables])
 
-  patched, refhold = partition(call.src[1:], lambda x: x.src[0] in args)
+  patched, refhold = partition(call.src[1:], lambda x: bool(x.src) and x.src[0] in args)
   by_root = {p.src[0]: p for p in patched}
   c_args = [by_root.get(a, a) for a in args]
 

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1216,8 +1216,9 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
 
   def to_elf(self) -> TinyELF:
     assert self.op is Ops.PROGRAM and isinstance(self.arg, ProgramInfo), "to_elf should only be called on a PROGRAM ast"
-    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape)
-                for u in tuple(filter(lambda u: u.op is Ops.PARAM and u.addrspace != AddrSpace.ALU, self.src[1].src)) + self.arg.vars)
+    params = sorted([u for u in self.src[1].src if u.op is Ops.PARAM and u.addrspace != AddrSpace.ALU] + list(self.arg.vars),
+                    key=lambda u: u.arg.slot)
+    sig = tuple((u.arg.name, u.arg.slot, u.dtype, u._shape, u.addrspace) for u in params)
     return TinyELF(self.src[3].arg, self.arg.function_name, self.arg.target, sig, self.key)
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Kernel parameters can interleave buffers and scalars, but several runtime paths assume that buffers come first. This can pass an input pointer or scalar to the wrong parameter, even when generated kernel source has the correct order.

This change preserves `ParamArg.slot` order through signature metadata, runtime argument packing/binding, and graph replay. It also handles unused parameter slots and adds regressions for direct execution, changing replay inputs, alignment, and backend-specific transports. The goal is to make the declared kernel interface work consistently across execution paths.

Validation on the original working base includes CPU and Metal execution, OpenCL/WebGPU tests, AMD/NV emulation, and QCOM/DSP compiler or transport tests. Mypy and Ruff pass. Physical accelerator coverage is incomplete, and known baseline HCQ2 failures remain.

Draft status: this work is based on fdb4109f5 and has not yet been ported or revalidated against current master. Upstream has since changed queue and buffer infrastructure. This draft is for discussion of the approach and scope; it is not ready to merge.
