### PR TITLE
IMAGE: preserve integer matmul precision

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Run backend tests
       run: SKIP_SLOW_TEST=1 DEV=PYTHON python3 -m pytest -n=auto test/backend/test_dtype.py test/backend/test_dtype_alu.py test/backend/test_ops.py test/backend/test_uops.py test/backend/test_symbolic_ops.py test/backend/test_renderer_failures.py::TestRendererFailures --durations=20
     - name: Test IMAGE support
-      run: IMAGE=1 DEV=PYTHON python3 test/backend/test_ops.py TestOps.test_gemm TestOps.test_simple_conv2d
+      run: IMAGE=1 DEV=PYTHON python3 test/backend/test_ops.py TestOps.test_gemm TestOps.test_simple_conv2d TestOps.test_gemm_int_precision
     - name: Test emulated tensor cores
       env:
         DEBUG: 2

--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1497,6 +1497,12 @@ class TestOps(unittest.TestCase):
                                                                          np.arange(64,128,dtype=np.float32).reshape(8,8)])
   def test_small_gemm_eye(self):
     helper_test_op(None, lambda x,y: x.matmul(y), lambda x,y: x@y, vals=[np.eye(8).astype(np.float32), np.eye(8).astype(np.float32)])
+  def test_gemm_int_precision(self):
+    # Preserve integer dtype and values, including integers not representable in float32.
+    vals = [np.array([[2**24+1, -2**24-1], [3, 4]], dtype=np.int32), np.eye(2, dtype=np.int32)]
+    for dtype in (None, dtypes.int32):
+      with self.subTest(dtype=dtype):
+        helper_test_op(None, lambda x,y: x@y, lambda x,y: x.dot(y, dtype=dtype), vals=vals, forward_only=True)
   @unittest.skipUnless(dtypes.half in Device[Device.DEFAULT].renderer.supported_dtypes(), "not precise enough when emulating")
   @unittest.skipIf(IMAGE>0, "image does math in float32")
   def test_gemm_fp16(self):

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -380,7 +380,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     print(a.dot(b).numpy())
     ```
     """
-    if IMAGE: return self.image_dot(w, dtype)
+    if IMAGE and dtypes.is_float(self.dtype) and dtypes.is_float(w.dtype): return self.image_dot(w, dtype)
     x, dx, dw = self, self.ndim, w.ndim
     if not (dx > 0 and dw > 0): raise RuntimeError(f"both tensors need to be at least 1D, got {dx}D and {dw}D")
     if x.shape[-1] != w.shape[axis_w:=-min(w.ndim,2)]: raise RuntimeError(f"cannot dot {x.shape} and {w.shape}")


### PR DESCRIPTION
Fixes #18086

Preserve integer matrix multiplication when `IMAGE` is enabled. The image path converts products to float32, so multiplying by an identity matrix can turn `16777217` into `16777216.0`. Use the ordinary dot path whenever either operand is non-floating, preserving its existing dtype promotion and accumulation behavior. Floating-point pairs keep their existing image path.

Adds an exact-integer regression for both default and explicit `dtype=int32` output. Both fail before the fix and pass afterward; the explicit-dtype case catches precision loss even when the returned dtype looks correct. The test runs without the QCOM emulator and is included in the existing Python IMAGE CI step.

Local validation:

- CPU IMAGE=1 operations suite: 412 passed, 20 skipped, 111 subtests; only the new regression failed on the matched baseline.
- Dtype suite: 29 additional passing tests, no new failures. The remaining 27 pre-existing failures concern floating-point image dtypes and unsigned-overflow assertions.
- IR3 compile-only operations: 406 passed, 26 skipped.
- Ruff and mypy passed (215 source files).

The full-suite upstream test base and branch base are both [fec703c](https://github.com/tinygrad/tinygrad/commit/fec703cbecad430857c6bedd94a9500e871a4bcc), with this patch applied for the patched runs. No QCOM hardware numerical validation is claimed.
