### PR TITLE
test: add Qualcomm A630 MockGPU emulator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,6 +168,26 @@ jobs:
     - name: Run TYPED=1
       run: CHECK_OOB=0 DEV=CPU TYPED=1 python test/test_tiny.py
 
+  qcommock:
+    name: QCOM A630 MockGPU
+    runs-on: ${{ github.repository == 'tinygrad/tinygrad' && github.event_name == 'pull_request' && github.event.pull_request.author_association == 'COLLABORATOR' && 'namespace-profile-tinygrad' || 'ubuntu-24.04' }}
+    timeout-minutes: 20
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v6
+    - name: Setup Environment
+      uses: ./.github/actions/setup-tinygrad
+      with:
+        key: qcom-mock
+        python-version: '3.12'
+        deps: mesa
+        pydeps: pytest pytest-xdist
+    - name: Run A630 MockGPU tests
+      env:
+        DEV: MOCK+QCOM:IR3
+        DERANDOMIZE_CI: 1
+      run: python3 -m pytest -n=auto test/mockgpu/qcom/ --durations=20
+
   nulltest:
     name: Null Tests
     runs-on: ${{ github.repository == 'tinygrad/tinygrad' && github.event_name == 'pull_request' && github.event.pull_request.author_association == 'COLLABORATOR' && 'namespace-profile-tinygrad' || 'ubuntu-24.04' }}

--- a/test/mockgpu/mockgpu.py
+++ b/test/mockgpu/mockgpu.py
@@ -5,10 +5,11 @@ from tinygrad.runtime.autogen import libc
 from test.mockgpu.nv.nvdriver import NVDriver
 from test.mockgpu.amd.amddriver import AMDDriver
 from test.mockgpu.am.amdriver import AMDriver, AMUSBDriver
+from test.mockgpu.qcom.qcomdriver import QCOMDriver
 start = time.perf_counter()
 
 drivers = [cls() for t in DEV.value if (cls:={"MOCKPCI+AMD": AMDriver, "MOCKKFD+AMD": AMDDriver, "MOCK+AMD": AMDDriver, "MOCKUSB+AMD": AMUSBDriver,
-                                              "MOCK+NV": NVDriver}.get(f"{t.interface}+{t.device}"))]
+                                               "MOCK+NV": NVDriver, "MOCK+QCOM": QCOMDriver}.get(f"{t.interface}+{t.device}"))]
 tracked_fds: dict[int, typing.Any] = {}
 
 original_memoryview = builtins.memoryview

--- a/test/mockgpu/qcom/qcomdriver.py
+++ b/test/mockgpu/qcom/qcomdriver.py
@@ -89,51 +89,51 @@ class QCOMDriver(VirtDriver):
   def ioctl(self, request:int, argp:int):
     nr = request & 0xff
     if nr == _ioctl_nr(kgsl.IOCTL_KGSL_DRAWCTXT_CREATE):
-      st = kgsl.struct_kgsl_drawctxt_create.from_address(argp)
-      st.drawctxt_id, self.next_ctx = self.next_ctx, self.next_ctx + 1
+      st_ctx = kgsl.struct_kgsl_drawctxt_create.from_address(argp)
+      st_ctx.drawctxt_id, self.next_ctx = self.next_ctx, self.next_ctx + 1
     elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_DRAWCTXT_DESTROY): pass
     elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_SETPROPERTY): pass
     elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_DEVICE_GETPROPERTY):
-      st = kgsl.struct_kgsl_device_getproperty.from_address(argp)
-      if st.type != kgsl.KGSL_PROP_DEVICE_INFO: raise NotImplementedError(f"unsupported KGSL property {st.type}")
-      info = kgsl.struct_kgsl_devinfo.from_address(st.value)
+      st_prop = kgsl.struct_kgsl_device_getproperty.from_address(argp)
+      if st_prop.type != kgsl.KGSL_PROP_DEVICE_INFO: raise NotImplementedError(f"unsupported KGSL property {st_prop.type}")
+      info = kgsl.struct_kgsl_devinfo.from_address(int(st_prop.value))
       info.device_id, info.chip_id, info.mmu_enabled = 0, A630_CHIP_ID, 1
       info.gpu_id, info.gmem_sizebytes = 630, 1024 * 1024
     elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_GPUOBJ_ALLOC):
-      st = kgsl.struct_kgsl_gpuobj_alloc.from_address(argp)
-      st.id, self.next_obj = self.next_obj, self.next_obj + 1
-      st.mmapsize = max(st.mmapsize, st.size)
-      self.objects[st.id] = {"size": int(st.mmapsize), "flags": int(st.flags), "addr": 0}
+      st_alloc = kgsl.struct_kgsl_gpuobj_alloc.from_address(argp)
+      st_alloc.id, self.next_obj = self.next_obj, self.next_obj + 1
+      st_alloc.mmapsize = max(st_alloc.mmapsize, st_alloc.size)
+      self.objects[st_alloc.id] = {"size": int(st_alloc.mmapsize), "flags": int(st_alloc.flags), "addr": 0}
     elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_GPUOBJ_FREE):
-      obj = self.objects.pop(kgsl.struct_kgsl_gpuobj_free.from_address(argp).id, None)
-      if obj is not None and obj["addr"]: self.gpu.unmap_range(obj["addr"], obj["size"])
+      freed = self.objects.pop(kgsl.struct_kgsl_gpuobj_free.from_address(argp).id, None)
+      if freed is not None and freed["addr"]: self.gpu.unmap_range(freed["addr"], freed["size"])
     elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_MAP_USER_MEM):
-      st = kgsl.struct_kgsl_map_user_mem.from_address(argp)
-      st.gpuaddr = st.hostptr
-      self.gpu.map_range(int(st.hostptr), int(st.len))
-      self.user_maps.setdefault(int(st.gpuaddr), []).append(int(st.len))
+      st_map = kgsl.struct_kgsl_map_user_mem.from_address(argp)
+      st_map.gpuaddr = st_map.hostptr
+      self.gpu.map_range(int(st_map.hostptr), int(st_map.len))
+      self.user_maps.setdefault(int(st_map.gpuaddr), []).append(int(st_map.len))
     elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_SHAREDMEM_FREE):
-      st = kgsl.struct_kgsl_sharedmem_free.from_address(argp)
-      if sizes:=self.user_maps.get(addr:=int(st.gpuaddr)):
+      st_free = kgsl.struct_kgsl_sharedmem_free.from_address(argp)
+      if sizes:=self.user_maps.get(addr:=int(st_free.gpuaddr)):
         self.gpu.unmap_range(addr, sizes.pop())
         if not sizes: self.user_maps.pop(addr)
     elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_GPU_COMMAND):
-      st = kgsl.struct_kgsl_gpu_command.from_address(argp)
+      st_cmd = kgsl.struct_kgsl_gpu_command.from_address(argp)
       if os.getenv("QCOM_TRACE"):
-        print(f"KGSL_GPU_COMMAND cmdlist={int(st.cmdlist):#x} cmdsize={st.cmdsize} numcmds={st.numcmds} "
-              f"context={st.context_id} objlist={int(st.objlist):#x} numobjs={st.numobjs}", flush=True)
+        print(f"KGSL_GPU_COMMAND cmdlist={int(st_cmd.cmdlist):#x} cmdsize={st_cmd.cmdsize} numcmds={st_cmd.numcmds} "
+              f"context={st_cmd.context_id} objlist={int(st_cmd.objlist):#x} numobjs={st_cmd.numobjs}", flush=True)
       if os.getenv("QCOM_MOCK_NOEXEC"): return 0
-      for i in range(st.numcmds):
-        obj = kgsl.struct_kgsl_command_object.from_address(st.cmdlist + i * st.cmdsize)
+      for i in range(st_cmd.numcmds):
+        cmd = kgsl.struct_kgsl_command_object.from_address(st_cmd.cmdlist + i * st_cmd.cmdsize)
         if os.getenv("QCOM_TRACE"):
-          print(f"  command[{i}] gpuaddr={int(obj.gpuaddr):#x} offset={int(obj.offset):#x} size={int(obj.size):#x} flags={obj.flags:#x}", flush=True)
-        self.gpu.submit_ib(int(obj.gpuaddr + obj.offset), int(obj.size))
+          print(f"  command[{i}] gpuaddr={int(cmd.gpuaddr):#x} offset={int(cmd.offset):#x} size={int(cmd.size):#x} flags={cmd.flags:#x}", flush=True)
+        self.gpu.submit_ib(int(cmd.gpuaddr + cmd.offset), int(cmd.size))
       self.gpu.execute()
       self.timestamp += 1
-      st.timestamp = self.timestamp
+      st_cmd.timestamp = self.timestamp
     elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_CMDSTREAM_READTIMESTAMP_CTXTID):
-      st = kgsl.struct_kgsl_cmdstream_readtimestamp_ctxtid.from_address(argp)
-      st.timestamp = self.timestamp
+      st_ts = kgsl.struct_kgsl_cmdstream_readtimestamp_ctxtid.from_address(argp)
+      st_ts.timestamp = self.timestamp
     elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_DEVICE_WAITTIMESTAMP_CTXTID): pass
     else: raise NotImplementedError(f"unsupported KGSL ioctl {nr:#x}")
     return 0

--- a/test/mockgpu/qcom/qcomdriver.py
+++ b/test/mockgpu/qcom/qcomdriver.py
@@ -60,9 +60,9 @@ class KGSLFileDesc(VirtFileDesc):
 class QCOMDriver(VirtDriver):
   def __init__(self):
     super().__init__()
