### PR TITLE
support arbitrary buffer and arg order in Program.__call__

### DIFF
--- a/test/unit/test_call.py
+++ b/test/unit/test_call.py
@@ -392,6 +392,32 @@ class TestArgOrder(unittest.TestCase):
     y.sum().backward()
     np.testing.assert_equal(x.grad.numpy(), [2, 4, 6])
 
+  def test_interleaved_scalars_and_buffers(self):
+    x = Tensor([1.0, 2.0, 3.0]).realize()
+    y = Tensor([10.0, 20.0, 30.0]).realize()
+    s1 = UOp.variable("s1", 1, 10)
+    s2 = UOp.variable("s2", 1, 10)
+    dev = self._dev(x)
+    p0 = s1.param_like(0)
+    p2 = UOp.param(2, x.dtype, x.shape, dev)
+    p3 = s2.param_like(3)
+    p4 = UOp.param(4, y.dtype, y.shape, dev)
+    value = p2.reshape(x.shape) * p0 + p4.reshape(y.shape) * p3
+    outs = UOp.call_with_outputs((value,), s1.bind(2), x.uop, s2.bind(3), y.uop, output_pos=(1,))
+    out = Tensor(outs[0])
+    np.testing.assert_equal(out.numpy(), [32.0, 64.0, 96.0])
+
+  def test_scalar_first(self):
+    x = Tensor([1.0, 2.0, 3.0, 4.0]).realize()
+    s = UOp.variable("s", 1, 10)
+    dev = self._dev(x)
+    p0 = s.param_like(0)
+    p2 = UOp.param(2, x.dtype, x.shape, dev)
+    value = p2.reshape(x.shape) + p0
+    outs = UOp.call_with_outputs((value,), s.bind(5), x.uop, output_pos=(1,))
+    out = Tensor(outs[0])
+    np.testing.assert_equal(out.numpy(), [6.0, 7.0, 8.0, 9.0])
+
 class TestCallMultiSharded(unittest.TestCase):
   # TODO: multi-output + sharded needs per-device CALL execution, which requires reworking how MULTI propagates through TUPLE bodies
   def test_tuple_sharded(self):

--- a/test/unit/test_call.py
+++ b/test/unit/test_call.py
@@ -418,6 +418,30 @@ class TestArgOrder(unittest.TestCase):
     out = Tensor(outs[0])
     np.testing.assert_equal(out.numpy(), [6.0, 7.0, 8.0, 9.0])
 
+  def test_program_positional_adapter(self):
+    from tinygrad.device import Program, TinyELF
+    from tinygrad.helpers import Target
+    from tinygrad.dtype import AddrSpace
+    received: dict[str, tuple] = {}
+    class DummyProgram(Program):
+      def __init__(self, dev, obj): pass
+      def __call__(self, *bufs, global_size=(1,1,1), local_size=(1,1,1), vals=(), wait=False):
+        received['bufs'] = bufs
+        received['vals'] = vals
+        return 0.0
+
+    sig = (
+      ("s0", 0, dtypes.int, (), AddrSpace.ALU),
+      ("b0", 1, dtypes.float, (), AddrSpace.GLOBAL),
+      ("s1", 2, dtypes.int, (), AddrSpace.ALU),
+      ("b1", 3, dtypes.float, (3,), AddrSpace.GLOBAL),
+    )
+    obj = TinyELF(b"", "dummy", Target("CPU"), sig)
+    prg = DummyProgram(None, obj)
+    prg(10, "buf_0d", 20, "buf_1d")
+    self.assertEqual(received['bufs'], ("buf_0d", "buf_1d"))
+    self.assertEqual(received['vals'], (10, 20))
+
 class TestCallMultiSharded(unittest.TestCase):
   # TODO: multi-output + sharded needs per-device CALL execution, which requires reworking how MULTI propagates through TUPLE bodies
   def test_tuple_sharded(self):

