### PR TITLE
[PR] Fuse contiguous sliced assignments across devices

### DIFF
--- a/test/backend/test_schedule.py
+++ b/test/backend/test_schedule.py
@@ -150,6 +150,15 @@ class TestSchedule(unittest.TestCase):
     run_linear(*check_schedule(out, 3))
     np.testing.assert_equal(out.numpy(), [4.])
 
+  def test_shrink_copy(self):
+    a = Tensor.arange(4).clone("CPU:1").realize()
+    b = a.to("CPU:2").shrink(((1, 3),)).to("CPU:3")
+    GlobalCounters.reset()
+    run_linear(*check_schedule(b, 2, filter_sink=False))
+    # copy the source slice directly from its buffer offset
+    self.assertEqual(GlobalCounters.global_mem, 4*4 + 2*4)
+    self.assertListEqual(b.tolist(), [1, 2])
+
 class TestLimitBufs(unittest.TestCase):
   @unittest.skipIf(DEV.interface.startswith("MOCK") and Device.DEFAULT == "NV", "crashes in ocelot")
   def test_limit_bufs_with_var(self):
@@ -377,15 +386,6 @@ class TestCopyFolding(unittest.TestCase):
   def test_clone(self):
     a = Tensor.empty(4)
     check_schedule(a.clone(), 1, filter_sink=False)
-
-  def test_shrink_copy(self):
-    a = Tensor.arange(4).clone("CPU:1").realize()
-    b = a.to("CPU:2").shrink(((1, 3),)).to("CPU:3")
-    GlobalCounters.reset()
-    run_linear(*check_schedule(b, 3, filter_sink=False))
-    # extra E kernel, copy exactly 4 bytes
-    self.assertEqual(GlobalCounters.global_mem, 4*4 + 2*4*2 + 2*4)
-    self.assertListEqual(b.tolist(), [1, 2])
 
   def test_expanded_copy(self):
     a = Tensor.arange(4).clone("CPU:1").realize()

--- a/test/null/test_memory_planner.py
+++ b/test/null/test_memory_planner.py
@@ -232,6 +232,31 @@ class TestMemoryPlanner(unittest.TestCase):
     ]
     check_assign(bs, copies=[(b(1), b(0)), (b(2), b(0))])
 