-    # MockQCOM's generated HCQ submit calls libc.ioctl through the bridge above.
-    # Keep that path on the CPU runtime by default rather than requiring generic
-    # Python CALL/FFI extensions.  An explicit HCQ_RUNTIME_DEV still wins.
+    # The generated QCOM HCQ submit calls libc.ioctl directly, which the Python
+    # HCQ runtime cannot service (it hangs on the QCOM synchronization op), so
+    # MockQCOM must run on the CPU HCQ runtime.  An explicit env var still wins.
     if "HCQ_RUNTIME_DEV" not in os.environ: hcq2.HCQ_RUNTIME_DEV.value = "CPU"
     self.tracked_files = [
       VirtFile('/dev/kgsl-3d0', functools.partial(KGSLFileDesc, driver=self)),
@@ -77,8 +77,8 @@ class QCOMDriver(VirtDriver):
     self.gpu = QCOMGPU(0)
     self.last_callback_error:BaseException|None = None
 
-    _qcom_drivers.append(self)
-    hcq2.cfunc_buf = _cfunc_buf
+    if self not in _qcom_drivers: _qcom_drivers.append(self)
+    if hcq2.cfunc_buf is not _cfunc_buf: hcq2.cfunc_buf = _cfunc_buf
 
   def _alloc_fd(self):
     fd, self.next_fd = self.next_fd, self.next_fd + 1

--- a/test/mockgpu/qcom/qcomdriver.py
+++ b/test/mockgpu/qcom/qcomdriver.py
@@ -1,0 +1,139 @@
+import ctypes, functools, mmap, os, traceback
+from tinygrad.runtime.autogen import kgsl, libc
+from tinygrad.runtime.support import hcq2
+from test.mockgpu.driver import VirtDriver, VirtFile, VirtFileDesc, TextFileDesc, DirFileDesc
+from test.mockgpu.qcom.qcomgpu import QCOMGPU
+
+A630_CHIP_ID = 0x06030001
+
+def _ioctl_nr(ioctl:functools.partial) -> int: return ioctl.args[2]
+
+# QCOM's HCQ submit path calls libc.ioctl from generated host code instead of
+# FileIOInterface.ioctl. Keep one process-wide bridge so multiple virtual QCOM
+# devices don't accidentally chain callbacks through each other.
+_real_ioctl = libc.dll.ioctl
+_qcom_drivers:list['QCOMDriver'] = []
+def _dispatch_ioctl(fd, request, argp):
+  for d in _qcom_drivers:
+    if fd not in d.fds: continue
+    if os.getenv("QCOM_TRACE"): print(f"mock kgsl ioctl fd={fd} req={request:#x} argp={int(argp or 0):#x}", flush=True)
+    try: return int(d.ioctl(request, int(argp or 0)) or 0)
+    except BaseException as e: # never unwind a Python exception through ctypes callback machinery
+      d.last_callback_error = e
+      if os.getenv("QCOM_TRACE"):
+        print(f"mock kgsl ioctl failed: {type(e).__name__}: {e}", flush=True)
+        traceback.print_exc()
+      return -1
+  return int(_real_ioctl(fd, request, argp))
+_mock_ioctl = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_uint32, ctypes.c_void_p)(_dispatch_ioctl)
+
+# cfunc_buf can already be cached when a generated CPU HCQ submit is built.
+# Rewrite the cached function pointer too, instead of relying only on the DLL
+# attribute replacement. This keeps the normal CPU HCQ path viable for MockQCOM.
+_orig_cfunc_buf = hcq2.cfunc_buf
+@functools.cache
+def _cfunc_buf(lib:str, name:str):
+  b = _orig_cfunc_buf(lib, name)
+  if lib == "libc" and name == "ioctl": b.host.view(fmt='Q')[0] = ctypes.cast(_mock_ioctl, ctypes.c_void_p).value
+  return b
+
+class KGSLFileDesc(VirtFileDesc):
+  def __init__(self, fd:int, driver:'QCOMDriver'):
+    super().__init__(fd)
+    self.driver = driver
+    driver.fds.add(fd)
+
+  def ioctl(self, fd, request, argp): return self.driver.ioctl(request, argp)
+  def close(self, fd):
+    self.driver.fds.discard(fd)
+    return 0
+
+  def mmap(self, start, sz, prot, flags, fd, offset):
+    obj_id = offset // 0x1000
+    if obj_id not in self.driver.objects: raise RuntimeError(f"mmap for unknown KGSL object {obj_id}")
+    addr = libc.mmap(start, sz, prot, (flags & ~mmap.MAP_SHARED) | mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS, -1, 0)
+    if not addr or addr == ctypes.c_void_p(-1).value: raise OSError(ctypes.get_errno(), "mock KGSL mmap failed")
+    self.driver.objects[obj_id]["addr"] = int(addr)
+    self.driver.gpu.map_range(int(addr), sz)
+    return int(addr)
+
+class QCOMDriver(VirtDriver):
+  def __init__(self):
+    super().__init__()
+    # MockQCOM's generated HCQ submit calls libc.ioctl through the bridge above.
+    # Keep that path on the CPU runtime by default rather than requiring generic
+    # Python CALL/FFI extensions.  An explicit HCQ_RUNTIME_DEV still wins.
+    if "HCQ_RUNTIME_DEV" not in os.environ: hcq2.HCQ_RUNTIME_DEV.value = "CPU"
+    self.tracked_files = [
+      VirtFile('/dev/kgsl-3d0', functools.partial(KGSLFileDesc, driver=self)),
+      VirtFile('/sys/class/kgsl', functools.partial(DirFileDesc, child_names=['kgsl-3d0'])),
+      VirtFile('/sys/class/kgsl/kgsl-3d0', functools.partial(DirFileDesc, child_names=['idle_timer'])),
+      VirtFile('/sys/class/kgsl/kgsl-3d0/idle_timer', functools.partial(TextFileDesc, text='10\n')),
+    ]
+    self.next_fd, self.next_ctx, self.next_obj, self.timestamp = 1 << 30, 1, 1, 0
+    self.objects:dict[int, dict[str, int]] = {}
+    self.user_maps:dict[int, list[int]] = {}
+    self.fds:set[int] = set()
+    self.gpu = QCOMGPU(0)
+    self.last_callback_error:BaseException|None = None
+
+    _qcom_drivers.append(self)
+    hcq2.cfunc_buf = _cfunc_buf
+
+  def _alloc_fd(self):
+    fd, self.next_fd = self.next_fd, self.next_fd + 1
+    return fd
+
+  def open(self, name, flags, mode, virtfile): return virtfile.fdcls(self._alloc_fd())
+
+  def ioctl(self, request:int, argp:int):
+    nr = request & 0xff
+    if nr == _ioctl_nr(kgsl.IOCTL_KGSL_DRAWCTXT_CREATE):
+      st = kgsl.struct_kgsl_drawctxt_create.from_address(argp)
+      st.drawctxt_id, self.next_ctx = self.next_ctx, self.next_ctx + 1
+    elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_DRAWCTXT_DESTROY): pass
+    elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_SETPROPERTY): pass
+    elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_DEVICE_GETPROPERTY):
+      st = kgsl.struct_kgsl_device_getproperty.from_address(argp)
+      if st.type != kgsl.KGSL_PROP_DEVICE_INFO: raise NotImplementedError(f"unsupported KGSL property {st.type}")
+      info = kgsl.struct_kgsl_devinfo.from_address(st.value)
+      info.device_id, info.chip_id, info.mmu_enabled = 0, A630_CHIP_ID, 1
+      info.gpu_id, info.gmem_sizebytes = 630, 1024 * 1024
+    elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_GPUOBJ_ALLOC):
+      st = kgsl.struct_kgsl_gpuobj_alloc.from_address(argp)
+      st.id, self.next_obj = self.next_obj, self.next_obj + 1
+      st.mmapsize = max(st.mmapsize, st.size)
+      self.objects[st.id] = {"size": int(st.mmapsize), "flags": int(st.flags), "addr": 0}
+    elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_GPUOBJ_FREE):
+      obj = self.objects.pop(kgsl.struct_kgsl_gpuobj_free.from_address(argp).id, None)
+      if obj is not None and obj["addr"]: self.gpu.unmap_range(obj["addr"], obj["size"])
+    elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_MAP_USER_MEM):
+      st = kgsl.struct_kgsl_map_user_mem.from_address(argp)
+      st.gpuaddr = st.hostptr
+      self.gpu.map_range(int(st.hostptr), int(st.len))
+      self.user_maps.setdefault(int(st.gpuaddr), []).append(int(st.len))
+    elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_SHAREDMEM_FREE):
+      st = kgsl.struct_kgsl_sharedmem_free.from_address(argp)
+      if sizes:=self.user_maps.get(addr:=int(st.gpuaddr)):
+        self.gpu.unmap_range(addr, sizes.pop())
+        if not sizes: self.user_maps.pop(addr)
+    elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_GPU_COMMAND):
+      st = kgsl.struct_kgsl_gpu_command.from_address(argp)
+      if os.getenv("QCOM_TRACE"):
+        print(f"KGSL_GPU_COMMAND cmdlist={int(st.cmdlist):#x} cmdsize={st.cmdsize} numcmds={st.numcmds} "
+              f"context={st.context_id} objlist={int(st.objlist):#x} numobjs={st.numobjs}", flush=True)
+      if os.getenv("QCOM_MOCK_NOEXEC"): return 0
+      for i in range(st.numcmds):
+        obj = kgsl.struct_kgsl_command_object.from_address(st.cmdlist + i * st.cmdsize)
+        if os.getenv("QCOM_TRACE"):
+          print(f"  command[{i}] gpuaddr={int(obj.gpuaddr):#x} offset={int(obj.offset):#x} size={int(obj.size):#x} flags={obj.flags:#x}", flush=True)
+        self.gpu.submit_ib(int(obj.gpuaddr + obj.offset), int(obj.size))
+      self.gpu.execute()
+      self.timestamp += 1
+      st.timestamp = self.timestamp
+    elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_CMDSTREAM_READTIMESTAMP_CTXTID):
+      st = kgsl.struct_kgsl_cmdstream_readtimestamp_ctxtid.from_address(argp)
+      st.timestamp = self.timestamp
+    elif nr == _ioctl_nr(kgsl.IOCTL_KGSL_DEVICE_WAITTIMESTAMP_CTXTID): pass
+    else: raise NotImplementedError(f"unsupported KGSL ioctl {nr:#x}")
+    return 0

--- a/test/mockgpu/qcom/qcomgpu.py
+++ b/test/mockgpu/qcom/qcomgpu.py
@@ -6,6 +6,14 @@ from test.mockgpu.gpu import VirtGPU
 
 _FLOAT_IMMS = (0.0, .5, 1.0, 2.0, math.e, math.pi, 1/math.pi, 1/math.log2(math.e), math.log2(math.e), 1/math.log2(10), math.log2(10), 4.0)
 
+def _float_imm(idx:int) -> float:
+  # The special-immediate source field is 10 bits wide, but only the low
+  # indices are defined.  An index past the table is an unrecognized encoding,
+  # not a value, so report it like the other unsupported encodings instead of
+  # raising a bare IndexError.
+  if idx >= len(_FLOAT_IMMS): raise NotImplementedError(f"A630 float immediate index {idx:#x}")
+  return _FLOAT_IMMS[idx]
+
 def _u32(x:int) -> int: return x & 0xffffffff
 def _s32(x:int) -> int: return (x & 0xffffffff) - (1 << 32) if x & (1 << 31) else x & 0xffffffff
 def _sext(x:int, bits:int) -> int: return x - (1 << bits) if x & (1 << (bits - 1)) else x
@@ -214,7 +222,7 @@ class QCOMGPU(VirtGPU):
       # CONST sources as full 32-bit entries.
       return val
     if kind == 4: return _sext(enc & 0x7ff, 11)
-    if kind == 5: return _f32bits(_FLOAT_IMMS[enc & 0x3ff])
+    if kind == 5: return _f32bits(_float_imm(enc & 0x3ff))
     raise NotImplementedError(f"A630 multisrc encoding {enc:#x}")
 
   @staticmethod
@@ -223,7 +231,7 @@ class QCOMGPU(VirtGPU):
     # Special float immediates denote a value, not a raw 32-bit register word.
     # In half instructions Mesa prints these as h(...); interpreting the low
     # 16 bits of their fp32 representation as fp16 corrupts the value.
-    if kind == 5: return _FLOAT_IMMS[enc & 0x3ff]
+    if kind == 5: return _float_imm(enc & 0x3ff)
     val = QCOMGPU._src(enc, gpr, hreg, consts, full)
     # Freedreno keeps half constant-register values as 32-bit floats for
     # floating-point opcodes.  Half GPR/immediate sources remain fp16.