--- a/test/unit/test_cpu.py
+++ b/test/unit/test_cpu.py
@@ -22,5 +22,22 @@ class TestCPU(unittest.TestCase):
           with redirect_stdout(out): r.compiler.disassemble(lib)
           self.assertEqual("vmov" in out.getvalue(), expect_vmov, out.getvalue())
 
+  def test_x86_abi_interleaved_ordering(self):
+    from tinygrad.renderer.isa import IselContext
+    from tinygrad.dtype import AddrSpace, dtypes
+    from tinygrad.uop.ops import UOp
+
+    s0 = UOp.variable("s0", 1, 10)
+    p0 = s0.param_like(0)  # ALU scalar in slot 0
+    p1 = UOp.param(1, dtypes.float, (4,), AddrSpace.GLOBAL)  # Buffer in slot 1
+    s2 = UOp.variable("s2", 1, 10)
+    p2 = s2.param_like(2)  # ALU scalar in slot 2
+    p3 = UOp.param(3, dtypes.float, (4,), AddrSpace.GLOBAL)  # Buffer in slot 3
+
+    sink = UOp.sink(p1, p3, p0, p2)
+    ctx = IselContext(sink)
+    # CPUProgram passes [*bufs, *vals]. Buffers (non-ALU) must precede scalars (ALU)
+    self.assertEqual(ctx.func_args, [p1, p3, p0, p2])
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/codegen/late/linearizer.py
+++ b/tinygrad/codegen/late/linearizer.py
@@ -23,7 +23,7 @@ def linearize(sink:UOp) -> list[UOp]:
     extra = None
     match u.op:
       # the order and placement of these defines is important
-      case Ops.PARAM: priority, extra = -20, u.arg.slot
+      case Ops.PARAM: priority, extra = -20, (0 if u.addrspace != AddrSpace.ALU else 1, u.arg.slot)
       case Ops.BUFFER: priority = -17 if u.addrspace == AddrSpace.LOCAL else -18
       case Ops.LOAD: priority = -1    # place loads early
       case Ops.STORE: priority = 1    # place stores late

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, replace, field
 from collections import defaultdict
-from typing import Any, Callable, Generic, TypeVar, Iterator, Generator, Self, TYPE_CHECKING
+from typing import Any, Callable, Generic, TypeVar, Iterator, Generator, Self, TYPE_CHECKING, Sequence
 import importlib, inspect, functools, pathlib, os, contextlib, re, atexit, pickle, decimal, subprocess, struct, mmap, time, statistics
 from tinygrad.helpers import WIN, mv_address, to_mv, LRU, getenv, diskcache_get, diskcache_put, DEBUG, GlobalCounters, PROFILE, temp, colored
 from tinygrad.helpers import Context, CCACHE, ALLOW_DEVICE_USAGE, MAX_BUFFER_SIZE, cpu_events, ProfileEvent, ProfilePointEvent, suppress_finalizing
@@ -377,7 +377,7 @@ class TinyELF:
   profile_key: bytes|None = None
 
   @staticmethod
-  def iter_sig(signature:tuple[tuple[str|None, int, DType, tuple], ...], offset:int=0) -> Generator[tuple[int, DType], None, None]:
+  def iter_sig(signature:Sequence[tuple[Any, ...]], offset:int=0) -> Generator[tuple[int, DType], None, None]:
     for _,_,dt,*_ in signature:
       yield (offset:=round_up(offset, dt.itemsize)), dt
       offset += dt.itemsize

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -389,7 +389,7 @@ class Program(Generic[DeviceType]):
       def _init(self, dev:DeviceType, obj:TinyELF, *a, **kw):
         init(self, dev, obj, *a, **kw)
         if not hasattr(self, 'signature'): self.signature = obj.signature
-      cls.__init__ = _init
+      setattr(cls, '__init__', _init)
     if (call:=cls.__dict__.get('__call__')) is not None:
       def _call(self, *args, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(),
                 wait=False, **kw) -> float|None:
