### PR TITLE
sqtt setprio handling on CDNA

### DIFF
--- a/test/amd/test_sqtt_profiler.py
+++ b/test/amd/test_sqtt_profiler.py
@@ -10,6 +10,7 @@ from tinygrad.codegen import to_program
 from tinygrad.viz.serve import load_amd_counters, VizData
 from tinygrad.renderer.amd.sqtt import decode, print_packets
 from tinygrad.renderer.amd.dsl import s, v
+from tinygrad.helpers import getenv
 
 @contextlib.contextmanager
 def save_sqtt():
@@ -20,6 +21,19 @@ def save_sqtt():
   Device[Device.DEFAULT].synchronize()
   Device[Device.DEFAULT]._at_profile_finalize()
   data[:] = [e for e in Compiled.profile_events[:profile_start] if isinstance(e, ProfileProgramEvent)]+Compiled.profile_events[profile_start:]
+  if getenv("PRINT_PKTS"):
+    sqtt_kernels = set()
+    for event in data:
+      if not isinstance(event, ProfileSQTTEvent) or not event.itrace: continue
+      print(f"\n=== SE {event.se} ===")
+      print_packets(decode(event.blob))
+      sqtt_kernels.add(event.kern)
+    for event in data:
+      if not isinstance(event, ProfileProgramEvent) or event.tag not in sqtt_kernels: continue
+      from test.null.test_viz import write_files, run_cli
+      with write_files(profile=data) as files:
+        out = run_cli(*files, "-s", f"{event.name} SQTT SE:0 PKTS", json_fmt=False)[0]["out"]
+      print(out)
 
 def map_sqtt(profile:list) -> list[dict]:
   load_amd_counters(data:=VizData(), profile)
@@ -101,14 +115,6 @@ class TestSQTTProfiler(unittest.TestCase):
     t = Tensor.empty(1)
     with save_sqtt() as data:
       t.custom_kernel(fxn=custom_asm_cdna if self.arch == "gfx950" else custom_asm_rdna)[0].realize()
-    for event in data:
-      if not isinstance(event, ProfileSQTTEvent) or not event.itrace: continue
-      print(f"\n=== SE {event.se} ===")
-      print_packets(decode(event.blob))
-    from test.null.test_viz import write_files, run_cli
-    with write_files(profile=data) as files:
-      out = run_cli(*files, "-s", "asm SQTT SE:0 PKTS", json_fmt=False)[0]["out"]
-    print(out)
 
   def test_multiple_runs(self):
     t = Tensor.empty(1) + 1

--- a/test/amd/test_sqtt_profiler.py
+++ b/test/amd/test_sqtt_profiler.py
@@ -126,14 +126,14 @@ class TestSQTTProfiler(unittest.TestCase):
       hw_id, wave_size, add = isa.HWREG.HW_REG_WAVE_HW_ID1.value, 32, isa.s_add_co_u32
       barrier = [isa.s_barrier_signal(ssrc0=-1), isa.s_barrier_wait(simm16=-1)]
     else: self.skipTest("tested on CDNA4 and RDNA4")
-    def setprio_kernel(A, high_priority=0):
+    def setprio_kernel(A, priority=0):
       insts = [
-        isa.s_getreg_b32(s[0], hw_id),  # bit 0 of the hardware wave slot
+        isa.s_getreg_b32(s[0], hw_id),
         isa.s_mov_b32(s[1], 0),
         isa.s_setprio(0),
         isa.s_cmp_eq_u32(s[0], 0),
         isa.s_cbranch_scc1(1),
-        isa.s_setprio(high_priority),
+        isa.s_setprio(priority),
         *barrier,
       ]
       # eight waves contend for scalar issue slots
@@ -142,8 +142,8 @@ class TestSQTTProfiler(unittest.TestCase):
       return custom_asm(A, insts, wave_size*8, (96 if self.arch == "gfx950" else 64)*1024)
 
     with Context(SQTT_LIMIT_SE=1), save_sqtt():