@@ -247,6 +255,15 @@ class QCOMGPU(VirtGPU):
     # As with CAT2 floating half operands, constant-file values are 32-bit
     # floats while half GPR values contain fp16 bits.
     return _f32(raw) if enc & 0x1000 else _f16(raw)
+
+  @staticmethod
+  def _cat1_src(ins:int, mode:int, sf:list[int], consts:list[int], si:int) -> int:
+    # CAT1 source selection: mode 2 = inline 32-bit immediate, mode 1 = 11-bit
+    # constant-file index (out-of-range reads default to 0, matching IR3's
+    # constant file behavior), otherwise a register from the selected file.
+    if mode == 2: return ins & 0xffffffff
+    if mode == 1: return consts[ins & 0x7ff] if (ins & 0x7ff) < len(consts) else 0
+    return sf[si]
 
   def _run_thread(self, local_id:tuple[int,int,int], group_id:tuple[int,int,int], shared:bytearray, shader:bytes, consts:list[int]):
     gpr, hreg, pc = [0]*256, [0]*256, 0
@@ -297,9 +314,7 @@ class QCOMGPU(VirtGPU):
           continue
         for rpt in range(((ins >> 40) & 3) + 1):
           si = (ins & 0xff) + (rpt if (ins >> 43) & 1 else 0)
