### PR TITLE
fix var param numbering with unused call args

### DIFF
--- a/test/backend/test_custom_kernel.py
+++ b/test/backend/test_custom_kernel.py
@@ -8,6 +8,7 @@ from tinygrad.renderer import Target
 from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.renderer.llvmir import AMDLLVMRenderer
 from tinygrad.codegen import to_program
+from tinygrad.engine.realize import run_linear
 from test.helpers import assert_kernel_count, KernelCountException
 
 # **** kernels ****
@@ -31,6 +32,12 @@ def custom_elementwise_add_kernel(C:UOp, A:UOp, B:UOp) -> UOp:
   C,A,B = C.flatten(), A.flatten(), B.flatten()
   i = UOp.range(C.numel(), 0)
   return C[i].store(A[i]+B[i]).end(i).sink(arg=KernelInfo(name=f"custom_add_kernel_{C.numel()}")).simplify()
+
+def custom_scale_last_kernel(C:UOp, X:UOp, Y:UOp, A:UOp) -> UOp:
+  # X and Y are unused, n is left for codegen to number
+  n = UOp.param(-1, dtypes.int, vmin_vmax=(1, 10), name="n", addrspace=AddrSpace.ALU)
+  i = UOp.range(C.numel(), 0)
+  return C[i].store(A[i] * n.cast(A.dtype)).end(i).sink(arg=KernelInfo(name=f"custom_scale_last_{C.numel()}"))
 
 def custom_elementwise_addmul_kernel(C:UOp, D:UOp, A:UOp, B:UOp) -> UOp:
   C,D,A,B = C.flatten(), D.flatten(), A.flatten(), B.flatten()
@@ -130,6 +137,13 @@ class TestCustomKernel(unittest.TestCase):
     # webgpu silently errors when a kernel has duplicate buffer args, so the list stays the same.
     # https://gpuweb.github.io/gpuweb/#abstract-opdef-encoder-bind-groups-alias-a-writable-resource
     self.assertEqual(x.tolist(), [1, 2, 3, 4] if Device.DEFAULT != "WEBGPU" else [0, 1, 2, 3])
+
+  def test_unused_args_with_variable(self):
+    # the kernel only reads slots 0 and 3, the variable has to be numbered past both
+    a = Tensor([1., 2., 3., 4.]).contiguous().realize()
+    c = Tensor.custom_kernel(Tensor.empty(4), Tensor.empty(4), Tensor.empty(4), a, fxn=custom_scale_last_kernel)[0]
+    run_linear(c.schedule_linear(), var_vals={"n": 3})
+    self.assertEqual(c.tolist(), [3., 6., 9., 12.])
 
   def test_simple_sharded(self):
     devs = ("CPU:0", "CPU:1")

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -390,8 +390,8 @@ def full_rewrite_to_sink(ast:UOp, ren:Renderer, optimize:bool=True) -> UOp:
   # this was the linearizer
   sink = graph_rewrite(sink, pm_add_control_flow, ctx=CFGContext(sink), name="add control flow", bottom_up=True)
 
-  # put unnumbered variable PARAMs in slots
-  num_params = len([x for x in sink.toposort() if x.op is Ops.PARAM and x.arg.slot != -1])
+  # put unnumbered variable PARAMs in slots after the highest used one, a kernel can use a sparse subset of its call's buffers
+  num_params = max([x.arg.slot for x in sink.toposort() if x.op is Ops.PARAM and x.arg.slot >= 0], default=-1) + 1
   sink = graph_rewrite(sink, pm_number_params, ctx=[num_params], name="number params with -1", walk=True)
 
   if VIZ: graph_rewrite(sink, PatternMatcher([]), name="View Output AST")


### PR DESCRIPTION
unnumbered var params get numbered from the count of numbered params, not from the highest slot. a custom kernel that skips some of its call's buffers has sparse slots, so with buffers on 0 and 3 the var lands on slot 2, between them. the linearizer and the x86 abi both order params by slot and give [buf0, n, buf3], the runtime launches [buf0, buf3, n], so the kernel reads n as a pointer. with n=3 it reads address 0x3, clang x86 and llvm all segfault. with buffers on 0 and 2 the var collides with a buffer slot.

numbering from the highest slot + 1 keeps vars after every buffer, which is what the launchers already assume.

this came in with #16640, and test_custom_kernel had no kernel with both unused args and a variable.

test: python -m pytest test/backend/test_custom_kernel.py -k test_unused_args_with_variable