-      Tensor.empty(1).custom_kernel(fxn=functools.partial(setprio_kernel, high_priority=3))[0].realize()
-      Tensor.empty(1).custom_kernel(fxn=functools.partial(setprio_kernel, high_priority=0))[0].realize()
+      Tensor.empty(1).custom_kernel(fxn=functools.partial(setprio_kernel, priority=3))[0].realize()
+      Tensor.empty(1).custom_kernel(fxn=functools.partial(setprio_kernel, priority=0))[0].realize()
 
   def test_multiple_runs(self):
     t = Tensor.empty(1) + 1

--- a/test/amd/test_sqtt_profiler.py
+++ b/test/amd/test_sqtt_profiler.py
@@ -116,6 +116,27 @@ class TestSQTTProfiler(unittest.TestCase):
     with save_sqtt() as data:
       t.custom_kernel(fxn=custom_asm_cdna if self.arch == "gfx950" else custom_asm_rdna)[0].realize()
 
+  def test_set_prio(self):
+    def setprio_kernel(A, high_priority=0):
+      insts = [
+        cdna.s_getreg_b32(s[0], cdna.HWREG.HW_REG_HW_ID.value | (3 << 11)),
+        cdna.s_and_b32(s[0], s[0], 1),
+        cdna.s_mov_b32(s[1], 0),
+        cdna.s_setprio(0),
+        cdna.s_cmp_eq_u32(s[0], 0),
+        cdna.s_cbranch_scc1(1),
+        cdna.s_setprio(high_priority),
+        cdna.s_barrier(),
+      ]
+      # contend for the CU's scalar issue resources
+      insts += [cdna.s_add_u32(s[1], s[1], 1) for _ in range(64)]
+      insts += [cdna.s_setprio(0), cdna.s_barrier(), cdna.s_endpgm()]
+      return custom_asm(A, insts, CDNA_WAVE_SIZE*8, 96*1024)
+
+    with save_sqtt() as data:
+      Tensor.empty(1).custom_kernel(fxn=functools.partial(setprio_kernel, high_priority=3))[0].realize()
+      Tensor.empty(1).custom_kernel(fxn=functools.partial(setprio_kernel, high_priority=0))[0].realize()
+
   def test_multiple_runs(self):
     t = Tensor.empty(1) + 1
     with save_sqtt() as data:

--- a/test/amd/test_sqtt_profiler.py
+++ b/test/amd/test_sqtt_profiler.py
@@ -1,4 +1,4 @@
-import unittest, contextlib
+import unittest, contextlib, functools
 from tinygrad import Device, Tensor, Context, TinyJit, dtypes
 from tinygrad.dtype import AddrSpace
 from test.helpers import is_hcq2_device
@@ -113,27 +113,35 @@ class TestSQTTProfiler(unittest.TestCase):
 
   def test_asm(self):
     t = Tensor.empty(1)
-    with save_sqtt() as data:
+    with save_sqtt():
       t.custom_kernel(fxn=custom_asm_cdna if self.arch == "gfx950" else custom_asm_rdna)[0].realize()
 
