### PR TITLE
benchmarks: reset mac chestnut

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -432,7 +432,7 @@ jobs:
         ./extra/hcq/hcq_smi.py amd kill_pids --sudoless
         ./extra/hcq/hcq_smi.py nv kill_pids --sudoless
     - name: reset chestnut
-      run: python3 extra/usbgpu/debug.py -rn
+      run: python3 extra/usbgpu/debug.py -rnw
     - name: UsbGPU boot time
       run: GMMU=0 DEBUG=2 AM_RESET=1 DEV=USB+AMD time python3.11 test/test_tiny.py TestTiny.test_plus
     - name: UsbGPU tiny tests

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -431,6 +431,8 @@ jobs:
       run: |
         ./extra/hcq/hcq_smi.py amd kill_pids --sudoless
         ./extra/hcq/hcq_smi.py nv kill_pids --sudoless
+    - name: reset chestnut
+      run: python3 extra/usbgpu/debug.py -rn
     - name: UsbGPU boot time
       run: GMMU=0 DEBUG=2 AM_RESET=1 DEV=USB+AMD time python3.11 test/test_tiny.py TestTiny.test_plus
     - name: UsbGPU tiny tests

--- a/extra/usbgpu/debug.py
+++ b/extra/usbgpu/debug.py
@@ -65,9 +65,26 @@ class USBGPUDebug:
     time.sleep(0.5)
     self.ftdi.set_cbus_gpio(self.CBUS_BOOTLOADER if bootloader else 0)
     if bootloader:
-      time.sleep(1)
+      self._wait_for_bootloader()
       self.ftdi.set_cbus_gpio(0)
     print("Device reset complete.")
+
+  def _wait_for_bootloader(self, timeout=10.0):
+    """Wait for the ASM2464 bootloader to enumerate on USB."""
+    import usb.core
+    SUPPORTED_CONTROLLERS = [
+      (0x174C, 0x2464),
+      (0x174C, 0x2463),
+      (0x3801, 0x0001),
+    ]
+    start = time.time()
+    while time.time() - start < timeout:
+      for vendor, device in SUPPORTED_CONTROLLERS:
+        dev = usb.core.find(idVendor=vendor, idProduct=device)
+        if dev is not None:
+          return  # Found it!
+      time.sleep(0.1)
+    raise RuntimeError(f"Bootloader did not enumerate within {timeout}s")
 
   def read(self) -> bytes:
     return self.ftdi.read_data(256).decode('utf-8', errors='replace')
@@ -80,6 +97,7 @@ if __name__ == "__main__":
   args.add_argument('--reset', '-r', action='store_true', default=False, help="Reset the device")
   args.add_argument('--bootloader', '-b', action='store_true', default=False, help="Reset to bootloader")
   args.add_argument('--no-read', '-n', action='store_true', default=False, help="Do not read debug output")
+  args.add_argument('--timeout', '-t', type=float, default=None, help="Timeout in seconds for reading")
 
   args = args.parse_args()
 
@@ -95,8 +113,10 @@ if __name__ == "__main__":
 
     if not args.no_read:
       print("Starting debug output. Press Ctrl-C to exit.\n------")
+      start_time = time.perf_counter()
       while True:
         sys.stdout.write(dbg.read())
         sys.stdout.flush()
+        if args.timeout is not None and (time.perf_counter() - start_time) >= args.timeout:
+          break
         time.sleep(0.001)
-

--- a/extra/usbgpu/debug.py
+++ b/extra/usbgpu/debug.py
@@ -57,26 +57,25 @@ class USBGPUDebug:
     self.provisioned = True
     print("Provisioning complete.")
 
-  def reset(self, bootloader=False):
+  def reset(self, bootloader=False, wait=False):
     if not self.provisioned:
       raise RuntimeError("Device not provisioned for usbgpu debugging. Use --provision to provision it.")
 
     self.ftdi.set_cbus_gpio(self.CBUS_RESET | (self.CBUS_BOOTLOADER if bootloader else 0))
     time.sleep(0.5)
     self.ftdi.set_cbus_gpio(self.CBUS_BOOTLOADER if bootloader else 0)
-    if bootloader:
-      self._wait_for_bootloader()
-      self.ftdi.set_cbus_gpio(0)
+    if bootloader or wait: self._wait_for(bootloader)
+    if bootloader: self.ftdi.set_cbus_gpio(0)
     print("Device reset complete.")
 
-  def _wait_for_bootloader(self, timeout=10.0):
-    """Wait for the ASM2464 bootloader to enumerate on USB."""
+  def _wait_for(self, bootloader: bool, timeout=10.0):
+    """Wait for the ASM2464 bootloader (or the device itself) to enumerate on USB."""
     import usb.core
     SUPPORTED_CONTROLLERS = [
       (0x174C, 0x2464),
       (0x174C, 0x2463),
       (0x3801, 0x0001),
-    ]
+    ] if bootloader else [(0x3801, 0x0001)]
     start = time.time()
     while time.time() - start < timeout:
       for vendor, device in SUPPORTED_CONTROLLERS:
@@ -84,7 +83,7 @@ class USBGPUDebug:
         if dev is not None:
           return  # Found it!
       time.sleep(0.1)
-    raise RuntimeError(f"Bootloader did not enumerate within {timeout}s")
+    raise RuntimeError(f"{'Bootloader' if bootloader else 'Device'} did not enumerate within {timeout}s")
 
   def read(self) -> bytes:
     return self.ftdi.read_data(256).decode('utf-8', errors='replace')
@@ -96,6 +95,7 @@ if __name__ == "__main__":
   args.add_argument('--provision', '-p', action='store_true', default=False, help="Provision the connected FTDI for usbgpu debugging")
   args.add_argument('--reset', '-r', action='store_true', default=False, help="Reset the device")
   args.add_argument('--bootloader', '-b', action='store_true', default=False, help="Reset to bootloader")
+  args.add_argument('--wait', '-w', action='store_true', default=False, help="Wait for the device to enumerate after reset")
   args.add_argument('--no-read', '-n', action='store_true', default=False, help="Do not read debug output")
   args.add_argument('--timeout', '-t', type=float, default=None, help="Timeout in seconds for reading")
 
@@ -106,10 +106,10 @@ if __name__ == "__main__":
       dbg.provision()
 
     if args.reset:
-      dbg.reset(bootloader=False)
+      dbg.reset(bootloader=False, wait=args.wait)
 
     if args.bootloader:
-      dbg.reset(bootloader=True)
+      dbg.reset(bootloader=True, wait=args.wait)
 
     if not args.no_read:
       print("Starting debug output. Press Ctrl-C to exit.\n------")


### PR DESCRIPTION
instability appears limited to RDNA3 gpus, so no resets for comma yet (many usb resets on agnos is flaky? https://github.com/tinygrad/tinygrad/actions/runs/30642359851/job/91210255001)