### PR TITLE
[PR] Bind eligible slice-copy destinations as buffer views

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -580,7 +580,7 @@ jobs:
         if: ${{ matrix.backend == 'amd' && matrix.arch == 'gfx950' }}
         run: PYTHONPATH=. DEV=NULL:HIP:gfx950 MXFP4=1 LLAMA_LAYERS=2 BENCHMARK=3 NULL_ALLOW_COPYOUT=1 NO_HIPCC=1 ROCM_PATH=/opt/rocm JITBEAM=0 examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama31_8b/implementations/tinybox_8xMI350X/profile.sh
       - name: Run pytest (amd)
-        run: python -m pytest -n=auto test/backend/test_ops.py test/backend/test_dtype.py test/backend/test_dtype_alu.py test/backend/test_linearizer.py test/backend/test_randomness.py test/backend/test_jit.py test/backend/test_graph.py test/backend/test_multitensor.py test/device/test_hcq2.py test/external/external_test_am.py test/backend/test_asm_gemm.py::TestAsmGEMM --durations=20
+        run: python -m pytest -n=auto test/backend/test_ops.py test/backend/test_dtype.py test/backend/test_dtype_alu.py test/backend/test_linearizer.py test/backend/test_randomness.py test/backend/test_jit.py test/backend/test_graph.py test/backend/test_multitensor.py test/device/test_hcq2.py test/external/external_test_am.py test/backend/test_asm_gemm.py::TestAsmGEMM test/backend/test_slice_copy.py --durations=20
       - name: Run opt tests
         run: python -m pytest -n=auto test/opt --durations=20
       - name: Run disk copy tests