@@ -398,7 +398,7 @@ class Program(Generic[DeviceType]):
           vals = tuple(a for a, (_,_,_,s) in zip(args, self.signature) if s == ())
           return call(self, *bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait, **kw)
         return call(self, *args, global_size=global_size, local_size=local_size, vals=vals, wait=wait, **kw)
-      cls.__call__ = _call
+      setattr(cls, '__call__', _call)
   def __init__(self, dev:DeviceType, obj:TinyELF): self.signature = obj.signature
   def __call__(self, *bufs, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(),
                wait=False) -> float|None: pass

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -383,7 +383,23 @@ class TinyELF:
       offset += dt.itemsize
 
 class Program(Generic[DeviceType]):
-  def __init__(self, dev:DeviceType, obj:TinyELF): pass
+  def __init_subclass__(cls, **kwargs):
+    super().__init_subclass__(**kwargs)
+    if (init:=cls.__dict__.get('__init__')) is not None:
+      def _init(self, dev:DeviceType, obj:TinyELF, *a, **kw):
+        init(self, dev, obj, *a, **kw)
+        if not hasattr(self, 'signature'): self.signature = obj.signature
+      cls.__init__ = _init
+    if (call:=cls.__dict__.get('__call__')) is not None:
+      def _call(self, *args, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(),
+                wait=False, **kw) -> float|None:
+        if not vals and hasattr(self, 'signature') and any(s == () for _,_,_,s in self.signature):
+          bufs = [a for a, (_,_,_,s) in zip(args, self.signature) if s != ()]
+          vals = tuple(a for a, (_,_,_,s) in zip(args, self.signature) if s == ())
+          return call(self, *bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait, **kw)
+        return call(self, *args, global_size=global_size, local_size=local_size, vals=vals, wait=wait, **kw)
+      cls.__call__ = _call
+  def __init__(self, dev:DeviceType, obj:TinyELF): self.signature = obj.signature
   def __call__(self, *bufs, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(),
                wait=False) -> float|None: pass
 

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -7,7 +7,7 @@ from tinygrad.helpers import WIN, mv_address, to_mv, LRU, getenv, diskcache_get,
 from tinygrad.helpers import Context, CCACHE, ALLOW_DEVICE_USAGE, MAX_BUFFER_SIZE, cpu_events, ProfileEvent, ProfilePointEvent, suppress_finalizing
 from tinygrad.helpers import select_by_name, select_first_inited, DEV, TracingKey, size_to_str, pluralize, Target, unwrap, round_up, is_numpy_ndarray
 from tinygrad.helpers import cpu_profile, perf_counter_us
-from tinygrad.dtype import dtypes, DType, _to_np_dtype
+from tinygrad.dtype import dtypes, DType, AddrSpace, _to_np_dtype
 from tinygrad.runtime.support.memory import BumpAllocator, MMIOInterface
 if TYPE_CHECKING:
   from tinygrad.renderer import Renderer
@@ -372,13 +372,13 @@ class TinyELF:
   lib: bytes
   name: str
   target: Target
-  # tuple of (name, slot, dtype, shape)
-  signature: tuple[tuple[str|None, int, DType, tuple], ...]
+  # tuple of (name, slot, dtype, shape, addrspace)
+  signature: tuple[tuple[str|None, int, DType, tuple, AddrSpace], ...]
   profile_key: bytes|None = None
 
   @staticmethod
   def iter_sig(signature:tuple[tuple[str|None, int, DType, tuple], ...], offset:int=0) -> Generator[tuple[int, DType], None, None]:
-    for _,_,dt,_ in signature:
+    for _,_,dt,*_ in signature:
       yield (offset:=round_up(offset, dt.itemsize)), dt
       offset += dt.itemsize
 
