### PR TITLE
add associative_scan on Tensor

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1194,6 +1194,12 @@ class TestOps(unittest.TestCase):
     np.testing.assert_allclose(rfwd.numpy(), [m0, m0 @ m1, m0 @ m1 @ m2])
     np.testing.assert_allclose(rrev.numpy(), [m0 @ m1 @ m2, m1 @ m2, m2])
 
+    # edge cases (0-D scalar, empty tensor, single element, negative axis)
+    assert Tensor(5.0).associative_scan(lambda a, b: a + b).item() == 5.0
+    assert Tensor([]).associative_scan(lambda a, b: a + b).shape == (0,)
+    assert Tensor([42.0]).associative_scan(lambda a, b: a + b).numpy().tolist() == [42.0]
+    np.testing.assert_allclose(x2d.associative_scan(lambda a, b: a + b, axis=-1).numpy(), [[1.0, 3.0, 6.0, 10.0], [5.0, 11.0, 18.0, 26.0]])
+
   def test_small_cumprod(self):
     helper_test_op([(10)],lambda x: torch.cumprod(x, dim=0),lambda x: Tensor.cumprod(x, axis=0))
   @slow_test

--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1175,6 +1175,25 @@ class TestOps(unittest.TestCase):
     np.testing.assert_allclose(r2.numpy(), [1.0, 2.0, 6.0, 24.0])
     np.testing.assert_allclose(r3.numpy(), [10.0, 9.0, 7.0, 4.0])
 