-  def test_set_prio(self):
+  def test_setprio(self):
+    if self.arch == "gfx950":
+      from tinygrad.runtime.autogen.amd.cdna import ins as isa
+      hw_id, wave_size, add = isa.HWREG.HW_REG_HW_ID.value, 64, isa.s_add_u32
+      barrier = [isa.s_barrier()]
+    elif self.arch.startswith("gfx12"):
+      from tinygrad.runtime.autogen.amd.rdna4 import ins as isa
+      hw_id, wave_size, add = isa.HWREG.HW_REG_WAVE_HW_ID1.value, 32, isa.s_add_co_u32
+      barrier = [isa.s_barrier_signal(ssrc0=-1), isa.s_barrier_wait(simm16=-1)]
+    else: self.skipTest("tested on CDNA4 and RDNA4")
     def setprio_kernel(A, high_priority=0):
       insts = [
-        cdna.s_getreg_b32(s[0], cdna.HWREG.HW_REG_HW_ID.value | (3 << 11)),
-        cdna.s_and_b32(s[0], s[0], 1),
-        cdna.s_mov_b32(s[1], 0),
-        cdna.s_setprio(0),
-        cdna.s_cmp_eq_u32(s[0], 0),
-        cdna.s_cbranch_scc1(1),
-        cdna.s_setprio(high_priority),
-        cdna.s_barrier(),
+        isa.s_getreg_b32(s[0], hw_id),  # bit 0 of the hardware wave slot
+        isa.s_mov_b32(s[1], 0),
+        isa.s_setprio(0),
+        isa.s_cmp_eq_u32(s[0], 0),
+        isa.s_cbranch_scc1(1),
+        isa.s_setprio(high_priority),
+        *barrier,
       ]
-      # contend for the CU's scalar issue resources
-      insts += [cdna.s_add_u32(s[1], s[1], 1) for _ in range(64)]
-      insts += [cdna.s_setprio(0), cdna.s_barrier(), cdna.s_endpgm()]
-      return custom_asm(A, insts, CDNA_WAVE_SIZE*8, 96*1024)
+      # eight waves contend for scalar issue slots
+      insts += [add(s[1], s[1], 1) for _ in range(64)]
+      insts += [isa.s_setprio(0), *barrier, isa.s_endpgm()]
+      return custom_asm(A, insts, wave_size*8, (96 if self.arch == "gfx950" else 64)*1024)
 
-    with save_sqtt() as data:
+    with Context(SQTT_LIMIT_SE=1), save_sqtt():
       Tensor.empty(1).custom_kernel(fxn=functools.partial(setprio_kernel, high_priority=3))[0].realize()
       Tensor.empty(1).custom_kernel(fxn=functools.partial(setprio_kernel, high_priority=0))[0].realize()
 

--- a/tinygrad/renderer/amd/sqtt.py
+++ b/tinygrad/renderer/amd/sqtt.py
@@ -653,7 +653,7 @@ def map_insts(data:bytes, lib:bytes, target:str) -> Iterator[tuple[PacketType, I
     pending = cdna_imm_queue[key]
     while pending and (p:=pending[0]) is not None:
       pending.pop(0)
-      if (inst:=pc_map[pc:=wave_pc[key]]).op_name not in {'S_NOP', 'S_WAITCNT'}: continue
+      if (inst:=pc_map[pc:=wave_pc[key]]).op_name not in {'S_NOP', 'S_WAITCNT', 'S_SETPRIO'}: continue
       wave_pc[key] += inst.size()
       yield (p, InstructionInfo(pc, key[1], inst))
   # RDNA selects one SIMD for instruction tracing, CDNA traces multiple SIMDs


### PR DESCRIPTION
some of the assembly FA kernels use setprio, in CDNA SQTT there's no CDNA_ISSUE packet for this instruction. RDNA4 issues IMMEDIATE.

setprio changes a wave’s scheduling priority

CDNA4 default vs prio 3 (MI350P)
<img width="3840" height="1234" alt="image" src="https://github.com/user-attachments/assets/b0559bb6-86c2-4ae6-a548-ad296939b7a2" />
<img width="3840" height="1234" alt="image" src="https://github.com/user-attachments/assets/c930f9c4-6c29-4e44-96ca-0ef36fd3fb85" />

RDNA4 default vs prio 3

<img width="3840" height="1234" alt="image" src="https://github.com/user-attachments/assets/e205e5a2-793b-4727-b60d-7455217cd141" />
<img width="3840" height="1234" alt="image" src="https://github.com/user-attachments/assets/f1741500-a2cc-4a07-9b0a-2ba6eba9d0bb" />