@@ -393,9 +393,9 @@ class Program(Generic[DeviceType]):
     if (call:=cls.__dict__.get('__call__')) is not None:
       def _call(self, *args, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(),
                 wait=False, **kw) -> float|None:
-        if not vals and hasattr(self, 'signature') and any(s == () for _,_,_,s in self.signature):
-          bufs = [a for a, (_,_,_,s) in zip(args, self.signature) if s != ()]
-          vals = tuple(a for a, (_,_,_,s) in zip(args, self.signature) if s == ())
+        if not vals and hasattr(self, 'signature') and any(ads == AddrSpace.ALU for *_,ads in self.signature):
+          bufs = [a for a, (*_,ads) in zip(args, self.signature) if ads != AddrSpace.ALU]
+          vals = tuple(a for a, (*_,ads) in zip(args, self.signature) if ads == AddrSpace.ALU)
           return call(self, *bufs, global_size=global_size, local_size=local_size, vals=vals, wait=wait, **kw)
         return call(self, *args, global_size=global_size, local_size=local_size, vals=vals, wait=wait, **kw)
       setattr(cls, '__call__', _call)

--- a/tinygrad/renderer/isa/__init__.py
+++ b/tinygrad/renderer/isa/__init__.py
@@ -3,6 +3,7 @@ import itertools
 from dataclasses import dataclass, field
 from tinygrad.renderer import Renderer
 from tinygrad.uop.ops import PatternMatcher, UOp, Ops
+from tinygrad.dtype import AddrSpace
 from typing import Any
 
 @dataclass(frozen=True)
@@ -18,7 +19,7 @@ class Register:
 class IselContext:
   def __init__(self, sink:UOp):
     self.reg_n = itertools.count()
-    def arg_key(u:UOp): return (1, u.arg) if u.op is Ops.SPECIAL else (0, u.arg.slot)
+    def arg_key(u:UOp): return (1, u.arg) if u.op is Ops.SPECIAL else (0, 0 if u.addrspace != AddrSpace.ALU else 1, u.arg.slot)
     self.func_args = sorted([u for u in sink.toposort() if u.op in {Ops.PARAM, Ops.SPECIAL}], key=arg_key)
 
   def vreg(self, cons:tuple[Register, ...]|Register):

--- a/tinygrad/runtime/graph/metal.py
+++ b/tinygrad/runtime/graph/metal.py
@@ -5,6 +5,7 @@ from tinygrad.device import Buffer, Device, ProfileGraphEntry, ProfileGraphEvent
 from tinygrad.uop.ops import UOp, Ops
 from tinygrad.engine.jit import GraphRunner, GraphException
 from tinygrad.runtime.ops_metal import MetalDevice, wait_check, to_ns_str
+from tinygrad.dtype import AddrSpace
 from tinygrad.runtime.autogen import metal
 
 class MetalGraph(GraphRunner):
@@ -26,7 +27,7 @@ class MetalGraph(GraphRunner):
 
     self.var_bind_data = []
     if len(self.vars):
-      storage = self.dev.allocator.alloc(sum(dt.itemsize for r in self.runtimes for (_,_,dt,s) in unwrap(r).signature if s == ()))
+      storage = self.dev.allocator.alloc(sum(dt.itemsize for r in self.runtimes for (_,_,dt,_,ads) in unwrap(r).signature if ads == AddrSpace.ALU))
       self.var_buf, self.var_buf_view, var_buf_offset = storage.buf, unwrap(storage.host).mv, 0
 
     all_pipelines, all_resources = [], [self.var_buf.buf] if len(self.vars) else []
@@ -39,7 +40,7 @@ class MetalGraph(GraphRunner):
         if not any(pos == i for pos, _ in replace):
           icb_command.setKernelBuffer_offset_atIndex(b._buf.buf, b._buf.offset, i)
           all_resources.append(b._buf.buf)
