### PR TITLE
fix gradient of assign through a strided slice

### DIFF
--- a/test/unit/test_after.py
+++ b/test/unit/test_after.py
@@ -72,7 +72,8 @@ class TestAfterCounterexamples(unittest.TestCase):
   def test_view_assign_gradient(self):
     for view, expected in ((lambda t: t.reshape(3, 2)[1:], [[1., 1., 0.], [0., 0., 0.]]),
                            (lambda t: t.permute(1, 0)[1:], [[1., 0., 0.], [1., 0., 0.]]),
-                           (lambda t: t.flip((0, 1))[:1], [[1., 1., 1.], [0., 0., 0.]])):
+                           (lambda t: t.flip((0, 1))[:1], [[1., 1., 1.], [0., 0., 0.]]),
+                           (lambda t: t[:, ::2], [[0., 1., 0.], [0., 1., 0.]])):
       with self.subTest(expected=expected):
         x = Tensor([[1., 2., 3.], [4., 5., 6.]])
         y = x.clone()

--- a/tinygrad/mixin/gradient.py
+++ b/tinygrad/mixin/gradient.py
@@ -70,7 +70,7 @@ def call_gradient(ctx:UOp, k:UOp, needed:set[int]) -> tuple[UOp|None, ...]:
 def partial_store_gradient(ctx:UOp, dest:UOp, view:UOp):
   # A write through a non-overlapping view replaces only that region of the returned state.
   path, base = [], view
-  while base is not dest and base.op in {Ops.RESHAPE, Ops.SHRINK, Ops.PERMUTE, Ops.FLIP}:
+  while base is not dest and base.op in {Ops.RESHAPE, Ops.SHRINK, Ops.PERMUTE, Ops.FLIP, Ops.PAD}:
     path.append(base)
     base = base.src[0]
   if base is not dest: return None


### PR DESCRIPTION
Backward through `t[:, ::2].assign(v)` raised "failed to compute gradient for Ops.AFTER" when the step does not divide the axis, since the slice's view has a PAD that `partial_store_gradient` did not walk. The existing test only covered views with no PAD.