-          if mode == 2: src = ins & 0xffffffff
-          elif mode == 1: src = consts[ins & 0x7ff] if (ins & 0x7ff) < len(consts) else 0
-          else: src = sf[si]
+          src = self._cat1_src(ins, mode, sf, consts, si)
           if src_type != dst_type:
             val = _cov_src(src, src_type, dst_type)
             cvt = (_f16bits, _f32bits, lambda x:int(x)&0xffff, lambda x:_u32(int(x)), lambda x:int(x)&0xffff,

--- a/test/mockgpu/qcom/qcomgpu.py
+++ b/test/mockgpu/qcom/qcomgpu.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+import ctypes, math, os, struct, time
+from tinygrad.helpers import to_mv
+from tinygrad.runtime.autogen import mesa
+from test.mockgpu.gpu import VirtGPU
+
+_FLOAT_IMMS = (0.0, .5, 1.0, 2.0, math.e, math.pi, 1/math.pi, 1/math.log2(math.e), math.log2(math.e), 1/math.log2(10), math.log2(10), 4.0)
+
+def _u32(x:int) -> int: return x & 0xffffffff
+def _s32(x:int) -> int: return (x & 0xffffffff) - (1 << 32) if x & (1 << 31) else x & 0xffffffff
+def _sext(x:int, bits:int) -> int: return x - (1 << bits) if x & (1 << (bits - 1)) else x
+def _cat2_signed(x:int, full:bool) -> int: return _s32(x) if full else _sext(x & 0xffff, 16)
+def _clz_b(x:int, full:bool) -> int:
+  bits = 32 if full else 16
+  x &= (1 << bits) - 1
+  # IR3 CLZ_B uses all-ones as the zero-input sentinel.  Mesa's 64-bit
+  # division lowering relies on this (for example, 31 - clz(0) wraps to 32).
+  return 0xffffffff if x == 0 else bits - x.bit_length()
+def _cat0_branch_taken(ins:int, gpr:list[int]) -> bool:
+  # A6xx CAT0 branch predicates live in p0.x..p0.w (r248..r251).  BR uses
+  # COMP1/INV1; BRAO and BRAA combine a second predicate with OR/AND.
+  kind = (ins >> 37) & 7
+  inv1, comp1 = bool((ins >> 52) & 1), (ins >> 53) & 3
+  p1 = bool(gpr[0xf8 + comp1]) ^ inv1
+  if kind == 0: return p1
+  inv2, comp2 = bool((ins >> 45) & 1), (ins >> 46) & 3
+  p2 = bool(gpr[0xf8 + comp2]) ^ inv2
+  if kind == 1: return p1 or p2
+  if kind == 2: return p1 and p2
+  raise NotImplementedError(f"A630 CAT0 branch kind {kind}")
+def _cat1_swz(ins:int, sf:list[int], df:list[int]) -> None:
+  s0, s1, d0, d1 = ins & 0xff, (ins >> 8) & 0xff, (ins >> 32) & 0xff, (ins >> 16) & 0xff
+  v0, v1 = sf[s0], sf[s1]  # SWZ is parallel: source/destination ranges may overlap.
+  df[d0], df[d1] = _u32(v0), _u32(v1)
+def _cat6_private_offset(ins:int, store:bool) -> int:
+  raw = ((((ins >> 9)&0x1f)<<8) | ((ins >> 32)&0xff)) if store else ((ins >> 1)&0x1fff)
+  return _sext(raw, 13)
+def _mul_s24(a:int, b:int) -> int: return _u32(_sext(a & 0xffffff, 24) * _sext(b & 0xffffff, 24))
+def _mull_u(a:int, b:int) -> int: return (a & 0xffff) * (b & 0xffff)
+def _madsh_m16(a:int, b:int, c:int) -> int: return _u32((((a & 0xffff) * ((b >> 16) & 0xffff)) << 16) + c)
+def _absneg_s(x:int, flags:int, bits:int=32) -> int:
+  mask = (1 << bits) - 1
+  sx = _sext(x & mask, bits)
+  if flags & 2: sx = abs(sx)
+  if flags & 1: sx = -sx
+  return sx & mask
+def _cov_src(src:int, src_type:int, dst_type:int):
+  # A6xx CAT1 has no distinct signed-8 source type in this encoding.  Mesa
+  # emits TYPE_U8 for 8-bit values and the destination type determines whether
+  # the byte is sign-extended (signed/float destinations) or zero-extended.
+  if src_type == mesa.TYPE_U8 and dst_type in (mesa.TYPE_S16, mesa.TYPE_S32, mesa.TYPE_F16, mesa.TYPE_F32):
+    return _sext(src & 0xff, 8)
+  return (_f16(src), _f32(src), src & 0xffff, src, _sext(src & 0xffff,16), _s32(src), src & 0xff, src & 0xff)[src_type]
+def _f32(x:int) -> float: return struct.unpack('<f', struct.pack('<I', x & 0xffffffff))[0]
+def _f32bits(x:float) -> int:
+  try: return struct.unpack('<I', struct.pack('<f', float(x)))[0]
+  except OverflowError: return 0x7f800000 if x >= 0 else 0xff800000
+def _f16(x:int) -> float: return struct.unpack('<e', struct.pack('<H', x & 0xffff))[0]
+def _f16bits(x:float) -> int:
+  try: return struct.unpack('<H', struct.pack('<e', float(x)))[0]
+  except OverflowError: return 0x7c00 if x >= 0 else 0xfc00
+def _rcp(x:float) -> float:
+  if math.isnan(x): return math.nan
+  if x == 0.0: return math.copysign(math.inf, x)
+  return 1.0/x
+def _rsqrt(x:float) -> float:
+  if math.isnan(x) or x < 0.0: return math.nan
+  if x == 0.0: return math.copysign(math.inf, x)
+  return 1.0/math.sqrt(x)
+def _log2(x:float) -> float:
+  if math.isnan(x): return math.nan
+  if x < 0.0: return math.nan
+  if x == 0.0: return -math.inf
+  return math.log2(x)
+def _exp2(x:float) -> float:
+  if math.isnan(x): return math.nan
+  if x == math.inf: return math.inf
+  if x == -math.inf: return 0.0
+  try: return 2.0**x
+  except OverflowError: return math.inf
+def _sin(x:float) -> float:
+  if not math.isfinite(x): return math.nan
+  return math.sin(x)
+def _cos(x:float) -> float:
+  if not math.isfinite(x): return math.nan
+  return math.cos(x)
+def _sqrt(x:float) -> float:
+  if math.isnan(x) or x < 0.0: return math.nan
+  return math.sqrt(x)
+def _trunc_f(x:float) -> float:
+  # IR3 trunc.f truncates toward zero while preserving IEEE non-finite values.
+  return x if not math.isfinite(x) else float(math.trunc(x))
+def _floor_f(x:float) -> float:
+  # Preserve IEEE non-finite values and signed zero; finite nonzero values use
+  # mathematical floor (unlike trunc.f, negative fractions round downward).
+  return x if not math.isfinite(x) or x == 0.0 else float(math.floor(x))
+def _sign_f(x:float) -> float:
+  # Matches Mesa IR3 lowering: negative -> -1, zero -> 0, otherwise -> +1.
+  # NaN therefore maps to +1 because both (x < 0) and (x == 0) are false.
+  return -1.0 if x < 0.0 else 0.0 if x == 0.0 else 1.0
+def _sat_f(x:float) -> float:
+  x = 0.0 if x < 0.0 else x
+  return x if x < 1.0 else 1.0
+def _mad_f16(a:float, b:float, c:float, neg:int=0, sat:bool=False) -> float:
+  if neg & 1: a = -a
+  if neg & 2: b = -b
+  if neg & 4: c = -c
+  out = a * b + c
+  return _sat_f(out) if sat else out
+def _cat4_fn(op:int):
+  # A6xx gives rsq/log2/exp2 distinct half-precision opcodes (base+8).
+  # rcp/sin/cos/sqrt reuse their base opcode and select precision with FULL.
+  fn = {0x0:_rcp, 0x1:_rsqrt, 0x2:_log2, 0x3:_exp2, 0x4:_sin, 0x5:_cos, 0x6:_sqrt,
+        0x9:_rsqrt, 0xa:_log2, 0xb:_exp2}
+  if op not in fn: raise NotImplementedError(f"A630 cat4 opcode {op:#x}")
+  return fn[op]
+def _fmod(x:float, enc:int) -> float:
+  mod = (enc >> 14) & 3
+  return -x if mod == 1 else abs(x) if mod == 2 else -abs(x) if mod == 3 else x
+
+class QCOMGPU(VirtGPU):
+  def __init__(self, gpuid):
+    super().__init__(gpuid)
+    self.regs:dict[int, int] = {}
+    self.ranges:list[tuple[int, int]] = []
+    self.ibs:list[tuple[int, int]] = []
+    self.const_addr, self.const_size = 0, 0
+    self.shader_addr, self.shader_size = 0, 0
+
+  def map_range(self, vaddr, size): self.ranges.append((int(vaddr), int(vaddr + size)))
+  def unmap_range(self, vaddr, size):
+    r = (int(vaddr), int(vaddr + size))
+    with __import__('contextlib').suppress(ValueError): self.ranges.remove(r)
+
+  def _check(self, addr:int, size:int):
+    if not any(st <= addr and addr + size <= en for st,en in self.ranges):
+      nearby = sorted(self.ranges, key=lambda r: min(abs(addr-r[0]), abs(addr-r[1])))[:4]
+      raise RuntimeError(f"unmapped A630 address {addr:#x}+{size:#x}, nearest={[(hex(st), hex(en)) for st,en in nearby]}")
+
+  def submit_ib(self, addr:int, size:int): self.ibs.append((addr, size))
+  def execute(self):
+    while self.ibs:
+      addr, size = self.ibs.pop(0)
+      self._exec_ib(addr, size)
+
+  def _exec_ib(self, addr:int, size:int):
+    self._check(addr, size)
+    words = list(to_mv(addr, size).cast('I'))
+    pos = 0
+    while pos < len(words):
+      hdr, pos = words[pos], pos + 1
+      typ = hdr >> 28
+      if typ == 4:
+        base, cnt = (hdr >> 8) & 0x3ffff, hdr & 0x7f
+        if os.getenv("QCOM_TRACE"): print(f"CP4 reg={base:#x} cnt={cnt}", flush=True)
+        for i in range(cnt): self.regs[base+i] = words[pos+i]
+        pos += cnt
+      elif typ == 7:
+        op, cnt = (hdr >> 16) & 0x7f, hdr & 0x3fff
+        p, pos = words[pos:pos+cnt], pos+cnt
+        if os.getenv("QCOM_TRACE"): print(f"CP7 op={op:#x} cnt={cnt} vals={[hex(x) for x in p]}", flush=True)
+        self._exec7(op, p)
+      else: raise RuntimeError(f"invalid A6xx PM4 packet type {typ} header={hdr:#x}")
+
+  def _exec7(self, op:int, p:list[int]):
+    if op in (mesa.CP_WAIT_FOR_IDLE, mesa.CP_WAIT_MEM_WRITES, mesa.CP_SET_MARKER): return
+    if op == mesa.CP_LOAD_STATE6_FRAG:
+      state_type, block = (p[0] >> 14) & 3, (p[0] >> 18) & 0xf
+      addr, units = p[1] | (p[2] << 32), p[0] >> 22
+      if os.getenv("QCOM_TRACE"): print(f"LOAD_STATE block={block} type={state_type} addr={addr:#x} units={units}", flush=True)
+      if block == mesa.SB6_CS_SHADER and state_type == mesa.ST_CONSTANTS:
+        self.const_addr, self.const_size = addr, units * 16
+      elif block == mesa.SB6_CS_SHADER and state_type == mesa.ST_SHADER:
+        self.shader_addr, self.shader_size = addr, units * 128
+      return
+    if op == mesa.CP_EVENT_WRITE:
+      if len(p) >= 4:
+        addr = p[1] | (p[2] << 32)
+        self._check(addr, 4)
+        to_mv(addr, 4).cast('I')[0] = p[3]
+      return
+    if op == mesa.CP_WAIT_REG_MEM:
+      fn, addr, ref, mask = p[0] & 7, p[1] | (p[2] << 32), p[3], p[4]
+      self._check(addr, 4)
+      cur = to_mv(addr, 4).cast('I')[0] & mask
+      if fn == mesa.WRITE_GE: ok = cur >= ref
+      elif fn == mesa.WRITE_EQ: ok = cur == ref
+      elif fn == mesa.WRITE_NE: ok = cur != ref
+      elif fn == mesa.WRITE_ALWAYS: ok = True
+      else: raise RuntimeError(f"unsupported CP_WAIT_REG_MEM function {fn}")
+      if not ok: raise RuntimeError(f"mock QCOM wait unsatisfied: {cur:#x} vs {ref:#x}")
+      return
+    if op == mesa.CP_REG_TO_MEM:
+      addr = p[1] | (p[2] << 32)
+      self._check(addr, 8)
+      to_mv(addr, 8).cast('Q')[0] = int(time.perf_counter() * 19.2e6)
+      return
+    if op == mesa.CP_EXEC_CS:
+      self._exec_cs((p[1], p[2], p[3]))
+      return
+    raise RuntimeError(f"unsupported A6xx type7 opcode {op:#x}")
+
+  @staticmethod
+  def _src(enc:int, gpr:list[int], hreg:list[int], consts:list[int], full:bool) -> int:
+    kind = (enc >> 11) & 7
+    if kind == 0: return (gpr if full else hreg)[enc & 0xff]
+    if kind in (2, 6):
+      idx = enc & 0x7ff
+      val = consts[idx] if idx < len(consts) else 0
+      # IR3 constant operands address the 32-bit constant file directly.  The
+      # decoder may print an h-prefixed constant in mixed half/full integer
+      # instructions, but that does not mean selecting a 16-bit half of the
+      # constant word here.  Mesa's structured decoder likewise materializes
+      # CONST sources as full 32-bit entries.
+      return val
+    if kind == 4: return _sext(enc & 0x7ff, 11)
+    if kind == 5: return _f32bits(_FLOAT_IMMS[enc & 0x3ff])
+    raise NotImplementedError(f"A630 multisrc encoding {enc:#x}")
+
+  @staticmethod
+  def _float_src(enc:int, gpr:list[int], hreg:list[int], consts:list[int], full:bool) -> float:
+    kind = (enc >> 11) & 7
+    # Special float immediates denote a value, not a raw 32-bit register word.
+    # In half instructions Mesa prints these as h(...); interpreting the low
+    # 16 bits of their fp32 representation as fp16 corrupts the value.
+    if kind == 5: return _FLOAT_IMMS[enc & 0x3ff]
+    val = QCOMGPU._src(enc, gpr, hreg, consts, full)
+    # Freedreno keeps half constant-register values as 32-bit floats for
+    # floating-point opcodes.  Half GPR/immediate sources remain fp16.
+    return _f32(val) if full or kind in (2, 6) else _f16(val)
+
+  @staticmethod
+  def _cat3_src(enc:int, regs:list[int], consts:list[int], immediate:bool=False) -> int:
+    if (enc >> 8) & 0x1f == 0: return regs[enc & 0xff]
+    if enc & 0x1000:
+      idx = enc & 0xfff
+      # A6xx CAT3 has two source encodings selected by instruction bit 13.
+      # Normal CAT3 treats this form as a constant-file index, while CAT3-alt
+      # (shrm/shlm/shrg/shlg/andg) treats it as an inline immediate.
+      if immediate: return idx
+      return consts[idx] if idx < len(consts) else 0
+    raise NotImplementedError(f"A630 cat3 source encoding {enc:#x}")
+
+  @staticmethod
+  def _cat3_f16_src(enc:int, hreg:list[int], consts:list[int]) -> float:
+    raw = QCOMGPU._cat3_src(enc, hreg, consts)
+    # As with CAT2 floating half operands, constant-file values are 32-bit
+    # floats while half GPR values contain fp16 bits.
+    return _f32(raw) if enc & 0x1000 else _f16(raw)
+
+  def _run_thread(self, local_id:tuple[int,int,int], group_id:tuple[int,int,int], shared:bytearray, shader:bytes, consts:list[int]):
+    gpr, hreg, pc = [0]*256, [0]*256, 0
+    # A6xx private memory is per work-item.  Keep it separate from workgroup
+    # shared memory; cumprod backward is the first broad backend workload that
+    # spills enough temporaries for Mesa to emit ldp/stp.
+    private = bytearray(32*1024)
+    # predt/predf snapshot p0.x when the region begins.  Since this emulator
+    # runs one work-item at a time, the A6xx execution mask reduces to a
+    # per-thread boolean until prede closes the region.
+    pred_mode, pred_value = 0, False
+    cfg = self.regs.get(mesa.REG_A6XX_SP_CS_CONST_CONFIG_0, 0)
+    wgid = (cfg >> mesa.A6XX_SP_CS_CONST_CONFIG_0_WGIDCONSTID__SHIFT) & 0xff
+    lid = (cfg >> mesa.A6XX_SP_CS_CONST_CONFIG_0_LOCALIDREGID__SHIFT) & 0xff
+    if wgid < 0xfc: gpr[wgid:wgid+3] = group_id
+    if lid < 0xfc: gpr[lid:lid+3] = local_id
+    trace_thread = bool(os.getenv("QCOM_TRACE")) and local_id[0] < 3 and local_id[1:] == (0,0) and group_id == (0,0,0)
+
+    while pc * 8 < len(shader):
+      ins = struct.unpack_from('<Q', shader, pc*8)[0]
+      cat, dst = (ins >> 61) & 7, (ins >> 32) & 0xff
+      if cat == 0:
+        op = (ins >> 55) & 0x3f
+        if op == 1 and _cat0_branch_taken(ins, gpr):
+          pc += _s32(ins & 0xffffffff)
+          continue
+        if op == 2:
+          pc += _s32(ins & 0xffffffff)
+          continue
+        if op == 6: break
+        if op == 0xd: pred_mode, pred_value = 1, bool(gpr[0xf8])  # predt
+        elif op == 0xe: pred_mode, pred_value = 2, bool(gpr[0xf8])  # predf
+        elif op == 0xf: pred_mode = 0  # prede
+      elif pred_mode and (pred_value if pred_mode == 1 else not pred_value) is False:
+        pc += 1
+        continue
+      elif cat == 1:
+        src_type, dst_type, mode = (ins >> 50) & 7, (ins >> 46) & 7, (ins >> 53) & 3
+        sf, df = (hreg if src_type in (0,2,4,6) else gpr), (hreg if dst_type in (0,2,4,6) else gpr)
+        # CAT1 SWZ is a two-source/two-destination parallel move.  Bit 58
+        # selects the SWZ encoding on A6xx; treating it as an ordinary MOV
+        # loses DST1 and is especially destructive when Mesa uses SWZ to swap
+        # the two 32-bit halves of a 64-bit pointer.
+        if (ins >> 58) & 1:
+          if src_type != dst_type: raise NotImplementedError(f"A630 cat1 swz type conversion {src_type}->{dst_type} pc={pc}")
+          _cat1_swz(ins, sf, df)
+          pc += 1
+          continue
+        for rpt in range(((ins >> 40) & 3) + 1):
+          si = (ins & 0xff) + (rpt if (ins >> 43) & 1 else 0)
+          src = (ins & 0xffffffff) if mode == 2 else (consts[ins & 0x7ff] if mode == 1 else sf[si])
+          if src_type != dst_type:
+            val = _cov_src(src, src_type, dst_type)
+            conv = (_f16bits, _f32bits, lambda x:int(x)&0xffff, lambda x:_u32(int(x)), lambda x:int(x)&0xffff,
+                    lambda x:_u32(int(x)), lambda x:int(x)&0xff, lambda x:int(x)&0xff)[dst_type]
+            src = conv(val)
+          df[dst+rpt] = _u32(src)
+      elif cat == 2:
+        full, conv, op = bool((ins >> 52) & 1), bool((ins >> 46) & 1), (ins >> 53) & 0x3f
+        for rpt in range(((ins >> 40) & 3) + 1):
+          ae, be = (ins & 0xffff) + (rpt if (ins >> 43)&1 else 0), ((ins >> 16)&0xffff) + (rpt if (ins >> 51)&1 else 0)
+          a, b = self._src(ae,gpr,hreg,consts,full), self._src(be,gpr,hreg,consts,full)
+          fa, fb = _fmod(self._float_src(ae,gpr,hreg,consts,full), ae), _fmod(self._float_src(be,gpr,hreg,consts,full), be)
+          outf = _f16bits if full == conv and dst <= 0xf7 else _f32bits
+          if op == 0x00: out = outf(fa + fb)
+          elif op == 0x01: out = outf(min(fa, fb))
+          elif op == 0x02: out = outf(max(fa, fb))
+          elif op == 0x03: out = outf(fa * fb)
+          elif op == 0x04: out = outf(_sign_f(fa))
+          elif op == 0x06: out = outf(fa)
+          elif op == 0x09: out = outf(_floor_f(fa))
+          elif op == 0x0d: out = outf(_trunc_f(fa))
+          elif op == 0x05:
+            cond = (ins >> 48) & 7
+            out = int((fa < fb, fa <= fb, fa > fb, fa >= fb, fa == fb, fa != fb)[cond])
+          elif op == 0x10: out = a + b
+          elif op in (0x12,0x13): out = a - b
+          elif op == 0x14:
+            cond = (ins >> 48) & 7
+            out = int((a < b, a <= b, a > b, a >= b, a == b, a != b)[cond])
+          elif op == 0x15:
+            cond, sa, sb = (ins >> 48) & 7, _cat2_signed(a, full), _cat2_signed(b, full)
+            out = int((sa < sb, sa <= sb, sa > sb, sa >= sb, sa == sb, sa != sb)[cond])
+          elif op == 0x16: out = min(a, b)
+          elif op == 0x17: out = _u32(min(_cat2_signed(a, full), _cat2_signed(b, full)))
+          elif op == 0x18: out = max(a, b)
+          elif op == 0x19: out = _u32(max(_cat2_signed(a, full), _cat2_signed(b, full)))
+          elif op == 0x1a: out = _absneg_s(a, (ae >> 14) & 3, 32 if full else 16)
+          elif op == 0x1c: out = a & b
+          elif op == 0x1d: out = a | b
+          elif op == 0x1e: out = ~a
+          elif op == 0x1f: out = a ^ b
+          elif op == 0x31: out = _mul_s24(a, b)
+          elif op == 0x32: out = _mull_u(a, b)
+          elif op == 0x35: out = _clz_b(a, full)
+          elif op == 0x36: out = a << (b & 31)
+          elif op == 0x37: out = a >> (b & 31)
+          elif op == 0x38: out = _cat2_signed(a, full) >> (b & 31)
+          else: raise NotImplementedError(f"A630 cat2 opcode {op:#x} pc={pc}")
+          (hreg if full == conv and dst <= 0xf7 else gpr)[dst+rpt] = _u32(out)
+      elif cat == 3:
+        op, alt = (ins >> 55) & 0xf, bool((ins >> 13) & 1)
+        for rpt in range(((ins >> 40) & 3) + 1):
+          ae = (ins & 0x1fff) + (rpt if (ins >> 43) & 1 else 0)
+          bi = ((ins >> 47) & 0xff) + (rpt if (ins >> 15) & 1 else 0)
+          ce = ((ins >> 16) & 0x1fff) + (rpt if (ins >> 29) & 1 else 0)
+          if alt:
+            # Mesa's CAT3-alt format (bit 13 set) reuses opcode values 8..c
+            # but changes SRC1/SRC3 to the immediate-capable source encoding.
+            # FULL (bit 42) describes SRC2 precision; DST_CONV (bit 46) flips
+            # the destination precision relative to SRC2.  Half-file shift
+            # ops are common in fp16/fp8 lowering, so routing these through
+            # the full GPR file corrupts unrelated full registers (including
+            # 64-bit pointer high words).
+            full, conv = bool((ins >> 42) & 1), bool((ins >> 46) & 1)
+            src_regs = gpr if full else hreg
+            dst_half = (not full) ^ conv
+            dst_regs = hreg if dst_half else gpr
+            a = self._cat3_src(ae, src_regs, consts, immediate=True)
+            b = src_regs[bi]
+            c = self._cat3_src(ce, src_regs, consts, immediate=True)
+            if op == 0x8: out = (b >> (a & 31)) & c       # shrm
+            elif op == 0x9: out = (b << (a & 31)) & c    # shlm
+            elif op == 0xa: out = (b >> (a & 31)) | c    # shrg
+            elif op == 0xb: out = (b << (a & 31)) | c    # shlg
+            elif op == 0xc: out = (a & b) | c             # andg
+            else: raise NotImplementedError(f"A630 cat3-alt opcode {op:#x} pc={pc}")
+            dst_regs[dst+rpt] = (_u32(out) & 0xffff) if dst_half else _u32(out)
+            continue
+
+          b, c = gpr[bi], self._cat3_src(ce, gpr, consts)
+          if op == 0x3:
+            a = consts[ae & 0xfff] if ae & 0x1000 and (ae & 0xfff) < len(consts) else gpr[ae & 0xff]
+            # madsh.m16 accumulates the cross term formed by SRC1.low16 and
+            # SRC2.high16, shifted into the upper half of the 32-bit result.
+            # This is used heavily by tinygrad's 64-bit multiply decomposition.
+            out = _madsh_m16(a, b, c)
+          elif op == 0x6:
+            a = self._cat3_f16_src(ae, hreg, consts)
+            bf = _f16(hreg[bi])
+            cf = self._cat3_f16_src(ce, hreg, consts)
+            neg = ((ins >> 14) & 1) | (((ins >> 30) & 1) << 1) | (((ins >> 31) & 1) << 2)
+            hreg[dst+rpt] = _f16bits(_mad_f16(a, bf, cf, neg, bool((ins >> 42) & 1)))
+            continue
+          elif op == 0x7:
+            a = _f32(self._cat3_src(ae, gpr, consts))
+            bf = _f32(gpr[bi])
+            cf = _f32(self._cat3_src(ce, gpr, consts))
+            neg = ((ins >> 14) & 1) | (((ins >> 30) & 1) << 1) | (((ins >> 31) & 1) << 2)
+            val = _mad_f16(a, bf, cf, neg, bool((ins >> 42) & 1))
+            # Normal CAT3 mad.f32 can convert its float32 result to a half-file
+            # destination.  Mesa exposes raw bit 46 as DST_HALF for this opcode.
+            if (ins >> 46) & 1: hreg[dst+rpt] = _f16bits(val)
+            else: gpr[dst+rpt] = _f32bits(val)
+            continue
+          elif op == 0x8:
+            # Normal opcode 8 is sel.b16. All three sources are half-file
+            # values (constant sources still address full 32-bit const words,
+            # with the destination write selecting the low 16 bits).
+            a, b, c = self._cat3_src(ae, hreg, consts), hreg[bi], self._cat3_src(ce, hreg, consts)
+            hreg[dst+rpt] = (a if b else c) & 0xffff
+            continue
+          elif op == 0x9:
+            a = self._cat3_src(ae, gpr, consts)
+            out = a if b else c
+          else: raise NotImplementedError(f"A630 cat3 opcode {op:#x} pc={pc}")
+          gpr[dst+rpt] = _u32(out)
+      elif cat == 4:
+        full, op, enc = bool((ins >> 52)&1), (ins >> 53)&0x3f, ins & 0xffff
+        try: fn = _cat4_fn(op)
+        except NotImplementedError as e: raise NotImplementedError(f"{e} pc={pc}") from e
+        for rpt in range(((ins >> 40) & 3) + 1):
+          src_enc = enc + (rpt if (ins >> 43) & 1 else 0)
+          x = _fmod(self._float_src(src_enc,gpr,hreg,consts,full), src_enc)
+          val = fn(x)
+          if (ins >> 42) & 1: val = _sat_f(val)
+          (gpr if full else hreg)[dst+rpt] = (_f32bits if full else _f16bits)(val)
+      elif cat == 6:
+        op, typ, size = (ins >> 54)&0x1f, (ins >> 49)&7, (ins >> 24)&7
+        width = 2 if typ in (0,2,4) else 1 if typ == 6 else 4
+        if op == 0:
+          ar = (ins >> 14)&0xff
+          addr = gpr[ar] | (gpr[(ar+1)&0xff] << 32)
+          off = _sext((ins >> 1)&0x1fff, 13) * width
+          try: self._check(addr+off, size*width)
+          except RuntimeError as e:
+            raise RuntimeError(f"{e}; pc={pc} cat6=ldg ar={ar} lo={gpr[ar]:#x} hi={gpr[(ar+1)&0xff]:#x} off={off} typ={typ} size={size}") from e
+          out = hreg if typ in (0,2,4,6) else gpr
+          for i in range(size): out[dst+i] = int.from_bytes(ctypes.string_at(addr+off+i*width, width), 'little')
+        elif op == 3:
+          src, ar = (ins >> 1)&0xff, (ins >> 41)&0xff
+          addr = gpr[ar] | (gpr[(ar+1)&0xff] << 32)
+          off = _sext((((ins >> 9)&0x1f)<<8) | ((ins >> 32)&0xff), 13) * width
+          try: self._check(addr+off, size*width)
+          except RuntimeError as e:
+            raise RuntimeError(f"{e}; pc={pc} cat6=stg ar={ar} lo={gpr[ar]:#x} hi={gpr[(ar+1)&0xff]:#x}"
+                               f" off={off} typ={typ} size={size} src={src}") from e
+          sf = hreg if typ in (0,2,4,6) else gpr
+          for i in range(size): ctypes.memmove(addr+off+i*width, struct.pack('<I', sf[src+i])[:width], width)
+        elif op == 1:
+          ar = (ins >> 14)&0xff
+          addr = gpr[ar]
+          if addr + size*width > len(shared): raise RuntimeError(f"A630 local load OOB {addr:#x}+{size*width:#x}")
+          out = hreg if typ in (0,2,4,6) else gpr
+          for i in range(size): out[dst+i] = int.from_bytes(shared[addr+i*width:addr+(i+1)*width], 'little')
+        elif op == 2:
+          # ldp offsets are byte offsets (Mesa disassembles these as p[rN+off]),
+          # unlike global ldg offsets which are scaled by the element width.
+          ar = (ins >> 14)&0xff
+          off = _cat6_private_offset(ins, store=False)
+          addr = gpr[ar] + off
+          if addr < 0 or addr + size*width > len(private): raise RuntimeError(f"A630 private load OOB {addr:#x}+{size*width:#x}")
+          out = hreg if typ in (0,2,4,6) else gpr
+          for i in range(size): out[dst+i] = int.from_bytes(private[addr+i*width:addr+(i+1)*width], 'little')
+        elif op == 4:
+          src, ar = (ins >> 1)&0xff, (ins >> 41)&0xff
+          addr = gpr[ar]
+          if addr + size*width > len(shared): raise RuntimeError(f"A630 local store OOB {addr:#x}+{size*width:#x}")
+          sf = hreg if typ in (0,2,4,6) else gpr
+          for i in range(size): shared[addr+i*width:addr+(i+1)*width] = struct.pack('<I', sf[src+i])[:width]
+        elif op == 5:
+          src, ar = (ins >> 1)&0xff, (ins >> 41)&0xff
+          off = _cat6_private_offset(ins, store=True)
+          addr = gpr[ar] + off
+          if addr < 0 or addr + size*width > len(private): raise RuntimeError(f"A630 private store OOB {addr:#x}+{size*width:#x}")
+          sf = hreg if typ in (0,2,4,6) else gpr
+          for i in range(size): private[addr+i*width:addr+(i+1)*width] = struct.pack('<I', sf[src+i])[:width]
+        else: raise NotImplementedError(f"A630 cat6 opcode {op:#x} pc={pc}")
+      elif cat == 7:
+        # Barrier: cooperative scheduler resumes all threads after each barrier.
+        yield
+      else: raise NotImplementedError(f"A630 instruction category {cat} pc={pc}")
+      if trace_thread and (pc <= 32 or int(os.getenv("QCOM_TRACE", "1")) >= 3):
+        print(f"IR3 lane={local_id[0]} pc={pc:02d} r0={gpr[0:4]} r1={gpr[4:8]} r2={gpr[8:12]} r3={gpr[12:16]} r4={gpr[16:20]} "
+              f"r8={gpr[32:36]} r9={gpr[36:40]} r10={gpr[40:44]} "
+              f"h0={hreg[0:4]} h2={hreg[8:12]} h3={hreg[12:16]} h4={hreg[16:20]} h5={hreg[20:24]} h6={hreg[24:28]}", flush=True)
+      pc += 1
+
+  def _exec_cs(self, groups:tuple[int,int,int]):
+    if not self.shader_addr: raise RuntimeError("CP_EXEC_CS without shader")
+    shader = bytes(to_mv(self.shader_addr, self.shader_size))
+    consts = list(to_mv(self.const_addr, self.const_size).cast('I')) if self.const_addr and self.const_size else []
+    n0 = self.regs.get(mesa.REG_A6XX_SP_CS_NDRANGE_0, 0)
+    local = (((n0 >> 2)&0x3ff)+1, ((n0 >> 12)&0x3ff)+1, ((n0 >> 22)&0x3ff)+1)
+    if os.getenv("QCOM_TRACE"):
+      print(f"EXEC_CS groups={groups} local={local} shader={self.shader_addr:#x}+{self.shader_size:#x}"
+            f" const={self.const_addr:#x}+{self.const_size:#x}", flush=True)
+      print(f"CONSTS {[hex(x) for x in consts[:16]]}", flush=True)
+      if int(os.getenv("QCOM_TRACE", "1")) > 1:
+        from tinygrad.runtime.support.compiler_mesa import disas_adreno
+        disas_adreno(shader)
+    for gz in range(groups[2]):
+      for gy in range(groups[1]):
+        for gx in range(groups[0]):
+          shared = bytearray(32*1024)
+          threads = [self._run_thread((lx,ly,lz),(gx,gy,gz),shared,shader,consts)
+                     for lz in range(local[2]) for ly in range(local[1]) for lx in range(local[0])]
+          while threads:
+            waiting = []
+            for th in threads:
+              try:
+                next(th)
+                waiting.append(th)
+              except StopIteration: pass
+            threads = waiting

--- a/test/mockgpu/qcom/qcomgpu.py
+++ b/test/mockgpu/qcom/qcomgpu.py
@@ -302,9 +302,9 @@ class QCOMGPU(VirtGPU):
           else: src = sf[si]
           if src_type != dst_type:
             val = _cov_src(src, src_type, dst_type)
-            conv = (_f16bits, _f32bits, lambda x:int(x)&0xffff, lambda x:_u32(int(x)), lambda x:int(x)&0xffff,
-                    lambda x:_u32(int(x)), lambda x:int(x)&0xff, lambda x:int(x)&0xff)[dst_type]
-            src = conv(val)
+            cvt = (_f16bits, _f32bits, lambda x:int(x)&0xffff, lambda x:_u32(int(x)), lambda x:int(x)&0xffff,
+                   lambda x:_u32(int(x)), lambda x:int(x)&0xff, lambda x:int(x)&0xff)[dst_type]
+            src = cvt(val)
           df[dst+rpt] = _u32(src)
       elif cat == 2:
         full, conv, op = bool((ins >> 52) & 1), bool((ins >> 46) & 1), (ins >> 53) & 0x3f
@@ -387,18 +387,18 @@ class QCOMGPU(VirtGPU):
             # This is used heavily by tinygrad's 64-bit multiply decomposition.
             out = _madsh_m16(a, b, c)
           elif op == 0x6:
-            a = self._cat3_f16_src(ae, hreg, consts)
+            af = self._cat3_f16_src(ae, hreg, consts)
             bf = _f16(hreg[bi])
             cf = self._cat3_f16_src(ce, hreg, consts)
             neg = ((ins >> 14) & 1) | (((ins >> 30) & 1) << 1) | (((ins >> 31) & 1) << 2)
-            hreg[dst+rpt] = _f16bits(_mad_f16(a, bf, cf, neg, bool((ins >> 42) & 1)))
+            hreg[dst+rpt] = _f16bits(_mad_f16(af, bf, cf, neg, bool((ins >> 42) & 1)))
             continue
           elif op == 0x7:
-            a = _f32(self._cat3_src(ae, gpr, consts))
+            af = _f32(self._cat3_src(ae, gpr, consts))
             bf = _f32(gpr[bi])
             cf = _f32(self._cat3_src(ce, gpr, consts))
             neg = ((ins >> 14) & 1) | (((ins >> 30) & 1) << 1) | (((ins >> 31) & 1) << 2)
-            val = _mad_f16(a, bf, cf, neg, bool((ins >> 42) & 1))
+            val = _mad_f16(af, bf, cf, neg, bool((ins >> 42) & 1))
             # Normal CAT3 mad.f32 can convert its float32 result to a half-file
             # destination.  Mesa exposes raw bit 46 as DST_HALF for this opcode.
             if (ins >> 46) & 1: hreg[dst+rpt] = _f16bits(val)
@@ -436,8 +436,8 @@ class QCOMGPU(VirtGPU):
           try: self._check(addr+off, size*width)
           except RuntimeError as e:
             raise RuntimeError(f"{e}; pc={pc} cat6=ldg ar={ar} lo={gpr[ar]:#x} hi={gpr[(ar+1)&0xff]:#x} off={off} typ={typ} size={size}") from e
-          out = hreg if typ in (0,2,4,6) else gpr
-          for i in range(size): out[dst+i] = int.from_bytes(ctypes.string_at(addr+off+i*width, width), 'little')
+          out_regs = hreg if typ in (0,2,4,6) else gpr
+          for i in range(size): out_regs[dst+i] = int.from_bytes(ctypes.string_at(addr+off+i*width, width), 'little')
         elif op == 3:
           src, ar = (ins >> 1)&0xff, (ins >> 41)&0xff
           addr = gpr[ar] | (gpr[(ar+1)&0xff] << 32)
@@ -452,8 +452,8 @@ class QCOMGPU(VirtGPU):
           ar = (ins >> 14)&0xff
           addr = gpr[ar]
           if addr + size*width > len(shared): raise RuntimeError(f"A630 local load OOB {addr:#x}+{size*width:#x}")
-          out = hreg if typ in (0,2,4,6) else gpr
-          for i in range(size): out[dst+i] = int.from_bytes(shared[addr+i*width:addr+(i+1)*width], 'little')
+          out_regs = hreg if typ in (0,2,4,6) else gpr
+          for i in range(size): out_regs[dst+i] = int.from_bytes(shared[addr+i*width:addr+(i+1)*width], 'little')
         elif op == 2:
           # ldp offsets are byte offsets (Mesa disassembles these as p[rN+off]),
           # unlike global ldg offsets which are scaled by the element width.
@@ -461,8 +461,8 @@ class QCOMGPU(VirtGPU):
           off = _cat6_private_offset(ins, store=False)
           addr = gpr[ar] + off
           if addr < 0 or addr + size*width > len(private): raise RuntimeError(f"A630 private load OOB {addr:#x}+{size*width:#x}")
-          out = hreg if typ in (0,2,4,6) else gpr
-          for i in range(size): out[dst+i] = int.from_bytes(private[addr+i*width:addr+(i+1)*width], 'little')
+          out_regs = hreg if typ in (0,2,4,6) else gpr
+          for i in range(size): out_regs[dst+i] = int.from_bytes(private[addr+i*width:addr+(i+1)*width], 'little')
         elif op == 4:
           src, ar = (ins >> 1)&0xff, (ins >> 41)&0xff
           addr = gpr[ar]

--- a/test/mockgpu/qcom/qcomgpu.py
+++ b/test/mockgpu/qcom/qcomgpu.py
@@ -297,7 +297,9 @@ class QCOMGPU(VirtGPU):
           continue
         for rpt in range(((ins >> 40) & 3) + 1):
           si = (ins & 0xff) + (rpt if (ins >> 43) & 1 else 0)
-          src = (ins & 0xffffffff) if mode == 2 else (consts[ins & 0x7ff] if mode == 1 else sf[si])
+          if mode == 2: src = ins & 0xffffffff
+          elif mode == 1: src = consts[ins & 0x7ff] if (ins & 0x7ff) < len(consts) else 0
+          else: src = sf[si]
           if src_type != dst_type:
             val = _cov_src(src, src_type, dst_type)
             conv = (_f16bits, _f32bits, lambda x:int(x)&0xffff, lambda x:_u32(int(x)), lambda x:int(x)&0xffff,

--- a/test/mockgpu/qcom/test_qcom_integration.py
+++ b/test/mockgpu/qcom/test_qcom_integration.py
@@ -1,4 +1,5 @@
 import math, unittest
+from typing import cast
 
 from tinygrad import Tensor, dtypes
 from tinygrad.helpers import DEV
@@ -29,14 +30,14 @@ class TestQCOMA630Integration(unittest.TestCase):
     self.assertEqual((lhs @ rhs).realize().tolist(), [[1.] * n])
 
   def test_random_convolution_and_sfu_select(self):
-    rnd = Tensor.rand(64, device="QCOM").realize().tolist()
+    rnd = cast(list[float], Tensor.rand(64, device="QCOM").realize().tolist())
     self.assertEqual(len(rnd), 64)
     self.assertTrue(all(0.0 <= x < 1.0 for x in rnd))
 
     conv = Tensor.ones(1, 1, 8, 8, device="QCOM").conv2d(Tensor.ones(2, 1, 3, 3, device="QCOM")).realize()
     self.assertEqual(conv.tolist(), [[[[9.] * 6 for _ in range(6)] for _ in range(2)]])
 
-    vals = Tensor([[-3.0, 2.0], [3.0, 4.0]], device="QCOM").sum(axis=1).elu().realize().tolist()
+    vals = cast(list[float], Tensor([[-3.0, 2.0], [3.0, 4.0]], device="QCOM").sum(axis=1).elu().realize().tolist())
     self.assertAlmostEqual(vals[0], math.expm1(-1.0), places=5)
     self.assertEqual(vals[1], 7.0)
 

--- a/test/mockgpu/qcom/test_qcom_integration.py
+++ b/test/mockgpu/qcom/test_qcom_integration.py
@@ -1,0 +1,44 @@
+import math, unittest
+
+from tinygrad import Tensor, dtypes
+from tinygrad.helpers import DEV
+
+
+@unittest.skipUnless(DEV.target("QCOM").interface == "MOCK", "requires DEV=MOCK+QCOM:IR3")
+class TestQCOMA630Integration(unittest.TestCase):
+  def test_dispatch_layouts(self):
+    for size in (1, 3, 17, 65, 257):
+      self.assertEqual(Tensor.full((size,), 1.0, device="QCOM").realize().tolist(), [1.0] * size)
+
+  def test_matrix_multiply(self):
+    a = Tensor([[1., 2., 3.], [4., 5., 6.]], device="QCOM")
+    b = Tensor([[7., 8.], [9., 10.], [11., 12.]], device="QCOM")
+    self.assertEqual((a @ b).realize().tolist(), [[58., 64.], [139., 154.]])
+
+  def test_tiled_matrix_multiply_float_and_half(self):
+    n = 64
+    for dtype in (dtypes.float, dtypes.half):
+      lhs = Tensor.ones(n, n, dtype=dtype, device="QCOM").contiguous()
+      rhs = Tensor.eye(n, dtype=dtype).to("QCOM").clone()
+      self.assertEqual((lhs @ rhs).realize().tolist(), [[1.] * n for _ in range(n)])
+
+  def test_reduction_shaped_matmul(self):
+    n = 64
+    lhs = Tensor.ones(1, n, device="QCOM").contiguous()
+    rhs = Tensor.eye(n).to("QCOM").clone()
+    self.assertEqual((lhs @ rhs).realize().tolist(), [[1.] * n])
+
+  def test_random_convolution_and_sfu_select(self):
+    rnd = Tensor.rand(64, device="QCOM").realize().tolist()
+    self.assertEqual(len(rnd), 64)
+    self.assertTrue(all(0.0 <= x < 1.0 for x in rnd))
+
+    conv = Tensor.ones(1, 1, 8, 8, device="QCOM").conv2d(Tensor.ones(2, 1, 3, 3, device="QCOM")).realize()
+    self.assertEqual(conv.tolist(), [[[[9.] * 6 for _ in range(6)] for _ in range(2)]])
+
+    vals = Tensor([[-3.0, 2.0], [3.0, 4.0]], device="QCOM").sum(axis=1).elu().realize().tolist()
+    self.assertAlmostEqual(vals[0], math.expm1(-1.0), places=5)
+    self.assertEqual(vals[1], 7.0)
+
+
+if __name__ == "__main__": unittest.main()

--- a/test/mockgpu/qcom/test_qcomgpu.py
+++ b/test/mockgpu/qcom/test_qcomgpu.py
@@ -1,0 +1,175 @@
+import math, unittest
+
+from tinygrad.runtime.autogen import mesa
+from test.mockgpu.qcom.qcomgpu import (
+  QCOMGPU, _cat0_branch_taken, _cat1_swz, _cat2_signed, _cat6_private_offset, _clz_b, _mul_s24,
+  _mull_u, _madsh_m16, _absneg_s, _cov_src, _cat4_fn, _rsqrt, _log2, _exp2, _trunc_f,
+  _floor_f, _sign_f, _mad_f16, _fmod)
+
+
+class TestQCOMGPUDecode(unittest.TestCase):
+  def test_cat3_constant_vs_inline_immediate(self):
+    gpr = list(range(256))
+    consts = [0] * 64
+    consts[16] = 0x7f800000
+
+    # The same raw 0x1010 field is context-sensitive in CAT3: sel.b32 uses it
+    # as c4.x (constant word 16), while shift SRC1 uses it as immediate 16.
+    self.assertEqual(QCOMGPU._cat3_src(0x1010, gpr, consts), 0x7f800000)
+    self.assertEqual(QCOMGPU._cat3_src(0x1010, gpr, consts, immediate=True), 16)
+    self.assertEqual(QCOMGPU._cat3_src(0x101e, gpr, consts, immediate=True), 30)
+    self.assertEqual(QCOMGPU._cat3_src(0x0003, gpr, consts), 3)
+
+  def test_half_float_constant_vs_half_gpr(self):
+    gpr, hreg = [0] * 256, [0] * 256
+    consts = [0] * 64
+    # hc5.x is constant word 20. Floating half instructions interpret a
+    # constant-file source as the full float32 value, not as its low fp16 bits.
+    consts[20] = 0xc3e00000  # -448.0f
+    hreg[3] = 0xa400         # -0.015625h
+
+    self.assertEqual(QCOMGPU._float_src(0x1014, gpr, hreg, consts, full=False), -448.0)
+    self.assertEqual(QCOMGPU._float_src(0x0003, gpr, hreg, consts, full=False), -0.015625)
+    # 0x2c07 is the encoded special immediate printed by Mesa as
+    # h(1/log2(e)); it is a value, not the low half of an fp32 bit pattern.
+    self.assertAlmostEqual(QCOMGPU._float_src(0x2c07, gpr, hreg, consts, full=False), 0.6931471805599453)
+
+  def test_mull_and_madsh_reconstruct_low_product(self):
+    a = b = 0xfffffa9d  # low word of int64(-1379)
+    out = _mull_u(a, b)
+    out = _madsh_m16(a, b, out)
+    out = _madsh_m16(b, a, out)
+    self.assertEqual(out, 0x001d0449)
+
+  def test_mul_s24_signed_operands(self):
+    self.assertEqual(_mul_s24(3, 7), 21)
+    self.assertEqual(_mul_s24(0xffffff, 9), 0xfffffff7)  # -1 * 9
+    self.assertEqual(_mul_s24(0x800000, 2), 0xff000000)  # -2^23 * 2
+    self.assertEqual(_mul_s24(0x1000001, 3), 3)          # truncate operands to 24 bits
+
+  def test_cat2_signed_precision(self):
+    self.assertEqual(_cat2_signed(0xffff, False), -1)
+    self.assertEqual(_cat2_signed(0x8000, False), -32768)
+    self.assertEqual(_cat2_signed(0x0000ffff, True), 65535)
+    self.assertEqual(_cat2_signed(0xffffffff, True), -1)
+
+  def test_clz_b_precision(self):
+    self.assertEqual(_clz_b(0, True), 0xffffffff)
+    self.assertEqual(_clz_b(1, True), 31)
+    self.assertEqual(_clz_b(0x80000000, True), 0)
+    self.assertEqual(_clz_b(0, False), 0xffffffff)
+    self.assertEqual(_clz_b(1, False), 15)
+    self.assertEqual(_clz_b(0x8000, False), 0)
+
+  def test_cat0_two_predicate_branches(self):
+    # Real uint64 modulo lowering: brao !p0.y, !p0.x.  With both predicates
+    # true neither negated condition is true, so the branch must fall through.
+    brao = 0x00b02020000000c1
+    gpr = [0] * 256
+    gpr[0xf8], gpr[0xf9] = 1, 1
+    self.assertFalse(_cat0_branch_taken(brao, gpr))
+    gpr[0xf8] = 0
+    self.assertTrue(_cat0_branch_taken(brao, gpr))
+
+    # Same predicate fields, BRAA instead of BRAO: both negated predicates
+    # must be true.  BR consumes only COMP1/INV1.
+    braa = (brao & ~(7 << 37)) | (2 << 37)
+    gpr[0xf8], gpr[0xf9] = 0, 0
+    self.assertTrue(_cat0_branch_taken(braa, gpr))
+    gpr[0xf8] = 1
+    self.assertFalse(_cat0_branch_taken(braa, gpr))
+    br = brao & ~(7 << 37)
+    gpr[0xf9] = 0
+    self.assertTrue(_cat0_branch_taken(br, gpr))
+    gpr[0xf9] = 1
+    self.assertFalse(_cat0_branch_taken(br, gpr))
+
+  def test_cat1_swz_parallel_pointer_halves(self):
+    # Real cumprod-backward lowering uses this exact SWZ to swap the two words
+    # of a 64-bit address.  The two writes must use the original source values.
+    swz = 0x240cc02b002c2b2c  # swz.u32u32 r10.w, r11.x, r11.x, r10.w
+    regs = [0] * 256
+    regs[43], regs[44] = 0x89abcdef, 0x00007fff
+    _cat1_swz(swz, regs, regs)
+    self.assertEqual(regs[43], 0x00007fff)
+    self.assertEqual(regs[44], 0x89abcdef)
+
+  def test_cat6_private_offsets(self):
+    # Exact Mesa encodings observed in cumprod backward spill/reload code.
+    ldp4 = 0xc086002b0180c009   # ldp.u32 r10.w, p[r0.w+4], 1
+    stp4 = 0xc146070401800042   # stp.u32 p[r0.w+4], r8.y, 1
+    stp28 = 0xc146071c018000ea  # stp.u32 p[r0.w+28], r29.y, 1
+    self.assertEqual(_cat6_private_offset(ldp4, store=False), 4)
+    self.assertEqual(_cat6_private_offset(stp4, store=True), 4)
+    self.assertEqual(_cat6_private_offset(stp28, store=True), 28)
+
+  def test_absneg_s_modifiers(self):
+    self.assertEqual(_absneg_s(7, 1), 0xfffffff9)       # neg
+    self.assertEqual(_absneg_s(0xfffffff9, 2), 7)       # abs
+    self.assertEqual(_absneg_s(0xfffffff9, 3), 0xfffffff9)  # abs then neg
+
+  def test_cat1_u8_signed_widening(self):
+    # Mesa lowers signed int8 shifts through ldg.u8 -> cov.u8s16 -> ashr.b.
+    # CAT1 therefore sign-extends TYPE_U8 when the destination is signed,
+    # while an unsigned destination keeps the ordinary zero-extension.
+    self.assertEqual(_cov_src(0xff, mesa.TYPE_U8, mesa.TYPE_S16), -1)
+    self.assertEqual(_cov_src(0xdb, mesa.TYPE_U8, mesa.TYPE_S16), -37)
+    self.assertEqual(_cov_src(0xff, mesa.TYPE_U8, mesa.TYPE_U16), 255)
+
+  def test_cat4_half_sfu_opcodes(self):
+    self.assertIs(_cat4_fn(0x9), _rsqrt)
+    self.assertIs(_cat4_fn(0xa), _log2)
+    self.assertIs(_cat4_fn(0xb), _exp2)
+    with self.assertRaises(NotImplementedError): _cat4_fn(0x8)
+
+  def test_trunc_f_ieee_semantics(self):
+    self.assertEqual(_trunc_f(3.75), 3.0)
+    self.assertEqual(_trunc_f(-3.75), -3.0)
+    self.assertEqual(_trunc_f(math.inf), math.inf)
+    self.assertEqual(_trunc_f(-math.inf), -math.inf)
+    self.assertTrue(math.isnan(_trunc_f(math.nan)))
+
+  def test_floor_f_ieee_semantics(self):
+    self.assertEqual(_floor_f(3.75), 3.0)
+    self.assertEqual(_floor_f(-3.25), -4.0)
+    self.assertEqual(_floor_f(math.inf), math.inf)
+    self.assertEqual(_floor_f(-math.inf), -math.inf)
+    self.assertTrue(math.isnan(_floor_f(math.nan)))
+    self.assertLess(math.copysign(1.0, _floor_f(-0.0)), 0.0)
+
+  def test_float_absneg_modifiers(self):
+    self.assertEqual(_fmod(3.5, 0 << 14), 3.5)
+    self.assertEqual(_fmod(3.5, 1 << 14), -3.5)
+    self.assertEqual(_fmod(-3.5, 2 << 14), 3.5)
+    self.assertEqual(_fmod(3.5, 3 << 14), -3.5)
+
+  def test_sign_f_semantics(self):
+    self.assertEqual(_sign_f(-2.0), -1.0)
+    self.assertEqual(_sign_f(-0.0), 0.0)
+    self.assertEqual(_sign_f(0.0), 0.0)
+    self.assertEqual(_sign_f(2.0), 1.0)
+    self.assertEqual(_sign_f(math.nan), 1.0)
+
+  def test_mad_f16_modifiers_and_constants(self):
+    self.assertEqual(_mad_f16(2.0, 3.0, 4.0), 10.0)
+    self.assertEqual(_mad_f16(2.0, 3.0, 4.0, 1), -2.0)
+    self.assertEqual(_mad_f16(2.0, 3.0, 4.0, 2), -2.0)
+    self.assertEqual(_mad_f16(2.0, 3.0, 4.0, 4), 2.0)
+    self.assertEqual(_mad_f16(2.0, 3.0, 4.0, sat=True), 1.0)
+    self.assertEqual(_mad_f16(-2.0, 3.0, 1.0, sat=True), 0.0)
+
+    hreg, consts = [0] * 256, [0] * 64
+    hreg[3] = 0x3c00       # 1.0h
+    consts[16] = 0x40000000  # 2.0f
+    self.assertEqual(QCOMGPU._cat3_f16_src(3, hreg, consts), 1.0)
+    self.assertEqual(QCOMGPU._cat3_f16_src(0x1010, hreg, consts), 2.0)
+
+  def test_address_range_lifecycle(self):
+    gpu = QCOMGPU(0)
+    gpu.map_range(0x1000, 0x100)
+    gpu._check(0x1040, 0x20)
+    gpu.unmap_range(0x1000, 0x100)
+    with self.assertRaises(RuntimeError): gpu._check(0x1040, 0x20)
+
+
+if __name__ == '__main__': unittest.main()

--- a/test/mockgpu/qcom/test_qcomgpu.py
+++ b/test/mockgpu/qcom/test_qcomgpu.py
@@ -1,4 +1,4 @@
-import math, struct, unittest
+import math, unittest
 
 from tinygrad.runtime.autogen import mesa
 from test.mockgpu.qcom.qcomgpu import (
@@ -164,14 +164,25 @@ class TestQCOMGPUDecode(unittest.TestCase):
     self.assertEqual(QCOMGPU._cat3_f16_src(3, hreg, consts), 1.0)
     self.assertEqual(QCOMGPU._cat3_f16_src(0x1010, hreg, consts), 2.0)
 
-  def test_cat1_constant_out_of_range_defaults_to_zero(self):
-    # CAT1 immediate-constant mode (mode=1) referencing a constant index far
-    # beyond the loaded constant buffer must default to 0 like every other
-    # const read in the emulator instead of raising IndexError.
-    gpu = QCOMGPU(0)
-    ins = (1 << 61) | (1 << 53) | (mesa.TYPE_S32 << 50) | (mesa.TYPE_S32 << 46) | 0x500
-    shader = struct.pack('<Q', ins)
-    list(gpu._run_thread((0, 0, 0), (0, 0, 0), bytearray(32 * 1024), shader, []))
+  def test_cat1_constant_source_bounds(self):
+    # CAT1 immediate-constant mode (mode=1) must default to 0 for an index past
+    # the loaded constant buffer, like every other const read, instead of
+    # raising IndexError.  In-range reads return the constant word.
+    sf = [0] * 256
+    consts = [0] * 64
+    consts[16] = 0xdeadbeef
+    self.assertEqual(QCOMGPU._cat1_src(0x1010, 1, sf, consts, 0), 0xdeadbeef)  # idx 16
+    self.assertEqual(QCOMGPU._cat1_src(0x1010, 1, sf, [], 0), 0)               # idx 16, empty consts
+    self.assertEqual(QCOMGPU._cat1_src(0x0042, 2, sf, [], 0), 0x42)            # inline immediate
+    sf[7] = 0x1234
+    self.assertEqual(QCOMGPU._cat1_src(0x0007, 0, sf, [], 7), 0x1234)          # register
+
+  def test_float_immediate_out_of_range(self):
+    # A 10-bit special-immediate field with an index outside the defined table
+    # is an unrecognized encoding: report it clearly, don't IndexError.
+    gpr, hreg = [0] * 256, [0] * 256
+    with self.assertRaises(NotImplementedError):
+      QCOMGPU._float_src((5 << 11) | 20, gpr, hreg, [], full=False)
 
   def test_address_range_lifecycle(self):
     gpu = QCOMGPU(0)

--- a/test/mockgpu/qcom/test_qcomgpu.py
+++ b/test/mockgpu/qcom/test_qcomgpu.py
@@ -1,4 +1,4 @@
-import math, unittest
+import math, struct, unittest
 
 from tinygrad.runtime.autogen import mesa
 from test.mockgpu.qcom.qcomgpu import (
@@ -163,6 +163,15 @@ class TestQCOMGPUDecode(unittest.TestCase):
     consts[16] = 0x40000000  # 2.0f
     self.assertEqual(QCOMGPU._cat3_f16_src(3, hreg, consts), 1.0)
     self.assertEqual(QCOMGPU._cat3_f16_src(0x1010, hreg, consts), 2.0)
+
+  def test_cat1_constant_out_of_range_defaults_to_zero(self):
+    # CAT1 immediate-constant mode (mode=1) referencing a constant index far
+    # beyond the loaded constant buffer must default to 0 like every other
+    # const read in the emulator instead of raising IndexError.
+    gpu = QCOMGPU(0)
+    ins = (1 << 61) | (1 << 53) | (mesa.TYPE_S32 << 50) | (mesa.TYPE_S32 << 46) | 0x500
+    shader = struct.pack('<Q', ins)
+    list(gpu._run_thread((0, 0, 0), (0, 0, 0), bytearray(32 * 1024), shader, []))
 
   def test_address_range_lifecycle(self):
     gpu = QCOMGPU(0)


### PR DESCRIPTION
# test: add Qualcomm A630 MockGPU emulator

Closes the **QCOM A630 emulator** bounty ($500, Hardware: None).

## What this is

A `DEV=MOCK+QCOM:IR3` backend that runs real tinygrad QCOM work with **no
Qualcomm hardware**:

```
Tensor/UOps -> IR3Renderer/NIR -> Mesa Freedreno IR3 -> A630 IR3 machine code
            -> QCOMComputeQueue -> A6xx PM4 -> virtual KGSL ioctl
            -> PM4 interpreter -> A630 IR3 emulator -> host-backed GPU memory
```

No CPU expected-output computation is used. The real QCOM renderer, compiler,
queue, and submit path are preserved; only the hardware boundary is replaced
by the mock stack.

## Architecture

- `test/mockgpu/qcom/qcomdriver.py` - virtual `/dev/kgsl-3d0` plus the QCOM
  KGSL ioctl surface: draw context create/destroy, device properties
  (A630, `chip_id=0x06030001`, 1 MB GMEM), GPU object alloc/free,
  user-memory map/free, command submission, timestamps, fd lifecycle.
  `hcq2.cfunc_buf` is rewritten so the generated host QCOM `libc.ioctl` calls
  route into the virtual driver (process-wide callback bridge, no chained
  wrappers).
- `test/mockgpu/qcom/qcomgpu.py` - A6xx PM4 interpreter (type-4 reg writes,
  type-7 packets: `LOAD_STATE6`, `EVENT_WRITE`, `WAIT_REG_MEM`, `REG_TO_MEM`,
  `EXEC_CS`) and the A630 IR3 instruction emulator:
  - per-thread GPR/HREG/predicate regions, private memory, workgroup shared
    memory, barriers (cooperative generators)
  - CAT0 branches (`br`/`brao`/`braa`, `predt`/`predf`/`prede`)
  - CAT1 moves/`cov` and parallel `swz`
  - CAT2 ALU incl. signed min/max, `clz.b(0)=0xffffffff`, `mul.s24`,
    `mull_u`, `absneg.s`, half/full float semantics
  - CAT3 normal/alternate encodings (bit-13 split), `madsh.m16`,
    `mad.f16/f32`, `sel.b16`, shifts, inline immediates vs constant file
  - CAT4 SFUs (`rcp`, `rsqrt`, `log2`, `exp2`, `sin`, `cos`, `sqrt`, half
    variants) with IEEE non-finite handling
  - CAT6 global/local/private loads and stores
- `test/mockgpu/qcom/test_qcomgpu.py` - 20 focused semantic/unit tests,
  including exact raw-instruction regressions (SWZ pointer halves, private
  offsets, CAT3 constant-vs-immediate ambiguity, CAT0 two-predicate branches,
  CAT1 constant-source bounds, float-immediate bounds).
- `test/mockgpu/qcom/test_qcom_integration.py` - 5 end-to-end tests:
  dispatch layouts (1/3/17/65/257), matmul, 64x64 float+half matmul,
  reduction matmul, random/conv/SFU.
- `test/mockgpu/mockgpu.py` - registers `"MOCK+QCOM": QCOMDriver`.
- `.github/workflows/test.yml` - adds a `QCOM A630 MockGPU` job that installs
  the `mesa` extra (tinymesa) and runs `test/mockgpu/qcom/` under
  `DEV=MOCK+QCOM:IR3`, so the emulator is exercised in CI with no hardware.

## Why in `test/mockgpu`

This installs as a MockGPU (like the existing NV/AMD/CDNA mock emulators),
so it requires no hardware, no driver changes, and no generic runtime
modification. The existing `test/mockgpu` harness already provides the
virtual-fd / tracked-memoryview machinery.

## Verification (base: current master `8b636f35`)

Environment: `DEV=MOCK+QCOM:IR3 PYTHONPATH=. DERANDOMIZE_CI=1`

```
test/mockgpu/qcom/test_qcomgpu.py          20 passed
test/mockgpu/qcom/test_qcom_integration.py  5 passed
test/test_tiny.py::TestTiny::test_plus     1 passed  (real QCOM path, [5 7 9])
test/backend/test_dtype_alu.py         44 passed, 16 skipped, 16 subtests
```

The `QCOM A630 MockGPU` CI job runs `pytest -n=auto test/mockgpu/qcom/` on
`ubuntu-24.04` with only `.[mesa] pytest pytest-xdist` installed, so the
emulator is validated in CI without any Qualcomm hardware.

No generic runtime changes are required on current master (`tinygrad/runtime`
is untouched by this PR).

## Known scope limitations

- Full wave-divergence is not emulated; execution uses one work-item per
  generator with predicate-region behavior and per-workgroup barriers.
- IEEE `atomics`, texture/image, and the QCOMCL (`DEV=MOCK+QCOM` without
  `:IR3`) runtime are not implemented.
- Follow-up subtests that need `devbuffers/latest` or full QCOMCL support
  are intentionally left out of this PR's test set.