+    # 2D non-default axis
+    x2d = Tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+    r2d_fwd = x2d.associative_scan(lambda a, b: a + b, axis=1)
+    r2d_rev = x2d.associative_scan(lambda a, b: a + b, axis=1, reverse=True)
+    Tensor.realize(r2d_fwd, r2d_rev)
+    np.testing.assert_allclose(r2d_fwd.numpy(), [[1.0, 3.0, 6.0, 10.0], [5.0, 11.0, 18.0, 26.0]])
+    np.testing.assert_allclose(r2d_rev.numpy(), [[10.0, 9.0, 7.0, 4.0], [26.0, 21.0, 15.0, 8.0]])
+
+    # non-commutative associative operation (matrix multiplication)
+    m0 = np.array([[1.0, 2.0], [0.0, 1.0]], dtype=np.float32)
+    m1 = np.array([[2.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+    m2 = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.float32)
+    mats = Tensor(np.stack([m0, m1, m2]))
+    rfwd = mats.associative_scan(lambda a, b: a @ b, axis=0)
+    rrev = mats.associative_scan(lambda a, b: a @ b, axis=0, reverse=True)
+    Tensor.realize(rfwd, rrev)
+    np.testing.assert_allclose(rfwd.numpy(), [m0, m0 @ m1, m0 @ m1 @ m2])
+    np.testing.assert_allclose(rrev.numpy(), [m0 @ m1 @ m2, m1 @ m2, m2])
+
   def test_small_cumprod(self):
     helper_test_op([(10)],lambda x: torch.cumprod(x, dim=0),lambda x: Tensor.cumprod(x, axis=0))
   @slow_test

--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -1166,6 +1166,15 @@ class TestOps(unittest.TestCase):
     helper_test_op([(0,3)], lambda x: torch.cumsum(x, dim=0), lambda x: Tensor.cumsum(x, axis=0))
     helper_test_op([(2,3,0)], lambda x: torch.cumsum(x, dim=2), lambda x: Tensor.cumsum(x, axis=2))
 
+  def test_associative_scan(self):
+    x = Tensor([1.0, 2.0, 3.0, 4.0])
+    r1, r2, r3 = x.associative_scan(lambda a, b: a + b), x.associative_scan(lambda a, b: a * b), x.associative_scan(lambda a, b: a + b, reverse=True)
+    Tensor.realize(r1, r2, r3)
+    if COMPILE_ONLY: return
+    np.testing.assert_allclose(r1.numpy(), [1.0, 3.0, 6.0, 10.0])
+    np.testing.assert_allclose(r2.numpy(), [1.0, 2.0, 6.0, 24.0])
+    np.testing.assert_allclose(r3.numpy(), [10.0, 9.0, 7.0, 4.0])
+
   def test_small_cumprod(self):
     helper_test_op([(10)],lambda x: torch.cumprod(x, dim=0),lambda x: Tensor.cumprod(x, axis=0))
   @slow_test

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -777,16 +777,17 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     print(t.associative_scan(lambda a, b: a + b).numpy())
     ```
     """
+    if self.ndim == 0 or 0 in self.shape: return self
     axis = self._resolve_dim(axis)
     x = self.flip(axis) if reverse else self
     n, offset = x.shape[axis], 1
+    idx = type(self).arange(n).reshape(*[n if d == axis else 1 for d in range(x.ndim)])
     while offset < n:
       p = tuple((offset, 0) if d == axis else (0, 0) for d in range(x.ndim))
       s = tuple((0, sz) if d == axis else (0, sz) for d, sz in enumerate(x.shape))
       shifted = x.pad(p).shrink(s)
       comb = fn(x, shifted) if reverse else fn(shifted, x)
-      m = type(self).arange(n).reshape(*[n if d == axis else 1 for d in range(x.ndim)]) >= offset
-      x = m.where(comb, x)
+      x = (idx >= offset).where(comb, x)
       offset <<= 1
     return x.flip(axis) if reverse else x
 

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -768,6 +768,15 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     return chunks.alu(op, base.unsqueeze(-1)).flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
 
   def associative_scan(self, fn:Callable[[Self, Self], Self], axis:int=0, reverse:bool=False) -> Self:
+    """
+    Computes the inclusive parallel associative prefix scan along the specified `axis` using `fn`.
+    `fn(a, b)` combines the accumulated prefix `a` with incoming element `b` (or `fn(b, a)` when `reverse=True`).
+
+    ```python exec="true" source="above" session="tensor" result="python"
+    t = Tensor([1.0, 2.0, 3.0, 4.0])
+    print(t.associative_scan(lambda a, b: a + b).numpy())
+    ```
+    """
     axis = self._resolve_dim(axis)
     x = self.flip(axis) if reverse else self
     n, offset = x.shape[axis], 1
@@ -775,7 +784,7 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
       p = tuple((offset, 0) if d == axis else (0, 0) for d in range(x.ndim))
       s = tuple((0, sz) if d == axis else (0, sz) for d, sz in enumerate(x.shape))
       shifted = x.pad(p).shrink(s)
-      comb = fn(shifted, x)
+      comb = fn(x, shifted) if reverse else fn(shifted, x)
       m = type(self).arange(n).reshape(*[n if d == axis else 1 for d in range(x.ndim)]) >= offset
       x = m.where(comb, x)
       offset <<= 1

--- a/tinygrad/mixin/op.py
+++ b/tinygrad/mixin/op.py
@@ -767,6 +767,20 @@ class OpMixin(ElementwiseMixin, ReduceMixin):
     base = chunks[..., -1]._cumalu(-1, op)._pad_constant((None,)*(chunks.ndim-2) + ((1, -1),), value)
     return chunks.alu(op, base.unsqueeze(-1)).flatten(start_dim=-2)[..., -s:].transpose(axis,-1)
 
+  def associative_scan(self, fn:Callable[[Self, Self], Self], axis:int=0, reverse:bool=False) -> Self:
+    axis = self._resolve_dim(axis)
+    x = self.flip(axis) if reverse else self
+    n, offset = x.shape[axis], 1
+    while offset < n:
+      p = tuple((offset, 0) if d == axis else (0, 0) for d in range(x.ndim))
+      s = tuple((0, sz) if d == axis else (0, sz) for d, sz in enumerate(x.shape))
+      shifted = x.pad(p).shrink(s)
+      comb = fn(shifted, x)
+      m = type(self).arange(n).reshape(*[n if d == axis else 1 for d in range(x.ndim)]) >= offset
+      x = m.where(comb, x)
+      offset <<= 1
+    return x.flip(axis) if reverse else x
+
   def cumsum(self, axis:int=0) -> Self:
     """
     Computes the cumulative sum of the tensor along the specified `axis`.


### PR DESCRIPTION
Implements parallel associative scan using shift-pad and masked-where without graph bloat. Closes #3039.