### PR TITLE
add generic associative scan

### DIFF
--- a/test/test_associative_scan.py
+++ b/test/test_associative_scan.py
@@ -1,0 +1,28 @@
+import unittest
+from tinygrad import Tensor
+
+class TestAssociativeScan(unittest.TestCase):
+  def test_add_lengths(self):
+    for n in range(1, 33):
+      x = Tensor(list(range(1, n+1)), device="PYTHON")
+      self.assertEqual(x.associative_scan(lambda a,b: a+b).tolist(), [i*(i+1)//2 for i in range(1, n+1)])
+
+  def test_axis(self):
+    x = Tensor([[1,2,3,4],[5,6,7,8]], device="PYTHON")
+    self.assertEqual(x.associative_scan(lambda a,b: a+b, axis=1).tolist(), [[1,3,6,10],[5,11,18,26]])
+
+  def test_non_commutative(self):
+    x = Tensor([[[1,1],[0,1]], [[1,0],[1,1]], [[2,0],[0,1]], [[1,2],[0,1]]], device="PYTHON")
+    got = x.associative_scan(lambda a,b: a.matmul(b), axis=0).tolist()
+    cur = Tensor([[1,0],[0,1]], device="PYTHON")
+    expected=[]
+    for i in range(4):
+      cur = cur.matmul(x[i])
+      expected.append(cur.tolist())
+    self.assertEqual(got, expected)
+
+  def test_singleton_and_empty(self):
+    self.assertEqual(Tensor([7], device="PYTHON").associative_scan(lambda a,b:a+b).tolist(), [7])
+    self.assertEqual(Tensor([], device="PYTHON").associative_scan(lambda a,b:a+b).tolist(), [])
+
+if __name__ == "__main__": unittest.main()

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -767,6 +767,25 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     base = chunks[..., -1]._cumalu(-1, op)._pad_constant((None,)*(chunks.ndim-2) + ((1, -1),), value)
     return chunks.alu(op, base.unsqueeze(-1)).flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
 
+  def associative_scan(self, fn:Callable[[Self, Self], Self], axis:int=0) -> Self:
+    """Computes an inclusive scan along `axis` for an associative binary function `fn`."""
+    axis = self._resolve_dim(axis)
+    if self.shape[axis] == 0 or self.shape[axis] == 1: return self
+    x = self.transpose(axis, 0) if axis != 0 else self
+
+    def rec(a:Self) -> Self:
+      n = int(a.shape[0])
+      if n <= 1: return a
+      odd = rec(fn(a[0:n-1:2], a[1:n:2]))
+      if n == 2: return a[:1].cat(odd, dim=0)
+      even_tail = fn(odd[:-1], a[2:n:2]) if n % 2 == 0 else fn(odd, a[2:n:2])
+      even = a[:1].cat(even_tail, dim=0)
+      paired = even[:odd.shape[0]].stack(odd, dim=1).flatten(0, 1)
+      return paired.cat(even[-1:], dim=0) if n % 2 else paired
+
+    out = rec(x)
+    return out.transpose(0, axis) if axis != 0 else out
+
   def cumsum(self, axis:int=0) -> Self:
     """
     Computes the cumulative sum of the tensor along the specified `axis`.


### PR DESCRIPTION
Progress toward #3039.

Adds `Tensor.associative_scan(fn, axis=0)` as an inclusive generic scan using a recursive pairwise construction, with focused tests for addition, nonzero axes, a non-commutative matrix-multiply operator, and empty/singleton inputs.

Why merge this: it provides the generic associative scan primitive requested by the bounty without special-casing a specific operator, while preserving operand order for non-commutative associative functions.

Verification so far: focused axis, non-commutative, empty/singleton tests pass on the PYTHON device; a length-32 additive scan was also checked against the expected prefix sums. The exhaustive length loop is comparatively slow on the PYTHON backend and is still being tightened for CI-friendly coverage.

AI disclosure: I used ChatGPT to help reason about the scan construction and testing strategy; I ran and checked the implementation and tests locally before opening this draft.