### PR TITLE
add associative tensor scan

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1144,6 +1144,41 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], torch.nn.functional.mish, Tensor.mish)
     helper_test_op([()], torch.nn.functional.mish, Tensor.mish)
 
+  def test_associative_scan_add(self):
+    self.assertEqual(Tensor([1, 2, 3, 4]).associative_scan(lambda a,b: a+b).tolist(), [1, 3, 6, 10])
+    for n in (0, 1, 2, 3, 5, 7, 17):
+      data = np.arange(1, n+1, dtype=np.float32)
+      out = Tensor(data).associative_scan(lambda a,b: a+b)
+      np.testing.assert_equal(out.numpy(), np.cumsum(data))
+      self.assertEqual(out.dtype, dtypes.float32)
+
+  def test_associative_scan_mul(self):
+    self.assertEqual(Tensor([2, 3, 4]).associative_scan(lambda a,b: a*b).tolist(), [2, 6, 24])
+    for n in (1, 2, 3, 5, 7, 17):
+      data = np.linspace(0.9, 1.1, n, dtype=np.float32)
+      np.testing.assert_allclose(Tensor(data).associative_scan(lambda a,b: a*b).numpy(), np.cumprod(data), rtol=1e-5)
+
+  def test_associative_scan_axes(self):
+    data = np.arange(105, dtype=np.float32).reshape(3, 5, 7)
+    for axis in range(-3, 3):
+      np.testing.assert_equal(Tensor(data).associative_scan(lambda a,b: a+b, axis).numpy(), np.cumsum(data, axis=axis))
+    for axis in (0, -1):
+      self.assertEqual(Tensor(3).associative_scan(lambda a,b: a+b, axis).item(), 3)
+    for shape, axis in (((), 1), ((), -2), ((0,), 1), ((3, 5), -3), ((3, 5), 2)):
+      with self.assertRaises(IndexError): Tensor.empty(shape).associative_scan(lambda a,b: a+b, axis)
+    with self.assertRaises(ValueError): Tensor.ones(5).associative_scan(lambda a,b: (a+b).sum())
+
+  def test_associative_scan_affine(self):
+    def reference(x):
+      states = [x[:, 0]]
+      for i in range(1, x.shape[1]):
+        a, b = x[:, i, ..., 0], x[:, i, ..., 1]
+        states.append(torch.stack((a*states[-1][..., 0], a*states[-1][..., 1]+b), dim=-1))
+      return torch.stack(states, dim=1)
+    def combine(left, right):
+      return (right[..., 0]*left[..., 0]).stack(right[..., 0]*left[..., 1]+right[..., 1], dim=-1)
+    helper_test_op([(2, 7, 3, 2)], reference, lambda x: x.associative_scan(combine, axis=1), low=0.5, high=1.0)
+
   def test_small_cumsum(self):
     helper_test_op([(10)], lambda x: torch.cumsum(x, dim=0), lambda x: Tensor.cumsum(x, axis=0))
   @slow_test

--- a/test/null/test_tensor_uop_mixin.py
+++ b/test/null/test_tensor_uop_mixin.py
@@ -154,6 +154,7 @@ class TestTensorUOpGetitem(unittest.TestCase):
     self.assertIs(_strip_unique(_t(4,5)[[[0,1],[2,3]]].uop), _strip_unique(_t(4,5).uop[[[0,1],[2,3]]]))
 
 class TestTensorUOpCumalu(unittest.TestCase):
+  def test_associative_scan(self): _check(self, _t(3, 5, 2), lambda x: x.associative_scan(lambda a,b: a+b, -2))
   def test_cumsum_1d(self):       _check(self, _t(5), lambda x: x.cumsum())
   def test_cumsum_2d(self):       _check(self, _t(3, 4), lambda x: x.cumsum(1))
   def test_cumsum_non_last(self): _check(self, _t(3, 4), lambda x: x.cumsum(0))

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -767,6 +767,33 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     base = chunks[..., -1]._cumalu(-1, op)._pad_constant((None,)*(chunks.ndim-2) + ((1, -1),), value)
     return chunks.alu(op, base.unsqueeze(-1)).flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
 
