### PR TITLE
Fix USB3 bulkwrite bug

### DIFF
--- a/test/mockgpu/usb.py
+++ b/test/mockgpu/usb.py
@@ -191,14 +191,15 @@ class MockUSB3:
   def bulk_write(self, data:bytes, timeout:int=1000):
     assert self._bulk_write_op is not None
     op, address, size = self._bulk_write_op
-    assert len(data) == size
+    assert len(data) <= size
     if op == "sram_write":
       ctrl, (host_addr, region_size) = next((ca, r) for ca, r in self.state._dma_regions.items() if ca <= address < ca + r[1])
       ctypes.memmove(host_addr + (address - ctrl), data, min(len(data), region_size - (address - ctrl)))
       self.state.driver._emulate_execute()  # landed data may un-stall a ring polling on it (e.g. copyin sentinels)
     elif op == "pcie_write": self.state._pcie_write(address, data)
     else: raise RuntimeError(f"cannot bulk write for {op}")
-    self._bulk_write_op = None
+
+    self._bulk_write_op = (op, address + len(data), size - len(data)) if len(data) < size else None
 
   def bulk_write_async(self, payload:memoryview, timeout:int=10000) -> int:  # the mock completes transfers synchronously
     self.bulk_write(bytes(payload), timeout)

--- a/test/mockgpu/usb.py
+++ b/test/mockgpu/usb.py
@@ -198,7 +198,6 @@ class MockUSB3:
       self.state.driver._emulate_execute()  # landed data may un-stall a ring polling on it (e.g. copyin sentinels)
     elif op == "pcie_write": self.state._pcie_write(address, data)
     else: raise RuntimeError(f"cannot bulk write for {op}")
-
     self._bulk_write_op = (op, address + len(data), size - len(data)) if len(data) < size else None
 
   def bulk_write_async(self, payload:memoryview, timeout:int=10000) -> int:  # the mock completes transfers synchronously

--- a/tinygrad/runtime/support/usb.py
+++ b/tinygrad/runtime/support/usb.py
@@ -187,7 +187,8 @@ class CustomASM24Controller:
     if not data: return
     assert len(data) % 4 == 0, f"pcie_mem_write requires 4-byte aligned size, got {len(data)}"
     self._f0_out(0x60, 0x0F, address, len(data) // 4, mode=1)
-    self.usb.bulk_write(data)
+    chunk_size = 1 << 20
+    for off in range(0, len(data), chunk_size): self.usb.bulk_write(data[off:off + chunk_size])
 
   def pcie_mem_read(self, address:int, nbytes:int) -> memoryview:
     """Streaming PCIe memory read via 0xF0 mode 2 + bulk IN. Returns little-endian bytes."""


### PR DESCRIPTION
Potential fix for #18136

We just chunk `pcie_mem_write` into `usb.bulk_write`s of 1mb instead of writing all at once which works. Also had to modify the mock to account for this change.

If this feels too hacky feel free to close, but hcq2 support is currently broken with USB3 and AMD. 