### PR TITLE
fix var of int input

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1670,6 +1670,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([(15, 25, 35)], lambda x: x.var())
     helper_test_op([(15, 25, 35)], lambda x: x.var(correction=0))
     helper_test_op([(15, 25, 35)], lambda x: x.var(correction=5))
+    helper_test_op(None, lambda x: x.float().var(), lambda x: x.var(), vals=[[1, 2, 3, 4]], forward_only=True)
     # TODO: fix this
     # helper_test_op([(10, 2)], lambda x: x.var(correction=50))
   @slow_test

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -545,7 +545,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     output_dtype = self.dtype if dtypes.is_float(self.dtype) else dtypes.float32
     squares = (self - self.mean(axis=axis, keepdim=True)).square()
     n = prod([si for si, so in zip(self.shape, squares.sum(axis=axis, keepdim=True).shape) if resolve(si != so)])
-    numerator = squares.cast(sum_acc_dtype(self.commit_dtype())).sum(axis=axis, keepdim=keepdim)
+    numerator = squares.cast(sum_acc_dtype(squares.dtype)).sum(axis=axis, keepdim=keepdim)
     return numerator.div(smax(n - correction, 0)).cast(output_dtype)
 
   def var_mean(self, axis:int|Sequence[int]|None=None, keepdim=False, correction=1) -> tuple[Self, Self]:


### PR DESCRIPTION
Since #17444 var casts the float squared deviations to the int accumulator of the input dtype, so Tensor([1,2]).var() is 0. test_var only used float input.
