### PR TITLE
tensor: raise ValueError on empty sequence in cat and stack

### DIFF
--- a/test/test_tiny.py
+++ b/test/test_tiny.py
@@ -35,6 +35,18 @@ class TestTiny(unittest.TestCase):
     out = Tensor.cat(Tensor.ones(8).contiguous(), Tensor.zeros(8).contiguous())
     self.assertListEqual(out.tolist(), [1]*8+[0]*8)
 
+  def test_cat_empty(self):
+    with self.assertRaisesRegex(ValueError, "cannot concatenate an empty sequence"):
+      Tensor.cat([])
+    with self.assertRaisesRegex(ValueError, "cannot concatenate an empty sequence"):
+      Tensor.cat(())
+
+  def test_stack_empty(self):
+    with self.assertRaisesRegex(ValueError, "cannot stack an empty sequence"):
+      Tensor.stack([])
+    with self.assertRaisesRegex(ValueError, "cannot stack an empty sequence"):
+      Tensor.stack(())
+
   def test_sum(self, N=getenv("SUM_N", 256)):
     out = Tensor.ones(N).contiguous().sum()
     self.assertEqual(out.item(), N)

--- a/tinygrad/mixin/movement.py
+++ b/tinygrad/mixin/movement.py
@@ -257,6 +257,7 @@ class MovementMixin:
   def stack(self, *args: Self, dim: int = 0) -> Self:
     """
     Concatenates self with other tensors in `args` along a new dimension specified by `dim`.
+    Raises a ValueError if the input sequence is empty.
 
     ```python exec="true" source="above" session="tensor" result="python"
     t0, t1, t2 = Tensor([1, 2]), Tensor([3, 4]), Tensor([5, 6])
@@ -267,6 +268,7 @@ class MovementMixin:
     ```
     """
     tensors = argfix(self, *args)
+    if not tensors: raise ValueError("cannot stack an empty sequence")
     dim = tensors[0]._resolve_dim(dim, extra=True)
     assert all(t.shape == tensors[0].shape for t in tensors), f"all shapes must match for stack, got {[t.shape for t in tensors]}"
     ret = tensors[0]._mop(Ops.STACK, arg=tuple(t._uop for t in tensors[1:]))

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -732,6 +732,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     """
     Concatenates self with other tensors in `args` along an axis specified by `dim`.
     All tensors must have the same shape except in the concatenating dimension.
+    Raises a ValueError if the input sequence is empty.
 
     ```python exec="true" source="above" session="tensor" result="python"
     t0, t1, t2 = Tensor([[1, 2]]), Tensor([[3, 4]]), Tensor([[5, 6]])
@@ -741,6 +742,9 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     print(t0.cat(t1, t2, dim=1).numpy())
     ```
     """
+    tensors = argfix(self, *args)
+    if not tensors: raise ValueError("cannot concatenate an empty sequence")
+    self, *args = tensors
     dim = self._resolve_dim(dim)
     for arg in args: assert arg.ndim==self.ndim and all(ti==ai for i,(ti,ai) in enumerate(zip(self.shape, arg.shape)) if i!=dim)
     tensors = [self, *args]


### PR DESCRIPTION
Explicitly validate that the sequence provided to Tensor.cat and Tensor.stack is non-empty before indexing or unpacking elements. When an empty list or tuple is passed, raise a ValueError stating that an empty sequence cannot be concatenated or stacked. Added targeted regression tests in test/test_tiny.py.

Validation observed for this change:
- `ruff check tinygrad/mixin/movement.py tinygrad/mixin/op.py test/test_tiny.py`
- `pytest test/test_tiny.py -k "test_cat_empty or test_stack_empty"`

<!-- repo-agent-case:5707a800-7238-4ece-a070-5bead2c2ef6b -->