+  def test_sliced_copy_keeps_backing_buffer_live(self):
+    a, other = [UOp.new_buffer("NULL", 256, dtypes.uint8) for _ in range(2)]
+    dst = UOp.new_buffer("NULL:1", 256, dtypes.uint8)
+    linear = UOp(Ops.LINEAR, src=(
+      a.copy_to_device(dst.device).call(dst, a),
+      UOp.sink().call(dst),
+      other.copy_to_device(dst.device).call(dst, other),
+      a[16:32].copy_to_device(dst.device).call(dst[:16], a[16:32]),
+    ))
+    result = memory_plan_rewrite(linear, {dst})
+    a_view, other_view = result.src[0].src[2].contiguous_view(), result.src[2].src[2].contiguous_view()
+    assert a_view is not None and other_view is not None
+    self.assertIs(a_view[0], other_view[0])
+    self.assertGreaterEqual(abs(a_view[1] - other_view[1]), a.nbytes())
+
+  def test_sliced_copy_uses_copy_lane(self):
+    a, compute = [UOp.new_buffer("NULL", 64, dtypes.float32) for _ in range(2)]
+    dst = UOp.new_buffer("NULL:1", 32, dtypes.uint8)
+    view = a[4:12].bitcast(dtypes.uint8)
+    linear = UOp(Ops.LINEAR, src=(UOp.sink().call(a, compute), view.copy_to_device(dst.device).call(dst, view)))
+    result = memory_plan_rewrite(linear, {dst})
+    copy_view, compute_view = result.src[0].src[1].contiguous_view(), result.src[0].src[2].contiguous_view()
+    assert copy_view is not None and compute_view is not None
+    self.assertIsNot(copy_view[0], compute_view[0])
+
   def test_copy_bufs_pinned_mixed(self):
     bs = [
       [b(0, pin=True), b(1), b(2)],

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -248,6 +248,14 @@ class TestDiskTensor(TempDirTestCase):
     out = t[1].to(Device.DEFAULT).tolist()
     assert out == list(range(16, 32))
 
+  def test_copy_slice_and_read_source(self):
+    source = Tensor(list(range(20)), device="CPU").to(f"DISK:{self.tmp('source')}").realize()
+    copied = source[2:10].to(f"DISK:{self.tmp('copy')}")
+    read = source[3:7].to("CPU")
+    Tensor.realize(copied, read)
+    self.assertEqual(copied.to("CPU").tolist(), list(range(2, 10)))
+    self.assertEqual(read.tolist(), [3, 4, 5, 6])
+
   def test_simple_read_bitcast(self):
     fn = pathlib.Path(self.tmp("dt_simple_read_bitcast"))
     fn.write_bytes(bytes(range(256))*2)

--- a/test/unit/test_jit.py
+++ b/test/unit/test_jit.py
@@ -1,7 +1,7 @@
 import unittest, numpy as np
 from test.helpers import assert_jit_cache_len
 from tinygrad import Tensor, TinyJit, Context, UOp, dtypes
-from tinygrad.engine.jit import JitError
+from tinygrad.engine.jit import JitError, MultiGraphRunner
 
 def _simple_test(add, extract=lambda x: x, N=10):
   for _ in range(5):
@@ -422,6 +422,22 @@ class TestJitInsideJit(unittest.TestCase):
     g(Tensor([1])).realize()
     with self.assertRaisesRegex(RuntimeError, "having TinyJit inside another TinyJit is not supported"):
       g(Tensor([1])).realize()
+
+class TestMultiGraphRunner(unittest.TestCase):
+  def test_copy_input_views(self):
+    dst = UOp.new_buffer("NULL", 20, dtypes.float32)
+    src = UOp.new_buffer("NULL:1", 20, dtypes.float32)
+    dst_param = UOp.param(0, dtypes.float32, 20, "NULL")
+    src_param = UOp.param(1, dtypes.float32, 20, "NULL:1")
+    for name, dest, source, supported in [
+      ("buffers", dst[10:12], src[13:15], True),
+      ("direct inputs", dst_param, src_param, True),
+      ("source view", dst[10:12], src_param[13:15], False),
+      ("destination view", dst_param[10:12], src[13:15], False),
+      ("bitcast source view", dst[10:12].bitcast(dtypes.uint8), src_param[13:15].bitcast(dtypes.uint8), False),
+    ]:
+      with self.subTest(name=name):
+        self.assertEqual(MultiGraphRunner.supports_uop([], source.copy_to_device(dest.device).call(dest, source)), supported)
 
 class TestJitRandom(unittest.TestCase):
   def test_jit_rangeify(self):

--- a/test/unit/test_setitem_schedule.py
+++ b/test/unit/test_setitem_schedule.py
@@ -1,5 +1,5 @@
 import unittest
-from tinygrad import Tensor, Device, dtypes, GlobalCounters
+from tinygrad import Tensor, Device, TinyJit, Variable, dtypes, GlobalCounters
 from test.helpers import assert_kernel_count
 
 class TestSetitemInto(unittest.TestCase):
@@ -139,16 +139,97 @@ class TestSetitemInto(unittest.TestCase):
     assert_kernel_count(1)
     self.assertEqual(GlobalCounters.global_mem, 100*4)  # full buffer written
 
-  @unittest.skipUnless(Device.DEFAULT != "CPU", "source must be on another device")
   def test_setitem_slice_assign_from_other_device(self):
-    # NOTE: this is 2 kernels, the cross-device copy should fuse with the assign into one
-    a = Tensor.ones(20, device="CPU")
-    b = Tensor.arange(20).float().clone()
-    Tensor.realize(a, b)
+    for device in ("CPU:1", Device.DEFAULT):
+      if device == "CPU": continue
+      with self.subTest(device=device):
+        a = Tensor.ones(20, device="CPU")
+        b = Tensor.arange(20).float().clone(device=device)
+        Tensor.realize(a, b)
+        GlobalCounters.reset()
+        a[10:12].assign(b[13:15].to(a.device)).realize()
+        # creation copies retain their own storage; backends without views materialize the source slice
+        assert_kernel_count(2 if device.split(":")[0] in {"PYTHON", "NPY", "CL", "WEBGPU"} else 1)
+        self.assertListEqual(a.tolist(), [1.0]*10 + [13.0, 14.0] + [1.0]*8)
+
+class TestSlicedCopy(unittest.TestCase):
+  def test_contiguous(self):
+    for size in (1, 2, 8, 20):
+      for dst_offset in (0, 20-size):
+        for src_offset in (0, 20-size):
+          with self.subTest(size=size, dst_offset=dst_offset, src_offset=src_offset):
+            a = Tensor([-1]*20, device="CPU").realize()
+            b = Tensor(list(range(20)), device="CPU:1").realize()
+            GlobalCounters.reset()
+            a[dst_offset:dst_offset+size].assign(b[src_offset:src_offset+size].to(a.device)).realize()
+            assert_kernel_count(1)
+            self.assertEqual(GlobalCounters.global_mem, size * a.dtype.itemsize)
+            self.assertListEqual(a.tolist(), [-1]*dst_offset + list(range(src_offset, src_offset+size)) + [-1]*(20-dst_offset-size))
+
+  def test_noncontiguous_destination(self):
+    a = Tensor([-1]*20, device="CPU").realize()
+    b = Tensor(list(range(10)), device="CPU:1").realize()
+    a[::2].assign(b.to(a.device)).realize()
+    self.assertListEqual(a.tolist(), [x for i in range(10) for x in (i, -1)])
+
+  def test_noncontiguous_source(self):
+    a = Tensor([-1]*20, device="CPU").realize()
+    b = Tensor(list(range(20)), device="CPU:1").realize()
+    a[5:15].assign(b[::2].to(a.device)).realize()
+    self.assertListEqual(a.tolist(), [-1]*5 + list(range(0, 20, 2)) + [-1]*5)
+
+  def test_reshaped_destination(self):
+    a = Tensor([-1]*20, device="CPU").reshape(4, 5).realize()
+    b = Tensor(list(range(20)), device="CPU:1").reshape(4, 5).realize()
     GlobalCounters.reset()
-    a[10:12].assign(b[13:15].to(a.device)).realize()
-    assert_kernel_count(2)
-    self.assertListEqual(a.tolist(), [1.0]*10 + [13.0, 14.0] + [1.0]*8)
+    a[1:3].assign(b[2:4].to(a.device)).realize()
+    assert_kernel_count(1)
+    self.assertListEqual(a.flatten().tolist(), [-1]*5 + list(range(10, 20)) + [-1]*5)
+
+  def test_symbolic_destination(self):
+    for size in (1, 3, 10):
+      a = Tensor([-1]*20, device="CPU").realize()
+      b = Tensor(list(range(20)), device="CPU:1").realize()
+      v = Variable("size", 1, 10).bind(size)
+      a[5:5+v].assign(b[:v].to(a.device)).realize()
+      self.assertListEqual(a.tolist(), [-1]*5 + list(range(size)) + [-1]*(15-size))
+
+  def test_source_write_ordering(self):
+    a = Tensor([-1]*20, device="CPU").realize()
+    b = Tensor(list(range(20)), device="CPU:1").realize()
+    a[10:12].assign(b[13:15].to(a.device))
+    b.assign(b + 100)
+    Tensor.realize(a, b)
+    self.assertListEqual(a.tolist(), [-1]*10 + [13, 14] + [-1]*8)
+    self.assertListEqual(b.tolist(), list(range(100, 120)))
+
+  def test_pending_destination_source_write_ordering(self):
+    a = Tensor([-1]*20, device="CPU").realize()
+    b = Tensor(list(range(20)), device="CPU:1").realize()
+    a.assign(a + 9)
+    a[3:7].assign(b[5:9].to(a.device))
+    b.assign(b + 200)
+    Tensor.realize(a, b)
+    self.assertListEqual(a.tolist(), [8]*3 + [5, 6, 7, 8] + [8]*13)
+    self.assertListEqual(b.tolist(), list(range(200, 220)))
+
+  def test_bitcast_source_write_ordering(self):
+    a = Tensor([-1.0]*20, device="CPU").realize()
+    b = Tensor.arange(20).float().clone(device="CPU:1").bitcast(dtypes.int32).contiguous().realize()
+    a[3:7].assign(b.bitcast(dtypes.float32)[5:9].to(a.device))
+    b.assign(b + 1)
+    Tensor.realize(a, b)
+    self.assertListEqual(a.tolist(), [-1.0]*3 + [5.0, 6.0, 7.0, 8.0] + [-1.0]*13)
+
+  def test_jit_new_buffers(self):
+    @TinyJit
+    def copy_slice(a, b):
+      return a[10:12].assign(b[13:15].to(a.device)).realize()
+    for i in range(5):
+      a = Tensor([-1]*20, device="CPU").realize()
+      b = Tensor([x+i for x in range(20)], device="CPU:1").realize()
+      copy_slice(a, b)
+      self.assertListEqual(a.tolist(), [-1]*10 + [13+i, 14+i] + [-1]*8)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -154,6 +154,9 @@ class GraphRunner:
 class MultiGraphRunner(GraphRunner):
   @staticmethod
   def supports_uop(batch_devs:list[Compiled], new_call:UOp) -> bool:
+    # Graph replay updates direct PARAM arguments only; views of inputs must use the ordinary copy runner.
+    if new_call.src[0].op is Ops.COPY and any(b.op is not Ops.PARAM and b.op_in_backward_slice_with_self(Ops.PARAM)
+                                            for b in get_call_arg_uops(new_call)): return False
     # Devices must be the same type
     return new_call.src[0].op in (Ops.PROGRAM, Ops.COPY) and len(dedup([type(d) for d in GraphRunner._all_devs(batch_devs, new_call)])) == 1
 

--- a/tinygrad/schedule/__init__.py
+++ b/tinygrad/schedule/__init__.py
@@ -154,7 +154,23 @@ def assert_all_same_devices(ast:UOp):
 
 def copy_kernel_to_copy_uop(call:UOp, dst:UOp, src:UOp, r:UOp|None=None):
   if dst.device == src.device and not (isinstance(dst.device, str) and dst.device.startswith("DISK")): return None
+  size = 1 if r is None else r.src[0].ssimplify()
+  if dst.arg.size != size or src.arg.size != size: return None
   return call.replace(src=(UOp(Ops.COPY, src=(src,), arg=dst.device),) + call.src[1:])
+
+def copy_kernel_with_offset(call:UOp, dst:UOp, src:UOp, r:UOp|None=None):
+  if dst.device == src.device: return None
+  size = 1 if r is None else r.src[0].ssimplify()
+  if not isinstance(size, int) or size <= 0: return None
+  views = []
+  for x in (dst, src):
+    if not isinstance(off:=(x.src[1] - (r if r is not None else 0)).ssimplify(), int): return None
+    buf = call.src[1+x.src[0].arg.slot]
+    if off < 0 or off+size > buf.max_numel(): return None
+    view = buf[off:off+size]
+    if view.contiguous_view() is None: return None
+    views.append(view)
+  return call.replace(src=(UOp(Ops.COPY, src=(src.src[0],), arg=dst.device),) + tuple(views))
 
 def simplify_copy_kernel(call:UOp, ast:UOp, dst:UOp, src:UOp):
   # NOTE: this is a codegen for SDMA devices
@@ -176,6 +192,14 @@ pm_copy_from_store = PatternMatcher([
   (UPat(Ops.CALL, src=(UPat(Ops.PARAM, name="dst").index(UPat(Ops.RANGE, name="r"))
                 .store(UPat(Ops.PARAM, name="src").index(UPat(Ops.RANGE, name="r"))).end(UPat(Ops.RANGE, name="r")).sink(),),
                 name="call", allow_any_len=True), copy_kernel_to_copy_uop),
+
+  # contiguous subranges copy directly through buffer views, preserving the surrounding destination elements
+  (UPat(Ops.CALL, src=(UPat(Ops.PARAM).index(UPat(), name="dst")
+                .store(UPat(Ops.PARAM).index(UPat(), name="src")).end(UPat(Ops.RANGE, name="r")).sink(),),
+                name="call", allow_any_len=True), copy_kernel_with_offset),
+  (UPat(Ops.CALL, src=(UPat(Ops.PARAM).index(UPat(), name="dst")
+                .store(UPat(Ops.PARAM).index(UPat(), name="src")).sink(),),
+                name="call", allow_any_len=True), copy_kernel_with_offset),
 
   # if it wasn't copy, it currently can't be cross device
   (UPat(Ops.CALL, src=(UPat(Ops.SINK, name="ast"),), allow_any_len=True), assert_all_same_devices),
@@ -209,5 +233,5 @@ def create_linear_with_vars(big_sink:UOp) -> tuple[UOp, dict[str, int]]:
     capturing[0].add_linear(linear, var_vals)
     return UOp(Ops.LINEAR, src=()), var_vals
 
-  held_bufs = ({b for b in linear_call.src[1:] if b.op is Ops.BUFFER} if linear_call.op is Ops.CALL else set())
+  held_bufs = ({b for a in linear_call.src[1:] for b in a.toposort() if b.op is Ops.BUFFER} if linear_call.op is Ops.CALL else set())
   return memory_plan_rewrite(linear, held_bufs), var_vals

--- a/tinygrad/schedule/indexing.py
+++ b/tinygrad/schedule/indexing.py
@@ -32,6 +32,7 @@ def realize_srcs(ctx:IndexingContext, rb:UOp) -> None:
     if s.base.op not in ALWAYS_CONTIGUOUS: ctx.realize_map[s] = None
 
 def is_copy_view(x:UOp) -> bool:
+  if not x.storage_base.has_buffer_identity(after_ok=True): return False
   if not all_int(x.shape) or (cv:=x.contiguous_view()) is None: return False
   return cv[0].dtype == x.dtype and cv[0].has_buffer_identity(after_ok=True)
 

--- a/tinygrad/schedule/indexing.py
+++ b/tinygrad/schedule/indexing.py
@@ -5,7 +5,7 @@ from tinygrad.dtype import dtypes, AddrSpace
 from tinygrad.uop.ops import PatternMatcher, UPat, Ops, UOp, resolve, GroupOp, graph_rewrite, sint, AxisType, rewrite_group, broadcast_axes
 from tinygrad.uop.ops import gate_kernel_sink
 from tinygrad.uop.symbolic import symbolic, pm_simplify_valid, pm_drop_and_clauses
-from tinygrad.helpers import argsort, all_same, cpu_profile, colored, Context, SPEC
+from tinygrad.helpers import argsort, all_same, all_int, cpu_profile, colored, Context, SPEC
 
 @dataclass
 class IndexingContext:
@@ -31,12 +31,17 @@ def realize_srcs(ctx:IndexingContext, rb:UOp) -> None:
   for s in rb.src:
     if s.base.op not in ALWAYS_CONTIGUOUS: ctx.realize_map[s] = None
 
+def is_copy_view(x:UOp) -> bool:
+  if not all_int(x.shape) or (cv:=x.contiguous_view()) is None: return False
+  return cv[0].dtype == x.dtype and cv[0].has_buffer_identity(after_ok=True)
+
 def realize_store_after_src(ctx:IndexingContext, dest:UOp, src:UOp):
   # you don't usually have to do this for assign unless there's a WAR hazard like TestAssign.test_assign_double_diamond_reduce
   if dest.base in src.toposort(enter_calls=False): ctx.realize_map[src] = None
-  # the source of a cross device STORE is materialized on its own device first: the STORE itself is the copy
+  # materialize cross-device values unless they already name the whole source buffer: the STORE itself is the copy
   # NOTE: buffer identity views (shard views with max_shape != shape) must be materialized too, copies can't read them
-  if src.device is not None and dest.device != src.device:
+  if src.device is not None and dest.device != src.device and not ((src.has_buffer_identity(after_ok=True) and src.shape == src.max_shape)
+                                                                 or is_copy_view(src)):
     ctx.realize_map[src] = ctx.non_removable[src] = None
 
 def realize_custom_kernel_srcs(ctx:IndexingContext, c:UOp) -> None:

--- a/tinygrad/schedule/memory.py
+++ b/tinygrad/schedule/memory.py
@@ -6,6 +6,7 @@ from tinygrad.runtime.support.memory import TLSFAllocator
 
 def _collect_bufs(u:UOp) -> list[UOp]:
   if u.op is Ops.BUFFER: return [u]
+  if u.op in {Ops.SHRINK, Ops.BITCAST}: return _collect_bufs(u.src[0])
   if u.op in {Ops.MSELECT, Ops.MSTACK}: return [b for s in u.src for b in _collect_bufs(s)]
   return []
 

--- a/tinygrad/schedule/prepare.py
+++ b/tinygrad/schedule/prepare.py
@@ -3,7 +3,7 @@ from tinygrad.uop.ops import PatternMatcher, UPat, Ops, UOp, resolve, GroupOp
 from tinygrad.uop.ops import graph_rewrite, rewrite_group, identity_element, resolve_returned_after
 from tinygrad.uop.movement import mop_cleanup
 from tinygrad.helpers import prod, getenv, all_int, DEBUG, SPLIT_REDUCEOP, OPENPILOT_HACKS, FLOAT16, argsort
-from tinygrad.schedule.indexing import apply_movement_op
+from tinygrad.schedule.indexing import apply_movement_op, is_copy_view
 from tinygrad.schedule.allreduce import create_allreduce_function
 from tinygrad.schedule.multi import multi_pm
 
@@ -132,7 +132,7 @@ def expand_bitcast(bc:UOp) -> UOp|None:
 
 def copy_to_anon_store(x:UOp, copy:UOp):
   # the buffer created here is inside the call and is not persisted, like the buffers created for contiguous
-  # copies must read from a whole buffer, not a view: materialize anything lacking buffer identity (SDMA can't do offset copies)
+  # materialize sources without buffer identity; input buffer views already have their own PARAM
   if not x.has_buffer_identity(after_ok=True): x = x.contiguous()
   buf = UOp.new_buffer(copy.device, prod(x.max_shape), copy.dtype).reshape(x.max_shape)
   return buf.after(buf.store(x)).reshape(copy.shape)
@@ -161,9 +161,9 @@ earliest_rewrites = mop_cleanup+PatternMatcher([
   # copy to same device is a no-op
   (UPat(Ops.COPY, src=(UPat.var("x"),), name="copy"), lambda x,copy: x if x.device == copy.device else None),
 
-  # a COPY in src[1] of a plain STORE can just be removed: a STORE to a buffer on a different device is a COPY
+  # a COPY feeding a contiguous STORE can target the destination buffer directly
   (UPat(Ops.STORE, src=(UPat.var("dst"), UPat(Ops.COPY, src=(UPat.var("x"),), name="cpy"))),
-   lambda dst,x,cpy: dst.store(x) if dst.device == cpy.device and dst.has_buffer_identity(after_ok=True) else None),
+   lambda dst,x,cpy: dst.store(x) if dst.device == cpy.device and (dst.has_buffer_identity(after_ok=True) or is_copy_view(dst)) else None),
 
   # a bare COPY is an anonymous store: realize it as a STORE into a fresh call-local buffer on the copy device
   (UPat(Ops.COPY, src=(UPat.var("x"),), name="copy"), copy_to_anon_store),

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -228,6 +228,9 @@ def transform_to_call(big_sink:UOp) -> tuple[UOp, dict[UOp, UOp]]:
         (not u.src[0].unsharded_base.is_unbound or u.src[1].op is Ops.STORE)):
       ctx.stores.append(u)
       if u.tag: ctx.buffer_map.update({t:graph_rewrite(u.src[0], pm_drop_after).shrink_to(t.shape) for t in u.tag})
+  # views of written buffers must share their base PARAM so the scheduler can order reads before writes
+  written = {s.buf_uop for s in ctx.stores}
+  ctx.views = {v for v in ctx.views if v.buf_uop not in written}
   ret = graph_rewrite(UOp.sink(*ctx.stores), pm_replace_buf+remove_all_tags, ctx=ctx, bottom_up=True, name="replace bufs").call(*ctx.replacements)
   assert not any(x in ctx.buffer_map for x in ctx.buffer_map.values())
   if VIZ: graph_rewrite(ret, PatternMatcher([]), name="View Call")

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -229,7 +229,7 @@ def transform_to_call(big_sink:UOp) -> tuple[UOp, dict[UOp, UOp]]:
       ctx.stores.append(u)
       if u.tag: ctx.buffer_map.update({t:graph_rewrite(u.src[0], pm_drop_after).shrink_to(t.shape) for t in u.tag})
   # views of written buffers must share their base PARAM so the scheduler can order reads before writes
-  written = {s.buf_uop for s in ctx.stores}
+  written = {s.buf_uop for s in ctx.stores if s.op is Ops.AFTER}
   ctx.views = {v for v in ctx.views if v.buf_uop not in written}
   ret = graph_rewrite(UOp.sink(*ctx.stores), pm_replace_buf+remove_all_tags, ctx=ctx, bottom_up=True, name="replace bufs").call(*ctx.replacements)
   assert not any(x in ctx.buffer_map for x in ctx.buffer_map.values())


### PR DESCRIPTION
The sliced assignment added in [b45cee5](https://github.com/tinygrad/tinygrad/commit/b45cee5ccd127266a70a8fed14ebe43196f7d95d)
currently copies into temporary storage and then writes the destination slice. This change lowers eligible
static contiguous assignments to one COPY using source and destination buffer offsets, preserving the
surrounding destination values and removing the intermediate copy/write from that case.

The lowering checks concrete sizes and bounds and reuses buffer views. It checks storage identity before
view analysis so computed sources do not trigger expensive graph rewrites. Views of written buffers retain
their base parameter so the scheduler preserves read-before-write ordering; memory planning follows the
backing allocations. COPY-to-DISK sources retain their view parameters because these copies are not write
effects on the source. JIT copies with arguments derived from input parameters, including views and device
selections, use ordinary replay because graph argument replacement only updates direct parameters. Symbolic/noncontiguous writes,
unsupported dtype views, and backends without suitable storage views retain their fallback paths.

Initial validation at `d7bde2da0633e5daeb46a61cc0702453ca7ec401`, based on
`7f40887c6ca9e869582352e37fc68455a47a24f3`, on Apple M1 Max,
macOS 26.6.2, Python 3.11.3:

- CPU `SPEC=2`, `test/unit test/backend test/opt`, excluding separately tested custom kernels:
  2,084 passed, 484 skipped, 18 expected failures. `MAX_BUFFER_SIZE=300000000` elements.
- NULL `SPEC=2`: 1,526 passed, 78 skipped, 16 expected failures.
- Native Metal setitem scheduling, assignment and unit JIT: 179 passed, 4 skipped.
- CPU custom kernels `SPEC=0`: 54 passed, 9 skipped. PYTHON setitem scheduling: 22 passed.
- Assertion-enabled process replay against `7f40887c6ca9e869582352e37fc68455a47a24f3`:
  3,415 captured CPU kernels, no differences. The intended schedule change is two operations to one.
- Ruff, mypy, tiny/device hooks, changed-file indentation checks, line-count limit, and ResNet50 scheduling
  passed. The comprehensive commit hook was covered by the broader suites run separately with `-n12`.
- UOp GC passes all 19 cases after initializing the CPU device. The raw CPU invocation fails at its first
  compiled kernel on both clean base and this change because lazy device initialization adds a persistent UOp.

A separate snapshot merging this branch with upstream `b496cd1910769ef86f502fc13fa3b3162d1ba7cf`
also passed focused integration checks: CPU setitem scheduling, DISK, JIT, memory planning, assignment
and setitem (290 passed, 13 skipped), and Metal setitem scheduling, assignment and JIT (179 passed,
4 skipped). The merge is conflict-free; the broader results above are from the original branch base.

CI follow-up in `ddbcaa6f0650ef7891088f93eb97c2d116ec37d5` corrects the existing shrink-copy test to
expect two operations and 24 bytes, and moves it to the CPU test group so CPU runs exercise it. It also
adds the early storage check described above, fixing the OpenClip scheduling timeout. Local validation:

- CPU schedule/copy/DISK/JIT/memory/assignment/setitem: 326 passed, 30 skipped.
- Metal schedule/copy/assignment/JIT: 229 passed, 7 skipped.
- Full NULL suite: 1,526 passed, 78 skipped, 16 expected failures. All four OpenClip cases passed
  with the original 120-second per-test limit.
- Comprehensive hook test set with `-n12`: 853 passed, 102 skipped, 1 expected failure.
- Fresh assertion-enabled replay: 222 captured CPU kernels, no differences against the same clean base.
- Ruff, mypy, tiny tests and available-device commit hooks passed. Claude CLI reviewed the correction;
  its coverage questions were checked with a trace of the timeout and an old/new eligibility comparison.

The initial QCOM compile-only job failed before test execution because the external compiler archive
URL returned sign-in HTML instead of the archive. A fresh request confirmed that redirect; the earlier
upstream run downloaded a valid archive from the same URL. No compiler download workaround is included.

The new regressions cover slice offsets and sizes, untouched destination values, fallback paths, pending
writes, bitcast source ordering, fresh JIT inputs, backing-buffer lifetime, graph eligibility, and simultaneous
sliced DISK-to-DISK copies with source reads to CPU. The original
regression also runs with an explicit CPU:1 source, enabling hardware-free coverage. The full upstream CI
and physical CUDA/AMD/QCOM runtime matrix have not been run locally.

Cached TinyJit host latency on the same machine (microseconds per call):

| Source → CPU | Slice | Base | Change |
| --- | ---: | ---: | ---: |
| CPU:1 | 8 B | 679.54 | 315.35 |
| CPU:1 | 64 KiB | 672.14 | 319.38 |
| METAL | 8 B | 682.03 | 314.90 |
| METAL | 64 KiB | 670.49 | 316.98 |

Base is `7f40887c6ca9e869582352e37fc68455a47a24f3`. Configuration was
`DEV=CPU SPEC=0 JIT=1 BEAM=0 SCACHE=1 NO_MEMORY_PLANNER=0 DEBUG=0`. Each source ran four processes in
base/change/change/base order. Each process used 50 warmup replays after three initial calls and seven
samples of 500 synchronized replays. The table reports the median of 14 sample means per variant.
The float32 buffers contained 20 elements for the 8-byte case (destination offset 10, source offset 13),
and 65,536 elements for the 64-KiB case (offsets 8,192 and 32,768). Full destination values were checked
before and after timing; eager/JIT operation counts were checked outside timing. These are cache-warm measurements including
Python replay overhead on shared-memory hardware, not discrete-GPU bandwidth results.

AI disclosure: Codex assisted with implementation, regression tests, debugging, test execution,
benchmarking, and review. Claude Code independently reviewed the diff and identified the DISK source-tracking
regression corrected here.