+  def associative_scan(self, fn:Callable[[Self, Self], Self], axis:int=0) -> Self:
+    """
+    Computes inclusive prefixes using the associative operation `fn(earlier, later)`.
+    `fn` must combine corresponding positions along `axis`, preserving shape, dtype and device.
+    Uses recursive pair reduction with linear combine work and logarithmic dependency depth.
+    Input dimensions must be concrete; no identity element is required.
+    """
+    axis = self._resolve_dim(axis)
+    if self.ndim == 0 or 0 in self.shape: return self
+    if not isinstance(n:=self.shape[axis], int): raise RuntimeError("associative_scan requires a concrete scan length")
+    if n == 1: return self
+    def part(x:Self, start:int, stop:int, step:int=1) -> Self:
+      return x[(slice(None),)*axis + (slice(start, stop, step),)]
+    pairs = fn(part(self, 0, n-1, 2), part(self, 1, n, 2))
+    expected = self.shape[:axis] + (n//2,) + self.shape[axis+1:]
+    if pairs.shape != expected: raise ValueError("associative_scan fn must preserve shape")
+    # Bound fusion at each level so shared prefixes are not repeatedly expanded into later kernels.
+    odd = pairs.contiguous().associative_scan(fn, axis)
+    even = part(self, 0, 1)
+    if n > 2:
+      rest = fn(part(odd, 0, (n-1)//2), part(self, 2, n, 2))
+      if rest.shape != self.shape[:axis] + ((n-1)//2,) + self.shape[axis+1:]:
+        raise ValueError("associative_scan fn must preserve shape")
+      even = even.cat(rest, dim=axis)
+    ret = part(even, 0, n//2).stack(odd, dim=axis+1).flatten(axis, axis+1)
+    return ret.cat(part(even, n//2, n//2+1), dim=axis) if n % 2 else ret
+
   def cumsum(self, axis:int=0) -> Self:
     """
     Computes the cumulative sum of the tensor along the specified `axis`.


### PR DESCRIPTION
Adds the general associative prefix scan requested in #3039.

`Tensor.associative_scan(fn, axis=0)` performs an inclusive forward scan using recursive adjacent-pair reduction and prefix reconstruction. It preserves operand order, supports positive/negative axes and odd lengths, and requires concrete dimensions. Logical combine work is O(N), with O(log N) combine dependency depth for a fixed-complexity callback.

The implementation uses existing lazy graph operations in OpMixin, with one pair-reduction contiguous boundary to limit fusion expansion. Existing cumsum/cumprod and backend operations are unchanged.

Tests:
- Addition, multiplication, representative odd lengths, axes, empty/scalar behavior and callback shape rejection.
- Noncommutative affine composition and gradients against a sequential PyTorch reference; Tensor/UOp parity.
- After updating onto upstream `1ea6dcde6`: focused CPU:X86 and CUDA runs passed 5 tests each; the nearby selection passed 246 tests with 2 skips.
- Commands: `python -m pytest test/backend/test_ops.py test/null/test_tensor_uop_mixin.py -k associative_scan -n12 -q`; `python -m pytest test/backend/test_ops.py test/null/test_tensor_uop_mixin.py test/test_tiny.py -k 'associative_scan or cumsum or cumprod or TestTiny or TestTensorUOp' -n12 -q`.
- Before the upstream update, the broader selection (`test/backend/test_ops.py test/null/test_tensor_uop_mixin.py test/backend/test_tensor.py test/test_tiny.py test/unit/test_helpers.py`, with `-n12`, `SKIP_SLOW_TEST=1`) passed 673 tests, skipped 74 and had 3 trigonometric failures reproduced on the unmodified base.
- Ruff on changed files and `git diff --check` passed after updating upstream. Linux-targeted mypy passed before that update.

Parallelism/benchmark:
- On the reviewed implementation before the upstream update, N=64/256/1024/4096 had combine depths 11/15/19/23, versus 63/255/1023/4095 for an explicit sequential Tensor graph. Logical combines were 120/502/2036/8178.
- At N=1024 on RTX 3080 Ti (driver 581.80), float32 associative addition measured 0.100–0.101 ms across three process medians; the sequential Tensor reference measured 0.302–1.152 ms. Affine scan measured 0.125–0.128 ms versus 0.191–0.584 ms for the sequential reference.
- Timings used three TinyJit warmup calls and nine synchronized replays per process. Sequential timings varied substantially, so no speedup ratio is claimed. Existing optimized cumsum measured 0.088–0.094 ms. Ryzen 7 5800X CPU:X86 overhead remained significant: 9.135 ms for addition and 8.633 ms for affine at N=1024.
- Benchmarks are scratch-only and are not included in this diff. These timings were collected before the upstream update and are not claimed as new measurements on the submission base.

AI disclosure:
OpenAI Codex was used for repository analysis, investigation of the previous #16500 attempt, implementation assistance, and testing/benchmark assistance. The contributor reviewed the final changes before submission.