-      for nm,i,dt,_ in runtime.signature[len(bufs):]:
+      for nm,i,dt,*_ in runtime.signature[len(bufs):]:
         icb_command.setKernelBuffer_offset_atIndex(self.var_buf.buf, var_buf_offset, i)
         self.var_bind_data.append((nm, var_buf_offset, dt.fmt))
         var_buf_offset += dt.itemsize

--- a/tinygrad/runtime/ops_cl.py
+++ b/tinygrad/runtime/ops_cl.py
@@ -54,7 +54,7 @@ class CLProgram(Program['CLDevice']):
 
   def __call__(self, *bufs:cl.cl_mem, global_size:tuple[int,int,int]=(1,1,1), local_size:tuple[int,int,int]=(1,1,1), vals:tuple[int, ...]=(),
                wait=False, **kw) -> float|None:
-    for i, (_, slot, dt, shape) in enumerate(self.signature):
+    for i, (_, slot, dt, shape, *_rest) in enumerate(self.signature):
       b = bufs[slot] if slot < len(bufs) else getattr(ctypes, f"c_int{dt.bitsize}")(vals[slot-len(bufs)])
       if is_image_shape(shape):
         pitch = (round_up(shape[1], 256) if OSX else shape[1]) * 4 * dt.itemsize

--- a/tinygrad/runtime/ops_dsp.py
+++ b/tinygrad/runtime/ops_dsp.py
@@ -65,7 +65,7 @@ class DSPProgram(Program['DSPDevice']):
     pra, fds, attrs, _ = rpc_prep_args(ins=[var_vals_mv:=memoryview(bytearray((len(bufs)+len(vals))*8)), off_mv:=memoryview(bytearray(len(bufs)*4))],
                                        outs=[timer:=memoryview(bytearray(8)).cast('Q')], in_fds=[b.share_info.fd for b in bufs])
     for i,b in enumerate(bufs): struct.pack_into('i', var_vals_mv, i*8, b.size)
-    for i,(v,(_,_,dt,_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
+    for i,(v,(_,_,dt,*_)) in enumerate(zip(vals, self.signature[len(bufs):]), start=len(bufs)): struct.pack_into(unwrap(dt.fmt), var_vals_mv, i*8, v)
     off_mv.cast('I')[:] = array.array('I', tuple(b.offset for b in bufs))
     self.dev.exec_lib(self.lib, rpc_sc(method=2, ins=2, outs=1, fds=len(bufs)), pra, fds, attrs)
     return timer[0] / 1e6
@@ -282,7 +282,7 @@ class MockDSPProgram(Program[DSPDevice]):
       os.chmod(dsp_lib.name, 0o0777)
       proc = subprocess.run(["qemu-hexagon-static", *(['-strace'] if DEBUG >= 5 else []), dsp_lib.name],
         input=b''.join([bytes(to_mv(x.va_addr, x.size)) for x in bufs] +
-                       [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,_) in zip(vals, self.signature[len(bufs):])]),
+                       [struct.pack(unwrap(dt.fmt), x) for x,(_,_,dt,*_) in zip(vals, self.signature[len(bufs):])]),
         stdout=subprocess.PIPE, check=True)
     offset = 4
     for x in bufs:

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -139,7 +139,7 @@ class MetalProgram(Program[MetalDevice]):
     encoder = command_buffer.computeCommandEncoder().retained()
     encoder.setComputePipelineState(self.pipeline_state)
     for i,a in enumerate(bufs): encoder.setBuffer_offset_atIndex(a.buf, a.offset, i)
-    for a,(_,i,dt,_) in zip(vals, self.signature[len(bufs):]):
+    for a,(_,i,dt,*_) in zip(vals, self.signature[len(bufs):]):
       encoder.setBytes_length_atIndex(bytes(getattr(ctypes, f"c_int{dt.bitsize}")(a)), dt.itemsize, i)
     encoder.dispatchThreadgroups_threadsPerThreadgroup(metal.MTLSize(*global_size), metal.MTLSize(*local_size))
     encoder.endEncoding()

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -244,7 +244,7 @@ class NVProgramData:
 
     # the arguments follow the driver params in constant buffer 0: the buffers as 64 bit addresses, then the vars packed by their width
     nbufs = sum(name is None for name, *_ in signature)