--- a/test/backend/test_slice_copy.py
+++ b/test/backend/test_slice_copy.py
@@ -1,0 +1,191 @@
+import unittest
+import numpy as np
+from tinygrad import Tensor, Device, GlobalCounters, TinyJit, Variable
+
+@unittest.skipUnless(Device.DEFAULT in {"CPU", "PYTHON", "CUDA", "NV", "AMD"}, "requires an offset-capable backend")
+class TestSliceCopy(unittest.TestCase):
+  @property
+  def peer(self): return Device.DEFAULT if Device.DEFAULT in {"CUDA", "NV", "AMD"} else "CPU:1"
+  @property
+  def directions(self): return (("CPU", self.peer), (self.peer, "CPU"))
+
+  def test_slice_layouts(self):
+    cases = [
+      ((20,), slice(10, 12), slice(13, 15), 1),
+      ((20,), slice(19, 20), slice(0, 1), 1),
+      ((20,), slice(0, 4), slice(16, 20), 1),
+      ((20,), slice(0, 2), slice(18, 20), 1),
+      ((20,), slice(18, 20), slice(0, 2), 1),
+      ((20,), slice(10, 12), slice(13, 15), 1),
+      ((4, 6), (slice(1, 2), slice(2, 5)), (slice(2, 3), slice(1, 4)), 1),
+      ((4, 6), (slice(1, 3), slice(None)), (slice(0, 2), slice(None)), 1),
+      ((2, 3, 4), (slice(1, 2), slice(1, 3), slice(None)), (slice(0, 1), slice(0, 2), slice(None)), 1),
+      ((2, 1, 4), (slice(1, 2), slice(None), slice(1, 3)), (slice(0, 1), slice(None), slice(2, 4)), 1),
+      ((2, 3, 1), (slice(0, 1), slice(1, 3), slice(None)), (slice(1, 2), slice(0, 2), slice(None)), 1),
+      ((2, 3, 4), (slice(1, 2), slice(1, 2), slice(1, 2)), (slice(0, 1), slice(2, 3), slice(3, 4)), 1),
+      ((4, 6), (slice(None), slice(1, 3)), (slice(None), slice(2, 4)), 3),
+      ((2, 1, 3, 4), (slice(None), slice(None), slice(1, 3), slice(None)),
+       (slice(None), slice(None), slice(0, 2), slice(None)), 3),
+      ((20,), slice(2, 10, 2), slice(4, 8), None),
+      ((20,), slice(4, 8), slice(2, 10, 2), None),
+      ((4, 6), (slice(0, 0), slice(1, 3)), (slice(0, 0), slice(1, 3)), 0),
+      ((4, 6), (slice(1, 3), slice(0, 0)), (slice(1, 3), slice(0, 0)), 0),
+    ]
+    for src, dst in self.directions:
+      held = []
+      for shape, di, si, count in cases:
+        with self.subTest(src=src, dst=dst, shape=shape, di=di, si=si):
+          expected, values = np.full(shape, -1., dtype=np.float32), np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+          a, b = Tensor(expected.copy(), device=dst).realize(), Tensor(values.copy(), device=src).realize()
+          GlobalCounters.reset()
+          a[di].assign(b[si].to(dst)).realize()
+          if count is not None: self.assertEqual(GlobalCounters.kernel_count, count)
+          expected[di] = values[si]
+          np.testing.assert_array_equal(a.numpy(), expected)
+          np.testing.assert_array_equal(b.numpy(), values)
+          held.append((a, b, expected, values))
+      for a, b, expected, values in held:
+        np.testing.assert_array_equal(a.numpy(), expected)
+        np.testing.assert_array_equal(b.numpy(), values)
+
+  def test_copy_byte_boundaries(self):
+    rng = np.random.default_rng(217)
+    for src, dst in self.directions:
+      for dtype in (np.uint8, np.float16, np.float32, np.int32, np.int64):
+        itemsize = np.dtype(dtype).itemsize
+        lengths = [1] + [boundary//itemsize+delta for boundary in (32, 64, 256, 4096) for delta in (-1, 0, 1)]
+        for i, n in enumerate(lengths):
+          do, so = ((1, 0), (3, 5), (19, 19))[i % 3]
+          with self.subTest(src=src, dst=dst, dtype=dtype, n=n, do=do, so=so):
+            av = np.frombuffer(rng.bytes((n+19)*itemsize), dtype=dtype).copy()
+            bv = np.frombuffer(rng.bytes((n+19)*itemsize), dtype=dtype).copy()
+            if dtype in (np.float16, np.float32):
+              bits = np.uint16 if dtype == np.float16 else np.uint32
+              patterns = [0, 0x8000, 0x7c00, 0xfc00, 0x7e01, 0x7d01, 1] if dtype == np.float16 else [
+                0, 0x80000000, 0x7f800000, 0xff800000, 0x7fc00001, 0x7f800001, 1]
+              bv.view(bits)[so:so+min(n, len(patterns))] = patterns[:min(n, len(patterns))]
+            expected = av.copy()
+            expected.view(np.uint8)[do*itemsize:(do+n)*itemsize] = bv.view(np.uint8)[so*itemsize:(so+n)*itemsize]
+            a, b = Tensor(av.copy(), device=dst).realize(), Tensor(bv.copy(), device=src).realize()
+            GlobalCounters.reset()
+            a[do:do+n].assign(b[so:so+n].to(dst)).realize()
+            self.assertEqual(GlobalCounters.kernel_count, 1)
+            self.assertEqual(a.numpy().tobytes(), expected.tobytes())
+            self.assertEqual(b.numpy().tobytes(), bv.tobytes())
+
+  def test_creation_copy_lifetime(self):
+    for kind in ("copy", "consumer", "view", "shared"):
+      with self.subTest(kind=kind):
+        a, other = Tensor([1.]*20, device=self.peer).realize(), Tensor([0.]*20, device=self.peer).realize()
+        b = Tensor([float(i) for i in range(20)], device="PYTHON").realize()
+        copied = b[13:15].to(a.device)
+        later = copied+1 if kind == "consumer" else copied[1:] if kind == "view" else copied
+        if kind == "shared": other[4:6].assign(copied)
+        GlobalCounters.reset()
+        a[10:12].assign(copied).realize()
+        self.assertEqual(GlobalCounters.kernel_count, 2)
+        a[10:12].assign(Tensor([99., 99.], device=a.device)).realize()
+        b[13:15].assign(Tensor([77., 77.], device="PYTHON")).realize()
+        self.assertEqual(a.tolist(), [1.]*10 + [99., 99.] + [1.]*8)
+        if kind == "shared": self.assertEqual(other.tolist(), [0.]*4 + [13., 14.] + [0.]*14)
+        else: self.assertEqual(later.tolist(), [14., 15.] if kind == "consumer" else [14.] if kind == "view" else [13., 14.])
+
+  def test_realized_copy_is_independent(self):
+    for src, dst in self.directions:
+      with self.subTest(src=src, dst=dst):
+        a, b = Tensor([1.]*20, device=dst).realize(), Tensor([float(i) for i in range(20)], device=src).realize()
+        copied = b[13:15].to(dst)
+        a[10:12].assign(copied).realize()
+        copied.realize()
+        a[10:12].assign(Tensor([99., 99.], device=dst)).realize()
+        b[13:15].assign(Tensor([77., 77.], device=src)).realize()
+        self.assertEqual(copied.tolist(), [13., 14.])
+
+  def test_pending_writes(self):
+    for src, dst in self.directions:
+      for first, second in (((1, 5), (3, 7)), ((3, 7), (1, 5)), ((1, 5), (5, 9)), ((1, 5), (9, 13))):
+        for read_between in (False, True):
+          with self.subTest(src=src, dst=dst, first=first, second=second, read_between=read_between):
+            expected = np.full(16, -17., dtype=np.float32)
+            bv, cv = np.arange(11, 15, dtype=np.float32), np.arange(31, 35, dtype=np.float32)
+            a, b, c = Tensor(expected.copy(), device=dst), Tensor(bv.copy(), device=src), Tensor(cv.copy(), device=src)
+            Tensor.realize(a, b, c)
+            a[slice(*first)].assign(b.to(dst))
+            mid = a[slice(*first)].sum().realize() if read_between else None
+            a[slice(*second)].assign(c.to(dst)).realize()
+            expected[slice(*first)], expected[slice(*second)] = bv, cv
+            np.testing.assert_array_equal(a.numpy(), expected)
+            np.testing.assert_array_equal(b.numpy(), bv)
+            np.testing.assert_array_equal(c.numpy(), cv)
+            if mid is not None: self.assertEqual(mid.item(), 50.)
+
+  def test_jit_rebinds_new_buffers(self):
+    for src, dst in (*self.directions, ("PYTHON", self.peer)):
+      with self.subTest(src=src, dst=dst):
+        @TinyJit
+        def write(a, b): a[5:13].assign(b[7:15].to(a.device)).realize()
+        held = []
+        for i in range(6):
+          av, bv = np.full(32, -100.-i, dtype=np.float32), np.arange(32, dtype=np.float32)+1000*i
+          a, b = Tensor(av.copy(), device=dst).realize(), Tensor(bv.copy(), device=src).realize()
+          write(a, b)
+          av[5:13] = bv[7:15]
+          held.append((a, b, av, bv))
+        for a, b, av, bv in held:
+          np.testing.assert_array_equal(a.numpy(), av)
+          np.testing.assert_array_equal(b.numpy(), bv)
+
+  def test_symbolic_rebindings(self):
+    for src, dst in self.directions:
+      for mode in ("offset", "length"):
+        with self.subTest(src=src, dst=dst, mode=mode):
+          @TinyJit
+          def write(a, b, v):
+            ds, ss = ((v, v+3), (9, 12)) if mode == "offset" else ((7, 7+v), (9, 9+v))
+            a.shrink((ds,)).assign(b.shrink((ss,)).to(a.device)).realize()
+          for i, value in enumerate((1, 4, 2, 1, 3, 4)):
+            av, bv = np.full(20, -i-10., dtype=np.float32), np.arange(24, dtype=np.float32)+i*100
+            a, b = Tensor(av.copy(), device=dst).realize(), Tensor(bv.copy(), device=src).realize()
+            write(a, b, Variable("v", 1, 4).bind(value))
+            start, n = (value, 3) if mode == "offset" else (7, value)
+            av[start:start+n] = bv[9:9+n]
+            np.testing.assert_array_equal(a.numpy(), av)
+            np.testing.assert_array_equal(b.numpy(), bv)
+
+  def test_computed_source_then_consumer(self):
+    for src, dst in self.directions:
+      with self.subTest(src=src, dst=dst):
+        av, bv = np.arange(1047, dtype=np.float32), np.arange(1053, dtype=np.float32)
+        a, b = Tensor(av.copy(), device=dst).realize(), Tensor(bv.copy(), device=src).realize()
+        a[7:1032].assign((b[13:1038]*3-7).to(dst))
+        result = (a*2+5).realize()
+        av[7:1032] = bv[13:1038]*3-7
+        np.testing.assert_array_equal(result.numpy(), av*2+5)
+        np.testing.assert_array_equal(a.numpy(), av)
+        np.testing.assert_array_equal(b.numpy(), bv)
+
+  @unittest.skipUnless(Device.DEFAULT == "CPU", "uses multiple logical CPU devices")
+  def test_replicated_destination(self):
+    devices = ("CPU", "CPU:1")
+    a = Tensor.ones(4, 6, device="CPU").shard(devices).realize()
+    values = np.arange(24, dtype=np.float32).reshape(4, 6)
+    b = Tensor(values, device="CPU:2").shard(("CPU:2", "CPU:3")).realize()
+    a[1:3, :].assign(b[:2, :].to(devices)).realize()
+    expected = np.ones((4, 6), dtype=np.float32)
+    expected[1:3, :] = values[:2, :]
+    np.testing.assert_array_equal(a.numpy(), expected)
+
+  @unittest.skipUnless(Device.DEFAULT == "CPU", "uses multiple logical CPU devices")
+  def test_explicit_reshard_before_assignment(self):
+    devices = ("CPU", "CPU:1")
+    a = Tensor.ones(4, 6, device="CPU").shard(devices, axis=0).realize()
+    values = np.arange(24, dtype=np.float32).reshape(4, 6)
+    b = Tensor(values, device="CPU:2").shard(("CPU:2", "CPU:3"), axis=0).realize()
+    rhs = b[:, 2:4].to("CPU:2").shard(devices, axis=0)
+    a[:, 1:3].assign(rhs).realize()
+    expected = np.ones((4, 6), dtype=np.float32)
+    expected[:, 1:3] = values[:, 2:4]
+    np.testing.assert_array_equal(a.numpy(), expected)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/unit/test_setitem_schedule.py
+++ b/test/unit/test_setitem_schedule.py
@@ -1,5 +1,5 @@
 import unittest
-from tinygrad import Tensor, Device, dtypes, GlobalCounters
+from tinygrad import Tensor, dtypes, GlobalCounters
 from test.helpers import assert_kernel_count
 
 class TestSetitemInto(unittest.TestCase):
@@ -139,15 +139,14 @@ class TestSetitemInto(unittest.TestCase):
     assert_kernel_count(1)
     self.assertEqual(GlobalCounters.global_mem, 100*4)  # full buffer written
 
-  @unittest.skipUnless(Device.DEFAULT != "CPU", "source must be on another device")
   def test_setitem_slice_assign_from_other_device(self):
-    # NOTE: this is 2 kernels, the cross-device copy should fuse with the assign into one
+    # Two logical CPU devices exercise the cross-device copy without requiring a GPU.
     a = Tensor.ones(20, device="CPU")
-    b = Tensor.arange(20).float().clone()
+    b = Tensor.arange(20).float().clone(device="CPU:1")
     Tensor.realize(a, b)
     GlobalCounters.reset()
     a[10:12].assign(b[13:15].to(a.device)).realize()
-    assert_kernel_count(2)
+    assert_kernel_count(1)
     self.assertListEqual(a.tolist(), [1.0]*10 + [13.0, 14.0] + [1.0]*8)
 
 if __name__ == '__main__':

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, cast, get_args, ParamSpec, TypeVar, Generic, T
 if TYPE_CHECKING: import numpy
 from tinygrad.dtype import DType, DTypeLike, dtypes, ConstType, least_upper_dtype, to_dtype, _from_np_dtype, _to_np_dtype, PyConst, AddrSpace
 from tinygrad.helpers import all_int, getenv, fetch, Metadata, TRACEMETA, TracingKey, is_numpy_ndarray
-from tinygrad.helpers import cpu_profile, suppress_finalizing, disable_gc, VIZ, pluralize, SPEC
+from tinygrad.helpers import cpu_profile, suppress_finalizing, disable_gc, VIZ, pluralize, SPEC, canonicalize_strides, strides_for_shape
 from tinygrad.uop.ops import UOp, Ops, sint, all_metadata, Variable, ConstLike, UPat, PatternMatcher, GroupOp, graph_rewrite, rewrite_group
 from tinygrad.uop.ops import resolve_returned_after, remove_all_tags
 from tinygrad.uop.spec import type_verify, spec_tensor
@@ -89,6 +89,13 @@ def contiguous_mops_to_view(ctx:AllocCtx, c:UOp, src:UOp):
   view = view.reshape(c.shape)
   return c.replace(src=(view,)+c.src[1:]) if c.op in {Ops.COPY, Ops.STORE} else view
 
+def copy_destination_to_view(ctx:AllocCtx, c:UOp, dst:UOp):
+  # Restrict this optimization to dense single-device storage with static shapes.
+  if not isinstance(dst.device, str) or not dst.src[0].has_buffer_identity(after_ok=True) or not all_int(dst.shape+dst.src[0].shape): return None
+  # SHRINK preserves its parent's strides; dimensions of length one do not constrain contiguity.
+  if strides_for_shape(dst.shape) != canonicalize_strides(dst.shape, strides_for_shape(dst.src[0].shape)): return None
+  return contiguous_mops_to_view(ctx, c, dst)
+
 def transform_precompiled_call(c:UOp) -> UOp|None:
   if c.arg is None or not c.arg.precompile or not c.has_unbound_outputs: return None
   assert c.src[0].op is Ops.SINK, "precompiled call bodies are SINKs of stores into the output PARAMs"
@@ -144,6 +151,8 @@ pm_early_transform_tensor_graph = PatternMatcher([
   # fold MOPS+BITCAST over BUFFER into SHRINK when movement ops collapse to contiguous range
   (UPat((Ops.COPY, Ops.CONTIGUOUS), src=(UPat(GroupOp.Movement|{Ops.BITCAST}, name="src"),), name="c"), contiguous_mops_to_view),
   (UPat(Ops.STORE, src=(UPat(Ops.BITCAST, name="src"), UPat()), name="c", allow_any_len=True), contiguous_mops_to_view),
+  # Bind a contiguous copy destination as a view, reusing the existing full-buffer COPY path.
+  (UPat(Ops.STORE, src=(UPat(Ops.SHRINK, name="dst"), UPat(Ops.COPY)), name="c"), copy_destination_to_view),
 
   # remove contiguous on movement ops before a copy on disk
   (UPat(GroupOp.Movement-{Ops.SHRINK, Ops.RESHAPE}, name="x").f(Ops.CONTIGUOUS).f(Ops.COPY, name="copy"), lambda x,copy:


### PR DESCRIPTION
An eligible cross-device sliced assignment currently copies into a temporary destination and then stores into the target slice. Bind dense, static, single-device SHRINK destinations through the existing `contiguous_mops_to_view` helper so COPY writes directly into the target region. The stride prefilter uses existing helpers; final view validation, ownership and creation-copy behavior remain unchanged. The production change adds nine net lines in tensor.py.

Validation on `8b636f3`:

- All five project pre-commit checks passed; the example hook was rerun after correcting the new environment's package installation.
- Process replay passed with assertions enabled for 2,736 captured code-generation records.
- Dedicated tests passed on CPU, physical CUDA, both NVIDIA mock backends and all six AMD mock configurations. Each configuration covers 197 subtests; two CPU-only sharding tests run on CPU and skip elsewhere.
- On an RTX 3060 Ti, five alternating process pairs measuring synchronized 8-byte and 1-MiB copies in both CPU/CUDA directions reduced median latency by 26–37% for ordinary execution and 46–56% with TinyJit. Eligible transfers execute once instead of twice; gapped transfers retain three executions and show no consistent timing improvement.

The stride helpers retain integer metadata without a capacity limit. A 1000-layout graph-only probe retained about 4.09 MiB more Python memory than the unmodified baseline; repeated layouts stabilized and tracked UOp/Buffer objects were collected. PYTHON creation sources retain their two-step behavior. Real AMD, NV/HCQ, multi-GPU/P2P and model throughput are not covered.

Context: [#18099](https://github.com/tinygrad/tinygrad/pull/18099); a related target-view approach exists in closed, unmerged [#18113](https://github.com/tinygrad/tinygrad/pull/18113).

AI was used to develop the implementation and tests, research alternatives, review code, and run and analyze local validation.