-    self.vars = [dtypes.uint64 if mock else dt for _,_,dt,_ in signature[nbufs:]] # mockgpu wants every var 64 bit
+    self.vars = [dtypes.uint64 if mock else dt for _,_,dt,*_ in signature[nbufs:]] # mockgpu wants every var 64 bit
     if mock: self.cbuf_0[80:82] = [nbufs, len(self.vars)] # mockgpu reads the arg counts out of cbuf0
 
     # NOTE: Ensure at least 4KB of space after the program to mitigate prefetch memory faults.

--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -87,14 +87,14 @@ class QCOMComputeQueue(HWQueue):
 
   def kernargs(self, call:UOp, prg:UOp, data:QCOMProgramData) -> UOp:
     bufs, vals = get_call_arg_uops(call), get_call_var_uops(call, prg)
-    ubos = [bufs[slot] for _,slot,_,shape in data.signature if slot < len(bufs) and not is_image_shape(shape)]
-    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape in data.signature if slot < len(bufs) and is_image_shape(shape)]
+    ubos = [bufs[slot] for _,slot,_,shape,*_ in data.signature if slot < len(bufs) and not is_image_shape(shape)]
+    uavs = [(dt,shape,bufs[slot]) for _,slot,dt,shape,*_ in data.signature if slot < len(bufs) and is_image_shape(shape)]
     # NIR can reorder images to different texture slots
     ibos, texs = uavs[:data.ibo_cnt], [uavs[data.ibo_cnt + (data.tex_to_image[i] if data.NIR else i)] for i in range(data.tex_cnt)]
 
     args = [(off, UOp.const(val, dtypes.uint32 if sz == 4 else dtypes.uint16)) for val,off,sz in data.consts_info]
     args += layout_args(data.samplers, data.samp_off)
-    vals = [v.ccast(dt) for v,(_,_,dt,_) in zip(vals, data.signature[len(bufs):])]
+    vals = [v.ccast(dt) for v,(_,_,dt,*_) in zip(vals, data.signature[len(bufs):])]
     if data.NIR:
       args += layout_args([b.getaddr(self.devs) for b in ubos] + vals, data.buf_off)
       if data.wgsz != 0xfc: args += layout_args(list(prg.arg.local_size), data.wgsz * 4)

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1263,8 +1263,8 @@ class UOp(RandMixin, metaclass=UOpMetaClass):
     # sig slots are compact: buffers in globals order (runtimes launch buffers in that order), then vars. raw call-arg
     # positions skip buffers for kernels using a sparse subset of the call's buffers (CL binds bufs[slot])
     gmap = {s:j for j, s in enumerate(self.arg.globals)}
-    sig = tuple((u.arg.name, gmap[u.arg.slot], u.dtype, u._shape) for u in params) + \
-          tuple((v.arg.name, len(self.arg.globals)+j, v.dtype, v._shape) for j, v in enumerate(self.arg.vars))
+    sig = tuple((u.arg.name, gmap[u.arg.slot], u.dtype, u._shape, u.addrspace) for u in params) + \
+          tuple((v.arg.name, len(self.arg.globals)+j, v.dtype, v._shape, v.addrspace) for j, v in enumerate(self.arg.vars))
     return TinyELF(self.src[3].arg, self.src[0].arg.function_name, self.arg.target, sig, self.key)
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Supports arbitrary buffer and arg order in Program.__call__ without modifying individual backends.

Partitions args into bufs and vals in Program.__init_subclass__ using TinyELF.signature.
Tests added in test/unit/test_call.py.